### PR TITLE
Improve Type Safety: Upgrade AicpuExecute Parameter from void* to Runtime*

### DIFF
--- a/src/platform/a2a3/aicpu/kernel.cpp
+++ b/src/platform/a2a3/aicpu/kernel.cpp
@@ -5,7 +5,7 @@
 #include "kernel_args.h"
 
 // Forward declaration of AicpuExecute (implemented in runtimeexecutor.cpp)
-extern "C" int AicpuExecute(void* arg);  // arg is Runtime*
+extern "C" int AicpuExecute(Runtime* arg);
 
 extern "C" __attribute__((visibility("default"))) int StaticTileFwkBackendKernelServer(void *arg) {
     if (arg == nullptr) {


### PR DESCRIPTION
This PR enhances type safety in the AICPU executor with the following improvements:

Enhanced Type Safety: Changed AicpuExecute function parameter from void* arg to Runtime* runtime, eliminating unsafe void pointer usage
Code Cleanup: Removed unnecessary type casting code auto runtime = (Runtime *)arg;
Naming Consistency: Renamed GraphExecutor to RuntimeExecutor for consistency with previous refactoring efforts
Simplified Dependencies: Removed unnecessary kernel_args.h include