### PR TITLE
Refactor: rename TensorDescriptor to Tensor and restore debug validation

### DIFF
--- a/examples/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp
+++ b/examples/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp
@@ -11,8 +11,8 @@
 
 #include <cstdint>
 #include <pto/pto-inst.hpp>
-#include <pto/common/constants.hpp>
-#include "tensor_descriptor.h"
+
+#include "tensor.h"
 
 using namespace pto;
 
@@ -36,12 +36,12 @@ using namespace pto;
  */
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
     // Unpack arguments (order matches runtimemaker.cpp)
-    __gm__ TensorDescriptor* src0_tensor_descriptor = reinterpret_cast<__gm__ TensorDescriptor*>(args[0]);
-    __gm__ TensorDescriptor* src1_tensor_descriptor = reinterpret_cast<__gm__ TensorDescriptor*>(args[1]);
-    __gm__ TensorDescriptor* out_tensor_descriptor = reinterpret_cast<__gm__ TensorDescriptor*>(args[2]);
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor_descriptor->buffer.addr);
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor_descriptor->buffer.addr);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor_descriptor->buffer.addr);
+    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
+    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr);
+    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr);
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr);
     // __gm__ float* src0 = reinterpret_cast<__gm__ float*>(args[0]);
     // __gm__ float* src1 = reinterpret_cast<__gm__ float*>(args[1]);
     // __gm__ float* out = reinterpret_cast<__gm__ float*>(args[2]);

--- a/examples/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/examples/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -11,8 +11,8 @@
 
 #include <cstdint>
 #include <pto/pto-inst.hpp>
-#include <pto/common/constants.hpp>
-#include "tensor_descriptor.h"
+
+#include "tensor.h"
 
 using namespace pto;
 
@@ -36,10 +36,10 @@ using namespace pto;
  */
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
     // Unpack arguments
-    __gm__ TensorDescriptor* src_tensor_descriptor = reinterpret_cast<__gm__ TensorDescriptor*>(args[0]);
-    __gm__ TensorDescriptor* out_tensor_descriptor = reinterpret_cast<__gm__ TensorDescriptor*>(args[2]);
-    __gm__ float* src = reinterpret_cast<__gm__ float*>(src_tensor_descriptor->buffer.addr);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor_descriptor->buffer.addr);
+    __gm__ Tensor* src_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ float* src = reinterpret_cast<__gm__ float*>(src_tensor->buffer.addr);
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr);
     // __gm__ float* src = reinterpret_cast<__gm__ float*>(args[0]);
 
     // Convert scalar from uint64_t to float

--- a/examples/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_mul.cpp
@@ -11,8 +11,8 @@
 
 #include <cstdint>
 #include <pto/pto-inst.hpp>
-#include <pto/common/constants.hpp>
-#include "tensor_descriptor.h"
+
+#include "tensor.h"
 
 using namespace pto;
 
@@ -36,12 +36,12 @@ using namespace pto;
  */
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
     // Unpack arguments (order matches runtimemaker.cpp)
-    __gm__ TensorDescriptor* src0_tensor_descriptor = reinterpret_cast<__gm__ TensorDescriptor*>(args[0]);
-    __gm__ TensorDescriptor* src1_tensor_descriptor = reinterpret_cast<__gm__ TensorDescriptor*>(args[1]);
-    __gm__ TensorDescriptor* out_tensor_descriptor = reinterpret_cast<__gm__ TensorDescriptor*>(args[2]);
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor_descriptor->buffer.addr);
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor_descriptor->buffer.addr);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor_descriptor->buffer.addr);
+    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
+    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr);
+    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr);
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr);
     // __gm__ float* src0 = reinterpret_cast<__gm__ float*>(args[0]);
     // __gm__ float* src1 = reinterpret_cast<__gm__ float*>(args[1]);
     // __gm__ float* out = reinterpret_cast<__gm__ float*>(args[2]);

--- a/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -308,8 +308,8 @@ static void build_pto2_payload(PTO2DispatchPayload* out, Runtime* runtime,
         if (task->params[i].type == PTOParamType::SCALAR) {
             out->args[n++] = task->params[i].scalar_value;
         } else {
-            // Pass pointer to the TensorDescriptor (in task-owned storage), not the raw buffer address.
-            // Kernels expect args[i] to be a TensorDescriptor* from which they read buffer.addr.
+            // Pass pointer to the Tensor (in task-owned storage), not the raw buffer address.
+            // Kernels expect args[i] to be a Tensor* from which they read buffer.addr.
             out->args[n++] = reinterpret_cast<uint64_t>(task->params[i].tensor);
         }
     }

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -282,7 +282,7 @@ typedef struct {
 
 
     PTOParam params[16];
-    TensorDescriptor tensor_copies[16];  // Owned tensor data (params[i].tensor points here)
+    Tensor tensor_copies[16];  // Owned tensor data (params[i].tensor points here)
     int param_count{0};
     
 } PTO2TaskDescriptor;

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -34,7 +34,7 @@
 #define PTO_TENSORMAP_H
 
 #include "pto_runtime2_types.h"
-#include "tensor_descriptor.h"
+#include "tensor.h"
 
 // =============================================================================
 // TensorMap Structure
@@ -55,7 +55,7 @@
  * - When lookup hits stale entry, truncate rest of chain
  */
 typedef struct {
-    TensorDescriptor region;      // Tensor region key (legacy, for simple 1D)
+    Tensor tensor;      // Tensor descriptor key
     int32_t producer_task_id;     // Task that produces this region
     int32_t next_in_bucket;       // Offset to next entry in hash bucket (-1 = end)
     int32_t next_in_task;         // Offset to next entry for same task (-1 = end)
@@ -135,10 +135,10 @@ void pto2_tensormap_sync_validity(PTO2TensorMap* tm, int32_t last_task_alive);
  * the rest of the chain (all subsequent entries are also stale).
  * 
  * @param tm      TensorMap
- * @param region  Tensor region to look up
+ * @param tensor  Tensor to look up
  * @return Producer task ID, or -1 if not found
  */
-int32_t pto2_tensormap_lookup(PTO2TensorMap* tm, TensorDescriptor* region);
+int32_t pto2_tensormap_lookup(PTO2TensorMap* tm, Tensor* tensor);
 
 /**
  * Insert a new entry (called when task produces output)
@@ -147,10 +147,10 @@ int32_t pto2_tensormap_lookup(PTO2TensorMap* tm, TensorDescriptor* region);
  * Inserts at head of hash bucket chain (maintains task_id ordering).
  * 
  * @param tm                TensorMap
- * @param region            Tensor region produced
+ * @param tensor            Tensor produced
  * @param producer_task_id  Task ID of producer
  */
-void pto2_tensormap_insert(PTO2TensorMap* tm, TensorDescriptor* region, 
+void pto2_tensormap_insert(PTO2TensorMap* tm, Tensor* tensor,
                             int32_t producer_task_id);
 
 /**
@@ -174,7 +174,7 @@ void pto2_tensormap_cleanup_retired(PTO2TensorMap* tm,
 /**
  * Compute hash for tensor region
  */
-uint32_t pto2_tensormap_hash(PTO2TensorMap* tm, TensorDescriptor* region);
+uint32_t pto2_tensormap_hash(PTO2TensorMap* tm, Tensor* tensor);
 
 /**
  * Check if entry is valid (producer has not retired)

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -5,8 +5,8 @@
  * - PTOParam: Parameter descriptor for pto_submit_task API
  * - PTOWorkerType: Worker types for heterogeneous scheduling
  *
- * Tensor descriptor types (TensorDescriptor, PTOBufferHandle, PTOOverlapStrategy) are
- * defined in tensor_descriptor.h.
+ * Tensor descriptor types (Tensor, PTOBufferHandle, PTOOverlapStrategy) are
+ * defined in tensor.h.
  *
  * This header is independent of orch_build_graph_runtime.h to allow inclusion from runtime.h
  * without type conflicts (Handshake, TensorPair, HostApi).
@@ -18,7 +18,7 @@
 #include <stdint.h>
 #include <assert.h>
 
-#include "tensor_descriptor.h"
+#include "tensor.h"
 
 // =============================================================================
 // Configuration
@@ -75,16 +75,16 @@ enum class PTOParamType : int32_t {
 /**
  * Parameter Descriptor for pto_submit_task
  *
- * Each parameter holds a pointer to the caller's TensorDescriptor for
+ * Each parameter holds a pointer to the caller's Tensor for
  * automatic dependency detection via TensorMap overlap checking.
  *
  * For OUTPUT params with tensor->buffer.addr == 0, the runtime allocates
  * a buffer and writes the address back through the pointer, implicitly
- * updating the caller's local TensorDescriptor. No manual sync needed.
+ * updating the caller's local Tensor. No manual sync needed.
  *
  * Example:
- *   TensorDescriptor td_a = make_tensor_external(dev_a, size);
- *   TensorDescriptor td_c = make_tensor(size);
+ *   Tensor td_a = make_tensor_external(dev_a, size);
+ *   Tensor td_c = make_tensor(size);
  *   PTOParam params[] = {
  *       make_input_param(td_a),
  *       make_output_param(td_c),
@@ -94,7 +94,7 @@ enum class PTOParamType : int32_t {
  */
 struct PTOParam {
     PTOParamType type;         // PTOParamType::INPUT, PTOParamType::OUTPUT, or PTOParamType::SCALAR
-    TensorDescriptor* tensor;  // Pointer to caller's tensor descriptor (NULL for SCALAR)
+    Tensor* tensor;  // Pointer to caller's tensor descriptor (NULL for SCALAR)
     uint64_t scalar_value;     // Raw value for PTOParamType::SCALAR (e.g., encoded float, int size)
 };
 
@@ -110,7 +110,7 @@ static inline PTOParam make_scalar_param(uint64_t value) {
     return p;
 }
 
-static inline PTOParam make_input_param(TensorDescriptor& td) {
+static inline PTOParam make_input_param(Tensor& td) {
     assert(td.buffer.addr != 0 && "INPUT param must have a non-NULL buffer address");
     PTOParam p = {};
     p.type = PTOParamType::INPUT;
@@ -119,7 +119,7 @@ static inline PTOParam make_input_param(TensorDescriptor& td) {
     return p;
 }
 
-static inline PTOParam make_output_param(TensorDescriptor& td) {
+static inline PTOParam make_output_param(Tensor& td) {
     PTOParam p = {};
     p.type = PTOParamType::OUTPUT;
     p.tensor = &td;
@@ -127,7 +127,7 @@ static inline PTOParam make_output_param(TensorDescriptor& td) {
     return p;
 }
 
-static inline PTOParam make_inout_param(TensorDescriptor& td) {
+static inline PTOParam make_inout_param(Tensor& td) {
     assert(td.buffer.addr != 0 && "INOUT param must have a non-NULL buffer address");
     PTOParam p = {};
     p.type = PTOParamType::INOUT;


### PR DESCRIPTION
- Rename TensorDescriptor struct to Tensor across all kernel, runtime, and orchestrator files; rename source files accordingly
- Remove remove_redundant_dims() from optimize() pipeline
- Restore validate_memory_access_preserved and collect_all_offsets debug implementations using std::vector
- Apply consistent code formatting (include order, parameter alignment)