### PR TITLE
Refactor: move Tensor ops to orch, add PA example, scale pool sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ venv/
 .claude
 .vscode
 *bak
+outputs
 
 # Generated example outputs (Ascend header backends)
 examples/output_ascend_a2a3/

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -15,7 +15,7 @@
 
 /** Max arguments per task; must match RUNTIME_MAX_ARGS and PTO2_MAX_OUTPUTS */
 #ifndef PTO2_DISPATCH_MAX_ARGS
-#define PTO2_DISPATCH_MAX_ARGS 16
+#define PTO2_DISPATCH_MAX_ARGS 32
 #endif
 
 /**

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -28,13 +28,13 @@
 // NOTE: PTO2_TASK_WINDOW_SIZE is now the DEFAULT value only.
 // Actual window size is passed at runtime to pto2_runtime_create_threaded_custom().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
-#define PTO2_TASK_WINDOW_SIZE     16384   // Default task window size (power of 2)
+#define PTO2_TASK_WINDOW_SIZE     65536   // Default task window size (power of 2)
 
 // Memory pools
-#define PTO2_HEAP_SIZE            (64 * 1024 * 1024)  // 64MB default heap
-#define PTO2_DEP_LIST_POOL_SIZE   65536   // Dependency list pool entries
-#define PTO2_TENSORMAP_POOL_SIZE  32768   // TensorMap entry pool
-#define PTO2_TENSORMAP_NUM_BUCKETS 4096   // Power of 2 for fast hash
+#define PTO2_HEAP_SIZE            (1024 * 1024 * 1024)  // 1GB default heap
+#define PTO2_DEP_LIST_POOL_SIZE    65536    // Dependency list pool entries
+#define PTO2_TENSORMAP_POOL_SIZE   (65536)   // TensorMap entry pool
+#define PTO2_TENSORMAP_NUM_BUCKETS 65536    // Power of 2 for fast hash
 
 // Task parameters
 #define PTO2_MAX_OUTPUTS          16      // Maximum outputs per task

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -306,10 +306,10 @@ void pto2_tensormap_insert(PTO2TensorMap* tm, Tensor* tensor, int32_t producer_t
     // Advance pool head (wrap around)
     tm->pool_head = (tm->pool_head + 1) % tm->pool_size;
 
-    int wait_count = 0;
+    size_t wait_count = 0;
     while (entry->in_bucket) {
         pto2_orchestrator_sync_tensormap(tm);
-        always_assert(wait_count++ <= 100000000);
+        always_assert(wait_count++ <= 1000000000UL);
     }
 
     // Initialize new entry

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -21,44 +21,6 @@
 #include "tensor.h"
 
 // =============================================================================
-// Configuration
-// =============================================================================
-
-#ifndef PTO_TENSORMAP_POOL_SIZE
-#define PTO_TENSORMAP_POOL_SIZE 4096
-#endif
-
-#ifndef PTO_TENSORMAP_NUM_BUCKETS
-#define PTO_TENSORMAP_NUM_BUCKETS 1024
-#endif
-
-#ifndef PTO_MAX_SCOPE_DEPTH
-#define PTO_MAX_SCOPE_DEPTH 32
-#endif
-
-// =============================================================================
-// Worker Types
-// =============================================================================
-
-/**
- * Worker types for heterogeneous scheduling
- *
- * Tasks are routed to different ready queues based on worker_type:
- * - PTOWorkerType::CUBE:   AICore-CUBE (matrix ops, convolution)
- * - PTOWorkerType::VECTOR: AICore-VECTOR (element-wise ops, activation)
- *
- * Note: AICPU is not a worker type - AICPU threads act as schedulers that
- * dispatch tasks to AICore workers.
- */
-enum class PTOWorkerType : int32_t {
-    CUBE = 0,    // AICore-CUBE
-    VECTOR = 1,  // AICore-VECTOR
-};
-
-// Number of worker types (used for array sizing)
-constexpr int32_t PTO_NUM_WORKER_TYPES = 2;
-
-// =============================================================================
 // Parameter Types (for pto_submit_task API)
 // =============================================================================
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -28,7 +28,7 @@
 // Configuration Macros
 // =============================================================================
 
-#define RUNTIME_MAX_ARGS 16
+#define RUNTIME_MAX_ARGS 32
 #define RUNTIME_MAX_WORKER 72  // 24 AIC + 48 AIV cores
 #define RUNTIME_MAX_TENSOR_PAIRS 64
 #define RUNTIME_MAX_FUNC_ID 32

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -1,0 +1,243 @@
+"""
+Paged Attention Golden Implementation - Production Scale
+
+Implements the online softmax algorithm for paged attention with:
+- bfloat16 Q/K/V inputs
+- Non-transposed K storage: (total_blocks, block_size, kv_head_num, head_dim)
+- GQA support (kv_head_num=1)
+- Head tiling: q_tile = min(q_head_num, 128)
+- Random block table mapping
+"""
+
+import os
+import struct
+import torch
+
+# Output tensor names
+__outputs__ = ["out"]
+
+# Tensor order matching orchestration function parameter order
+TENSOR_ORDER = ["query", "key_cache", "value_cache", "block_table", "context_lens", "out", "config"]
+
+# Comparison tolerances
+RTOL = 1e-3
+ATOL = 1e-3
+
+
+# All test cases - production scale
+ALL_CASES = {
+    "Case1": {
+        "batch": 2,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 2048,
+        "max_model_len": 4096,
+    },
+    "Case2": {
+        "batch": 64,
+        "num_heads": 64,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 64,
+        "context_len": 8192,
+        "max_model_len": 8192,
+    },
+}
+
+# Select case by env var PA_CASE, default to Case1
+_selected = os.environ.get("PA_CASE", "Case1")
+PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
+
+
+def generate_inputs(params: dict) -> dict:
+    """Generate input tensors and zeroed output tensor."""
+    batch = params["batch"]
+    num_heads = params["num_heads"]
+    kv_head_num = params["kv_head_num"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    context_len = params["context_len"]
+    max_model_len = params["max_model_len"]
+
+    max_num_blocks_per_req = max_model_len // block_size
+    cur_valid_blocks = (context_len + block_size - 1) // block_size
+    total_blocks = batch * cur_valid_blocks
+    scale_value = 1.0
+    scale_bits = struct.unpack('I', struct.pack('f', scale_value))[0]
+
+    # Random block table: (batch, max_num_blocks_per_req) int32
+    block_table = torch.randint(
+        0,
+        max(total_blocks, 1),
+        size=(batch, max_num_blocks_per_req),
+        dtype=torch.int32,
+    )
+
+    # Context lens: all = context_len
+    context_lens = torch.full((batch,), context_len, dtype=torch.int32)
+
+    config = torch.tensor(
+        [batch, num_heads, kv_head_num, head_dim, block_size,
+         max_num_blocks_per_req, scale_bits],
+        dtype=torch.int64,
+    )
+
+    # Query: (batch, 1, num_heads * head_dim) -> (batch, num_heads, head_dim) bfloat16
+    query_bf16 = torch.empty(batch, 1, num_heads * head_dim).uniform_(-0.5, 0.5).to(torch.bfloat16)
+    query_bf16 = query_bf16.reshape(batch, num_heads, head_dim)
+
+    # Key cache: (total_blocks, block_size, kv_head_num, head_dim) bfloat16
+    key_bf16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-0.5, 0.5).to(torch.bfloat16)
+
+    # Value cache: (total_blocks, block_size, kv_head_num, head_dim) bfloat16
+    value_bf16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-1, 1).to(torch.bfloat16)
+
+    return {
+        "query": query_bf16.flatten(),
+        "key_cache": key_bf16.flatten(),
+        "value_cache": value_bf16.flatten(),
+        "block_table": block_table.flatten(),
+        "context_lens": context_lens,
+        "out": torch.zeros(batch * num_heads * head_dim, dtype=torch.float32),
+        "config": config,
+    }
+
+
+def paged_attention(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    num_kv_heads: int,
+    num_heads: int,
+    scale_value: float,
+    block_table: torch.Tensor,
+    context_lens: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Compute paged attention using online softmax with head tiling and GQA.
+
+    Args:
+        query: (batch, num_heads, head_dim) bfloat16
+        key_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
+        value_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
+        num_kv_heads: int
+        num_heads: int
+        scale_value: float
+        block_table: (batch, block_num) int32
+        context_lens: (batch,) int32
+
+    Returns:
+        out: (batch, num_heads, head_dim) float32
+    """
+    assert num_kv_heads == 1
+    batch, num_heads, head_dim = query.shape
+    _, block_size, _, _ = key_cache.shape
+    _, block_num = block_table.shape
+
+    query = query.reshape(-1, head_dim)
+    key_cache = key_cache.reshape(-1, block_size, head_dim)
+    value_cache = value_cache.reshape(-1, block_size, head_dim)
+
+    out = torch.zeros((batch * num_heads, head_dim), dtype=torch.float32)
+
+    for b_idx in range(batch):
+        cur_seq = int(context_lens[b_idx])
+        bn_this_batch = (cur_seq + block_size - 1) // block_size
+        assert bn_this_batch <= block_num
+
+        q_tile = min(num_heads, 128)
+        for cur_offset in range(0, num_heads, q_tile):
+            q_tile_size = min(q_tile, num_heads - cur_offset)
+            base_idx = b_idx * num_heads + cur_offset
+            qi = query[base_idx : base_idx + q_tile_size].to(torch.float32)
+
+            oi = None
+            li = None
+            mi = None
+
+            for bn in range(bn_this_batch):
+                cur_block_idx = block_table[b_idx, bn]
+                valid_len = min(block_size, cur_seq - bn * block_size)
+                kj = key_cache[cur_block_idx, :valid_len, :].to(torch.float32)
+                vj = value_cache[cur_block_idx, :valid_len, :].to(torch.float32)
+
+                sij = (qi @ kj.T) * scale_value
+                mij = sij.max(dim=-1, keepdim=True)[0]
+                pij = torch.exp(sij - mij).to(torch.bfloat16).to(torch.float32)
+                lij = pij.sum(dim=1, keepdim=True)
+
+                if bn == 0:
+                    oi = pij @ vj
+                    li = lij
+                    mi = mij
+                else:
+                    mi_new = torch.maximum(mi, mij)
+                    alpha = torch.exp(mi - mi_new)
+                    beta = torch.exp(mij - mi_new)
+                    li_new = alpha * li + beta * lij
+                    oi_new = pij @ vj
+                    oi = alpha * oi + beta * oi_new
+                    li = li_new
+                    mi = mi_new
+
+                if bn == bn_this_batch - 1:
+                    oi = oi / li
+
+            out[base_idx : base_idx + q_tile_size] = oi
+
+    return out
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute expected output in-place using online softmax paged attention."""
+    batch = params["batch"]
+    num_heads = params["num_heads"]
+    kv_head_num = params["kv_head_num"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    max_model_len = params["max_model_len"]
+
+    max_num_blocks_per_req = max_model_len // block_size
+
+    # Reconstruct shaped tensors from flat tensors
+    query = tensors["query"].reshape(batch, num_heads, head_dim)
+    key_cache = tensors["key_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    value_cache = tensors["value_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    block_table = tensors["block_table"].reshape(batch, max_num_blocks_per_req)
+    context_lens = tensors["context_lens"]
+
+    out = paged_attention(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        num_kv_heads=kv_head_num,
+        num_heads=num_heads,
+        scale_value=1.0,
+        block_table=block_table,
+        context_lens=context_lens,
+    )
+
+    tensors["out"][:] = out.flatten()
+
+
+if __name__ == "__main__":
+    params = PARAMS_LIST[0]
+    tensors = generate_inputs(params)
+    compute_golden(tensors, params)
+
+    print(f"=== Paged Attention Golden Test ({params['name']}) ===")
+    print(f"batch={params['batch']}, num_heads={params['num_heads']}, head_dim={params['head_dim']}")
+    print(f"kv_head_num={params['kv_head_num']}, block_size={params['block_size']}")
+    print(f"context_len={params['context_len']}")
+
+    max_num_blocks = params['max_model_len'] // params['block_size']
+    q_tile = min(params['num_heads'], 128)
+    print(f"max_num_blocks_per_req={max_num_blocks}, q_tile_size={q_tile}")
+
+    out = tensors["out"].reshape(params["batch"] * params["num_heads"], params["head_dim"])
+    print(f"Output shape: {out.shape}")
+    print(f"Output range: [{out.min():.4f}, {out.max():.4f}]")
+    print(f"Output mean: {out.mean():.4f}")
+    print("Golden test passed!")

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_hub.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_hub.cpp
@@ -1,0 +1,18 @@
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+constexpr int M = 16;
+constexpr int K = 16;
+constexpr int N = 16;
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,0 +1,97 @@
+// PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
+//
+// Supports two tile configurations via runtime dispatch:
+//   Case1: (16, 128) @ (128, 128) -> (16, 128)
+//   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//
+// pij is bfloat16 (converted from fp32 in softmax_prepare via TCVT).
+// vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
+// Standard non-transposed B pattern: ND GlobalB + ColMajor/RowMajor TileMatB.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int K, int N>
+static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __gm__ Tensor* oi) {
+    __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
+    __gm__ bfloat16_t* vj_addr = reinterpret_cast<__gm__ bfloat16_t*>(vj->buffer.addr);
+    __gm__ float* oi_addr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
+
+    // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
+
+    GlobalA pijGlobal(pij_addr + pij->start_offset);
+    GlobalB vjGlobal(vj_addr + vj->start_offset);
+    GlobalOut oiGlobal(oi_addr + oi->start_offset);
+
+    // L1 Mat tiles: standard ND pattern for both A and B
+    using TileMatA = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
+
+    // L0 tiles
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile = TileRight<bfloat16_t, K, N, K, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    // Load pij and vj to L1
+    TLOAD(aMatTile, pijGlobal);
+    TLOAD(bMatTile, vjGlobal);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    // Move to L0A/L0B
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    // Single matmul: (M,K) x (K,N) -> (M,N)
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(oiGlobal, cTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* vj = reinterpret_cast<__gm__ Tensor*>(args[1]);
+    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    uint64_t q_tile_size = static_cast<uint64_t>(pij->repeats[0]);
+    // args[4] = block_size, args[5] = head_dim
+
+    if (q_tile_size == 16) {
+        pv_matmul_impl<16, 128, 128>(pij, vj, oi_new);
+    } else {
+        pv_matmul_impl<64, 64, 128>(pij, vj, oi_new);
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,0 +1,98 @@
+// QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
+//
+// Supports two tile configurations via runtime dispatch:
+//   Case1: (16, 128) @ (128, 128).T -> (16, 128)
+//   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//
+// kj is stored as (N, K) = (block_size, head_dim) in row-major memory.
+// This is equivalent to (K, N) in column-major (DN) layout.
+// Using DN GlobalB + RowMajor/ColMajor TileMatB to handle the transposed B pattern.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int K, int N>
+static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm__ Tensor* sij) {
+    __gm__ bfloat16_t* qi_addr = reinterpret_cast<__gm__ bfloat16_t*>(qi->buffer.addr);
+    __gm__ bfloat16_t* kj_addr = reinterpret_cast<__gm__ bfloat16_t*>(kj->buffer.addr);
+    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
+
+    // qi (M, K) bf16 in ND (row-major) layout
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
+
+    GlobalA qiGlobal(qi_addr + qi->start_offset);
+    GlobalB kjGlobal(kj_addr + kj->start_offset);
+    GlobalOut sijGlobal(sij_addr + sij->start_offset);
+
+    // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
+    using TileMatA = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
+
+    // L0 tiles
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile = TileRight<bfloat16_t, K, N, K, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    // // Load A and B to L1
+    TLOAD(aMatTile, qiGlobal);
+    TLOAD(bMatTile, kjGlobal);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    // Move from L1 to L0A/L0B
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    // Matmul
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(sijGlobal, cTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* qi = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* kj = reinterpret_cast<__gm__ Tensor*>(args[1]);
+    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    uint64_t q_tile_size = static_cast<uint64_t>(qi->repeats[0]);
+    // args[4] = head_dim (128), args[5] = block_size
+
+    if (q_tile_size == 16) {
+        qk_matmul_impl<16, 128, 128>(qi, kj, sij);
+    } else {
+        qk_matmul_impl<64, 128, 64>(qi, kj, sij);
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_hub.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_hub.cpp
@@ -1,0 +1,18 @@
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+constexpr int M = 16;
+constexpr int K = 16;
+constexpr int N = 16;
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,0 +1,242 @@
+// Online Softmax Update + Normalize Kernel (AIV)
+//
+// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+//   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
+//   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//
+// Scalar layout strategy:
+//   M scalar floats stored contiguously in GM can be loaded as either:
+//   - ND (kScalarRows, kScalarCols) RowMajor for element-wise ops (TMAX, TSUB, TEXP, TMUL, TADD)
+//   - DN (kAlignedRows, 1) ColMajor for row-broadcast ops (TROWEXPANDMUL, TROWEXPANDDIV)
+//   Conversion between layouts uses GM round-trip: ND TSTORE → DN TLOAD.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int N>
+static __aicore__ void online_update_impl(__gm__ Tensor* mij,
+    __gm__ Tensor* lij,
+    __gm__ Tensor* oi_new,
+    __gm__ Tensor* mi,
+    __gm__ Tensor* li,
+    __gm__ Tensor* oi,
+    uint64_t is_first,
+    uint64_t is_last,
+    __gm__ Tensor* dst) {
+    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
+    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
+    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
+    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
+    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
+    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
+    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+
+    // Scalar tile dimensions for RowMajor layout:
+    // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
+    // kScalarRows = M / 8 (M=16 → 2 rows, M=64 → 8 rows)
+    constexpr int kScalarCols = 32 / sizeof(float);
+    constexpr int kScalarRows = M / kScalarCols;
+    // Aligned rows for ColMajor DN tiles (32-byte alignment)
+    constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+
+    // --- GlobalTensor types ---
+
+    // Data (M, N) RowMajor
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+
+    // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
+
+    // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+
+    // --- GlobalTensor instances ---
+
+    GlobalDataMxN oiNewGlobal(oi_new_ptr + oi_new->start_offset);
+    GlobalDataMxN oiGlobal(oi_ptr + oi->start_offset);
+    GlobalDataMxN dstGlobal(dst_ptr + dst->start_offset);
+
+    // ND globals for scalar element-wise operations
+    GlobalScalarND mijGlobalND(mij_ptr + mij->start_offset);
+    GlobalScalarND lijGlobalND(lij_ptr + lij->start_offset);
+    GlobalScalarND miGlobalND(mi_ptr + mi->start_offset);
+    GlobalScalarND liGlobalND(li_ptr + li->start_offset);
+
+    // DN globals aliased to same GM for ColMajor reload (used after ND TSTORE)
+    GlobalScalarDN mijGlobalDN(mij_ptr + mij->start_offset);
+    GlobalScalarDN lijGlobalDN(lij_ptr + lij->start_offset);
+    GlobalScalarDN liGlobalDN(li_ptr + li->start_offset);
+
+    // --- Tile types ---
+
+    using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+
+    // --- UB memory layout ---
+
+    constexpr int kDataBytes = M * N * sizeof(float);
+    constexpr int kScalarNDBytes = kScalarRows * kScalarCols * sizeof(float);
+    constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
+
+    // Data tiles
+    TileDataMxN oiNewTile;
+    TileDataMxN oiTile;
+
+    // Scalar ND tiles for element-wise arithmetic
+    TileScalarND mijND, lijND, miND, liND;
+    TileScalarND miNewND, alphaND, betaND, tmpND;
+
+    // Scalar DN tiles for TROWEXPAND operations
+    TileScalarDN alphaDN, betaDN, liDN;
+
+    TASSIGN(oiNewTile, 0);
+    TASSIGN(oiTile, kDataBytes);
+    TASSIGN(mijND, 2 * kDataBytes);
+    TASSIGN(lijND, 2 * kDataBytes + kScalarNDBytes);
+    TASSIGN(miND, 2 * kDataBytes + 2 * kScalarNDBytes);
+    TASSIGN(liND, 2 * kDataBytes + 3 * kScalarNDBytes);
+    TASSIGN(miNewND, 2 * kDataBytes + 4 * kScalarNDBytes);
+    TASSIGN(alphaND, 2 * kDataBytes + 5 * kScalarNDBytes);
+    TASSIGN(betaND, 2 * kDataBytes + 6 * kScalarNDBytes);
+    TASSIGN(tmpND, 2 * kDataBytes + 7 * kScalarNDBytes);
+    TASSIGN(alphaDN, 2 * kDataBytes + 8 * kScalarNDBytes);
+    TASSIGN(betaDN, 2 * kDataBytes + 8 * kScalarNDBytes + kScalarDNBytes);
+    TASSIGN(liDN, 2 * kDataBytes + 8 * kScalarNDBytes + 2 * kScalarDNBytes);
+
+    if (is_first) {
+        // --- First block: copy inputs to accumulators ---
+        TLOAD(oiNewTile, oiNewGlobal);
+        TLOAD(mijND, mijGlobalND);
+        TLOAD(lijND, lijGlobalND);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // Passthrough to MTE3 (no V compute needed)
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
+
+        if (is_last) {
+            // Single block: normalize dst = oi_new / lij
+            // lij stored to li buffer in ND format; reload as DN for TROWEXPANDDIV
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            TLOAD(liDN, liGlobalDN);
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+            TROWEXPANDDIV(oiNewTile, oiNewTile, liDN);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TSTORE(dstGlobal, oiNewTile);
+        }
+    } else {
+        // --- Subsequent blocks: accumulate ---
+
+        // Phase 1: Load all inputs
+        TLOAD(oiNewTile, oiNewGlobal);
+        TLOAD(oiTile, oiGlobal);
+        TLOAD(mijND, mijGlobalND);
+        TLOAD(lijND, lijGlobalND);
+        TLOAD(miND, miGlobalND);
+        TLOAD(liND, liGlobalND);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
+        // pipe_barrier(PIPE_V) required between each dependent vector operation
+        // to resolve RAW hazards on shared UB tiles.
+        TMAX(miNewND, miND, mijND);  // mi_new = max(mi, mij)
+        pipe_barrier(PIPE_V);
+        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
+        pipe_barrier(PIPE_V);
+        TEXP(alphaND, alphaND);  // alpha = exp(mi - mi_new)
+        pipe_barrier(PIPE_V);
+        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
+        pipe_barrier(PIPE_V);
+        TEXP(betaND, betaND);  // beta = exp(mij - mi_new)
+        pipe_barrier(PIPE_V);
+        TMUL(liND, alphaND, liND);  // li = alpha * li
+        pipe_barrier(PIPE_V);
+        TMUL(tmpND, betaND, lijND);  // tmp = beta * lij
+        pipe_barrier(PIPE_V);
+        TADD(liND, liND, tmpND);  // li = alpha * li + beta * lij (= li_new)
+
+        // Phase 3: Store scalar results to GM (ND format)
+        // mi_new → mi accumulator, li_new → li accumulator
+        // alpha → mij buffer (reuse), beta → lij buffer (reuse)
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(miGlobalND, miNewND);   // persist mi_new
+        TSTORE(liGlobalND, liND);      // persist li_new
+        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
+
+        // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
+        if (is_last) {
+            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
+        }
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+
+        // Phase 5: Scale data tiles using row-broadcast multiply
+        TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
+        pipe_barrier(PIPE_V);
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
+
+        if (is_last) {
+            // Phase 6: Normalize and output
+            pipe_barrier(PIPE_V);
+            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TSTORE(dstGlobal, oiTile);
+        } else {
+            // Phase 6: Store updated accumulators
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TSTORE(oiGlobal, oiTile);
+        }
+    }
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[1]);
+    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ Tensor* mi = reinterpret_cast<__gm__ Tensor*>(args[3]);
+    __gm__ Tensor* li = reinterpret_cast<__gm__ Tensor*>(args[4]);
+    __gm__ Tensor* oi = reinterpret_cast<__gm__ Tensor*>(args[5]);
+    __gm__ Tensor* dst = reinterpret_cast<__gm__ Tensor*>(args[6]);
+    uint64_t is_first = static_cast<uint64_t>(args[7]);
+    uint64_t is_last = static_cast<uint64_t>(args[8]);
+    uint64_t q_tile_size = static_cast<uint64_t>(mij->repeats[0]);
+    // args[10] = head_dim (128)
+
+    if (q_tile_size == 16) {
+        online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else {
+        online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,0 +1,133 @@
+// Softmax Preparation Kernel (AIV) with partial block masking
+//
+// Operates on (M, N) tile where M=q_tile_size, N=block_size:
+//   Case1: sij is (16, 128)
+//   Case2: sij is (64, 64)
+//
+// For partial blocks (valid_len < N), positions [valid_len, N) in sij are
+// filled with -inf via TFILLPAD_INPLACE before softmax, ensuring exp(-inf)=0
+// so that invalid key positions contribute zero attention weight.
+//
+// Computes:
+//   sij_masked = TFILLPAD(sij, valid_len, pad=-inf)
+//   sij_scale = sij_masked * scale
+//   mij = row_max(sij_scale)        -> (M, 1)
+//   pij = exp(sij_scale - mij)      -> (M, N)
+//   lij = row_sum(pij)              -> (M, 1)
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int N>
+static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
+    float scale_value,
+    __gm__ Tensor* pij,
+    __gm__ Tensor* mij,
+    __gm__ Tensor* lij,
+    uint64_t valid_len) {
+    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
+    __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
+    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
+    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
+
+    constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalDataMxN_bf16 = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+
+    GlobalDataMxN sijGlobal(sij_addr + sij->start_offset);
+    GlobalDataMxN_bf16 pijGlobal(pij_addr + pij->start_offset);
+    GlobalScalarDN mijGlobal(mij_addr + mij->start_offset);
+    GlobalScalarDN lijGlobal(lij_addr + lij->start_offset);
+
+    // Dynamic-cols tile: marks which columns are valid for TFILLPAD boundary
+    using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
+    // Padded tile: TFILLPAD_INPLACE fills positions [valid_len, N) with -inf
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N, SLayout::NoneBox, 512, PadValue::Min>;
+
+    using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+
+    TileVecMxN sijTile;
+    TileSijDyn sijDynTile(static_cast<size_t>(valid_len));
+    TileSijPad sijPadTile;
+    TileVecMxN pijTile;
+    TileVecMxN tmpTile;
+    TileScalarDN maxTile;
+    TileScalarDN sumTile;
+    TileVecMxN_bf16 pijBf16Tile;
+
+    // All sij tiles share UB address 0x0 (in-place masking)
+    TASSIGN(sijTile, 0x0);
+    TASSIGN(sijDynTile, 0x0);
+    TASSIGN(sijPadTile, 0x0);
+    TASSIGN(pijTile, M * N * sizeof(float));
+    TASSIGN(tmpTile, 2 * M * N * sizeof(float));
+    TASSIGN(maxTile, 3 * M * N * sizeof(float));
+    TASSIGN(sumTile, 3 * M * N * sizeof(float) + kAlignedRows * sizeof(float));
+    TASSIGN(pijBf16Tile, 3 * M * N * sizeof(float) + 2 * kAlignedRows * sizeof(float));
+
+    // Load full sij (M, N) tile from GM - all N columns including garbage for partial blocks
+    // printf("sij addr incore %x\n", sij->buffer.addr);
+    TLOAD(sijTile, sijGlobal);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    // Mask columns [valid_len, N) with -inf. sijDynTile provides the valid boundary,
+    // sijPadTile provides PadValue::Min as the fill value. No-op when valid_len == N.
+    TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+
+    TMULS(sijTile, sijTile, scale_value);
+    pipe_barrier(PIPE_V);
+    TROWMAX(maxTile, sijTile, tmpTile);
+    pipe_barrier(PIPE_V);
+    TROWEXPANDSUB(pijTile, sijTile, maxTile);
+    pipe_barrier(PIPE_V);
+    TEXP(pijTile, pijTile);
+    // Truncate pij to bf16 first, then compute lij from truncated values (matches golden)
+    TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
+    TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
+    TROWSUM(sumTile, pijTile, tmpTile);
+
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(mijGlobal, maxTile);
+    TSTORE(lijGlobal, sumTile);
+    TSTORE(pijGlobal, pijBf16Tile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
+    scale_conv.u = static_cast<uint64_t>(args[1]);
+    float scale_value = scale_conv.f;
+    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[3]);
+    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[4]);
+    uint64_t q_tile_size = static_cast<uint64_t>(sij->repeats[0]);
+    // args[6] = block_size
+    uint64_t valid_len = static_cast<uint64_t>(sij->repeats[1]);
+
+    if (q_tile_size == 16) {
+        softmax_prepare_impl<16, 128>(sij, scale_value, pij, mij, lij, valid_len);
+    } else {
+        softmax_prepare_impl<64, 64>(sij, scale_value, pij, mij, lij, valid_len);
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
@@ -1,0 +1,45 @@
+"""
+Paged Attention Kernel and Orchestration Configuration
+
+Defines the kernels and orchestration function for paged attention
+with AIC/AIV subgraph splitting:
+
+AIC Kernels (Matrix Multiplication):
+  - aic_qk_matmul: Q @ K^T computation
+  - aic_pv_matmul: P @ V computation
+
+AIV Kernels (Vector Operations):
+  - aiv_softmax_prepare: scale, rowmax, exp, rowsum
+  - aiv_online_update: online softmax accumulation + fused normalization
+
+Note: aiv_normalize has been merged into aiv_online_update for efficiency.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+# Orchestration config
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "paged_attention_orch.cpp"),
+    "function_name": "build_paged_attention_graph",
+}
+
+# Kernel configs (aiv_normalize removed - merged into aiv_online_update)
+KERNELS = [
+    # AIC kernels (matrix multiplication using Cube unit)
+    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),       "core_type": "aic"},
+    # AIV kernels (vector operations)
+    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
+    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
+    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),       "core_type": "aiv"},
+]
+
+# Runtime configuration
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 24,
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -1,0 +1,211 @@
+/**
+ * Paged Attention Orchestration Function - 16x16 Version
+ *
+ * Simplified for 16x16 framework-generated matmul kernels.
+ * Each block processes a single 16x16 matmul operation.
+ *
+ * Memory Layout:
+ *   Query: (batch, 16, 16) - one 16x16 tile per batch
+ *   Key:   (total_blocks, 16, 16) - stored as K^T for direct matmul
+ *   Value: (total_blocks, 16, 16) - direct format
+ */
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_QK_MATMUL 0
+#define FUNC_SOFTMAX_PREPARE 1
+#define FUNC_PV_MATMUL 2
+#define FUNC_ONLINE_UPDATE 3
+#define FUNC_AIC_HUB 4
+#define FUNC_AIV_HUB 5
+
+// Helper to encode float as uint64_t for scalar params
+static uint64_t float_to_u64(float f) {
+    union {
+        float f32;
+        uint64_t u64;
+    } conv;
+    conv.u64 = 0;  // Clear upper bits
+    conv.f32 = f;
+    return conv.u64;
+}
+
+extern "C" {
+/**
+ * Orchestration config — the executor reads these values to set up
+ * shared memory and runtime before calling aicpu_orchestration_entry.
+ */
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
+    uint64_t* args, int arg_count) {
+    (void)args;
+    (void)arg_count;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 15,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
+    int submit_task_count = 0;
+    uint64_t submit_task_total_ns = 0;
+
+#define TIMED_SUBMIT_TASK(rt, func, worker, name, params, params_count)                                     \
+    do {                                                                                                    \
+        auto _t0 = std::chrono::high_resolution_clock::now();                                               \
+        pto2_rt_submit_task(rt, func, worker, name, params, params_count);                                  \
+        auto _t1 = std::chrono::high_resolution_clock::now();                                               \
+        submit_task_total_ns +=                                                                             \
+            static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(_t1 - _t0).count()); \
+        submit_task_count++;                                                                                \
+    } while (0)
+
+    // Extract device pointers
+    // Extract pointers (first 7)
+    void* host_query = reinterpret_cast<void*>(args[0]);        // [batch, num_heads, head_dim]
+    void* host_key_cache = reinterpret_cast<void*>(args[1]);    // [batch, block_num, block_size, head_dim]
+    void* host_value_cache = reinterpret_cast<void*>(args[2]);  // [batch, block_num, block_size, head_dim]
+    int* host_block_table = reinterpret_cast<int*>(args[3]);    // [batch, block_num]
+    int* host_context_lens = reinterpret_cast<int*>(args[4]);   // [batch]
+    void* host_out = reinterpret_cast<void*>(args[5]);          // [batch, num_heads, head_dim]
+    int64_t* host_config = reinterpret_cast<int64_t*>(args[6]);
+
+    // Extract sizes (next 7)
+    size_t query_size = static_cast<size_t>(args[7]);
+    size_t key_cache_size = static_cast<size_t>(args[8]);
+    size_t value_cache_size = static_cast<size_t>(args[9]);
+    size_t block_table_size = static_cast<size_t>(args[10]);
+    size_t context_lens_size = static_cast<size_t>(args[11]);
+    size_t out_size = static_cast<size_t>(args[12]);
+    size_t config_size = static_cast<size_t>(args[13]);
+
+    // Extract config parameters
+    uint64_t batch = static_cast<uint64_t>(static_cast<int>(host_config[0]));
+    uint64_t num_heads = static_cast<uint64_t>(static_cast<int>(host_config[1]));
+    int kv_head_num = static_cast<int>(host_config[2]);
+    uint64_t head_dim = static_cast<uint64_t>(static_cast<int>(host_config[3]));
+    uint64_t block_size = static_cast<uint64_t>(static_cast<int>(host_config[4]));
+    uint64_t block_num = static_cast<uint64_t>(static_cast<int>(host_config[5]));
+    union {
+        uint32_t u;
+        float f;
+    } scale_conv;
+    scale_conv.u = static_cast<uint32_t>(host_config[6]);
+    float scale_value = scale_conv.f;
+    uint64_t q_head_num = num_heads;
+    uint64_t q_tile = std::min(num_heads, 128UL);
+    uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;
+    DataType data_type = DataType::BFLOAT16;  // 用例是float32的，这个考虑要如何扩展成其他类型
+
+    printf("batch = %lu\n", batch);
+
+    // query_size = batch * num_heads * head_dim * data_type
+    // key_cache_size = batch * block_num * block_size * head_dim * data_type
+    // value_cache_size = batch * block_num * block_size * head_dim * data_type
+    // out = batch * num_heads * head_dim * data_type
+    uint64_t query_shapes[2] = {batch * num_heads, head_dim};
+    uint64_t key_cache_shapes[2] = {batch * block_num * block_size, head_dim};
+    uint64_t value_cache_shapes[2] = {batch * block_num * block_size, head_dim};
+    uint64_t out_shapes[2] = {batch * num_heads, head_dim};
+    Tensor query = make_tensor_external(host_query, query_shapes, 2, data_type);
+    Tensor key_cache = make_tensor_external(host_key_cache, key_cache_shapes, 2, data_type);
+    Tensor value_cache = make_tensor_external(host_value_cache, value_cache_shapes, 2, data_type);
+    // Tensor block_table = make_tensor_external(host_block_table, block_table_size);
+    // Tensor context_lens = make_tensor_external(host_context_lens, context_lens_size);
+    Tensor out = make_tensor_external(host_out, out_shapes, 2, DataType::FLOAT32);
+    printf("query=%s\n", query.dump().c_str());
+    printf("key_cache=%s\n", key_cache.dump().c_str());
+    printf("value_cache=%s\n", value_cache.dump().c_str());
+    printf("out=%s\n", out.dump().c_str());
+
+    int total_tasks = 0;
+
+    for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
+        uint64_t cur_seq = host_context_lens[b_idx];
+        uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
+        for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
+            PTO2_SCOPE(rt) {
+                uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
+                uint64_t oi_shapes[2] = {q_tile, head_dim};
+                uint64_t li_shapes[1] = {q_tile};
+                uint64_t mi_shapes[1] = {q_tile};
+                Tensor oi = make_tensor(oi_shapes, 2, DataType::FLOAT32);
+                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32);
+                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32);
+
+                PTOParam params_inplace[] = {
+                    make_output_param(oi),
+                    make_output_param(li_update),
+                    make_output_param(mi_update),
+                };
+                TIMED_SUBMIT_TASK(rt, FUNC_AIV_HUB, PTO2_WORKER_VECTOR, "create_inplace", params_inplace, 3);
+
+                for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
+                    Tensor qi = query.view({q_tile, head_dim}, {cur_offset, 0});
+                    uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
+                    uint64_t valid_len = std::min(block_size, cur_seq - bn * block_size);
+                    Tensor kj = key_cache.view({valid_len, head_dim}, {cur_block_idx * block_size, 0});
+                    Tensor vj = value_cache.view({valid_len, head_dim}, {cur_block_idx * block_size, 0});
+
+                    uint64_t sij_shapes[2] = {q_tile, valid_len};
+                    Tensor sij = make_tensor(sij_shapes, 2, DataType::FLOAT32);
+                    Tensor pij_f16 = make_tensor(sij_shapes, 2, data_type);
+
+                    PTOParam params_qk[] = {
+                        make_input_param(qi),
+                        make_input_param(kj),
+                        make_output_param(sij),
+                    };
+                    TIMED_SUBMIT_TASK(rt, FUNC_QK_MATMUL, PTO2_WORKER_CUBE, "c1", params_qk, 3);
+
+                    Tensor li = make_tensor(li_shapes, 1, DataType::FLOAT32);
+                    Tensor mi = make_tensor(mi_shapes, 1, DataType::FLOAT32);
+                    PTOParam params_sf[] = {
+                        make_input_param(sij),
+                        make_scalar_param(float_to_u64(scale_value)),
+                        make_output_param(pij_f16),
+                        make_output_param(mi),
+                        make_output_param(li),
+                    };
+                    TIMED_SUBMIT_TASK(rt, FUNC_SOFTMAX_PREPARE, PTO2_WORKER_VECTOR, "v1", params_sf, 5);
+
+                    uint64_t oi_tmp_shapes[2] = {q_tile, head_dim};
+                    Tensor oi_tmp = make_tensor(oi_tmp_shapes, 2, DataType::FLOAT32);
+
+                    PTOParam params_pv[] = {
+                        make_input_param(pij_f16),
+                        make_input_param(vj),
+                        make_output_param(oi_tmp),
+                    };
+                    TIMED_SUBMIT_TASK(rt, FUNC_PV_MATMUL, PTO2_WORKER_CUBE, "c2", params_pv, 3);
+
+                    uint64_t is_first = (bn == 0) ? 1 : 0;
+                    uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
+
+                    Tensor out_view = out.view({q_tile, head_dim}, {cur_offset, 0});
+                    PTOParam params_up[] = {
+                        make_input_param(mi),
+                        make_input_param(li),
+                        make_input_param(oi_tmp),
+                        make_inout_param(mi_update),
+                        make_inout_param(li_update),
+                        make_inout_param(oi),
+                        make_output_param(out_view),
+                        make_scalar_param(is_first),
+                        make_scalar_param(is_last),
+                    };
+                    TIMED_SUBMIT_TASK(rt, FUNC_ONLINE_UPDATE, PTO2_WORKER_VECTOR, "v2", params_up, 9);
+                }
+            }
+        }
+    }
+
+    printf(
+        "[orch stats] pto2_submit_task called %d times, total cost %lu ns\n", submit_task_count, submit_task_total_ns);
+
+#undef TIMED_SUBMIT_TASK
+}
+
+}  // extern "C"

--- a/tools/swimlane_converter.py
+++ b/tools/swimlane_converter.py
@@ -155,6 +155,7 @@ def print_task_statistics(tasks, func_id_to_name=None):
     print("=" * 104)
 
 
+
 def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose=False):
     """Generate Chrome Trace Event Format JSON from task data.
 


### PR DESCRIPTION
- Move view/reshape/transpose/dump/numel from tensor.cpp to tensor_orch.cpp so orchestration .so can link them directly
- Add vector overloads for view() and offset_ndim_to_1d()
- Add multi-dim make_tensor/make_tensor_external factories
- Increase heap (64MB->1GB), task window (16K->64K), tensormap buckets (4K->64K), max args (16->32) for paged attention scale
- Improve stacktrace with dladdr and inline chain expansion
- Add paged attention orchestration and kernel examples