### PR TITLE
Add: Paged Attention example with AIC/AIV kernel splitting

### DIFF
--- a/examples/paged_attention/README.md
+++ b/examples/paged_attention/README.md
@@ -1,0 +1,199 @@
+# Paged Attention Example - Simulation Platform (a2a3sim)
+
+This example demonstrates Paged Attention implementation with AIC/AIV kernel splitting using the thread-based simulation platform.
+
+## Overview
+
+Paged Attention is an efficient attention mechanism that processes KV cache in fixed-size blocks, enabling memory-efficient inference for long sequences. This implementation uses the Online Softmax algorithm for numerically stable incremental computation.
+
+### Algorithm
+
+For each query token, the attention is computed incrementally across KV cache blocks:
+
+```
+For each block j:
+    sij = Qi @ Kj.T                    # QK MatMul
+    pij = softmax(sij * scale)         # Softmax
+    oi_new = pij @ Vj                  # PV MatMul
+    oi = online_update(oi, oi_new)     # Accumulate with Online Softmax
+```
+
+### Kernel Design (AIC/AIV Split)
+
+| Kernel | Core Type | Operation |
+|--------|-----------|-----------|
+| `aic_qk_matmul` | AIC (Cube) | Q @ K^T matrix multiplication |
+| `aiv_softmax_prepare` | AIV (Vector) | scale, rowmax, exp, rowsum |
+| `aic_pv_matmul` | AIC (Cube) | P @ V matrix multiplication |
+| `aiv_online_update` | AIV (Vector) | Online Softmax accumulation + normalize |
+
+### Task Graph Structure
+
+For each batch, the task dependency pattern is:
+
+```
+Block 0: QK -> SF -> PV --+
+Block 1: QK -> SF -> PV --+--> UP[0] -> UP[1] -> UP[2] -> UP[3]
+Block 2: QK -> SF -> PV --+
+Block 3: QK -> SF -> PV --+
+```
+
+- **QK/SF/PV chains**: Run in parallel across blocks
+- **UP (Online Update)**: Serialized within batch due to accumulator dependency
+
+## Dependencies
+
+- Python 3
+- NumPy
+- gcc/g++ compiler
+
+No Ascend SDK or CANN toolkit required.
+
+## Quick Start
+
+```bash
+# From repository root
+python examples/scripts/run_example.py \
+  -k examples/paged_attention/kernels \
+  -g examples/paged_attention/golden.py \
+  -p a2a3sim
+
+# With verbose output
+python examples/scripts/run_example.py \
+  -k examples/paged_attention/kernels \
+  -g examples/paged_attention/golden.py \
+  -p a2a3sim \
+  -v
+```
+
+## Directory Structure
+
+```
+paged_attention/
+├── README.md                    # This file
+├── golden.py                    # Input generation and expected output
+└── kernels/
+    ├── kernel_config.py         # Kernel configuration
+    ├── aic/                      # AIC kernel implementations (Cube unit)
+    │   ├── aic_qk_matmul.cpp     # Q @ K^T matrix multiplication
+    │   └── aic_pv_matmul.cpp     # P @ V matrix multiplication
+    ├── aiv/                      # AIV kernel implementations (Vector unit)
+    │   ├── aiv_softmax_prepare.cpp  # Softmax preparation
+    │   └── aiv_online_update.cpp    # Online Softmax update + normalize
+    └── orchestration/
+        └── paged_attention_orch.cpp # Task graph building function
+```
+
+## Files
+
+### `golden.py`
+
+Defines input tensors and expected output computation:
+
+```python
+__outputs__ = ["out"]
+TENSOR_ORDER = ["query", "key_cache", "value_cache", "block_table", 
+                "context_lens", "out", "config"]
+
+PARAMS_LIST = [
+    {
+        "batch": 2,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 64,
+        "block_num": 4,
+        "context_len": 256,
+    },
+]
+
+def generate_inputs(params: dict) -> dict:
+    # Returns all tensors including config
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    # Computes expected output using Online Softmax algorithm
+```
+
+### `kernels/kernel_config.py`
+
+Defines kernel sources and orchestration function:
+
+```python
+KERNELS = [
+    {"func_id": 0, "source": ".../aic_qk_matmul.cpp",       "core_type": "aic"},
+    {"func_id": 1, "source": ".../aiv_softmax_prepare.cpp", "core_type": "aiv"},
+    {"func_id": 2, "source": ".../aic_pv_matmul.cpp",       "core_type": "aic"},
+    {"func_id": 3, "source": ".../aiv_online_update.cpp",   "core_type": "aiv"},
+]
+
+ORCHESTRATION = {
+    "source": ".../paged_attention_orch.cpp",
+    "function_name": "build_paged_attention_graph"
+}
+```
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `batch` | Batch size | 2 |
+| `num_heads` | Number of query heads | 16 |
+| `kv_head_num` | Number of KV heads (for GQA) | 1 |
+| `head_dim` | Head dimension | 128 |
+| `block_size` | KV cache block size | 64 |
+| `block_num` | Number of blocks per batch | 4 |
+| `context_len` | Context length | 256 |
+
+## Expected Output
+
+```
+=== Building Runtime: host_build_graph (platform: a2a3sim) ===
+...
+=== Compiling and Registering Kernels ===
+Compiling kernel: .../aic_qk_matmul.cpp (func_id=0)
+Compiling kernel: .../aiv_softmax_prepare.cpp (func_id=1)
+Compiling kernel: .../aic_pv_matmul.cpp (func_id=2)
+Compiling kernel: .../aiv_online_update.cpp (func_id=3)
+...
+=== build_paged_attention_graph (multi-head per task) ===
+batch=2, num_heads=16, kv_head_num=1, head_dim=128
+block_size=64, block_num=4
+...
+Created 32 tasks
+...
+=== Comparing Results ===
+Comparing out: shape=(4096,), dtype=float32
+  out: PASS (4096/4096 elements matched)
+
+============================================================
+TEST PASSED
+============================================================
+```
+
+## Kernels
+
+### AIC Kernels (Cube Unit)
+
+- **aic_qk_matmul.cpp** - Computes Q @ K^T for all heads
+- **aic_pv_matmul.cpp** - Computes P @ V for all heads
+
+### AIV Kernels (Vector Unit)
+
+- **aiv_softmax_prepare.cpp** - Computes scale, rowmax, exp, rowsum for softmax
+- **aiv_online_update.cpp** - Online Softmax accumulation with fused final normalization
+
+## GQA Support
+
+This implementation supports Grouped Query Attention (GQA) where multiple query heads share a single KV head:
+
+```
+heads_per_kv = num_heads / kv_head_num
+```
+
+For example, with `num_heads=16` and `kv_head_num=1`, all 16 query heads share the same KV cache.
+
+## See Also
+
+- [Test Framework Documentation](../scripts/README.md)
+- [Simple Example](../host_build_graph_sim_example/) - Basic task graph example
+- [Main Project README](../../README.md)

--- a/examples/paged_attention/golden.py
+++ b/examples/paged_attention/golden.py
@@ -1,0 +1,169 @@
+"""
+Paged Attention Golden Implementation
+
+Implements the online softmax algorithm for paged attention computation.
+Used as reference for validation of the simulation results.
+"""
+
+import os
+import struct
+import numpy as np
+
+# Output tensor names
+__outputs__ = ["out"]
+
+# Tensor order matching orchestration function parameter order
+# Args layout: [7 ptrs, 7 sizes, count] = 15 args
+TENSOR_ORDER = ["query", "key_cache", "value_cache", "block_table", "context_lens", "out", "config"]
+
+# Comparison tolerances
+RTOL = 1e-3
+ATOL = 1e-3
+
+# All test cases
+ALL_CASES = {
+    "Case1": {
+        "batch": 256,
+        "num_heads": 16,       # q_head_num
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "block_num": 4,
+        "context_len": 512,    # block_size * block_num
+    },
+    "Case2": {
+        "batch": 64,
+        "num_heads": 64,       # q_head_num
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 64,
+        "block_num": 4,
+        "context_len": 256,    # block_size * block_num
+    },
+}
+
+# Select case by env var PA_CASE, default to Case2
+_selected = os.environ.get("PA_CASE", "Case2")
+PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
+
+
+def generate_inputs(params: dict) -> dict:
+    batch = params["batch"]
+    num_heads = params["num_heads"]
+    kv_head_num = params["kv_head_num"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    block_num = params["block_num"]
+    context_len = params["context_len"]
+    seed = params.get("seed", 42)
+
+    np.random.seed(seed)
+
+    total_blocks = batch * block_num
+    scale_value = 1.0 / np.sqrt(head_dim)
+    scale_bits = struct.unpack('I', struct.pack('f', scale_value))[0]
+
+    block_table = np.zeros(batch * block_num, dtype=np.int32)
+    for b in range(batch):
+        for bn in range(block_num):
+            block_table[b * block_num + bn] = b * block_num + bn
+
+    context_lens = np.full(batch, context_len, dtype=np.int32)
+
+    config = np.array(
+        [batch, num_heads, kv_head_num, head_dim, block_size, block_num, scale_bits],
+        dtype=np.int64,
+    )
+
+    return {
+        "query": np.random.randn(batch * num_heads * head_dim).astype(np.float32) * 0.1,
+        "key_cache": np.random.randn(total_blocks * block_size * kv_head_num * head_dim).astype(np.float32) * 0.1,
+        "value_cache": np.random.randn(total_blocks * block_size * kv_head_num * head_dim).astype(np.float32) * 0.1,
+        "block_table": block_table,
+        "context_lens": context_lens,
+        "out": np.zeros(batch * num_heads * head_dim, dtype=np.float32),
+        "config": config,
+    }
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    batch = params["batch"]
+    num_heads = params["num_heads"]
+    kv_head_num = params["kv_head_num"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    block_num = params["block_num"]
+
+    heads_per_kv = num_heads // kv_head_num
+    scale_value = 1.0 / np.sqrt(head_dim)
+
+    query = tensors["query"].reshape(batch, num_heads, head_dim)
+    key_cache = tensors["key_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    value_cache = tensors["value_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    block_table = tensors["block_table"].reshape(batch, block_num)
+    context_lens = tensors["context_lens"]
+
+    out = np.zeros((batch, num_heads, head_dim), dtype=np.float32)
+
+    for b_idx in range(batch):
+        cur_seq = context_lens[b_idx]
+        bn_this_batch = (cur_seq + block_size - 1) // block_size
+
+        for h_idx in range(num_heads):
+            kv_h_idx = h_idx // heads_per_kv
+            qi = query[b_idx, h_idx, :]
+
+            mi = -np.inf
+            li = 0.0
+            oi = np.zeros(head_dim, dtype=np.float32)
+
+            for bn in range(bn_this_batch):
+                cur_block_idx = block_table[b_idx, bn]
+                kj = key_cache[cur_block_idx, :, kv_h_idx, :]
+                vj = value_cache[cur_block_idx, :, kv_h_idx, :]
+
+                valid_tokens = cur_seq - bn * block_size if bn == bn_this_batch - 1 else block_size
+
+                sij = qi @ kj.T
+                sij_scale = sij * scale_value
+
+                if valid_tokens < block_size:
+                    sij_scale[valid_tokens:] = -np.inf
+
+                mij = np.max(sij_scale)
+                pij = np.exp(sij_scale - mij)
+                lij = np.sum(pij)
+                oi_new = pij @ vj
+
+                if bn == 0:
+                    mi, li, oi = mij, lij, oi_new
+                else:
+                    mi_new = max(mi, mij)
+                    alpha = np.exp(mi - mi_new)
+                    beta = np.exp(mij - mi_new)
+                    li = alpha * li + beta * lij
+                    oi = alpha * oi + beta * oi_new
+                    mi = mi_new
+
+            oi = oi / li
+            out[b_idx, h_idx, :] = oi
+
+    tensors["out"][:] = out.flatten()
+
+
+if __name__ == "__main__":
+    params = PARAMS_LIST[0]
+    tensors = generate_inputs(params)
+
+    print(f"=== Paged Attention Golden Test ({params['name']}) ===")
+    print(f"batch={params['batch']}, num_heads={params['num_heads']}, head_dim={params['head_dim']}")
+    print(f"block_size={params['block_size']}, block_num={params['block_num']}")
+    print(f"Tasks needed: {params['batch'] * params['block_num'] * 4}")
+
+    compute_golden(tensors, params)
+
+    out = tensors["out"].reshape(params["batch"], params["num_heads"], params["head_dim"])
+    print(f"Output shape: {out.shape}")
+    print(f"Output range: [{out.min():.4f}, {out.max():.4f}]")
+    print(f"Output mean: {out.mean():.4f}")
+    print("Golden test passed!")

--- a/examples/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,0 +1,39 @@
+/**
+ * PV MatMul Kernel (AIC) - Multi-Head
+ *
+ * Computes: oi_new[h] = pij[h] @ vj[kv_h]  for all heads h
+ *
+ * Memory layout:
+ *   pij:    (num_heads, block_size)  contiguous
+ *   vj:     (block_size, kv_head_num, head_dim)  strided
+ *   oi_new: (num_heads, head_dim)  contiguous output
+ */
+#include <cstdint>
+
+extern "C" void aic_pv_matmul(int64_t* args) {
+    float* pij    = reinterpret_cast<float*>(args[0]);  // (num_heads, block_size)
+    float* vj     = reinterpret_cast<float*>(args[1]);  // (block_size, kv_head_num, head_dim)
+    float* oi_new = reinterpret_cast<float*>(args[2]);  // (num_heads, head_dim)
+    int num_heads   = static_cast<int>(args[3]);
+    int kv_head_num = static_cast<int>(args[4]);
+    int block_size  = static_cast<int>(args[5]);
+    int head_dim    = static_cast<int>(args[6]);
+
+    int heads_per_kv = num_heads / kv_head_num;
+    int kv_stride = kv_head_num * head_dim;  // stride between tokens in V
+
+    for (int h = 0; h < num_heads; h++) {
+        int kv_h = h / heads_per_kv;
+        float* pij_h = pij + h * block_size;
+        float* oi_new_h = oi_new + h * head_dim;
+
+        for (int d = 0; d < head_dim; d++) {
+            float sum = 0.0f;
+            for (int k = 0; k < block_size; k++) {
+                float* vj_token = vj + k * kv_stride + kv_h * head_dim;
+                sum += pij_h[k] * vj_token[d];
+            }
+            oi_new_h[d] = sum;
+        }
+    }
+}

--- a/examples/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,0 +1,38 @@
+/**
+ * QK MatMul Kernel (AIC) - Multi-Head
+ *
+ * Computes: sij[h] = qi[h] @ kj[kv_h].T  for all heads h
+ *
+ * Memory layout:
+ *   qi:  (num_heads, head_dim)  contiguous
+ *   kj:  (block_size, kv_head_num, head_dim)  strided
+ *   sij: (num_heads, block_size)  contiguous output
+ */
+#include <cstdint>
+
+extern "C" void aic_qk_matmul(int64_t* args) {
+    float* qi  = reinterpret_cast<float*>(args[0]);   // (num_heads, head_dim)
+    float* kj  = reinterpret_cast<float*>(args[1]);   // (block_size, kv_head_num, head_dim)
+    float* sij = reinterpret_cast<float*>(args[2]);   // (num_heads, block_size)
+    int num_heads   = static_cast<int>(args[3]);
+    int kv_head_num = static_cast<int>(args[4]);
+    int block_size  = static_cast<int>(args[5]);
+    int head_dim    = static_cast<int>(args[6]);
+
+    int heads_per_kv = num_heads / kv_head_num;
+    int kv_stride = kv_head_num * head_dim;  // stride between tokens in K
+
+    for (int h = 0; h < num_heads; h++) {
+        int kv_h = h / heads_per_kv;
+        float* qi_h = qi + h * head_dim;
+
+        for (int j = 0; j < block_size; j++) {
+            float* kj_token = kj + j * kv_stride + kv_h * head_dim;
+            float sum = 0.0f;
+            for (int d = 0; d < head_dim; d++) {
+                sum += qi_h[d] * kj_token[d];
+            }
+            sij[h * block_size + j] = sum;
+        }
+    }
+}

--- a/examples/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,0 +1,80 @@
+/**
+ * Online Softmax Update + Normalize Kernel (AIV) - Multi-Head
+ *
+ * Processes ALL heads in one task.
+ *
+ * Memory layout:
+ *   mij:    (num_heads,)             current block row max
+ *   lij:    (num_heads,)             current block row sum
+ *   oi_new: (num_heads, head_dim)    current block PV output
+ *   mi:     (num_heads,)             accumulated max  (in/out)
+ *   li:     (num_heads,)             accumulated sum  (in/out)
+ *   oi:     (num_heads, head_dim)    accumulated out  (in/out)
+ *   dst:    (num_heads, head_dim)    final output (written when is_last)
+ */
+#include <cstdint>
+
+static inline float my_exp(float x) {
+    if (x < -88.0f) return 0.0f;
+    if (x > 88.0f) x = 88.0f;
+
+    const float ln2 = 0.6931471805599453f;
+    const float inv_ln2 = 1.4426950408889634f;
+
+    float n_float = x * inv_ln2;
+    int n = (int)(n_float + (n_float >= 0.0f ? 0.5f : -0.5f));
+    float r = x - n * ln2;
+
+    float result = 1.0f + r * (1.0f + r * (0.5f + r * (0.16666667f + r * 0.041666668f)));
+
+    union { float f; int i; } bias;
+    bias.i = (n + 127) << 23;
+    return result * bias.f;
+}
+
+extern "C" void aiv_online_update(int64_t* args) {
+    float* mij    = reinterpret_cast<float*>(args[0]);
+    float* lij    = reinterpret_cast<float*>(args[1]);
+    float* oi_new = reinterpret_cast<float*>(args[2]);
+    float* mi     = reinterpret_cast<float*>(args[3]);
+    float* li     = reinterpret_cast<float*>(args[4]);
+    float* oi     = reinterpret_cast<float*>(args[5]);
+    int is_first  = static_cast<int>(args[6]);
+    int is_last   = static_cast<int>(args[7]);
+    float* dst    = reinterpret_cast<float*>(args[8]);
+    int num_heads = static_cast<int>(args[9]);
+    int head_dim  = static_cast<int>(args[10]);
+
+    for (int h = 0; h < num_heads; h++) {
+        float* oi_new_h = oi_new + h * head_dim;
+        float* oi_h     = oi     + h * head_dim;
+
+        if (is_first) {
+            mi[h] = mij[h];
+            li[h] = lij[h];
+            for (int d = 0; d < head_dim; d++) {
+                oi_h[d] = oi_new_h[d];
+            }
+        } else {
+            float mi_new = (mi[h] > mij[h]) ? mi[h] : mij[h];
+            float alpha = my_exp(mi[h] - mi_new);
+            float beta  = my_exp(mij[h] - mi_new);
+
+            li[h] = alpha * li[h] + beta * lij[h];
+
+            for (int d = 0; d < head_dim; d++) {
+                oi_h[d] = alpha * oi_h[d] + beta * oi_new_h[d];
+            }
+            mi[h] = mi_new;
+        }
+
+        // Fused normalize on last block
+        if (is_last) {
+            float inv_li = 1.0f / li[h];
+            float* dst_h = dst + h * head_dim;
+            for (int d = 0; d < head_dim; d++) {
+                dst_h[d] = oi_h[d] * inv_li;
+            }
+        }
+    }
+}

--- a/examples/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,0 +1,72 @@
+/**
+ * Softmax Prepare Kernel (AIV) - Multi-Head
+ *
+ * Computes for all heads h:
+ *   sij_scale[h] = sij[h] * scale
+ *   mij[h] = max(sij_scale[h])
+ *   pij[h] = exp(sij_scale[h] - mij[h])
+ *   lij[h] = sum(pij[h])
+ *
+ * Memory layout:
+ *   sij: (num_heads, block_size)  in-place scaled
+ *   pij: (num_heads, block_size)  output
+ *   mij: (num_heads,)             output
+ *   lij: (num_heads,)             output
+ */
+#include <cstdint>
+
+static inline float my_exp(float x) {
+    if (x < -88.0f) return 0.0f;
+    if (x > 88.0f) x = 88.0f;
+
+    const float ln2 = 0.6931471805599453f;
+    const float inv_ln2 = 1.4426950408889634f;
+
+    float n_float = x * inv_ln2;
+    int n = (int)(n_float + (n_float >= 0.0f ? 0.5f : -0.5f));
+    float r = x - n * ln2;
+
+    float result = 1.0f + r * (1.0f + r * (0.5f + r * (0.16666667f + r * 0.041666668f)));
+
+    union { float f; int i; } bias;
+    bias.i = (n + 127) << 23;
+    return result * bias.f;
+}
+
+extern "C" void aiv_softmax_prepare(int64_t* args) {
+    float* sij = reinterpret_cast<float*>(args[0]);   // (num_heads, block_size)
+    union { uint64_t u; float f; } scale_conv;
+    scale_conv.u = static_cast<uint64_t>(args[1]);
+    float scale_value = scale_conv.f;
+    float* pij = reinterpret_cast<float*>(args[2]);    // (num_heads, block_size)
+    float* mij = reinterpret_cast<float*>(args[3]);    // (num_heads,)
+    float* lij = reinterpret_cast<float*>(args[4]);    // (num_heads,)
+    int num_heads  = static_cast<int>(args[5]);
+    int block_size = static_cast<int>(args[6]);
+    int valid_len  = static_cast<int>(args[7]);
+
+    const float NEG_INF = -1e30f;
+
+    for (int h = 0; h < num_heads; h++) {
+        float* sij_h = sij + h * block_size;
+        float* pij_h = pij + h * block_size;
+
+        // Scale and find row max
+        float max_val = NEG_INF;
+        for (int j = 0; j < block_size; j++) {
+            float val = (j < valid_len) ? sij_h[j] * scale_value : NEG_INF;
+            sij_h[j] = val;
+            if (val > max_val) max_val = val;
+        }
+        mij[h] = max_val;
+
+        // Exp and row sum
+        float sum_val = 0.0f;
+        for (int j = 0; j < block_size; j++) {
+            float exp_val = (j < valid_len) ? my_exp(sij_h[j] - max_val) : 0.0f;
+            pij_h[j] = exp_val;
+            sum_val += exp_val;
+        }
+        lij[h] = sum_val;
+    }
+}

--- a/examples/paged_attention/kernels/kernel_config.py
+++ b/examples/paged_attention/kernels/kernel_config.py
@@ -1,0 +1,36 @@
+"""
+Paged Attention Kernel and Orchestration Configuration
+
+Defines the kernels and orchestration function for paged attention
+with AIC/AIV subgraph splitting:
+
+AIC Kernels (Matrix Multiplication):
+  - aic_qk_matmul: Q @ K^T computation
+  - aic_pv_matmul: P @ V computation
+
+AIV Kernels (Vector Operations):
+  - aiv_softmax_prepare: scale, rowmax, exp, rowsum
+  - aiv_online_update: online softmax accumulation + fused normalization
+
+Note: aiv_normalize has been merged into aiv_online_update for efficiency.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+# Orchestration config
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "paged_attention_orch.cpp"),
+    "function_name": "build_paged_attention_graph",
+}
+
+# Kernel configs (aiv_normalize removed - merged into aiv_online_update)
+KERNELS = [
+    # AIC kernels (matrix multiplication using Cube unit)
+    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
+    # AIV kernels (vector operations)
+    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
+    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
+]

--- a/examples/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -1,0 +1,274 @@
+/**
+ * Paged Attention Orchestration Function (Multi-Head per Task)
+ *
+ * Each task processes ALL heads for a given (batch, block).
+ * This dramatically reduces task count and improves NPU utilization.
+ *
+ * Task count: batch * block_num * 4  (instead of batch * num_heads * block_num * 4)
+ *
+ * Parallelism:
+ *   - Different batches run in parallel
+ *   - Different blocks: QK->SF->PV chains run in parallel
+ *   - Only UP within same batch is serialized (accumulator dependency)
+ *
+ * Buffer allocation:
+ *   - Per-batch-per-block: sij, pij, mij, lij, oi_new  (all heads)
+ *   - Per-batch accumulators: mi, li, oi  (all heads)
+ */
+
+#include "runtime.h"
+#include <iostream>
+#include <cstring>
+
+#define FUNC_QK_MATMUL       0
+#define FUNC_SOFTMAX_PREPARE 1
+#define FUNC_PV_MATMUL       2
+#define FUNC_ONLINE_UPDATE   3
+
+#define MAX_BLOCKS 64
+
+extern "C" {
+
+int build_paged_attention_graph(Runtime* runtime, uint64_t* args, int arg_count) {
+    // Expected args layout from CodeRunner:
+    // [ptr_query, ptr_key_cache, ptr_value_cache, ptr_block_table, ptr_context_lens, ptr_out, ptr_config,
+    //  size_query, size_key_cache, size_value_cache, size_block_table, size_context_lens, size_out, size_config,
+    //  count]
+    if (arg_count < 15) {
+        std::cerr << "Expected at least 15 args, got " << arg_count << '\n';
+        return -1;
+    }
+
+    // Extract pointers (first 7)
+    void* host_query = reinterpret_cast<void*>(args[0]);
+    void* host_key_cache = reinterpret_cast<void*>(args[1]);
+    void* host_value_cache = reinterpret_cast<void*>(args[2]);
+    int* host_block_table = reinterpret_cast<int*>(args[3]);
+    int* host_context_lens = reinterpret_cast<int*>(args[4]);
+    void* host_out = reinterpret_cast<void*>(args[5]);
+    int64_t* host_config = reinterpret_cast<int64_t*>(args[6]);
+
+    // Extract sizes (next 7)
+    size_t query_size = static_cast<size_t>(args[7]);
+    size_t key_cache_size = static_cast<size_t>(args[8]);
+    size_t value_cache_size = static_cast<size_t>(args[9]);
+    size_t block_table_size = static_cast<size_t>(args[10]);
+    size_t context_lens_size = static_cast<size_t>(args[11]);
+    size_t out_size = static_cast<size_t>(args[12]);
+    size_t config_size = static_cast<size_t>(args[13]);
+
+    // Extract config parameters from config array
+    // config = [batch, num_heads, kv_head_num, head_dim, block_size, block_num, scale_bits]
+    int batch = static_cast<int>(host_config[0]);
+    int num_heads = static_cast<int>(host_config[1]);
+    int kv_head_num = static_cast<int>(host_config[2]);
+    int head_dim = static_cast<int>(host_config[3]);
+    int block_size = static_cast<int>(host_config[4]);
+    int block_num = static_cast<int>(host_config[5]);
+    uint64_t scale_value_bits = static_cast<uint64_t>(host_config[6]);
+
+    std::cout << "\n=== build_paged_attention_graph (multi-head per task) ===" << '\n';
+    std::cout << "batch=" << batch << ", num_heads=" << num_heads
+              << ", kv_head_num=" << kv_head_num << ", head_dim=" << head_dim << '\n';
+    std::cout << "block_size=" << block_size << ", block_num=" << block_num << '\n';
+
+    // Allocate device memory for inputs
+    void* dev_query = runtime->host_api.device_malloc(query_size);
+    void* dev_key_cache = runtime->host_api.device_malloc(key_cache_size);
+    void* dev_value_cache = runtime->host_api.device_malloc(value_cache_size);
+    void* dev_out = runtime->host_api.device_malloc(out_size);
+
+    if (!dev_query || !dev_key_cache || !dev_value_cache || !dev_out) {
+        std::cerr << "Error: Failed to allocate device memory\n";
+        return -1;
+    }
+
+    runtime->host_api.copy_to_device(dev_query, host_query, query_size);
+    runtime->host_api.copy_to_device(dev_key_cache, host_key_cache, key_cache_size);
+    runtime->host_api.copy_to_device(dev_value_cache, host_value_cache, value_cache_size);
+    runtime->record_tensor_pair(host_out, dev_out, out_size);
+
+    // Buffer sizes (all heads packed together)
+    size_t sij_size    = num_heads * block_size * sizeof(float);   // (num_heads, block_size)
+    size_t scalar_size = num_heads * sizeof(float);                // (num_heads,)
+    size_t vec_size    = num_heads * head_dim * sizeof(float);     // (num_heads, head_dim)
+
+    // Per-batch-per-block intermediate buffers
+    // Index: [b_idx * block_num + bn]
+    int total_buffers = batch * block_num;
+    void** dev_sij_arr    = new void*[total_buffers];
+    void** dev_pij_arr    = new void*[total_buffers];
+    void** dev_mij_arr    = new void*[total_buffers];
+    void** dev_lij_arr    = new void*[total_buffers];
+    void** dev_oi_new_arr = new void*[total_buffers];
+
+    for (int i = 0; i < total_buffers; i++) {
+        dev_sij_arr[i]    = runtime->host_api.device_malloc(sij_size);
+        dev_pij_arr[i]    = runtime->host_api.device_malloc(sij_size);
+        dev_mij_arr[i]    = runtime->host_api.device_malloc(scalar_size);
+        dev_lij_arr[i]    = runtime->host_api.device_malloc(scalar_size);
+        dev_oi_new_arr[i] = runtime->host_api.device_malloc(vec_size);
+    }
+
+    // Per-batch accumulators (mi, li, oi) — all heads packed
+    void** dev_mi_arr = new void*[batch];
+    void** dev_li_arr = new void*[batch];
+    void** dev_oi_arr = new void*[batch];
+
+    for (int i = 0; i < batch; i++) {
+        dev_mi_arr[i] = runtime->host_api.device_malloc(scalar_size);
+        dev_li_arr[i] = runtime->host_api.device_malloc(scalar_size);
+        dev_oi_arr[i] = runtime->host_api.device_malloc(vec_size);
+    }
+
+    std::cout << "Allocated " << total_buffers << " per-batch-per-block buffers (all heads packed)\n";
+    std::cout << "Allocated " << batch << " per-batch accumulators (all heads packed)\n";
+
+    int total_tasks = 0;
+
+    for (int b_idx = 0; b_idx < batch; b_idx++) {
+        int cur_seq = host_context_lens[b_idx];
+        int bn_this_batch = (cur_seq + block_size - 1) / block_size;
+
+        // Query pointer for this batch (all heads): (num_heads, head_dim)
+        float* qi_ptr = reinterpret_cast<float*>(dev_query)
+                      + b_idx * num_heads * head_dim;
+
+        // Output pointer for this batch (all heads): (num_heads, head_dim)
+        float* out_ptr = reinterpret_cast<float*>(dev_out)
+                       + b_idx * num_heads * head_dim;
+
+        // Per-batch accumulators
+        void* dev_mi = dev_mi_arr[b_idx];
+        void* dev_li = dev_li_arr[b_idx];
+        void* dev_oi = dev_oi_arr[b_idx];
+
+        int t_pv_arr[MAX_BLOCKS];
+
+        // Phase 1: Create parallel QK -> SF -> PV chains for all blocks
+        for (int bn = 0; bn < bn_this_batch; bn++) {
+            int cur_block_idx = host_block_table[b_idx * block_num + bn];
+
+            int valid_len = (bn == bn_this_batch - 1)
+                          ? (cur_seq - bn * block_size)
+                          : block_size;
+
+            // K/V block base pointer: (block_size, kv_head_num, head_dim)
+            float* kj_ptr = reinterpret_cast<float*>(dev_key_cache)
+                          + cur_block_idx * block_size * kv_head_num * head_dim;
+            float* vj_ptr = reinterpret_cast<float*>(dev_value_cache)
+                          + cur_block_idx * block_size * kv_head_num * head_dim;
+
+            // Per-batch-per-block buffers
+            int buf_idx = b_idx * block_num + bn;
+            void* dev_sij    = dev_sij_arr[buf_idx];
+            void* dev_pij    = dev_pij_arr[buf_idx];
+            void* dev_mij    = dev_mij_arr[buf_idx];
+            void* dev_lij    = dev_lij_arr[buf_idx];
+            void* dev_oi_new = dev_oi_new_arr[buf_idx];
+
+            // QK MatMul (AIC) — all heads
+            uint64_t qk_args[7] = {
+                reinterpret_cast<uint64_t>(qi_ptr),
+                reinterpret_cast<uint64_t>(kj_ptr),
+                reinterpret_cast<uint64_t>(dev_sij),
+                static_cast<uint64_t>(num_heads),
+                static_cast<uint64_t>(kv_head_num),
+                static_cast<uint64_t>(block_size),
+                static_cast<uint64_t>(head_dim)
+            };
+            int t_qk = runtime->add_task(qk_args, 7, FUNC_QK_MATMUL, CoreType::AIC);
+            total_tasks++;
+
+            // Softmax Prepare (AIV) — all heads
+            uint64_t sf_args[8] = {
+                reinterpret_cast<uint64_t>(dev_sij),
+                scale_value_bits,
+                reinterpret_cast<uint64_t>(dev_pij),
+                reinterpret_cast<uint64_t>(dev_mij),
+                reinterpret_cast<uint64_t>(dev_lij),
+                static_cast<uint64_t>(num_heads),
+                static_cast<uint64_t>(block_size),
+                static_cast<uint64_t>(valid_len)
+            };
+            int t_sf = runtime->add_task(sf_args, 8, FUNC_SOFTMAX_PREPARE, CoreType::AIV);
+            total_tasks++;
+
+            // PV MatMul (AIC) — all heads
+            uint64_t pv_args[7] = {
+                reinterpret_cast<uint64_t>(dev_pij),
+                reinterpret_cast<uint64_t>(vj_ptr),
+                reinterpret_cast<uint64_t>(dev_oi_new),
+                static_cast<uint64_t>(num_heads),
+                static_cast<uint64_t>(kv_head_num),
+                static_cast<uint64_t>(block_size),
+                static_cast<uint64_t>(head_dim)
+            };
+            int t_pv = runtime->add_task(pv_args, 7, FUNC_PV_MATMUL, CoreType::AIC);
+            total_tasks++;
+
+            // Dependencies: QK -> SF -> PV
+            runtime->add_successor(t_qk, t_sf);
+            runtime->add_successor(t_sf, t_pv);
+
+            t_pv_arr[bn] = t_pv;
+        }
+
+        // Phase 2: Create serialized UP chain (within this batch)
+        int t_up_prev = -1;
+        for (int bn = 0; bn < bn_this_batch; bn++) {
+            int is_first = (bn == 0) ? 1 : 0;
+            int is_last  = (bn == bn_this_batch - 1) ? 1 : 0;
+
+            int buf_idx = b_idx * block_num + bn;
+            void* dev_mij    = dev_mij_arr[buf_idx];
+            void* dev_lij    = dev_lij_arr[buf_idx];
+            void* dev_oi_new = dev_oi_new_arr[buf_idx];
+
+            // Online Update (AIV) — all heads
+            uint64_t up_args[11] = {
+                reinterpret_cast<uint64_t>(dev_mij),
+                reinterpret_cast<uint64_t>(dev_lij),
+                reinterpret_cast<uint64_t>(dev_oi_new),
+                reinterpret_cast<uint64_t>(dev_mi),
+                reinterpret_cast<uint64_t>(dev_li),
+                reinterpret_cast<uint64_t>(dev_oi),
+                static_cast<uint64_t>(is_first),
+                static_cast<uint64_t>(is_last),
+                reinterpret_cast<uint64_t>(out_ptr),
+                static_cast<uint64_t>(num_heads),
+                static_cast<uint64_t>(head_dim)
+            };
+            int t_up = runtime->add_task(up_args, 11, FUNC_ONLINE_UPDATE, CoreType::AIV);
+            total_tasks++;
+
+            // UP[bn] depends on PV[bn]
+            runtime->add_successor(t_pv_arr[bn], t_up);
+
+            // UP[bn] depends on UP[bn-1] (within same batch)
+            if (t_up_prev >= 0) {
+                runtime->add_successor(t_up_prev, t_up);
+            }
+
+            t_up_prev = t_up;
+        }
+    }
+
+    // Cleanup
+    delete[] dev_sij_arr;
+    delete[] dev_pij_arr;
+    delete[] dev_mij_arr;
+    delete[] dev_lij_arr;
+    delete[] dev_oi_new_arr;
+    delete[] dev_mi_arr;
+    delete[] dev_li_arr;
+    delete[] dev_oi_arr;
+
+    
+    std::cout << "Created " << total_tasks << " tasks\n";
+    runtime->print_runtime();
+
+    return 0;
+}
+
+}

--- a/src/runtime/host_build_graph/runtime/runtime.h
+++ b/src/runtime/host_build_graph/runtime/runtime.h
@@ -32,7 +32,7 @@
 // =============================================================================
 
 #ifndef RUNTIME_MAX_TASKS
-#define RUNTIME_MAX_TASKS 1024
+#define RUNTIME_MAX_TASKS 4096
 #endif
 
 #ifndef RUNTIME_MAX_ARGS


### PR DESCRIPTION
Implement Paged Attention algorithm on a2a3sim platform with manual AIC/AIV kernel splitting and parallel task orchestration.

- Add 4-kernel design with AIC/AIV split
  - aic_qk_matmul: Q @ K^T matrix multiplication (Cube unit)
  - aiv_softmax_prepare: scale, rowmax, exp, rowsum (Vector unit)
  - aic_pv_matmul: P @ V matrix multiplication (Cube unit)
  - aiv_online_update: Online Softmax accumulation + fused normalize (Vector unit)

- Add parallel orchestration strategy
  - QK/SF/PV chains run in parallel across blocks
  - UP tasks serialized within batch due to accumulator dependency
  - Support for GQA (Grouped Query Attention) with configurable kv_head_num

- Add golden.py following test framework conventions
  - TENSOR_ORDER and __outputs__ for CodeRunner compatibility
  - generate_inputs() for tensor generation with config parameters
  - compute_golden() implementing Online Softmax reference algorithm

- Add gen_mermaid_graph.py for task dependency visualization
  - Runs simulation and generates Mermaid flowchart
  - Supports batch filtering and custom output file
  - High contrast colors for AIC (blue) and AIV (orange) kernels

- Add comprehensive README.md documentation

Files:

- examples/paged_attention/golden.py
- examples/paged_attention/README.md
- examples/paged_attention/kernels/kernel_config.py
- examples/paged_attention/kernels/aic/aic_qk_matmul.cpp
- examples/paged_attention/kernels/aic/aic_pv_matmul.cpp
- examples/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
- examples/paged_attention/kernels/aiv/aiv_online_update.cpp
- examples/paged_attention/kernels/orchestration/paged_attention_orch.cpp