### PR TITLE
Refactor: Replace preprocessor platform detection with build-system s…

### DIFF
--- a/src/platform/a2a3/aicore/CMakeLists.txt
+++ b/src/platform/a2a3/aicore/CMakeLists.txt
@@ -41,7 +41,6 @@ set(AICORE_FLAGS
     -mllvm -cce-aicore-record-overflow=false \
     -mllvm -cce-aicore-addr-transform \
     -mllvm -cce-aicore-dcci-insert-for-scalar=false \
-    -D__PLATFORM_A2A3__ \
     ${CMAKE_CUSTOM_INCLUDE_DIR_FLAGS}"
 )
 separate_arguments(AICORE_FLAGS)

--- a/src/platform/a2a3/aicore/inner_kernel.h
+++ b/src/platform/a2a3/aicore/inner_kernel.h
@@ -1,0 +1,20 @@
+/**
+ * @file inner_kernel.h
+ * @brief Platform-specific AICore definitions for real hardware (a2a3)
+ *
+ * This header provides platform-specific macro definitions for AICore kernels
+ * running on real Ascend hardware with CANN compiler support.
+ */
+
+#ifndef PLATFORM_A2A3_AICORE_INNER_KERNEL_H_
+#define PLATFORM_A2A3_AICORE_INNER_KERNEL_H_
+
+// AICore function attribute for CANN compiler
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+// dcci (Data Cache Clean and Invalidate) is provided by CANN headers
+// No need to define it here - it's a hardware instruction
+
+#endif  // PLATFORM_A2A3_AICORE_INNER_KERNEL_H_

--- a/src/platform/a2a3/aicpu/CMakeLists.txt
+++ b/src/platform/a2a3/aicpu/CMakeLists.txt
@@ -47,12 +47,6 @@ target_compile_options(aicpu_kernel
         -g
 )
 
-# Platform definition
-target_compile_definitions(aicpu_kernel
-    PRIVATE
-        __PLATFORM_A2A3__
-)
-
 target_include_directories(aicpu_kernel
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/platform/a2a3/aicpu/device_log.cpp
+++ b/src/platform/a2a3/aicpu/device_log.cpp
@@ -3,15 +3,61 @@
  */
 
 #include "aicpu/device_log.h"
+#include "dlog_pub.h"  // CANN dlog API
+#include <cstdarg>
+#include <cstdio>
 
 bool g_is_log_enable_debug = false;
 bool g_is_log_enable_info = false;
 bool g_is_log_enable_warn = false;
 bool g_is_log_enable_error = false;
 
+const char* TILE_FWK_DEVICE_MACHINE = "AI_CPU";
+
 void init_log_switch() {
     g_is_log_enable_debug = CheckLogLevel(AICPU, DLOG_DEBUG);
     g_is_log_enable_info = CheckLogLevel(AICPU, DLOG_INFO);
     g_is_log_enable_warn = CheckLogLevel(AICPU, DLOG_WARN);
     g_is_log_enable_error = CheckLogLevel(AICPU, DLOG_ERROR);
+}
+
+// =============================================================================
+// Platform-Specific Logging Functions (Real Hardware: use CANN dlog API)
+// =============================================================================
+
+void dev_log_debug(const char* func, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    char buffer[2048];
+    vsnprintf(buffer, sizeof(buffer), fmt, args);
+    va_end(args);
+    // Add quotes around message to match original behavior (#fmt stringification)
+    dlog_debug(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
+}
+
+void dev_log_info(const char* func, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    char buffer[2048];
+    vsnprintf(buffer, sizeof(buffer), fmt, args);
+    va_end(args);
+    dlog_info(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
+}
+
+void dev_log_warn(const char* func, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    char buffer[2048];
+    vsnprintf(buffer, sizeof(buffer), fmt, args);
+    va_end(args);
+    dlog_warn(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
+}
+
+void dev_log_error(const char* func, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    char buffer[2048];
+    vsnprintf(buffer, sizeof(buffer), fmt, args);
+    va_end(args);
+    dlog_error(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
 }

--- a/src/platform/a2a3/host/CMakeLists.txt
+++ b/src/platform/a2a3/host/CMakeLists.txt
@@ -47,12 +47,6 @@ target_compile_options(host_runtime
         -g
 )
 
-# Platform definition
-target_compile_definitions(host_runtime
-    PRIVATE
-        __PLATFORM_A2A3__
-)
-
 # Include directories - always include local headers
 target_include_directories(host_runtime
     PRIVATE

--- a/src/platform/a2a3sim/aicore/inner_kernel.h
+++ b/src/platform/a2a3sim/aicore/inner_kernel.h
@@ -1,0 +1,24 @@
+/**
+ * @file inner_kernel.h
+ * @brief Platform-specific AICore definitions for simulation (a2a3sim)
+ *
+ * This header provides platform-specific macro definitions for AICore kernels
+ * running in host-based simulation environment.
+ */
+
+#ifndef PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
+#define PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
+
+// AICore function attribute - no-op in simulation
+#ifndef __aicore__
+#define __aicore__
+#endif
+
+// dcci (Data Cache Clean and Invalidate) - no-op in simulation
+#define dcci(addr, mode, opt) ((void)0)
+
+// Cache coherency constants (no-op in simulation)
+#define ENTIRE_DATA_CACHE 0
+#define CACHELINE_OUT 0
+
+#endif  // PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_

--- a/src/platform/a2a3sim/aicpu/CMakeLists.txt
+++ b/src/platform/a2a3sim/aicpu/CMakeLists.txt
@@ -22,9 +22,14 @@ else()
     message(FATAL_ERROR "MUST set CUSTOM_INCLUDE_DIRS to build AICPU (simulation)")
 endif()
 
-# Build complete source list
+# Build complete source list from CUSTOM_SOURCE_DIRS and platform sources
 set(AICPU_SOURCES "")
 
+# First, collect all .cpp files from the current platform directory
+file(GLOB PLATFORM_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+list(APPEND AICPU_SOURCES ${PLATFORM_SOURCES})
+
+# Then, collect sources from CUSTOM_SOURCE_DIRS (runtime sources)
 if(DEFINED CUSTOM_SOURCE_DIRS)
     foreach(SRC_DIR ${CUSTOM_SOURCE_DIRS})
         file(GLOB DIR_SOURCES "${SRC_DIR}/*.cpp" "${SRC_DIR}/*.c")

--- a/src/platform/a2a3sim/aicpu/device_log.cpp
+++ b/src/platform/a2a3sim/aicpu/device_log.cpp
@@ -1,0 +1,76 @@
+/**
+ * @file device_log.cpp
+ * @brief Simulation Platform Log Implementation
+ *
+ * Provides log enable flags and initialization for simulation environment.
+ * Simulation always enables all log levels by default.
+ */
+
+#include "aicpu/device_log.h"
+#include <cstdarg>
+#include <cstdio>
+
+// =============================================================================
+// Log Enable Flags (Simulation: always enabled)
+// =============================================================================
+
+bool g_is_log_enable_debug = true;
+bool g_is_log_enable_info = true;
+bool g_is_log_enable_warn = true;
+bool g_is_log_enable_error = true;
+
+// =============================================================================
+// Platform Constant
+// =============================================================================
+
+const char* TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
+
+// =============================================================================
+// Log Initialization (No-op for simulation)
+// =============================================================================
+
+void init_log_switch() {
+    // Simulation: no initialization needed
+    // All log levels are enabled by default
+    // Future: could read from environment variables if needed
+}
+
+// =============================================================================
+// Platform-Specific Logging Functions (Simulation: use printf)
+// =============================================================================
+
+void dev_log_debug(const char* func, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    printf("[DEBUG] %s: ", func);
+    vprintf(fmt, args);
+    printf("\n");
+    va_end(args);
+}
+
+void dev_log_info(const char* func, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    printf("[INFO] %s: ", func);
+    vprintf(fmt, args);
+    printf("\n");
+    va_end(args);
+}
+
+void dev_log_warn(const char* func, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    printf("[WARN] %s: ", func);
+    vprintf(fmt, args);
+    printf("\n");
+    va_end(args);
+}
+
+void dev_log_error(const char* func, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    printf("[ERROR] %s: ", func);
+    vprintf(fmt, args);
+    printf("\n");
+    va_end(args);
+}

--- a/src/platform/include/aicore/aicore.h
+++ b/src/platform/include/aicore/aicore.h
@@ -7,8 +7,8 @@
  * the appropriate implementation.
  *
  * Platform Support:
- * - a2a3 (__PLATFORM_A2A3__): Real Ascend hardware with CANN compiler
- * - a2a3sim (default): Host-based simulation using standard C++
+ * - a2a3: Real Ascend hardware with CANN compiler
+ * - a2a3sim: Host-based simulation using standard C++
  */
 
 #ifndef PLATFORM_AICORE_H_
@@ -37,23 +37,11 @@
 // =============================================================================
 // Platform-Specific Definitions
 // =============================================================================
+// Platform-specific macros (__aicore__, dcci) are defined in inner_kernel.h
+// The build system selects the correct implementation based on platform:
+// - src/platform/a2a3/aicore/inner_kernel.h (real hardware)
+// - src/platform/a2a3sim/aicore/inner_kernel.h (simulation)
 
-#if defined(__PLATFORM_A2A3__)
-    // Real hardware: Use CANN compiler attributes
-    #ifndef __aicore__
-    #define __aicore__ [aicore]
-    #endif
-
-#else
-    // Simulation: No-op macros for host execution
-    #ifndef __aicore__
-    #define __aicore__
-    #endif
-
-    // Cache coherency operations (no-op on unified memory)
-    #define ENTIRE_DATA_CACHE 0
-    #define CACHELINE_OUT 0
-    #define dcci(addr, mode, opt) ((void)0)
-#endif
+#include "inner_kernel.h"
 
 #endif  // PLATFORM_AICORE_H_


### PR DESCRIPTION
…election

Remove __PLATFORM_A2A3__ compile-time macro and refactor platform abstraction to use build system directory structure for platform selection. This improves code maintainability and reduces preprocessor complexity.

Key changes:
- Remove __PLATFORM_A2A3__ definitions from all CMakeLists.txt files
- Add platform-specific inner_kernel.h headers for AICore definitions
- Refactor logging from macro-based to function-based implementation
- Split device_log.cpp into platform-specific implementations (a2a3/a2a3sim)
- Unify public headers (aicore.h, device_log.h) to be platform-agnostic
- Update include paths to support platform-specific header inclusion

Benefits:
- Cleaner separation between platform-specific and common code
- Build system selects correct implementation based on directory structure
- Eliminates complex #ifdef blocks in public headers
- Easier to add new platform support in the future