### PR TITLE
efactor: Rename Graph to Runtime to Better Reflect Its Responsibility

### DIFF
--- a/example/main.py
+++ b/example/main.py
@@ -50,10 +50,10 @@ def check_and_build_runtime():
     print("\n[1/3] Compiling AICore kernel...")
     try:
         aicore_include_dirs = [
-            str(runtime_root / "src" / "runtime" / "graph"),
+            str(runtime_root / "src" / "runtime" / "runtime"),
         ]
         aicore_source_dirs = [
-            str(runtime_root / "src" / "runtime" / "graph"),
+            str(runtime_root / "src" / "runtime" / "runtime"),
         ]
         aicore_binary = compiler.compile("aicore", aicore_include_dirs, aicore_source_dirs)
     except Exception as e:
@@ -64,11 +64,11 @@ def check_and_build_runtime():
     print("\n[2/3] Compiling AICPU kernel...")
     try:
         aicpu_include_dirs = [
-            str(runtime_root / "src" / "runtime" / "graph"),
+            str(runtime_root / "src" / "runtime" / "runtime"),
         ]
         aicpu_source_dirs = [
             str(runtime_root / "src" / "runtime" / "aicpu"),
-            str(runtime_root / "src" / "runtime" / "graph"),
+            str(runtime_root / "src" / "runtime" / "runtime"),
         ]
         aicpu_binary = compiler.compile("aicpu", aicpu_include_dirs, aicpu_source_dirs)
     except Exception as e:
@@ -79,11 +79,11 @@ def check_and_build_runtime():
     print("\n[3/3] Compiling Host runtime...")
     try:
         host_include_dirs = [
-            str(runtime_root / "src" / "runtime" / "graph"),
+            str(runtime_root / "src" / "runtime" / "runtime"),
         ]
         host_source_dirs = [
             str(runtime_root / "src" / "runtime" / "host"),
-            str(runtime_root / "src" / "runtime" / "graph"),
+            str(runtime_root / "src" / "runtime" / "runtime"),
         ]
         host_binary = compiler.compile("host", host_include_dirs, host_source_dirs)
     except Exception as e:
@@ -120,7 +120,7 @@ def main():
 
     # Load runtime library and get bindings
     print("\n=== Loading Runtime Library ===")
-    DeviceRunner, Graph = load_runtime(host_binary)
+    DeviceRunner, Runtime = load_runtime(host_binary)
     print(f"Loaded runtime ({len(host_binary)} bytes)")
 
     # Initialize DeviceRunner
@@ -128,21 +128,21 @@ def main():
     runner = DeviceRunner()
     runner.init(device_id, aicpu_binary, aicore_binary, pto_isa_root)
 
-    # Create and initialize graph
-    # C++ handles: allocate Graph, allocate tensors, build tasks, initialize data
-    print("\n=== Creating and Initializing Graph ===")
-    graph = Graph()
-    graph.initialize()
+    # Create and initialize runtime
+    # C++ handles: allocate Runtime, allocate tensors, build tasks, initialize data
+    print("\n=== Creating and Initializing Runtime ===")
+    runtime = Runtime()
+    runtime.initialize()
 
-    # Execute graph on device
-    # Python now controls when the graph is executed
-    print("\n=== Executing Graph on Device ===")
-    runner.run(graph, block_dim=6, launch_aicpu_num=3)
+    # Execute runtime on device
+    # Python now controls when the runtime is executed
+    print("\n=== Executing Runtime on Device ===")
+    runner.run(runtime, block_dim=6, launch_aicpu_num=3)
 
     # Validate results and cleanup
-    # C++ handles: copy results from device, validate, free tensors, delete graph
+    # C++ handles: copy results from device, validate, free tensors, delete runtime
     print("\n=== Validating Results and Cleaning Up ===")
-    graph.validate_and_cleanup()
+    runtime.validate_and_cleanup()
 
     # Finalize runner
     print("\n=== Finalizing DeviceRunner ===")

--- a/src/platform/a2a3/aicore/kernel.cpp
+++ b/src/platform/a2a3/aicore/kernel.cpp
@@ -3,7 +3,7 @@
 */
 
 #include <cstdint>
-#include "graph.h"
+#include "runtime.h"
 
 #ifndef __gm__
 #define __gm__
@@ -93,9 +93,9 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
 *
 * Each core (AIC or AIV) gets its own handshake buffer indexed by blockIdx.
 *
-* @param graph Address of Graph structure in device memory
+* @param runtime Address of Runtime structure in device memory
 */
-extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Graph* graph) {
+extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime* runtime) {
     // Calculate blockIdx for this core
 #ifdef __AIV__
     blockIdx = get_block_idx() * get_subblockdim() + get_subblockid() + get_block_num();
@@ -103,7 +103,7 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Graph* 
     blockIdx = get_block_idx();
 #endif
 
-    __gm__ Handshake* my_hank = (__gm__ Handshake *)(&graph->workers[blockIdx]);
+    __gm__ Handshake* my_hank = (__gm__ Handshake *)(&runtime->workers[blockIdx]);
 
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {

--- a/src/platform/a2a3/aicpu/kernel.cpp
+++ b/src/platform/a2a3/aicpu/kernel.cpp
@@ -1,11 +1,11 @@
 #include <cstdint>
 #include <cstdio>
 #include "device_log.h"
-#include "graph.h"
+#include "runtime.h"
 #include "kernel_args.h"
 
-// Forward declaration of AicpuExecute (implemented in graphexecutor.cpp)
-extern "C" int AicpuExecute(void* arg);  // arg is Graph*
+// Forward declaration of AicpuExecute (implemented in runtimeexecutor.cpp)
+extern "C" int AicpuExecute(void* arg);  // arg is Runtime*
 
 extern "C" __attribute__((visibility("default"))) int StaticTileFwkBackendKernelServer(void *arg) {
     if (arg == nullptr) {
@@ -34,19 +34,19 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
         return -1;
     }
 
-    DEV_INFO("%s", "Graph Executor Init: Initializing AICPU kernel");
+    DEV_INFO("%s", "Runtime Executor Init: Initializing AICPU kernel");
     return 0;
 }
 
 /**
  * AICPU kernel main execution entry point
  *
- * This is the main entry point for the AICPU graph executor kernel.
- * It extracts the Graph from KernelArgs and delegates to AicpuExecute.
+ * This is the main entry point for the AICPU runtime executor kernel.
+ * It extracts the Runtime from KernelArgs and delegates to AicpuExecute.
  *
  * Note: Function name is hardcoded in libaicpu_extend_kernels.so
  *
- * @param arg Pointer to KernelArgs structure containing graphArgs
+ * @param arg Pointer to KernelArgs structure containing runtimeArgs
  * @return 0 on success, non-zero on error
  */
 extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelServer(void *arg) {
@@ -55,17 +55,17 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
         return -1;
     }
 
-    // Extract Graph from KernelArgs
+    // Extract Runtime from KernelArgs
     auto kargs = (KernelArgs *)arg;
-    Graph* graph = kargs->graphArgs;
+    Runtime* runtime = kargs->runtimeArgs;
 
-    if (graph == nullptr) {
-        DEV_ERROR("%s", "Invalid graphArgs: null pointer");
+    if (runtime == nullptr) {
+        DEV_ERROR("%s", "Invalid runtimeArgs: null pointer");
         return -1;
     }
 
-    DEV_INFO("%s", "DynTileFwkBackendKernelServer: Calling AicpuExecute with Graph");
-    int rc = AicpuExecute(graph);  // Pass Graph* instead of KernelArgs*
+    DEV_INFO("%s", "DynTileFwkBackendKernelServer: Calling AicpuExecute with Runtime");
+    int rc = AicpuExecute(runtime);  // Pass Runtime* instead of KernelArgs*
     if (rc != 0) {
         DEV_ERROR("DynTileFwkBackendKernelServer: AicpuExecute failed with rc=%d", rc);
         return rc;

--- a/src/platform/a2a3/common/kernel_args.h
+++ b/src/platform/a2a3/common/kernel_args.h
@@ -16,7 +16,7 @@
 #include <cstdint>
 
 // Forward declaration
-class Graph;
+class Runtime;
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,18 +36,18 @@ extern "C" {
  * Field Access Patterns:
  * - unused[5]: Padding for alignment with CANN runtime expectations
  * - deviceArgs: Written by host, read by AICPU (contains aicpuSoBin/aicpuSoLen)
- * - graphArgs: Written by host, read by AICPU (task graph with execution parameters)
- *              Graph contains: workers[], worker_count, block_dim, scheCpuNum, tasks[]
+ * - runtimeArgs: Written by host, read by AICPU (task runtime with execution parameters)
+ *                Runtime contains: workers[], worker_count, block_dim, scheCpuNum, tasks[]
  *
- * Note: AICore kernels receive Graph* directly, not KernelArgs
- *       - AICPU: accesses graphArgs->workers, graphArgs->block_dim, etc.
- *       - AICore: receives Graph* pointer with workers at offset 0
+ * Note: AICore kernels receive Runtime* directly, not KernelArgs
+ *       - AICPU: accesses runtimeArgs->workers, runtimeArgs->block_dim, etc.
+ *       - AICore: receives Runtime* pointer with workers at offset 0
  */
 struct KernelArgs {
     uint64_t unused[5] = {0};        // Alignment padding (required by CANN runtime offset)
     uint64_t *deviceArgs{nullptr};    // Device arguments (AICPU reads, contains SO info)
-    uint64_t *runtime{nullptr};       // Runtime context (AICPU reads)
-    Graph *graphArgs{nullptr};        // Task graph in device memory
+    uint64_t *runtimeCtx{nullptr};    // Runtime context (AICPU reads)
+    Runtime *runtimeArgs{nullptr};    // Task runtime in device memory
 };
 
 #ifdef __cplusplus

--- a/src/platform/a2a3/host/devicerunner.h
+++ b/src/platform/a2a3/host/devicerunner.h
@@ -25,7 +25,7 @@
 
 // Forward declaration for method parameters
 // Full definition included in devicerunner.cpp
-class Graph;
+class Runtime;
 
 /**
  * DeviceArgs structure for AICPU device arguments
@@ -72,16 +72,16 @@ struct KernelArgsHelper {
     int FinalizeDeviceArgs();
 
     /**
-     * Initialize graph arguments by allocating device memory and copying data
+     * Initialize runtime arguments by allocating device memory and copying data
      *
-     * @param hostGraph  Host-side graph to copy to device
-     * @param allocator  Memory allocator to use
+     * @param hostRuntime  Host-side runtime to copy to device
+     * @param allocator    Memory allocator to use
      * @return 0 on success, error code on failure
      */
-    int InitGraphArgs(const Graph& hostGraph, MemoryAllocator& allocator);
+    int InitGraphArgs(const Runtime& hostRuntime, MemoryAllocator& allocator);
 
     /**
-     * Free device memory allocated for graph arguments
+     * Free device memory allocated for runtime arguments
      *
      * @return 0 on success, error code on failure
      */
@@ -199,33 +199,33 @@ public:
     int CopyFromDevice(void* hostPtr, const void* devPtr, size_t bytes);
 
     /**
-     * Execute a graph
+     * Execute a runtime
      *
      * This method:
-     * 1. Initializes worker handshake buffers in the graph based on blockDim
-     * 2. Transfers graph to device memory
+     * 1. Initializes worker handshake buffers in the runtime based on blockDim
+     * 2. Transfers runtime to device memory
      * 3. Launches AICPU init kernel
      * 4. Launches AICPU main kernel
      * 5. Launches AICore kernel
      * 6. Synchronizes streams
-     * 7. Cleans up graph memory
+     * 7. Cleans up runtime memory
      *
-     * @param graph          Graph to execute (will be modified to initialize workers)
+     * @param runtime         Runtime to execute (will be modified to initialize workers)
      * @param blockDim        Number of blocks (1 block = 1 AIC + 2 AIV)
      * @param launchAicpuNum Number of AICPU instances (default: 1)
      * @return 0 on success, error code on failure
      */
-    int Run(Graph& graph, int blockDim, int launchAicpuNum = 1);
+    int Run(Runtime& runtime, int blockDim, int launchAicpuNum = 1);
 
     /**
      * Print handshake results from device
      *
      * Copies handshake buffers from device and prints their status.
-     * Must be called after Run() with the same graph.
+     * Must be called after Run() with the same runtime.
      *
-     * @param graph  The graph whose handshake results should be printed
+     * @param runtime  The runtime whose handshake results should be printed
      */
-    void PrintHandshakeResults(Graph& graph);
+    void PrintHandshakeResults(Runtime& runtime);
 
     /**
      * Cleanup all resources
@@ -255,11 +255,11 @@ public:
      *
      * Internal method used by Run(). Can be called directly for custom workflows.
      *
-     * @param stream  AICore stream
-     * @param graph   Pointer to device graph
+     * @param stream   AICore stream
+     * @param runtime  Pointer to device runtime
      * @return 0 on success, error code on failure
      */
-    int LaunchAicoreKernel(rtStream_t stream, Graph *graph);
+    int LaunchAicoreKernel(rtStream_t stream, Runtime *runtime);
 
     /**
      * Register a kernel binary path for a func_id

--- a/src/platform/a2a3/host/pto_runtime_c_api.cpp
+++ b/src/platform/a2a3/host/pto_runtime_c_api.cpp
@@ -7,36 +7,36 @@
 
 #include "pto_runtime_c_api.h"
 #include "devicerunner.h"
-#include "graph.h"  // Included from tests/example_graph_impl via CMake include paths
+#include "runtime.h"  // Included from tests/example_graph_impl via CMake include paths
 
 extern "C" {
 
 /* =========================================================================== */
-/* Graph API Implementation */
+/* Runtime API Implementation */
 /* =========================================================================== */
-int InitGraphImpl(Graph **graph);
-int ValidateGraphImpl(Graph *graph);
+int InitGraphImpl(Runtime **runtime);
+int ValidateGraphImpl(Runtime *runtime);
 
-int InitGraph(GraphHandle graph) {
-    if (graph == NULL) {
+int InitGraph(GraphHandle runtime) {
+    if (runtime == NULL) {
         return -1;
     }
     try {
-        // graph is a void*, we need to pass its address as Graph**
-        Graph** g_ptr = reinterpret_cast<Graph**>(graph);
-        return InitGraphImpl(g_ptr);
+        // runtime is a void*, we need to pass its address as Runtime**
+        Runtime** r_ptr = reinterpret_cast<Runtime**>(runtime);
+        return InitGraphImpl(r_ptr);
     } catch (...) {
         return -1;
     }
 }
 
-int ValidateGraph(GraphHandle graph) {
-    if (graph == NULL) {
+int ValidateGraph(GraphHandle runtime) {
+    if (runtime == NULL) {
         return -1;
     }
     try {
-        Graph* g = static_cast<Graph*>(graph);
-        return ValidateGraphImpl(g);
+        Runtime* r = static_cast<Runtime*>(runtime);
+        return ValidateGraphImpl(r);
     } catch (...) {
         return -1;
     }
@@ -64,27 +64,27 @@ int DeviceRunner_Init(int device_id,
     }
 }
 
-int DeviceRunner_Run(GraphHandle graph, int block_dim, int launch_aicpu_num) {
-    if (graph == NULL) {
+int DeviceRunner_Run(GraphHandle runtime, int block_dim, int launch_aicpu_num) {
+    if (runtime == NULL) {
         return -1;
     }
     try {
         DeviceRunner& runner = DeviceRunner::Get();
-        Graph* g = static_cast<Graph*>(graph);
-        return runner.Run(*g, block_dim, launch_aicpu_num);
+        Runtime* r = static_cast<Runtime*>(runtime);
+        return runner.Run(*r, block_dim, launch_aicpu_num);
     } catch (...) {
         return -1;
     }
 }
 
-void DeviceRunner_PrintHandshakeResults(GraphHandle graph) {
-    if (graph == NULL) {
+void DeviceRunner_PrintHandshakeResults(GraphHandle runtime) {
+    if (runtime == NULL) {
         return;
     }
     try {
         DeviceRunner& runner = DeviceRunner::Get();
-        Graph* g = static_cast<Graph*>(graph);
-        runner.PrintHandshakeResults(*g);
+        Runtime* r = static_cast<Runtime*>(runtime);
+        runner.PrintHandshakeResults(*r);
     } catch (...) {
         // Silently ignore errors on print
     }

--- a/src/runtime/host/runtimemaker.cpp
+++ b/src/runtime/host/runtimemaker.cpp
@@ -1,7 +1,7 @@
 /**
- * Graph Builder - Basic Example
+ * Runtime Builder - Basic Example
  *
- * Initializes a pre-allocated graph with the following task structure:
+ * Initializes a pre-allocated runtime with the following task structure:
  * Formula: (a + b + 1)(a + b + 2)
  *
  * Tasks:
@@ -17,7 +17,6 @@
  *   task2 -> task3
  */
 
-#include "graph/graph.h"
 #include <stdint.h>
 #include <stddef.h>
 #include <new>
@@ -27,7 +26,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include "graph.h"
+#include "runtime.h"
 #include "devicerunner.h"
 
 #ifdef __cplusplus
@@ -44,15 +43,15 @@ static void* g_dev_f = nullptr;
 static size_t g_tensor_bytes = 0;
 
 /**
- * Initialize a pre-allocated graph for the basic example.
+ * Initialize a pre-allocated runtime for the basic example.
  *
- * This function takes a pre-allocated Graph pointer and builds the complete
- * example graph inside it. All graph building logic is handled in C++.
+ * This function takes a pre-allocated Runtime pointer and builds the complete
+ * example runtime inside it. All runtime building logic is handled in C++.
  *
- * @param graph      Pointer to pointer to Graph (will allocate and fill)
+ * @param runtime      Pointer to pointer to Runtime (will allocate and fill)
  * @return 0 on success, -1 on failure
  */
-int InitGraphImpl(Graph **graph) {
+int InitGraphImpl(Runtime **runtime) {
     int rc = 0;
 
     // Initialize DeviceRunner
@@ -131,9 +130,9 @@ int InitGraphImpl(Graph **graph) {
     std::cout << "Initialized input tensors: a=2.0, b=3.0 (all elements)\n";
     std::cout << "Expected result: f = (2+3+1)*(2+3+2) = 6*7 = 42.0\n";
 
-    // Allocate Graph on heap
-    *graph = new Graph();
-    Graph* g = *graph;
+    // Allocate Runtime on heap
+    *runtime = new Runtime();
+    Runtime* g = *runtime;
 
     // Store tensor pointers for later use by ValidateGraphImpl
     g_dev_a = dev_a;
@@ -145,9 +144,9 @@ int InitGraphImpl(Graph **graph) {
     g_tensor_bytes = BYTES;
 
     // =========================================================================
-    // BUILD GRAPH - This is the core graph building logic
+    // BUILD RUNTIME - This is the core runtime building logic
     // =========================================================================
-    std::cout << "\n=== Creating Task Graph for Formula ===" << '\n';
+    std::cout << "\n=== Creating Task Runtime for Formula ===" << '\n';
     std::cout << "Formula: (a + b + 1)(a + b + 2)\n";
     std::cout << "Tasks:\n";
     std::cout << "  task0: c = a + b\n";
@@ -201,17 +200,17 @@ int InitGraphImpl(Graph **graph) {
     g->add_successor(t1, t3);  // t1 → t3
     g->add_successor(t2, t3);  // t2 → t3
 
-    std::cout << "Created graph with " << g->get_task_count() << " tasks\n";
-    g->print_graph();
+    std::cout << "Created runtime with " << g->get_task_count() << " tasks\n";
+    g->print_runtime();
 
-    std::cout << "\nGraph initialized. Ready for execution from Python.\n";
+    std::cout << "\nRuntime initialized. Ready for execution from Python.\n";
 
     return 0;
 }
 
-int ValidateGraphImpl(Graph *graph) {
-    if (graph == nullptr) {
-        std::cerr << "Error: Graph pointer is null\n";
+int ValidateGraphImpl(Runtime *runtime) {
+    if (runtime == nullptr) {
+        std::cerr << "Error: Runtime pointer is null\n";
         return -1;
     }
 
@@ -273,7 +272,7 @@ int ValidateGraphImpl(Graph *graph) {
     }
 
     // Print handshake results
-    runner.PrintHandshakeResults(*graph);
+    runner.PrintHandshakeResults(*runtime);
 
     // Cleanup
     std::cout << "\n=== Cleaning Up ===" << '\n';
@@ -285,8 +284,8 @@ int ValidateGraphImpl(Graph *graph) {
     runner.FreeTensor(dev_f);
     std::cout << "Freed all device tensors\n";
 
-    // Delete the graph
-    delete graph;
+    // Delete the runtime
+    delete runtime;
 
     // Clear global tensor pointers
     g_dev_a = g_dev_b = g_dev_c = g_dev_d = g_dev_e = g_dev_f = nullptr;

--- a/src/runtime/runtime/runtime.cpp
+++ b/src/runtime/runtime/runtime.cpp
@@ -1,19 +1,19 @@
 /**
- * Graph Class - Implementation
+ * Runtime Class - Implementation
  *
  * Task dependency graph management with circular ready queue.
  * Follows patterns from pto_runtime.c for consistency.
  */
 
-#include "graph.h"
+#include "runtime.h"
 
 // =============================================================================
 // Constructor
 // =============================================================================
 
-Graph::Graph() {
+Runtime::Runtime() {
     // Initialize task array (cannot use memset with atomic members)
-    for (int i = 0; i < GRAPH_MAX_TASKS; i++) {
+    for (int i = 0; i < RUNTIME_MAX_TASKS; i++) {
         tasks[i].task_id = 0;
         tasks[i].func_id = 0;
         tasks[i].num_args = 0;
@@ -35,16 +35,16 @@ Graph::Graph() {
 // Task Management
 // =============================================================================
 
-int Graph::add_task(uint64_t* args, int num_args, int func_id, int core_type) {
+int Runtime::add_task(uint64_t* args, int num_args, int func_id, int core_type) {
     // Check bounds
-    if (next_task_id >= GRAPH_MAX_TASKS) {
-        fprintf(stderr, "[Graph] ERROR: Task table full (max=%d)\n", GRAPH_MAX_TASKS);
+    if (next_task_id >= RUNTIME_MAX_TASKS) {
+        fprintf(stderr, "[Runtime] ERROR: Task table full (max=%d)\n", RUNTIME_MAX_TASKS);
         return -1;
     }
 
-    if (num_args > GRAPH_MAX_ARGS) {
-        fprintf(stderr, "[Graph] ERROR: Too many args (%d > %d)\n",
-                num_args, GRAPH_MAX_ARGS);
+    if (num_args > RUNTIME_MAX_ARGS) {
+        fprintf(stderr, "[Runtime] ERROR: Too many args (%d > %d)\n",
+                num_args, RUNTIME_MAX_ARGS);
         return -1;
     }
 
@@ -68,15 +68,15 @@ int Graph::add_task(uint64_t* args, int num_args, int func_id, int core_type) {
     return task_id;
 }
 
-void Graph::add_successor(int from_task, int to_task) {
+void Runtime::add_successor(int from_task, int to_task) {
     // Validate task IDs
     if (from_task < 0 || from_task >= next_task_id) {
-        fprintf(stderr, "[Graph] ERROR: Invalid from_task ID %d\n", from_task);
+        fprintf(stderr, "[Runtime] ERROR: Invalid from_task ID %d\n", from_task);
         return;
     }
 
     if (to_task < 0 || to_task >= next_task_id) {
-        fprintf(stderr, "[Graph] ERROR: Invalid to_task ID %d\n", to_task);
+        fprintf(stderr, "[Runtime] ERROR: Invalid to_task ID %d\n", to_task);
         return;
     }
 
@@ -84,9 +84,9 @@ void Graph::add_successor(int from_task, int to_task) {
     Task* to = &tasks[to_task];
 
     // Add to_task to from_task's fanout
-    if (from->fanout_count >= GRAPH_MAX_FANOUT) {
-        fprintf(stderr, "[Graph] ERROR: Fanout overflow for task %d (max=%d)\n",
-                from_task, GRAPH_MAX_FANOUT);
+    if (from->fanout_count >= RUNTIME_MAX_FANOUT) {
+        fprintf(stderr, "[Runtime] ERROR: Fanout overflow for task %d (max=%d)\n",
+                from_task, RUNTIME_MAX_FANOUT);
         return;
     }
 
@@ -98,18 +98,18 @@ void Graph::add_successor(int from_task, int to_task) {
 // Query Methods
 // =============================================================================
 
-Task* Graph::get_task(int task_id) {
+Task* Runtime::get_task(int task_id) {
     if (task_id < 0 || task_id >= next_task_id) {
         return nullptr;
     }
     return &tasks[task_id];
 }
 
-int Graph::get_task_count() const {
+int Runtime::get_task_count() const {
     return next_task_id;
 }
 
-int Graph::get_initial_ready_tasks(int* ready_tasks) {
+int Runtime::get_initial_ready_tasks(int* ready_tasks) {
     initial_ready_count = 0;
     for (int i = 0; i < next_task_id; i++) {
         if (tasks[i].fanin == 0) {
@@ -127,9 +127,9 @@ int Graph::get_initial_ready_tasks(int* ready_tasks) {
 // Utility Methods
 // =============================================================================
 
-void Graph::print_graph() const {
+void Runtime::print_runtime() const {
     printf("\n================================================================================\n");
-    printf("[Graph] Task Graph Status\n");
+    printf("[Runtime] Task Runtime Status\n");
     printf("================================================================================\n");
     printf("  Total tasks: %d\n", next_task_id);
 


### PR DESCRIPTION
This PR performs a comprehensive renaming refactoring across the codebase, unifying all Graph-related naming to Runtime to more accurately reflect the module's actual responsibility—managing the task runtime execution environment, rather than merely representing a task dependency graph.

Major Changes
1. File and Directory Renaming

src/runtime/graph/ → src/runtime/runtime/
graph.h/cpp → runtime.h/cpp
graphexecutor.cpp → runtimeexecutor.cpp
graphmaker.cpp → runtimemaker.cpp
2. Class and Type Renaming

class Graph → class Runtime
GraphExecutor → RuntimeExecutor (struct name unchanged, but responsibilities updated)
3. Macro Definition Renaming

GRAPH_MAX_TASKS → RUNTIME_MAX_TASKS
GRAPH_MAX_ARGS → RUNTIME_MAX_ARGS
GRAPH_MAX_FANOUT → RUNTIME_MAX_FANOUT
GRAPH_MAX_WORKER → RUNTIME_MAX_WORKER
4. Variable and Field Renaming

KernelArgs.graphArgs → KernelArgs.runtimeArgs
KernelArgs.runtime → KernelArgs.runtimeCtx (to avoid naming conflict)
All local variables renamed from graph-related names to runtime
5. Method Renaming

print_graph() → print_runtime()
InitGraphArgs() → InitGraphArgs() (kept unchanged, parameter types updated)