### PR TITLE
Fix: Add task_status check to prevent duplicate task execution

### DIFF
--- a/src/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -67,7 +67,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
         }
 
         // Execute task if assigned (task != 0 means valid Task* pointer)
-        if (my_hank->task != 0) {
+        if (my_hank->task_status == 1 && my_hank->task != 0) {
             __gm__ Task* task_ptr = reinterpret_cast<__gm__ Task*>(my_hank->task);
             execute_task(task_ptr);
             // Mark task as complete (task_status: 0=idle, 1=busy)


### PR DESCRIPTION
Add task_status verification before executing tasks in aicore_executor. This check was lost during a previous rebase and could cause tasks to be executed multiple times.