### PR TITLE
Refactor: direct-owner scope model with nested scope example

### DIFF
--- a/examples/tensormap_and_ringbuffer/vector_example/golden.py
+++ b/examples/tensormap_and_ringbuffer/vector_example/golden.py
@@ -5,8 +5,8 @@ This script defines the input data generation and expected output computation
 for the tensormap_and_ringbuffer example (both a2a3 and a2a3sim platforms).
 
 Computation:
-    f = (a + b + 1) * (a + b + 2)
-    where a=2.0, b=3.0, so f=42.0
+    f = (a + b + 1) * (a + b + 2) + (a + b)
+    where a=2.0, b=3.0, so f=47.0
 
 This is the same computation as host_build_graph/vector_example, but uses
 device-side orchestration (tensormap_and_ringbuffer runtime).
@@ -19,7 +19,7 @@ __outputs__ = ["f"]
 
 # Tensor order for orchestration function arguments
 # tensormap_and_ringbuffer args layout: [dev_a, dev_b, dev_f, size_a, size_b, size_f, SIZE]
-# Note: intermediate tensors (c, d, e) are allocated on-device by the runtime heap
+# Note: intermediate tensors (c, d, e, g) are allocated on-device by the runtime heap
 TENSOR_ORDER = ["a", "b", "f"]
 
 # Comparison tolerances
@@ -54,10 +54,10 @@ def compute_golden(tensors: dict, params: dict) -> None:
     """
     Compute expected output in-place.
 
-    f = (a + b + 1) * (a + b + 2)
-      = (2 + 3 + 1) * (2 + 3 + 2)
-      = 6 * 7
-      = 42
+    f = (a + b + 1) * (a + b + 2) + (a + b)
+      = (2 + 3 + 1) * (2 + 3 + 2) + (2 + 3)
+      = 6 * 7 + 5
+      = 47
 
     Args:
         tensors: Dict containing all tensors (inputs and outputs)
@@ -65,4 +65,4 @@ def compute_golden(tensors: dict, params: dict) -> None:
     """
     a = tensors["a"]
     b = tensors["b"]
-    tensors["f"][:] = (a + b + 1) * (a + b + 2)
+    tensors["f"][:] = (a + b + 1) * (a + b + 2) + (a + b)

--- a/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -1,12 +1,18 @@
 /**
  * Example: aicpu_orchestration_entry 设备端编排
  *
- * DAG structure for formula: (a + b + 1)(a + b + 2)
- *   t0: c = a + b     (func_id=0, kernel_add)
- *   t1: d = c + 1     (func_id=1, kernel_add_scalar)
- *   t2: e = c + 2     (func_id=1, kernel_add_scalar)
- *   t3: f = d * e     (func_id=2, kernel_mul)
- *   Dependencies: t0->t1, t0->t2, t1->t3, t2->t3
+ * DAG structure for formula: (a + b + 1)(a + b + 2) + (a + b)
+ *   t0: c = a + b     (func_id=0, kernel_add)       [outer scope]
+ *   t1: d = c + 1     (func_id=1, kernel_add_scalar) [inner scope]
+ *   t2: e = c + 2     (func_id=1, kernel_add_scalar) [inner scope]
+ *   t3: g = d * e     (func_id=2, kernel_mul)        [inner scope]
+ *   t4: f = g + c     (func_id=0, kernel_add)        [outer scope]
+ *   Dependencies: t0->t1, t0->t2, t1->t3, t2->t3, t0->t4, t3->t4
+ *
+ * Nested scope demonstration:
+ *   - Inner scope owns t1, t2, t3; intermediates d, e release on inner scope end
+ *   - Outer scope owns t0, t4; c persists across inner scope for t4
+ *   - g crosses scope boundary (produced in inner, consumed in outer)
  *
  * Compiled with PTO2 runtime sources for device execution.
  */
@@ -22,11 +28,11 @@
 // Base args from code_runner.py: [tensors..., sizes..., SIZE]
 // Extended by runtime_maker.cpp: [..., gm_heap, heap_size] (always last 2)
 //
-// For this example (a+b+1)(a+b+2):
+// For this example (a+b+1)(a+b+2)+(a+b):
 //   [a, b, f, size_a, size_b, size_f, SIZE]
 //   + [gm_heap, heap_size] appended by runtime_maker.cpp
 //
-// Intermediate tensors (c, d, e) are allocated on-device by the runtime heap.
+// Intermediate tensors (c, d, e, g) are allocated on-device by the runtime heap.
 // Generic access: gm_heap = args[arg_count - 2], heap_size = args[arg_count - 1]
 // =============================================================================
 
@@ -135,17 +141,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(void* sm_p
     Tensor ext_td_a = make_tensor_external(arg_a_ptr, size_a);
     Tensor ext_td_b = make_tensor_external(arg_b_ptr, size_b);
     Tensor ext_td_f = make_tensor_external(arg_f_ptr, size_f);
-    Tensor td_c = make_tensor(BYTES);  // c = a + b
-    Tensor td_d = make_tensor(BYTES);  // d = c + 1
-    Tensor td_e = make_tensor(BYTES);  // e = c + 2
 
-    // Use RAII scope guard for automatic scope management.
-    // PTO2_SCOPE creates a scoped block where pto2_rt_scope_begin() is called
-    // at the start and pto2_rt_scope_end() is called automatically at the end
-    // (even in error paths). This eliminates manual cleanup and prevents bugs.
-    // See src/runtime/rt2/runtime/pto_runtime2.h for alternative usage patterns.
+    // Nested scope demonstration:
+    // Outer scope owns t0 and t4; inner scope owns t1, t2, t3.
+    // When inner scope ends, intermediates d and e can be released.
+    // Tensor c persists in outer scope for t4. Tensor g crosses the boundary.
     PTO2_SCOPE(rt) {
-        // t0: c = a + b (kernel_id=0, kernel_add)
+        Tensor td_c = make_tensor(BYTES);  // c = a + b
+        Tensor td_g = make_tensor(BYTES);  // g = d * e (produced in inner, consumed here)
+
+        // t0: c = a + b (kernel_id=0, kernel_add) [outer scope]
         PTOParam params_t0[] = {
             make_input_param(ext_td_a),
             make_input_param(ext_td_b),
@@ -153,33 +158,46 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(void* sm_p
         };
         pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t0, 3);
 
-        // t1: d = c + 1 (kernel_id=1, kernel_add_scalar)
-        PTOParam params_t1[] = {
-            make_input_param(td_c),
-            make_scalar_param(float_to_u64(1.0f)),
-            make_output_param(td_d),
-            make_scalar_param((uint64_t)3),
-        };
-        pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t1, 3);
+        PTO2_SCOPE(rt) {
+            Tensor td_d = make_tensor(BYTES);  // d = c + 1
+            Tensor td_e = make_tensor(BYTES);  // e = c + 2
 
-        // t2: e = c + 2 (kernel_id=1, kernel_add_scalar)
-        PTOParam params_t2[] = {
-            make_input_param(td_c),
-            make_scalar_param(float_to_u64(2.0f)),
-            make_output_param(td_e),
-            make_scalar_param((uint64_t)3),
-        };
-        pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t2, 3);
+            // t1: d = c + 1 (kernel_id=1, kernel_add_scalar) [inner scope]
+            PTOParam params_t1[] = {
+                make_input_param(td_c),
+                make_scalar_param(float_to_u64(1.0f)),
+                make_output_param(td_d),
+                make_scalar_param((uint64_t)3),
+            };
+            pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t1, 3);
 
-        // t3: f = d * e (kernel_id=2, kernel_mul)
-        PTOParam params_t3[] = {
-            make_input_param(td_d),
-            make_input_param(td_e),
+            // t2: e = c + 2 (kernel_id=1, kernel_add_scalar) [inner scope]
+            PTOParam params_t2[] = {
+                make_input_param(td_c),
+                make_scalar_param(float_to_u64(2.0f)),
+                make_output_param(td_e),
+                make_scalar_param((uint64_t)3),
+            };
+            pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t2, 3);
+
+            // t3: g = d * e (kernel_id=2, kernel_mul) [inner scope]
+            PTOParam params_t3[] = {
+                make_input_param(td_d),
+                make_input_param(td_e),
+                make_output_param(td_g),
+                make_scalar_param((uint64_t)3),
+            };
+            pto2_rt_submit_task(rt, 2, PTO2_WORKER_VECTOR, "kernel_mul", params_t3, 3);
+        }  // inner scope ends: releases t1, t2, t3
+
+        // t4: f = g + c (kernel_id=0, kernel_add) [outer scope]
+        PTOParam params_t4[] = {
+            make_input_param(td_g),
+            make_input_param(td_c),
             make_output_param(ext_td_f),
-            make_scalar_param((uint64_t)3),
         };
-        pto2_rt_submit_task(rt, 2, PTO2_WORKER_VECTOR, "kernel_mul", params_t3, 3);
-    }  // PTO2_SCOPE ends here - automatic pto2_rt_scope_end() called
+        pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t4, 3);
+    }  // outer scope ends: releases t0, t4
 
     pto2_rt_orchestration_done(rt);
     pto2_runtime_destroy(rt);

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -174,7 +174,7 @@ void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
     ring->last_alive_ptr = last_alive_ptr;
 }
 
-// Flow control spin limit - if exceeded, likely deadlock due to scope_depth/fanout_count
+// Flow control spin limit - if exceeded, likely deadlock due to scope/fanout_count
 #define PTO2_FLOW_CONTROL_SPIN_LIMIT  100000
 
 int32_t pto2_task_ring_alloc(PTO2TaskRing* ring) {
@@ -233,7 +233,7 @@ int32_t pto2_task_ring_alloc(PTO2TaskRing* ring) {
             fprintf(stderr, "\n");
             fprintf(stderr, "Root Cause:\n");
             fprintf(stderr, "  Tasks cannot transition to CONSUMED state because:\n");
-            fprintf(stderr, "  - fanout_count is initialized to scope_depth\n");
+            fprintf(stderr, "  - fanout_count includes 1 for the owning scope\n");
             fprintf(stderr, "  - scope_end() requires orchestrator to continue\n");
             fprintf(stderr, "  - But orchestrator is blocked waiting for task ring space\n");
             fprintf(stderr, "  This creates a circular dependency (deadlock).\n");

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -317,10 +317,10 @@ void pto2_scheduler_on_task_complete(PTO2SchedulerState* sched, int32_t task_id)
     check_and_handle_consumed(sched, task_id, task);
 }
 
-void pto2_scheduler_on_scope_end(PTO2SchedulerState* sched, 
-                                  int32_t begin_pos, int32_t end_pos) {
-    for (int32_t task_id = begin_pos; task_id < end_pos; task_id++) {
-        pto2_scheduler_release_producer(sched, task_id);
+void pto2_scheduler_on_scope_end(PTO2SchedulerState* sched,
+                                  const int32_t* task_ids, int32_t count) {
+    for (int32_t i = 0; i < count; i++) {
+        pto2_scheduler_release_producer(sched, task_ids[i]);
     }
 }
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -230,16 +230,16 @@ void pto2_scheduler_on_task_complete(PTO2SchedulerState* sched, int32_t task_id)
 
 /**
  * Handle scope end (called when orchestrator ends a scope)
- * 
- * Increments fanout_refcount for all tasks in [begin_pos, end_pos).
+ *
+ * Increments fanout_refcount for each task in the provided list.
  * May transition some tasks to CONSUMED.
- * 
+ *
  * @param sched     Scheduler state
- * @param begin_pos First task in scope (absolute ID)
- * @param end_pos   One past last task in scope (absolute ID)
+ * @param task_ids  Array of task IDs owned by the ending scope
+ * @param count     Number of task IDs in the array
  */
-void pto2_scheduler_on_scope_end(PTO2SchedulerState* sched, 
-                                  int32_t begin_pos, int32_t end_pos);
+void pto2_scheduler_on_scope_end(PTO2SchedulerState* sched,
+                                  const int32_t* task_ids, int32_t count);
 
 /**
  * Increment fanout_refcount and check CONSUMED


### PR DESCRIPTION
Replace the old scope model (every enclosing scope holds a reference via scope_depth) with direct-owner-only: each task belongs to the scope at stack top when submitted, fanout_count initializes to 1 for the owning scope. Use a contiguous flat buffer for scope task tracking with minimal allocations. Update the vector example to demonstrate nested scopes with cross-boundary data flow.