### PR TITLE
Refactor: Decouple Platform and Runtime via Core Topology and Compile…

### DIFF
--- a/src/platform/a2a3/aicpu/CMakeLists.txt
+++ b/src/platform/a2a3/aicpu/CMakeLists.txt
@@ -49,6 +49,15 @@ target_compile_options(aicpu_kernel
         -g
 )
 
+# Add platform-specific compile definitions
+target_compile_definitions(aicpu_kernel
+    PRIVATE
+        PLATFORM_MAX_AICPU_THREADS=4
+        PLATFORM_MAX_AIC_PER_THREAD=24
+        PLATFORM_MAX_AIV_PER_THREAD=48
+        PLATFORM_MAX_CORES_PER_THREAD=72
+)
+
 target_include_directories(aicpu_kernel
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/platform/a2a3/host/CMakeLists.txt
+++ b/src/platform/a2a3/host/CMakeLists.txt
@@ -23,6 +23,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/device_runner.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/memory_allocator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/pto_runtime_c_api.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform_config.cpp"
 )
 if(DEFINED CUSTOM_SOURCE_DIRS)
     foreach(SRC_DIR ${CUSTOM_SOURCE_DIRS})
@@ -45,6 +46,15 @@ target_compile_options(host_runtime
         -fPIC
         -O3
         -g
+)
+
+# Add platform-specific compile definitions
+target_compile_definitions(host_runtime
+    PRIVATE
+        PLATFORM_MAX_AICPU_THREADS=4
+        PLATFORM_MAX_AIC_PER_THREAD=24
+        PLATFORM_MAX_AIV_PER_THREAD=48
+        PLATFORM_MAX_CORES_PER_THREAD=72
 )
 
 # Include directories - always include local headers

--- a/src/platform/a2a3/host/device_runner.cpp
+++ b/src/platform/a2a3/host/device_runner.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <vector>
 
+#include "platform_config.h"
 #include "runtime.h"
 
 // =============================================================================
@@ -253,29 +254,38 @@ int DeviceRunner::run(Runtime& runtime,
     // Calculate execution parameters
     block_dim_ = block_dim;
 
-    int num_ai_core = block_dim * cores_per_blockdim_;
-    // Initialize handshake buffers in runtime
-    if (num_ai_core > RUNTIME_MAX_WORKER) {
-        std::cerr << "Error: block_dim (" << block_dim << ") exceeds RUNTIME_MAX_WORKER (" << RUNTIME_MAX_WORKER << ")\n";
+    // Initialize platform-specific core topology (NEW)
+    rc = init_runtime_core_topology(&runtime, block_dim);
+    if (rc != 0) {
+        std::cerr << "Error: init_runtime_core_topology failed: " << rc << '\n';
+        return rc;
+    }
+
+    // Use core topology to initialize runtime parameters (NEW)
+    int aicore_num = runtime.core_topology.total_cores;
+    if (aicore_num > RUNTIME_MAX_WORKER) {
+        std::cerr << "Error: total cores (" << aicore_num << ") exceeds RUNTIME_MAX_WORKER (" << RUNTIME_MAX_WORKER << ")\n";
         return -1;
     }
 
-    runtime.worker_count = num_ai_core;
-    worker_count_ = num_ai_core;  // Store for print_handshake_results in destructor
-    runtime.block_dim = block_dim;
+    runtime.worker_count = aicore_num;
+    worker_count_ = aicore_num;  // Store for print_handshake_results in destructor
     runtime.sche_cpu_num = launch_aicpu_num;
 
-    // Calculate number of AIC cores (1/3 of total)
-    int num_aic = block_dim;  // Round up for 1/3
+    // Initialize handshake buffers using core topology (NEW)
+    for (int i = 0; i < aicore_num; i++) {
+        const CoreInfo* info = runtime.get_core_info(i);
+        if (info == nullptr) {
+            std::cerr << "Error: Failed to get core info for core " << i << '\n';
+            return -1;
+        }
 
-    for (int i = 0; i < num_ai_core; i++) {
         runtime.workers[i].aicpu_ready = 0;
         runtime.workers[i].aicore_done = 0;
         runtime.workers[i].control = 0;
         runtime.workers[i].task = 0;
         runtime.workers[i].task_status = 0;
-        // Set core type: first 1/3 are AIC (0), remaining 2/3 are AIV (1)
-        runtime.workers[i].core_type = (i < num_aic) ? 0 : 1;
+        runtime.workers[i].core_type = info->core_type;  // Use topology info
     }
 
     // Set function_bin_addr for all tasks (NEW - Runtime function pointer

--- a/src/platform/a2a3/host/device_runner.h
+++ b/src/platform/a2a3/host/device_runner.h
@@ -25,6 +25,7 @@
 #include "kernel_args.h"
 #include "memory_allocator.h"
 #include "runtime.h"
+#include "platform_config.h"
 
 /**
  * DeviceArgs structure for AICPU device arguments

--- a/src/platform/a2a3/host/platform_config.cpp
+++ b/src/platform/a2a3/host/platform_config.cpp
@@ -1,0 +1,87 @@
+/**
+ * Platform Configuration Implementation - a2a3 Platform
+ *
+ * This file implements platform-specific runtime configuration functions
+ * for the a2a3 platform, specifically the core topology initialization.
+ */
+
+#include "platform_config.h"
+#include "runtime.h"
+#include <iostream>
+
+/**
+ * Initialize core topology for a2a3 platform
+ *
+ * a2a3 topology characteristics:
+ * - Each block has 3 cores: 1 AIC + 2 AIV
+ * - Total cores = block_dim * 3
+ * - AIC cores are indexed [0, block_dim)
+ * - AIV cores are indexed [block_dim, block_dim + 2*block_dim)
+ * - block_idx mapping:
+ *   - AIC core i: block_idx = i (direct mapping)
+ *   - AIV core at position (block_dim + 2*b + offset): block_idx = b
+ *     where offset is 0 or 1 for the two AIV cores in block b
+ *
+ * This mapping must match the platform kernel's block_idx calculation:
+ * - AICore kernel (kernel.cpp): block_idx = get_block_idx()
+ * - AIVector kernel (kernel.cpp): block_idx = get_block_idx() * get_subblockdim() + get_subblockid() + get_block_num()
+ */
+extern "C" int init_runtime_core_topology(Runtime* runtime, int block_dim) {
+    if (runtime == nullptr) {
+        std::cerr << "Error: Runtime pointer is null\n";
+        return -1;
+    }
+
+    if (block_dim <= 0) {
+        std::cerr << "Error: Invalid block_dim: " << block_dim << "\n";
+        return -1;
+    }
+
+    // Calculate core counts
+    int num_aic = block_dim;           // 1 AIC per block
+    int num_aiv = block_dim * 2;       // 2 AIV per block
+    int total_cores = num_aic + num_aiv;
+
+    if (total_cores > RUNTIME_MAX_WORKER) {
+        std::cerr << "Error: Total cores (" << total_cores
+                  << ") exceeds RUNTIME_MAX_WORKER (" << RUNTIME_MAX_WORKER << ")\n";
+        return -1;
+    }
+
+    // Initialize topology metadata
+    runtime->core_topology.total_cores = total_cores;
+
+    // Configure AIC cores: [0, block_dim)
+    // Each AIC core i belongs to block i
+    for (int i = 0; i < num_aic; i++) {
+        runtime->core_topology.cores[i].core_id = i;
+        runtime->core_topology.cores[i].block_idx = i;
+        runtime->core_topology.cores[i].core_type = 0;  // AIC
+    }
+
+    // Configure AIV cores: [block_dim, block_dim + 2*block_dim)
+    // For each block b:
+    //   - First AIV:  core_id = block_dim + 2*b,     block_idx = b
+    //   - Second AIV: core_id = block_dim + 2*b + 1, block_idx = b
+    for (int b = 0; b < block_dim; b++) {
+        int aiv_core_0 = num_aic + b * 2;      // First AIV of block b
+        int aiv_core_1 = num_aic + b * 2 + 1;  // Second AIV of block b
+
+        runtime->core_topology.cores[aiv_core_0].core_id = aiv_core_0;
+        runtime->core_topology.cores[aiv_core_0].block_idx = b;
+        runtime->core_topology.cores[aiv_core_0].core_type = 1;  // AIV
+
+        runtime->core_topology.cores[aiv_core_1].core_id = aiv_core_1;
+        runtime->core_topology.cores[aiv_core_1].block_idx = b;
+        runtime->core_topology.cores[aiv_core_1].core_type = 1;  // AIV
+    }
+
+    // Mark topology as initialized
+    runtime->core_topology.initialized = true;
+
+    std::cout << "Platform config: Initialized a2a3 core topology - "
+              << num_aic << " AIC + " << num_aiv << " AIV = "
+              << total_cores << " total cores\n";
+
+    return 0;
+}

--- a/src/platform/a2a3/host/platform_config.h
+++ b/src/platform/a2a3/host/platform_config.h
@@ -1,0 +1,67 @@
+/**
+ * Platform Configuration - a2a3 Platform
+ *
+ * This header declares platform-specific initialization functions
+ * for configuring the runtime with a2a3 platform characteristics.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Forward declaration
+class Runtime;
+
+// =============================================================================
+// Platform-specific execution configuration
+// =============================================================================
+
+/**
+ * Maximum number of AICPU threads for task scheduling
+ * a2a3 platform supports up to 4 AICPU threads
+ */
+#define PLATFORM_MAX_AICPU_THREADS 4
+
+/**
+ * Maximum number of AIC cores per AICPU thread
+ * a2a3 platform: each block has 1 AIC, max 24 blocks per thread
+ */
+#define PLATFORM_MAX_AIC_PER_THREAD 24
+
+/**
+ * Maximum number of AIV cores per AICPU thread
+ * a2a3 platform: each block has 2 AIV, max 24 blocks per thread = 48 AIV
+ */
+#define PLATFORM_MAX_AIV_PER_THREAD 48
+
+/**
+ * Maximum total cores (AIC + AIV) per AICPU thread
+ */
+#define PLATFORM_MAX_CORES_PER_THREAD (PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD)
+
+/**
+ * Initialize runtime core topology for a2a3 platform
+ *
+ * This function configures the core topology based on a2a3 platform
+ * characteristics:
+ * - Each block has 3 cores: 1 AIC + 2 AIV
+ * - AIC cores: [0, block_dim)
+ * - AIV cores: [block_dim, block_dim + 2*block_dim)
+ * - block_idx mapping:
+ *   - AIC core i: block_idx = i
+ *   - AIV core (block_dim + 2*b + offset): block_idx = b
+ *
+ * @param runtime   Pointer to Runtime to configure
+ * @param block_dim Number of blocks in the configuration
+ * @return 0 on success, negative on error
+ */
+int init_runtime_core_topology(Runtime* runtime, int block_dim);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // PLATFORM_CONFIG_H

--- a/src/platform/a2a3sim/aicpu/CMakeLists.txt
+++ b/src/platform/a2a3sim/aicpu/CMakeLists.txt
@@ -48,6 +48,15 @@ target_compile_options(aicpu_kernel
         -g
 )
 
+# Add platform-specific compile definitions
+target_compile_definitions(aicpu_kernel
+    PRIVATE
+        PLATFORM_MAX_AICPU_THREADS=4
+        PLATFORM_MAX_AIC_PER_THREAD=24
+        PLATFORM_MAX_AIV_PER_THREAD=48
+        PLATFORM_MAX_CORES_PER_THREAD=72
+)
+
 # Include directories
 target_include_directories(aicpu_kernel
     PRIVATE

--- a/src/platform/a2a3sim/host/CMakeLists.txt
+++ b/src/platform/a2a3sim/host/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/device_runner.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/memory_allocator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/pto_runtime_c_api.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/platform_config.cpp"
 )
 
 if(DEFINED CUSTOM_SOURCE_DIRS)
@@ -51,6 +52,15 @@ target_compile_options(host_runtime
         -fPIC
         -O3
         -g
+)
+
+# Add platform-specific compile definitions
+target_compile_definitions(host_runtime
+    PRIVATE
+        PLATFORM_MAX_AICPU_THREADS=4
+        PLATFORM_MAX_AIC_PER_THREAD=24
+        PLATFORM_MAX_AIV_PER_THREAD=48
+        PLATFORM_MAX_CORES_PER_THREAD=72
 )
 
 # Include directories

--- a/src/platform/a2a3sim/host/device_runner.cpp
+++ b/src/platform/a2a3sim/host/device_runner.cpp
@@ -16,6 +16,8 @@
 
 #include "device_runner.h"
 
+#include "platform_config.h"
+
 #include <cstdio>
 #include <cstring>
 #include <dlfcn.h>
@@ -168,7 +170,16 @@ int DeviceRunner::run(Runtime& runtime,
 
     // Calculate execution parameters
     block_dim_ = block_dim;
-    int num_cores = block_dim * cores_per_blockdim_;
+
+    // Initialize platform-specific core topology (NEW)
+    rc = init_runtime_core_topology(&runtime, block_dim);
+    if (rc != 0) {
+        std::cerr << "Error: init_runtime_core_topology failed: " << rc << '\n';
+        return rc;
+    }
+
+    // Use core topology to initialize runtime parameters (NEW)
+    int num_cores = runtime.core_topology.total_cores;
 
     if (num_cores > RUNTIME_MAX_WORKER) {
         std::cerr << "Error: num_cores (" << num_cores << ") exceeds RUNTIME_MAX_WORKER ("
@@ -179,20 +190,22 @@ int DeviceRunner::run(Runtime& runtime,
     // Initialize handshake buffers
     runtime.worker_count = num_cores;
     worker_count_ = num_cores;
-    runtime.block_dim = block_dim;
     runtime.sche_cpu_num = launch_aicpu_num;
 
-    // Calculate number of AIC cores
-    int num_aic = block_dim;
-
+    // Initialize handshake buffers using core topology (NEW)
     for (int i = 0; i < num_cores; i++) {
+        const CoreInfo* info = runtime.get_core_info(i);
+        if (info == nullptr) {
+            std::cerr << "Error: Failed to get core info for core " << i << '\n';
+            return -1;
+        }
+
         runtime.workers[i].aicpu_ready = 0;
         runtime.workers[i].aicore_done = 0;
         runtime.workers[i].control = 0;
         runtime.workers[i].task = 0;
         runtime.workers[i].task_status = 0;
-        // First 1/3 are AIC (0), remaining 2/3 are AIV (1)
-        runtime.workers[i].core_type = (i < num_aic) ? 0 : 1;
+        runtime.workers[i].core_type = info->core_type;  // Use topology info
     }
 
     // Set function_bin_addr for all tasks

--- a/src/platform/a2a3sim/host/device_runner.h
+++ b/src/platform/a2a3sim/host/device_runner.h
@@ -23,6 +23,7 @@
 #include "kernel_args.h"
 #include "memory_allocator.h"
 #include "runtime.h"
+#include "platform_config.h"
 
 /**
  * Mapped kernel binary in executable memory

--- a/src/platform/a2a3sim/host/platform_config.cpp
+++ b/src/platform/a2a3sim/host/platform_config.cpp
@@ -1,0 +1,87 @@
+/**
+ * Platform Configuration Implementation - a2a3 Platform
+ *
+ * This file implements platform-specific runtime configuration functions
+ * for the a2a3 platform, specifically the core topology initialization.
+ */
+
+#include "platform_config.h"
+#include "runtime.h"
+#include <iostream>
+
+/**
+ * Initialize core topology for a2a3 platform
+ *
+ * a2a3 topology characteristics:
+ * - Each block has 3 cores: 1 AIC + 2 AIV
+ * - Total cores = block_dim * 3
+ * - AIC cores are indexed [0, block_dim)
+ * - AIV cores are indexed [block_dim, block_dim + 2*block_dim)
+ * - block_idx mapping:
+ *   - AIC core i: block_idx = i (direct mapping)
+ *   - AIV core at position (block_dim + 2*b + offset): block_idx = b
+ *     where offset is 0 or 1 for the two AIV cores in block b
+ *
+ * This mapping must match the platform kernel's block_idx calculation:
+ * - AICore kernel (kernel.cpp): block_idx = get_block_idx()
+ * - AIVector kernel (kernel.cpp): block_idx = get_block_idx() * get_subblockdim() + get_subblockid() + get_block_num()
+ */
+extern "C" int init_runtime_core_topology(Runtime* runtime, int block_dim) {
+    if (runtime == nullptr) {
+        std::cerr << "Error: Runtime pointer is null\n";
+        return -1;
+    }
+
+    if (block_dim <= 0) {
+        std::cerr << "Error: Invalid block_dim: " << block_dim << "\n";
+        return -1;
+    }
+
+    // Calculate core counts
+    int num_aic = block_dim;           // 1 AIC per block
+    int num_aiv = block_dim * 2;       // 2 AIV per block
+    int total_cores = num_aic + num_aiv;
+
+    if (total_cores > RUNTIME_MAX_WORKER) {
+        std::cerr << "Error: Total cores (" << total_cores
+                  << ") exceeds RUNTIME_MAX_WORKER (" << RUNTIME_MAX_WORKER << ")\n";
+        return -1;
+    }
+
+    // Initialize topology metadata
+    runtime->core_topology.total_cores = total_cores;
+
+    // Configure AIC cores: [0, block_dim)
+    // Each AIC core i belongs to block i
+    for (int i = 0; i < num_aic; i++) {
+        runtime->core_topology.cores[i].core_id = i;
+        runtime->core_topology.cores[i].block_idx = i;
+        runtime->core_topology.cores[i].core_type = 0;  // AIC
+    }
+
+    // Configure AIV cores: [block_dim, block_dim + 2*block_dim)
+    // For each block b:
+    //   - First AIV:  core_id = block_dim + 2*b,     block_idx = b
+    //   - Second AIV: core_id = block_dim + 2*b + 1, block_idx = b
+    for (int b = 0; b < block_dim; b++) {
+        int aiv_core_0 = num_aic + b * 2;      // First AIV of block b
+        int aiv_core_1 = num_aic + b * 2 + 1;  // Second AIV of block b
+
+        runtime->core_topology.cores[aiv_core_0].core_id = aiv_core_0;
+        runtime->core_topology.cores[aiv_core_0].block_idx = b;
+        runtime->core_topology.cores[aiv_core_0].core_type = 1;  // AIV
+
+        runtime->core_topology.cores[aiv_core_1].core_id = aiv_core_1;
+        runtime->core_topology.cores[aiv_core_1].block_idx = b;
+        runtime->core_topology.cores[aiv_core_1].core_type = 1;  // AIV
+    }
+
+    // Mark topology as initialized
+    runtime->core_topology.initialized = true;
+
+    std::cout << "Platform config: Initialized a2a3 core topology - "
+              << num_aic << " AIC + " << num_aiv << " AIV = "
+              << total_cores << " total cores\n";
+
+    return 0;
+}

--- a/src/platform/a2a3sim/host/platform_config.h
+++ b/src/platform/a2a3sim/host/platform_config.h
@@ -1,0 +1,67 @@
+/**
+ * Platform Configuration - a2a3 Platform
+ *
+ * This header declares platform-specific initialization functions
+ * for configuring the runtime with a2a3 platform characteristics.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Forward declaration
+class Runtime;
+
+// =============================================================================
+// Platform-specific execution configuration
+// =============================================================================
+
+/**
+ * Maximum number of AICPU threads for task scheduling
+ * a2a3 platform supports up to 4 AICPU threads
+ */
+#define PLATFORM_MAX_AICPU_THREADS 4
+
+/**
+ * Maximum number of AIC cores per AICPU thread
+ * a2a3 platform: each block has 1 AIC, max 24 blocks per thread
+ */
+#define PLATFORM_MAX_AIC_PER_THREAD 24
+
+/**
+ * Maximum number of AIV cores per AICPU thread
+ * a2a3 platform: each block has 2 AIV, max 24 blocks per thread = 48 AIV
+ */
+#define PLATFORM_MAX_AIV_PER_THREAD 48
+
+/**
+ * Maximum total cores (AIC + AIV) per AICPU thread
+ */
+#define PLATFORM_MAX_CORES_PER_THREAD (PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD)
+
+/**
+ * Initialize runtime core topology for a2a3 platform
+ *
+ * This function configures the core topology based on a2a3 platform
+ * characteristics:
+ * - Each block has 3 cores: 1 AIC + 2 AIV
+ * - AIC cores: [0, block_dim)
+ * - AIV cores: [block_dim, block_dim + 2*block_dim)
+ * - block_idx mapping:
+ *   - AIC core i: block_idx = i
+ *   - AIV core (block_dim + 2*b + offset): block_idx = b
+ *
+ * @param runtime   Pointer to Runtime to configure
+ * @param block_dim Number of blocks in the configuration
+ * @return 0 on success, negative on error
+ */
+int init_runtime_core_topology(Runtime* runtime, int block_dim);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // PLATFORM_CONFIG_H

--- a/src/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -5,10 +5,13 @@
 #include "device_log.h"
 #include "runtime.h"
 
-constexpr int MAX_AICPU_THREADS = 4;
-constexpr int MAX_AIC_PER_THREAD = 24;
-constexpr int MAX_AIV_PER_THREAD = 48;
-constexpr int MAX_CORES_PER_THREAD = MAX_AIC_PER_THREAD + MAX_AIV_PER_THREAD;
+// Platform-specific constants are provided via CMake compile definitions
+// (PLATFORM_MAX_AICPU_THREADS, PLATFORM_MAX_AIC_PER_THREAD, etc.)
+// defined in src/platform/*/host/CMakeLists.txt
+constexpr int MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
+constexpr int MAX_AIC_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD;
+constexpr int MAX_AIV_PER_THREAD = PLATFORM_MAX_AIV_PER_THREAD;
+constexpr int MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 
 struct AicpuExecutor {
     // ===== Thread management state =====
@@ -20,7 +23,6 @@ struct AicpuExecutor {
 
     int thread_num_{0};
     int cores_total_num_{0};
-    int blockdim_cores_num_{3};
     int thread_cores_num_{0};
     int core_assignments_[MAX_AICPU_THREADS][MAX_CORES_PER_THREAD];
 
@@ -67,6 +69,13 @@ int AicpuExecutor::init(Runtime* runtime) {
         return -1;
     }
 
+    // Verify core topology has been initialized by platform
+    if (!runtime->core_topology.initialized) {
+        DEV_ERROR("Core topology not initialized by platform");
+        init_failed_.store(true, std::memory_order_release);
+        return -1;
+    }
+
     // Read execution parameters from runtime
     thread_num_ = runtime->sche_cpu_num;
     if (thread_num_ == 0) thread_num_ = 1;
@@ -77,7 +86,8 @@ int AicpuExecutor::init(Runtime* runtime) {
         return -1;
     }
 
-    cores_total_num_ = runtime->block_dim * blockdim_cores_num_;
+    // Use core topology instead of hardcoded calculation
+    cores_total_num_ = runtime->core_topology.total_cores;
     thread_cores_num_ = cores_total_num_ / thread_num_;
 
     if (cores_total_num_ > MAX_CORES_PER_THREAD) {
@@ -88,52 +98,69 @@ int AicpuExecutor::init(Runtime* runtime) {
 
     DEV_INFO("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num_);
 
-    // Pre-compute core assignments for each thread
-    // Each thread manages blocks_per_thread blocks
-    // For each block b: AIC is core b, AIVs are cores (nrAic + b*2) and (nrAic
-    // + b*2 + 1)
-    int num_aic = runtime->block_dim;  // Total AIC cores (= block_dim)
-    int blocks_per_thread = runtime->block_dim / thread_num_;
+    // Infer block information from core topology
+    // Find the maximum block_idx to determine number of blocks
+    int num_blocks = 0;
+    for (int i = 0; i < cores_total_num_; i++) {
+        const CoreInfo* info = runtime->get_core_info(i);
+        if (info && info->block_idx + 1 > num_blocks) {
+            num_blocks = info->block_idx + 1;
+        }
+    }
 
-    // Validate block distribution
-    if (runtime->block_dim % thread_num_ != 0) {
-        DEV_ERROR("block_dim (%d) must be divisible by thread_num (%d)", runtime->block_dim, thread_num_);
+    // Calculate blocks per thread
+    int blocks_per_thread = num_blocks / thread_num_;
+    if (num_blocks % thread_num_ != 0) {
+        DEV_ERROR("Number of blocks (%d) must be divisible by thread_num (%d)", num_blocks, thread_num_);
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
 
     DEV_INFO("Block assignment: %d blocks, %d threads, %d blocks per thread",
-        runtime->block_dim,
+        num_blocks,
         thread_num_,
         blocks_per_thread);
 
+    // Assign cores to threads using platform-provided topology
+    // Maintain original allocation order: group by blocks, AIC first then AIV
     for (int t = 0; t < thread_num_; t++) {
         int start_block = t * blocks_per_thread;
         int end_block = (t + 1) * blocks_per_thread;
         int core_idx = 0;
 
-        // Assign AIC cores for all blocks managed by this thread
-        for (int b = start_block; b < end_block; b++) {
-            core_assignments_[t][core_idx++] = b;  // AIC core ID = block ID
+        int aic_start = -1, aic_end = -1;
+        int aiv_start = -1, aiv_end = -1;
+
+        // First, assign all AIC cores for this thread's blocks
+        for (int i = 0; i < cores_total_num_; i++) {
+            const CoreInfo* info = runtime->get_core_info(i);
+            if (info && info->core_type == 0 &&
+                info->block_idx >= start_block && info->block_idx < end_block) {
+                if (aic_start == -1) aic_start = info->core_id;
+                aic_end = info->core_id;
+                core_assignments_[t][core_idx++] = info->core_id;
+            }
         }
 
-        // Assign AIV cores for all blocks managed by this thread
-        for (int b = start_block; b < end_block; b++) {
-            int aiv_base = num_aic;                                   // AIV cores start after all AIC cores
-            core_assignments_[t][core_idx++] = aiv_base + b * 2;      // First AIV of block b
-            core_assignments_[t][core_idx++] = aiv_base + b * 2 + 1;  // Second AIV of block b
+        // Then, assign all AIV cores for this thread's blocks
+        for (int i = 0; i < cores_total_num_; i++) {
+            const CoreInfo* info = runtime->get_core_info(i);
+            if (info && info->core_type == 1 &&
+                info->block_idx >= start_block && info->block_idx < end_block) {
+                if (aiv_start == -1) aiv_start = info->core_id;
+                aiv_end = info->core_id;
+                core_assignments_[t][core_idx++] = info->core_id;
+            }
         }
 
         DEV_INFO(
-            "Thread %d: manages blockDims [%d-%d], cores: AIC[%d-%d] "
-            "AIV[%d-%d]",
+            "Thread %d: manages cores: AIC[%d-%d] AIV[%d-%d], total %d cores",
             t,
-            start_block,
-            end_block - 1,
-            start_block,
-            end_block - 1,
-            num_aic + start_block * 2,
-            num_aic + (end_block - 1) * 2 + 1);
+            aic_start,
+            aic_end,
+            aiv_start,
+            aiv_end,
+            core_idx);
     }
 
     // Initialize runtime execution state

--- a/src/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/runtime/host_build_graph/runtime/runtime.cpp
@@ -32,7 +32,6 @@ Runtime::Runtime() {
     next_task_id = 0;
     initial_ready_count = 0;
     worker_count = 0;
-    block_dim = 0;
     sche_cpu_num = 1;
     tensor_pair_count = 0;
 }

--- a/src/runtime/host_build_graph/runtime/runtime.h
+++ b/src/runtime/host_build_graph/runtime/runtime.h
@@ -108,6 +108,35 @@ enum class CoreType : int {
 };
 
 /**
+ * Core Information - Platform-agnostic core descriptor
+ *
+ * This structure describes a single core's properties without encoding
+ * platform-specific mapping logic. Platform code is responsible for
+ * populating these structures, while runtime code uses them.
+ */
+struct CoreInfo {
+    int core_id;      // Logical core ID (index into Handshake buffer)
+    int block_idx;    // Block index for this core (platform-specific mapping)
+    int core_type;    // Core type: 0=AIC, 1=AIV
+};
+
+/**
+ * Core Topology - Platform-provided core mapping
+ *
+ * This structure contains the complete core topology for the current
+ * platform configuration. The platform must initialize this before
+ * runtime execution begins. This allows the runtime to remain completely
+ * platform-agnostic while still handling diverse core configurations.
+ */
+struct CoreTopology {
+    int total_cores;                    // Total number of cores
+    CoreInfo cores[RUNTIME_MAX_WORKER]; // Per-core information
+    bool initialized;                   // Has topology been set?
+
+    CoreTopology() : total_cores(0), initialized(false) {}
+};
+
+/**
  * Tensor pair for tracking host-device memory mappings.
  * Used for copy-back during finalize.
  */
@@ -179,8 +208,11 @@ public:
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int block_dim;     // Number of AIC blocks (block dimension)
     int sche_cpu_num;  // Number of AICPU threads for scheduling
+
+    // Platform-provided core topology (NEW)
+    // The platform must initialize this before runtime execution
+    CoreTopology core_topology;
 
 private:
     // Task storage
@@ -245,6 +277,23 @@ public:
      * @return Total task count
      */
     int get_task_count() const;
+
+    /**
+     * Query core information by core ID (used by runtime executor)
+     *
+     * This method provides platform-agnostic access to core properties.
+     * The runtime executor uses this to determine core assignments without
+     * needing to know platform-specific mapping logic.
+     *
+     * @param core_id  Core ID to query (index into Handshake buffer)
+     * @return Pointer to CoreInfo, or nullptr if invalid or not initialized
+     */
+    const CoreInfo* get_core_info(int core_id) const {
+        if (!core_topology.initialized || core_id < 0 || core_id >= core_topology.total_cores) {
+            return nullptr;
+        }
+        return &core_topology.cores[core_id];
+    }
 
     /**
      * Get initially ready tasks (fanin == 0) as entry point for execution


### PR DESCRIPTION
…-Time Configuration

## Problem
Runtime had tight coupling with Platform in two aspects:
1. Core mapping logic: Runtime hardcoded platform-specific block_idx calculations
   - AicpuExecutor contained platform knowledge (blockdim_cores_num_)
   - Runtime::block_dim field exposed platform concept to scheduler
2. Platform constants: Runtime hardcoded platform-specific execution limits
   - MAX_AICPU_THREADS, MAX_AIC_PER_THREAD, MAX_AIV_PER_THREAD
   - Different platforms require recompiling Runtime code

## Solution
1. Core Topology Abstraction (Runtime):
   - Add CoreInfo/CoreTopology structures to Runtime (data only)
   - Platform implements init_runtime_core_topology() with mapping logic
   - Runtime queries topology via get_core_info() (platform-agnostic)
   - Remove Runtime::block_dim and blockdim_cores_num_ fields

2. Compile-Time Platform Configuration (Build System):
   - Define PLATFORM_MAX_* constants in platform_config.h (documentation)
   - Pass constants via CMake target_compile_definitions in each platform
   - AicpuExecutor uses compile-time macros without including platform headers
   - Zero runtime overhead, complete layer separation

## Result
Clean separation of concerns:
- Runtime has zero knowledge of platform-specific concepts (block_dim/block_idx)
- Platform-specific logic isolated in platform_config.cpp and CMakeLists.txt
- New platforms only implement init_runtime_core_topology() + set CMake defines
- No header dependency from Runtime to Platform layer