### PR TITLE
Fix: Add macOS compatibility for a2a3sim platform

### DIFF
--- a/python/elf_parser.py
+++ b/python/elf_parser.py
@@ -1,7 +1,7 @@
 """
-ELF64 Parser for AICore Kernel Binaries
+Object File Parser for AICore Kernel Binaries
 
-Pure Python implementation for extracting .text section from ELF64 .o files.
+Pure Python implementation for extracting .text section from ELF64 or Mach-O .o files.
 Based on the C++ implementation in binary_loader.cpp.
 """
 
@@ -16,79 +16,63 @@ ELFMAG1 = ord('E')
 ELFMAG2 = ord('L')
 ELFMAG3 = ord('F')
 
+# Mach-O Magic Numbers
+MH_MAGIC_64 = 0xFEEDFACF
 
-def extract_text_section(elf_input: Union[str, Path, bytes]) -> bytes:
+# Mach-O Load Command types
+LC_SEGMENT_64 = 0x19
+
+
+def extract_text_section(obj_input: Union[str, Path, bytes]) -> bytes:
     """
-    Extract .text section from an ELF64 .o file.
+    Extract .text section from an ELF64 or Mach-O .o file.
 
     Args:
-        elf_input: Either a path to the ELF .o file (str/Path) or the ELF binary data (bytes)
+        obj_input: Either a path to the .o file (str/Path) or the binary data (bytes)
 
     Returns:
         Binary data of the .text section
 
     Raises:
         FileNotFoundError: If file path is provided and does not exist
-        ValueError: If data is not a valid ELF or .text section not found
+        ValueError: If data is not a valid object file or .text section not found
     """
     # Handle input: either path or bytes
-    if isinstance(elf_input, bytes):
-        elf_data = elf_input
+    if isinstance(obj_input, bytes):
+        obj_data = obj_input
         source_name = "<bytes>"
     else:
-        path = Path(elf_input)
+        path = Path(obj_input)
         if not path.exists():
-            raise FileNotFoundError(f"ELF file not found: {elf_input}")
-        with open(elf_input, 'rb') as f:
-            elf_data = f.read()
-        source_name = str(elf_input)
+            raise FileNotFoundError(f"Object file not found: {obj_input}")
+        with open(obj_input, 'rb') as f:
+            obj_data = f.read()
+        source_name = str(obj_input)
 
+    if len(obj_data) < 4:
+        raise ValueError(f"Data too small to be a valid object file: {source_name}")
+
+    # Detect format by magic number
+    magic32 = struct.unpack('<I', obj_data[:4])[0]
+    if magic32 == MH_MAGIC_64:
+        return _extract_text_macho64(obj_data, source_name)
+
+    if (obj_data[0] == ELFMAG0 and obj_data[1] == ELFMAG1 and
+        obj_data[2] == ELFMAG2 and obj_data[3] == ELFMAG3):
+        return _extract_text_elf64(obj_data, source_name)
+
+    raise ValueError(f"Not a valid ELF or Mach-O file: {source_name}")
+
+
+def _extract_text_elf64(elf_data: bytes, source_name: str) -> bytes:
+    """Extract .text section from ELF64 data."""
     if len(elf_data) < 64:
         raise ValueError(f"Data too small to be a valid ELF: {source_name}")
 
-    # Step 1: Parse ELF64 Header (64 bytes)
-    # Reference: https://en.wikipedia.org/wiki/Executable_and_Linkable_Format
-    # Elf64_Ehdr structure:
-    #   e_ident[16]     - Magic number and file class
-    #   e_type          - Object file type (2 bytes)
-    #   e_machine       - Architecture (2 bytes)
-    #   e_version       - Version (4 bytes)
-    #   e_entry         - Entry point (8 bytes)
-    #   e_phoff         - Program header offset (8 bytes)
-    #   e_shoff         - Section header offset (8 bytes) <-- at offset 40
-    #   e_flags         - Flags (4 bytes)
-    #   e_ehsize        - ELF header size (2 bytes)
-    #   e_phentsize     - Program header entry size (2 bytes)
-    #   e_phnum         - Program header count (2 bytes)
-    #   e_shentsize     - Section header entry size (2 bytes)
-    #   e_shnum         - Section header count (2 bytes) <-- at offset 60
-    #   e_shstrndx      - String table index (2 bytes) <-- at offset 62
-
-    # Verify ELF magic number
-    if (elf_data[0] != ELFMAG0 or
-        elf_data[1] != ELFMAG1 or
-        elf_data[2] != ELFMAG2 or
-        elf_data[3] != ELFMAG3):
-        raise ValueError(f"Not a valid ELF file: {source_name}")
-
     # Extract section header table info from ELF header
-    # Use little-endian ('<') format
-    e_shoff = struct.unpack('<Q', elf_data[40:48])[0]      # Section header offset
-    e_shnum = struct.unpack('<H', elf_data[60:62])[0]      # Section header count
-    e_shstrndx = struct.unpack('<H', elf_data[62:64])[0]   # String table index
-
-    # Step 2: Parse Section Headers
-    # Each Elf64_Shdr is 64 bytes:
-    #   sh_name      - Section name offset (4 bytes)
-    #   sh_type      - Section type (4 bytes)
-    #   sh_flags     - Section flags (8 bytes)
-    #   sh_addr      - Section address (8 bytes)
-    #   sh_offset    - File offset (8 bytes) <-- at +24
-    #   sh_size      - Section size (8 bytes) <-- at +32
-    #   sh_link      - Link to another section (4 bytes)
-    #   sh_info      - Additional info (4 bytes)
-    #   sh_addralign - Alignment (8 bytes)
-    #   sh_entsize   - Entry size (8 bytes)
+    e_shoff = struct.unpack('<Q', elf_data[40:48])[0]
+    e_shnum = struct.unpack('<H', elf_data[60:62])[0]
+    e_shstrndx = struct.unpack('<H', elf_data[62:64])[0]
 
     # Get string table section header
     shstr_offset = e_shoff + e_shstrndx * 64
@@ -98,25 +82,62 @@ def extract_text_section(elf_input: Union[str, Path, bytes]) -> bytes:
     # Extract string table
     strtab = elf_data[shstr_sh_offset:shstr_sh_offset+shstr_sh_size]
 
-    # Step 3: Find .text section
+    # Find .text section
     for i in range(e_shnum):
         section_offset = e_shoff + i * 64
-
-        # Parse section header
         sh_name = struct.unpack('<I', elf_data[section_offset:section_offset+4])[0]
         sh_offset = struct.unpack('<Q', elf_data[section_offset+24:section_offset+32])[0]
         sh_size = struct.unpack('<Q', elf_data[section_offset+32:section_offset+40])[0]
 
-        # Get section name from string table
         section_name = _extract_cstring(strtab, sh_name)
-
         if section_name == '.text':
-            # Extract .text section binary data
             text_data = elf_data[sh_offset:sh_offset+sh_size]
             print(f"Loaded .text section from {source_name} (size: {sh_size} bytes)")
             return text_data
 
     raise ValueError(f".text section not found in: {source_name}")
+
+
+def _extract_text_macho64(data: bytes, source_name: str) -> bytes:
+    """Extract __text section from Mach-O 64-bit data."""
+    # Mach-O 64-bit header: magic(4) + cputype(4) + cpusubtype(4) + filetype(4)
+    #                        + ncmds(4) + sizeofcmds(4) + flags(4) + reserved(4) = 32 bytes
+    if len(data) < 32:
+        raise ValueError(f"Data too small to be a valid Mach-O: {source_name}")
+
+    ncmds = struct.unpack('<I', data[16:20])[0]
+
+    # Walk load commands starting at offset 32
+    offset = 32
+    for _ in range(ncmds):
+        if offset + 8 > len(data):
+            break
+        cmd = struct.unpack('<I', data[offset:offset+4])[0]
+        cmdsize = struct.unpack('<I', data[offset+4:offset+8])[0]
+
+        if cmd == LC_SEGMENT_64:
+            # segment_command_64: cmd(4) + cmdsize(4) + segname(16) + vmaddr(8)
+            #   + vmsize(8) + fileoff(8) + filesize(8) + maxprot(4) + initprot(4)
+            #   + nsects(4) + flags(4) = 72 bytes header
+            nsects = struct.unpack('<I', data[offset+64:offset+68])[0]
+
+            # Sections start at offset+72, each section_64 is 80 bytes:
+            # sectname(16) + segname(16) + addr(8) + size(8) + offset(4) + align(4)
+            # + reloff(4) + nreloc(4) + flags(4) + reserved1(4) + reserved2(4) + reserved3(4)
+            sect_base = offset + 72
+            for s in range(nsects):
+                sect_off = sect_base + s * 80
+                sectname = data[sect_off:sect_off+16].split(b'\x00')[0].decode('ascii')
+                if sectname == '__text':
+                    s_size = struct.unpack('<Q', data[sect_off+40:sect_off+48])[0]
+                    s_offset = struct.unpack('<I', data[sect_off+48:sect_off+52])[0]
+                    text_data = data[s_offset:s_offset+s_size]
+                    print(f"Loaded __text section from {source_name} (size: {s_size} bytes)")
+                    return text_data
+
+        offset += cmdsize
+
+    raise ValueError(f"__text section not found in: {source_name}")
 
 
 def _extract_cstring(data: bytes, offset: int) -> str:

--- a/python/pto_compiler.py
+++ b/python/pto_compiler.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import List, Optional
@@ -261,6 +262,11 @@ class PTOCompiler:
             "-O3", "-g",
             "-std=c++17",
         ]
+
+        # On macOS, allow undefined symbols to be resolved at dlopen time
+        if sys.platform == "darwin":
+            cmd.append("-undefined")
+            cmd.append("dynamic_lookup")
 
         # Add include dirs
         if extra_include_dirs:

--- a/src/platform/a2a3sim/aicore/CMakeLists.txt
+++ b/src/platform/a2a3sim/aicore/CMakeLists.txt
@@ -58,4 +58,9 @@ target_include_directories(aicore_kernel
         ${CMAKE_CUSTOM_INCLUDE_DIRS}
 )
 
-set_target_properties(aicore_kernel PROPERTIES OUTPUT_NAME "aicore_kernel")
+set_target_properties(aicore_kernel PROPERTIES
+    OUTPUT_NAME "aicore_kernel"
+    # Force .so suffix on all platforms (macOS defaults to .dylib)
+    # This matches the hardcoded paths in Python/C++ code
+    SUFFIX ".so"
+)

--- a/src/platform/a2a3sim/aicpu/CMakeLists.txt
+++ b/src/platform/a2a3sim/aicpu/CMakeLists.txt
@@ -60,4 +60,9 @@ target_link_libraries(aicpu_kernel
         pthread
 )
 
-set_target_properties(aicpu_kernel PROPERTIES OUTPUT_NAME "aicpu_kernel")
+set_target_properties(aicpu_kernel PROPERTIES
+    OUTPUT_NAME "aicpu_kernel"
+    # Force .so suffix on all platforms (macOS defaults to .dylib)
+    # This matches the hardcoded paths in Python/C++ code
+    SUFFIX ".so"
+)

--- a/src/platform/a2a3sim/host/CMakeLists.txt
+++ b/src/platform/a2a3sim/host/CMakeLists.txt
@@ -67,4 +67,9 @@ target_link_libraries(host_runtime
         dl
 )
 
-set_target_properties(host_runtime PROPERTIES OUTPUT_NAME "host_runtime")
+set_target_properties(host_runtime PROPERTIES
+    OUTPUT_NAME "host_runtime"
+    # Force .so suffix on all platforms (macOS defaults to .dylib)
+    # This matches the hardcoded paths in Python/C++ code
+    SUFFIX ".so"
+)

--- a/src/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -47,6 +47,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
 }
 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, int core_type) {
+    (void)core_type;
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal


### PR DESCRIPTION
- Force .so suffix in CMake for a2a3sim targets (macOS defaults to .dylib)
- Replace Linux-only memfd_create with cross-platform temp file approach
- Add Mach-O object file parsing support in elf_parser.py
- Add -undefined dynamic_lookup flag for orchestration SO on macOS
- Add MAP_JIT and W^X memory handling for Apple Silicon executable memory
- Fix unused variable warning in aicore_executor.cpp