### PR TITLE
Refactor: Better SCOPE api and remove redundant code

### DIFF
--- a/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -151,7 +151,7 @@ void aicpu_orchestration_entry(void* sm_ptr, uint64_t* args, int arg_count) {
             PTO2_INPUT(dev_b, tile, sz),
             PTO2_OUTPUT(dev_c, tile, sz),
         };
-        if (pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, nullptr, "kernel_add", params_t0, 3) < 0) {
+        if (pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t0, 3) < 0) {
             pto2_rt_orchestration_done(rt);
             pto2_runtime_destroy(rt);
             *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
@@ -163,7 +163,7 @@ void aicpu_orchestration_entry(void* sm_ptr, uint64_t* args, int arg_count) {
             PTO2_INPUT(dev_c, tile, sz),
             PTO2_OUTPUT(dev_d, tile, sz),
         };
-        if (pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, nullptr, "kernel_add_scalar", params_t1, 2) < 0) {
+        if (pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t1, 2) < 0) {
             pto2_rt_orchestration_done(rt);
             pto2_runtime_destroy(rt);
             *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
@@ -175,7 +175,7 @@ void aicpu_orchestration_entry(void* sm_ptr, uint64_t* args, int arg_count) {
             PTO2_INPUT(dev_c, tile, sz),
             PTO2_OUTPUT(dev_e, tile, sz),
         };
-        if (pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, nullptr, "kernel_add_scalar", params_t2, 2) < 0) {
+        if (pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t2, 2) < 0) {
             pto2_rt_orchestration_done(rt);
             pto2_runtime_destroy(rt);
             *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
@@ -188,7 +188,7 @@ void aicpu_orchestration_entry(void* sm_ptr, uint64_t* args, int arg_count) {
             PTO2_INPUT(dev_e, tile, sz),
             PTO2_OUTPUT(dev_f, tile, sz),
         };
-        int32_t task3_id = pto2_rt_submit_task(rt, 2, PTO2_WORKER_VECTOR, nullptr, "kernel_mul", params_t3, 3);
+        int32_t task3_id = pto2_rt_submit_task(rt, 2, PTO2_WORKER_VECTOR, "kernel_mul", params_t3, 3);
         if (task3_id < 0) {
             pto2_rt_orchestration_done(rt);
             pto2_runtime_destroy(rt);

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.c
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.c
@@ -276,28 +276,26 @@ void pto2_param_fix_sizes(void* params_base, int32_t num_params, int32_t size_by
 int32_t pto2_submit_task(PTO2OrchestratorState* orch,
                           int32_t kernel_id,
                           PTO2WorkerType worker_type,
-                          void* func_ptr,
                           const char* func_name,
                           PTO2TaskParam* params,
                           int32_t num_params) {
-    
+
     // === STEP 0: Sync TensorMap validity and optional cleanup ===
     pto2_orchestrator_sync_tensormap(orch);
-    
+
     // === STEP 1: Allocate task slot from Task Ring (may stall) ===
     int32_t task_id = pto2_task_ring_alloc(&orch->task_ring);
     if (task_id < 0) {
         return -1;  // Should not happen (stalls instead)
     }
-    
+
     PTO2TaskDescriptor* task = pto2_task_ring_get(&orch->task_ring, task_id);
-    
+
     // Initialize task descriptor
     task->task_id = task_id;
     task->kernel_id = kernel_id;
     task->worker_type = worker_type;
     task->scope_depth = pto2_get_scope_depth(orch);
-    task->func_ptr = func_ptr;
     task->func_name = func_name;
     task->fanin_head = 0;
     task->fanin_count = 0;

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -151,7 +151,7 @@ static inline int32_t pto2_get_scope_depth(PTO2OrchestratorState* orch) {
 
 /**
  * Submit a task with InCore function and parameters
- * 
+ *
  * This is the main API for building the task graph:
  * 1. Allocates task slot from TaskRing (may stall)
  * 2. Allocates packed output buffer from HeapRing (may stall)
@@ -159,11 +159,10 @@ static inline int32_t pto2_get_scope_depth(PTO2OrchestratorState* orch) {
  * 4. Updates producer's fanout_count/list (with spinlock)
  * 5. Registers outputs in TensorMap
  * 6. Initializes task state in scheduler
- * 
+ *
  * @param orch        Orchestrator state
  * @param kernel_id   InCore function ID
  * @param worker_type Target worker type (CUBE, VECTOR, AI_CPU, ACCELERATOR)
- * @param func_ptr    Function pointer (optional)
  * @param func_name   Function name (for debugging)
  * @param params      Array of task parameters
  * @param num_params  Number of parameters
@@ -172,7 +171,6 @@ static inline int32_t pto2_get_scope_depth(PTO2OrchestratorState* orch) {
 int32_t pto2_submit_task(PTO2OrchestratorState* orch,
                           int32_t kernel_id,
                           PTO2WorkerType worker_type,
-                          void* func_ptr,
                           const char* func_name,
                           PTO2TaskParam* params,
                           int32_t num_params);

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.c
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.c
@@ -164,22 +164,20 @@ void pto2_rt_scope_end(PTO2Runtime* rt) {
 int32_t pto2_rt_submit_task(PTO2Runtime* rt,
                              int32_t kernel_id,
                              PTO2WorkerType worker_type,
-                             void* func_ptr,
                              const char* func_name,
                              PTO2TaskParam* params,
                              int32_t num_params) {
     return pto2_submit_task(&rt->orchestrator, kernel_id, worker_type,
-                            func_ptr, func_name, params, num_params);
+                            func_name, params, num_params);
 }
 
 int32_t pto2_rt_submit(PTO2Runtime* rt,
                         const char* func_name,
-                        void* func_ptr,
                         PTO2TaskParam* params,
                         int32_t num_params) {
     // Auto-detect worker type based on function name
     PTO2WorkerType worker_type = PTO2_WORKER_VECTOR;  // Default
-    
+
     if (func_name) {
         if (strstr(func_name, "gemm") || strstr(func_name, "matmul") ||
             strstr(func_name, "conv") || strstr(func_name, "cube")) {
@@ -190,9 +188,9 @@ int32_t pto2_rt_submit(PTO2Runtime* rt,
             worker_type = PTO2_WORKER_AI_CPU;
         }
     }
-    
+
     return pto2_submit_task(&rt->orchestrator, 0, worker_type,
-                            func_ptr, func_name, params, num_params);
+                            func_name, params, num_params);
 }
 
 void pto2_rt_orchestration_done(PTO2Runtime* rt) {
@@ -204,212 +202,5 @@ void* pto2_rt_get_output(PTO2Runtime* rt, int32_t task_id, int32_t output_idx) {
 }
 
 // =============================================================================
-// Execution API
-// =============================================================================
-
-void pto2_runtime_execute(PTO2Runtime* rt) {
-    if (rt->mode == PTO2_MODE_GRAPH_ONLY) {
-        return;  // Nothing to execute
-    }
-    
-    // In simulated mode, process tasks in dependency order
-    // For real execution, would dispatch to actual workers
-    
-    int max_iterations = rt->orchestrator.tasks_submitted * 10 + 1000;
-    int iterations = 0;
-    
-    while (!pto2_scheduler_is_done(&rt->scheduler) && iterations < max_iterations) {
-        iterations++;
-        bool dispatched = false;
-        
-        // Try to dispatch ready tasks for each worker type
-        for (int wtype = 0; wtype < PTO2_NUM_WORKER_TYPES; wtype++) {
-            int32_t task_id = pto2_scheduler_get_ready_task(&rt->scheduler, (PTO2WorkerType)wtype);
-            
-            if (task_id >= 0) {
-                dispatched = true;
-                
-                // Mark as running
-                pto2_scheduler_mark_running(&rt->scheduler, task_id);
-                
-                // Execute task (in real mode, would dispatch to worker)
-                PTO2TaskDescriptor* task = pto2_sm_get_task(rt->sm_handle, task_id);
-                
-                if (rt->mode == PTO2_MODE_SIMULATE) {
-                    // Simulate execution with cycle counting
-                    // TODO: Use cycle cost function
-                    int64_t cycles = 1000;  // Placeholder
-                    rt->total_cycles += cycles;
-                }
-                
-                // Call the function if provided
-                if (task->func_ptr) {
-                    // Build args array from task parameters
-                    void* args[PTO2_MAX_OUTPUTS];
-                    int num_args = 0;
-                    
-                    // Add output pointers
-                    for (int i = 0; i < task->num_outputs; i++) {
-                        args[num_args++] = (char*)task->packed_buffer_base + 
-                                          task->output_offsets[i];
-                    }
-                    
-                    // Call function
-                    PTO2InCoreFunc func = (PTO2InCoreFunc)task->func_ptr;
-                    func(args, num_args);
-                }
-                
-                // Mark task complete
-                pto2_scheduler_on_task_complete(&rt->scheduler, task_id);
-            }
-        }
-        
-        if (!dispatched) {
-            // No tasks ready, brief pause to avoid busy-waiting
-            PTO2_SPIN_PAUSE();
-        }
-    }
-}
-
-void pto2_rt_task_complete(PTO2Runtime* rt, int32_t task_id) {
-    pto2_scheduler_on_task_complete(&rt->scheduler, task_id);
-}
-
-int32_t pto2_rt_get_ready_task(PTO2Runtime* rt, PTO2WorkerType worker_type) {
-    return pto2_scheduler_get_ready_task(&rt->scheduler, worker_type);
-}
-
-bool pto2_runtime_is_done(PTO2Runtime* rt) {
-    return pto2_scheduler_is_done(&rt->scheduler);
-}
-
-// =============================================================================
 // Statistics and Debug API
 // =============================================================================
-
-void pto2_runtime_print_stats(PTO2Runtime* rt) {
-    printf("\n========== PTO Runtime2 Statistics ==========\n\n");
-    
-    // Shared memory layout
-    pto2_sm_print_layout(rt->sm_handle);
-    printf("\n");
-    
-    // Orchestrator stats
-    pto2_orchestrator_print_stats(&rt->orchestrator);
-    printf("\n");
-    
-    // Scheduler stats
-    pto2_scheduler_print_stats(&rt->scheduler);
-    printf("\n");
-    
-    // Ready queues
-    pto2_scheduler_print_queues(&rt->scheduler);
-    printf("\n");
-    
-    // TensorMap stats
-    pto2_tensormap_print_stats(&rt->orchestrator.tensor_map);
-    printf("\n");
-    
-    // Overall stats
-    printf("=== Overall ===\n");
-    printf("Mode:          %s\n", 
-           rt->mode == PTO2_MODE_EXECUTE ? "EXECUTE" :
-           rt->mode == PTO2_MODE_SIMULATE ? "SIMULATE" : "GRAPH_ONLY");
-    printf("Total cycles:  %lld\n", (long long)rt->total_cycles);
-    printf("===============\n");
-    
-    printf("\n================================================\n");
-}
-
-int64_t pto2_runtime_get_cycles(PTO2Runtime* rt) {
-    return rt->total_cycles;
-}
-
-int pto2_runtime_dump_graph(PTO2Runtime* rt, const char* filename) {
-    FILE* f = fopen(filename, "w");
-    if (!f) {
-        return -1;
-    }
-    
-    fprintf(f, "# PTO Runtime2 Task Graph\n");
-    fprintf(f, "# Tasks: %lld\n\n", (long long)rt->orchestrator.tasks_submitted);
-    
-    // Dump task descriptors
-    int32_t current_index = rt->sm_handle->header->current_task_index;
-    int32_t last_alive = rt->sm_handle->header->last_task_alive;
-    
-    for (int32_t task_id = last_alive; task_id < current_index; task_id++) {
-        PTO2TaskDescriptor* task = pto2_sm_get_task(rt->sm_handle, task_id);
-        
-        fprintf(f, "task %d: %s (kernel=%d, worker=%d)\n",
-                task_id, 
-                task->func_name ? task->func_name : "unknown",
-                task->kernel_id,
-                task->worker_type);
-        
-        // Dump fanin (dependencies)
-        fprintf(f, "  fanin (%d): ", task->fanin_count);
-        int32_t current = task->fanin_head;
-        while (current > 0) {
-            PTO2DepListEntry* entry = pto2_dep_pool_get(&rt->orchestrator.dep_pool, current);
-            if (!entry) break;
-            fprintf(f, "%d ", entry->task_id);
-            current = entry->next_offset;
-        }
-        fprintf(f, "\n");
-        
-        // Dump fanout (consumers)
-        fprintf(f, "  fanout (%d): ", task->fanout_count);
-        current = task->fanout_head;
-        while (current > 0) {
-            PTO2DepListEntry* entry = pto2_dep_pool_get(&rt->orchestrator.dep_pool, current);
-            if (!entry) break;
-            fprintf(f, "%d ", entry->task_id);
-            current = entry->next_offset;
-        }
-        fprintf(f, "\n\n");
-    }
-    
-    fclose(f);
-    return 0;
-}
-
-bool pto2_runtime_validate(PTO2Runtime* rt) {
-    if (!rt) return false;
-    
-    // Validate shared memory
-    if (!pto2_sm_validate(rt->sm_handle)) {
-        fprintf(stderr, "Validation failed: shared memory\n");
-        return false;
-    }
-    
-    // Validate task ring consistency
-    int32_t current_index = rt->sm_handle->header->current_task_index;
-    int32_t last_alive = rt->sm_handle->header->last_task_alive;
-    
-    if (current_index < last_alive) {
-        fprintf(stderr, "Validation failed: current_index < last_alive\n");
-        return false;
-    }
-    
-    if (current_index - last_alive > PTO2_TASK_WINDOW_SIZE) {
-        fprintf(stderr, "Validation failed: task window overflow\n");
-        return false;
-    }
-    
-    // Validate heap ring consistency
-    int32_t heap_top = rt->sm_handle->header->heap_top;
-    int32_t heap_tail = rt->sm_handle->header->heap_tail;
-    
-    if (heap_top < 0 || heap_top > rt->gm_heap_size) {
-        fprintf(stderr, "Validation failed: heap_top out of range\n");
-        return false;
-    }
-    
-    if (heap_tail < 0 || heap_tail > rt->gm_heap_size) {
-        fprintf(stderr, "Validation failed: heap_tail out of range\n");
-        return false;
-    }
-    
-    return true;
-}

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -17,8 +17,7 @@
  *      - pto2_scope_begin() / pto2_scope_end()
  *      - pto2_submit_task()
  *   3. Mark orchestration complete: pto2_orchestrator_done()
- *   4. Execute or simulate: pto2_runtime_execute() / pto2_runtime_simulate()
- *   5. Destroy runtime: pto2_runtime_destroy()
+ *   4. Destroy runtime: pto2_runtime_destroy()
  *
  * Based on: docs/runtime_buffer_manager_methods.md
  */
@@ -158,7 +157,6 @@ void pto2_rt_scope_end(PTO2Runtime* rt);
  * @param rt          Runtime context
  * @param kernel_id   InCore function ID
  * @param worker_type Target worker type
- * @param func_ptr    Function pointer (optional)
  * @param func_name   Function name (for debugging)
  * @param params      Array of task parameters
  * @param num_params  Number of parameters
@@ -167,7 +165,6 @@ void pto2_rt_scope_end(PTO2Runtime* rt);
 int32_t pto2_rt_submit_task(PTO2Runtime* rt,
                              int32_t kernel_id,
                              PTO2WorkerType worker_type,
-                             void* func_ptr,
                              const char* func_name,
                              PTO2TaskParam* params,
                              int32_t num_params);
@@ -177,7 +174,6 @@ int32_t pto2_rt_submit_task(PTO2Runtime* rt,
  */
 int32_t pto2_rt_submit(PTO2Runtime* rt,
                         const char* func_name,
-                        void* func_ptr,
                         PTO2TaskParam* params,
                         int32_t num_params);
 
@@ -192,71 +188,6 @@ void pto2_rt_orchestration_done(PTO2Runtime* rt);
  * Get output buffer pointer for a task
  */
 void* pto2_rt_get_output(PTO2Runtime* rt, int32_t task_id, int32_t output_idx);
-
-// =============================================================================
-// Execution API
-// =============================================================================
-
-/**
- * Execute all submitted tasks
- *
- * In EXECUTE mode, dispatches tasks to workers.
- * In SIMULATE mode, simulates execution with cycle counting.
- * In GRAPH_ONLY mode, does nothing (graph already built).
- *
- * Blocks until all tasks complete.
- */
-void pto2_runtime_execute(PTO2Runtime* rt);
-
-/**
- * Signal task completion (called by worker)
- *
- * @param rt      Runtime context
- * @param task_id Completed task ID
- */
-void pto2_rt_task_complete(PTO2Runtime* rt, int32_t task_id);
-
-/**
- * Get next ready task for worker type
- *
- * @param rt          Runtime context
- * @param worker_type Worker type requesting task
- * @return Task ID, or -1 if no ready tasks
- */
-int32_t pto2_rt_get_ready_task(PTO2Runtime* rt, PTO2WorkerType worker_type);
-
-/**
- * Check if all tasks are complete
- */
-bool pto2_runtime_is_done(PTO2Runtime* rt);
-
-// =============================================================================
-// Statistics and Debug API
-// =============================================================================
-
-/**
- * Print runtime statistics
- */
-void pto2_runtime_print_stats(PTO2Runtime* rt);
-
-/**
- * Get total simulated cycles
- */
-int64_t pto2_runtime_get_cycles(PTO2Runtime* rt);
-
-/**
- * Dump task graph to file
- *
- * @param rt       Runtime context
- * @param filename Output file path
- * @return 0 on success, -1 on failure
- */
-int pto2_runtime_dump_graph(PTO2Runtime* rt, const char* filename);
-
-/**
- * Validate runtime state (for debugging)
- */
-bool pto2_runtime_validate(PTO2Runtime* rt);
 
 // =============================================================================
 // Convenience Macros (if not already defined in pto_runtime2_types.h)

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -328,9 +328,8 @@ typedef struct {
     
     // Input buffer pointers (for dependency resolution)
     int32_t  num_inputs;          // Number of input buffers
-    
-    // Function pointer (for execution)
-    void*    func_ptr;            // InCore function pointer
+
+    // Function name (for debugging/tracing)
     const char* func_name;        // Function name (for debugging/tracing)
     
     // Status flags


### PR DESCRIPTION
1. RAII pto scope, automatically quit scope.
2. Remove unused RT2 runtime functions and func_ptr field.