### PR TITLE
Refactor: replace PTOBufferHandle with TensorDescriptor and remove buffer pointer

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -308,9 +308,9 @@ static void build_pto2_payload(PTO2DispatchPayload* out, Runtime* runtime,
         if (task->params[i].type == PTOParamType::SCALAR) {
             out->args[n++] = task->params[i].scalar_value;
         } else {
-            // Pass pointer to the TensorDescriptor (in shared memory), not the raw buffer address.
+            // Pass pointer to the TensorDescriptor (in task-owned storage), not the raw buffer address.
             // Kernels expect args[i] to be a TensorDescriptor* from which they read buffer.addr.
-            out->args[n++] = reinterpret_cast<uint64_t>(&task->params[i].tensor);
+            out->args[n++] = reinterpret_cast<uint64_t>(task->params[i].tensor);
         }
     }
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -183,34 +183,6 @@ void pto2_rt_submit(PTO2Runtime* rt,
  */
 void pto2_rt_orchestration_done(PTO2Runtime* rt);
 
-// =============================================================================
-// Convenience Macros (if not already defined in pto_runtime2_types.h)
-// =============================================================================
-
-#ifndef PTO2_INPUT
-/**
- * Create input parameter
- */
-#define PTO2_INPUT(buf, tile, sz) \
-    ((PTO2TaskParam){.type = PTO2_PARAM_INPUT, ._pad = {0}, .buffer = (buf), .tile_index = (tile), .size = (sz)})
-#endif
-
-#ifndef PTO2_OUTPUT
-/**
- * Create output parameter
- */
-#define PTO2_OUTPUT(buf, tile, sz) \
-    ((PTO2TaskParam){.type = PTO2_PARAM_OUTPUT, ._pad = {0}, .buffer = (buf), .tile_index = (tile), .size = (sz)})
-#endif
-
-#ifndef PTO2_INOUT
-/**
- * Create in-out parameter
- */
-#define PTO2_INOUT(buf, tile, sz) \
-    ((PTO2TaskParam){.type = PTO2_PARAM_INOUT, ._pad = {0}, .buffer = (buf), .tile_index = (tile), .size = (sz)})
-#endif
-
 /**
  * Scope helper macros for C
  *
@@ -225,11 +197,6 @@ void pto2_rt_orchestration_done(PTO2Runtime* rt);
  */
 #define PTO2_SCOPE_BEGIN(rt) pto2_rt_scope_begin(rt)
 #define PTO2_SCOPE_END(rt)   pto2_rt_scope_end(rt)
-
-/** Fill a single PTO2TaskParam using direct field access (for C++ callers). */
-void pto2_param_set_input(PTO2TaskParam* p, void* buf, int32_t tile_index, int32_t size_bytes);
-void pto2_param_set_output(PTO2TaskParam* p, void* buf, int32_t tile_index, int32_t size_bytes);
-void pto2_param_set_inout(PTO2TaskParam* p, void* buf, int32_t tile_index, int32_t size_bytes);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Remove PTOBufferHandle* buffer from PTOParam; use value-copy TensorDescriptor with post-submit sync pattern (td = params[i].tensor) for address writeback
- Delete deprecated PTO2TaskParam, PTO2ParamType, PTO2_INPUT/OUTPUT/INOUT macros, and pto2_param_set_* functions
- Redesign param helpers to accept const TensorDescriptor& instead of PTOBufferHandle& with size/version
- Add TensorDescriptor::make_1d_contiguous static member; replace make_external_handle/make_output_handle/make_tensor_bbox with make_tensor_external and make_tensor free functions
- Update example_orchestration.cpp: ext_td_ prefix for external tensors, td_ prefix for intermediates, post-submit sync after each output