### PR TITLE
Fix: Update ci.sh to use new run_example.py entry point

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -3,5 +3,5 @@
 # run all tests
 pytest tests
 # run all examples
-python examples/host_build_graph_example/main.py
-python examples/host_build_graph_sim_example/main.py
+python examples/scripts/run_example.py -k examples/host_build_graph_example/kernels -g examples/host_build_graph_example/golden.py
+python examples/scripts/run_example.py -k examples/host_build_graph_sim_example/kernels -g examples/host_build_graph_sim_example/golden.py -p a2a3sim


### PR DESCRIPTION
The old main.py files no longer exist. Update example commands to use the unified run_example.py script with appropriate arguments.