### PR TITLE
Add: PTO ISA kernel support for simulation platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Clone pto-isa headers
+        run: |
+          git clone --depth 1 --branch ci_simpler \
+            https://gitcode.com/zhangqi-chen/pto-isa.git \
+            third_party/pto-isa
+
+      - name: Install g++-15 (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-15 || sudo apt-get install -y g++
+          if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
+
+      - name: Install g++-15 (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install gcc@15 || brew install gcc
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -24,4 +42,6 @@ jobs:
         run: pip install numpy
 
       - name: Run simulation example
+        env:
+          PTO_ISA_ROOT: ${{ github.workspace }}/third_party/pto-isa
         run: python examples/scripts/run_example.py -k examples/host_build_graph_sim_example/kernels -g examples/host_build_graph_sim_example/golden.py -p a2a3sim

--- a/examples/host_build_graph_sim_example/kernels/aiv/kernel_add.cpp
+++ b/examples/host_build_graph_sim_example/kernels/aiv/kernel_add.cpp
@@ -1,30 +1,73 @@
 /**
- * Element-wise Tensor Addition Kernel (Simulation)
+ * Element-wise Tensor Addition Kernel
  *
  * Implements: out[i] = src0[i] + src1[i]
  *
- * This is a simple loop-based implementation for simulation.
- * The real a2a3 version uses PTO tile-based operations.
+ * This kernel performs element-wise addition of two tensors. It's compiled
+ * separately as a standalone kernel and linked with the dispatcher using
+ * function pointers, demonstrating the separation pattern used in production
+ * systems where kernel binaries are loaded dynamically.
  */
 
 #include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
 
 /**
  * Element-wise addition kernel implementation
  *
+ * Unified signature: all arguments passed via int64_t array
  * @param args  Argument array:
  *              args[0] = src0 pointer (first input tensor)
  *              args[1] = src1 pointer (second input tensor)
  *              args[2] = out pointer (output tensor)
  *              args[3] = size (number of elements)
  */
-extern "C" void kernel_add(int64_t* args) {
-    float* src0 = reinterpret_cast<float*>(args[0]);
-    float* src1 = reinterpret_cast<float*>(args[1]);
-    float* out = reinterpret_cast<float*>(args[2]);
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_add(__gm__ int64_t* args) {
+    // Unpack arguments (order matches runtimemaker.cpp)
+    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(args[0]);
+    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(args[1]);
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(args[2]);
     int size = static_cast<int>(args[3]);
 
-    for (int i = 0; i < size; i++) {
-        out[i] = src0[i] + src1[i];
-    }
+    // Configuration: float, 128, 128, 128, 128
+    constexpr int kTRows_ = 128;
+    constexpr int kTCols_ = 128;
+    constexpr int vRows = 128;
+    constexpr int vCols = 128;
+
+    using DynShapeDim5 = Shape<1, 1, 1, vRows, vCols>;
+    using DynStridDim5 = Stride<1, 1, 1, kTCols_, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
+
+    TileData src0Tile(vRows, vCols);
+    TileData src1Tile(vRows, vCols);
+    TileData dstTile(vRows, vCols);
+    TASSIGN(src0Tile, 0x0);
+    TASSIGN(src1Tile, 0x10000);
+    TASSIGN(dstTile, 0x20000);
+
+    GlobalData src0Global(src0);
+    GlobalData src1Global(src1);
+    GlobalData dstGlobal(out);
+
+    TLOAD(src0Tile, src0Global);
+    TLOAD(src1Tile, src1Global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(dstTile, src0Tile, src1Tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, dstTile);
 }

--- a/examples/host_build_graph_sim_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/host_build_graph_sim_example/kernels/aiv/kernel_mul.cpp
@@ -1,29 +1,73 @@
 /**
- * Element-wise Tensor Multiplication Kernel (Simulation)
+ * Element-wise Tensor Multiplication Kernel
  *
  * Implements: out[i] = src0[i] * src1[i]
  *
- * This is a simple loop-based implementation for simulation.
+ * This kernel performs element-wise multiplication of two tensors. It's
+ * compiled separately as a standalone kernel and linked with the dispatcher
+ * using function pointers, demonstrating the separation pattern used in
+ * production systems where kernel binaries are loaded dynamically.
  */
 
 #include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
 
 /**
  * Element-wise multiplication kernel implementation
  *
+ * Unified signature: all arguments passed via int64_t array
  * @param args  Argument array:
  *              args[0] = src0 pointer (first input tensor)
  *              args[1] = src1 pointer (second input tensor)
  *              args[2] = out pointer (output tensor)
  *              args[3] = size (number of elements)
  */
-extern "C" void kernel_mul(int64_t* args) {
-    float* src0 = reinterpret_cast<float*>(args[0]);
-    float* src1 = reinterpret_cast<float*>(args[1]);
-    float* out = reinterpret_cast<float*>(args[2]);
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_mul(__gm__ int64_t* args) {
+    // Unpack arguments (order matches runtimemaker.cpp)
+    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(args[0]);
+    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(args[1]);
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(args[2]);
     int size = static_cast<int>(args[3]);
 
-    for (int i = 0; i < size; i++) {
-        out[i] = src0[i] * src1[i];
-    }
+    // Configuration: float, 128, 128, 128, 128
+    constexpr int kTRows_ = 128;
+    constexpr int kTCols_ = 128;
+    constexpr int vRows = 128;
+    constexpr int vCols = 128;
+
+    using DynShapeDim5 = Shape<1, 1, 1, vRows, vCols>;
+    using DynStridDim5 = Stride<1, 1, 1, kTCols_, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
+
+    TileData src0Tile(vRows, vCols);
+    TileData src1Tile(vRows, vCols);
+    TileData dstTile(vRows, vCols);
+    TASSIGN(src0Tile, 0x0);
+    TASSIGN(src1Tile, 0x10000);
+    TASSIGN(dstTile, 0x20000);
+
+    GlobalData src0Global(src0);
+    GlobalData src1Global(src1);
+    GlobalData dstGlobal(out);
+
+    TLOAD(src0Tile, src0Global);
+    TLOAD(src1Tile, src1Global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TMUL(dstTile, src0Tile, src1Tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, dstTile);
 }


### PR DESCRIPTION
Rewrite simulation kernels from simple for-loops to PTO ISA instructions (TLOAD, TADD, TADDS, TMUL, TSTORE). The -DPTO_CPU_TEXT_STANDALONE macro enables CPU simulation mode that eliminates external symbol dependencies (std::thread, std::vector, assert, memset) from the .text section.

Add func_offset parameter throughout register_kernel call stack to handle PTO ISA kernels where template helper functions are placed before the kernel entry point in .text section.