### PR TITLE
Add paged attention test for aicpu_build_graph runtime

### DIFF
--- a/tests/device_tests/aicpu_build_graph/paged_attention/README.md
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/README.md
@@ -1,0 +1,113 @@
+# Paged Attention (Device Test - aicpu_build_graph)
+
+This test demonstrates Paged Attention using the **aicpu_build_graph** runtime, where the AICPU device builds the task graph at runtime via a dlopen'd orchestration plugin while scheduler threads execute tasks concurrently.
+
+The kernel implementations are identical to the `host_build_graph` version. Only the orchestration and runtime configuration differ.
+
+## Overview
+
+Paged Attention is an efficient attention mechanism that processes KV cache in fixed-size blocks, enabling memory-efficient inference for long sequences. This implementation uses:
+
+- **CCE-style codegen** for AIC kernels (Cube unit matmul)
+- **PTO Tile API** for AIV kernels (Vector unit operations)
+- **Online Softmax** algorithm for numerically stable incremental computation
+
+### Runtime Architecture
+
+In `aicpu_build_graph` mode:
+- **1 AICPU builder thread** runs the orchestration plugin (builds the task graph)
+- **3 AICPU scheduler threads** execute tasks concurrently with graph construction
+- The orchestration plugin is compiled as a `.so`, embedded in Runtime, and dlopen'd on AICPU
+- The framework pre-allocates device memory for I/O tensors and populates `orch_args[]`
+
+### Supported Platforms
+
+| Platform | Description |
+|----------|-------------|
+| a2a3 | Ascend hardware (requires device ID) |
+
+> This test uses bfloat16 data types and production-scale shapes that are not supported by the a2a3sim simulator. It only runs on real hardware.
+
+### Algorithm
+
+For each query token, the attention is computed incrementally across KV cache blocks:
+
+```
+For each block j:
+    sij = Qi @ Kj^T                    # QK MatMul (AIC)
+    mij, lij, pij = softmax_prepare(sij)  # Softmax (AIV)
+    oi_new = pij @ Vj                  # PV MatMul (AIC)
+    oi = online_update(oi, oi_new, mij, lij)  # Accumulate (AIV)
+```
+
+### Task Graph Structure
+
+For each batch, the task dependency pattern is:
+
+```
+Block 0: QK -> SF -> PV --+
+Block 1: QK -> SF -> PV --+--> UP[0] -> UP[1] -> ... -> UP[n]
+Block n: QK -> SF -> PV --+
+```
+
+- **QK/SF/PV chains**: Run in parallel across blocks
+- **UP (Online Update)**: Serialized within batch due to accumulator dependency
+
+## Quick Start
+
+```bash
+# Run on hardware (specify device ID)
+python examples/scripts/run_example.py \
+  -k tests/device_tests/aicpu_build_graph/paged_attention/kernels \
+  -g tests/device_tests/aicpu_build_graph/paged_attention/golden.py \
+  -p a2a3 -d 0
+
+# Run multi-block test case
+PA_CASE=Case2 python examples/scripts/run_example.py \
+  -k tests/device_tests/aicpu_build_graph/paged_attention/kernels \
+  -g tests/device_tests/aicpu_build_graph/paged_attention/golden.py \
+  -p a2a3 -d 0
+```
+
+## Directory Structure
+
+```
+paged_attention/
+├── README.md                    # This file
+├── golden.py                    # Input generation and expected output
+└── kernels/
+    ├── kernel_config.py         # Kernel registration config (aicpu_build_graph)
+    ├── aic/                      # AIC kernels (CCE codegen style)
+    │   ├── aic_qk_matmul.cpp     # Q @ K^T matmul
+    │   └── aic_pv_matmul.cpp     # P @ V matmul
+    ├── aiv/                      # AIV kernels (PTO Tile API)
+    │   ├── aiv_softmax_prepare.cpp  # Softmax preparation
+    │   └── aiv_online_update.cpp    # Online Softmax update + normalize
+    └── orchestration/
+        └── paged_attention_orch.cpp # AICPU task graph builder (dlopen'd plugin)
+```
+
+## Test Cases
+
+| Case | batch | num_heads | kv_head_num | head_dim | block_size | context_len | Description |
+|------|-------|-----------|-------------|----------|------------|-------------|-------------|
+| Case1 | 256 | 16 | 1 | 128 | 128 | 8192 | Default |
+| Case2 | 64 | 64 | 1 | 128 | 64 | 8192 | Multi-block |
+
+All test cases use **bfloat16** Q/K/V inputs with GQA (kv_head_num=1).
+
+## Key Differences from host_build_graph Version
+
+| Aspect | host_build_graph | aicpu_build_graph |
+|--------|------------------|-------------------|
+| Graph building | Host CPU | AICPU device (dlopen'd plugin) |
+| I/O memory | Orchestration allocates + copies | Framework pre-manages |
+| Task API | `runtime->add_task()` | `api.add_task()` |
+| Dependency API | `runtime->add_successor()` | `api.add_successor_conditional()` |
+| Task visibility | Implicit | Explicit `api.publish_task()` |
+| Thread model | 3 scheduler threads | 1 builder + 3 scheduler threads |
+
+## See Also
+
+- [host_build_graph version](../../host_build_graph/paged_attention/README.md)
+- [Test Framework Documentation](../../../../examples/scripts/README.md)

--- a/tests/device_tests/aicpu_build_graph/paged_attention/golden.py
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/golden.py
@@ -1,0 +1,246 @@
+"""
+Paged Attention Golden Implementation - Production Scale
+
+Implements the online softmax algorithm for paged attention with:
+- bfloat16 Q/K/V inputs
+- Non-transposed K storage: (total_blocks, block_size, kv_head_num, head_dim)
+- GQA support (kv_head_num=1)
+- Head tiling: q_tile = min(q_head_num, 128)
+- Random block table mapping
+"""
+
+import os
+import struct
+import numpy as np
+import ml_dtypes
+
+# Output tensor names
+__outputs__ = ["out"]
+
+# Tensor order matching orchestration function parameter order
+TENSOR_ORDER = ["query", "key_cache", "value_cache", "block_table", "context_lens", "out", "config"]
+
+# Comparison tolerances
+RTOL = 1e-3
+ATOL = 1e-3
+
+
+# All test cases
+ALL_CASES = {
+    "Case1": {
+        "batch": 256,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 8192,
+        "max_model_len": 32768,
+    },
+    "Case2": {
+        "batch": 64,
+        "num_heads": 64,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 64,
+        "context_len": 8192,
+        "max_model_len": 32768,
+    },
+}
+
+# Select case by env var PA_CASE, default to Case1
+_selected = os.environ.get("PA_CASE", "Case1")
+PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
+
+
+def generate_inputs(params: dict) -> dict:
+    """Generate input tensors and zeroed output tensor."""
+    batch = params["batch"]
+    num_heads = params["num_heads"]
+    kv_head_num = params["kv_head_num"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    context_len = params["context_len"]
+    max_model_len = params["max_model_len"]
+
+    np.random.seed(None)
+
+    max_num_blocks_per_req = max_model_len // block_size
+    cur_valid_blocks = context_len // block_size
+    total_blocks = (batch * context_len + block_size - 1) // block_size
+    scale_value = 1.0
+    scale_bits = struct.unpack('I', struct.pack('f', scale_value))[0]
+
+    # Random block table: (batch, max_num_blocks_per_req) int32
+    block_table = np.random.randint(
+        0,
+        batch * cur_valid_blocks - 1,
+        size=(batch, max_num_blocks_per_req),
+        dtype=np.int32,
+    )
+
+    # Context lens: all = context_len
+    context_lens = np.full(batch, context_len, dtype=np.int32)
+
+    config = np.array(
+        [batch, num_heads, kv_head_num, head_dim, block_size,
+         max_num_blocks_per_req, scale_bits],
+        dtype=np.int64,
+    )
+
+    # Query: (batch, 1, num_heads * head_dim) -> (batch, num_heads, head_dim) bfloat16
+    query_bf16 = np.random.uniform(-0.5, 0.5, size=(batch, 1, num_heads * head_dim)).astype(ml_dtypes.bfloat16)
+    query_bf16 = query_bf16.reshape(batch, num_heads, head_dim)
+
+    # Key cache: (total_blocks, block_size, kv_head_num, head_dim) bfloat16
+    key_bf16 = np.random.uniform(-0.5, 0.5, size=(total_blocks, block_size, kv_head_num, head_dim)).astype(ml_dtypes.bfloat16)
+
+    # Value cache: (total_blocks, block_size, kv_head_num, head_dim) bfloat16
+    value_bf16 = np.random.uniform(-1, 1, size=(total_blocks, block_size, kv_head_num, head_dim)).astype(ml_dtypes.bfloat16)
+
+    return {
+        "query": query_bf16.flatten(),
+        "key_cache": key_bf16.flatten(),
+        "value_cache": value_bf16.flatten(),
+        "block_table": block_table.flatten(),
+        "context_lens": context_lens,
+        "out": np.zeros(batch * num_heads * head_dim, dtype=np.float32),
+        "config": config,
+    }
+
+
+def paged_attention(
+    query: np.ndarray,
+    key_cache: np.ndarray,
+    value_cache: np.ndarray,
+    num_kv_heads: int,
+    num_heads: int,
+    scale_value: float,
+    block_table: np.ndarray,
+    context_lens: np.ndarray,
+) -> np.ndarray:
+    """
+    Compute paged attention using online softmax with head tiling and GQA.
+
+    Args:
+        query: (batch, num_heads, head_dim) bfloat16
+        key_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
+        value_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
+        num_kv_heads: int
+        num_heads: int
+        scale_value: float
+        block_table: (batch, block_num) int32
+        context_lens: (batch,) int32
+
+    Returns:
+        out: (batch, num_heads, head_dim) float32
+    """
+    assert num_kv_heads == 1
+    batch, num_heads, head_dim = query.shape
+    _, block_size, _, _ = key_cache.shape
+    _, block_num = block_table.shape
+
+    query = query.reshape(-1, head_dim)
+    key_cache = key_cache.reshape(-1, block_size, head_dim)
+    value_cache = value_cache.reshape(-1, block_size, head_dim)
+
+    out = np.zeros((batch * num_heads, head_dim), dtype=np.float32)
+
+    for b_idx in range(batch):
+        cur_seq = int(context_lens[b_idx])
+        bn_this_batch = (cur_seq + block_size - 1) // block_size
+        assert bn_this_batch <= block_num
+
+        q_tile = min(num_heads, 128)
+        for cur_offset in range(0, num_heads, q_tile):
+            q_tile_size = min(q_tile, num_heads - cur_offset)
+            base_idx = b_idx * num_heads + cur_offset
+            qi = query[base_idx : base_idx + q_tile_size].astype(np.float32)
+
+            oi = None
+            li = None
+            mi = None
+
+            for bn in range(bn_this_batch):
+                cur_block_idx = block_table[b_idx, bn]
+                valid_len = min(block_size, cur_seq - bn * block_size)
+                kj = key_cache[cur_block_idx, :valid_len, :].astype(np.float32)
+                vj = value_cache[cur_block_idx, :valid_len, :].astype(np.float32)
+
+                sij = (qi @ kj.T) * scale_value
+                mij = sij.max(axis=-1, keepdims=True)
+                pij = np.exp(sij - mij).astype(ml_dtypes.bfloat16).astype(np.float32)
+                lij = np.sum(pij, axis=1, keepdims=True)
+
+                if bn == 0:
+                    oi = pij @ vj
+                    li = lij
+                    mi = mij
+                else:
+                    mi_new = np.maximum(mi, mij)
+                    alpha = np.exp(mi - mi_new)
+                    beta = np.exp(mij - mi_new)
+                    li_new = alpha * li + beta * lij
+                    oi_new = pij @ vj
+                    oi = alpha * oi + beta * oi_new
+                    li = li_new
+                    mi = mi_new
+
+                if bn == bn_this_batch - 1:
+                    oi = oi / li
+
+            out[base_idx : base_idx + q_tile_size] = oi
+
+    return out
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute expected output in-place using online softmax paged attention."""
+    batch = params["batch"]
+    num_heads = params["num_heads"]
+    kv_head_num = params["kv_head_num"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    max_model_len = params["max_model_len"]
+
+    max_num_blocks_per_req = max_model_len // block_size
+
+    # Reconstruct shaped arrays from flat bfloat16 tensors
+    query = tensors["query"].reshape(batch, num_heads, head_dim)
+    key_cache = tensors["key_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    value_cache = tensors["value_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    block_table = tensors["block_table"].reshape(batch, max_num_blocks_per_req)
+    context_lens = tensors["context_lens"]
+
+    out = paged_attention(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        num_kv_heads=kv_head_num,
+        num_heads=num_heads,
+        scale_value=1.0,
+        block_table=block_table,
+        context_lens=context_lens,
+    )
+
+    tensors["out"][:] = out.flatten()
+
+
+if __name__ == "__main__":
+    params = PARAMS_LIST[0]
+    tensors = generate_inputs(params)
+    compute_golden(tensors, params)
+
+    print(f"=== Paged Attention Golden Test ({params['name']}) ===")
+    print(f"batch={params['batch']}, num_heads={params['num_heads']}, head_dim={params['head_dim']}")
+    print(f"kv_head_num={params['kv_head_num']}, block_size={params['block_size']}")
+    print(f"context_len={params['context_len']}")
+
+    max_num_blocks = params['max_model_len'] // params['block_size']
+    q_tile = min(params['num_heads'], 128)
+    print(f"max_num_blocks_per_req={max_num_blocks}, q_tile_size={q_tile}")
+
+    out = tensors["out"].reshape(params["batch"] * params["num_heads"], params["head_dim"])
+    print(f"Output shape: {out.shape}")
+    print(f"Output range: [{out.min():.4f}, {out.max():.4f}]")
+    print(f"Output mean: {out.mean():.4f}")
+    print("Golden test passed!")

--- a/tests/device_tests/aicpu_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,0 +1,98 @@
+// PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
+//
+// Supports two tile configurations via runtime dispatch:
+//   Case1: (16, 128) @ (128, 128) -> (16, 128)
+//   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//
+// pij is bfloat16 (converted from fp32 in softmax_prepare via TCVT).
+// vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
+// Standard non-transposed B pattern: ND GlobalB + ColMajor/RowMajor TileMatB.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int K, int N>
+static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw)
+{
+    __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
+    __gm__ bfloat16_t* vj  = reinterpret_cast<__gm__ bfloat16_t*>(vj_raw);
+    __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
+
+    // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
+    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+
+    GlobalA   pijGlobal(pij);
+    GlobalB   vjGlobal(vj);
+    GlobalOut oiGlobal(oi);
+
+    // L1 Mat tiles: standard ND pattern for both A and B
+    using TileMatA = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
+
+    // L0 tiles
+    using LeftTile  = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile = TileRight<bfloat16_t, K, N, K, N>;
+    using AccTile   = TileAcc<float, M, N, M, N>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile  aTile;
+    RightTile bTile;
+    AccTile   cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    // Load pij and vj to L1
+    TLOAD(aMatTile, pijGlobal);
+    TLOAD(bMatTile, vjGlobal);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    // Move to L0A/L0B
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    // Single matmul: (M,K) x (K,N) -> (M,N)
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(oiGlobal, cTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
+{
+    __gm__ uint8_t* pij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* vj     = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+    __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+    int q_tile_size = static_cast<int>(args[3]);
+    // args[4] = block_size, args[5] = head_dim
+
+    if (q_tile_size == 16) {
+        pv_matmul_impl<16, 128, 128>(pij, vj, oi_new);
+    } else {
+        pv_matmul_impl<64, 64, 128>(pij, vj, oi_new);
+    }
+}

--- a/tests/device_tests/aicpu_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,0 +1,99 @@
+// QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
+//
+// Supports two tile configurations via runtime dispatch:
+//   Case1: (16, 128) @ (128, 128).T -> (16, 128)
+//   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//
+// kj is stored as (N, K) = (block_size, head_dim) in row-major memory.
+// This is equivalent to (K, N) in column-major (DN) layout.
+// Using DN GlobalB + RowMajor/ColMajor TileMatB to handle the transposed B pattern.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int K, int N>
+static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw)
+{
+    __gm__ bfloat16_t* qi  = reinterpret_cast<__gm__ bfloat16_t*>(qi_raw);
+    __gm__ bfloat16_t* kj  = reinterpret_cast<__gm__ bfloat16_t*>(kj_raw);
+    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+
+    // qi (M, K) bf16 in ND (row-major) layout
+    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
+    // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
+    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+
+    GlobalA   qiGlobal(qi);
+    GlobalB   kjGlobal(kj);
+    GlobalOut sijGlobal(sij);
+
+    // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
+    using TileMatA = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
+
+    // L0 tiles
+    using LeftTile  = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile = TileRight<bfloat16_t, K, N, K, N>;
+    using AccTile   = TileAcc<float, M, N, M, N>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile  aTile;
+    RightTile bTile;
+    AccTile   cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    // Load qi and kj to L1
+    TLOAD(aMatTile, qiGlobal);
+    TLOAD(bMatTile, kjGlobal);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    // Move to L0A/L0B
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    // Single matmul: (M,K) x (K,N) -> (M,N)
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(sijGlobal, cTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
+{
+    __gm__ uint8_t* qi  = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* kj  = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+    __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+    int q_tile_size = static_cast<int>(args[3]);
+    // args[4] = head_dim (128), args[5] = block_size
+
+    if (q_tile_size == 16) {
+        qk_matmul_impl<16, 128, 128>(qi, kj, sij);
+    } else {
+        qk_matmul_impl<64, 128, 64>(qi, kj, sij);
+    }
+}

--- a/tests/device_tests/aicpu_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,0 +1,238 @@
+// Online Softmax Update + Normalize Kernel (AIV)
+//
+// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+//   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
+//   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//
+// Scalar layout strategy:
+//   M scalar floats stored contiguously in GM can be loaded as either:
+//   - ND (kScalarRows, kScalarCols) RowMajor for element-wise ops (TMAX, TSUB, TEXP, TMUL, TADD)
+//   - DN (kAlignedRows, 1) ColMajor for row-broadcast ops (TROWEXPANDMUL, TROWEXPANDDIV)
+//   Conversion between layouts uses GM round-trip: ND TSTORE → DN TLOAD.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int N>
+static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_t* lij_raw,
+                               __gm__ uint8_t* oi_new_raw, __gm__ uint8_t* mi_raw,
+                               __gm__ uint8_t* li_raw, __gm__ uint8_t* oi_raw,
+                               int is_first, int is_last, __gm__ uint8_t* dst_raw)
+{
+    __gm__ float* mij_ptr    = reinterpret_cast<__gm__ float*>(mij_raw);
+    __gm__ float* lij_ptr    = reinterpret_cast<__gm__ float*>(lij_raw);
+    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new_raw);
+    __gm__ float* mi_ptr     = reinterpret_cast<__gm__ float*>(mi_raw);
+    __gm__ float* li_ptr     = reinterpret_cast<__gm__ float*>(li_raw);
+    __gm__ float* oi_ptr     = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ float* dst_ptr    = reinterpret_cast<__gm__ float*>(dst_raw);
+
+    // Scalar tile dimensions for RowMajor layout:
+    // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
+    // kScalarRows = M / 8 (M=16 → 2 rows, M=64 → 8 rows)
+    constexpr int kScalarCols = 32 / sizeof(float);
+    constexpr int kScalarRows = M / kScalarCols;
+    // Aligned rows for ColMajor DN tiles (32-byte alignment)
+    constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+
+    // --- GlobalTensor types ---
+
+    // Data (M, N) RowMajor
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+
+    // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
+    using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
+                                        Stride<1, 1, 1, kScalarCols, 1>>;
+
+    // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
+                                        Stride<1, 1, 1, 1, 1>, Layout::DN>;
+
+    // --- GlobalTensor instances ---
+
+    GlobalDataMxN oiNewGlobal(oi_new_ptr);
+    GlobalDataMxN oiGlobal(oi_ptr);
+    GlobalDataMxN dstGlobal(dst_ptr);
+
+    // ND globals for scalar element-wise operations
+    GlobalScalarND mijGlobalND(mij_ptr);
+    GlobalScalarND lijGlobalND(lij_ptr);
+    GlobalScalarND miGlobalND(mi_ptr);
+    GlobalScalarND liGlobalND(li_ptr);
+
+    // DN globals aliased to same GM for ColMajor reload (used after ND TSTORE)
+    GlobalScalarDN mijGlobalDN(mij_ptr);
+    GlobalScalarDN lijGlobalDN(lij_ptr);
+    GlobalScalarDN liGlobalDN(li_ptr);
+
+    // --- Tile types ---
+
+    using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarND = Tile<TileType::Vec, float, kScalarRows, kScalarCols,
+                              BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+
+    // --- UB memory layout ---
+
+    constexpr int kDataBytes = M * N * sizeof(float);
+    constexpr int kScalarNDBytes = kScalarRows * kScalarCols * sizeof(float);
+    constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
+
+    // Data tiles
+    TileDataMxN oiNewTile;
+    TileDataMxN oiTile;
+
+    // Scalar ND tiles for element-wise arithmetic
+    TileScalarND mijND, lijND, miND, liND;
+    TileScalarND miNewND, alphaND, betaND, tmpND;
+
+    // Scalar DN tiles for TROWEXPAND operations
+    TileScalarDN alphaDN, betaDN, liDN;
+
+    TASSIGN(oiNewTile, 0);
+    TASSIGN(oiTile, kDataBytes);
+    TASSIGN(mijND, 2 * kDataBytes);
+    TASSIGN(lijND, 2 * kDataBytes + kScalarNDBytes);
+    TASSIGN(miND, 2 * kDataBytes + 2 * kScalarNDBytes);
+    TASSIGN(liND, 2 * kDataBytes + 3 * kScalarNDBytes);
+    TASSIGN(miNewND, 2 * kDataBytes + 4 * kScalarNDBytes);
+    TASSIGN(alphaND, 2 * kDataBytes + 5 * kScalarNDBytes);
+    TASSIGN(betaND, 2 * kDataBytes + 6 * kScalarNDBytes);
+    TASSIGN(tmpND, 2 * kDataBytes + 7 * kScalarNDBytes);
+    TASSIGN(alphaDN, 2 * kDataBytes + 8 * kScalarNDBytes);
+    TASSIGN(betaDN, 2 * kDataBytes + 8 * kScalarNDBytes + kScalarDNBytes);
+    TASSIGN(liDN, 2 * kDataBytes + 8 * kScalarNDBytes + 2 * kScalarDNBytes);
+
+    if (is_first) {
+        // --- First block: copy inputs to accumulators ---
+        TLOAD(oiNewTile, oiNewGlobal);
+        TLOAD(mijND, mijGlobalND);
+        TLOAD(lijND, lijGlobalND);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // Passthrough to MTE3 (no V compute needed)
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(miGlobalND, mijND);     // mi = mij
+        TSTORE(liGlobalND, lijND);     // li = lij
+        TSTORE(oiGlobal, oiNewTile);   // oi = oi_new
+
+        if (is_last) {
+            // Single block: normalize dst = oi_new / lij
+            // lij stored to li buffer in ND format; reload as DN for TROWEXPANDDIV
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            TLOAD(liDN, liGlobalDN);
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+            TROWEXPANDDIV(oiNewTile, oiNewTile, liDN);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TSTORE(dstGlobal, oiNewTile);
+        }
+    } else {
+        // --- Subsequent blocks: accumulate ---
+
+        // Phase 1: Load all inputs
+        TLOAD(oiNewTile, oiNewGlobal);
+        TLOAD(oiTile, oiGlobal);
+        TLOAD(mijND, mijGlobalND);
+        TLOAD(lijND, lijGlobalND);
+        TLOAD(miND, miGlobalND);
+        TLOAD(liND, liGlobalND);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
+        // pipe_barrier(PIPE_V) required between each dependent vector operation
+        // to resolve RAW hazards on shared UB tiles.
+        TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
+        pipe_barrier(PIPE_V);
+        TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
+        pipe_barrier(PIPE_V);
+        TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
+        pipe_barrier(PIPE_V);
+        TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
+        pipe_barrier(PIPE_V);
+        TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
+        pipe_barrier(PIPE_V);
+        TMUL(liND, alphaND, liND);           // li = alpha * li
+        pipe_barrier(PIPE_V);
+        TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
+        pipe_barrier(PIPE_V);
+        TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
+
+        // Phase 3: Store scalar results to GM (ND format)
+        // mi_new → mi accumulator, li_new → li accumulator
+        // alpha → mij buffer (reuse), beta → lij buffer (reuse)
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(miGlobalND, miNewND);         // persist mi_new
+        TSTORE(liGlobalND, liND);            // persist li_new
+        TSTORE(mijGlobalND, alphaND);        // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);         // temp: beta to lij buffer
+
+        // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        TLOAD(alphaDN, mijGlobalDN);         // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);          // beta from lij buffer as DN
+        if (is_last) {
+            TLOAD(liDN, liGlobalDN);         // li_new from li buffer as DN
+        }
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+
+        // Phase 5: Scale data tiles using row-broadcast multiply
+        TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        pipe_barrier(PIPE_V);
+        TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
+
+        if (is_last) {
+            // Phase 6: Normalize and output
+            pipe_barrier(PIPE_V);
+            TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TSTORE(dstGlobal, oiTile);
+        } else {
+            // Phase 6: Store updated accumulators
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TSTORE(oiGlobal, oiTile);
+        }
+    }
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ uint8_t* mij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* lij    = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+    __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+    __gm__ uint8_t* mi     = reinterpret_cast<__gm__ uint8_t*>(args[3]);
+    __gm__ uint8_t* li     = reinterpret_cast<__gm__ uint8_t*>(args[4]);
+    __gm__ uint8_t* oi     = reinterpret_cast<__gm__ uint8_t*>(args[5]);
+    int is_first  = static_cast<int>(args[6]);
+    int is_last   = static_cast<int>(args[7]);
+    __gm__ uint8_t* dst    = reinterpret_cast<__gm__ uint8_t*>(args[8]);
+    int q_tile_size = static_cast<int>(args[9]);
+    // args[10] = head_dim (128)
+
+    if (q_tile_size == 16) {
+        online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else {
+        online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    }
+}

--- a/tests/device_tests/aicpu_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,0 +1,102 @@
+// Softmax Preparation Kernel (AIV)
+//
+// Operates on full (M, N) tile where M=q_tile_size, N=block_size:
+//   Case1: sij is (16, 128)
+//   Case2: sij is (64, 64)
+//
+// Computes:
+//   sij_scale = sij * scale
+//   mij = row_max(sij_scale)        -> (M, 1)
+//   pij = exp(sij_scale - mij)      -> (M, N)
+//   lij = row_sum(pij)              -> (M, 1)
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int N>
+static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
+                                 __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
+                                 __gm__ uint8_t* lij_raw)
+{
+    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+    __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
+    __gm__ float*      mij = reinterpret_cast<__gm__ float*>(mij_raw);
+    __gm__ float*      lij = reinterpret_cast<__gm__ float*>(lij_raw);
+
+    constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalDataMxN_bf16 = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+
+    GlobalDataMxN sijGlobal(sij);
+    GlobalDataMxN_bf16 pijGlobal(pij);
+    GlobalScalarDN mijGlobal(mij);
+    GlobalScalarDN lijGlobal(lij);
+
+    using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+
+    TileVecMxN sijTile;
+    TileVecMxN pijTile;
+    TileVecMxN tmpTile;
+    TileScalarDN maxTile;
+    TileScalarDN sumTile;
+    TileVecMxN_bf16 pijBf16Tile;
+
+    TASSIGN(sijTile, 0x0);
+    TASSIGN(pijTile, M * N * sizeof(float));
+    TASSIGN(tmpTile, 2 * M * N * sizeof(float));
+    TASSIGN(maxTile, 3 * M * N * sizeof(float));
+    TASSIGN(sumTile, 3 * M * N * sizeof(float) + kAlignedRows * sizeof(float));
+    TASSIGN(pijBf16Tile, 3 * M * N * sizeof(float) + 2 * kAlignedRows * sizeof(float));
+
+    TLOAD(sijTile, sijGlobal);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    TMULS(sijTile, sijTile, scale_value);
+    TROWMAX(maxTile, sijTile, tmpTile);
+    TROWEXPANDSUB(pijTile, sijTile, maxTile);
+    TEXP(pijTile, pijTile);
+    // Truncate pij to bf16 first, then compute lij from truncated values (matches golden)
+    TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
+    TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
+    TROWSUM(sumTile, pijTile, tmpTile);
+
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(mijGlobal, maxTile);
+    TSTORE(lijGlobal, sumTile);
+    TSTORE(pijGlobal, pijBf16Tile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    union { uint64_t u; float f; } scale_conv;
+    scale_conv.u = static_cast<uint64_t>(args[1]);
+    float scale_value = scale_conv.f;
+    __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+    __gm__ uint8_t* mij = reinterpret_cast<__gm__ uint8_t*>(args[3]);
+    __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[4]);
+    int q_tile_size = static_cast<int>(args[5]);
+    // args[6] = block_size
+
+    if (q_tile_size == 16) {
+        softmax_prepare_impl<16, 128>(sij, scale_value, pij, mij, lij);
+    } else {
+        softmax_prepare_impl<64, 64>(sij, scale_value, pij, mij, lij);
+    }
+}

--- a/tests/device_tests/aicpu_build_graph/paged_attention/kernels/kernel_config.py
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/kernels/kernel_config.py
@@ -1,0 +1,54 @@
+"""
+Paged Attention Kernel and Orchestration Configuration (aicpu_build_graph)
+
+Uses the aicpu_build_graph runtime where the AICPU device builds the task
+graph via a dlopen'd orchestration plugin, while scheduler threads execute
+tasks concurrently.
+
+Kernels are identical to the host_build_graph version:
+
+AIC Kernels (Matrix Multiplication):
+  - aic_qk_matmul: Q @ K^T computation
+  - aic_pv_matmul: P @ V computation
+
+AIV Kernels (Vector Operations):
+  - aiv_softmax_prepare: scale, rowmax, exp, rowsum
+  - aiv_online_update: online softmax accumulation + fused normalization
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+RUNTIME_CONFIG = {
+    "runtime": "aicpu_build_graph",
+    # 1 AICPU thread builds tasks while 3 AICPU threads schedule/execute.
+    "aicpu_thread_num": 4,
+    "block_dim": 24,
+}
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "paged_attention_orch.cpp"),
+    "function_name": "orchestration",
+}
+
+# Runtime behavior knobs.
+#
+# `RUNTIME_ENV` is applied both during runtime compilation and during runtime
+# initialization (host `dlopen()` + orchestrator call).
+#
+# PTO_AICPU_BUILD_GRAPH_BUILD_MODE = "1" (concurrent build||schedule, default)
+# PTO_AICPU_BUILD_GRAPH_BUILD_MODE = "0" (sequential build->schedule)
+RUNTIME_ENV = {
+    "PTO_AICPU_BUILD_GRAPH_BUILD_MODE": "1",
+}
+
+# Kernel configs (same func_ids and core_types as host_build_graph version)
+KERNELS = [
+    # AIC kernels (matrix multiplication using Cube unit)
+    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
+    # AIV kernels (vector operations)
+    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
+    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
+]

--- a/tests/device_tests/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -1,0 +1,271 @@
+/**
+ * Paged Attention Orchestration - AICPU Build Graph Version
+ *
+ * Runs on AICPU. The framework has already allocated device memory for I/O
+ * tensors and populated orch_args[] with device pointers and scalar values.
+ *
+ * orch_args[] layout (from TENSOR_ORDER in golden.py):
+ *   orch_args[0]  = dev_query         (device ptr, bf16)
+ *   orch_args[1]  = dev_key_cache     (device ptr, bf16)
+ *   orch_args[2]  = dev_value_cache   (device ptr, bf16)
+ *   orch_args[3]  = dev_block_table   (device ptr, int32)
+ *   orch_args[4]  = dev_context_lens  (device ptr, int32)
+ *   orch_args[5]  = dev_out           (device ptr, float32)
+ *   orch_args[6]  = dev_config        (device ptr, int64)
+ *   orch_args[7]  = query_nbytes      (scalar)
+ *   orch_args[8]  = key_cache_nbytes  (scalar)
+ *   orch_args[9]  = value_cache_nbytes(scalar)
+ *   orch_args[10] = block_table_nbytes(scalar)
+ *   orch_args[11] = context_lens_nbytes(scalar)
+ *   orch_args[12] = out_nbytes        (scalar)
+ *   orch_args[13] = config_nbytes     (scalar)
+ *   orch_args[14] = element_count     (scalar, element count of first tensor)
+ *
+ * AICPU is on-device and can directly read dev_config, dev_context_lens,
+ * and dev_block_table from HBM to determine graph structure.
+ *
+ * Supports production-scale paged attention with:
+ *   Query: (batch, q_head_num, head_dim) bf16
+ *   Key:   (total_blocks, block_size, kv_head_num, head_dim) bf16
+ *   Value: (total_blocks, block_size, kv_head_num, head_dim) bf16
+ *   Output: (batch * q_head_num, head_dim) float32
+ *
+ * Head tiling: q_tile_size = min(num_heads, 128)
+ * GQA: kv_head_num can differ from q_head_num
+ */
+
+#include <cstdint>
+
+#include "runtime.h"
+
+#define FUNC_QK_MATMUL       0
+#define FUNC_SOFTMAX_PREPARE 1
+#define FUNC_PV_MATMUL       2
+#define FUNC_ONLINE_UPDATE   3
+
+namespace {
+
+// orch_args[] index constants
+constexpr int IDX_QUERY         = 0;
+constexpr int IDX_KEY_CACHE     = 1;
+constexpr int IDX_VALUE_CACHE   = 2;
+constexpr int IDX_BLOCK_TABLE   = 3;
+constexpr int IDX_CONTEXT_LENS  = 4;
+constexpr int IDX_OUT           = 5;
+constexpr int IDX_CONFIG        = 6;
+
+inline int min_int(int a, int b) { return (a < b) ? a : b; }
+
+}  // namespace
+
+extern "C" int orchestration(Runtime* runtime) {
+    if (runtime == nullptr) {
+        return -1;
+    }
+
+    if (runtime->orch_argc < 15) {
+        return -1;
+    }
+
+    const AicpuBuildApi& api = runtime->aicpu_build_api;
+    if (api.add_task == nullptr || api.add_successor_conditional == nullptr ||
+        api.publish_task == nullptr || api.device_malloc == nullptr) {
+        return -1;
+    }
+
+    // Device pointers (already allocated and populated by the framework)
+    uint8_t* dev_query       = reinterpret_cast<uint8_t*>(runtime->orch_args[IDX_QUERY]);
+    uint8_t* dev_key_cache   = reinterpret_cast<uint8_t*>(runtime->orch_args[IDX_KEY_CACHE]);
+    uint8_t* dev_value_cache = reinterpret_cast<uint8_t*>(runtime->orch_args[IDX_VALUE_CACHE]);
+    int* dev_block_table     = reinterpret_cast<int*>(runtime->orch_args[IDX_BLOCK_TABLE]);
+    int* dev_context_lens    = reinterpret_cast<int*>(runtime->orch_args[IDX_CONTEXT_LENS]);
+    uint8_t* dev_out         = reinterpret_cast<uint8_t*>(runtime->orch_args[IDX_OUT]);
+    int64_t* dev_config      = reinterpret_cast<int64_t*>(runtime->orch_args[IDX_CONFIG]);
+
+    // Read config from device memory (AICPU can access HBM directly)
+    int batch          = static_cast<int>(dev_config[0]);
+    int num_heads      = static_cast<int>(dev_config[1]);
+    int kv_head_num    = static_cast<int>(dev_config[2]);
+    int head_dim       = static_cast<int>(dev_config[3]);
+    int block_size     = static_cast<int>(dev_config[4]);
+    int max_num_blocks = static_cast<int>(dev_config[5]);
+    uint64_t scale_value_bits = static_cast<uint64_t>(dev_config[6]);
+
+    int q_tile_size     = min_int(num_heads, 128);
+    int num_head_tiles  = (num_heads + q_tile_size - 1) / q_tile_size;
+
+    // Buffer sizes for per-block intermediates
+    size_t sij_size    = static_cast<size_t>(q_tile_size) * block_size * sizeof(float);
+    size_t pij_size    = static_cast<size_t>(q_tile_size) * block_size * sizeof(uint16_t);
+    size_t mij_size    = static_cast<size_t>(q_tile_size) * sizeof(float);
+    size_t lij_size    = mij_size;
+    size_t oi_new_size = static_cast<size_t>(q_tile_size) * head_dim * sizeof(float);
+
+    // Allocate per-block intermediate buffers on device (HBM)
+    int total_buffers = batch * max_num_blocks;
+    void** dev_sij_arr    = new void*[total_buffers];
+    void** dev_pij_arr    = new void*[total_buffers];
+    void** dev_mij_arr    = new void*[total_buffers];
+    void** dev_lij_arr    = new void*[total_buffers];
+    void** dev_oi_new_arr = new void*[total_buffers];
+
+    for (int i = 0; i < total_buffers; i++) {
+        dev_sij_arr[i]    = api.device_malloc(sij_size);
+        dev_pij_arr[i]    = api.device_malloc(pij_size);
+        dev_mij_arr[i]    = api.device_malloc(mij_size);
+        dev_lij_arr[i]    = api.device_malloc(lij_size);
+        dev_oi_new_arr[i] = api.device_malloc(oi_new_size);
+    }
+
+    // Per-(batch, head_tile) accumulators
+    int total_accums = batch * num_head_tiles;
+    size_t mi_size = static_cast<size_t>(q_tile_size) * sizeof(float);
+    size_t li_size = mi_size;
+    size_t oi_size = static_cast<size_t>(q_tile_size) * head_dim * sizeof(float);
+
+    void** dev_mi_arr = new void*[total_accums];
+    void** dev_li_arr = new void*[total_accums];
+    void** dev_oi_arr = new void*[total_accums];
+
+    for (int i = 0; i < total_accums; i++) {
+        dev_mi_arr[i] = api.device_malloc(mi_size);
+        dev_li_arr[i] = api.device_malloc(li_size);
+        dev_oi_arr[i] = api.device_malloc(oi_size);
+    }
+
+    // Build the task graph
+    for (int b_idx = 0; b_idx < batch; b_idx++) {
+        int cur_seq = dev_context_lens[b_idx];
+        int bn_this_batch = (cur_seq + block_size - 1) / block_size;
+
+        for (int ht = 0; ht < num_head_tiles; ht++) {
+            int cur_offset = ht * q_tile_size;
+
+            // Query: (batch, q_head_num, head_dim) bf16
+            uint8_t* qi_ptr = dev_query
+                + static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
+
+            // Output: (batch * q_head_num, head_dim) float32
+            uint8_t* out_ptr = dev_out
+                + static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
+
+            // GQA: which kv_head this head tile maps to
+            int kv_head_idx = cur_offset / (num_heads / kv_head_num);
+
+            // Per-(batch, head_tile) accumulators
+            int accum_idx = b_idx * num_head_tiles + ht;
+            void* dev_mi = dev_mi_arr[accum_idx];
+            void* dev_li = dev_li_arr[accum_idx];
+            void* dev_oi = dev_oi_arr[accum_idx];
+
+            int t_up_prev = -1;
+
+            for (int bn = 0; bn < bn_this_batch; bn++) {
+                int cur_block_idx = dev_block_table[b_idx * max_num_blocks + bn];
+
+                // Key: (total_blocks, block_size, kv_head_num, head_dim) bf16
+                uint8_t* kj_ptr = dev_key_cache
+                    + (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx)
+                      * head_dim * sizeof(uint16_t);
+
+                // Value: same layout as key
+                uint8_t* vj_ptr = dev_value_cache
+                    + (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx)
+                      * head_dim * sizeof(uint16_t);
+
+                int buf_idx = b_idx * max_num_blocks + bn;
+                void* dev_sij    = dev_sij_arr[buf_idx];
+                void* dev_pij    = dev_pij_arr[buf_idx];
+                void* dev_mij    = dev_mij_arr[buf_idx];
+                void* dev_lij    = dev_lij_arr[buf_idx];
+                void* dev_oi_new = dev_oi_new_arr[buf_idx];
+
+                // QK: qi(M, K) @ kj.T(K, N) -> sij(M, N)
+                uint64_t qk_args[6] = {
+                    reinterpret_cast<uint64_t>(qi_ptr),
+                    reinterpret_cast<uint64_t>(kj_ptr),
+                    reinterpret_cast<uint64_t>(dev_sij),
+                    static_cast<uint64_t>(q_tile_size),
+                    static_cast<uint64_t>(head_dim),
+                    static_cast<uint64_t>(block_size)
+                };
+                int t_qk = api.add_task(runtime, qk_args, 6, FUNC_QK_MATMUL, CoreType::AIC, 0);
+                if (t_qk < 0) return -1;
+
+                // SF: scale, rowmax, exp, rowsum -> pij, mij, lij
+                uint64_t sf_args[7] = {
+                    reinterpret_cast<uint64_t>(dev_sij),
+                    scale_value_bits,
+                    reinterpret_cast<uint64_t>(dev_pij),
+                    reinterpret_cast<uint64_t>(dev_mij),
+                    reinterpret_cast<uint64_t>(dev_lij),
+                    static_cast<uint64_t>(q_tile_size),
+                    static_cast<uint64_t>(block_size)
+                };
+                int t_sf = api.add_task(runtime, sf_args, 7, FUNC_SOFTMAX_PREPARE, CoreType::AIV, 0);
+                if (t_sf < 0) return -1;
+
+                // PV: pij(M, K') @ vj(K', N') -> oi_new(M, N')
+                uint64_t pv_args[6] = {
+                    reinterpret_cast<uint64_t>(dev_pij),
+                    reinterpret_cast<uint64_t>(vj_ptr),
+                    reinterpret_cast<uint64_t>(dev_oi_new),
+                    static_cast<uint64_t>(q_tile_size),
+                    static_cast<uint64_t>(block_size),
+                    static_cast<uint64_t>(head_dim)
+                };
+                int t_pv = api.add_task(runtime, pv_args, 6, FUNC_PV_MATMUL, CoreType::AIC, 0);
+                if (t_pv < 0) return -1;
+
+                // Dependencies: QK -> SF -> PV
+                api.add_successor_conditional(runtime, t_qk, t_sf);
+                api.add_successor_conditional(runtime, t_sf, t_pv);
+
+                // Publish QK, SF, PV
+                api.publish_task(runtime, t_qk);
+                api.publish_task(runtime, t_sf);
+                api.publish_task(runtime, t_pv);
+
+                // Online Update: serialized across blocks
+                int is_first = (bn == 0) ? 1 : 0;
+                int is_last  = (bn == bn_this_batch - 1) ? 1 : 0;
+
+                uint64_t up_args[11] = {
+                    reinterpret_cast<uint64_t>(dev_mij),
+                    reinterpret_cast<uint64_t>(dev_lij),
+                    reinterpret_cast<uint64_t>(dev_oi_new),
+                    reinterpret_cast<uint64_t>(dev_mi),
+                    reinterpret_cast<uint64_t>(dev_li),
+                    reinterpret_cast<uint64_t>(dev_oi),
+                    static_cast<uint64_t>(is_first),
+                    static_cast<uint64_t>(is_last),
+                    reinterpret_cast<uint64_t>(out_ptr),
+                    static_cast<uint64_t>(q_tile_size),
+                    static_cast<uint64_t>(head_dim)
+                };
+                int t_up = api.add_task(runtime, up_args, 11, FUNC_ONLINE_UPDATE, CoreType::AIV, 0);
+                if (t_up < 0) return -1;
+
+                // UP depends on PV completing, and on previous UP (serialized)
+                api.add_successor_conditional(runtime, t_pv, t_up);
+                if (t_up_prev >= 0) {
+                    api.add_successor_conditional(runtime, t_up_prev, t_up);
+                }
+                api.publish_task(runtime, t_up);
+
+                t_up_prev = t_up;
+            }
+        }
+    }
+
+    delete[] dev_sij_arr;
+    delete[] dev_pij_arr;
+    delete[] dev_mij_arr;
+    delete[] dev_lij_arr;
+    delete[] dev_oi_new_arr;
+    delete[] dev_mi_arr;
+    delete[] dev_li_arr;
+    delete[] dev_oi_arr;
+
+    return 0;
+}


### PR DESCRIPTION
Port paged attention from host_build_graph to aicpu_build_graph where the AICPU device builds the task graph via a dlopen'd orchestration plugin with concurrent build||schedule. Kernels are identical; only the orchestration and kernel_config differ.