### PR TITLE
Refactor: use PTO2SharedMemoryHeader for sm_ptr access in orchestration

### DIFF
--- a/.ai-instruction/coding/codestyle.md
+++ b/.ai-instruction/coding/codestyle.md
@@ -1,0 +1,18 @@
+# Codestyle Rules
+
+1. **Avoid plan specific comments** such as Phase 1, Step 1, or Gap #3 which reflect planning details but don't aid code comprehension.
+2. Use `enum class` preferentially for basic enumeration usage. Use `enum` only when implementing bitmask patterns or when bitwise operations are required.
+
+    **Good:**
+    ```cpp
+    enum class CoreType : int { AIC = 0, AIV = 1 };
+    CoreType type = CoreType::AIC;
+    ```
+
+    **Bad (unless implementing bitmask):**
+    ```cpp
+    enum CoreType { AIC = 0, AIV = 1 };  // Avoid this for basic enums
+    ```
+
+3. Prefer `volatile` decorator on struct members rather than volatile pointer casts unless necessary.
+4. Avoid using pointer arithmetic with hardcoded offsets when `offsetof` is available.

--- a/.ai-instruction/terminologies/ascend-device.md
+++ b/.ai-instruction/terminologies/ascend-device.md
@@ -1,0 +1,7 @@
+# Terminology (Based on Ascend NPU Architecture)
+
+## Hardware Units
+
+- **AIC** = **AICore-CUBE**: Matrix computation unit for tensor operations (matmul, convolution)
+- **AIV** = **AICore-VECTOR**: Vector computation unit for element-wise operations (add, mul, activation)
+- **AICPU**: Control processor for task scheduling and data movement (not a worker type - acts as scheduler)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,34 +18,8 @@ Each developer role has a designated working directory. Stay within your assigne
 
 ## Important Rules
 
-1. **Do not modify directories outside your assigned area** unless the user explicitly requests it
-2. Create new subdirectories under your assigned directory as needed
-3. When in doubt, ask the user before making changes to other areas
-4. **Avoid including private information in documentation** such as usernames, absolute paths with usernames, or other personally identifiable information. Use relative paths or generic placeholders instead
-5. **Avoid plan specific comments** such as Phase 1, Step 1, or Gap #3 which reflect planning details but don't aid code comprehension. This rule *does not apply* to commit info
-
-## Coding Standards
-
-1. Use `enum class` preferentially for basic enumeration usage. Use `enum` only when implementing bitmask patterns or when bitwise operations are required.
-
-    **Good:**
-    ```cpp
-    enum class CoreType : int { AIC = 0, AIV = 1 };
-    CoreType type = CoreType::AIC;
-    ```
-
-    **Bad (unless implementing bitmask):**
-    ```cpp
-    enum CoreType { AIC = 0, AIV = 1 };  // Avoid this for basic enums
-    ```
-
-2. Prefer `volatile` decorator on struct members rather than volatile pointer casts unless necessary.
-3. Avoid using pointer arithmetic with hardcoded offsets when `offsetof` is available.
-
-## Terminology (Based on Ascend NPU Architecture)
-
-### Hardware Units
-
-- **AIC** = **AICore-CUBE**: Matrix computation unit for tensor operations (matmul, convolution)
-- **AIV** = **AICore-VECTOR**: Vector computation unit for element-wise operations (add, mul, activation)
-- **AICPU**: Control processor for task scheduling and data movement (not a worker type - acts as scheduler)
+1. **Read `.ai-instruction/` directory first** before starting any work to understand codestyle rules and terminology guidelines
+2. **Do not modify directories outside your assigned area** unless the user explicitly requests it
+3. Create new subdirectories under your assigned directory as needed
+4. When in doubt, ask the user before making changes to other areas
+5. **Avoid including private information in documentation or code** such as usernames, absolute paths with usernames, or other personally identifiable information. Use relative paths or generic placeholders instead

--- a/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -134,10 +134,13 @@ extern "C" {
 
 __attribute__((visibility("default")))
 void aicpu_orchestration_entry(void* sm_ptr, uint64_t* args, int arg_count) {
+    // Get shared memory header for proper access
+    PTO2SharedMemoryHeader* header = (PTO2SharedMemoryHeader*)sm_ptr;
+
     // Validate inputs
     if (!sm_ptr || !args || arg_count < 13) {
-        if (sm_ptr) {
-            *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
+        if (header) {
+            header->orchestrator_done = 1;
         }
         return;
     }
@@ -166,7 +169,7 @@ void aicpu_orchestration_entry(void* sm_ptr, uint64_t* args, int arg_count) {
         PTO2_DEP_LIST_POOL_SIZE
     );
     if (!sm_handle) {
-        *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
+        header->orchestrator_done = 1;
         return;
     }
 
@@ -193,7 +196,7 @@ void aicpu_orchestration_entry(void* sm_ptr, uint64_t* args, int arg_count) {
     );
     if (!rt) {
         pto2_sm_destroy(sm_handle);
-        *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
+        header->orchestrator_done = 1;
         return;
     }
 
@@ -260,7 +263,7 @@ void aicpu_orchestration_entry(void* sm_ptr, uint64_t* args, int arg_count) {
     pto2_runtime_destroy(rt);
 
     // Signal orchestration complete
-    *(volatile int32_t*)((char*)sm_ptr + 8) = 1;
+    header->orchestrator_done = 1;
 }
 
 }  // extern "C"


### PR DESCRIPTION
Replace hardcoded pointer arithmetic (char*)sm_ptr + 8 with proper struct member access via PTO2SharedMemoryHeader->orchestrator_done. This follows codestyle rule #4 (avoid hardcoded offsets) and rule #3 (prefer volatile on struct members).