### PR TITLE
Refactor: implement OUTPUT dual-mode allocation and promote make_* helpers

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -167,26 +167,13 @@ static inline int32_t pto2_get_scope_depth(PTO2OrchestratorState* orch) {
  * @param func_name   Function name (for debugging)
  * @param params      Array of task parameters
  * @param num_params  Number of parameters
- * @return Task ID of the submitted task
  */
-int32_t pto2_submit_task(PTO2OrchestratorState* orch,
-                          int32_t kernel_id,
-                          PTO2WorkerType worker_type,
-                          const char* func_name,
-                          PTOParam* params,
-                          int32_t num_params);
-
-/**
- * Get pointer to specific output of a task
- * 
- * @param orch       Orchestrator state
- * @param task_id    Task ID
- * @param output_idx Output index (0-based)
- * @return Pointer to output buffer
- */
-void* pto2_task_get_output(PTO2OrchestratorState* orch, 
-                            int32_t task_id, 
-                            int32_t output_idx);
+void pto2_submit_task(PTO2OrchestratorState* orch,
+                      int32_t kernel_id,
+                      PTO2WorkerType worker_type,
+                      const char* func_name,
+                      PTOParam* params,
+                      int32_t num_params);
 
 // =============================================================================
 // Flow Control

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -161,20 +161,20 @@ void pto2_rt_scope_end(PTO2Runtime* rt) {
     pto2_scope_end(&rt->orchestrator);
 }
 
-int32_t pto2_rt_submit_task(PTO2Runtime* rt,
-                             int32_t kernel_id,
-                             PTO2WorkerType worker_type,
-                             const char* func_name,
-                             PTOParam* params,
-                             int32_t num_params) {
-    return pto2_submit_task(&rt->orchestrator, kernel_id, worker_type,
-                            func_name, params, num_params);
+void pto2_rt_submit_task(PTO2Runtime* rt,
+                         int32_t kernel_id,
+                         PTO2WorkerType worker_type,
+                         const char* func_name,
+                         PTOParam* params,
+                         int32_t num_params) {
+    pto2_submit_task(&rt->orchestrator, kernel_id, worker_type,
+                     func_name, params, num_params);
 }
 
-int32_t pto2_rt_submit(PTO2Runtime* rt,
-                        const char* func_name,
-                        PTOParam* params,
-                        int32_t num_params) {
+void pto2_rt_submit(PTO2Runtime* rt,
+                    const char* func_name,
+                    PTOParam* params,
+                    int32_t num_params) {
     // Auto-detect worker type based on function name
     PTO2WorkerType worker_type = PTO2_WORKER_VECTOR;  // Default
 
@@ -189,14 +189,10 @@ int32_t pto2_rt_submit(PTO2Runtime* rt,
         }
     }
 
-    return pto2_submit_task(&rt->orchestrator, 0, worker_type,
-                            func_name, params, num_params);
+    pto2_submit_task(&rt->orchestrator, 0, worker_type,
+                     func_name, params, num_params);
 }
 
 void pto2_rt_orchestration_done(PTO2Runtime* rt) {
     pto2_orchestrator_done(&rt->orchestrator);
-}
-
-void* pto2_rt_get_output(PTO2Runtime* rt, int32_t task_id, int32_t output_idx) {
-    return pto2_task_get_output(&rt->orchestrator, task_id, output_idx);
 }

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -160,24 +160,21 @@ void pto2_rt_scope_end(PTO2Runtime* rt);
  * @param func_name   Function name (for debugging)
  * @param params      Array of task parameters
  * @param num_params  Number of parameters
- * @return Task ID of the submitted task
  */
-int32_t pto2_rt_submit_task(PTO2Runtime* rt,
-                             int32_t kernel_id,
-                             PTO2WorkerType worker_type,
-                             const char* func_name,
-                             PTOParam* params,
-                             int32_t num_params);
+void pto2_rt_submit_task(PTO2Runtime* rt,
+                         int32_t kernel_id,
+                         PTO2WorkerType worker_type,
+                         const char* func_name,
+                         PTOParam* params,
+                         int32_t num_params);
 
 /**
  * Simplified task submission (auto-detect worker type)
- *
- * @return Task ID of the submitted task
  */
-int32_t pto2_rt_submit(PTO2Runtime* rt,
-                        const char* func_name,
-                        PTOParam* params,
-                        int32_t num_params);
+void pto2_rt_submit(PTO2Runtime* rt,
+                    const char* func_name,
+                    PTOParam* params,
+                    int32_t num_params);
 
 /**
  * Mark orchestration as complete
@@ -185,11 +182,6 @@ int32_t pto2_rt_submit(PTO2Runtime* rt,
  * Signals that no more tasks will be submitted.
  */
 void pto2_rt_orchestration_done(PTO2Runtime* rt);
-
-/**
- * Get output buffer pointer for a task
- */
-void* pto2_rt_get_output(PTO2Runtime* rt, int32_t task_id, int32_t output_idx);
 
 // =============================================================================
 // Convenience Macros (if not already defined in pto_runtime2_types.h)

--- a/src/runtime/tensormap_and_ringbuffer/runtime/tensor_descriptor.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/tensor_descriptor.h
@@ -157,3 +157,30 @@ struct TensorDescriptor {
 
     bool complex_overlap(const TensorDescriptor& pre_task_output) const;
 };
+
+// =============================================================================
+// Factory Helpers
+// =============================================================================
+
+static inline PTOBufferHandle make_external_handle(void* addr, int32_t size) {
+    PTOBufferHandle h = {};
+    h.addr = (uint64_t)addr;
+    h.size = size;
+    return h;
+}
+
+static inline PTOBufferHandle make_output_handle(int32_t size) {
+    PTOBufferHandle h = {};
+    h.addr = 0;
+    h.size = size;
+    return h;
+}
+
+static inline TensorDescriptor make_tensor_bbox(uint64_t addr, int32_t size_bytes,
+        int32_t version = 0, DataType dtype = DataType::FLOAT32) {
+    uint64_t size_elements = size_bytes / get_element_size(dtype);
+    uint64_t strides[] = {1};
+    uint64_t repeats[] = {size_elements};
+    TensorDescriptor t(addr, size_bytes, 0, strides, repeats, 1, dtype, version);
+    return t;
+}


### PR DESCRIPTION
- OUTPUT params now support dual-mode: NULL addr triggers runtime ring-buffer allocation; non-NULL addr is used as-is (external memory)
- Promote make_*_param/make_*_handle factory helpers from example into runtime headers (tensor_descriptor.h, pto_types.h) with NULL assertions
- Remove pto2_rt_get_output / pto2_task_get_output APIs; submit returns void
- Clarify INOUT semantics as "modifier" (read-then-write) vs OUTPUT "producer"
- Reorder PTOParamType enum: INOUT=2, SCALAR=3