### PR TITLE
Refactor: unify memory pool size configs into pto_runtime2_types.h

### DIFF
--- a/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -73,9 +73,6 @@ PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count
     (void)arg_count;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
-        .task_window_size   = 16384,
-        .dep_list_pool_size = 65536,
-        .heap_size          = 256 * 1024,
     };
 }
 

--- a/src/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -140,9 +140,6 @@ private:
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
 struct PTO2OrchestrationConfig {
     int         expected_arg_count;
-    int32_t     task_window_size;
-    int32_t     dep_list_pool_size;
-    int32_t     heap_size;
 };
 #endif
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -407,9 +407,6 @@ private:
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
 struct PTO2OrchestrationConfig {
     int         expected_arg_count;
-    int32_t     task_window_size;
-    int32_t     dep_list_pool_size;
-    int32_t     heap_size;
 };
 #endif
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -27,12 +27,8 @@
 // Task management
 // NOTE: PTO2_TASK_WINDOW_SIZE is now the DEFAULT value only.
 // Actual window size is passed at runtime to pto2_runtime_create_threaded_custom().
-// Use pto2_task_slot(sched, task_id) instead of PTO2_TASK_SLOT macro.
+// Use pto2_task_slot(sched, task_id) for slot calculation.
 #define PTO2_TASK_WINDOW_SIZE     16384   // Default task window size (power of 2)
-
-// DEPRECATED: Use pto2_task_slot(sched, task_id) instead
-// This macro only works when runtime window == PTO2_TASK_WINDOW_SIZE
-#define PTO2_TASK_SLOT(task_id)   ((task_id) & (PTO2_TASK_WINDOW_SIZE - 1))
 
 // Memory pools
 #define PTO2_HEAP_SIZE            (64 * 1024 * 1024)  // 64MB default heap

--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -26,6 +26,7 @@ Runtime::Runtime() {
     // Initialize device orchestration state
     orch_built_on_host_ = true;
     pto2_gm_sm_ptr_ = nullptr;
+    pto2_gm_heap_ptr_ = nullptr;
     orch_args_ = nullptr;
     orch_arg_count_ = 0;
 
@@ -72,6 +73,7 @@ void Runtime::clear_tensor_pairs() {
 
 bool Runtime::get_orch_built_on_host() const { return orch_built_on_host_; }
 void* Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
+void* Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
 uint64_t* Runtime::get_orch_args() const {
     // Return embedded storage directly (not the pointer) so device code gets correct device address
     // When Runtime is copied to device memory, computing address relative to 'this' gives valid device address
@@ -80,6 +82,7 @@ uint64_t* Runtime::get_orch_args() const {
 int Runtime::get_orch_arg_count() const { return orch_arg_count_; }
 void Runtime::set_orch_built_on_host(bool v) { orch_built_on_host_ = v; }
 void Runtime::set_pto2_gm_sm_ptr(void* p) { pto2_gm_sm_ptr_ = p; }
+void Runtime::set_pto2_gm_heap(void* p) { pto2_gm_heap_ptr_ = p; }
 void Runtime::set_orch_args(uint64_t* args, int count) {
     orch_arg_count_ = count <= RUNTIME_MAX_ARGS ? count : RUNTIME_MAX_ARGS;
     if (args && orch_arg_count_ > 0) {

--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -28,25 +28,11 @@
 // Configuration Macros
 // =============================================================================
 
-#ifndef RUNTIME_MAX_ARGS
 #define RUNTIME_MAX_ARGS 16
-#endif
-
-#ifndef RUNTIME_MAX_WORKER
 #define RUNTIME_MAX_WORKER 72  // 24 AIC + 48 AIV cores
-#endif
-
-#ifndef RUNTIME_MAX_TENSOR_PAIRS
 #define RUNTIME_MAX_TENSOR_PAIRS 64
-#endif
-
-#ifndef RUNTIME_MAX_FUNC_ID
 #define RUNTIME_MAX_FUNC_ID 32
-#endif
-
-#ifndef RUNTIME_MAX_ORCH_SO_SIZE
 #define RUNTIME_MAX_ORCH_SO_SIZE (4 * 1024 * 1024)  // 1MB max for orchestration SO
-#endif
 
 // =============================================================================
 // Data Structures
@@ -166,6 +152,7 @@ private:
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
     void* pto2_gm_sm_ptr_;  // GM pointer to PTO2 shared memory (device)
+    void* pto2_gm_heap_ptr_;  // GM heap for orchestrator output buffers (device)
     uint64_t* orch_args_;   // Arguments for device orchestration
     int orch_arg_count_;
     uint64_t orch_args_storage_[RUNTIME_MAX_ARGS];  // Copy of args for device
@@ -211,10 +198,12 @@ public:
 
     bool get_orch_built_on_host() const;
     void* get_pto2_gm_sm_ptr() const;
+    void* get_pto2_gm_heap_ptr() const;
     uint64_t* get_orch_args() const;
     int get_orch_arg_count() const;
     void set_orch_built_on_host(bool v);
     void set_pto2_gm_sm_ptr(void* p);
+    void set_pto2_gm_heap(void* p);
     void set_orch_args(uint64_t* args, int count);
 
     // Device orchestration SO binary (for dlopen on AICPU thread 3)


### PR DESCRIPTION
- Remove duplicate RT2_GM_HEAP_SIZE macro, use PTO2_HEAP_SIZE everywhere
- Remove deprecated PTO2_TASK_SLOT macro (replaced by pto2_task_slot())
- Remove memory fields from PTO2OrchestrationConfig, use macros directly
- Store GM heap pointer in Runtime instead of passing via args array
- Remove redundant pto2_gm_heap_size_ field from Runtime