### PR TITLE
Refactor: upgrade TensorMap chains to doubly-linked lists

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -1,22 +1,24 @@
 /**
  * PTO Runtime2 - TensorMap Implementation
- * 
+ *
  * Implements TensorMap with ring buffer pool, lazy invalidation,
  * and chain truncation optimization.
- * 
+ *
  * Key features:
  * 1. O(1) insert at bucket head
  * 2. O(valid_entries) lookup with chain truncation
  * 3. Automatic stale entry cleanup during lookup
  * 4. Periodic explicit cleanup for long chains
- * 
+ *
  * Based on: docs/runtime_buffer_manager_methods.md
  */
 
 #include "pto_tensormap.h"
+
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
+
 #include "tensor.h"
 
 // =============================================================================
@@ -28,20 +30,20 @@ bool pto2_tensormap_init(PTO2TensorMap* tm, int32_t num_buckets, int32_t pool_si
     if ((num_buckets & (num_buckets - 1)) != 0) {
         return false;  // num_buckets must be power of 2
     }
-    
+
     // Allocate buckets
     tm->buckets = (int32_t*)malloc(num_buckets * sizeof(int32_t));
     if (!tm->buckets) {
         return false;
     }
-    
+
     // Initialize all buckets to empty (-1)
     for (int32_t i = 0; i < num_buckets; i++) {
         tm->buckets[i] = -1;
     }
-    
+
     tm->num_buckets = num_buckets;
-    
+
     // Allocate entry pool
     tm->entry_pool = (PTO2TensorMapEntry*)calloc(pool_size, sizeof(PTO2TensorMapEntry));
     if (!tm->entry_pool) {
@@ -49,18 +51,20 @@ bool pto2_tensormap_init(PTO2TensorMap* tm, int32_t num_buckets, int32_t pool_si
         tm->buckets = NULL;
         return false;
     }
-    
+
     tm->pool_size = pool_size;
     tm->pool_head = 0;
-    
+
     // Initialize all entries as not in bucket
     for (int32_t i = 0; i < pool_size; i++) {
         tm->entry_pool[i].in_bucket = false;
         tm->entry_pool[i].next_in_bucket = -1;
+        tm->entry_pool[i].prev_in_bucket = -1;
         tm->entry_pool[i].next_in_task = -1;
+        tm->entry_pool[i].prev_in_task = -1;
         tm->entry_pool[i].producer_task_id = -1;
     }
-    
+
     // Allocate per-task entry tracking
     tm->task_entry_head = (int32_t*)malloc(PTO2_TASK_WINDOW_SIZE * sizeof(int32_t));
     if (!tm->task_entry_head) {
@@ -70,14 +74,14 @@ bool pto2_tensormap_init(PTO2TensorMap* tm, int32_t num_buckets, int32_t pool_si
         tm->buckets = NULL;
         return false;
     }
-    
+
     // Initialize all task entry heads to -1 (no entries)
     for (int32_t i = 0; i < PTO2_TASK_WINDOW_SIZE; i++) {
         tm->task_entry_head[i] = -1;
     }
-    
+
     tm->last_task_alive = 0;
-    
+
     return true;
 }
 
@@ -90,12 +94,12 @@ void pto2_tensormap_destroy(PTO2TensorMap* tm) {
         free(tm->buckets);
         tm->buckets = NULL;
     }
-    
+
     if (tm->entry_pool) {
         free(tm->entry_pool);
         tm->entry_pool = NULL;
     }
-    
+
     if (tm->task_entry_head) {
         free(tm->task_entry_head);
         tm->task_entry_head = NULL;
@@ -107,20 +111,22 @@ void pto2_tensormap_reset(PTO2TensorMap* tm) {
     for (int32_t i = 0; i < tm->num_buckets; i++) {
         tm->buckets[i] = -1;
     }
-    
+
     // Reset all entries
     for (int32_t i = 0; i < tm->pool_size; i++) {
         tm->entry_pool[i].in_bucket = false;
         tm->entry_pool[i].next_in_bucket = -1;
+        tm->entry_pool[i].prev_in_bucket = -1;
         tm->entry_pool[i].next_in_task = -1;
+        tm->entry_pool[i].prev_in_task = -1;
         tm->entry_pool[i].producer_task_id = -1;
     }
-    
+
     // Reset per-task entry tracking
     for (int32_t i = 0; i < PTO2_TASK_WINDOW_SIZE; i++) {
         tm->task_entry_head[i] = -1;
     }
-    
+
     tm->pool_head = 0;
     tm->last_task_alive = 0;
 }
@@ -133,7 +139,7 @@ uint32_t pto2_tensormap_hash(PTO2TensorMap* tm, Tensor* tensor) {
     // ========================================================================
     // CRITICAL: Hash ONLY by base_ptr for correct overlap detection!
     // ========================================================================
-    // 
+    //
     // For overlap detection to work, ALL regions accessing the same base
     // tensor MUST be in the SAME hash bucket. This allows lookup to find
     // and check all potentially overlapping regions.
@@ -148,11 +154,11 @@ uint32_t pto2_tensormap_hash(PTO2TensorMap* tm, Tensor* tensor) {
     //   Region B: base=X, offset=128 → bucket 5   (CORRECT! Same bucket)
     //
     uint64_t key = (uint64_t)(uintptr_t)tensor->buffer.addr;
-    
+
     // Improve distribution by mixing bits (pointers often have aligned low bits)
     key = key ^ (key >> 16);
     key = key ^ (key >> 32);
-    
+
     // Use bitwise AND for power-of-2 modulo (faster than %)
     return (uint32_t)(key & (tm->num_buckets - 1));
 }
@@ -161,50 +167,71 @@ uint32_t pto2_tensormap_hash(PTO2TensorMap* tm, Tensor* tensor) {
 // Validity and Cleanup
 // =============================================================================
 
-void pto2_tensormap_sync_validity(PTO2TensorMap* tm, int32_t last_task_alive) {
-    tm->last_task_alive = last_task_alive;
-}
+void pto2_tensormap_sync_validity(PTO2TensorMap* tm, int32_t last_task_alive) { tm->last_task_alive = last_task_alive; }
 
 void pto2_tensormap_remove_from_bucket(PTO2TensorMap* tm, PTO2TensorMapEntry* entry) {
     if (!entry->in_bucket) {
         return;  // Already removed
     }
-    
-    uint32_t bucket = pto2_tensormap_hash(tm, &entry->tensor);
-    int32_t* prev_ptr = &tm->buckets[bucket];
-    int32_t offset = *prev_ptr;
-    int32_t target_offset = entry - tm->entry_pool;
-    
-    while (offset >= 0) {
-        if (offset == target_offset) {
-            *prev_ptr = entry->next_in_bucket;
-            entry->in_bucket = false;
-            entry->next_in_bucket = -1;
-            return;
-        }
-        prev_ptr = &tm->entry_pool[offset].next_in_bucket;
-        offset = *prev_ptr;
+
+    // Update predecessor's next pointer (O(1) via prev_in_bucket)
+    if (entry->prev_in_bucket == -1) {
+        // Entry is the head of its bucket chain, update bucket head
+        uint32_t bucket = pto2_tensormap_hash(tm, &entry->tensor);
+        tm->buckets[bucket] = entry->next_in_bucket;
+    } else {
+        tm->entry_pool[entry->prev_in_bucket].next_in_bucket = entry->next_in_bucket;
     }
+
+    // Update successor's prev pointer
+    if (entry->next_in_bucket >= 0) {
+        tm->entry_pool[entry->next_in_bucket].prev_in_bucket = entry->prev_in_bucket;
+    }
+
+    entry->in_bucket = false;
+    entry->next_in_bucket = -1;
+    entry->prev_in_bucket = -1;
 }
 
-void pto2_tensormap_cleanup_retired(PTO2TensorMap* tm, 
-                                     int32_t old_last_task_alive,
-                                     int32_t new_last_task_alive) {
+void pto2_tensormap_remove_from_task(PTO2TensorMap* tm, PTO2TensorMapEntry* entry) {
+    // Update predecessor's next pointer (O(1) via prev_in_task)
+    if (entry->prev_in_task == -1) {
+        // Entry is the head of its task chain, update task_entry_head
+        int32_t task_slot = entry->producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+        tm->task_entry_head[task_slot] = entry->next_in_task;
+    } else {
+        tm->entry_pool[entry->prev_in_task].next_in_task = entry->next_in_task;
+    }
+
+    // Update successor's prev pointer
+    if (entry->next_in_task >= 0) {
+        tm->entry_pool[entry->next_in_task].prev_in_task = entry->prev_in_task;
+    }
+
+    entry->next_in_task = -1;
+    entry->prev_in_task = -1;
+}
+
+void pto2_tensormap_cleanup_retired(PTO2TensorMap* tm, int32_t old_last_task_alive, int32_t new_last_task_alive) {
     // Iterate through retired tasks and remove their entries from bucket chains
     for (int32_t task_id = old_last_task_alive; task_id < new_last_task_alive; task_id++) {
         int32_t task_slot = task_id & (PTO2_TASK_WINDOW_SIZE - 1);
         int32_t offset = tm->task_entry_head[task_slot];
-        
+
         while (offset >= 0) {
             PTO2TensorMapEntry* entry = &tm->entry_pool[offset];
+            int32_t next = entry->next_in_task;  // Save before clearing
             // Only remove if this entry belongs to the retiring task
             // (slot may have been reused by a newer task)
             if (entry->producer_task_id == task_id) {
                 pto2_tensormap_remove_from_bucket(tm, entry);
+                // Clear task chain pointers (entire chain is being destroyed)
+                entry->next_in_task = -1;
+                entry->prev_in_task = -1;
             }
-            offset = entry->next_in_task;
+            offset = next;
         }
-        
+
         // Clear task's entry head (slot will be reused by task_id + TASK_WINDOW_SIZE)
         tm->task_entry_head[task_slot] = -1;
     }
@@ -218,41 +245,42 @@ int32_t pto2_tensormap_lookup(PTO2TensorMap* tm, Tensor* tensor) {
     uint32_t bucket = pto2_tensormap_hash(tm, tensor);
     int32_t* prev_ptr = &tm->buckets[bucket];  // For truncation
     int32_t offset = *prev_ptr;
-    
+
     while (offset >= 0) {
         PTO2TensorMapEntry* entry = &tm->entry_pool[offset];
-        
+
         // Check validity first
         if (!pto2_tensormap_entry_valid(tm, entry)) {
             // ========== STALE ENTRY: Truncate chain here ==========
             // All subsequent entries are guaranteed to be stale too!
             // Truncate: unlink this and all following entries
             *prev_ptr = -1;  // Terminate chain at previous entry
-            
+
             // Mark truncated entries as not in bucket (for correct reuse)
             while (offset >= 0) {
                 PTO2TensorMapEntry* stale = &tm->entry_pool[offset];
                 int32_t next = stale->next_in_bucket;
                 stale->in_bucket = false;
                 stale->next_in_bucket = -1;
+                stale->prev_in_bucket = -1;
                 offset = next;
             }
-            
+
             return -1;  // Not found (and cleaned up stale tail)
         }
-        
+
         // Entry is valid - check if regions OVERLAP (not just exact match)
         // Since we hash only by base_ptr, all entries in this bucket have
         // potential to overlap. We must check actual byte-range overlap.
         if (tensor->is_overlap(entry->tensor)) {
             return entry->producer_task_id;  // FOUND (overlapping region)
         }
-        
+
         // Move to next entry
         prev_ptr = &entry->next_in_bucket;
         offset = *prev_ptr;
     }
-    
+
     return -1;  // Not found
 }
 
@@ -260,35 +288,43 @@ int32_t pto2_tensormap_lookup(PTO2TensorMap* tm, Tensor* tensor) {
 // Insert
 // =============================================================================
 
-void pto2_tensormap_insert(PTO2TensorMap* tm, Tensor* tensor,
-                            int32_t producer_task_id) {
+void pto2_tensormap_insert(PTO2TensorMap* tm, Tensor* tensor, int32_t producer_task_id) {
     // Allocate entry from ring buffer pool
     int32_t entry_offset = tm->pool_head;
     PTO2TensorMapEntry* entry = &tm->entry_pool[entry_offset];
-    
+
     // Advance pool head (wrap around)
     tm->pool_head = (tm->pool_head + 1) % tm->pool_size;
-    
-    // ========== CRITICAL: MUST remove old entry from its bucket chain ==========
-    // Even if entry is STALE (producer retired), it's still linked in its old 
-    // bucket chain. If we overwrite without unlinking, the chain gets corrupted!
+
+    // TODO：这里需要改成不断等待tensor_map清理旧task数据
     if (entry->in_bucket) {
         pto2_tensormap_remove_from_bucket(tm, entry);
+        pto2_tensormap_remove_from_task(tm, entry);
     }
-    
+
     // Initialize new entry
     entry->tensor = *tensor;
     entry->producer_task_id = producer_task_id;
-    
+
     // Insert at head of hash bucket (maintains task_id descending order)
     uint32_t bucket = pto2_tensormap_hash(tm, tensor);
     entry->next_in_bucket = tm->buckets[bucket];
+    entry->prev_in_bucket = -1;  // New head has no predecessor
+    // Update old head's prev pointer
+    if (entry->next_in_bucket >= 0) {
+        tm->entry_pool[entry->next_in_bucket].prev_in_bucket = entry_offset;
+    }
     tm->buckets[bucket] = entry_offset;
     entry->in_bucket = true;
-    
+
     // Link to task's entry list (for cleanup)
     int32_t task_slot = producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
     entry->next_in_task = tm->task_entry_head[task_slot];
+    entry->prev_in_task = -1;  // New head has no predecessor
+    // Update old head's prev pointer
+    if (entry->next_in_task >= 0) {
+        tm->entry_pool[entry->next_in_task].prev_in_task = entry_offset;
+    }
     tm->task_entry_head[task_slot] = entry_offset;
 }
 
@@ -303,7 +339,7 @@ void pto2_tensormap_print_stats(PTO2TensorMap* tm) {
     int32_t max_chain = 0;
     int64_t total_chain = 0;
     int32_t non_empty_buckets = 0;
-    
+
     // Count entries
     for (int32_t i = 0; i < tm->pool_size; i++) {
         if (tm->entry_pool[i].in_bucket) {
@@ -314,17 +350,17 @@ void pto2_tensormap_print_stats(PTO2TensorMap* tm) {
             }
         }
     }
-    
+
     // Count bucket stats
     for (int32_t b = 0; b < tm->num_buckets; b++) {
         int32_t chain_len = 0;
         int32_t offset = tm->buckets[b];
-        
+
         while (offset >= 0) {
             chain_len++;
             offset = tm->entry_pool[offset].next_in_bucket;
         }
-        
+
         if (chain_len == 0) {
             empty_buckets++;
         } else {
@@ -335,7 +371,7 @@ void pto2_tensormap_print_stats(PTO2TensorMap* tm) {
             }
         }
     }
-    
+
     printf("=== TensorMap Statistics ===\n");
     printf("Pool size:       %d\n", tm->pool_size);
     printf("Pool head:       %d\n", tm->pool_head);
@@ -344,21 +380,19 @@ void pto2_tensormap_print_stats(PTO2TensorMap* tm) {
     printf("Stale entries:   %d\n", stale);
     printf("Empty buckets:   %d\n", empty_buckets);
     printf("Max chain len:   %d\n", max_chain);
-    printf("Avg chain len:   %.2f\n", 
-           non_empty_buckets > 0 ? (float)total_chain / non_empty_buckets : 0);
+    printf("Avg chain len:   %.2f\n", non_empty_buckets > 0 ? (float)total_chain / non_empty_buckets : 0);
     printf("Last task alive: %d\n", tm->last_task_alive);
     printf("============================\n");
 }
 
 int32_t pto2_tensormap_valid_count(PTO2TensorMap* tm) {
     int32_t count = 0;
-    
+
     for (int32_t i = 0; i < tm->pool_size; i++) {
-        if (tm->entry_pool[i].in_bucket && 
-            pto2_tensormap_entry_valid(tm, &tm->entry_pool[i])) {
+        if (tm->entry_pool[i].in_bucket && pto2_tensormap_entry_valid(tm, &tm->entry_pool[i])) {
             count++;
         }
     }
-    
+
     return count;
 }

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -58,7 +58,9 @@ typedef struct {
     Tensor tensor;      // Tensor descriptor key
     int32_t producer_task_id;     // Task that produces this region
     int32_t next_in_bucket;       // Offset to next entry in hash bucket (-1 = end)
+    int32_t prev_in_bucket;       // Offset to prev entry in hash bucket (-1 = head is buckets[bucket])
     int32_t next_in_task;         // Offset to next entry for same task (-1 = end)
+    int32_t prev_in_task;         // Offset to prev entry for same task (-1 = head is task_entry_head[slot])
     bool    in_bucket;            // True if entry is linked in a bucket chain
                                   // CRITICAL: Must be set false before overwriting!
 } PTO2TensorMapEntry;
@@ -184,10 +186,16 @@ static inline bool pto2_tensormap_entry_valid(PTO2TensorMap* tm, PTO2TensorMapEn
 }
 
 /**
- * Remove entry from its bucket chain
+ * Remove entry from its bucket chain (O(1) with prev pointer)
  * Called during pool wrap-around or cleanup.
  */
 void pto2_tensormap_remove_from_bucket(PTO2TensorMap* tm, PTO2TensorMapEntry* entry);
+
+/**
+ * Remove entry from its task chain (O(1) with prev pointer)
+ * Called during pool wrap-around to unlink reused entries.
+ */
+void pto2_tensormap_remove_from_task(PTO2TensorMap* tm, PTO2TensorMapEntry* entry);
 
 // =============================================================================
 // Debug Utilities


### PR DESCRIPTION
Refactor: upgrade TensorMap chains to doubly-linked lists for O(1) removal

Add prev_in_bucket and prev_in_task pointers to PTO2TensorMapEntry, converting both bucket chains and task chains from singly-linked to doubly-linked lists. This eliminates O(n) traversal in remove_from_bucket and adds a new remove_from_task function, both achieving O(1) entry removal during pool wrap-around and cleanup.