### PR TITLE
refactor: Convert all variable/function names to snake_case

### DIFF
--- a/python/runtime_bindings.py
+++ b/python/runtime_bindings.py
@@ -75,13 +75,13 @@ class RuntimeLibraryLoader:
     def _setup_functions(self):
         """Set up ctypes function signatures."""
 
-        # GetRuntimeSize - returns sizeof(Runtime) for user allocation
-        self.lib.GetRuntimeSize.argtypes = []
-        self.lib.GetRuntimeSize.restype = c_size_t
+        # get_runtime_size - returns sizeof(Runtime) for user allocation
+        self.lib.get_runtime_size.argtypes = []
+        self.lib.get_runtime_size.restype = c_size_t
 
-        # InitRuntime - placement new + build runtime
-        self.lib.InitRuntime.argtypes = [c_void_p]
-        self.lib.InitRuntime.restype = c_int
+        # init_runtime - placement new + build runtime
+        self.lib.init_runtime.argtypes = [c_void_p]
+        self.lib.init_runtime.restype = c_int
 
         # launch_runtime - device init + execute runtime
         self.lib.launch_runtime.argtypes = [
@@ -96,13 +96,13 @@ class RuntimeLibraryLoader:
         ]
         self.lib.launch_runtime.restype = c_int
 
-        # FinalizeRuntime - validate + cleanup
-        self.lib.FinalizeRuntime.argtypes = [c_void_p]
-        self.lib.FinalizeRuntime.restype = c_int
+        # finalize_runtime - validate + cleanup
+        self.lib.finalize_runtime.argtypes = [c_void_p]
+        self.lib.finalize_runtime.restype = c_int
 
-        # RegisterKernel - register kernel binary for func_id
-        self.lib.RegisterKernel.argtypes = [c_int, POINTER(c_uint8), c_size_t]
-        self.lib.RegisterKernel.restype = c_int
+        # register_kernel - register kernel binary for func_id
+        self.lib.register_kernel.argtypes = [c_int, POINTER(c_uint8), c_size_t]
+        self.lib.register_kernel.restype = c_int
 
         # set_device - set device and create streams
         self.lib.set_device.argtypes = [c_int]
@@ -133,8 +133,8 @@ class Runtime:
         """
 
         self.lib = lib
-        # Allocate buffer of size GetRuntimeSize() for placement new
-        size = lib.GetRuntimeSize()
+        # Allocate buffer of size get_runtime_size() for placement new
+        size = lib.get_runtime_size()
         self._buffer = ctypes.create_string_buffer(size)
         self._handle = ctypes.cast(self._buffer, c_void_p)
 
@@ -143,32 +143,32 @@ class Runtime:
 
         Initialize the runtime structure.
 
-        Calls InitRuntime() in C++ which uses placement new to construct
+        Calls init_runtime() in C++ which uses placement new to construct
         the Runtime, builds tasks, allocates device tensors, and initializes data.
 
         Raises:
             RuntimeError: If initialization fails
         """
 
-        rc = self.lib.InitRuntime(self._handle)
+        rc = self.lib.init_runtime(self._handle)
         if rc != 0:
-            raise RuntimeError(f"InitRuntime failed: {rc}")
+            raise RuntimeError(f"init_runtime failed: {rc}")
 
     def finalize(self) -> None:
         """
 
         Finalize and cleanup the runtime.
 
-        Calls FinalizeRuntime() in C++ which validates computation results,
+        Calls finalize_runtime() in C++ which validates computation results,
         frees device tensors, and calls the Runtime destructor.
 
         Raises:
             RuntimeError: If finalization fails
         """
 
-        rc = self.lib.FinalizeRuntime(self._handle)
+        rc = self.lib.finalize_runtime(self._handle)
         if rc != 0:
-            raise RuntimeError(f"FinalizeRuntime failed: {rc}")
+            raise RuntimeError(f"finalize_runtime failed: {rc}")
 
     def __del__(self):
         """Clean up runtime resources."""
@@ -208,9 +208,9 @@ def register_kernel(func_id: int, binary_data: bytes) -> None:
 
     # Convert bytes to ctypes array
     bin_array = (c_uint8 * len(binary_data)).from_buffer_copy(binary_data)
-    rc = _lib.RegisterKernel(func_id, bin_array, len(binary_data))
+    rc = _lib.register_kernel(func_id, bin_array, len(binary_data))
     if rc != 0:
-        raise RuntimeError(f"RegisterKernel failed: {rc}")
+        raise RuntimeError(f"register_kernel failed: {rc}")
 
 
 def set_device(device_id: int) -> None:

--- a/src/platform/a2a3/aicore/kernel.cpp
+++ b/src/platform/a2a3/aicore/kernel.cpp
@@ -11,18 +11,18 @@ class Runtime;
 #define KERNEL_ENTRY(x) \
     x##_0_mix_aiv  // 动态生成函数名 KERNEL_ENTRY(my_kernel) ->
                    // my_kernel_0_mix_aiv
-#define blockIdx blockIdx_aiv
-#define coreType coreType_aiv
+#define block_idx block_idx_aiv
+#define core_type core_type_aiv
 #else
 #define KERNEL_ENTRY(x) x##_0_mix_aic
-#define blockIdx blockIdx_aic
-#define coreType coreType_aic
+#define block_idx block_idx_aic
+#define core_type core_type_aic
 #endif
 
-[[block_local]] int blockIdx;
-[[block_local]] int coreType;
+[[block_local]] int block_idx;
+[[block_local]] int core_type;
 
-extern __aicore__ void AicoreExecute(__gm__ Runtime* runtime, int blockIdx, int coreType);
+extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, int core_type);
 
 /**
  * Kernel entry point with control loop
@@ -35,18 +35,18 @@ extern __aicore__ void AicoreExecute(__gm__ Runtime* runtime, int blockIdx, int 
  *    - If task pointer is non-zero, execute task and mark as complete
  *    - Use DCCI to ensure cache coherency with AICPU
  *
- * Each core (AIC or AIV) gets its own handshake buffer indexed by blockIdx.
+ * Each core (AIC or AIV) gets its own handshake buffer indexed by block_idx.
  *
  * @param runtime Address of Runtime structure in device memory
  */
 extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime* runtime) {
-    // Calculate blockIdx for this core
+    // Calculate block_idx for this core
 #ifdef __AIV__
-    blockIdx = get_block_idx() * get_subblockdim() + get_subblockid() + get_block_num();
-    coreType = 1;
+    block_idx = get_block_idx() * get_subblockdim() + get_subblockid() + get_block_num();
+    core_type = 1;
 #else
-    blockIdx = get_block_idx();
-    coreType = 0;
+    block_idx = get_block_idx();
+    core_type = 0;
 #endif
-    AicoreExecute(runtime, blockIdx, coreType);
+    aicore_execute(runtime, block_idx, core_type);
 }

--- a/src/platform/a2a3/aicpu/device_log.cpp
+++ b/src/platform/a2a3/aicpu/device_log.cpp
@@ -4,14 +4,14 @@
 
 #include "device_log.h"
 
-bool g_isLogEnableDebug = false;
-bool g_isLogEnableInfo = false;
-bool g_isLogEnableWarn = false;
-bool g_isLogEnableError = false;
+bool g_is_log_enable_debug = false;
+bool g_is_log_enable_info = false;
+bool g_is_log_enable_warn = false;
+bool g_is_log_enable_error = false;
 
-void InitLogSwitch() {
-    g_isLogEnableDebug = CheckLogLevel(AICPU, DLOG_DEBUG);
-    g_isLogEnableInfo = CheckLogLevel(AICPU, DLOG_INFO);
-    g_isLogEnableWarn = CheckLogLevel(AICPU, DLOG_WARN);
-    g_isLogEnableError = CheckLogLevel(AICPU, DLOG_ERROR);
+void init_log_switch() {
+    g_is_log_enable_debug = CheckLogLevel(AICPU, DLOG_DEBUG);
+    g_is_log_enable_info = CheckLogLevel(AICPU, DLOG_INFO);
+    g_is_log_enable_warn = CheckLogLevel(AICPU, DLOG_WARN);
+    g_is_log_enable_error = CheckLogLevel(AICPU, DLOG_ERROR);
 }

--- a/src/platform/a2a3/aicpu/device_log.h
+++ b/src/platform/a2a3/aicpu/device_log.h
@@ -11,45 +11,45 @@
 
 #include "dlog_pub.h"
 
-extern bool g_isLogEnableDebug;
-extern bool g_isLogEnableInfo;
-extern bool g_isLogEnableWarn;
-extern bool g_isLogEnableError;
+extern bool g_is_log_enable_debug;
+extern bool g_is_log_enable_info;
+extern bool g_is_log_enable_warn;
+extern bool g_is_log_enable_error;
 
-static inline bool IsLogEnableDebug() { return g_isLogEnableDebug; }
-static inline bool IsLogEnableInfo() { return g_isLogEnableInfo; }
-static inline bool IsLogEnableWarn() { return g_isLogEnableWarn; }
-static inline bool IsLogEnableError() { return g_isLogEnableError; }
+static inline bool is_log_enable_debug() { return g_is_log_enable_debug; }
+static inline bool is_log_enable_info() { return g_is_log_enable_info; }
+static inline bool is_log_enable_warn() { return g_is_log_enable_warn; }
+static inline bool is_log_enable_error() { return g_is_log_enable_error; }
 
 #define GET_TID() syscall(__NR_gettid)
 constexpr const char *TILE_FWK_DEVICE_MACHINE = "AI_CPU";
 
-inline bool IsDebugMode() { return g_isLogEnableDebug; }
+inline bool is_debug_mode() { return g_is_log_enable_debug; }
 
 #define D_DEV_LOGD(MODE_NAME, fmt, ...)                                                 \
     do {                                                                                \
-        if (IsLogEnableDebug()) {                                                       \
+        if (is_log_enable_debug()) {                                                       \
             dlog_debug(AICPU, "%lu %s\n" #fmt, GET_TID(), __FUNCTION__, ##__VA_ARGS__); \
         }                                                                               \
     } while (false)
 
 #define D_DEV_LOGI(MODE_NAME, fmt, ...)                                                \
     do {                                                                               \
-        if (IsLogEnableInfo()) {                                                       \
+        if (is_log_enable_info()) {                                                       \
             dlog_info(AICPU, "%lu %s\n" #fmt, GET_TID(), __FUNCTION__, ##__VA_ARGS__); \
         }                                                                              \
     } while (false)
 
 #define D_DEV_LOGW(MODE_NAME, fmt, ...)                                                \
     do {                                                                               \
-        if (IsLogEnableWarn()) {                                                       \
+        if (is_log_enable_warn()) {                                                       \
             dlog_warn(AICPU, "%lu %s\n" #fmt, GET_TID(), __FUNCTION__, ##__VA_ARGS__); \
         }                                                                              \
     } while (false)
 
 #define D_DEV_LOGE(MODE_NAME, fmt, ...)                                                 \
     do {                                                                                \
-        if (IsLogEnableError()) {                                                       \
+        if (is_log_enable_error()) {                                                       \
             dlog_error(AICPU, "%lu %s\n" #fmt, GET_TID(), __FUNCTION__, ##__VA_ARGS__); \
         }                                                                               \
     } while (false)
@@ -85,4 +85,4 @@ inline bool IsDebugMode() { return g_isLogEnableDebug; }
 
 #define DEV_DEBUG_ASSERT_MSG(expr, fmt, args...) DEV_ASSERT_MSG(expr, fmt, ##args)
 
-void InitLogSwitch();
+void init_log_switch();

--- a/src/platform/a2a3/aicpu/kernel.cpp
+++ b/src/platform/a2a3/aicpu/kernel.cpp
@@ -5,8 +5,8 @@
 #include "kernel_args.h"
 #include "runtime.h"
 
-// Forward declaration of AicpuExecute (implemented in aicpu_executor.cpp)
-extern "C" int AicpuExecute(Runtime *arg);
+// Forward declaration of aicpu_execute (implemented in aicpu_executor.cpp)
+extern "C" int aicpu_execute(Runtime *arg);
 
 extern "C" __attribute__((visibility("default"))) int StaticTileFwkBackendKernelServer(void *arg) {
     if (arg == nullptr) {
@@ -29,7 +29,7 @@ extern "C" __attribute__((visibility("default"))) int StaticTileFwkBackendKernel
  * @return 0 on success, -1 on error
  */
 extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelServerInit(void *arg) {
-    InitLogSwitch();
+    init_log_switch();
     if (arg == nullptr) {
         DEV_ERROR("%s", "Invalid kernel arguments: null pointer");
         return -1;
@@ -47,7 +47,7 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
  *
  * Note: Function name is hardcoded in libaicpu_extend_kernels.so
  *
- * @param arg Pointer to KernelArgs structure containing runtimeArgs
+ * @param arg Pointer to KernelArgs structure containing runtime_args
  * @return 0 on success, non-zero on error
  */
 extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelServer(void *arg) {
@@ -57,21 +57,21 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     }
 
     // Extract Runtime from KernelArgs
-    auto kargs = (KernelArgs *)arg;
-    Runtime *runtime = kargs->runtimeArgs;
+    auto k_args = (KernelArgs *)arg;
+    Runtime *runtime = k_args->runtime_args;
 
     if (runtime == nullptr) {
-        DEV_ERROR("%s", "Invalid runtimeArgs: null pointer");
+        DEV_ERROR("%s", "Invalid runtime_args: null pointer");
         return -1;
     }
 
-    DEV_INFO("%s", "DynTileFwkBackendKernelServer: Calling AicpuExecute with Runtime");
-    int rc = AicpuExecute(runtime);  // Pass Runtime* instead of KernelArgs*
+    DEV_INFO("%s", "DynTileFwkBackendKernelServer: Calling aicpu_execute with Runtime");
+    int rc = aicpu_execute(runtime);  // Pass Runtime* instead of KernelArgs*
     if (rc != 0) {
-        DEV_ERROR("DynTileFwkBackendKernelServer: AicpuExecute failed with rc=%d", rc);
+        DEV_ERROR("DynTileFwkBackendKernelServer: aicpu_execute failed with rc=%d", rc);
         return rc;
     }
-    DEV_INFO("%s", "DynTileFwkBackendKernelServer: AicpuExecute completed successfully");
+    DEV_INFO("%s", "DynTileFwkBackendKernelServer: aicpu_execute completed successfully");
 
     return rc;
 }

--- a/src/platform/a2a3/common/kernel_args.h
+++ b/src/platform/a2a3/common/kernel_args.h
@@ -36,23 +36,18 @@ extern "C" {
  *
  * Field Access Patterns:
  * - unused[5]: Padding for alignment with CANN runtime expectations
- * - deviceArgs: Written by host, read by AICPU (contains aicpuSoBin/aicpuSoLen)
- * - block_dim: Written by host, read by AICPU (number of blocks, each block = 1
- * AIC + 2 AIV)
- * - nrAic: Written by host, read by AICPU (number of AIC cores)
- * - scheCpuNum: Written by host, read by AICPU (number of AICPU scheduling
- * threads)
- * - runtimeArgs: Written by host, read by AICPU (task runtime, includes
+ * - device_args: Written by host, read by AICPU (contains aicpu_so_bin/aicpu_so_len)
+ * - runtime_args: Written by host, read by AICPU (task runtime, includes
  * handshake buffers)
  *
  * Note: AICore kernels receive Runtime* directly, not KernelArgs
- *       - AICPU: accesses runtimeArgs->workers directly
+ *       - AICPU: accesses runtime_args->workers directly
  *       - AICore: receives Runtime* pointer with workers at offset 0
  */
 struct KernelArgs {
-    uint64_t unused[5] = {0};         // Alignment padding (required by CANN runtime offset)
-    DeviceArgs *deviceArgs{nullptr};  // Device arguments (AICPU reads, contains SO info)
-    Runtime *runtimeArgs{nullptr};    // Task runtime in device memory
+    uint64_t unused[5] = {0};          // Alignment padding (required by CANN runtime offset)
+    DeviceArgs *device_args{nullptr};  // Device arguments (AICPU reads, contains SO info)
+    Runtime *runtime_args{nullptr};     // Task runtime in device memory
 };
 
 #ifdef __cplusplus

--- a/src/platform/a2a3/host/devicerunner.cpp
+++ b/src/platform/a2a3/host/devicerunner.cpp
@@ -17,66 +17,66 @@
 // KernelArgsHelper Implementation
 // =============================================================================
 
-int KernelArgsHelper::InitDeviceArgs(const DeviceArgs& hostDeviceArgs, MemoryAllocator& allocator) {
+int KernelArgsHelper::init_device_args(const DeviceArgs& host_device_args, MemoryAllocator& allocator) {
     allocator_ = &allocator;
 
-    // Allocate device memory for deviceArgs
-    if (args.deviceArgs == nullptr) {
-        uint64_t deviceArgsSize = sizeof(DeviceArgs);
-        void* deviceArgsDev = allocator_->Alloc(deviceArgsSize);
-        if (deviceArgsDev == nullptr) {
-            std::cerr << "Error: Alloc for deviceArgs failed\n";
+    // Allocate device memory for device_args
+    if (args.device_args == nullptr) {
+        uint64_t device_args_size = sizeof(DeviceArgs);
+        void* device_args_dev = allocator_->alloc(device_args_size);
+        if (device_args_dev == nullptr) {
+            std::cerr << "Error: Alloc for device_args failed\n";
             return -1;
         }
-        args.deviceArgs = reinterpret_cast<DeviceArgs*>(deviceArgsDev);
+        args.device_args = reinterpret_cast<DeviceArgs*>(device_args_dev);
     }
-    // Copy hostDeviceArgs to device memory via deviceArgs
+    // Copy host_device_args to device memory via device_args
     int rc =
-        rtMemcpy(args.deviceArgs, sizeof(DeviceArgs), &hostDeviceArgs, sizeof(DeviceArgs), RT_MEMCPY_HOST_TO_DEVICE);
+        rtMemcpy(args.device_args, sizeof(DeviceArgs), &host_device_args, sizeof(DeviceArgs), RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
         std::cerr << "Error: rtMemcpy failed: " << rc << '\n';
-        allocator_->Free(args.deviceArgs);
-        args.deviceArgs = nullptr;
+        allocator_->free(args.device_args);
+        args.device_args = nullptr;
         return rc;
     }
     return 0;
 }
 
-int KernelArgsHelper::FinalizeDeviceArgs() {
-    if (args.deviceArgs != nullptr && allocator_ != nullptr) {
-        int rc = allocator_->Free(args.deviceArgs);
-        args.deviceArgs = nullptr;
+int KernelArgsHelper::finalize_device_args() {
+    if (args.device_args != nullptr && allocator_ != nullptr) {
+        int rc = allocator_->free(args.device_args);
+        args.device_args = nullptr;
         return rc;
     }
     return 0;
 }
 
-int KernelArgsHelper::InitRuntimeArgs(const Runtime& hostRuntime, MemoryAllocator& allocator) {
+int KernelArgsHelper::init_runtime_args(const Runtime& host_runtime, MemoryAllocator& allocator) {
     allocator_ = &allocator;
 
-    if (args.runtimeArgs == nullptr) {
-        uint64_t runtimeSize = sizeof(Runtime);
-        void* runtimeDev = allocator_->Alloc(runtimeSize);
-        if (runtimeDev == nullptr) {
-            std::cerr << "Error: Alloc for runtimeArgs failed\n";
+    if (args.runtime_args == nullptr) {
+        uint64_t runtime_size = sizeof(Runtime);
+        void* runtime_dev = allocator_->alloc(runtime_size);
+        if (runtime_dev == nullptr) {
+            std::cerr << "Error: Alloc for runtime_args failed\n";
             return -1;
         }
-        args.runtimeArgs = reinterpret_cast<Runtime*>(runtimeDev);
+        args.runtime_args = reinterpret_cast<Runtime*>(runtime_dev);
     }
-    int rc = rtMemcpy(args.runtimeArgs, sizeof(Runtime), &hostRuntime, sizeof(Runtime), RT_MEMCPY_HOST_TO_DEVICE);
+    int rc = rtMemcpy(args.runtime_args, sizeof(Runtime), &host_runtime, sizeof(Runtime), RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
         std::cerr << "Error: rtMemcpy for runtime failed: " << rc << '\n';
-        allocator_->Free(args.runtimeArgs);
-        args.runtimeArgs = nullptr;
+        allocator_->free(args.runtime_args);
+        args.runtime_args = nullptr;
         return rc;
     }
     return 0;
 }
 
-int KernelArgsHelper::FinalizeRuntimeArgs() {
-    if (args.runtimeArgs != nullptr && allocator_ != nullptr) {
-        int rc = allocator_->Free(args.runtimeArgs);
-        args.runtimeArgs = nullptr;
+int KernelArgsHelper::finalize_runtime_args() {
+    if (args.runtime_args != nullptr && allocator_ != nullptr) {
+        int rc = allocator_->free(args.runtime_args);
+        args.runtime_args = nullptr;
         return rc;
     }
     return 0;
@@ -86,38 +86,38 @@ int KernelArgsHelper::FinalizeRuntimeArgs() {
 // AicpuSoInfo Implementation
 // =============================================================================
 
-int AicpuSoInfo::Init(const std::vector<uint8_t>& aicpuSoBinary, MemoryAllocator& allocator) {
+int AicpuSoInfo::init(const std::vector<uint8_t>& aicpu_so_binary, MemoryAllocator& allocator) {
     allocator_ = &allocator;
 
-    if (aicpuSoBinary.empty()) {
+    if (aicpu_so_binary.empty()) {
         std::cerr << "Error: AICPU binary is empty\n";
         return -1;
     }
 
-    size_t fileSize = aicpuSoBinary.size();
-    void* dAicpuData = allocator_->Alloc(fileSize);
-    if (dAicpuData == nullptr) {
+    size_t file_size = aicpu_so_binary.size();
+    void* d_aicpu_data = allocator_->alloc(file_size);
+    if (d_aicpu_data == nullptr) {
         std::cerr << "Error: Alloc failed for AICPU SO\n";
         return -1;
     }
 
-    int rc = rtMemcpy(dAicpuData, fileSize, aicpuSoBinary.data(), fileSize, RT_MEMCPY_HOST_TO_DEVICE);
+    int rc = rtMemcpy(d_aicpu_data, file_size, aicpu_so_binary.data(), file_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
         std::cerr << "Error: rtMemcpy failed: " << rc << '\n';
-        allocator_->Free(dAicpuData);
-        dAicpuData = nullptr;
+        allocator_->free(d_aicpu_data);
+        d_aicpu_data = nullptr;
         return rc;
     }
 
-    aicpuSoBin = reinterpret_cast<uint64_t>(dAicpuData);
-    aicpuSoLen = fileSize;
+    aicpu_so_bin = reinterpret_cast<uint64_t>(d_aicpu_data);
+    aicpu_so_len = file_size;
     return 0;
 }
 
-int AicpuSoInfo::Finalize() {
-    if (aicpuSoBin != 0 && allocator_ != nullptr) {
-        int rc = allocator_->Free(reinterpret_cast<void*>(aicpuSoBin));
-        aicpuSoBin = 0;
+int AicpuSoInfo::finalize() {
+    if (aicpu_so_bin != 0 && allocator_ != nullptr) {
+        int rc = allocator_->free(reinterpret_cast<void*>(aicpu_so_bin));
+        aicpu_so_bin = 0;
         return rc;
     }
     return 0;
@@ -127,236 +127,236 @@ int AicpuSoInfo::Finalize() {
 // DeviceRunner Implementation
 // =============================================================================
 
-DeviceRunner& DeviceRunner::Get() {
+DeviceRunner& DeviceRunner::get() {
     static DeviceRunner runner;
     return runner;
 }
 
-DeviceRunner::~DeviceRunner() { Finalize(); }
+DeviceRunner::~DeviceRunner() { finalize(); }
 
-int DeviceRunner::EnsureDeviceInitialized(
-    int deviceId, const std::vector<uint8_t>& aicpuSoBinary, const std::vector<uint8_t>& aicoreKernelBinary) {
+int DeviceRunner::ensure_device_initialized(
+    int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
     // First ensure device is set and streams are created
-    int rc = EnsureDeviceSet(deviceId);
+    int rc = ensure_device_set(device_id);
     if (rc != 0) {
         return rc;
     }
 
     // Then ensure binaries are loaded
-    return EnsureBinariesLoaded(aicpuSoBinary, aicoreKernelBinary);
+    return ensure_binaries_loaded(aicpu_so_binary, aicore_kernel_binary);
 }
 
-int DeviceRunner::EnsureDeviceSet(int deviceId) {
+int DeviceRunner::ensure_device_set(int device_id) {
     // Check if already initialized
-    if (streamAicpu_ != nullptr) {
+    if (stream_aicpu_ != nullptr) {
         return 0;
     }
 
-    deviceId_ = deviceId;
+    device_id_ = device_id;
 
     // Set device
-    int rc = rtSetDevice(deviceId);
+    int rc = rtSetDevice(device_id);
     if (rc != 0) {
-        std::cerr << "Error: rtSetDevice(" << deviceId << ") failed: " << rc << '\n';
+        std::cerr << "Error: rtSetDevice(" << device_id << ") failed: " << rc << '\n';
         return rc;
     }
 
     // Create streams
-    rc = rtStreamCreate(&streamAicpu_, 0);
+    rc = rtStreamCreate(&stream_aicpu_, 0);
     if (rc != 0) {
         std::cerr << "Error: rtStreamCreate (AICPU) failed: " << rc << '\n';
         return rc;
     }
 
-    rc = rtStreamCreate(&streamAicore_, 0);
+    rc = rtStreamCreate(&stream_aicore_, 0);
     if (rc != 0) {
         std::cerr << "Error: rtStreamCreate (AICore) failed: " << rc << '\n';
-        rtStreamDestroy(streamAicpu_);
-        streamAicpu_ = nullptr;
+        rtStreamDestroy(stream_aicpu_);
+        stream_aicpu_ = nullptr;
         return rc;
     }
 
-    std::cout << "DeviceRunner: device=" << deviceId << " set, streams created\n";
+    std::cout << "DeviceRunner: device=" << device_id << " set, streams created\n";
     return 0;
 }
 
-int DeviceRunner::EnsureBinariesLoaded(
-    const std::vector<uint8_t>& aicpuSoBinary, const std::vector<uint8_t>& aicoreKernelBinary) {
+int DeviceRunner::ensure_binaries_loaded(
+    const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
     // Check if already loaded
-    if (binariesLoaded_) {
+    if (binaries_loaded_) {
         // Just update kernel binary if different
-        if (aicoreKernelBinary_ != aicoreKernelBinary) {
-            aicoreKernelBinary_ = aicoreKernelBinary;
+        if (aicore_kernel_binary_ != aicore_kernel_binary) {
+            aicore_kernel_binary_ = aicore_kernel_binary;
         }
         return 0;
     }
 
     // Device must be set first
-    if (streamAicpu_ == nullptr) {
+    if (stream_aicpu_ == nullptr) {
         std::cerr << "Error: Device not set before loading binaries\n";
         return -1;
     }
 
-    aicoreKernelBinary_ = aicoreKernelBinary;
+    aicore_kernel_binary_ = aicore_kernel_binary;
 
     // Load AICPU SO
-    int rc = soInfo_.Init(aicpuSoBinary, memAlloc_);
+    int rc = so_info_.init(aicpu_so_binary, mem_alloc_);
     if (rc != 0) {
-        std::cerr << "Error: AicpuSoInfo::Init failed: " << rc << '\n';
+        std::cerr << "Error: AicpuSoInfo::init failed: " << rc << '\n';
         return rc;
     }
 
     // Initialize device args
-    deviceArgs_.aicpuSoBin = soInfo_.aicpuSoBin;
-    deviceArgs_.aicpuSoLen = soInfo_.aicpuSoLen;
-    rc = kernelArgs_.InitDeviceArgs(deviceArgs_, memAlloc_);
+    device_args_.aicpu_so_bin = so_info_.aicpu_so_bin;
+    device_args_.aicpu_so_len = so_info_.aicpu_so_len;
+    rc = kernel_args_.init_device_args(device_args_, mem_alloc_);
     if (rc != 0) {
-        std::cerr << "Error: InitDeviceArgs failed: " << rc << '\n';
-        soInfo_.Finalize();
+        std::cerr << "Error: init_device_args failed: " << rc << '\n';
+        so_info_.finalize();
         return rc;
     }
 
-    binariesLoaded_ = true;
+    binaries_loaded_ = true;
     std::cout << "DeviceRunner: binaries loaded\n";
     return 0;
 }
 
-void* DeviceRunner::AllocateTensor(size_t bytes) { return memAlloc_.Alloc(bytes); }
+void* DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
 
-void DeviceRunner::FreeTensor(void* devPtr) {
-    if (devPtr != nullptr) {
-        memAlloc_.Free(devPtr);
+void DeviceRunner::free_tensor(void* dev_ptr) {
+    if (dev_ptr != nullptr) {
+        mem_alloc_.free(dev_ptr);
     }
 }
 
-int DeviceRunner::CopyToDevice(void* devPtr, const void* hostPtr, size_t bytes) {
-    return rtMemcpy(devPtr, bytes, hostPtr, bytes, RT_MEMCPY_HOST_TO_DEVICE);
+int DeviceRunner::copy_to_device(void* dev_ptr, const void* host_ptr, size_t bytes) {
+    return rtMemcpy(dev_ptr, bytes, host_ptr, bytes, RT_MEMCPY_HOST_TO_DEVICE);
 }
 
-int DeviceRunner::CopyFromDevice(void* hostPtr, const void* devPtr, size_t bytes) {
-    return rtMemcpy(hostPtr, bytes, devPtr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
+int DeviceRunner::copy_from_device(void* host_ptr, const void* dev_ptr, size_t bytes) {
+    return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
-int DeviceRunner::Run(Runtime& runtime,
-    int blockDim,
-    int deviceId,
-    const std::vector<uint8_t>& aicpuSoBinary,
-    const std::vector<uint8_t>& aicoreKernelBinary,
-    int launchAicpuNum) {
+int DeviceRunner::run(Runtime& runtime,
+    int block_dim,
+    int device_id,
+    const std::vector<uint8_t>& aicpu_so_binary,
+    const std::vector<uint8_t>& aicore_kernel_binary,
+    int launch_aicpu_num) {
     // Ensure device is initialized (lazy initialization)
-    int rc = EnsureDeviceInitialized(deviceId, aicpuSoBinary, aicoreKernelBinary);
+    int rc = ensure_device_initialized(device_id, aicpu_so_binary, aicore_kernel_binary);
     if (rc != 0) {
-        std::cerr << "Error: EnsureDeviceInitialized failed: " << rc << '\n';
+        std::cerr << "Error: ensure_device_initialized failed: " << rc << '\n';
         return rc;
     }
 
     // Commit any pending kernels to device memory
-    rc = CommitKernels();
+    rc = commit_kernels();
     if (rc != 0) {
-        std::cerr << "Error: CommitKernels failed: " << rc << '\n';
+        std::cerr << "Error: commit_kernels failed: " << rc << '\n';
         return rc;
     }
 
     // Calculate execution parameters
-    blockDim_ = blockDim;
+    block_dim_ = block_dim;
 
-    int numAiCore = blockDim * coresPerBlockdim_;
+    int num_ai_core = block_dim * cores_per_blockdim_;
     // Initialize handshake buffers in runtime
-    if (numAiCore > RUNTIME_MAX_WORKER) {
-        std::cerr << "Error: blockDim (" << blockDim << ") exceeds RUNTIME_MAX_WORKER (" << RUNTIME_MAX_WORKER << ")\n";
+    if (num_ai_core > RUNTIME_MAX_WORKER) {
+        std::cerr << "Error: block_dim (" << block_dim << ") exceeds RUNTIME_MAX_WORKER (" << RUNTIME_MAX_WORKER << ")\n";
         return -1;
     }
 
-    runtime.worker_count = numAiCore;
-    runtime.block_dim = blockDim;
-    runtime.scheCpuNum = launchAicpuNum;
+    runtime.worker_count = num_ai_core;
+    runtime.block_dim = block_dim;
+    runtime.sche_cpu_num = launch_aicpu_num;
 
     // Calculate number of AIC cores (1/3 of total)
-    int numAic = blockDim;  // Round up for 1/3
+    int num_aic = block_dim;  // Round up for 1/3
 
-    for (int i = 0; i < numAiCore; i++) {
+    for (int i = 0; i < num_ai_core; i++) {
         runtime.workers[i].aicpu_ready = 0;
         runtime.workers[i].aicore_done = 0;
         runtime.workers[i].control = 0;
         runtime.workers[i].task = 0;
         runtime.workers[i].task_status = 0;
         // Set core type: first 1/3 are AIC (0), remaining 2/3 are AIV (1)
-        runtime.workers[i].core_type = (i < numAic) ? 0 : 1;
+        runtime.workers[i].core_type = (i < num_aic) ? 0 : 1;
     }
 
-    // Set functionBinAddr for all tasks (NEW - Runtime function pointer
+    // Set function_bin_addr for all tasks (NEW - Runtime function pointer
     // dispatch)
-    std::cout << "\n=== Setting functionBinAddr for Tasks ===" << '\n';
+    std::cout << "\n=== Setting function_bin_addr for Tasks ===" << '\n';
     for (int i = 0; i < runtime.get_task_count(); i++) {
         Task* task = runtime.get_task(i);
         if (task != nullptr) {
-            uint64_t addr = GetFunctionBinAddr(task->func_id);
-            task->functionBinAddr = addr;
-            std::cout << "  Task " << i << " (func_id=" << task->func_id << ") -> functionBinAddr=0x" << std::hex
+            uint64_t addr = get_function_bin_addr(task->func_id);
+            task->function_bin_addr = addr;
+            std::cout << "  Task " << i << " (func_id=" << task->func_id << ") -> function_bin_addr=0x" << std::hex
                       << addr << std::dec << '\n';
         }
     }
     std::cout << '\n';
 
     // Initialize runtime args
-    rc = kernelArgs_.InitRuntimeArgs(runtime, memAlloc_);
+    rc = kernel_args_.init_runtime_args(runtime, mem_alloc_);
     if (rc != 0) {
-        std::cerr << "Error: InitRuntimeArgs failed: " << rc << '\n';
+        std::cerr << "Error: init_runtime_args failed: " << rc << '\n';
         return rc;
     }
 
     // Launch AICPU init kernel
-    rc = LaunchAiCpuKernel(streamAicpu_, &kernelArgs_.args, "DynTileFwkKernelServerInit", 1);
+    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServerInit", 1);
     if (rc != 0) {
-        std::cerr << "Error: LaunchAiCpuKernel (init) failed: " << rc << '\n';
-        kernelArgs_.FinalizeRuntimeArgs();
+        std::cerr << "Error: launch_aicpu_kernel (init) failed: " << rc << '\n';
+        kernel_args_.finalize_runtime_args();
         return rc;
     }
 
     // Launch AICPU main kernel
-    rc = LaunchAiCpuKernel(streamAicpu_, &kernelArgs_.args, "DynTileFwkKernelServer", launchAicpuNum);
+    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", launch_aicpu_num);
     if (rc != 0) {
-        std::cerr << "Error: LaunchAiCpuKernel (main) failed: " << rc << '\n';
-        kernelArgs_.FinalizeRuntimeArgs();
+        std::cerr << "Error: launch_aicpu_kernel (main) failed: " << rc << '\n';
+        kernel_args_.finalize_runtime_args();
         return rc;
     }
 
     // Launch AICore kernel
-    rc = LaunchAicoreKernel(streamAicore_, kernelArgs_.args.runtimeArgs);
+    rc = launch_aicore_kernel(stream_aicore_, kernel_args_.args.runtime_args);
     if (rc != 0) {
-        std::cerr << "Error: LaunchAicoreKernel failed: " << rc << '\n';
-        kernelArgs_.FinalizeRuntimeArgs();
+        std::cerr << "Error: launch_aicore_kernel failed: " << rc << '\n';
+        kernel_args_.finalize_runtime_args();
         return rc;
     }
 
     // Synchronize streams
-    rc = rtStreamSynchronize(streamAicpu_);
+    rc = rtStreamSynchronize(stream_aicpu_);
     if (rc != 0) {
         std::cerr << "Error: rtStreamSynchronize (AICPU) failed: " << rc << '\n';
-        kernelArgs_.FinalizeRuntimeArgs();
+        kernel_args_.finalize_runtime_args();
         return rc;
     }
 
-    rc = rtStreamSynchronize(streamAicore_);
+    rc = rtStreamSynchronize(stream_aicore_);
     if (rc != 0) {
         std::cerr << "Error: rtStreamSynchronize (AICore) failed: " << rc << '\n';
-        kernelArgs_.FinalizeRuntimeArgs();
+        kernel_args_.finalize_runtime_args();
         return rc;
     }
 
     // Cleanup runtime args
-    kernelArgs_.FinalizeRuntimeArgs();
+    kernel_args_.finalize_runtime_args();
 
     return 0;
 }
 
-void DeviceRunner::PrintHandshakeResults(Runtime& runtime) {
-    if (streamAicpu_ == nullptr || runtime.worker_count == 0) {
+void DeviceRunner::print_handshake_results(Runtime& runtime) {
+    if (stream_aicpu_ == nullptr || runtime.worker_count == 0) {
         return;
     }
 
     size_t total_size = sizeof(Handshake) * runtime.worker_count;
-    rtMemcpy(runtime.workers, total_size, kernelArgs_.args.runtimeArgs->workers, total_size, RT_MEMCPY_DEVICE_TO_HOST);
+    rtMemcpy(runtime.workers, total_size, kernel_args_.args.runtime_args->workers, total_size, RT_MEMCPY_DEVICE_TO_HOST);
 
     std::cout << "Handshake results for " << runtime.worker_count << " cores:" << std::endl;
     for (int i = 0; i < runtime.worker_count; i++) {
@@ -366,83 +366,83 @@ void DeviceRunner::PrintHandshakeResults(Runtime& runtime) {
     }
 }
 
-int DeviceRunner::Finalize() {
-    if (streamAicpu_ == nullptr) {
+int DeviceRunner::finalize() {
+    if (stream_aicpu_ == nullptr) {
         return 0;
     }
 
-    // Cleanup kernel args (deviceArgs, runtimeArgs if any)
-    kernelArgs_.FinalizeDeviceArgs();
+    // Cleanup kernel args (device_args, runtime_args if any)
+    kernel_args_.finalize_device_args();
 
     // Cleanup AICPU SO
-    soInfo_.Finalize();
+    so_info_.finalize();
 
     // Clear kernel address mapping and pending kernels
-    funcIdToAddr_.clear();
-    pendingKernels_.clear();
-    kernelsCommitted_ = false;
-    binariesLoaded_ = false;
+    func_id_to_addr_.clear();
+    pending_kernels_.clear();
+    kernels_committed_ = false;
+    binaries_loaded_ = false;
 
     // Destroy streams
-    if (streamAicpu_ != nullptr) {
-        rtStreamDestroy(streamAicpu_);
-        streamAicpu_ = nullptr;
+    if (stream_aicpu_ != nullptr) {
+        rtStreamDestroy(stream_aicpu_);
+        stream_aicpu_ = nullptr;
     }
-    if (streamAicore_ != nullptr) {
-        rtStreamDestroy(streamAicore_);
-        streamAicore_ = nullptr;
+    if (stream_aicore_ != nullptr) {
+        rtStreamDestroy(stream_aicore_);
+        stream_aicore_ = nullptr;
     }
 
     // Free all remaining allocations (including handshake buffer and binGmAddr)
-    memAlloc_.Finalize();
+    mem_alloc_.finalize();
 
-    deviceId_ = -1;
-    aicoreKernelBinary_.clear();
+    device_id_ = -1;
+    aicore_kernel_binary_.clear();
 
     std::cout << "DeviceRunner finalized\n";
     return 0;
 }
 
-int DeviceRunner::LaunchAiCpuKernel(rtStream_t stream, KernelArgs* kArgs, const char* kernelName, int aicpuNum) {
+int DeviceRunner::launch_aicpu_kernel(rtStream_t stream, KernelArgs* k_args, const char* kernel_name, int aicpu_num) {
     struct Args {
-        KernelArgs kArgs;
-        char kernelName[32];
-        const char soName[32] = {"libaicpu_extend_kernels.so"};
-        const char opName[32] = {""};
+        KernelArgs k_args;
+        char kernel_name[32];
+        const char so_name[32] = {"libaicpu_extend_kernels.so"};
+        const char op_name[32] = {""};
     } args;
 
-    args.kArgs = *kArgs;
-    std::strncpy(args.kernelName, kernelName, sizeof(args.kernelName) - 1);
-    args.kernelName[sizeof(args.kernelName) - 1] = '\0';
+    args.k_args = *k_args;
+    std::strncpy(args.kernel_name, kernel_name, sizeof(args.kernel_name) - 1);
+    args.kernel_name[sizeof(args.kernel_name) - 1] = '\0';
 
-    rtAicpuArgsEx_t rtArgs;
-    std::memset(&rtArgs, 0, sizeof(rtArgs));
-    rtArgs.args = &args;
-    rtArgs.argsSize = sizeof(args);
-    rtArgs.kernelNameAddrOffset = offsetof(struct Args, kernelName);
-    rtArgs.soNameAddrOffset = offsetof(struct Args, soName);
+    rtAicpuArgsEx_t rt_args;
+    std::memset(&rt_args, 0, sizeof(rt_args));
+    rt_args.args = &args;
+    rt_args.argsSize = sizeof(args);
+    rt_args.kernelNameAddrOffset = offsetof(struct Args, kernel_name);
+    rt_args.soNameAddrOffset = offsetof(struct Args, so_name);
 
     return rtAicpuKernelLaunchExWithArgs(
-        rtKernelType_t::KERNEL_TYPE_AICPU_KFC, "AST_DYN_AICPU", aicpuNum, &rtArgs, nullptr, stream, 0);
+        rtKernelType_t::KERNEL_TYPE_AICPU_KFC, "AST_DYN_AICPU", aicpu_num, &rt_args, nullptr, stream, 0);
 }
 
-int DeviceRunner::LaunchAicoreKernel(rtStream_t stream, Runtime* runtime) {
-    if (aicoreKernelBinary_.empty()) {
+int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime* runtime) {
+    if (aicore_kernel_binary_.empty()) {
         std::cerr << "Error: AICore kernel binary is empty\n";
         return -1;
     }
 
-    size_t binSize = aicoreKernelBinary_.size();
-    const void* binData = aicoreKernelBinary_.data();
+    size_t bin_size = aicore_kernel_binary_.size();
+    const void* bin_data = aicore_kernel_binary_.data();
 
     rtDevBinary_t binary;
     std::memset(&binary, 0, sizeof(binary));
     binary.magic = RT_DEV_BINARY_MAGIC_ELF;
     binary.version = 0;
-    binary.data = binData;
-    binary.length = binSize;
-    void* binHandle = nullptr;
-    int rc = rtRegisterAllKernel(&binary, &binHandle);
+    binary.data = bin_data;
+    binary.length = bin_size;
+    void* bin_handle = nullptr;
+    int rc = rtRegisterAllKernel(&binary, &bin_handle);
     if (rc != RT_ERROR_NONE) {
         std::cerr << "rtRegisterAllKernel失败: " << rc << '\n';
         return rc;
@@ -453,15 +453,15 @@ int DeviceRunner::LaunchAicoreKernel(rtStream_t stream, Runtime* runtime) {
     };
     // Pass device address of Runtime to AICore
     Args args = {runtime};
-    rtArgsEx_t rtArgs;
-    std::memset(&rtArgs, 0, sizeof(rtArgs));
-    rtArgs.args = &args;
-    rtArgs.argsSize = sizeof(args);
+    rtArgsEx_t rt_args;
+    std::memset(&rt_args, 0, sizeof(rt_args));
+    rt_args.args = &args;
+    rt_args.argsSize = sizeof(args);
 
     rtTaskCfgInfo_t cfg = {};
     cfg.schemMode = RT_SCHEM_MODE_BATCH;
 
-    rc = rtKernelLaunchWithHandleV2(binHandle, 0, blockDim_, &rtArgs, nullptr, stream, &cfg);
+    rc = rtKernelLaunchWithHandleV2(bin_handle, 0, block_dim_, &rt_args, nullptr, stream, &cfg);
     if (rc != RT_ERROR_NONE) {
         std::cerr << "rtKernelLaunchWithHandleV2失败: " << rc << '\n';
         return rc;
@@ -474,92 +474,92 @@ int DeviceRunner::LaunchAicoreKernel(rtStream_t stream, Runtime* runtime) {
 // Kernel Binary Registration (Python provides pre-extracted .text section)
 // =============================================================================
 
-int DeviceRunner::RegisterKernel(int funcId, const uint8_t* binData, size_t binSize) {
-    if (binData == nullptr || binSize == 0) {
+int DeviceRunner::register_kernel(int func_id, const uint8_t* bin_data, size_t bin_size) {
+    if (bin_data == nullptr || bin_size == 0) {
         std::cerr << "Error: Invalid kernel binary data\n";
         return -1;
     }
 
-    std::cout << "Registering kernel: func_id=" << funcId << ", size=" << binSize << " bytes\n";
+    std::cout << "Registering kernel: func_id=" << func_id << ", size=" << bin_size << " bytes\n";
 
     // Store kernel binary in host memory (will be copied to device in
-    // CommitKernels)
+    // commit_kernels)
     PendingKernel kernel;
-    kernel.data.assign(binData, binData + binSize);
-    pendingKernels_[funcId] = std::move(kernel);
+    kernel.data.assign(bin_data, bin_data + bin_size);
+    pending_kernels_[func_id] = std::move(kernel);
 
     // If already initialized and committed, need to copy this kernel
     // immediately
-    if (streamAicpu_ != nullptr && kernelsCommitted_) {
+    if (stream_aicpu_ != nullptr && kernels_committed_) {
         // Re-commit just this kernel
-        kernelsCommitted_ = false;  // Force re-commit
+        kernels_committed_ = false;  // Force re-commit
     }
 
     return 0;
 }
 
-int DeviceRunner::CommitKernels() {
-    if (kernelsCommitted_) {
+int DeviceRunner::commit_kernels() {
+    if (kernels_committed_) {
         return 0;  // Already committed
     }
 
-    if (streamAicpu_ == nullptr) {
+    if (stream_aicpu_ == nullptr) {
         std::cerr << "Error: Cannot commit kernels - DeviceRunner not initialized\n";
         return -1;
     }
 
-    std::cout << "Committing " << pendingKernels_.size() << " kernels to device memory\n";
+    std::cout << "Committing " << pending_kernels_.size() << " kernels to device memory\n";
 
-    for (auto& [funcId, kernel] : pendingKernels_) {
-        // Skip if already in funcIdToAddr_
-        if (funcIdToAddr_.find(funcId) != funcIdToAddr_.end()) {
+    for (auto& [func_id, kernel] : pending_kernels_) {
+        // Skip if already in func_id_to_addr_
+        if (func_id_to_addr_.find(func_id) != func_id_to_addr_.end()) {
             continue;
         }
 
-        size_t binSize = kernel.data.size();
+        size_t bin_size = kernel.data.size();
 
         // Step 1: Allocate device GM memory (size field + binary data)
-        uint64_t allocSize = sizeof(uint64_t) + binSize;
-        void* gmAddr = memAlloc_.Alloc(allocSize);
-        if (gmAddr == nullptr) {
+        uint64_t alloc_size = sizeof(uint64_t) + bin_size;
+        void* gm_addr = mem_alloc_.alloc(alloc_size);
+        if (gm_addr == nullptr) {
             std::cerr << "Error: Failed to allocate device GM memory for "
                          "kernel func_id="
-                      << funcId << '\n';
+                      << func_id << '\n';
             return -1;
         }
 
         // Step 2: Build host buffer with CoreFunctionBin structure (size +
         // data)
-        std::vector<uint8_t> hostBuf(allocSize);
-        uint64_t* sizePtr = reinterpret_cast<uint64_t*>(hostBuf.data());
-        *sizePtr = binSize;
-        std::memcpy(hostBuf.data() + sizeof(uint64_t), kernel.data.data(), binSize);
+        std::vector<uint8_t> host_buf(alloc_size);
+        uint64_t* size_ptr = reinterpret_cast<uint64_t*>(host_buf.data());
+        *size_ptr = bin_size;
+        std::memcpy(host_buf.data() + sizeof(uint64_t), kernel.data.data(), bin_size);
 
         // Step 3: Copy to device
-        int rc = rtMemcpy(gmAddr, allocSize, hostBuf.data(), allocSize, RT_MEMCPY_HOST_TO_DEVICE);
+        int rc = rtMemcpy(gm_addr, alloc_size, host_buf.data(), alloc_size, RT_MEMCPY_HOST_TO_DEVICE);
         if (rc != 0) {
             std::cerr << "Error: rtMemcpy to device failed: " << rc << '\n';
-            memAlloc_.Free(gmAddr);
+            mem_alloc_.free(gm_addr);
             return rc;
         }
 
-        // Step 4: Calculate functionBinAddr (skip size field to get actual code
+        // Step 4: Calculate function_bin_addr (skip size field to get actual code
         // address)
-        uint64_t functionBinAddr = reinterpret_cast<uint64_t>(gmAddr) + sizeof(uint64_t);
-        funcIdToAddr_[funcId] = functionBinAddr;
+        uint64_t function_bin_addr = reinterpret_cast<uint64_t>(gm_addr) + sizeof(uint64_t);
+        func_id_to_addr_[func_id] = function_bin_addr;
 
-        std::cout << "  func_id=" << funcId << " -> functionBinAddr=0x" << std::hex << functionBinAddr << std::dec
+        std::cout << "  func_id=" << func_id << " -> function_bin_addr=0x" << std::hex << function_bin_addr << std::dec
                   << '\n';
     }
 
-    kernelsCommitted_ = true;
+    kernels_committed_ = true;
     return 0;
 }
 
-uint64_t DeviceRunner::GetFunctionBinAddr(int funcId) {
-    auto it = funcIdToAddr_.find(funcId);
-    if (it == funcIdToAddr_.end()) {
-        std::cerr << "Warning: functionBinAddr not found for func_id=" << funcId << '\n';
+uint64_t DeviceRunner::get_function_bin_addr(int func_id) {
+    auto it = func_id_to_addr_.find(func_id);
+    if (it == func_id_to_addr_.end()) {
+        std::cerr << "Warning: function_bin_addr not found for func_id=" << func_id << '\n';
         return 0;
     }
     return it->second;

--- a/src/platform/a2a3/host/devicerunner.h
+++ b/src/platform/a2a3/host/devicerunner.h
@@ -31,12 +31,12 @@
  *
  * This structure contains pointers to device memory for the AICPU shared
  * object. The layout is hardcoded in libaicpu_extend_kernels.so, which expects
- * specific offsets for aicpuSoBin and aicpuSoLen fields.
+ * specific offsets for aicpu_so_bin and aicpu_so_len fields.
  */
 struct DeviceArgs {
     uint64_t unused[12] = {0};
-    uint64_t aicpuSoBin{0};
-    uint64_t aicpuSoLen{0};
+    uint64_t aicpu_so_bin{0};
+    uint64_t aicpu_so_len{0};
 };
 
 /**
@@ -57,34 +57,34 @@ struct KernelArgsHelper {
     /**
      * Initialize device arguments by allocating device memory and copying data
      *
-     * @param hostDeviceArgs  Host-side device arguments to copy
+     * @param host_device_args  Host-side device arguments to copy
      * @param allocator       Memory allocator to use
      * @return 0 on success, error code on failure
      */
-    int InitDeviceArgs(const DeviceArgs& hostDeviceArgs, MemoryAllocator& allocator);
+    int init_device_args(const DeviceArgs& host_device_args, MemoryAllocator& allocator);
 
     /**
      * Free device memory allocated for device arguments
      *
      * @return 0 on success, error code on failure
      */
-    int FinalizeDeviceArgs();
+    int finalize_device_args();
 
     /**
      * Initialize runtime arguments by allocating device memory and copying data
      *
-     * @param hostRuntime  Host-side runtime to copy to device
+     * @param host_runtime  Host-side runtime to copy to device
      * @param allocator  Memory allocator to use
      * @return 0 on success, error code on failure
      */
-    int InitRuntimeArgs(const Runtime& hostRuntime, MemoryAllocator& allocator);
+    int init_runtime_args(const Runtime& host_runtime, MemoryAllocator& allocator);
 
     /**
      * Free device memory allocated for runtime arguments
      *
      * @return 0 on success, error code on failure
      */
-    int FinalizeRuntimeArgs();
+    int finalize_runtime_args();
 
     /**
      * Implicit conversion operators for seamless use with runtime APIs
@@ -104,25 +104,25 @@ struct KernelArgsHelper {
  * shared object (.so) files.
  */
 struct AicpuSoInfo {
-    uint64_t aicpuSoBin{0};
-    uint64_t aicpuSoLen{0};
+    uint64_t aicpu_so_bin{0};
+    uint64_t aicpu_so_len{0};
     MemoryAllocator* allocator_{nullptr};
 
     /**
      * Load shared object binary data and copy to device memory
      *
-     * @param aicpuSoBinary  Binary data of the AICPU shared object
+     * @param aicpu_so_binary  Binary data of the AICPU shared object
      * @param allocator      Memory allocator to use
      * @return 0 on success, error code on failure
      */
-    int Init(const std::vector<uint8_t>& aicpuSoBinary, MemoryAllocator& allocator);
+    int init(const std::vector<uint8_t>& aicpu_so_binary, MemoryAllocator& allocator);
 
     /**
      * Free device memory allocated for shared object
      *
      * @return 0 on success, error code on failure
      */
-    int Finalize();
+    int finalize();
 };
 
 /**
@@ -144,7 +144,7 @@ public:
      *
      * @return Reference to the singleton DeviceRunner instance
      */
-    static DeviceRunner& Get();
+    static DeviceRunner& get();
 
     /**
      * Allocate device tensor memory
@@ -152,41 +152,41 @@ public:
      * @param bytes  Size of tensor in bytes
      * @return Device pointer on success, nullptr on failure
      */
-    void* AllocateTensor(size_t bytes);
+    void* allocate_tensor(size_t bytes);
 
     /**
      * Free device tensor memory
      *
-     * @param devPtr  Device pointer to free
+     * @param dev_ptr  Device pointer to free
      */
-    void FreeTensor(void* devPtr);
+    void free_tensor(void* dev_ptr);
 
     /**
      * Copy data from host to device
      *
-     * @param devPtr   Device pointer
-     * @param hostPtr  Host pointer
+     * @param dev_ptr   Device pointer
+     * @param host_ptr  Host pointer
      * @param bytes    Number of bytes to copy
      * @return 0 on success, error code on failure
      */
-    int CopyToDevice(void* devPtr, const void* hostPtr, size_t bytes);
+    int copy_to_device(void* dev_ptr, const void* host_ptr, size_t bytes);
 
     /**
      * Copy data from device to host
      *
-     * @param hostPtr  Host pointer
-     * @param devPtr   Device pointer
+     * @param host_ptr  Host pointer
+     * @param dev_ptr   Device pointer
      * @param bytes    Number of bytes to copy
      * @return 0 on success, error code on failure
      */
-    int CopyFromDevice(void* hostPtr, const void* devPtr, size_t bytes);
+    int copy_from_device(void* host_ptr, const void* dev_ptr, size_t bytes);
 
     /**
      * Execute a runtime
      *
      * This method:
      * 1. Initializes device if not already done (lazy initialization)
-     * 2. Initializes worker handshake buffers in the runtime based on blockDim
+     * 2. Initializes worker handshake buffers in the runtime based on block_dim
      * 3. Transfers runtime to device memory
      * 4. Launches AICPU init kernel
      * 5. Launches AICPU main kernel
@@ -196,19 +196,19 @@ public:
      *
      * @param runtime             Runtime to execute (will be modified to
      * initialize workers)
-     * @param blockDim            Number of blocks (1 block = 1 AIC + 2 AIV)
-     * @param deviceId            Device ID (0-15)
-     * @param aicpuSoBinary       Binary data of AICPU shared object
-     * @param aicoreKernelBinary  Binary data of AICore kernel
-     * @param launchAicpuNum      Number of AICPU instances (default: 1)
+     * @param block_dim            Number of blocks (1 block = 1 AIC + 2 AIV)
+     * @param device_id            Device ID (0-15)
+     * @param aicpu_so_binary       Binary data of AICPU shared object
+     * @param aicore_kernel_binary  Binary data of AICore kernel
+     * @param launch_aicpu_num      Number of AICPU instances (default: 1)
      * @return 0 on success, error code on failure
      */
-    int Run(Runtime& runtime,
-        int blockDim,
-        int deviceId,
-        const std::vector<uint8_t>& aicpuSoBinary,
-        const std::vector<uint8_t>& aicoreKernelBinary,
-        int launchAicpuNum = 1);
+    int run(Runtime& runtime,
+        int block_dim,
+        int device_id,
+        const std::vector<uint8_t>& aicpu_so_binary,
+        const std::vector<uint8_t>& aicore_kernel_binary,
+        int launch_aicpu_num = 1);
 
     /**
      * Print handshake results from device
@@ -218,7 +218,7 @@ public:
      *
      * @param runtime  The runtime whose handshake results should be printed
      */
-    void PrintHandshakeResults(Runtime& runtime);
+    void print_handshake_results(Runtime& runtime);
 
     /**
      * Cleanup all resources
@@ -227,7 +227,7 @@ public:
      *
      * @return 0 on success, error code on failure
      */
-    int Finalize();
+    int finalize();
 
     /**
      * Launch an AICPU kernel
@@ -236,12 +236,12 @@ public:
      * workflows.
      *
      * @param stream      AICPU stream
-     * @param kArgs       Kernel arguments
-     * @param kernelName  Name of the kernel to launch
-     * @param aicpuNum    Number of AICPU instances to launch
+     * @param k_args       Kernel arguments
+     * @param kernel_name  Name of the kernel to launch
+     * @param aicpu_num    Number of AICPU instances to launch
      * @return 0 on success, error code on failure
      */
-    int LaunchAiCpuKernel(rtStream_t stream, KernelArgs* kArgs, const char* kernelName, int aicpuNum);
+    int launch_aicpu_kernel(rtStream_t stream, KernelArgs* k_args, const char* kernel_name, int aicpu_num);
 
     /**
      * Launch an AICore kernel
@@ -253,92 +253,93 @@ public:
      * @param runtime   Pointer to device runtime
      * @return 0 on success, error code on failure
      */
-    int LaunchAicoreKernel(rtStream_t stream, Runtime* runtime);
+    int launch_aicore_kernel(rtStream_t stream, Runtime* runtime);
 
     /**
      * Register a kernel binary for a func_id
      *
      * Receives pre-extracted .text section binary data from Python,
      * allocates device GM memory, copies the binary to device,
-     * and stores the GM address in funcIdToAddr_.
+     * and stores the GM address in func_id_to_addr_.
      *
-     * @param funcId   Function identifier (0, 1, 2, ...)
-     * @param binData  Kernel .text section binary data
-     * @param binSize  Size of binary data in bytes
+     * @param func_id   Function identifier (0, 1, 2, ...)
+     * @param bin_data  Kernel .text section binary data
+     * @param bin_size  Size of binary data in bytes
      * @return 0 on success, -1 on error
      */
-    int RegisterKernel(int funcId, const uint8_t* binData, size_t binSize);
+    int register_kernel(int func_id, const uint8_t* bin_data, size_t bin_size);
 
     /**
-     * Get functionBinAddr for a given func_id
+     * Get function_bin_addr for a given func_id
      *
      * Returns the device GM address where the kernel binary resides.
      * This address can be cast to a function pointer and called.
      *
-     * @param funcId  Function identifier
+     * @param func_id  Function identifier
      * @return Device GM address of kernel, or 0 if not found
      */
-    uint64_t GetFunctionBinAddr(int funcId);
+    uint64_t get_function_bin_addr(int func_id);
 
     /**
      * Ensure device is set and streams are created (minimal initialization)
      *
      * This is called by set_device() C API to enable memory allocation
      * before InitRuntime(). Only performs:
-     * - rtSetDevice(deviceId)
+     * - rtSetDevice(device_id)
      * - Create AICPU and AICore streams
      *
-     * @param deviceId  Device ID (0-15)
+     * @param device_id  Device ID (0-15)
      * @return 0 on success, error code on failure
      */
-    int EnsureDeviceSet(int deviceId);
+    int ensure_device_set(int device_id);
 
 private:
     DeviceRunner() = default;
     ~DeviceRunner();
 
     // Internal state
-    int deviceId_{-1};
-    int blockDim_{0};
-    int coresPerBlockdim_{3};
-    std::vector<uint8_t> aicoreKernelBinary_;
+    int device_id_{-1};
+    int block_dim_{0};
+    int cores_per_blockdim_{3};
+    std::vector<uint8_t> aicore_kernel_binary_;
 
     // Memory management
-    MemoryAllocator memAlloc_;
+    MemoryAllocator mem_alloc_;
 
     // Device resources
-    rtStream_t streamAicpu_{nullptr};
-    rtStream_t streamAicore_{nullptr};
-    AicpuSoInfo soInfo_;
-    KernelArgsHelper kernelArgs_;
-    DeviceArgs deviceArgs_;
+    rtStream_t stream_aicpu_{nullptr};
+    rtStream_t stream_aicore_{nullptr};
+    AicpuSoInfo so_info_;
+    KernelArgsHelper kernel_args_;
+    DeviceArgs device_args_;
 
     // Kernel binary management
     // Host-side storage for pending kernels (before device init)
     struct PendingKernel {
         std::vector<uint8_t> data;
     };
-    std::map<int, PendingKernel> pendingKernels_;  // func_id -> host binary
-    bool kernelsCommitted_{false};                 // true after kernels copied to device
-    bool binariesLoaded_{false};                   // true after AICPU SO loaded
-    std::map<int, uint64_t> funcIdToAddr_;         // func_id -> functionBinAddr (device GM)
+    std::map<int, PendingKernel> pending_kernels_;  // func_id -> host binary
+    bool kernels_committed_{false};                 // true after kernels copied to device
+    bool binaries_loaded_{false};                   // true after AICPU SO loaded
+    std::map<int, uint64_t> func_id_to_addr_;         // func_id -> function_bin_addr (device GM)
 
     /**
      * Ensure device is initialized (lazy initialization)
      *
      * Checks if device is already initialized. If not, performs:
-     * - rtSetDevice(deviceId)
+     * - rtSetDevice(device_id)
      * - Create AICPU and AICore streams
      * - Load AICPU SO to device memory
      * - Initialize device args
      *
-     * @param deviceId            Device ID (0-15)
-     * @param aicpuSoBinary       Binary data of AICPU shared object
-     * @param aicoreKernelBinary  Binary data of AICore kernel
+     * @param device_id            Device ID (0-15)
+     * @param aicpu_so_binary       Binary data of AICPU shared object
+     * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int EnsureDeviceInitialized(
-        int deviceId, const std::vector<uint8_t>& aicpuSoBinary, const std::vector<uint8_t>& aicoreKernelBinary);
+    int ensure_device_initialized(int device_id,
+                                const std::vector<uint8_t>& aicpu_so_binary,
+                                const std::vector<uint8_t>& aicore_kernel_binary);
 
     /**
      * Load AICPU SO and initialize device args
@@ -347,11 +348,11 @@ private:
      * - Load AICPU SO to device memory
      * - Initialize device args
      *
-     * @param aicpuSoBinary       Binary data of AICPU shared object
-     * @param aicoreKernelBinary  Binary data of AICore kernel
+     * @param aicpu_so_binary       Binary data of AICPU shared object
+     * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int EnsureBinariesLoaded(const std::vector<uint8_t>& aicpuSoBinary, const std::vector<uint8_t>& aicoreKernelBinary);
+    int ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
 
     /**
      * Copy pending kernels from host to device memory
@@ -360,7 +361,7 @@ private:
      *
      * @return 0 on success, -1 on error
      */
-    int CommitKernels();
+    int commit_kernels();
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/platform/a2a3/host/function_cache.h
+++ b/src/platform/a2a3/host/function_cache.h
@@ -12,7 +12,7 @@
  * ┌────────────────────────────────────────────────┐
  * │ CoreFunctionBinCache                            │
  * │ ┌────────────────────────────────────────────┐ │
- * │ │ dataSize                                   │ │
+ * │ │ data_size                                  │ │
  * │ ├────────────────────────────────────────────┤ │
  * │ │ offset[0]                                  │ │
  * │ │ offset[1]                                  │ │
@@ -55,20 +55,20 @@ struct CoreFunctionBin {
  * memory block for efficient device memory allocation and copying.
  *
  * Memory Layout:
- * [dataSize][numKernels][offset0][offset1]...[offsetN][CoreFunctionBin0][CoreFunctionBin1]...
+ * [data_size][num_kernels][offset0][offset1]...[offsetN][CoreFunctionBin0][CoreFunctionBin1]...
  *
  * Each offset points to the start of a CoreFunctionBin structure relative
  * to the beginning of the cache.
  */
 struct CoreFunctionBinCache {
-    uint64_t dataSize;    // Total size of all data (excluding this header)
-    uint64_t numKernels;  // Number of kernels in this cache
+    uint64_t data_size;    // Total size of all data (excluding this header)
+    uint64_t num_kernels;  // Number of kernels in this cache
 
     /**
      * Get offset array pointer
      * @return Pointer to array of offsets
      */
-    uint64_t* GetOffsets() {
+    uint64_t* get_offsets() {
         return reinterpret_cast<uint64_t*>(reinterpret_cast<uint8_t*>(this) + sizeof(CoreFunctionBinCache));
     }
 
@@ -76,26 +76,26 @@ struct CoreFunctionBinCache {
      * Get pointer to binary data region
      * @return Pointer to start of binary data
      */
-    uint8_t* GetBinaryData() { return reinterpret_cast<uint8_t*>(GetOffsets()) + numKernels * sizeof(uint64_t); }
+    uint8_t* get_binary_data() { return reinterpret_cast<uint8_t*>(get_offsets()) + num_kernels * sizeof(uint64_t); }
 
     /**
      * Get CoreFunctionBin by index
      * @param index  Kernel index
      * @return Pointer to CoreFunctionBin structure
      */
-    CoreFunctionBin* GetKernel(uint64_t index) {
-        if (index >= numKernels) {
+    CoreFunctionBin* get_kernel(uint64_t index) {
+        if (index >= num_kernels) {
             return nullptr;
         }
-        uint64_t offset = GetOffsets()[index];
-        return reinterpret_cast<CoreFunctionBin*>(GetBinaryData() + offset);
+        uint64_t offset = get_offsets()[index];
+        return reinterpret_cast<CoreFunctionBin*>(get_binary_data() + offset);
     }
 
     /**
      * Calculate total cache size including header
      * @return Total size in bytes
      */
-    uint64_t GetTotalSize() const { return sizeof(CoreFunctionBinCache) + numKernels * sizeof(uint64_t) + dataSize; }
+    uint64_t get_total_size() const { return sizeof(CoreFunctionBinCache) + num_kernels * sizeof(uint64_t) + data_size; }
 };
 
 #endif  // RUNTIME_FUNCTION_CACHE_H

--- a/src/platform/a2a3/host/memoryallocator.cpp
+++ b/src/platform/a2a3/host/memoryallocator.cpp
@@ -11,9 +11,9 @@
 
 #include <iostream>
 
-MemoryAllocator::~MemoryAllocator() { Finalize(); }
+MemoryAllocator::~MemoryAllocator() { finalize(); }
 
-void* MemoryAllocator::Alloc(size_t size) {
+void* MemoryAllocator::alloc(size_t size) {
     void* ptr = nullptr;
     int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
     if (rc != 0) {
@@ -22,18 +22,18 @@ void* MemoryAllocator::Alloc(size_t size) {
     }
 
     // Track the pointer
-    ptrSet_.insert(ptr);
+    ptr_set_.insert(ptr);
     return ptr;
 }
 
-int MemoryAllocator::Free(void* ptr) {
+int MemoryAllocator::free(void* ptr) {
     if (ptr == nullptr) {
         return 0;
     }
 
     // Check if we're tracking this pointer
-    auto it = ptrSet_.find(ptr);
-    if (it == ptrSet_.end()) {
+    auto it = ptr_set_.find(ptr);
+    if (it == ptr_set_.end()) {
         // Not tracked by us, don't free
         return 0;
     }
@@ -46,30 +46,30 @@ int MemoryAllocator::Free(void* ptr) {
     }
 
     // Remove from tracking set
-    ptrSet_.erase(it);
+    ptr_set_.erase(it);
     return 0;
 }
 
-int MemoryAllocator::Finalize() {
+int MemoryAllocator::finalize() {
     // Idempotent - safe to call multiple times
     if (finalized_) {
         return 0;
     }
 
-    int lastError = 0;
+    int last_error = 0;
 
     // Free all remaining tracked pointers
-    for (void* ptr : ptrSet_) {
+    for (void* ptr : ptr_set_) {
         int rc = rtFree(ptr);
         if (rc != 0) {
             std::cerr << "Error: rtFree failed during Finalize: " << rc << '\n';
-            lastError = rc;
+            last_error = rc;
         }
     }
 
     // Clear the set
-    ptrSet_.clear();
+    ptr_set_.clear();
     finalized_ = true;
 
-    return lastError;
+    return last_error;
 }

--- a/src/platform/a2a3/host/memoryallocator.h
+++ b/src/platform/a2a3/host/memoryallocator.h
@@ -9,7 +9,7 @@
  * - Automatic tracking of all allocated device memory
  * - Safe deallocation with existence checking
  * - Automatic cleanup via destructor (RAII pattern)
- * - Idempotent Finalize() for explicit cleanup with error checking
+ * - Idempotent finalize() for explicit cleanup with error checking
  */
 
 #ifndef RUNTIME_MEMORYALLOCATOR_H
@@ -43,7 +43,7 @@ public:
      * @param size  Size in bytes to allocate
      * @return Device pointer on success, nullptr on failure
      */
-    void* Alloc(size_t size);
+    void* alloc(size_t size);
 
     /**
      * Free device memory if tracked
@@ -55,7 +55,7 @@ public:
      * @param ptr  Device pointer to free
      * @return 0 on success, error code on failure, 0 if ptr not tracked
      */
-    int Free(void* ptr);
+    int free(void* ptr);
 
     /**
      * Free all remaining tracked allocations
@@ -67,17 +67,17 @@ public:
      *
      * @return 0 on success, error code if any frees failed
      */
-    int Finalize();
+    int finalize();
 
     /**
      * Get number of tracked allocations
      *
      * @return Number of currently tracked pointers
      */
-    size_t GetAllocationCount() const { return ptrSet_.size(); }
+    size_t get_allocation_count() const { return ptr_set_.size(); }
 
 private:
-    std::set<void*> ptrSet_;
+    std::set<void*> ptr_set_;
     bool finalized_{false};
 };
 

--- a/src/platform/a2a3/host/pto_runtime_c_api.cpp
+++ b/src/platform/a2a3/host/pto_runtime_c_api.cpp
@@ -20,8 +20,8 @@ extern "C" {
 /* Runtime Implementation Functions (defined in runtimemaker.cpp) */
 /* ===========================================================================
  */
-int InitRuntimeImpl(Runtime* runtime);
-int ValidateRuntimeImpl(Runtime* runtime);
+int init_runtime_impl(Runtime* runtime);
+int validate_runtime_impl(Runtime* runtime);
 
 /* ===========================================================================
  */
@@ -29,16 +29,16 @@ int ValidateRuntimeImpl(Runtime* runtime);
 /* ===========================================================================
  */
 
-size_t GetRuntimeSize(void) { return sizeof(Runtime); }
+size_t get_runtime_size(void) { return sizeof(Runtime); }
 
-int InitRuntime(RuntimeHandle runtime) {
+int init_runtime(RuntimeHandle runtime) {
     if (runtime == NULL) {
         return -1;
     }
     try {
         // Placement new to construct Runtime in user-allocated memory
         Runtime* r = new (runtime) Runtime();
-        return InitRuntimeImpl(r);
+        return init_runtime_impl(r);
     } catch (...) {
         return -1;
     }
@@ -59,27 +59,27 @@ int launch_runtime(RuntimeHandle runtime,
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::Get();
+        DeviceRunner& runner = DeviceRunner::get();
 
         // Convert to vectors for Run()
-        std::vector<uint8_t> aicpuVec(aicpu_binary, aicpu_binary + aicpu_size);
-        std::vector<uint8_t> aicoreVec(aicore_binary, aicore_binary + aicore_size);
+        std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
+        std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
 
         // Run the runtime (device initialization is handled internally)
         Runtime* r = static_cast<Runtime*>(runtime);
-        return runner.Run(*r, block_dim, device_id, aicpuVec, aicoreVec, aicpu_thread_num);
+        return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
         return -1;
     }
 }
 
-int FinalizeRuntime(RuntimeHandle runtime) {
+int finalize_runtime(RuntimeHandle runtime) {
     if (runtime == NULL) {
         return -1;
     }
     try {
         Runtime* r = static_cast<Runtime*>(runtime);
-        int rc = ValidateRuntimeImpl(r);
+        int rc = validate_runtime_impl(r);
         // Call destructor (user will call free())
         r->~Runtime();
         return rc;
@@ -90,20 +90,20 @@ int FinalizeRuntime(RuntimeHandle runtime) {
 
 int set_device(int device_id) {
     try {
-        DeviceRunner& runner = DeviceRunner::Get();
-        return runner.EnsureDeviceSet(device_id);
+        DeviceRunner& runner = DeviceRunner::get();
+        return runner.ensure_device_set(device_id);
     } catch (...) {
         return -1;
     }
 }
 
-int RegisterKernel(int func_id, const uint8_t* bin_data, size_t bin_size) {
+int register_kernel(int func_id, const uint8_t* bin_data, size_t bin_size) {
     if (bin_data == NULL || bin_size == 0) {
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::Get();
-        return runner.RegisterKernel(func_id, bin_data, bin_size);
+        DeviceRunner& runner = DeviceRunner::get();
+        return runner.register_kernel(func_id, bin_data, bin_size);
     } catch (...) {
         return -1;
     }

--- a/src/platform/a2a3/host/pto_runtime_c_api.h
+++ b/src/platform/a2a3/host/pto_runtime_c_api.h
@@ -8,7 +8,7 @@
  * - All functions use C linkage (extern "C")
  * - Opaque pointers hide C++ implementation details
  * - Error codes: 0 = success, negative = error
- * - Memory management: User allocates Runtime with malloc(GetRuntimeSize())
+ * - Memory management: User allocates Runtime with malloc(get_runtime_size())
  */
 
 #ifndef PTO_RUNTIME_C_API_H
@@ -36,11 +36,11 @@ typedef void* RuntimeHandle;
 /**
  * Get the size of Runtime structure for memory allocation.
  *
- * User should allocate: Runtime* r = (Runtime*)malloc(GetRuntimeSize());
+ * User should allocate: Runtime* r = (Runtime*)malloc(get_runtime_size());
  *
  * @return Size of Runtime structure in bytes
  */
-size_t GetRuntimeSize(void);
+size_t get_runtime_size(void);
 
 /**
  * Initialize a runtime for the basic example.
@@ -49,10 +49,10 @@ size_t GetRuntimeSize(void);
  * Builds the task runtime, allocates device tensors, initializes data.
  * Does NOT initialize device runner - that happens in launch_runtime().
  *
- * @param runtime  User-allocated memory of size GetRuntimeSize()
+ * @param runtime  User-allocated memory of size get_runtime_size()
  * @return 0 on success, -1 on failure
  */
-int InitRuntime(RuntimeHandle runtime);
+int init_runtime(RuntimeHandle runtime);
 
 /**
  * Execute a runtime on the device.
@@ -89,12 +89,12 @@ int launch_runtime(RuntimeHandle runtime,
  * @param runtime  Runtime handle to finalize
  * @return 0 on success, -1 on failure
  */
-int FinalizeRuntime(RuntimeHandle runtime);
+int finalize_runtime(RuntimeHandle runtime);
 
 /**
  * Set device and create streams for memory operations.
  *
- * Must be called before InitRuntime() to enable device tensor allocation.
+ * Must be called before init_runtime() to enable device tensor allocation.
  * Only performs minimal initialization:
  * - rtSetDevice(device_id)
  * - Create AICPU and AICore streams
@@ -118,7 +118,7 @@ int set_device(int device_id);
  * @param bin_size  Size of binary data in bytes
  * @return 0 on success, error code on failure
  */
-int RegisterKernel(int func_id, const uint8_t* bin_data, size_t bin_size);
+int register_kernel(int func_id, const uint8_t* bin_data, size_t bin_size);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/runtime/host/runtimemaker.cpp
+++ b/src/runtime/host/runtimemaker.cpp
@@ -35,7 +35,7 @@
 extern "C" {
 #endif
 
-// Static storage for tensor pointers (used by ValidateRuntimeImpl)
+// Static storage for tensor pointers (used by validate_runtime_impl)
 static void* g_dev_a = nullptr;
 static void* g_dev_b = nullptr;
 static void* g_dev_c = nullptr;
@@ -53,11 +53,11 @@ static size_t g_tensor_bytes = 0;
  * @param runtime    Pointer to pre-constructed Runtime
  * @return 0 on success, -1 on failure
  */
-int InitRuntimeImpl(Runtime* runtime) {
+int init_runtime_impl(Runtime* runtime) {
     int rc = 0;
 
     // Initialize DeviceRunner
-    DeviceRunner& runner = DeviceRunner::Get();
+    DeviceRunner& runner = DeviceRunner::get();
     // Note: DeviceRunner should already be initialized by Python before calling
     // InitRuntime Note: Kernels should be registered via Python's
     // runner.register_kernel() before calling InitRuntime
@@ -69,12 +69,12 @@ int InitRuntimeImpl(Runtime* runtime) {
     constexpr size_t BYTES = SIZE * sizeof(float);
 
     std::cout << "\n=== Allocating Device Memory ===" << '\n';
-    void* dev_a = runner.AllocateTensor(BYTES);
-    void* dev_b = runner.AllocateTensor(BYTES);
-    void* dev_c = runner.AllocateTensor(BYTES);
-    void* dev_d = runner.AllocateTensor(BYTES);
-    void* dev_e = runner.AllocateTensor(BYTES);
-    void* dev_f = runner.AllocateTensor(BYTES);
+    void* dev_a = runner.allocate_tensor(BYTES);
+    void* dev_b = runner.allocate_tensor(BYTES);
+    void* dev_c = runner.allocate_tensor(BYTES);
+    void* dev_d = runner.allocate_tensor(BYTES);
+    void* dev_e = runner.allocate_tensor(BYTES);
+    void* dev_f = runner.allocate_tensor(BYTES);
 
     if (!dev_a || !dev_b || !dev_c || !dev_d || !dev_e || !dev_f) {
         std::cerr << "Error: Failed to allocate device tensors" << '\n';
@@ -86,34 +86,34 @@ int InitRuntimeImpl(Runtime* runtime) {
     std::vector<float> host_a(SIZE, 2.0f);
     std::vector<float> host_b(SIZE, 3.0f);
 
-    rc = runner.CopyToDevice(dev_a, host_a.data(), BYTES);
+    rc = runner.copy_to_device(dev_a, host_a.data(), BYTES);
     if (rc != 0) {
         std::cerr << "Error: Failed to copy input a to device" << '\n';
-        runner.FreeTensor(dev_a);
-        runner.FreeTensor(dev_b);
-        runner.FreeTensor(dev_c);
-        runner.FreeTensor(dev_d);
-        runner.FreeTensor(dev_e);
-        runner.FreeTensor(dev_f);
+        runner.free_tensor(dev_a);
+        runner.free_tensor(dev_b);
+        runner.free_tensor(dev_c);
+        runner.free_tensor(dev_d);
+        runner.free_tensor(dev_e);
+        runner.free_tensor(dev_f);
         return rc;
     }
 
-    rc = runner.CopyToDevice(dev_b, host_b.data(), BYTES);
+    rc = runner.copy_to_device(dev_b, host_b.data(), BYTES);
     if (rc != 0) {
         std::cerr << "Error: Failed to copy input b to device" << '\n';
-        runner.FreeTensor(dev_a);
-        runner.FreeTensor(dev_b);
-        runner.FreeTensor(dev_c);
-        runner.FreeTensor(dev_d);
-        runner.FreeTensor(dev_e);
-        runner.FreeTensor(dev_f);
+        runner.free_tensor(dev_a);
+        runner.free_tensor(dev_b);
+        runner.free_tensor(dev_c);
+        runner.free_tensor(dev_d);
+        runner.free_tensor(dev_e);
+        runner.free_tensor(dev_f);
         return rc;
     }
 
     std::cout << "Initialized input tensors: a=2.0, b=3.0 (all elements)\n";
     std::cout << "Expected result: f = (2+3+1)*(2+3+2) = 6*7 = 42.0\n";
 
-    // Store tensor pointers for later use by ValidateRuntimeImpl
+    // Store tensor pointers for later use by validate_runtime_impl
     g_dev_a = dev_a;
     g_dev_b = dev_b;
     g_dev_c = dev_c;
@@ -187,14 +187,14 @@ int InitRuntimeImpl(Runtime* runtime) {
     return 0;
 }
 
-int ValidateRuntimeImpl(Runtime* runtime) {
+int validate_runtime_impl(Runtime* runtime) {
     if (runtime == nullptr) {
         std::cerr << "Error: Runtime pointer is null\n";
         return -1;
     }
 
     // Get DeviceRunner instance
-    DeviceRunner& runner = DeviceRunner::Get();
+    DeviceRunner& runner = DeviceRunner::get();
 
     // Use globally stored tensor pointers
     void* dev_a = g_dev_a;
@@ -207,22 +207,22 @@ int ValidateRuntimeImpl(Runtime* runtime) {
 
     constexpr int ROWS = 128;
     constexpr int COLS = 128;
-    constexpr int SIZE = ROWS * COLS;  // Must match InitRuntimeImpl
+    constexpr int SIZE = ROWS * COLS;  // Must match init_runtime_impl
 
     // =========================================================================
     // VALIDATE RESULTS - Retrieve and verify output
     // =========================================================================
     std::cout << "\n=== Validating Results ===" << '\n';
     std::vector<float> host_result(SIZE);
-    int rc = runner.CopyFromDevice(host_result.data(), dev_f, BYTES);
+    int rc = runner.copy_from_device(host_result.data(), dev_f, BYTES);
     if (rc != 0) {
         std::cerr << "Error: Failed to copy result from device: " << rc << '\n';
-        runner.FreeTensor(dev_a);
-        runner.FreeTensor(dev_b);
-        runner.FreeTensor(dev_c);
-        runner.FreeTensor(dev_d);
-        runner.FreeTensor(dev_e);
-        runner.FreeTensor(dev_f);
+        runner.free_tensor(dev_a);
+        runner.free_tensor(dev_b);
+        runner.free_tensor(dev_c);
+        runner.free_tensor(dev_d);
+        runner.free_tensor(dev_e);
+        runner.free_tensor(dev_f);
         return rc;
     }
 
@@ -255,16 +255,16 @@ int ValidateRuntimeImpl(Runtime* runtime) {
     }
 
     // Print handshake results
-    runner.PrintHandshakeResults(*runtime);
+    runner.print_handshake_results(*runtime);
 
     // Cleanup device tensors
     std::cout << "\n=== Cleaning Up ===" << '\n';
-    runner.FreeTensor(dev_a);
-    runner.FreeTensor(dev_b);
-    runner.FreeTensor(dev_c);
-    runner.FreeTensor(dev_d);
-    runner.FreeTensor(dev_e);
-    runner.FreeTensor(dev_f);
+    runner.free_tensor(dev_a);
+    runner.free_tensor(dev_b);
+    runner.free_tensor(dev_c);
+    runner.free_tensor(dev_d);
+    runner.free_tensor(dev_e);
+    runner.free_tensor(dev_f);
     std::cout << "Freed all device tensors\n";
 
     // Note: Runtime destructor is called by FinalizeRuntime() after this

--- a/src/runtime/runtime/runtime.cpp
+++ b/src/runtime/runtime/runtime.cpp
@@ -17,7 +17,7 @@ Runtime::Runtime() {
         tasks[i].task_id = 0;
         tasks[i].func_id = 0;
         tasks[i].num_args = 0;
-        tasks[i].functionBinAddr = 0;
+        tasks[i].function_bin_addr = 0;
         tasks[i].core_type = 0;
         tasks[i].fanin = 0;
         tasks[i].fanout_count = 0;
@@ -30,7 +30,7 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     block_dim = 0;
-    scheCpuNum = 1;
+    sche_cpu_num = 1;
 }
 
 // =============================================================================
@@ -60,8 +60,8 @@ int Runtime::add_task(uint64_t* args, int num_args, int func_id, int core_type) 
     if (args && num_args > 0) {
         memcpy(task->args, args, num_args * sizeof(uint64_t));
     }
-    task->functionBinAddr = 0;    // Will be set by host before copying to device
-    task->core_type = core_type;  // Set core type (0=AIC, 1=AIV)
+    task->function_bin_addr = 0;    // Will be set by host before copying to device
+    task->core_type = core_type;    // Set core type (0=AIC, 1=AIV)
     task->fanin = 0;
     task->fanout_count = 0;
     memset(task->fanout, 0, sizeof(task->fanout));

--- a/src/runtime/runtime/runtime.h
+++ b/src/runtime/runtime/runtime.h
@@ -117,8 +117,8 @@ typedef struct {
 
     // Runtime function pointer address (NEW)
     // This is the GM address where the kernel binary resides
-    // It's cast to a function pointer at runtime: (KernelFunc)functionBinAddr
-    uint64_t functionBinAddr;  // Address of kernel in device GM memory
+    // It's cast to a function pointer at runtime: (KernelFunc)function_bin_addr
+    uint64_t function_bin_addr;  // Address of kernel in device GM memory
 
     // Core type specification (NEW)
     // Specifies which core type this task should run on: 0=AIC, 1=AIV
@@ -154,8 +154,8 @@ public:
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int block_dim;   // Number of AIC blocks (block dimension)
-    int scheCpuNum;  // Number of AICPU threads for scheduling
+    int block_dim;     // Number of AIC blocks (block dimension)
+    int sche_cpu_num;  // Number of AICPU threads for scheduling
 
 private:
     // Task storage


### PR DESCRIPTION
Normalize naming convention across the codebase to follow snake_case standard for all variables, function parameters, and function names.

Changes:
- Runtime struct: functionBinAddr → function_bin_addr, scheCpuNum → sche_cpu_num
- DeviceRunner: blockDim_ → block_dim_, deviceId_ → device_id_, etc.
- Method parameters: Converted CamelCase to snake_case (e.g., hostDeviceArgs → host_device_args)
- Local variables: Converted CamelCase to snake_case
- Comments: Updated references to use new snake_case names
- DeviceArgs struct: aicpuSoBin → aicpu_so_bin, aicpuSoLen → aicpu_so_len
- KernelArgs struct: deviceArgs → device_args

Affected files:
- src/runtime/runtime/runtime.h (.2 fields)
- src/runtime/runtime/runtime.cpp (3 usages)
- src/platform/a2a3/common/kernel_args.h (1 field)
- src/platform/a2a3/host/devicerunner.h (19 parameters + 10 members)
- src/platform/a2a3/host/devicerunner.cpp (20 usages)
- src/platform/a2a3/host/memoryallocator.cpp (1 variable)
- src/platform/a2a3/host/pto_runtime_c_api.cpp (2 variables)
- src/runtime/aicore/aicore_executor.cpp (5 usages in comments/code)
- src/runtime/aicpu/aicpu_executor.cpp (2 usages)

Total changes: 45 identifiers across 9 files