### PR TITLE
Update block_dim default to 24 and increase AICPU idle timeout thresholds

### DIFF
--- a/examples/host_build_graph/paged_attention/kernels/kernel_config.py
+++ b/examples/host_build_graph/paged_attention/kernels/kernel_config.py
@@ -39,5 +39,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "host_build_graph",
     "aicpu_thread_num": 3,
-    "block_dim": 3,
+    "block_dim": 24,
 }

--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -340,7 +340,7 @@ class CodeRunner:
         # Runtime configuration - read from kernel_config or use defaults
         runtime_config = getattr(self._kernel_config, 'RUNTIME_CONFIG', {})
         self.aicpu_thread_num = runtime_config.get('aicpu_thread_num', 3)
-        self.block_dim = runtime_config.get('block_dim', 3)
+        self.block_dim = runtime_config.get('block_dim', 24)
 
         # Resolve runtime_name from RUNTIME_CONFIG if not explicitly provided
         if runtime_name is None:

--- a/src/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -337,7 +337,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
 
     // Timeout detection using idle iteration counting
     int idle_iterations = 0;
-    const int MAX_IDLE_ITERATIONS = 10000000;
+    const int MAX_IDLE_ITERATIONS = 50000000;
     const int WARN_INTERVAL = 1000000;
     bool made_progress = false;
 

--- a/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -453,8 +453,8 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
     int cur_thread_completed = 0;
     int cur_thread_tasks_in_flight = 0;
     int idle_iterations = 0;
-    const int MAX_IDLE_ITERATIONS = 1000000;
-    const int WARN_INTERVAL = 100000;
+    const int MAX_IDLE_ITERATIONS = 50000000;
+    const int WARN_INTERVAL = 1000000;
 
     while (true) {
         if (completed_tasks_.load(std::memory_order_acquire) >= task_count) {


### PR DESCRIPTION
- Increase block_dim from 3 to 24 in kernel_config and code_runner defaults to better match actual hardware parallelism
- Raise MAX_IDLE_ITERATIONS to 50M across both runtimes to reduce false timeout errors under heavier workloads
- Align WARN_INTERVAL to 1M in tensormap_and_ringbuffer runtime