### PR TITLE
Refactor: overlap-aware TensorMap lookup with INOUT chain dependency optimization

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -1,28 +1,28 @@
 /**
  * PTO Runtime2 - Orchestrator Interface
- * 
+ *
  * The Orchestrator is responsible for:
  * 1. Executing the orchestration function (Turing-complete control flow)
  * 2. Allocating intermediate buffers from the heap
  * 3. Submitting tasks via async InCore function calls
  * 4. Building the dependency graph using TensorMap
  * 5. Managing buffer scopes for lifecycle control
- * 
+ *
  * The Orchestrator can run on either:
  * - Host CPU (lower latency for complex control, easier debugging)
  * - Device AI_CPU (lower latency for task submission)
- * 
+ *
  * Based on: docs/runtime_buffer_manager_methods.md
  */
 
 #ifndef PTO_ORCHESTRATOR_H
 #define PTO_ORCHESTRATOR_H
 
-#include "pto_runtime2_types.h"
-#include "pto_shared_memory.h"
 #include "pto_ring_buffer.h"
-#include "pto_tensormap.h"
+#include "pto_runtime2_types.h"
 #include "pto_scheduler.h"
+#include "pto_shared_memory.h"
+#include "pto_tensormap.h"
 #include "pto_types.h"
 
 // =============================================================================
@@ -31,49 +31,48 @@
 
 /**
  * Orchestrator state structure (private to Orchestrator)
- * 
+ *
  * Contains all state needed for task graph construction and buffer management.
  */
-typedef struct {
+struct PTO2OrchestratorState {
     // === SHARED MEMORY ACCESS ===
     PTO2SharedMemoryHandle* sm_handle;
-    
+
     // === RING BUFFERS ===
-    PTO2HeapRing    heap_ring;      // Output buffer allocation
-    PTO2TaskRing    task_ring;      // Task slot allocation
-    PTO2DepListPool dep_pool;       // Dependency list allocation
-    
+    PTO2HeapRing heap_ring;    // Output buffer allocation
+    PTO2TaskRing task_ring;    // Task slot allocation
+    PTO2DepListPool dep_pool;  // Dependency list allocation
+
     // === TENSOR MAP (Private) ===
-    PTO2TensorMap   tensor_map;     // Producer lookup
-    int32_t         tensormap_last_cleanup;  // Last cleanup threshold
-    
+    PTO2TensorMap tensor_map;        // Producer lookup
+    int32_t tensormap_last_cleanup;  // Last cleanup threshold
+
     // === SCOPE STACK (Private) ===
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    int32_t*  scope_tasks;           // Flat buffer of task IDs (all scopes concatenated)
-    int32_t   scope_tasks_size;      // Number of task IDs currently in the buffer
-    int32_t   scope_tasks_capacity;  // Allocated capacity of scope_tasks
-    int32_t*  scope_begins;          // scope_begins[i] = start index of scope i in scope_tasks
-    int32_t   scope_stack_top;       // Current top of stack (-1 = no scope open)
-    int32_t   scope_stack_capacity;  // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
-    
+    int32_t* scope_tasks;          // Flat buffer of task IDs (all scopes concatenated)
+    int32_t scope_tasks_size;      // Number of task IDs currently in the buffer
+    int32_t scope_tasks_capacity;  // Allocated capacity of scope_tasks
+    int32_t* scope_begins;         // scope_begins[i] = start index of scope i in scope_tasks
+    int32_t scope_stack_top;       // Current top of stack (-1 = no scope open)
+    int32_t scope_stack_capacity;  // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+
     // === SCHEDULER REFERENCE ===
     // Note: In simulated mode, orchestrator and scheduler share address space
     // In real mode, they communicate via shared memory only
     PTO2SchedulerState* scheduler;  // For simulated mode only
     bool init_task_on_submit;       // If true, call scheduler_init_task on submit
-    
+
     // === GM HEAP (for output buffers) ===
-    void*           gm_heap_base;   // Base address of GM heap
-    int32_t         gm_heap_size;   // Size of GM heap
-    
+    void* gm_heap_base;    // Base address of GM heap
+    int32_t gm_heap_size;  // Size of GM heap
+
     // === STATISTICS ===
-    int64_t         tasks_submitted;
-    int64_t         buffers_allocated;
-    int64_t         bytes_allocated;
-    
-} PTO2OrchestratorState;
+    int64_t tasks_submitted;
+    int64_t buffers_allocated;
+    int64_t bytes_allocated;
+};
 
 // =============================================================================
 // Orchestrator API
@@ -81,17 +80,15 @@ typedef struct {
 
 /**
  * Initialize orchestrator state
- * 
+ *
  * @param orch       Orchestrator state to initialize
  * @param sm_handle  Shared memory handle
  * @param gm_heap    GM heap memory for output buffers
  * @param heap_size  Size of GM heap
  * @return true on success
  */
-bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
-                             PTO2SharedMemoryHandle* sm_handle,
-                             void* gm_heap,
-                             int32_t heap_size);
+bool pto2_orchestrator_init(
+    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, int32_t heap_size);
 
 /**
  * Destroy orchestrator state and free resources
@@ -106,20 +103,18 @@ void pto2_orchestrator_reset(PTO2OrchestratorState* orch);
 /**
  * Set scheduler reference (for simulated mode)
  */
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch,
-                                      PTO2SchedulerState* scheduler);
+void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler);
 
 /**
  * Set scheduler reference with mode control
- * 
+ *
  * @param orch           Orchestrator state
  * @param scheduler      Scheduler state
  * @param init_on_submit If true, init task on submit (single-threaded mode)
  *                       If false, scheduler thread polls for new tasks (multi-threaded)
  */
-void pto2_orchestrator_set_scheduler_mode(PTO2OrchestratorState* orch,
-                                           PTO2SchedulerState* scheduler,
-                                           bool init_on_submit);
+void pto2_orchestrator_set_scheduler_mode(
+    PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler, bool init_on_submit);
 
 // =============================================================================
 // Scope Management
@@ -166,11 +161,11 @@ void pto2_scope_end(PTO2OrchestratorState* orch);
  * @param num_params  Number of parameters
  */
 void pto2_submit_task(PTO2OrchestratorState* orch,
-                      int32_t kernel_id,
-                      PTO2WorkerType worker_type,
-                      const char* func_name,
-                      PTOParam* params,
-                      int32_t num_params);
+    int32_t kernel_id,
+    PTO2WorkerType worker_type,
+    const char* func_name,
+    PTOParam* params,
+    int32_t num_params);
 
 // =============================================================================
 // Flow Control
@@ -178,14 +173,14 @@ void pto2_submit_task(PTO2OrchestratorState* orch,
 
 /**
  * Mark orchestration as complete
- * 
+ *
  * Signals to scheduler that no more tasks will be submitted.
  */
 void pto2_orchestrator_done(PTO2OrchestratorState* orch);
 
 /**
  * Wait for all tasks to complete
- * 
+ *
  * Blocks until scheduler reports all tasks consumed.
  * Only valid in simulated mode or with shared address space.
  */
@@ -197,18 +192,6 @@ void pto2_orchestrator_wait_all(PTO2OrchestratorState* orch);
 bool pto2_orchestrator_has_space(PTO2OrchestratorState* orch);
 
 // =============================================================================
-// TensorMap Synchronization
-// =============================================================================
-
-/**
- * Sync TensorMap validity threshold from shared memory
- * 
- * Called periodically to refresh the lazy invalidation threshold.
- * Also triggers cleanup if threshold has advanced significantly.
- */
-void pto2_orchestrator_sync_tensormap(PTO2OrchestratorState* orch);
-
-// =============================================================================
 // Internal Helpers
 // =============================================================================
 
@@ -216,10 +199,8 @@ void pto2_orchestrator_sync_tensormap(PTO2OrchestratorState* orch);
  * Add consumer to producer's fanout list (with spinlock)
  * Also checks if producer has already completed and updates consumer's fanin_refcount
  */
-void pto2_add_consumer_to_producer(PTO2OrchestratorState* orch,
-                                    PTO2TaskDescriptor* producer,
-                                    int32_t producer_id,
-                                    int32_t consumer_id);
+void pto2_add_consumer_to_producer(
+    PTO2OrchestratorState* orch, PTO2TaskDescriptor* producer, int32_t producer_id, int32_t consumer_id);
 
 /**
  * Allocate packed output buffer for a task
@@ -240,4 +221,4 @@ void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch);
  */
 void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch);
 
-#endif // PTO_ORCHESTRATOR_H
+#endif  // PTO_ORCHESTRATOR_H

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -1,32 +1,32 @@
 /**
  * PTO Runtime2 - TensorMap Interface
- * 
+ *
  * TensorMap provides producer lookup for dependency discovery:
  * - Maps Tensor -> producer task ID
  * - Used by pto_submit_task() to find dependencies
- * 
+ *
  * Key design features:
  * 1. Ring buffer pool for entries (no malloc/free)
  * 2. Lazy invalidation (entries become stale when producer retires)
  * 3. Chain truncation optimization (truncate on first stale entry)
  * 4. Per-task entry tracking for efficient cleanup
  * 5. OVERLAP DETECTION: Detects dependencies for overlapping sub-regions
- * 
+ *
  * Hash table with chaining:
  * - buckets[] array of head offsets
  * - Entries linked via next_in_bucket
  * - Insert at head (newest first) for sorted chains
- * 
+ *
  * CRITICAL: Hash only by base_ptr
  * ==============================
  * For overlap detection to work, ALL sub-regions of the same base tensor
  * MUST be in the SAME hash bucket. This allows lookup to compare all
  * potentially overlapping regions.
- * 
+ *
  * Overlap detection: Two regions create a dependency if:
  *   1. Same base_ptr (raw tensor pointer)
  *   2. Byte ranges [offset, offset+size) intersect
- * 
+ *
  * Based on: docs/runtime_buffer_manager_methods.md
  */
 
@@ -36,57 +36,60 @@
 #include "pto_runtime2_types.h"
 #include "tensor.h"
 
+struct PTO2OrchestratorState;  // forward declare
+
 // =============================================================================
 // TensorMap Structure
 // =============================================================================
 
-
 /**
  * TensorMap entry structure
  * Maps tensor region -> producer task ID
- * 
+ *
  * Stored in ring buffer pool with lazy invalidation:
  * - Entry is valid only if producer_task_id >= last_task_alive
  * - Stale entries ignored during lookup
  * - Pool wraps around, overwriting stale entries
- * 
+ *
  * Chain truncation optimization:
  * - Entries in bucket chains sorted by task_id (newest first)
  * - When lookup hits stale entry, truncate rest of chain
  */
 typedef struct {
-    Tensor tensor;      // Tensor descriptor key
-    int32_t producer_task_id;     // Task that produces this region
-    int32_t next_in_bucket;       // Offset to next entry in hash bucket (-1 = end)
-    int32_t prev_in_bucket;       // Offset to prev entry in hash bucket (-1 = head is buckets[bucket])
-    int32_t next_in_task;         // Offset to next entry for same task (-1 = end)
-    int32_t prev_in_task;         // Offset to prev entry for same task (-1 = head is task_entry_head[slot])
-    bool    in_bucket;            // True if entry is linked in a bucket chain
-                                  // CRITICAL: Must be set false before overwriting!
+    Tensor tensor;             // Tensor descriptor key
+    int32_t producer_task_id;  // Task that produces this region
+    int32_t next_in_bucket;    // Offset to next entry in hash bucket (-1 = end)
+    int32_t prev_in_bucket;    // Offset to prev entry in hash bucket (-1 = head is buckets[bucket])
+    int32_t next_in_task;      // Offset to next entry for same task (-1 = end)
+    int32_t prev_in_task;      // Offset to prev entry for same task (-1 = head is task_entry_head[slot])
+    bool in_bucket;            // True if entry is linked in a bucket chain
+                               // CRITICAL: Must be set false before overwriting!
+    bool with_alloc{true};     // True if entry is task output, False if entry is task inout
 } PTO2TensorMapEntry;
 
 /**
  * TensorMap structure
- * 
+ *
  * Hash table with ring buffer entry pool and lazy invalidation.
  */
 typedef struct {
     // Hash table buckets (fixed size, power of 2)
-    int32_t* buckets;             // Array of offsets into entry_pool (-1 = empty)
-    int32_t  num_buckets;         // Must be power of 2 for fast modulo
-    
+    int32_t* buckets;     // Array of offsets into entry_pool (-1 = empty)
+    int32_t num_buckets;  // Must be power of 2 for fast modulo
+
     // Entry pool as ring buffer
-    PTO2TensorMapEntry* entry_pool;   // Ring buffer of entries
-    int32_t pool_size;                // Total pool capacity
-    int32_t pool_head;                // Next allocation position (wraps around)
-    
+    PTO2TensorMapEntry* entry_pool;  // Ring buffer of entries
+    int32_t pool_size;               // Total pool capacity
+    int32_t pool_head;               // Next allocation position (wraps around)
+
     // Per-task entry tracking (for efficient bucket cleanup)
-    int32_t* task_entry_head;     // Per-task head offset (-1 = no entries)
-                                  // Indexed by task_id % TASK_WINDOW_SIZE
-    
+    int32_t* task_entry_head;  // Per-task head offset (-1 = no entries)
+                               // Indexed by task_id % TASK_WINDOW_SIZE
+
     // Validity threshold (for lazy invalidation)
-    int32_t last_task_alive;      // Cached value from shared memory
-    
+    int32_t last_task_alive;  // Cached value from shared memory
+
+    PTO2OrchestratorState* orch{nullptr};
 } PTO2TensorMap;
 
 // =============================================================================
@@ -95,7 +98,7 @@ typedef struct {
 
 /**
  * Initialize TensorMap
- * 
+ *
  * @param tm          TensorMap to initialize
  * @param num_buckets Number of hash buckets (must be power of 2)
  * @param pool_size   Size of entry pool
@@ -121,7 +124,7 @@ void pto2_tensormap_reset(PTO2TensorMap* tm);
 /**
  * Update validity threshold from shared memory
  * Called periodically to refresh the lazy invalidation threshold.
- * 
+ *
  * @param tm               TensorMap
  * @param last_task_alive  Current value from shared memory
  */
@@ -129,45 +132,42 @@ void pto2_tensormap_sync_validity(PTO2TensorMap* tm, int32_t last_task_alive);
 
 /**
  * Lookup producer for a tensor region
- * 
+ *
  * Searches the hash table for a matching region.
- * Returns producer task ID if found and valid, -1 otherwise.
- * 
+ * Returns producer entry if found and valid.
+ *
  * Chain truncation: When first stale entry is found, truncates
  * the rest of the chain (all subsequent entries are also stale).
- * 
+ *
  * @param tm      TensorMap
  * @param tensor  Tensor to look up
- * @return Producer task ID, or -1 if not found
+ * @return Producer entry, and overlap status
  */
-int32_t pto2_tensormap_lookup(PTO2TensorMap* tm, Tensor* tensor);
+std::vector<std::pair<PTO2TensorMapEntry*, OverlapStatus>> pto2_tensormap_lookup(PTO2TensorMap* tm, Tensor* tensor);
 
 /**
  * Insert a new entry (called when task produces output)
- * 
+ *
  * Allocates from ring buffer pool, may overwrite stale entries.
  * Inserts at head of hash bucket chain (maintains task_id ordering).
- * 
+ *
  * @param tm                TensorMap
  * @param tensor            Tensor produced
  * @param producer_task_id  Task ID of producer
  */
-void pto2_tensormap_insert(PTO2TensorMap* tm, Tensor* tensor,
-                            int32_t producer_task_id);
+void pto2_tensormap_insert(PTO2TensorMap* tm, Tensor* tensor, int32_t producer_task_id, bool with_alloc);
 
 /**
  * Cleanup stale entries for retired tasks
- * 
+ *
  * Called periodically by Orchestrator when last_task_alive advances.
  * Removes entries from bucket chains for tasks in [old, new) range.
- * 
+ *
  * @param tm                   TensorMap
  * @param old_last_task_alive  Previous threshold
  * @param new_last_task_alive  New threshold
  */
-void pto2_tensormap_cleanup_retired(PTO2TensorMap* tm, 
-                                     int32_t old_last_task_alive,
-                                     int32_t new_last_task_alive);
+void pto2_tensormap_cleanup_retired(PTO2TensorMap* tm, int32_t old_last_task_alive, int32_t new_last_task_alive);
 
 // =============================================================================
 // Internal Helpers (exposed for testing)
@@ -184,6 +184,8 @@ uint32_t pto2_tensormap_hash(PTO2TensorMap* tm, Tensor* tensor);
 static inline bool pto2_tensormap_entry_valid(PTO2TensorMap* tm, PTO2TensorMapEntry* entry) {
     return entry->producer_task_id >= tm->last_task_alive;
 }
+
+void pto2_tensormap_remove_entry(PTO2TensorMap& tm, PTO2TensorMapEntry* entry);
 
 /**
  * Remove entry from its bucket chain (O(1) with prev pointer)
@@ -211,4 +213,16 @@ void pto2_tensormap_print_stats(PTO2TensorMap* tm);
  */
 int32_t pto2_tensormap_valid_count(PTO2TensorMap* tm);
 
-#endif // PTO_TENSORMAP_H
+// =============================================================================
+// TensorMap Synchronization
+// =============================================================================
+
+/**
+ * Sync TensorMap validity threshold from shared memory
+ *
+ * Called periodically to refresh the lazy invalidation threshold.
+ * Also triggers cleanup if threshold has advanced significantly.
+ */
+void pto2_orchestrator_sync_tensormap(PTO2TensorMap* tm);
+
+#endif  // PTO_TENSORMAP_H

--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -45,7 +45,7 @@
 #endif
 
 #ifndef RUNTIME_MAX_ORCH_SO_SIZE
-#define RUNTIME_MAX_ORCH_SO_SIZE (1024 * 1024)  // 1MB max for orchestration SO
+#define RUNTIME_MAX_ORCH_SO_SIZE (4 * 1024 * 1024)  // 1MB max for orchestration SO
 #endif
 
 // =============================================================================
@@ -86,14 +86,14 @@
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;  // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;  // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;         // Task pointer: 0=no task, non-zero=PTO2DispatchPayload*
-    volatile int32_t task_status;   // Task execution status: 0=idle, 1=busy
-    volatile int32_t control;       // Control signal: 0=execute, 1=quit
-    volatile CoreType core_type;    // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t perf_records_addr; // Performance records address
-    volatile uint32_t perf_buffer_status; // 0 = not full, 1 == full
+    volatile uint32_t aicpu_ready;         // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;         // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                // Task pointer: 0=no task, non-zero=PTO2DispatchPayload*
+    volatile int32_t task_status;          // Task execution status: 0=idle, 1=busy
+    volatile int32_t control;              // Control signal: 0=execute, 1=quit
+    volatile CoreType core_type;           // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t perf_records_addr;   // Performance records address
+    volatile uint32_t perf_buffer_status;  // 0 = not full, 1 == full
 } __attribute__((aligned(64)));
 
 /**
@@ -155,8 +155,8 @@ public:
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
     // Profiling support
-    bool enable_profiling;                  // Enable profiling flag
-    uint64_t perf_data_base;                // Performance data shared memory base address (device-side)
+    bool enable_profiling;    // Enable profiling flag
+    uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
 
 private:
     // Tensor pairs for host-device memory tracking
@@ -165,8 +165,8 @@ private:
 
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
-    void* pto2_gm_sm_ptr_;   // GM pointer to PTO2 shared memory (device)
-    uint64_t* orch_args_;    // Arguments for device orchestration
+    void* pto2_gm_sm_ptr_;  // GM pointer to PTO2 shared memory (device)
+    uint64_t* orch_args_;   // Arguments for device orchestration
     int orch_arg_count_;
     uint64_t orch_args_storage_[RUNTIME_MAX_ARGS];  // Copy of args for device
 
@@ -240,7 +240,7 @@ public:
     bool get_use_pto2_dispatch() const { return true; }
 
     /** @deprecated Use PTO2 dispatch mode */
-    void set_use_pto2_dispatch(bool) { }
+    void set_use_pto2_dispatch(bool) {}
 
     // =========================================================================
     // Host API (host-only, not copied to device)

--- a/src/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -41,11 +41,18 @@ enum class OverlapType {
     Fuzzy = 1,
 };
 
+enum class OverlapStatus {
+    NO_OVERLAP,
+    COVERED,
+    OTHER,
+};
+
 struct Segment {
     uint64_t begin;
     uint64_t end;
 
     bool line_segment_intersection(const Segment& other) const { return end > other.begin && other.end > begin; }
+    bool contains(const Segment& other) const { return begin <= other.begin && other.end <= end; }
 };
 
 // 特殊值，表示 reshape 后需要分配新地址
@@ -157,7 +164,7 @@ struct Tensor {
 
     uint64_t offset_ndim_to_1d(const uint64_t offset_ndims[]) const;
 
-    bool is_overlap(const Tensor& pre_task_output) const;
+    OverlapStatus is_overlap(const Tensor& pre_task_output) const;
 
     bool complex_overlap(const Tensor& pre_task_output) const;
 
@@ -190,7 +197,6 @@ static inline Tensor make_tensor_external(
  * Create a Tensor for runtime-allocated output (addr=0).
  * The runtime fills in the actual address during pto2_submit_task.
  */
-static inline Tensor make_tensor(
-    int32_t size_bytes, int32_t version = 0, DataType dtype = DataType::FLOAT32) {
+static inline Tensor make_tensor(int32_t size_bytes, int32_t version = 0, DataType dtype = DataType::FLOAT32) {
     return Tensor::make_1d_contiguous(0, size_bytes, version, dtype);
 }


### PR DESCRIPTION
Refactor: overlap-aware TensorMap lookup with INOUT chain dependency optimization

- Change Tensor::is_overlap to return OverlapStatus enum (NO_OVERLAP/COVERED/OTHER) with Segment::contains for full-coverage detection
- Upgrade TensorMap lookup to return all overlapping entries with overlap status, enabling multi-producer dependency discovery
- Merge INOUT into INPUT handling in submit_task; for INOUT params that fully cover a non-alloc entry, remove the covered entry from TensorMap to minimize dependency fan-in and favor chain dependencies
- Move sync_tensormap from Orchestrator to TensorMap with back-pointer to orch, and spin-wait on pool exhaustion instead of force-removing entries
- Add with_alloc field to TensorMapEntry to distinguish OUTPUT vs INOUT producers
- Bump RUNTIME_MAX_ORCH_SO_SIZE to 4MB