### PR TITLE
Refactor AICPU core assignment to support dynamic block distribution

### DIFF
--- a/example/main.py
+++ b/example/main.py
@@ -137,7 +137,7 @@ def main():
     # Execute graph on device
     # Python now controls when the graph is executed
     print("\n=== Executing Graph on Device ===")
-    runner.run(graph, block_dim=1, launch_aicpu_num=1)
+    runner.run(graph, block_dim=6, launch_aicpu_num=3)
 
     # Validate results and cleanup
     # C++ handles: copy results from device, validate, free tensors, delete graph


### PR DESCRIPTION
## Summary
Improved the GraphExecutor core assignment logic to properly distribute AICore resources across multiple threads based on block_dim configuration.

## Key Changes
- Changed core limit validation from per-thread to total cores check
- Implemented block-based core assignment: each thread now manages blocks_per_thread blocks (each block = 1 AIC + 2 AIV cores)
- Added validation to ensure block_dim is divisible by thread_num
- Fixed core utilization issue where only 33% of cores were assigned

## Example
With 6 blocks and 3 threads, each thread manages 2 blocks:
- Thread 0: AIC[0,1] + AIV[6,7,8,9]
- Thread 1: AIC[2,3] + AIV[10,11,12,13]
- Thread 2: AIC[4,5] + AIV[14,15,16,17]