### PR TITLE
Support: Add performance profiling system for a2a3 and a2a3sim platforms

### DIFF
--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -355,6 +355,7 @@ class CodeRunner:
         runtime_name: Optional[str] = None,
         device_id: Optional[int] = None,
         platform: str = "a2a3",
+        enable_profiling: bool = False,
     ):
         # Setup logging if not already configured (e.g., when used directly, not via run_example.py)
         _setup_logging_if_needed()
@@ -362,6 +363,7 @@ class CodeRunner:
         self.kernels_dir = Path(kernels_dir).resolve()
         self.golden_path = Path(golden_path).resolve()
         self.platform = platform
+        self.enable_profiling = enable_profiling
         self.project_root = _get_project_root()
 
         # Resolve device ID
@@ -763,6 +765,11 @@ class CodeRunner:
                 )
             if run_env:
                 logger.debug(f"Runtime init env overrides: {run_env}")
+            
+            # Enable profiling if requested (must be before initialize)
+            if self.enable_profiling:
+                runtime.enable_profiling(True)
+                logger.info("Profiling enabled")
 
             with _temporary_env(run_env):
                 runtime.initialize(

--- a/examples/scripts/run_example.py
+++ b/examples/scripts/run_example.py
@@ -111,6 +111,12 @@ Golden.py interface:
         help="Set log level explicitly (overrides --verbose and --silent)"
     )
 
+    parser.add_argument(
+        "--enable-profiling",
+        action="store_true",
+        help="Enable profiling and generate swimlane.json"
+    )
+
     args = parser.parse_args()
 
     # Determine log level from arguments
@@ -172,6 +178,7 @@ Golden.py interface:
             golden_path=str(args.golden),
             device_id=args.device,
             platform=args.platform,
+            enable_profiling=args.enable_profiling,
         )
 
         runner.run()

--- a/python/bindings.py
+++ b/python/bindings.py
@@ -169,6 +169,10 @@ class RuntimeLibraryLoader:
         self.lib.get_pto2_sm_size.argtypes = [c_void_p]
         self.lib.get_pto2_sm_size.restype = c_int32
 
+        # enable_runtime_profiling - enable profiling for swimlane
+        self.lib.enable_runtime_profiling.argtypes = [c_void_p, c_int]
+        self.lib.enable_runtime_profiling.restype = c_int
+
 
 # ============================================================================
 # Python Wrapper Classes
@@ -315,6 +319,24 @@ class Runtime:
         rc = self.lib.finalize_runtime(self._handle)
         if rc != 0:
             raise RuntimeError(f"finalize_runtime failed: {rc}")
+
+    def enable_profiling(self, enabled: bool = True) -> None:
+        """
+        Enable or disable performance profiling for swimlane visualization.
+
+        Must be called before initialize() to enable profiling.
+        When enabled, the runtime records task execution timestamps and
+        generates swim_time.json after finalize().
+
+        Args:
+            enabled: True to enable profiling, False to disable
+
+        Raises:
+            RuntimeError: If enable operation fails
+        """
+        rc = self.lib.enable_runtime_profiling(self._handle, 1 if enabled else 0)
+        if rc != 0:
+            raise RuntimeError(f"enable_runtime_profiling failed: {rc}")
 
     def __del__(self):
         """Clean up runtime resources."""

--- a/src/platform/a2a3/host/CMakeLists.txt
+++ b/src/platform/a2a3/host/CMakeLists.txt
@@ -65,6 +65,7 @@ target_include_directories(host_runtime
         ${ASCEND_HOME_PATH}/pkg_inc
         ${ASCEND_HOME_PATH}/pkg_inc/runtime
         ${ASCEND_HOME_PATH}/pkg_inc/profiling
+        ${ASCEND_HOME_PATH}/aarch64-linux/include/driver
 )
 
 target_link_directories(host_runtime
@@ -74,10 +75,13 @@ target_link_directories(host_runtime
 )
 
 # Link against CANN runtime libraries
+# ascend_hal is NOT linked here; it is loaded lazily via dlopen in device_runner
+# when performance profiling is used, so set_device() does not pull in driver/HAL.
 target_link_libraries(host_runtime
     PRIVATE
         runtime
         ascendcl
+        dl
 )
 
 set_target_properties(host_runtime PROPERTIES OUTPUT_NAME "host_runtime")

--- a/src/platform/a2a3/host/pto_runtime_c_api.cpp
+++ b/src/platform/a2a3/host/pto_runtime_c_api.cpp
@@ -243,4 +243,17 @@ int32_t get_pto2_sm_size(RuntimeHandle runtime) {
     return 4 * 1024 * 1024;  // 4 MiB
 }
 
+int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
+    if (runtime == NULL) {
+        return -1;
+    }
+    try {
+        Runtime* r = static_cast<Runtime*>(runtime);
+        r->enable_profiling = (enabled != 0);
+        return 0;
+    } catch (...) {
+        return -1;
+    }
+}
+
 } /* extern "C" */

--- a/src/platform/a2a3sim/aicore/inner_kernel.h
+++ b/src/platform/a2a3sim/aicore/inner_kernel.h
@@ -9,6 +9,11 @@
 #ifndef PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
 #define PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
 
+#include <chrono>
+#include <cstdint>
+
+#include "common/platform_config.h"
+
 // AICore function attribute - no-op in simulation
 #ifndef __aicore__
 #define __aicore__
@@ -20,5 +25,54 @@
 // Cache coherency constants (no-op in simulation)
 #define ENTIRE_DATA_CACHE 0
 #define CACHELINE_OUT 0
+
+// =============================================================================
+// System Counter Simulation
+// =============================================================================
+
+/**
+ * Simulated system counter for performance profiling
+ *
+ * Mimics hardware counter behavior by returning a monotonic value
+ * at 1850 MHz frequency (matching a2a3 hardware counter).
+ *
+ * Implementation:
+ * - Uses std::chrono::high_resolution_clock as time source
+ * - Converts elapsed nanoseconds to counter ticks
+ * - Counter frequency: PLATFORM_PROF_SYS_CNT_FREQ (1850 MHz)
+ *
+ * This ensures performance data calculation uses the same formula
+ * as the real a2a3 platform:
+ *   duration_us = (counter_ticks * 1000000) / 1850000000
+ *
+ * Thread-safety: The static variable is initialized once globally,
+ * ensuring all threads share the same time base for consistent
+ * cross-thread time comparison.
+ *
+ * @return Simulated counter value (ticks since program start)
+ */
+inline uint64_t get_sys_cnt() {
+    // Use a global start time to ensure consistency across all threads
+    static auto program_start = std::chrono::high_resolution_clock::now();
+
+    auto now = std::chrono::high_resolution_clock::now();
+    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        now - program_start
+    ).count();
+
+    // Convert nanoseconds to counter ticks at PLATFORM_PROF_SYS_CNT_FREQ (1850 MHz)
+    // Formula: ticks = (ns * freq_hz) / 1e9
+    //
+    // To avoid overflow, break down the calculation:
+    // 1. Split elapsed_ns into seconds and remainder nanoseconds
+    // 2. Calculate ticks for each part separately
+    uint64_t seconds = elapsed_ns / 1000000000ULL;
+    uint64_t remaining_ns = elapsed_ns % 1000000000ULL;
+
+    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ +
+                     (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / 1000000000ULL;
+
+    return ticks;
+}
 
 #endif  // PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_

--- a/src/platform/a2a3sim/host/device_runner.cpp
+++ b/src/platform/a2a3sim/host/device_runner.cpp
@@ -16,19 +16,6 @@
 
 #include "device_runner.h"
 
-#include <cstdio>
-#include <cstring>
-#include <dlfcn.h>
-#include <fstream>
-#include <iostream>
-#include <thread>
-#include <unistd.h>
-#include <vector>
-
-#include "common/platform_config.h"
-#include "common/unified_log.h"
-#include "runtime.h"
-
 // Function pointer types for dynamically loaded executors
 typedef int (*aicpu_execute_func_t)(Runtime* runtime);
 typedef void (*aicore_execute_func_t)(Runtime* runtime, int block_idx, CoreType core_type);
@@ -217,6 +204,15 @@ int DeviceRunner::run(Runtime& runtime,
     // Store runtime pointer for print_handshake_results
     last_runtime_ = &runtime;
 
+    // Initialize performance profiling if enabled
+    if (runtime.enable_profiling) {
+        rc = init_performance_profiling(runtime, num_cores, device_id);
+        if (rc != 0) {
+            LOG_ERROR("init_performance_profiling failed: %d", rc);
+            return rc;
+        }
+    }
+
     // Check if executors are loaded
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
@@ -242,6 +238,14 @@ int DeviceRunner::run(Runtime& runtime,
         });
     }
 
+    // Poll and collect performance data during execution (if enabled)
+    std::thread collector_thread;
+    if (runtime.enable_profiling) {
+        collector_thread = std::thread([this, &runtime, num_cores]() {
+            poll_and_collect_performance_data(num_cores, runtime.get_task_count());
+        });
+    }
+
     // Wait for all threads to complete
     LOG_INFO("=== Waiting for threads to complete ===");
     for (auto& t : aicpu_threads) {
@@ -251,7 +255,18 @@ int DeviceRunner::run(Runtime& runtime,
         t.join();
     }
 
+    // Wait for collector thread if it was launched
+    if (runtime.enable_profiling && collector_thread.joinable()) {
+        collector_thread.join();
+    }
+
     LOG_INFO("=== All threads completed ===");
+
+    // Print performance data after execution completes
+    if (runtime.enable_profiling) {
+        print_performance_data();
+    }
+
     return 0;
 }
 
@@ -279,6 +294,14 @@ int DeviceRunner::finalize() {
 
     // Print handshake results before cleanup
     print_handshake_results();
+
+    // Cleanup performance profiling resources (inline, matching a2a3 style)
+    if (perf_shared_mem_dev_ != nullptr) {
+        free(perf_shared_mem_dev_);
+        perf_shared_mem_dev_ = nullptr;
+        perf_shared_mem_host_ = nullptr;
+    }
+    collected_perf_records_.clear();
 
     // Close all dlopen'd kernel libraries
     for (auto& pair : func_id_to_addr_) {
@@ -386,4 +409,277 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
                   func_id, kernel.func_addr, handle);
 
     return kernel.func_addr;
+}
+
+// =============================================================================
+// Performance Profiling Implementation
+// =============================================================================
+
+int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_cores, int device_id) {
+    (void)device_id;  // Unused in simulation
+
+    LOG_INFO("\n=== Initializing Performance Profiling ===");
+
+    // Step 1: Calculate total memory size (header + all DoubleBuffers)
+    size_t total_size = calc_perf_data_size(num_cores);
+
+    size_t header_size = sizeof(PerfDataHeader);
+    size_t single_db_size = sizeof(DoubleBuffer);
+    size_t buffers_size = num_cores * single_db_size;
+
+    LOG_INFO("  Memory allocation plan:");
+    LOG_INFO("    - Number of cores:      %d", num_cores);
+    LOG_INFO("    - Header size:          %zu bytes", header_size);
+    LOG_INFO("      (includes ready queue: %d entries)", PLATFORM_MAX_CORES * 2);
+    LOG_INFO("    - Single DoubleBuffer:  %zu bytes", single_db_size);
+    LOG_INFO("    - All DoubleBuffers:    %zu bytes", buffers_size);
+    LOG_INFO("    - Total size:           %zu bytes (%zu KB, %zu MB)",
+             total_size, total_size / 1024, total_size / (1024 * 1024));
+
+    // Step 2: Allocate device shared memory (simulation: use malloc for host memory)
+    void* perf_dev_ptr = malloc(total_size);
+    if (perf_dev_ptr == nullptr) {
+        LOG_ERROR("Failed to allocate device memory for profiling (%zu bytes)", total_size);
+        return -1;
+    }
+    LOG_INFO("  Allocated device memory: %p", perf_dev_ptr);
+
+    // Step 3: Register to host mapping (simulation: both pointers point to same memory)
+    void* perf_host_ptr = perf_dev_ptr;  // In simulation, both point to same memory
+    LOG_INFO("  Mapped to host memory:   %p", perf_host_ptr);
+
+    // Step 4: Initialize fixed header (using host_ptr)
+    PerfDataHeader* header = get_perf_header(perf_host_ptr);
+
+    // Initialize queue
+    memset(header->queue, 0, sizeof(header->queue));
+    header->queue_head = 0;
+    header->queue_tail = 0;
+
+    // Initialize metadata
+    header->num_cores = num_cores;
+
+    LOG_INFO("  Initialized PerfDataHeader:");
+    LOG_INFO("    - num_cores:        %d", header->num_cores);
+    LOG_INFO("    - buffer_capacity:  %d", PLATFORM_PROF_BUFFER_SIZE);
+    LOG_INFO("    - queue capacity:   %d", PLATFORM_MAX_CORES * 2);
+
+    // Step 5: Initialize all DoubleBuffers (all buffers start as 0=idle)
+    DoubleBuffer* buffers = get_double_buffers(perf_host_ptr);
+
+    for (int i = 0; i < num_cores; i++) {
+        DoubleBuffer* db = &buffers[i];
+
+        // Initialize buffer1
+        memset(&db->buffer1, 0, sizeof(PerfBuffer));
+        db->buffer1.count = 0;
+        db->buffer1.first_task_time = 0;
+        db->buffer1_status = BufferStatus::IDLE;
+
+        // Initialize buffer2
+        memset(&db->buffer2, 0, sizeof(PerfBuffer));
+        db->buffer2.count = 0;
+        db->buffer2.first_task_time = 0;
+        db->buffer2_status = BufferStatus::IDLE;
+    }
+
+    LOG_INFO("  Initialized %d DoubleBuffers (all status=0, idle)", num_cores);
+
+    // Step 6: Write memory barrier (ensure all initialization visible to workers)
+    wmb();
+
+    // Step 7: Pass to Runtime (device base address)
+    runtime.perf_data_base = (uint64_t)perf_dev_ptr;
+
+    LOG_INFO("  Set runtime.perf_data_base = 0x%lx", runtime.perf_data_base);
+
+    // Step 8: Save pointers to member variables
+    perf_shared_mem_dev_ = perf_dev_ptr;
+    perf_shared_mem_host_ = perf_host_ptr;
+
+    LOG_INFO("=== Performance Profiling Initialized ===");
+
+    return 0;
+}
+
+void DeviceRunner::poll_and_collect_performance_data(int num_cores, int expected_tasks) {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;  // Profiling not enabled
+    }
+
+    LOG_INFO("=== Collecting Performance Data (Before Stream Sync) ===");
+    LOG_INFO("  Expected tasks: %d", expected_tasks);
+
+    PerfDataHeader* header = get_perf_header(perf_shared_mem_host_);
+    DoubleBuffer* buffers = get_double_buffers(perf_shared_mem_host_);
+
+    uint32_t capacity = PLATFORM_MAX_CORES * 2;
+    int total_records_collected = 0;
+    int buffers_processed = 0;
+
+    // Clear previous collection
+    collected_perf_records_.clear();
+
+    // Timeout configuration
+    const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);  // 30 second timeout
+    const auto start_time = std::chrono::steady_clock::now();
+    int empty_poll_count = 0;
+
+    // Poll the ready queue until all expected tasks are collected
+    while (total_records_collected < expected_tasks) {
+        // Read queue status with memory barrier
+        rmb();
+        uint32_t head = header->queue_head;
+        uint32_t tail = header->queue_tail;
+
+        // Check if queue is empty
+        if (head == tail) {
+            // Queue is empty but we haven't collected all tasks yet
+            // Check for timeout periodically
+            empty_poll_count++;
+            if (empty_poll_count >= PLATFORM_PROF_EMPTY_POLLS_CHECK_NUM) {
+                empty_poll_count = 0;
+                auto elapsed = std::chrono::steady_clock::now() - start_time;
+                if (elapsed >= timeout_duration) {
+                    LOG_WARN("  WARNING: Performance data collection timeout after %ld seconds",
+                             std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                    LOG_WARN("  Collected %d / %d records before timeout",
+                             total_records_collected, expected_tasks);
+                    break;  // Exit with partial data
+                }
+            }
+            // Continue polling (AICPU may still be producing data)
+            continue;
+        }
+
+        // Reset empty poll counter when we find data
+        empty_poll_count = 0;
+
+        // Dequeue entry
+        ReadyQueueEntry entry = header->queue[head];
+        uint32_t core_index = entry.core_index;
+        uint32_t buffer_id = entry.buffer_id;
+
+        // Validate core index
+        if (core_index >= static_cast<uint32_t>(num_cores)) {
+            LOG_ERROR("  ERROR: Invalid core_index %u (max=%d)", core_index, num_cores);
+            break;
+        }
+
+        LOG_DEBUG("  Processing: core=%u, buffer=%u", core_index, buffer_id);
+
+        // Get the buffer and status pointer
+        DoubleBuffer* db = &buffers[core_index];
+        PerfBuffer* buf = nullptr;
+        volatile BufferStatus* status = nullptr;
+        get_buffer_and_status(db, buffer_id, &buf, &status);
+
+        // Read buffer data with memory barrier
+        rmb();
+        uint32_t count = buf->count;
+        uint64_t first_task_time = buf->first_task_time;
+
+        LOG_DEBUG("    Records in buffer: %u", count);
+        LOG_DEBUG("    First task time: %lu", first_task_time);
+
+        // Collect records
+        for (uint32_t i = 0; i < count && i < PLATFORM_PROF_BUFFER_SIZE; i++) {
+            collected_perf_records_.push_back(buf->records[i]);
+            total_records_collected++;
+        }
+
+        // Clear buffer
+        buf->count = 0;
+        buf->first_task_time = 0;
+
+        // Set buffer status to IDLE
+        *status = BufferStatus::IDLE;
+        wmb();  // Ensure status is visible to AICPU
+
+        // Update queue head
+        header->queue_head = (head + 1) % capacity;
+        wmb();  // Ensure head update is visible to AICPU
+
+        buffers_processed++;
+    }
+
+    LOG_INFO("  Total buffers processed: %d", buffers_processed);
+    LOG_INFO("  Total records collected: %d", total_records_collected);
+
+    if (total_records_collected < expected_tasks) {
+        LOG_WARN("  WARNING: Incomplete collection (%d / %d records)",
+                 total_records_collected, expected_tasks);
+    }
+
+    LOG_INFO("=== Performance Data Collection Complete ===\n");
+}
+
+void DeviceRunner::print_performance_data() {
+    if (collected_perf_records_.empty()) {
+        LOG_INFO("=== No Performance Data to Print ===");
+        return;
+    }
+
+    LOG_INFO("=== Performance Records Detail ===");
+
+    // Calculate min start time for normalization
+    uint64_t min_time = UINT64_MAX;
+    for (const auto& record : collected_perf_records_) {
+        if (record.start_time < min_time) {
+            min_time = record.start_time;
+        }
+    }
+
+    // Print detailed records only in DEBUG mode
+    LOG_DEBUG("  Base time (for normalization): %lu", min_time);
+    LOG_DEBUG("");
+    LOG_DEBUG("  Task execution records:");
+    LOG_DEBUG("  ┌────────┬─────────┬─────────┬────────────┬──────────────────┬──────────────────┬──────────────┬──────────┐");
+    LOG_DEBUG("  │ Task ID│ Func ID │ Core ID │ Core Type  │  Start (cycles)  │   End (cycles)   │Duration(cyc) │  Fanout  │");
+    LOG_DEBUG("  ├────────┼─────────┼─────────┼────────────┼──────────────────┼──────────────────┼──────────────┼──────────┤");
+
+    for (size_t i = 0; i < collected_perf_records_.size() && i < 50; i++) {  // Limit to first 50 for display
+        const PerfRecord& record = collected_perf_records_[i];
+
+        // Normalize times
+        uint64_t norm_start = record.start_time - min_time;
+        uint64_t norm_end = record.end_time - min_time;
+
+        char line_buf[256];
+        snprintf(line_buf, sizeof(line_buf),
+                 "  │ %6u │ %7u │ %7u │ %10s │ %16lu │ %16lu │ %12lu │ %8u │",
+                 record.task_id, record.func_id, record.core_id,
+                 (record.core_type == CoreType::AIC ? "AIC" : "AIV"),
+                 norm_start, norm_end, record.duration, record.fanout_count);
+        LOG_DEBUG("%s", line_buf);
+    }
+
+    LOG_DEBUG("  └────────┴─────────┴─────────┴────────────┴──────────────────┴──────────────────┴──────────────┴──────────┘");
+
+    if (collected_perf_records_.size() > 50) {
+        LOG_DEBUG("  ... (%zu more records not shown)", collected_perf_records_.size() - 50);
+    }
+
+    // Calculate statistics
+    uint64_t total_duration = 0;
+    uint64_t max_duration = 0;
+    uint64_t min_duration = UINT64_MAX;
+
+    for (const auto& record : collected_perf_records_) {
+        total_duration += record.duration;
+        if (record.duration > max_duration) max_duration = record.duration;
+        if (record.duration < min_duration) min_duration = record.duration;
+    }
+
+    double avg_duration = static_cast<double>(total_duration) / collected_perf_records_.size();
+
+    LOG_INFO("");
+    LOG_INFO("  Performance Statistics:");
+    LOG_INFO("    Total tasks:     %zu", collected_perf_records_.size());
+    LOG_INFO("    Avg duration:    %lu cycles", static_cast<uint64_t>(avg_duration));
+    LOG_INFO("    Min duration:    %lu cycles", min_duration);
+    LOG_INFO("    Max duration:    %lu cycles", max_duration);
+    LOG_INFO("    Total duration:  %lu cycles", total_duration);
+
+    LOG_INFO("=== Performance Data Print Complete ===");
 }

--- a/src/platform/a2a3sim/host/pto_runtime_c_api.cpp
+++ b/src/platform/a2a3sim/host/pto_runtime_c_api.cpp
@@ -210,6 +210,19 @@ int set_device(int device_id) {
     return 0;
 }
 
+int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
+    if (runtime == NULL) {
+        return -1;
+    }
+    try {
+        Runtime* r = static_cast<Runtime*>(runtime);
+        r->enable_profiling = (enabled != 0);
+        return 0;
+    } catch (...) {
+        return -1;
+    }
+}
+
 /* Note: register_kernel() has been internalized into init_runtime().
  * Kernel binaries are now passed directly to init_runtime() which handles
  * registration and stores addresses in Runtime's func_id_to_addr_[] array.

--- a/src/platform/include/common/memory_barrier.h
+++ b/src/platform/include/common/memory_barrier.h
@@ -1,0 +1,44 @@
+/**
+ * @file memory_barrier.h
+ * @brief Memory barrier definitions for shared memory synchronization
+ *
+ * This header provides platform-specific memory barrier macros for
+ * synchronizing shared memory accesses between Host, AICPU, and AICore.
+ *
+ * Memory barriers ensure that:
+ * - Read barriers (rmb): All reads before the barrier complete before any reads after
+ * - Write barriers (wmb): All writes before the barrier complete before any writes after
+ *
+ * These are critical for correct operation of lock-free data structures
+ * and shared memory protocols across different processing units.
+ */
+
+#ifndef PLATFORM_COMMON_MEMORY_BARRIER_H_
+#define PLATFORM_COMMON_MEMORY_BARRIER_H_
+
+// =============================================================================
+// Memory Barrier Macros
+// =============================================================================
+
+#ifdef __aarch64__
+    /**
+     * Read memory barrier (ARM64)
+     * Ensures all loads before this point complete before any loads after.
+     */
+    #define rmb() __asm__ __volatile__("dsb ld" ::: "memory")
+
+    /**
+     * Write memory barrier (ARM64)
+     * Ensures all stores before this point complete before any stores after.
+     */
+    #define wmb() __asm__ __volatile__("dsb st" ::: "memory")
+#else
+    /**
+     * Compiler barrier (fallback for non-ARM64 platforms)
+     * Prevents compiler reordering but does not emit hardware barriers.
+     */
+    #define rmb() __asm__ __volatile__("" ::: "memory")
+    #define wmb() __asm__ __volatile__("" ::: "memory")
+#endif
+
+#endif  // PLATFORM_COMMON_MEMORY_BARRIER_H_

--- a/src/platform/include/common/perf_profiling.h
+++ b/src/platform/include/common/perf_profiling.h
@@ -1,0 +1,265 @@
+/**
+ * @file perf_profiling.h
+ * @brief Performance profiling data structures
+ *
+ * Architecture: Fixed header + dynamic tail
+ *
+ * Memory layout:
+ * ┌────────────────────────────────────────────────────────────┐
+ * │ PerfDataHeader (fixed header)                              │
+ * │  - ReadyQueue (FIFO, capacity=PLATFORM_MAX_CORES*2)        │
+ * │  - Metadata (num_cores, buffer_capacity, flags)            │
+ * ├────────────────────────────────────────────────────────────┤
+ * │ DoubleBuffer[0] (Core 0)                                   │
+ * │  - buffer1, buffer2 (PerfBuffer)                           │
+ * │  - buffer1_status, buffer2_status (0/1/2)                  │
+ * ├────────────────────────────────────────────────────────────┤
+ * │ DoubleBuffer[1] (Core 1)                                   │
+ * ├────────────────────────────────────────────────────────────┤
+ * │ ...                                                        │
+ * ├────────────────────────────────────────────────────────────┤
+ * │ DoubleBuffer[num_cores-1]                                  │
+ * └────────────────────────────────────────────────────────────┘
+ *
+ * Total size = sizeof(PerfDataHeader) + num_cores * sizeof(DoubleBuffer)
+ */
+
+#ifndef PLATFORM_COMMON_PERF_PROFILING_H_
+#define PLATFORM_COMMON_PERF_PROFILING_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "platform_config.h"
+#include "core_type.h"
+
+// Maximum number of successor tasks per PerfRecord (matches Task::fanout)
+#ifndef RUNTIME_MAX_FANOUT
+#define RUNTIME_MAX_FANOUT 512
+#endif
+
+// Maximum cores that can be profiled simultaneously
+#ifndef PLATFORM_MAX_CORES
+#define PLATFORM_MAX_CORES 72  // 24 blocks × 3 cores/block
+#endif
+
+// =============================================================================
+// Buffer Status Enumeration
+// =============================================================================
+
+/**
+ * Buffer status enumeration (3-state design)
+ *
+ * State transition flow:
+ * IDLE (0) → WRITING (1) → READY (2) → IDLE (0)
+ *
+ * - AICPU: IDLE→WRITING (on allocation), WRITING→READY (when buffer full)
+ * - AICore: Only writes data, does not modify status
+ * - Host:   READY→IDLE (after reading)
+ *
+ * Note: Using uint32_t for binary compatibility with volatile fields.
+ */
+enum class BufferStatus : uint32_t {
+    IDLE    = 0,  // Idle: can be allocated by AICPU
+    WRITING = 1,  // Writing: in use by AICore
+    READY   = 2   // Ready: full, waiting for Host
+};
+
+// =============================================================================
+// PerfRecord - Single Task Execution Record
+// =============================================================================
+
+/**
+ * Single task execution record
+ */
+struct PerfRecord {
+    // Timing information (device clock timestamps)
+    uint64_t start_time;      // Task start timestamp (get_sys_cnt)
+    uint64_t end_time;        // Task end timestamp
+    uint64_t duration;        // Execution duration (end - start)
+
+    // Task identification
+    uint32_t task_id;         // Task unique identifier
+    uint32_t func_id;         // Kernel function identifier
+    uint32_t core_id;         // Physical core ID (0-71)
+    CoreType core_type;       // Core type (AIC/AIV)
+
+    // Dependency relationship (fanout only)
+    int32_t fanout[RUNTIME_MAX_FANOUT];  // Successor task ID array
+    int32_t fanout_count;                 // Number of successor tasks
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(PerfRecord) % 64 == 0,
+              "PerfRecord must be 64-byte aligned for optimal cache performance");
+
+// =============================================================================
+// PerfBuffer - Fixed-Size Record Buffer
+// =============================================================================
+
+/**
+ * Fixed-size performance record buffer
+ *
+ * Capacity: PLATFORM_PROF_BUFFER_SIZE (defined in platform_config.h)
+ *
+ * Additional feature: Records the first task's time for cross-core time alignment
+ */
+struct PerfBuffer {
+    PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Record array
+    volatile uint32_t count;                         // Current record count
+
+    // Time alignment support (each buffer records independently)
+    volatile uint64_t first_task_time;               // Start time of first task
+} __attribute__((aligned(64)));
+
+// =============================================================================
+// DoubleBuffer - Per-Core Ping-Pong Buffers
+// =============================================================================
+
+/**
+ * Per-core double buffer with status management
+ *
+ * Design highlights:
+ * 1. Two independent PerfBuffers (buffer1, buffer2)
+ * 2. Each buffer has independent status field (0/1/2)
+ * 3. AICPU checks status to decide if buffer can be allocated to AICore
+ * 4. Host retrieves ready buffers from queue for reading
+ *
+ * State transitions:
+ * - AICPU: 0→1 (allocation), 1→2 (detected full, enqueue)
+ * - AICore: Only writes records, increments count (does not modify status)
+ * - Host:   2→0 (after reading, clear to zero)
+ *
+ * Priority strategy:
+ * - When both buffers are idle, AICPU prioritizes buffer1
+ */
+struct DoubleBuffer {
+    // Buffer 1 (Ping)
+    PerfBuffer buffer1;                              // First buffer
+    volatile BufferStatus buffer1_status;            // Buffer1 status (IDLE/WRITING/READY)
+
+    // Buffer 2 (Pong)
+    PerfBuffer buffer2;                              // Second buffer
+    volatile BufferStatus buffer2_status;            // Buffer2 status (IDLE/WRITING/READY)
+} __attribute__((aligned(64)));
+
+// =============================================================================
+// ReadyQueueEntry - Queue Entry for Ready Buffers
+// =============================================================================
+
+/**
+ * Ready queue entry
+ *
+ * When a buffer on a core is full, AICPU adds this entry to the queue.
+ * Host retrieves entries from the queue to locate (core_index, buffer_id) for reading.
+ */
+struct ReadyQueueEntry {
+    uint32_t core_index;      // Core index (0 ~ num_cores-1)
+    uint32_t buffer_id;       // Buffer ID (1=buffer1, 2=buffer2)
+} __attribute__((aligned(16)));
+
+// =============================================================================
+// PerfDataHeader - Fixed Header
+// =============================================================================
+
+/**
+ * Performance data fixed header
+ *
+ * Located at the start of shared memory, contains:
+ * 1. Ready queue (FIFO Circular Buffer)
+ * 2. Metadata (core count)
+ *
+ * Ready queue design:
+ * - Capacity: PLATFORM_MAX_CORES * 2 (max 2 buffers ready per core)
+ * - Implementation: Circular Buffer
+ * - Producer: AICPU (adds full buffers)
+ * - Consumer: Host (reads and clears buffers)
+ * - Queue empty: head == tail
+ * - Queue full: (tail + 1) % capacity == head
+ */
+struct PerfDataHeader {
+    // Ready queue (FIFO Circular Buffer)
+    ReadyQueueEntry queue[PLATFORM_MAX_CORES * 2];  // Queue array (capacity=144)
+    volatile uint32_t queue_head;                    // Consumer read position (Host modifies)
+    volatile uint32_t queue_tail;                    // Producer write position (AICPU modifies)
+
+    // Metadata (Host initializes, Device read-only)
+    uint32_t num_cores;                              // Actual number of cores launched
+} __attribute__((aligned(64)));
+
+// =============================================================================
+// Helper Functions - Memory Layout
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Calculate total memory size for performance data
+ *
+ * Formula: Total size = Fixed header + Dynamic tail
+ *                     = sizeof(PerfDataHeader) + num_cores × sizeof(DoubleBuffer)
+ *
+ * @param num_cores Number of cores (block_dim × PLATFORM_CORES_PER_BLOCKDIM)
+ * @return Total bytes
+ */
+inline size_t calc_perf_data_size(int num_cores) {
+    return sizeof(PerfDataHeader) + num_cores * sizeof(DoubleBuffer);
+}
+
+/**
+ * Get header pointer
+ *
+ * @param base_ptr Shared memory base address (device_ptr or host_ptr)
+ * @return PerfDataHeader pointer
+ */
+inline PerfDataHeader* get_perf_header(void* base_ptr) {
+    return (PerfDataHeader*)base_ptr;
+}
+
+/**
+ * Get DoubleBuffer array start address
+ *
+ * @param base_ptr Shared memory base address
+ * @return DoubleBuffer array pointer
+ */
+inline DoubleBuffer* get_double_buffers(void* base_ptr) {
+    return (DoubleBuffer*)((char*)base_ptr + sizeof(PerfDataHeader));
+}
+
+/**
+ * Get DoubleBuffer for specified core
+ *
+ * @param base_ptr Shared memory base address
+ * @param core_index Core index (0 ~ num_cores-1)
+ * @return DoubleBuffer pointer
+ */
+inline DoubleBuffer* get_core_double_buffer(void* base_ptr, int core_index) {
+    DoubleBuffer* buffers = get_double_buffers(base_ptr);
+    return &buffers[core_index];
+}
+
+/**
+ * Get buffer pointer and status pointer for specified buffer
+ *
+ * @param db DoubleBuffer pointer
+ * @param buffer_id Buffer ID (1=buffer1, 2=buffer2)
+ * @param[out] buf PerfBuffer pointer
+ * @param[out] status Status pointer
+ */
+inline void get_buffer_and_status(DoubleBuffer* db, uint32_t buffer_id,
+                                  PerfBuffer** buf, volatile BufferStatus** status) {
+    if (buffer_id == 1) {
+        *buf = &db->buffer1;
+        *status = &db->buffer1_status;
+    } else {
+        *buf = &db->buffer2;
+        *status = &db->buffer2_status;
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // PLATFORM_COMMON_PERF_PROFILING_H_

--- a/src/platform/include/common/platform_config.h
+++ b/src/platform/include/common/platform_config.h
@@ -61,4 +61,31 @@ constexpr int PLATFORM_MAX_AIV_PER_THREAD =
 constexpr int PLATFORM_MAX_CORES_PER_THREAD =
     PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD;  // 72
 
+// =============================================================================
+// Performance Profiling Configuration
+// =============================================================================
+
+/**
+ * Maximum number of cores that can be profiled simultaneously
+ * Calculated as: MAX_BLOCKDIM * CORES_PER_BLOCKDIM = 24 * 3 = 72
+ */
+constexpr int PLATFORM_MAX_CORES =
+    PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 72
+
+/**
+ * DoubleBuffer size for AICPU-Host communication
+ * TEMPORARY: Set to 200 records for functional verification of Ping-Pong logic.
+ * This will be increased to 20000 after validation.
+ */
+constexpr int PLATFORM_PROF_BUFFER_SIZE = 20;
+
+/**
+ * System counter frequency (get_sys_cnt)
+ * Used to convert timestamps to microseconds.
+ */
+constexpr uint64_t PLATFORM_PROF_SYS_CNT_FREQ = 1850000000;  // 1850 MHz
+
+constexpr int PLATFORM_PROF_TIMEOUT_SECONDS = 10;
+
+constexpr int PLATFORM_PROF_EMPTY_POLLS_CHECK_NUM = 1000;
 #endif  // PLATFORM_COMMON_PLATFORM_CONFIG_H_

--- a/src/platform/include/host/pto_runtime_c_api.h
+++ b/src/platform/include/host/pto_runtime_c_api.h
@@ -223,6 +223,19 @@ void set_pto2_gm_sm_ptr(RuntimeHandle runtime, void* dev_ptr);
  */
 int32_t get_pto2_sm_size(RuntimeHandle runtime);
 
+/**
+ * Enable or disable performance profiling for swimlane visualization.
+ *
+ * Must be called before init_runtime() to enable profiling.
+ * When enabled, the runtime will record task execution timestamps on AICore/AICPU
+ * and generate swim_time.json after finalize_runtime().
+ *
+ * @param runtime  Runtime handle
+ * @param enabled  1 to enable profiling, 0 to disable
+ * @return 0 on success, -1 on failure
+ */
+int enable_runtime_profiling(RuntimeHandle runtime, int enabled);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/runtime/aicpu_build_graph/runtime/runtime.h
@@ -113,6 +113,8 @@ struct Handshake {
     volatile int32_t task_status;   // Task execution status: 0=idle, 1=busy
     volatile int32_t control;       // Control signal: 0=execute, 1=quit
     volatile CoreType core_type;    // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t perf_records_addr; // Performance records address
+    volatile uint32_t perf_buffer_status; // 0 = not full, 1 == full
 } __attribute__((aligned(64)));
 
 /**
@@ -307,6 +309,10 @@ public:
      * against `aicpu_runtime_*` symbols directly.
      */
     AicpuBuildApi aicpu_build_api;
+
+    // Profiling support
+    bool enable_profiling;                  // Enable profiling flag
+    uint64_t perf_data_base;                // Performance data shared memory base address (device-side)
 
 private:
     // Task storage

--- a/src/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -4,6 +4,8 @@
 
 #include "common/unified_log.h"
 #include "common/platform_config.h"
+#include "common/perf_profiling.h"
+#include "common/memory_barrier.h"
 #include "runtime.h"
 #include "aicpu/device_log.h"
 
@@ -55,6 +57,9 @@ struct AicpuExecutor {
     std::atomic<int> total_tasks_{0};
     std::atomic<int> finished_count_{0};
 
+    // ===== Performance profiling state =====
+    std::mutex perf_ready_queue_mutex_;  // Protects enqueue_ready_buffer operations
+
     // ===== Methods =====
     int init(Runtime* runtime);
     int handshake_all_cores(Runtime* runtime);
@@ -65,6 +70,12 @@ struct AicpuExecutor {
     void deinit();
     void diagnose_stuck_state(Runtime& runtime, int thread_idx, const int* cur_thread_cores,
                               int core_num, Handshake* hank);
+
+    // Performance profiling methods
+    void init_performance_profiling(Runtime* runtime);
+    void switch_perf_buffer(Runtime* runtime, int core_id, int thread_idx);
+    int enqueue_ready_buffer(PerfDataHeader* header, uint32_t core_index, uint32_t buffer_id);
+    void flush_performance_buffers(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num);
 };
 
 static AicpuExecutor g_aicpu_executor;
@@ -148,6 +159,11 @@ int AicpuExecutor::init(Runtime* runtime) {
     LOG_INFO("Init: Initial ready tasks: AIC=%d, AIV=%d", aic_count, aiv_count);
 
     finished_count_.store(0, std::memory_order_release);
+
+    // Performance profiling initialization
+    if (runtime->enable_profiling) {
+        init_performance_profiling(runtime);
+    }
 
     init_done_.store(true, std::memory_order_release);
     LOG_INFO("AicpuExecutor: Init complete");
@@ -396,6 +412,10 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
 
             // Core finished a task (idle + task not null)
             if (h->task_status == 0 && h->task != 0) {
+                // Check and switch performance buffer if needed
+                if (runtime.enable_profiling && h->perf_buffer_status == 1) {
+                    switch_perf_buffer(&runtime, core_id, thread_idx);
+                }
                 // Get completed task and immediately clear the pointer to prevent duplicate detection
                 Task* task = reinterpret_cast<Task*>(h->task);
                 h->task = 0;  // Clear immediately to minimize race condition window
@@ -538,6 +558,11 @@ int AicpuExecutor::run(Runtime* runtime) {
         return rc;
     }
 
+    // Flush performance buffers for cores managed by this thread
+    if (runtime->enable_profiling) {
+        flush_performance_buffers(runtime, thread_idx, cur_thread_cores, thread_cores_num_);
+    }
+
     LOG_INFO("Thread %d: Completed", thread_idx);
 
     // Check if this is the last thread to finish
@@ -644,6 +669,283 @@ void AicpuExecutor::diagnose_stuck_state(Runtime& runtime, int thread_idx,
     }
 
     LOG_ERROR("========== END DIAGNOSTIC ==========");
+}
+
+// =============================================================================
+// Performance Profiling Methods
+// =============================================================================
+
+/**
+ * Initialize performance profiling for all cores
+ *
+ * Called once in init() after core discovery.
+ * Assigns buffer1 to each core and sets initial states.
+ */
+ void AicpuExecutor::init_performance_profiling(Runtime* runtime) {
+    void* perf_base = (void*)runtime->perf_data_base;
+    if (perf_base == nullptr) {
+        DEV_ERROR("perf_data_base is NULL, profiling disabled");
+        return;
+    }
+
+    DoubleBuffer* buffers = get_double_buffers(perf_base);
+
+    DEV_INFO("Initializing performance profiling for %d cores", runtime->worker_count);
+
+    // Assign initial buffer (buffer1) to each AICore
+    for (int i = 0; i < runtime->worker_count; i++) {
+        Handshake* h = &runtime->workers[i];
+        DoubleBuffer* db = &buffers[i];
+
+        // Read memory barrier before checking buffer1 status
+        rmb();
+        if (db->buffer1_status != BufferStatus::IDLE) {
+            DEV_WARN("Core %d: buffer1 not idle (status=%u)", i, static_cast<uint32_t>(db->buffer1_status));
+        }
+
+        // Assign buffer1 to AICore
+        h->perf_records_addr = (uint64_t)&db->buffer1;
+        h->perf_buffer_status = 0;  // 0 = can write
+
+        // Write barrier: ensure writes visible to AICore before changing status
+        wmb();
+        db->buffer1_status = BufferStatus::WRITING;
+
+        DEV_INFO("Core %d: assigned buffer1 (addr=0x%lx)", i, h->perf_records_addr);
+    }
+
+    DEV_INFO("Performance profiling initialized for %d cores", runtime->worker_count);
+}
+
+/**
+ * Switch performance buffer for a core
+ *
+ * Called when perf_buffer_status == 1 (buffer full).
+ * Determines which buffer is full by address comparison,
+ * then switches to the alternate buffer if available.
+ *
+ * @param runtime Runtime instance
+ * @param core_id AICore ID
+ * @param thread_idx AICPU thread ID (for logging)
+ */
+void AicpuExecutor::switch_perf_buffer(Runtime* runtime, int core_id, int thread_idx) {
+    void* perf_base = (void*)runtime->perf_data_base;
+    if (perf_base == nullptr) {
+        return;
+    }
+
+    Handshake* h = &runtime->workers[core_id];
+    PerfDataHeader* header = get_perf_header(perf_base);
+    DoubleBuffer* db = get_core_double_buffer(perf_base, core_id);
+
+    // Determine if current buffer is buffer1 or buffer2 by address comparison
+    uint64_t current_addr = h->perf_records_addr;
+    uint64_t buffer1_addr = (uint64_t)&db->buffer1;
+    uint64_t buffer2_addr = (uint64_t)&db->buffer2;
+
+    uint32_t full_buffer_id = 0;
+    PerfBuffer* full_buf = nullptr;
+    volatile BufferStatus* full_status_ptr = nullptr;
+    PerfBuffer* alternate_buf = nullptr;
+    volatile BufferStatus* alternate_status_ptr = nullptr;
+    uint32_t alternate_buffer_id = 0;
+
+    if (current_addr == buffer1_addr) {
+        // Current buffer is buffer1, it's full
+        full_buffer_id = 1;
+        full_buf = &db->buffer1;
+        full_status_ptr = &db->buffer1_status;
+        alternate_buf = &db->buffer2;
+        alternate_status_ptr = &db->buffer2_status;
+        alternate_buffer_id = 2;
+    } else if (current_addr == buffer2_addr) {
+        // Current buffer is buffer2, it's full
+        full_buffer_id = 2;
+        full_buf = &db->buffer2;
+        full_status_ptr = &db->buffer2_status;
+        alternate_buf = &db->buffer1;
+        alternate_status_ptr = &db->buffer1_status;
+        alternate_buffer_id = 1;
+    } else {
+        DEV_ERROR("Thread %d: Core %d has invalid perf_records_addr=0x%lx",
+                  thread_idx, core_id, current_addr);
+        return;
+    }
+
+    DEV_INFO("Thread %d: Core %d buffer%u is full (count=%u)",
+             thread_idx, core_id, full_buffer_id, full_buf->count);
+
+    // Read alternate buffer status (rmb needed, since status is modified by Host)
+    rmb();
+    BufferStatus alternate_status = *alternate_status_ptr;
+
+    // If alternate buffer is not idle, spin wait for Host to finish reading
+    if (alternate_status != BufferStatus::IDLE) {
+        DEV_WARN("Thread %d: Core %d cannot switch, buffer%u status=%u, spinning until Host reads it",
+                 thread_idx, core_id, alternate_buffer_id, static_cast<uint32_t>(alternate_status));
+
+        // Spin wait: continuously check alternate buffer status until Host sets it to IDLE
+        while (true) {
+            rmb();  // Read barrier: ensure reading latest status modified by Host
+            alternate_status = *alternate_status_ptr;
+
+            if (alternate_status == BufferStatus::IDLE) {
+                DEV_INFO("Thread %d: Core %d buffer%u now idle, proceeding with switch",
+                         thread_idx, core_id, alternate_buffer_id);
+                break;
+            }
+        }
+    }
+
+    // Alternate buffer is idle, can switch
+
+    // Step 1: Enqueue full buffer to ready queue
+    int enqueue_result = enqueue_ready_buffer(header, core_id, full_buffer_id);
+    if (enqueue_result != 0) {
+        DEV_WARN("Thread %d: Core %d failed to enqueue buffer%u (queue full)",
+                 thread_idx, core_id, full_buffer_id);
+        return;
+    }
+
+    // Step 2: Change full buffer status to READY (visible to Host)
+    *full_status_ptr = BufferStatus::READY;
+    // Step 3: Change alternate buffer status to WRITING (visible to Host)
+    *alternate_status_ptr = BufferStatus::WRITING;
+    wmb();  // Write barrier: ensure status changes visible to Host
+
+    DEV_INFO("Thread %d: Core %d enqueued buffer%u", thread_idx, core_id, full_buffer_id);
+
+    // Step 4: Switch perf_records_addr to alternate buffer (visible to AICore)
+    h->perf_records_addr = (uint64_t)alternate_buf;
+    // No wmb needed: AICore will dcci read at loop start
+
+    // Step 5: Reset perf_buffer_status = 0 (notify AICore can continue writing)
+    h->perf_buffer_status = 0;
+    // No wmb needed: AICore will dcci read at loop start
+
+    DEV_INFO("Thread %d: Core %d switched to buffer%u (status=0)",
+             thread_idx, core_id, alternate_buffer_id);
+}
+
+/**
+ * Enqueue a ready buffer to the queue
+ *
+ * Thread-safe: Uses mutex to protect queue operations since multiple
+ * AICPU threads may enqueue concurrently.
+ *
+ * @return 0=success, -1=queue full
+ */
+int AicpuExecutor::enqueue_ready_buffer(PerfDataHeader* header, uint32_t core_index, uint32_t buffer_id) {
+    std::lock_guard<std::mutex> lock(perf_ready_queue_mutex_);
+
+    uint32_t capacity = PLATFORM_MAX_CORES * 2;
+
+    // Check if queue is full
+    uint32_t next_tail = (header->queue_tail + 1) % capacity;
+    if (next_tail == header->queue_head) {
+        return -1;  // Queue full
+    }
+
+    // Enqueue entry
+    uint32_t tail = header->queue_tail;
+    header->queue[tail].core_index = core_index;
+    header->queue[tail].buffer_id = buffer_id;
+
+    // Write memory barrier: ensure data written before updating tail, visible to Host
+    wmb();
+
+    header->queue_tail = next_tail;
+    return 0;
+}
+
+/**
+ * Flush performance buffers for cores managed by this thread
+ *
+ * Called after shutdown_aicore to ensure all buffers with data
+ * (even if not full) are enqueued for Host collection.
+ *
+ * For each core managed by this thread:
+ * - Check which buffer is currently assigned (via perf_records_addr)
+ * - If buffer has data (count > 0), mark it as READY and enqueue
+ *
+ * @param runtime Runtime instance
+ * @param thread_idx Current thread index
+ * @param cur_thread_cores Array of core IDs managed by this thread
+ * @param core_num Number of cores managed by this thread
+ */
+void AicpuExecutor::flush_performance_buffers(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
+    if (!runtime->enable_profiling) {
+        return;
+    }
+
+    void* perf_base = (void*)runtime->perf_data_base;
+    if (perf_base == nullptr) {
+        return;
+    }
+
+    PerfDataHeader* header = get_perf_header(perf_base);
+    DoubleBuffer* buffers = get_double_buffers(perf_base);
+
+    DEV_INFO("Thread %d: Flushing performance buffers for %d cores", thread_idx, core_num);
+
+    int flushed_count = 0;
+
+    // Only process cores managed by this thread
+    for (int i = 0; i < core_num; i++) {
+        int core_id = cur_thread_cores[i];
+        Handshake* h = &runtime->workers[core_id];
+        DoubleBuffer* db = &buffers[core_id];
+
+        // Read current buffer address
+        uint64_t current_addr = h->perf_records_addr;
+        if (current_addr == 0) {
+            continue;  // No buffer assigned
+        }
+
+        // Determine which buffer is current
+        uint64_t buf1_addr = (uint64_t)&db->buffer1;
+        uint64_t buf2_addr = (uint64_t)&db->buffer2;
+
+        PerfBuffer* current_buf = nullptr;
+        volatile BufferStatus* current_status = nullptr;
+        uint32_t buffer_id = 0;
+
+        if (current_addr == buf1_addr) {
+            current_buf = &db->buffer1;
+            current_status = &db->buffer1_status;
+            buffer_id = 1;
+        } else if (current_addr == buf2_addr) {
+            current_buf = &db->buffer2;
+            current_status = &db->buffer2_status;
+            buffer_id = 2;
+        } else {
+            DEV_WARN("Thread %d: Core %d perf_records_addr=0x%lx doesn't match buffer1=0x%lx or buffer2=0x%lx",
+                     thread_idx, core_id, current_addr, buf1_addr, buf2_addr);
+            continue;
+        }
+
+        // Read buffer count with memory barrier
+        rmb();
+        uint32_t count = current_buf->count;
+
+        // If buffer has data, enqueue it
+        if (count > 0) {
+            // Mark buffer as READY
+            *current_status = BufferStatus::READY;
+            wmb();
+
+            // Enqueue to ready queue
+            int rc = enqueue_ready_buffer(header, core_id, buffer_id);
+            if (rc == 0) {
+                DEV_INFO("Thread %d: Core %d flushed buffer%d with %u records", thread_idx, core_id, buffer_id, count);
+                flushed_count++;
+            } else {
+                DEV_WARN("Thread %d: Core %d failed to enqueue buffer%d (queue full)", thread_idx, core_id, buffer_id);
+            }
+        }
+    }
+
+    DEV_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
 }
 
 // ===== Public Entry Point =====

--- a/src/runtime/host_build_graph/runtime/runtime.h
+++ b/src/runtime/host_build_graph/runtime/runtime.h
@@ -103,6 +103,8 @@ struct Handshake {
     volatile int32_t task_status;   // Task execution status: 0=idle, 1=busy
     volatile int32_t control;       // Control signal: 0=execute, 1=quit
     volatile CoreType core_type;    // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t perf_records_addr; // Performance records address
+    volatile uint32_t perf_buffer_status; // 0 = not full, 1 == full
 } __attribute__((aligned(64)));
 
 /**
@@ -179,6 +181,9 @@ public:
     // Execution parameters for AICPU scheduling
     int sche_cpu_num;  // Number of AICPU threads for scheduling
 
+    // Profiling support
+    bool enable_profiling;                  // Enable profiling flag
+    uint64_t perf_data_base;                // Performance data shared memory base address (device-side)
 private:
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array

--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -92,6 +92,8 @@ struct Handshake {
     volatile int32_t task_status;   // Task execution status: 0=idle, 1=busy
     volatile int32_t control;       // Control signal: 0=execute, 1=quit
     volatile CoreType core_type;    // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t perf_records_addr; // Performance records address
+    volatile uint32_t perf_buffer_status; // 0 = not full, 1 == full
 } __attribute__((aligned(64)));
 
 /**
@@ -150,6 +152,10 @@ public:
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
     // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
+
+    // Profiling support
+    bool enable_profiling;                  // Enable profiling flag
+    uint64_t perf_data_base;                // Performance data shared memory base address (device-side)
 
 private:
     // Tensor pairs for host-device memory tracking


### PR DESCRIPTION
Implement comprehensive performance profiling infrastructure for both a2a3 (hardware) and a2a3sim (simulation) platforms with unified interface and complete platform/runtime separation.

Key features:
- Performance data collection using double-buffering (Ping-Pong buffers)
- Lock-free ready queue for buffer coordination between cores
- Detailed task execution records (cycles, timestamps, fanouts)
- Simulated 1850 MHz system counter for consistent timing across platforms
- Unified output format with Unicode tables showing task execution details

Architecture:
- Shared data structures in platform/include/common/perf_profiling.h
- Platform-specific implementations in respective device_runner.cpp
- get_sys_cnt() abstraction: hardware counter (a2a3) vs chrono (a2a3sim)

This enables developers to profile task execution timing on both hardware and simulation platforms with identical interface and data format.