### PR TITLE
Refactor: remove corruption guards from pto2_submit_task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,31 @@ Each developer role has a designated working directory. Stay within your assigne
 1. **Do not modify directories outside your assigned area** unless the user explicitly requests it
 2. Create new subdirectories under your assigned directory as needed
 3. When in doubt, ask the user before making changes to other areas
+4. **Avoid including private information in documentation** such as usernames, absolute paths with usernames, or other personally identifiable information. Use relative paths or generic placeholders instead
+5. **Avoid plan specific comments** such as Phase 1, Step 1, or Gap #3 which reflect planning details but don't aid code comprehension. This rule *does not apply* to commit info
+
+## Coding Standards
+
+1. Use `enum class` preferentially for basic enumeration usage. Use `enum` only when implementing bitmask patterns or when bitwise operations are required.
+
+    **Good:**
+    ```cpp
+    enum class CoreType : int { AIC = 0, AIV = 1 };
+    CoreType type = CoreType::AIC;
+    ```
+
+    **Bad (unless implementing bitmask):**
+    ```cpp
+    enum CoreType { AIC = 0, AIV = 1 };  // Avoid this for basic enums
+    ```
+
+2. Prefer `volatile` decorator on struct members rather than volatile pointer casts unless necessary.
+3. Avoid using pointer arithmetic with hardcoded offsets when `offsetof` is available.
+
+## Terminology (Based on Ascend NPU Architecture)
+
+### Hardware Units
+
+- **AIC** = **AICore-CUBE**: Matrix computation unit for tensor operations (matmul, convolution)
+- **AIV** = **AICore-VECTOR**: Vector computation unit for element-wise operations (add, mul, activation)
+- **AICPU**: Control processor for task scheduling and data movement (not a worker type - acts as scheduler)

--- a/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -151,36 +151,21 @@ void aicpu_orchestration_entry(void* sm_ptr, uint64_t* args, int arg_count) {
             PTO2_INPUT(dev_b, tile, sz),
             PTO2_OUTPUT(dev_c, tile, sz),
         };
-        if (pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t0, 3) < 0) {
-            pto2_rt_orchestration_done(rt);
-            pto2_runtime_destroy(rt);
-            *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
-            return;
-        }
+        (void)pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t0, 3);
 
         // t1: d = c + 1 (kernel_id=1, kernel_add_scalar)
         PTO2TaskParam params_t1[] = {
             PTO2_INPUT(dev_c, tile, sz),
             PTO2_OUTPUT(dev_d, tile, sz),
         };
-        if (pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t1, 2) < 0) {
-            pto2_rt_orchestration_done(rt);
-            pto2_runtime_destroy(rt);
-            *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
-            return;
-        }
+        (void)pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t1, 2);
 
         // t2: e = c + 2 (kernel_id=1, kernel_add_scalar)
         PTO2TaskParam params_t2[] = {
             PTO2_INPUT(dev_c, tile, sz),
             PTO2_OUTPUT(dev_e, tile, sz),
         };
-        if (pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t2, 2) < 0) {
-            pto2_rt_orchestration_done(rt);
-            pto2_runtime_destroy(rt);
-            *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
-            return;
-        }
+        (void)pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t2, 2);
 
         // t3: f = d * e (kernel_id=2, kernel_mul)
         PTO2TaskParam params_t3[] = {
@@ -189,12 +174,6 @@ void aicpu_orchestration_entry(void* sm_ptr, uint64_t* args, int arg_count) {
             PTO2_OUTPUT(dev_f, tile, sz),
         };
         int32_t task3_id = pto2_rt_submit_task(rt, 2, PTO2_WORKER_VECTOR, "kernel_mul", params_t3, 3);
-        if (task3_id < 0) {
-            pto2_rt_orchestration_done(rt);
-            pto2_runtime_destroy(rt);
-            *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
-            return;
-        }
 
         // Set graph output pointer for host copy-back
         void* graph_out_ptr = pto2_rt_get_output(rt, task3_id, 0);

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -153,8 +153,8 @@ static inline int32_t pto2_get_scope_depth(PTO2OrchestratorState* orch) {
  * Submit a task with InCore function and parameters
  *
  * This is the main API for building the task graph:
- * 1. Allocates task slot from TaskRing (may stall)
- * 2. Allocates packed output buffer from HeapRing (may stall)
+ * 1. Allocates task slot from TaskRing (blocks until available)
+ * 2. Allocates packed output buffer from HeapRing (blocks until available)
  * 3. Looks up inputs in TensorMap to find dependencies
  * 4. Updates producer's fanout_count/list (with spinlock)
  * 5. Registers outputs in TensorMap
@@ -166,7 +166,7 @@ static inline int32_t pto2_get_scope_depth(PTO2OrchestratorState* orch) {
  * @param func_name   Function name (for debugging)
  * @param params      Array of task parameters
  * @param num_params  Number of parameters
- * @return Task ID, or -1 on failure
+ * @return Task ID of the submitted task
  */
 int32_t pto2_submit_task(PTO2OrchestratorState* orch,
                           int32_t kernel_id,

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -160,7 +160,7 @@ void pto2_rt_scope_end(PTO2Runtime* rt);
  * @param func_name   Function name (for debugging)
  * @param params      Array of task parameters
  * @param num_params  Number of parameters
- * @return Task ID, or -1 on failure
+ * @return Task ID of the submitted task
  */
 int32_t pto2_rt_submit_task(PTO2Runtime* rt,
                              int32_t kernel_id,
@@ -171,6 +171,8 @@ int32_t pto2_rt_submit_task(PTO2Runtime* rt,
 
 /**
  * Simplified task submission (auto-detect worker type)
+ *
+ * @return Task ID of the submitted task
  */
 int32_t pto2_rt_submit(PTO2Runtime* rt,
                         const char* func_name,
@@ -232,13 +234,10 @@ void* pto2_rt_get_output(PTO2Runtime* rt, int32_t task_id, int32_t output_idx);
 #define PTO2_SCOPE_BEGIN(rt) pto2_rt_scope_begin(rt)
 #define PTO2_SCOPE_END(rt)   pto2_rt_scope_end(rt)
 
-/** Fill a single PTO2TaskParam at ABI-stable offsets (for C++ callers). */
+/** Fill a single PTO2TaskParam using direct field access (for C++ callers). */
 void pto2_param_set_input(PTO2TaskParam* p, void* buf, int32_t tile_index, int32_t size_bytes);
 void pto2_param_set_output(PTO2TaskParam* p, void* buf, int32_t tile_index, int32_t size_bytes);
 void pto2_param_set_inout(PTO2TaskParam* p, void* buf, int32_t tile_index, int32_t size_bytes);
-
-/** Force size at offset 20 in each 24-byte param slot. Call before submit to avoid C/C++ layout issues. */
-void pto2_param_fix_sizes(void* params_base, int32_t num_params, int32_t size_bytes);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Remove 16MB size validation and recovery logic that was likely unnecessary paranoia. Parameters are stack-allocated in single-threaded context with no concurrent access at creation time.

Changes:
- Remove PTO2_PARAM_SIZE volatile macro, use direct p->size access
- Remove proactive size propagation workaround
- Remove corruption detection/recovery in OUTPUT and INOUT handling
- Simplify pto2_param_set to use direct field assignment
- Remove pto2_param_fix_sizes function
- Clean up example code (~40 lines of error checks removed)
- Add coding standards for volatile usage and pointer arithmetic