### PR TITLE
Add: Paged Attention example with AIC/AIV subgraph split

### DIFF
--- a/examples/paged_attention/README.md
+++ b/examples/paged_attention/README.md
@@ -1,0 +1,234 @@
+# Paged Attention AIC/AIV 子图切分实现
+
+本样例展示了如何将 Paged Attention 算法按照计算特性手动切分为 AIC 和 AIV 子图，并在 a2a3sim 仿真平台上验证正确性。
+
+## 算法原理
+
+### Paged Attention
+
+Paged Attention 是一种用于 LLM 推理的高效 KV cache 管理机制，将 KV cache 组织为固定大小的 block（page），每个 block 包含 `block_size` 个 token 的 K 和 V。
+
+**输入：**
+
+- `query`: (batch, num_heads, head_dim) - 当前 query
+- `key_cache`: (total_blocks, block_size, kv_head_num, head_dim) - K cache
+- `value_cache`: (total_blocks, block_size, kv_head_num, head_dim) - V cache
+- `block_table`: (batch, block_num) - block 索引表
+- `context_lens`: (batch,) - 每个序列的有效长度
+
+**输出：**
+
+- `out`: (batch, num_heads, head_dim) - attention 结果
+
+### Online Softmax
+
+为避免一次性加载所有 KV 到内存，Paged Attention 采用 **Online Softmax** 算法，逐 block 计算并累积结果：
+
+```python
+for each block bn:
+    # Step 1: QK MatMul
+    sij = qi @ kj.T  # (q_tile_size, valid_len)
+    
+    # Step 2: Softmax 预处理
+    sij_scale = sij * scale_value
+    mij = rowmax(sij_scale)           # (q_tile_size,)
+    pij = exp(sij_scale - mij)        # (q_tile_size, valid_len)
+    lij = rowsum(pij)                 # (q_tile_size,)
+    
+    # Step 3: PV MatMul
+    oi_new = pij @ vj  # (q_tile_size, head_dim)
+    
+    # Step 4: Online 累积更新
+    if bn == 0:
+        mi, li, oi = mij, lij, oi_new
+    else:
+        mi_new = max(mi, mij)
+        alpha = exp(mi - mi_new)
+        beta = exp(mij - mi_new)
+        li = alpha * li + beta * lij
+        oi = alpha * oi + beta * oi_new
+        mi = mi_new
+    
+    # Step 5: 最终归一化（融合在最后一个 block 中）
+    if bn == last_block:
+        out = oi / li
+```
+
+## AIC/AIV 子图切分方案
+
+根据计算特性，将 Paged Attention 切分为 4 个 kernel（normalize 已融合进 online_update）：
+
+| Kernel | Core Type | 功能 | 输入 | 输出 |
+|--------|-----------|------|------|------|
+| `aic_qk_matmul` | AIC (Cube) | Q @ K^T 矩阵乘法 | qi, kj | sij |
+| `aiv_softmax_prepare` | AIV (Vector) | scale, rowmax, exp, rowsum | sij, scale | pij, mij, lij |
+| `aic_pv_matmul` | AIC (Cube) | P @ V 矩阵乘法 | pij, vj | oi_new |
+| `aiv_online_update` | AIV (Vector) | Online Softmax 累积 + 归一化 | mij, lij, oi_new, mi, li, oi, is_last | mi, li, oi, out |
+
+### Task Graph 结构
+
+对每个 (batch, head) 的计算流程：
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Block Loop                             │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  [AIC] QK MatMul: sij = qi @ kj^T                    │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                         ↓                                   │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  [AIV] Softmax Prepare: pij, mij, lij = f(sij)       │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                         ↓                                   │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  [AIC] PV MatMul: oi_new = pij @ vj                  │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                         ↓                                   │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  [AIV] Online Update: mi, li, oi = f(mij, lij, ...)  │   │
+│  │        (if is_last: out = oi / li)                   │   │
+│  └──────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Kernel 融合优化
+
+本实现将 `aiv_normalize` 融合进了 `aiv_online_update`：
+
+**原实现（5 个 kernel）：**
+```
+QK MatMul → Softmax Prepare → PV MatMul → Online Update → Normalize
+```
+
+**融合后（4 个 kernel）：**
+```
+QK MatMul → Softmax Prepare → PV MatMul → Online Update (+ Fused Normalize)
+```
+
+**优势：**
+- 减少 task 数量：每个 (batch, head) 少 1 个 normalize task
+- 避免额外的内存读写：`oi` 和 `li` 不需要再次从内存读取
+
+## Task Graph 并行化优化
+
+### 依赖分析
+
+```
+QK[bn] → SF[bn] → PV[bn] → UP[bn]
+```
+
+- QK → SF → PV：**不同 block 之间无依赖**，可以完全并行
+- UP：依赖上一轮的 UP 结果（Online Softmax 累加器），**必须串行**
+- 不同 (batch, head) 之间完全独立，可以并行
+
+### 并行化策略
+
+**串行版本（优化前）：**
+```
+Head 0: QK[0]→SF[0]→PV[0]→UP[0]→QK[1]→SF[1]→PV[1]→UP[1]→...
+Head 1: (等待 Head 0 全部完成)→QK[0]→SF[0]→PV[0]→UP[0]→...
+
+初始就绪任务：1
+```
+
+**全并行版本（优化后）：**
+```
+Head 0:  QK[0]→SF[0]→PV[0]─┬─→UP[0]
+         QK[1]→SF[1]→PV[1]─┼──────→UP[1]
+         QK[2]→SF[2]→PV[2]─┼─────────────→UP[2]
+         QK[3]→SF[3]→PV[3]─┴─────────────────────→UP[3]
+
+Head 1:  QK[0]→SF[0]→PV[0]─┬─→UP[0]                        (与 Head 0 并行!)
+         QK[1]→SF[1]→PV[1]─┼──────→UP[1]
+         ...
+
+初始就绪任务：32（= batch × num_heads × block_num = 2 × 4 × 4）
+```
+
+### Buffer 分配策略
+
+为实现 batch 间、head 间和 block 间的并行，中间 buffer 按以下方式分配：
+
+| Buffer | 分配粒度 | 索引方式 | 原因 |
+|--------|---------|---------|------|
+| sij, pij, mij, lij, oi_new | per-batch × per-head × per-block | `[(b*H+h)*B+bn]` | QK/SF/PV 跨 batch/head/block 并行 |
+| mi, li, oi | per-batch × per-head | `[b*H+h]` | UP 在 (batch,head) 内串行，跨 (batch,head) 并行 |
+
+## 目录结构
+
+```
+paged_attention_example/
+├── README.md                   # 说明文档
+├── main.py                     # 主程序入口
+├── golden.py                   # Python golden 参考实现
+├── gen_mermaid_graph.py        # Mermaid 依赖图生成脚本
+├── task_graph.md               # 完整 Task 依赖图
+├── task_graph_b0h0.md          # Batch 0, Head 0 的依赖图
+└── kernels/
+    ├── kernel_config.py
+    ├── aic/
+    │   ├── aic_qk_matmul.cpp
+    │   └── aic_pv_matmul.cpp
+    ├── aiv/
+    │   ├── aiv_softmax_prepare.cpp
+    │   └── aiv_online_update.cpp
+    └── orchestration/
+        └── paged_attention_orch.cpp
+```
+
+## 编译和运行
+
+```bash
+cd /data/w00949583/simpler/examples/paged_attention_example
+python3 main.py
+```
+
+### 生成依赖图
+
+```bash
+# 生成完整依赖图
+python3 gen_mermaid_graph.py --output task_graph.md
+
+# 生成单个 (batch, head) 的依赖图（更易读）
+python3 gen_mermaid_graph.py --batch 0 --head 0 --output task_graph_b0h0.md
+```
+
+## 测试结果
+
+```
+batch=2, num_heads=4, head_dim=128
+block_size=64, block_num=4
+
+Allocated 32 per-batch-per-head-per-block buffers
+Allocated 8 per-batch-per-head accumulators
+Created 128 tasks (full parallel)
+
+Initially ready tasks: AIC=32, AIV=0
+
+SUCCESS: All 1024 elements match within tolerance
+```
+
+## 关键技术点
+
+### 无外部库函数调用
+
+a2a3sim 从 `.o` 文件中直接提取 `.text` section 作为可执行代码，跳过了链接步骤。
+因此 kernel 代码不能调用任何标准库函数（如 `expf`, `memcpy`, `fmax`），否则会导致 bus error。
+
+### Fused Kernel 设计
+
+`aiv_online_update` 通过 `is_last` 参数判断是否执行归一化：
+
+```cpp
+if (is_last) {
+    for (int i = 0; i < q_tile; i++) {
+        float inv_li = 1.0f / li[i];
+        for (int j = 0; j < head_dim; j++)
+            dst[i * head_dim + j] = oi[i * head_dim + j] * inv_li;
+    }
+}
+```
+
+## License
+
+本示例代码仅供学习和研究使用。

--- a/examples/paged_attention/golden.py
+++ b/examples/paged_attention/golden.py
@@ -1,0 +1,171 @@
+"""
+Paged Attention Golden Implementation
+
+Implements the online softmax algorithm for paged attention computation.
+Used as reference for validation of the simulation results.
+"""
+
+import numpy as np
+
+
+def paged_attention_golden(
+    query: np.ndarray,      # (batch, num_heads, head_dim)
+    key_cache: np.ndarray,  # (total_blocks, block_size, kv_head_num, head_dim)
+    value_cache: np.ndarray,  # (total_blocks, block_size, kv_head_num, head_dim)
+    block_table: np.ndarray,  # (batch, block_num)
+    context_lens: np.ndarray,  # (batch,)
+    scale_value: float = 1.0,
+) -> np.ndarray:
+    """
+    Paged attention with online softmax.
+    
+    Returns:
+        out: (batch, num_heads, head_dim)
+    """
+    batch, num_heads, head_dim = query.shape
+    _, block_size, kv_head_num, _ = key_cache.shape
+    block_num = block_table.shape[1]
+    
+    # Number of query heads per KV head (for GQA)
+    heads_per_kv = num_heads // kv_head_num
+    
+    out = np.zeros((batch, num_heads, head_dim), dtype=np.float32)
+    
+    for b_idx in range(batch):
+        cur_seq = context_lens[b_idx]
+        bn_this_batch = (cur_seq + block_size - 1) // block_size
+        
+        for h_idx in range(num_heads):
+            # Get the corresponding KV head
+            kv_h_idx = h_idx // heads_per_kv
+            
+            # Query for this batch and head
+            qi = query[b_idx, h_idx, :]  # (head_dim,)
+            
+            # Initialize online softmax accumulators
+            mi = -np.inf  # max
+            li = 0.0      # sum
+            oi = np.zeros(head_dim, dtype=np.float32)  # output
+            
+            for bn in range(bn_this_batch):
+                cur_block_idx = block_table[b_idx, bn]
+                
+                # Get K and V for this block
+                # key_cache: (total_blocks, block_size, kv_head_num, head_dim)
+                kj = key_cache[cur_block_idx, :, kv_h_idx, :]  # (block_size, head_dim)
+                vj = value_cache[cur_block_idx, :, kv_h_idx, :]  # (block_size, head_dim)
+                
+                # Handle last block with partial tokens
+                if bn == bn_this_batch - 1:
+                    valid_tokens = cur_seq - bn * block_size
+                else:
+                    valid_tokens = block_size
+                
+                # QK matmul: qi @ kj.T -> (block_size,)
+                sij = qi @ kj.T  # (block_size,)
+                
+                # Apply scale
+                sij_scale = sij * scale_value
+                
+                # Mask invalid positions
+                if valid_tokens < block_size:
+                    sij_scale[valid_tokens:] = -np.inf
+                
+                # Row max
+                mij = np.max(sij_scale)
+                
+                # Exp and row sum
+                pij = np.exp(sij_scale - mij)
+                lij = np.sum(pij)
+                
+                # PV matmul: pij @ vj -> (head_dim,)
+                oi_new = pij @ vj  # (head_dim,)
+                
+                # Online softmax update
+                if bn == 0:
+                    mi = mij
+                    li = lij
+                    oi = oi_new
+                else:
+                    mi_new = max(mi, mij)
+                    alpha = np.exp(mi - mi_new)
+                    beta = np.exp(mij - mi_new)
+                    li = alpha * li + beta * lij
+                    oi = alpha * oi + beta * oi_new
+                    mi = mi_new
+            
+            # Final normalize
+            oi = oi / li
+            out[b_idx, h_idx, :] = oi
+    
+    return out
+
+
+def generate_test_data(
+    batch: int = 2,
+    num_heads: int = 4,
+    kv_head_num: int = 1,
+    head_dim: int = 128,
+    block_size: int = 64,
+    block_num: int = 4,
+    context_len: int = 256,
+    seed: int = 42,
+):
+    """Generate test data for paged attention."""
+    np.random.seed(seed)
+    
+    total_blocks = batch * block_num
+    
+    # Generate random tensors
+    query = np.random.randn(batch, num_heads, head_dim).astype(np.float32) * 0.1
+    key_cache = np.random.randn(total_blocks, block_size, kv_head_num, head_dim).astype(np.float32) * 0.1
+    value_cache = np.random.randn(total_blocks, block_size, kv_head_num, head_dim).astype(np.float32) * 0.1
+    
+    # Block table: simple sequential mapping
+    block_table = np.zeros((batch, block_num), dtype=np.int32)
+    for b in range(batch):
+        for bn in range(block_num):
+            block_table[b, bn] = b * block_num + bn
+    
+    # Context lengths
+    context_lens = np.full(batch, context_len, dtype=np.int32)
+    
+    scale_value = 1.0 / np.sqrt(head_dim)
+    
+    return {
+        "query": query,
+        "key_cache": key_cache,
+        "value_cache": value_cache,
+        "block_table": block_table,
+        "context_lens": context_lens,
+        "scale_value": scale_value,
+        "batch": batch,
+        "num_heads": num_heads,
+        "kv_head_num": kv_head_num,
+        "head_dim": head_dim,
+        "block_size": block_size,
+        "block_num": block_num,
+    }
+
+
+if __name__ == "__main__":
+    # Test the golden implementation
+    data = generate_test_data()
+    
+    print("=== Paged Attention Golden Test ===")
+    print(f"batch={data['batch']}, num_heads={data['num_heads']}, head_dim={data['head_dim']}")
+    print(f"block_size={data['block_size']}, block_num={data['block_num']}")
+    
+    out = paged_attention_golden(
+        data["query"],
+        data["key_cache"],
+        data["value_cache"],
+        data["block_table"],
+        data["context_lens"],
+        data["scale_value"],
+    )
+    
+    print(f"Output shape: {out.shape}")
+    print(f"Output range: [{out.min():.4f}, {out.max():.4f}]")
+    print(f"Output mean: {out.mean():.4f}")
+    print("Golden test passed!")

--- a/examples/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,0 +1,24 @@
+/**
+ * PV MatMul Kernel (AIC) - No external library calls
+ * Computes: oi_new = pij @ vj
+ */
+#include <cstdint>
+
+extern "C" void aic_pv_matmul(int64_t* args) {
+    float* pij = reinterpret_cast<float*>(args[0]);
+    float* vj = reinterpret_cast<float*>(args[1]);
+    float* oi_new = reinterpret_cast<float*>(args[2]);
+    int q_tile = static_cast<int>(args[3]);
+    int block_size = static_cast<int>(args[4]);
+    int head_dim = static_cast<int>(args[5]);
+
+    for (int i = 0; i < q_tile; i++) {
+        for (int j = 0; j < head_dim; j++) {
+            float sum = 0.0f;
+            for (int k = 0; k < block_size; k++) {
+                sum += pij[i * block_size + k] * vj[k * head_dim + j];
+            }
+            oi_new[i * head_dim + j] = sum;
+        }
+    }
+}

--- a/examples/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,0 +1,24 @@
+/**
+ * QK MatMul Kernel (AIC) - No external library calls
+ * Computes: sij = qi @ kj^T
+ */
+#include <cstdint>
+
+extern "C" void aic_qk_matmul(int64_t* args) {
+    float* qi = reinterpret_cast<float*>(args[0]);
+    float* kj = reinterpret_cast<float*>(args[1]);
+    float* sij = reinterpret_cast<float*>(args[2]);
+    int q_tile = static_cast<int>(args[3]);
+    int block_size = static_cast<int>(args[4]);
+    int head_dim = static_cast<int>(args[5]);
+
+    for (int i = 0; i < q_tile; i++) {
+        for (int j = 0; j < block_size; j++) {
+            float sum = 0.0f;
+            for (int k = 0; k < head_dim; k++) {
+                sum += qi[i * head_dim + k] * kj[j * head_dim + k];
+            }
+            sij[i * block_size + j] = sum;
+        }
+    }
+}

--- a/examples/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,0 +1,96 @@
+/**
+ * Online Softmax Update + Normalize Kernel (AIV) - No external library calls
+ *
+ * Fused kernel: online softmax accumulation + optional final normalization.
+ *
+ * When is_last == 0: performs standard online softmax update.
+ * When is_last == 1: after the update, normalizes and writes result to dst.
+ *
+ * This eliminates the separate aiv_normalize kernel, saving one task launch
+ * per (batch, head) and avoiding an extra read of oi/li from memory.
+ */
+#include <cstdint>
+
+// Inline exp approximation (no external library calls)
+static inline float my_exp(float x) {
+    if (x < -88.0f) return 0.0f;
+    if (x > 88.0f) x = 88.0f;
+
+    const float ln2 = 0.6931471805599453f;
+    const float inv_ln2 = 1.4426950408889634f;
+
+    float n_float = x * inv_ln2;
+    int n = (int)(n_float + (n_float >= 0.0f ? 0.5f : -0.5f));
+    float r = x - n * ln2;
+
+    float result = 1.0f + r * (1.0f + r * (0.5f + r * (0.16666667f + r * 0.041666668f)));
+
+    union { float f; int i; } bias;
+    bias.i = (n + 127) << 23;
+    return result * bias.f;
+}
+
+/**
+ * Fused online update + normalize kernel
+ *
+ * @param args  Argument array:
+ *   args[0]  = mij      (q_tile,)       current block row max
+ *   args[1]  = lij      (q_tile,)       current block row sum
+ *   args[2]  = oi_new   (q_tile, head_dim) current block PV output
+ *   args[3]  = mi       (q_tile,)       accumulated max  (in/out)
+ *   args[4]  = li       (q_tile,)       accumulated sum  (in/out)
+ *   args[5]  = oi       (q_tile, head_dim) accumulated out (in/out)
+ *   args[6]  = is_first 1 if first block, 0 otherwise
+ *   args[7]  = is_last  1 if last block, 0 otherwise
+ *   args[8]  = dst      output pointer (only written when is_last == 1)
+ *   args[9]  = q_tile
+ *   args[10] = head_dim
+ */
+extern "C" void aiv_online_update(int64_t* args) {
+    float* mij    = reinterpret_cast<float*>(args[0]);
+    float* lij    = reinterpret_cast<float*>(args[1]);
+    float* oi_new = reinterpret_cast<float*>(args[2]);
+    float* mi     = reinterpret_cast<float*>(args[3]);
+    float* li     = reinterpret_cast<float*>(args[4]);
+    float* oi     = reinterpret_cast<float*>(args[5]);
+    int is_first  = static_cast<int>(args[6]);
+    int is_last   = static_cast<int>(args[7]);
+    float* dst    = reinterpret_cast<float*>(args[8]);
+    int q_tile    = static_cast<int>(args[9]);
+    int head_dim  = static_cast<int>(args[10]);
+
+    // ---- Online Softmax Update ----
+    if (is_first) {
+        for (int i = 0; i < q_tile; i++) {
+            mi[i] = mij[i];
+            li[i] = lij[i];
+        }
+        for (int i = 0; i < q_tile * head_dim; i++) {
+            oi[i] = oi_new[i];
+        }
+    } else {
+        for (int i = 0; i < q_tile; i++) {
+            float mi_new = (mi[i] > mij[i]) ? mi[i] : mij[i];
+            float alpha = my_exp(mi[i] - mi_new);
+            float beta  = my_exp(mij[i] - mi_new);
+
+            li[i] = alpha * li[i] + beta * lij[i];
+
+            for (int j = 0; j < head_dim; j++) {
+                oi[i * head_dim + j] = alpha * oi[i * head_dim + j]
+                                     + beta  * oi_new[i * head_dim + j];
+            }
+            mi[i] = mi_new;
+        }
+    }
+
+    // ---- Fused Normalize (only on last block) ----
+    if (is_last) {
+        for (int i = 0; i < q_tile; i++) {
+            float inv_li = 1.0f / li[i];
+            for (int j = 0; j < head_dim; j++) {
+                dst[i * head_dim + j] = oi[i * head_dim + j] * inv_li;
+            }
+        }
+    }
+}

--- a/examples/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,0 +1,74 @@
+/**
+ * Softmax Prepare Kernel (AIV) - No external library calls
+ * Computes: pij, mij, lij from sij with scale
+ */
+#include <cstdint>
+
+// Inline exp approximation (no library call)
+static inline float my_exp(float x) {
+    // Clamp to avoid overflow/underflow
+    if (x < -88.0f) return 0.0f;
+    if (x > 88.0f) x = 88.0f;
+    
+    // Range reduction: x = n*ln2 + r
+    const float ln2 = 0.6931471805599453f;
+    const float inv_ln2 = 1.4426950408889634f;
+    
+    float n_float = x * inv_ln2;
+    int n = (int)(n_float + (n_float >= 0.0f ? 0.5f : -0.5f));
+    float r = x - n * ln2;
+    
+    // Polynomial approx for exp(r) where |r| < ln2/2
+    float r2 = r * r;
+    float result = 1.0f + r * (1.0f + r * (0.5f + r * (0.16666667f + r * 0.041666668f)));
+    
+    // Multiply by 2^n
+    union { float f; int i; } bias;
+    bias.i = (n + 127) << 23;
+    return result * bias.f;
+}
+
+extern "C" void aiv_softmax_prepare(int64_t* args) {
+    float* sij = reinterpret_cast<float*>(args[0]);
+    union { uint64_t u; float f; } scale_conv;
+    scale_conv.u = static_cast<uint64_t>(args[1]);
+    float scale_value = scale_conv.f;
+    float* pij = reinterpret_cast<float*>(args[2]);
+    float* mij = reinterpret_cast<float*>(args[3]);
+    float* lij = reinterpret_cast<float*>(args[4]);
+    int q_tile = static_cast<int>(args[5]);
+    int block_size = static_cast<int>(args[6]);
+    int valid_len = static_cast<int>(args[7]);
+
+    const float NEG_INF = -1e30f;
+
+    for (int i = 0; i < q_tile; i++) {
+        // Scale and find row max
+        float max_val = NEG_INF;
+        for (int j = 0; j < block_size; j++) {
+            float val;
+            if (j < valid_len) {
+                val = sij[i * block_size + j] * scale_value;
+            } else {
+                val = NEG_INF;
+            }
+            sij[i * block_size + j] = val;
+            if (val > max_val) max_val = val;
+        }
+        mij[i] = max_val;
+
+        // Exp and row sum
+        float sum_val = 0.0f;
+        for (int j = 0; j < block_size; j++) {
+            float exp_val;
+            if (j < valid_len) {
+                exp_val = my_exp(sij[i * block_size + j] - max_val);
+            } else {
+                exp_val = 0.0f;
+            }
+            pij[i * block_size + j] = exp_val;
+            sum_val += exp_val;
+        }
+        lij[i] = sum_val;
+    }
+}

--- a/examples/paged_attention/kernels/kernel_config.py
+++ b/examples/paged_attention/kernels/kernel_config.py
@@ -1,0 +1,36 @@
+"""
+Paged Attention Kernel and Orchestration Configuration
+
+Defines the kernels and orchestration function for paged attention
+with AIC/AIV subgraph splitting:
+
+AIC Kernels (Matrix Multiplication):
+  - aic_qk_matmul: Q @ K^T computation
+  - aic_pv_matmul: P @ V computation
+
+AIV Kernels (Vector Operations):
+  - aiv_softmax_prepare: scale, rowmax, exp, rowsum
+  - aiv_online_update: online softmax accumulation + fused normalization
+
+Note: aiv_normalize has been merged into aiv_online_update for efficiency.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+# Orchestration config
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "paged_attention_orch.cpp"),
+    "function_name": "build_paged_attention_graph",
+}
+
+# Kernel configs (aiv_normalize removed - merged into aiv_online_update)
+KERNELS = [
+    # AIC kernels (matrix multiplication using Cube unit)
+    {"func_id": 0, "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 2, "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
+    # AIV kernels (vector operations)
+    {"func_id": 1, "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
+    {"func_id": 3, "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
+]

--- a/examples/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -1,0 +1,264 @@
+/**
+ * Paged Attention Orchestration Function (Full Parallel)
+ *
+ * Parallelism:
+ *   - Different batches run in parallel (independent buffers per batch)
+ *   - Different heads run in parallel (independent buffers per head)
+ *   - Different blocks within a head: QK→SF→PV run in parallel
+ *   - Only UP within same (batch, head) is serialized (accumulator dependency)
+ *
+ * Buffer allocation:
+ *   - Per-batch-per-head-per-block buffers: sij, pij, mij, lij, oi_new
+ *   - Per-batch-per-head accumulators: mi, li, oi
+ */
+
+#include "runtime.h"
+#include <iostream>
+
+#define FUNC_QK_MATMUL       0
+#define FUNC_SOFTMAX_PREPARE 1
+#define FUNC_PV_MATMUL       2
+#define FUNC_ONLINE_UPDATE   3
+
+#define MAX_BLOCKS 64
+
+extern "C" {
+
+int build_paged_attention_graph(Runtime* runtime, uint64_t* args, int arg_count) {
+    if (arg_count < 19) {
+        std::cerr << "Expected 19 args, got " << arg_count << '\n';
+        return -1;
+    }
+
+    void* host_query = reinterpret_cast<void*>(args[0]);
+    void* host_key_cache = reinterpret_cast<void*>(args[1]);
+    void* host_value_cache = reinterpret_cast<void*>(args[2]);
+    int* host_block_table = reinterpret_cast<int*>(args[3]);
+    int* host_context_lens = reinterpret_cast<int*>(args[4]);
+    void* host_out = reinterpret_cast<void*>(args[5]);
+
+    size_t query_size = static_cast<size_t>(args[6]);
+    size_t key_cache_size = static_cast<size_t>(args[7]);
+    size_t value_cache_size = static_cast<size_t>(args[8]);
+    size_t out_size = static_cast<size_t>(args[11]);
+
+    int batch = static_cast<int>(args[12]);
+    int num_heads = static_cast<int>(args[13]);
+    int kv_head_num = static_cast<int>(args[14]);
+    int head_dim = static_cast<int>(args[15]);
+    int block_size = static_cast<int>(args[16]);
+    int block_num = static_cast<int>(args[17]);
+    uint64_t scale_value_bits = args[18];
+
+    int heads_per_kv = num_heads / kv_head_num;
+    int q_tile = 1;
+
+    std::cout << "\n=== build_paged_attention_graph (full parallel) ===" << '\n';
+    std::cout << "batch=" << batch << ", num_heads=" << num_heads
+              << ", head_dim=" << head_dim << '\n';
+    std::cout << "block_size=" << block_size << ", block_num=" << block_num << '\n';
+
+    // Allocate device memory for inputs
+    void* dev_query = runtime->host_api.device_malloc(query_size);
+    void* dev_key_cache = runtime->host_api.device_malloc(key_cache_size);
+    void* dev_value_cache = runtime->host_api.device_malloc(value_cache_size);
+    void* dev_out = runtime->host_api.device_malloc(out_size);
+
+    if (!dev_query || !dev_key_cache || !dev_value_cache || !dev_out) {
+        std::cerr << "Error: Failed to allocate device memory\n";
+        return -1;
+    }
+
+    runtime->host_api.copy_to_device(dev_query, host_query, query_size);
+    runtime->host_api.copy_to_device(dev_key_cache, host_key_cache, key_cache_size);
+    runtime->host_api.copy_to_device(dev_value_cache, host_value_cache, value_cache_size);
+    runtime->record_tensor_pair(host_out, dev_out, out_size);
+
+    // Buffer sizes
+    size_t sij_size = q_tile * block_size * sizeof(float);
+    size_t scalar_size = q_tile * sizeof(float);
+    size_t vec_size = q_tile * head_dim * sizeof(float);
+
+    // Per-batch-per-head-per-block intermediate buffers (for full parallelism)
+    // Index: [(b_idx * num_heads + h_idx) * block_num + bn]
+    int total_buffers = batch * num_heads * block_num;
+    void** dev_sij_arr = new void*[total_buffers];
+    void** dev_pij_arr = new void*[total_buffers];
+    void** dev_mij_arr = new void*[total_buffers];
+    void** dev_lij_arr = new void*[total_buffers];
+    void** dev_oi_new_arr = new void*[total_buffers];
+
+    for (int i = 0; i < total_buffers; i++) {
+        dev_sij_arr[i] = runtime->host_api.device_malloc(sij_size);
+        dev_pij_arr[i] = runtime->host_api.device_malloc(sij_size);
+        dev_mij_arr[i] = runtime->host_api.device_malloc(scalar_size);
+        dev_lij_arr[i] = runtime->host_api.device_malloc(scalar_size);
+        dev_oi_new_arr[i] = runtime->host_api.device_malloc(vec_size);
+    }
+
+    // Per-batch-per-head accumulators (mi, li, oi)
+    int total_accumulators = batch * num_heads;
+    void** dev_mi_arr = new void*[total_accumulators];
+    void** dev_li_arr = new void*[total_accumulators];
+    void** dev_oi_arr = new void*[total_accumulators];
+
+    for (int i = 0; i < total_accumulators; i++) {
+        dev_mi_arr[i] = runtime->host_api.device_malloc(scalar_size);
+        dev_li_arr[i] = runtime->host_api.device_malloc(scalar_size);
+        dev_oi_arr[i] = runtime->host_api.device_malloc(vec_size);
+    }
+
+    std::cout << "Allocated " << total_buffers << " per-batch-per-head-per-block buffers\n";
+    std::cout << "Allocated " << total_accumulators << " per-batch-per-head accumulators\n";
+
+    int total_tasks = 0;
+
+    for (int b_idx = 0; b_idx < batch; b_idx++) {
+        int cur_seq = host_context_lens[b_idx];
+        int bn_this_batch = (cur_seq + block_size - 1) / block_size;
+
+        for (int h_idx = 0; h_idx < num_heads; h_idx++) {
+            int kv_h_idx = h_idx / heads_per_kv;
+
+            float* qi_ptr = reinterpret_cast<float*>(dev_query)
+                          + (b_idx * num_heads + h_idx) * head_dim;
+
+            float* out_ptr = reinterpret_cast<float*>(dev_out)
+                           + (b_idx * num_heads + h_idx) * head_dim;
+
+            // Per-batch-per-head accumulators
+            int acc_idx = b_idx * num_heads + h_idx;
+            void* dev_mi = dev_mi_arr[acc_idx];
+            void* dev_li = dev_li_arr[acc_idx];
+            void* dev_oi = dev_oi_arr[acc_idx];
+
+            int t_pv_arr[MAX_BLOCKS];  // Store PV task IDs
+
+            // Phase 1: Create parallel QK → SF → PV chains for all blocks
+            for (int bn = 0; bn < bn_this_batch; bn++) {
+                int cur_block_idx = host_block_table[b_idx * block_num + bn];
+
+                int valid_len = (bn == bn_this_batch - 1)
+                              ? (cur_seq - bn * block_size)
+                              : block_size;
+
+                float* kj_ptr = reinterpret_cast<float*>(dev_key_cache)
+                              + cur_block_idx * block_size * kv_head_num * head_dim
+                              + kv_h_idx * head_dim;
+                float* vj_ptr = reinterpret_cast<float*>(dev_value_cache)
+                              + cur_block_idx * block_size * kv_head_num * head_dim
+                              + kv_h_idx * head_dim;
+
+                // Per-batch-per-head-per-block buffers
+                int buf_idx = (b_idx * num_heads + h_idx) * block_num + bn;
+                void* dev_sij = dev_sij_arr[buf_idx];
+                void* dev_pij = dev_pij_arr[buf_idx];
+                void* dev_mij = dev_mij_arr[buf_idx];
+                void* dev_lij = dev_lij_arr[buf_idx];
+                void* dev_oi_new = dev_oi_new_arr[buf_idx];
+
+                // QK MatMul (AIC)
+                uint64_t qk_args[6] = {
+                    reinterpret_cast<uint64_t>(qi_ptr),
+                    reinterpret_cast<uint64_t>(kj_ptr),
+                    reinterpret_cast<uint64_t>(dev_sij),
+                    static_cast<uint64_t>(q_tile),
+                    static_cast<uint64_t>(block_size),
+                    static_cast<uint64_t>(head_dim)
+                };
+                int t_qk = runtime->add_task(qk_args, 6, FUNC_QK_MATMUL, 0);
+                total_tasks++;
+
+                // Softmax Prepare (AIV)
+                uint64_t sf_args[8] = {
+                    reinterpret_cast<uint64_t>(dev_sij),
+                    scale_value_bits,
+                    reinterpret_cast<uint64_t>(dev_pij),
+                    reinterpret_cast<uint64_t>(dev_mij),
+                    reinterpret_cast<uint64_t>(dev_lij),
+                    static_cast<uint64_t>(q_tile),
+                    static_cast<uint64_t>(block_size),
+                    static_cast<uint64_t>(valid_len)
+                };
+                int t_sf = runtime->add_task(sf_args, 8, FUNC_SOFTMAX_PREPARE, 1);
+                total_tasks++;
+
+                // PV MatMul (AIC)
+                uint64_t pv_args[6] = {
+                    reinterpret_cast<uint64_t>(dev_pij),
+                    reinterpret_cast<uint64_t>(vj_ptr),
+                    reinterpret_cast<uint64_t>(dev_oi_new),
+                    static_cast<uint64_t>(q_tile),
+                    static_cast<uint64_t>(block_size),
+                    static_cast<uint64_t>(head_dim)
+                };
+                int t_pv = runtime->add_task(pv_args, 6, FUNC_PV_MATMUL, 0);
+                total_tasks++;
+
+                // Dependencies: QK → SF → PV
+                runtime->add_successor(t_qk, t_sf);
+                runtime->add_successor(t_sf, t_pv);
+
+                // No cross-batch or cross-head dependency! Each (batch, head) has independent buffers.
+
+                t_pv_arr[bn] = t_pv;
+            }
+
+            // Phase 2: Create serialized UP chain (within this (batch, head) only)
+            int t_up_prev = -1;
+            for (int bn = 0; bn < bn_this_batch; bn++) {
+                int is_first = (bn == 0) ? 1 : 0;
+                int is_last  = (bn == bn_this_batch - 1) ? 1 : 0;
+
+                int buf_idx = (b_idx * num_heads + h_idx) * block_num + bn;
+                void* dev_mij = dev_mij_arr[buf_idx];
+                void* dev_lij = dev_lij_arr[buf_idx];
+                void* dev_oi_new = dev_oi_new_arr[buf_idx];
+
+                // Online Update (AIV)
+                uint64_t up_args[11] = {
+                    reinterpret_cast<uint64_t>(dev_mij),
+                    reinterpret_cast<uint64_t>(dev_lij),
+                    reinterpret_cast<uint64_t>(dev_oi_new),
+                    reinterpret_cast<uint64_t>(dev_mi),
+                    reinterpret_cast<uint64_t>(dev_li),
+                    reinterpret_cast<uint64_t>(dev_oi),
+                    static_cast<uint64_t>(is_first),
+                    static_cast<uint64_t>(is_last),
+                    reinterpret_cast<uint64_t>(out_ptr),
+                    static_cast<uint64_t>(q_tile),
+                    static_cast<uint64_t>(head_dim)
+                };
+                int t_up = runtime->add_task(up_args, 11, FUNC_ONLINE_UPDATE, 1);
+                total_tasks++;
+
+                // UP[bn] depends on PV[bn]
+                runtime->add_successor(t_pv_arr[bn], t_up);
+
+                // UP[bn] depends on UP[bn-1] (within same (batch, head))
+                if (t_up_prev >= 0) {
+                    runtime->add_successor(t_up_prev, t_up);
+                }
+
+                t_up_prev = t_up;
+            }
+        }
+    }
+
+    // Cleanup
+    delete[] dev_sij_arr;
+    delete[] dev_pij_arr;
+    delete[] dev_mij_arr;
+    delete[] dev_lij_arr;
+    delete[] dev_oi_new_arr;
+    delete[] dev_mi_arr;
+    delete[] dev_li_arr;
+    delete[] dev_oi_arr;
+
+    std::cout << "Created " << total_tasks << " tasks (full parallel)\n";
+    runtime->print_runtime();
+
+    return 0;
+}
+
+}

--- a/examples/paged_attention/main.py
+++ b/examples/paged_attention/main.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+Paged Attention AIC/AIV Split Simulation
+
+This example demonstrates paged attention with manual AIC/AIV subgraph splitting:
+- AIC (AICore): QK MatMul, PV MatMul
+- AIV (AIVector): Softmax Prepare, Online Update, Normalize
+
+Uses a2a3sim platform for thread-based simulation.
+"""
+
+import sys
+import struct
+import argparse
+from pathlib import Path
+import numpy as np
+
+# Add parent directory to path
+example_root = Path(__file__).parent
+runtime_root = Path(__file__).parent.parent.parent
+runtime_dir = runtime_root / "python"
+sys.path.insert(0, str(runtime_dir))
+sys.path.insert(0, str(example_root))
+
+try:
+    from runtime_builder import RuntimeBuilder
+    from bindings import bind_host_binary, register_kernel, set_device, launch_runtime
+    from elf_parser import extract_text_section
+    from kernels.kernel_config import KERNELS, ORCHESTRATION
+    from golden import paged_attention_golden, generate_test_data
+except ImportError as e:
+    print(f"Error: Cannot import module: {e}")
+    print("Make sure you are running this from the correct directory")
+    sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Paged Attention AIC/AIV Split Simulation")
+    parser.add_argument("-d", "--device", type=int, default=0, help="Device ID")
+    parser.add_argument("--batch", type=int, default=2, help="Batch size")
+    parser.add_argument("--num_heads", type=int, default=4, help="Number of query heads")
+    parser.add_argument("--kv_head_num", type=int, default=1, help="Number of KV heads")
+    parser.add_argument("--head_dim", type=int, default=128, help="Head dimension")
+    parser.add_argument("--block_size", type=int, default=64, help="Block size")
+    parser.add_argument("--block_num", type=int, default=4, help="Number of blocks per batch")
+    parser.add_argument("--context_len", type=int, default=256, help="Context length")
+    args = parser.parse_args()
+
+    device_id = args.device
+
+    # Generate test data
+    print("\n=== Generating Test Data ===")
+    data = generate_test_data(
+        batch=args.batch,
+        num_heads=args.num_heads,
+        kv_head_num=args.kv_head_num,
+        head_dim=args.head_dim,
+        block_size=args.block_size,
+        block_num=args.block_num,
+        context_len=args.context_len,
+    )
+    
+    print(f"batch={data['batch']}, num_heads={data['num_heads']}, head_dim={data['head_dim']}")
+    print(f"kv_head_num={data['kv_head_num']}, block_size={data['block_size']}, block_num={data['block_num']}")
+
+    # Compute golden result
+    print("\n=== Computing Golden Result ===")
+    golden_out = paged_attention_golden(
+        data["query"],
+        data["key_cache"],
+        data["value_cache"],
+        data["block_table"],
+        data["context_lens"],
+        data["scale_value"],
+    )
+    print(f"Golden output shape: {golden_out.shape}")
+    print(f"Golden output range: [{golden_out.min():.4f}, {golden_out.max():.4f}]")
+
+    # Build simulation runtime
+    print("\n=== Building Simulation Runtime ===")
+    builder = RuntimeBuilder(platform="a2a3sim")
+    pto_compiler = builder.get_pto_compiler()
+    
+    try:
+        host_binary, aicpu_binary, aicore_binary = builder.build("host_build_graph")
+    except Exception as e:
+        print(f"Error: Failed to build runtime libraries: {e}")
+        return -1
+
+    # Load runtime library
+    print("\n=== Loading Runtime Library ===")
+    Runtime = bind_host_binary(host_binary)
+    set_device(device_id)
+
+    # Compile orchestration
+    print("\n=== Compiling Orchestration Function ===")
+    orch_so_binary = pto_compiler.compile_orchestration(
+        ORCHESTRATION["source"],
+        extra_include_dirs=[
+            str(runtime_root / "src" / "runtime" / "host_build_graph" / "runtime"),
+        ] + pto_compiler.get_platform_include_dirs()
+    )
+    print(f"Compiled orchestration: {len(orch_so_binary)} bytes")
+
+    # Compile and register kernels
+    print("\n=== Compiling and Registering Kernels ===")
+    pto_isa_root = "/data/wcwxy/workspace/pypto/pto-isa"
+
+    for kernel in KERNELS:
+        print(f"Compiling {Path(kernel['source']).name}...")
+        kernel_o = pto_compiler.compile_incore(
+            kernel["source"],
+            core_type=kernel.get("core_type", "aiv"),
+            pto_isa_root=pto_isa_root
+        )
+        kernel_bin = extract_text_section(kernel_o)
+        register_kernel(kernel["func_id"], kernel_bin)
+
+    print("All kernels compiled and registered")
+
+    # Prepare tensors
+    print("\n=== Preparing Tensors ===")
+    host_query = data["query"].astype(np.float32).flatten()
+    host_key_cache = data["key_cache"].astype(np.float32).flatten()
+    host_value_cache = data["value_cache"].astype(np.float32).flatten()
+    host_block_table = data["block_table"].astype(np.int32).flatten()
+    host_context_lens = data["context_lens"].astype(np.int32)
+    host_out = np.zeros(data["batch"] * data["num_heads"] * data["head_dim"], dtype=np.float32)
+
+    # Convert scale_value to uint64 bits
+    scale_bytes = struct.pack('f', data["scale_value"])
+    scale_bits = struct.unpack('I', scale_bytes)[0]
+
+    # Build func_args
+    func_args = [
+        host_query.ctypes.data,
+        host_key_cache.ctypes.data,
+        host_value_cache.ctypes.data,
+        host_block_table.ctypes.data,
+        host_context_lens.ctypes.data,
+        host_out.ctypes.data,
+        host_query.nbytes,
+        host_key_cache.nbytes,
+        host_value_cache.nbytes,
+        host_block_table.nbytes,
+        host_context_lens.nbytes,
+        host_out.nbytes,
+        data["batch"],
+        data["num_heads"],
+        data["kv_head_num"],
+        data["head_dim"],
+        data["block_size"],
+        data["block_num"],
+        scale_bits,
+    ]
+
+    # Create and initialize runtime
+    print("\n=== Creating and Initializing Runtime ===")
+    runtime = Runtime()
+    runtime.initialize(orch_so_binary, ORCHESTRATION["function_name"], func_args)
+
+    # Execute runtime
+    print("\n=== Executing Runtime (Simulation) ===")
+    launch_runtime(runtime,
+                   aicpu_thread_num=3,
+                   block_dim=3,
+                   device_id=device_id,
+                   aicpu_binary=aicpu_binary,
+                   aicore_binary=aicore_binary)
+
+    # Finalize
+    print("\n=== Finalizing ===")
+    runtime.finalize()
+
+    # Validate results
+    print("\n=== Validating Results ===")
+    sim_out = host_out.reshape(data["batch"], data["num_heads"], data["head_dim"])
+    
+    print(f"Simulation output shape: {sim_out.shape}")
+    print(f"Simulation output range: [{sim_out.min():.4f}, {sim_out.max():.4f}]")
+
+    # Compare with golden
+    max_error = np.abs(sim_out - golden_out).max()
+    mean_error = np.abs(sim_out - golden_out).mean()
+    
+    print(f"\nMax absolute error: {max_error:.6f}")
+    print(f"Mean absolute error: {mean_error:.6f}")
+
+    # Check tolerance
+    rtol = 1e-3
+    atol = 1e-3
+    all_close = np.allclose(sim_out, golden_out, rtol=rtol, atol=atol)
+    error_count = np.sum(~np.isclose(sim_out, golden_out, rtol=rtol, atol=atol))
+    total_elements = sim_out.size
+
+    if all_close:
+        print(f"\nSUCCESS: All {total_elements} elements match within tolerance")
+    else:
+        error_ratio = error_count / total_elements * 100
+        print(f"\nWARNING: {error_count}/{total_elements} ({error_ratio:.2f}%) elements exceed tolerance")
+        if error_ratio < 1.0:
+            print("Error ratio < 1%, considered acceptable for bfloat16 precision")
+
+    # Print sample values
+    print("\nSample comparison (first 5 elements of first head):")
+    for i in range(min(5, data["head_dim"])):
+        print(f"  [{i}] golden={golden_out[0,0,i]:.6f}, sim={sim_out[0,0,i]:.6f}, "
+              f"diff={abs(golden_out[0,0,i]-sim_out[0,0,i]):.6f}")
+
+    return 0 if all_close else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Implement Paged Attention algorithm on a2a3sim platform with manual AIC/AIV kernel split and full parallel orchestration.

Features:

- 4-kernel design with AIC/AIV split:
  - aic_qk_matmul: Q @ K^T matrix multiplication (Cube)
  - aiv_softmax_prepare: scale, rowmax, exp, rowsum (Vector)
  - aic_pv_matmul: P @ V matrix multiplication (Cube)
  - aiv_online_update: Online Softmax accumulation + fused normalize (Vector)

- Full parallel orchestration strategy:
  - Per-batch × per-head × per-block buffer allocation for sij/pij/mij/lij/oi_new
  - Per-batch × per-head accumulator allocation for mi/li/oi
  - 32 initially ready tasks (batch=2 × heads=4 × blocks=4)
  - 128 total tasks with maximum parallelism

- Kernel fusion optimization:
  - Fused normalize into aiv_online_update via is_last flag
  - Reduced task count and memory traffic

- Golden Python reference implementation for correctness validation

Files:

- examples/paged_attention/main.py: Main entry point
- examples/paged_attention/golden.py: Python reference implementation
- examples/paged_attention/README.md: Documentation
- examples/paged_attention/kernels/aic/: AIC kernels (qk_matmul, pv_matmul)
- examples/paged_attention/kernels/aiv/: AIV kernels (softmax_prepare, online_update)
- examples/paged_attention/kernels/orchestration/paged_attention_orch.cpp

Co-authored-by: Claude Opus 4.5 <[noreply@anthropic.com](mailto:noreply@anthropic.com)>