### PR TITLE
Handle partial last block in paged attention via TFILLPAD -inf masking

### DIFF
--- a/tests/device_tests/aicpu_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,11 +1,16 @@
-// Softmax Preparation Kernel (AIV)
+// Softmax Preparation Kernel (AIV) with partial block masking
 //
-// Operates on full (M, N) tile where M=q_tile_size, N=block_size:
+// Operates on (M, N) tile where M=q_tile_size, N=block_size:
 //   Case1: sij is (16, 128)
 //   Case2: sij is (64, 64)
 //
+// For partial blocks (valid_len < N), positions [valid_len, N) in sij are
+// filled with -inf via TFILLPAD_INPLACE before softmax, ensuring exp(-inf)=0
+// so that invalid key positions contribute zero attention weight.
+//
 // Computes:
-//   sij_scale = sij * scale
+//   sij_masked = TFILLPAD(sij, valid_len, pad=-inf)
+//   sij_scale = sij_masked * scale
 //   mij = row_max(sij_scale)        -> (M, 1)
 //   pij = exp(sij_scale - mij)      -> (M, N)
 //   lij = row_sum(pij)              -> (M, 1)
@@ -27,7 +32,7 @@ using namespace pto;
 template <int M, int N>
 static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
                                  __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
-                                 __gm__ uint8_t* lij_raw)
+                                 __gm__ uint8_t* lij_raw, int valid_len)
 {
     __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
     __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
@@ -45,27 +50,43 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
     GlobalScalarDN mijGlobal(mij);
     GlobalScalarDN lijGlobal(lij);
 
+    // Dynamic-cols tile: marks which columns are valid for TFILLPAD boundary
+    using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
+    // Padded tile: TFILLPAD_INPLACE fills positions [valid_len, N) with -inf
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N,
+                            SLayout::NoneBox, 512, PadValue::Min>;
+
     using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
     using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     TileVecMxN sijTile;
+    TileSijDyn sijDynTile(static_cast<size_t>(valid_len));
+    TileSijPad sijPadTile;
     TileVecMxN pijTile;
     TileVecMxN tmpTile;
     TileScalarDN maxTile;
     TileScalarDN sumTile;
     TileVecMxN_bf16 pijBf16Tile;
 
+    // All sij tiles share UB address 0x0 (in-place masking)
     TASSIGN(sijTile, 0x0);
+    TASSIGN(sijDynTile, 0x0);
+    TASSIGN(sijPadTile, 0x0);
     TASSIGN(pijTile, M * N * sizeof(float));
     TASSIGN(tmpTile, 2 * M * N * sizeof(float));
     TASSIGN(maxTile, 3 * M * N * sizeof(float));
     TASSIGN(sumTile, 3 * M * N * sizeof(float) + kAlignedRows * sizeof(float));
     TASSIGN(pijBf16Tile, 3 * M * N * sizeof(float) + 2 * kAlignedRows * sizeof(float));
 
+    // Load full sij (M, N) tile from GM - all N columns including garbage for partial blocks
     TLOAD(sijTile, sijGlobal);
     set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
     wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    // Mask columns [valid_len, N) with -inf. sijDynTile provides the valid boundary,
+    // sijPadTile provides PadValue::Min as the fill value. No-op when valid_len == N.
+    TFILLPAD_INPLACE(sijPadTile, sijDynTile);
 
     TMULS(sijTile, sijTile, scale_value);
     TROWMAX(maxTile, sijTile, tmpTile);
@@ -93,10 +114,11 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[4]);
     int q_tile_size = static_cast<int>(args[5]);
     // args[6] = block_size
+    int valid_len = static_cast<int>(args[7]);
 
     if (q_tile_size == 16) {
-        softmax_prepare_impl<16, 128>(sij, scale_value, pij, mij, lij);
+        softmax_prepare_impl<16, 128>(sij, scale_value, pij, mij, lij, valid_len);
     } else {
-        softmax_prepare_impl<64, 64>(sij, scale_value, pij, mij, lij);
+        softmax_prepare_impl<64, 64>(sij, scale_value, pij, mij, lij, valid_len);
     }
 }

--- a/tests/device_tests/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -162,6 +162,7 @@ extern "C" int orchestration(Runtime* runtime) {
 
             for (int bn = 0; bn < bn_this_batch; bn++) {
                 int cur_block_idx = dev_block_table[b_idx * max_num_blocks + bn];
+                int valid_len = min_int(block_size, cur_seq - bn * block_size);
 
                 // Key: (total_blocks, block_size, kv_head_num, head_dim) bf16
                 uint8_t* kj_ptr = dev_key_cache
@@ -193,16 +194,17 @@ extern "C" int orchestration(Runtime* runtime) {
                 if (t_qk < 0) return -1;
 
                 // SF: scale, rowmax, exp, rowsum -> pij, mij, lij
-                uint64_t sf_args[7] = {
+                uint64_t sf_args[8] = {
                     reinterpret_cast<uint64_t>(dev_sij),
                     scale_value_bits,
                     reinterpret_cast<uint64_t>(dev_pij),
                     reinterpret_cast<uint64_t>(dev_mij),
                     reinterpret_cast<uint64_t>(dev_lij),
                     static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size)
+                    static_cast<uint64_t>(block_size),
+                    static_cast<uint64_t>(valid_len)
                 };
-                int t_sf = api.add_task(runtime, sf_args, 7, FUNC_SOFTMAX_PREPARE, CoreType::AIV, 0);
+                int t_sf = api.add_task(runtime, sf_args, 8, FUNC_SOFTMAX_PREPARE, CoreType::AIV, 0);
                 if (t_sf < 0) return -1;
 
                 // PV: pij(M, K') @ vj(K', N') -> oi_new(M, N')

--- a/tests/device_tests/host_build_graph/paged_attention/golden.py
+++ b/tests/device_tests/host_build_graph/paged_attention/golden.py
@@ -33,7 +33,7 @@ ALL_CASES = {
         "kv_head_num": 1,
         "head_dim": 128,
         "block_size": 128,
-        "context_len": 8192,
+        "context_len": 8100,
         "max_model_len": 32768,
     },
     "Case2": {
@@ -42,7 +42,7 @@ ALL_CASES = {
         "kv_head_num": 1,
         "head_dim": 128,
         "block_size": 64,
-        "context_len": 8192,
+        "context_len": 8150,
         "max_model_len": 32768,
     },
 }

--- a/tests/device_tests/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,11 +1,16 @@
-// Softmax Preparation Kernel (AIV)
+// Softmax Preparation Kernel (AIV) with partial block masking
 //
-// Operates on full (M, N) tile where M=q_tile_size, N=block_size:
+// Operates on (M, N) tile where M=q_tile_size, N=block_size:
 //   Case1: sij is (16, 128)
 //   Case2: sij is (64, 64)
 //
+// For partial blocks (valid_len < N), positions [valid_len, N) in sij are
+// filled with -inf via TFILLPAD_INPLACE before softmax, ensuring exp(-inf)=0
+// so that invalid key positions contribute zero attention weight.
+//
 // Computes:
-//   sij_scale = sij * scale
+//   sij_masked = TFILLPAD(sij, valid_len, pad=-inf)
+//   sij_scale = sij_masked * scale
 //   mij = row_max(sij_scale)        -> (M, 1)
 //   pij = exp(sij_scale - mij)      -> (M, N)
 //   lij = row_sum(pij)              -> (M, 1)
@@ -27,7 +32,7 @@ using namespace pto;
 template <int M, int N>
 static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
                                  __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
-                                 __gm__ uint8_t* lij_raw)
+                                 __gm__ uint8_t* lij_raw, int valid_len)
 {
     __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
     __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
@@ -45,27 +50,43 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
     GlobalScalarDN mijGlobal(mij);
     GlobalScalarDN lijGlobal(lij);
 
+    // Dynamic-cols tile: marks which columns are valid for TFILLPAD boundary
+    using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
+    // Padded tile: TFILLPAD_INPLACE fills positions [valid_len, N) with -inf
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N,
+                            SLayout::NoneBox, 512, PadValue::Min>;
+
     using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
     using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     TileVecMxN sijTile;
+    TileSijDyn sijDynTile(static_cast<size_t>(valid_len));
+    TileSijPad sijPadTile;
     TileVecMxN pijTile;
     TileVecMxN tmpTile;
     TileScalarDN maxTile;
     TileScalarDN sumTile;
     TileVecMxN_bf16 pijBf16Tile;
 
+    // All sij tiles share UB address 0x0 (in-place masking)
     TASSIGN(sijTile, 0x0);
+    TASSIGN(sijDynTile, 0x0);
+    TASSIGN(sijPadTile, 0x0);
     TASSIGN(pijTile, M * N * sizeof(float));
     TASSIGN(tmpTile, 2 * M * N * sizeof(float));
     TASSIGN(maxTile, 3 * M * N * sizeof(float));
     TASSIGN(sumTile, 3 * M * N * sizeof(float) + kAlignedRows * sizeof(float));
     TASSIGN(pijBf16Tile, 3 * M * N * sizeof(float) + 2 * kAlignedRows * sizeof(float));
 
+    // Load full sij (M, N) tile from GM - all N columns including garbage for partial blocks
     TLOAD(sijTile, sijGlobal);
     set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
     wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    // Mask columns [valid_len, N) with -inf. sijDynTile provides the valid boundary,
+    // sijPadTile provides PadValue::Min as the fill value. No-op when valid_len == N.
+    TFILLPAD_INPLACE(sijPadTile, sijDynTile);
 
     TMULS(sijTile, sijTile, scale_value);
     TROWMAX(maxTile, sijTile, tmpTile);
@@ -93,10 +114,11 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[4]);
     int q_tile_size = static_cast<int>(args[5]);
     // args[6] = block_size
+    int valid_len = static_cast<int>(args[7]);
 
     if (q_tile_size == 16) {
-        softmax_prepare_impl<16, 128>(sij, scale_value, pij, mij, lij);
+        softmax_prepare_impl<16, 128>(sij, scale_value, pij, mij, lij, valid_len);
     } else {
-        softmax_prepare_impl<64, 64>(sij, scale_value, pij, mij, lij);
+        softmax_prepare_impl<64, 64>(sij, scale_value, pij, mij, lij, valid_len);
     }
 }


### PR DESCRIPTION
When cur_seq is not a multiple of block_size, the last KV cache block is only partially filled. Previously, the softmax kernel operated on garbage scores for the invalid positions. This adds masking in the softmax kernel using TFILLPAD_INPLACE with PadValue::Min (-inf) so that exp(-inf)=0 gives zero attention weight to invalid positions, propagating correctness through PV matmul and online update without needing changes to those kernels.