### PR TITLE
Add: BGEMM example for aicpu_build_graph and host_build_graph runtimes

### DIFF
--- a/examples/aicpu_build_graph/bgemm/README.md
+++ b/examples/aicpu_build_graph/bgemm/README.md
@@ -1,0 +1,82 @@
+# BGEMM Example (AICPU Build Graph Runtime)
+
+Tiled matrix multiplication example demonstrating Cube (AIC) and Vector (AIV) core cooperation.
+
+## Computation
+
+```
+C = A @ B
+```
+
+Tiled computation with 4x4x4 grid:
+- Tile size: 64 x 64
+- Matrix A: 256 x 256 (4x4 tiles)
+- Matrix B: 256 x 256 (4x4 tiles)
+- Matrix C: 256 x 256 (4x4 tiles)
+
+## Task Graph
+
+For each output tile C[m,n]:
+```
+for k in [0, GRID_K):
+    P = A[m,k] @ B[k,n]    (gemm_tile on Cube core)
+    C[m,n] = C[m,n] + P    (tile_add on Vector core)
+```
+
+Dependencies:
+- gemm_tile → tile_add: P must be computed before accumulation
+- tile_add[k] → gemm_tile[k+1]: K-dimension accumulation is sequential
+
+Total tasks: 128 (64 gemm + 64 add)
+
+## Kernels
+
+| Kernel | Core Type | Function |
+|--------|-----------|----------|
+| kernel_gemm_tile | AIC (Cube) | 64x64 matrix multiplication |
+| kernel_tile_add | AIV (Vector) | 64x64 element-wise addition |
+
+## File Structure
+
+```
+bgemm/
+├── golden.py                          # Test specification
+├── README.md                          # This file
+└── kernels/
+    ├── kernel_config.py               # Kernel configuration
+    ├── orchestration/
+    │   └── bgemm_orch.cpp             # Task graph builder
+    ├── aic/
+    │   └── kernel_gemm_tile.cpp       # Cube core matmul kernel
+    └── aiv/
+        └── kernel_tile_add.cpp        # Vector core add kernel
+```
+
+## Technical Details
+
+### Memory Layout (Tile-First)
+
+```
+A: [BATCH, GRID_M, GRID_K, TILE_M, TILE_K]
+B: [BATCH, GRID_K, GRID_N, TILE_K, TILE_N]
+C: [BATCH, GRID_M, GRID_N, TILE_M, TILE_N]
+```
+
+### Runtime Characteristics
+
+- Task graph is built on AICPU
+- Framework automatically manages I/O tensor device memory
+- Orchestration function allocates intermediate buffers via AicpuBuildApi
+
+### Kernel Implementation
+
+Both kernels use PTO ISA tile operations:
+
+- **kernel_gemm_tile**: Uses `TileLeft`, `TileRight`, `TileAcc` types with `TLOAD`, `TMOV`, `TMATMUL`, `TSTORE` instructions
+- **kernel_tile_add**: Uses `TileVec` type with `TLOAD`, `TADD`, `TSTORE` instructions
+
+### Pipeline Synchronization
+
+Kernels include proper pipeline synchronization:
+- `PIPE_MTE2` → `PIPE_M`/`PIPE_V`: After loads, before compute
+- `PIPE_M`/`PIPE_V` → `PIPE_MTE3`: After compute, before store

--- a/examples/aicpu_build_graph/bgemm/golden.py
+++ b/examples/aicpu_build_graph/bgemm/golden.py
@@ -1,0 +1,59 @@
+"""
+Golden test specification for BGEMM (AICPU Build Graph Runtime).
+
+Computation: C = A @ B (tiled matrix multiplication)
+Configuration: 4x4x4 grid, 64x64 tiles
+"""
+
+import numpy as np
+
+__outputs__ = ["C"]
+TENSOR_ORDER = ["A", "B", "C"]
+RTOL = 1e-3
+ATOL = 1e-3
+
+TILE_M = 64
+TILE_K = 64
+TILE_N = 64
+
+GRID_M = 4
+GRID_K = 4
+GRID_N = 4
+BATCH = 1
+
+M = TILE_M * GRID_M
+K = TILE_K * GRID_K
+N = TILE_N * GRID_N
+
+
+def generate_inputs(params: dict) -> dict:
+    """Generate input tensors with tile-first memory layout."""
+    A = np.random.randn(BATCH, GRID_M, GRID_K, TILE_M, TILE_K).astype(np.float32) * 0.01
+    B = np.random.randn(BATCH, GRID_K, GRID_N, TILE_K, TILE_N).astype(np.float32) * 0.01
+    C = np.zeros((BATCH, GRID_M, GRID_N, TILE_M, TILE_N), dtype=np.float32)
+
+    return {
+        "A": A.flatten(),
+        "B": B.flatten(),
+        "C": C.flatten(),
+    }
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute golden result: C[m,n] = sum(k) A[m,k] @ B[k,n]."""
+    A = tensors["A"].reshape(BATCH, GRID_M, GRID_K, TILE_M, TILE_K)
+    B = tensors["B"].reshape(BATCH, GRID_K, GRID_N, TILE_K, TILE_N)
+    C = tensors["C"].reshape(BATCH, GRID_M, GRID_N, TILE_M, TILE_N)
+
+    C[:] = 0.0
+
+    for batch in range(BATCH):
+        for m_idx in range(GRID_M):
+            for n_idx in range(GRID_N):
+                for k_idx in range(GRID_K):
+                    C[batch, m_idx, n_idx] += np.matmul(
+                        A[batch, m_idx, k_idx],
+                        B[batch, k_idx, n_idx]
+                    )
+
+    tensors["C"][:] = C.flatten()

--- a/examples/aicpu_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/aicpu_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -1,0 +1,90 @@
+/**
+ * Tile-based Matrix Multiplication Kernel (Cube Core)
+ *
+ * Computes: output = input_a @ input_b (64x64 tile matmul)
+ * Uses TMATMUL instruction
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <typename T>
+AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
+    if (num_2 == 0) {
+        return 0;
+    }
+    return (num_1 + num_2 - 1) / num_2 * num_2;
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(args[0]);
+    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(args[1]);
+    __gm__ float* output = reinterpret_cast<__gm__ float*>(args[2]);
+
+    constexpr int TILE = 64;
+    constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
+    constexpr int M = CeilAlign<int>(TILE, 16);
+    constexpr int K = CeilAlign<int>(TILE, blockAlign);
+    constexpr int N = CeilAlign<int>(TILE, blockAlign);
+
+    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+
+    GlobalDataA src0Global(input_a);
+    GlobalDataB src1Global(input_b);
+    GlobalDataC dstGlobal(output);
+
+    using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+
+    using LeftTile = TileLeft<float, M, K, TILE, TILE>;
+    using RightTile = TileRight<float, K, N, TILE, TILE>;
+    using AccTile = TileAcc<float, M, N, TILE, TILE>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    TLOAD(aMatTile, src0Global);
+    TLOAD(bMatTile, src1Global);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(dstGlobal, cTile);
+}

--- a/examples/aicpu_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/aicpu_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -1,0 +1,53 @@
+/**
+ * Tile-based Element-wise Addition Kernel (Vector Core)
+ *
+ * Computes: output = input_a + input_b (64x64 tile addition)
+ * Uses TADD instruction
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(args[0]);
+    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(args[1]);
+    __gm__ float* output = reinterpret_cast<__gm__ float*>(args[2]);
+
+    constexpr int TILE = 64;
+
+    using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
+    using DynStridDim5 = Stride<1, 1, 1, TILE, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, TILE, TILE, BLayout::RowMajor, -1, -1>;
+
+    TileData aTile(TILE, TILE);
+    TileData bTile(TILE, TILE);
+    TileData outTile(TILE, TILE);
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x10000);
+    TASSIGN(outTile, 0x20000);
+
+    GlobalData aGlobal(input_a);
+    GlobalData bGlobal(input_b);
+    GlobalData outGlobal(output);
+
+    TLOAD(aTile, aGlobal);
+    TLOAD(bTile, bGlobal);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(outTile, aTile, bTile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(outGlobal, outTile);
+}

--- a/examples/aicpu_build_graph/bgemm/kernels/kernel_config.py
+++ b/examples/aicpu_build_graph/bgemm/kernels/kernel_config.py
@@ -1,0 +1,37 @@
+"""
+Kernel configuration for BGEMM (AICPU Build Graph Runtime).
+
+Cube core (AIC) for matrix multiplication, Vector core (AIV) for element-wise addition.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+RUNTIME_CONFIG = {
+    "runtime": "aicpu_build_graph",
+    "aicpu_thread_num": 4,
+    "block_dim": 24,
+}
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "bgemm_orch.cpp"),
+    "function_name": "orchestration",
+}
+
+RUNTIME_ENV = {
+    "PTO_AICPU_BUILD_GRAPH_BUILD_MODE": "1",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_gemm_tile.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_tile_add.cpp"),
+        "core_type": "aiv",
+    },
+]

--- a/examples/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -1,0 +1,153 @@
+/**
+ * BGEMM Orchestration Function (AICPU Build Graph Runtime)
+ *
+ * Builds the task graph for tiled matrix multiplication: C = A @ B
+ *
+ * Configuration:
+ *   - Tile size: 64 x 64
+ *   - Grid: 4 x 4 x 4 (GRID_M x GRID_K x GRID_N)
+ *
+ * Memory layout (tile-first):
+ *   A: [BATCH, GRID_M, GRID_K, TILE_M, TILE_K]
+ *   B: [BATCH, GRID_K, GRID_N, TILE_K, TILE_N]
+ *   C: [BATCH, GRID_M, GRID_N, TILE_M, TILE_N]
+ *
+ * Task graph per output tile:
+ *   for k in [0, GRID_K):
+ *     P = A[m,k] @ B[k,n]    (gemm_tile on Cube core)
+ *     C[m,n] = C[m,n] + P    (tile_add on Vector core)
+ */
+
+#include <cstdint>
+
+#include "runtime.h"
+
+namespace {
+constexpr int TILE = 64;
+constexpr int GRID_M = 4;
+constexpr int GRID_K = 4;
+constexpr int GRID_N = 4;
+constexpr int BATCH = 1;
+
+constexpr size_t TILE_BYTES = TILE * TILE * sizeof(float);
+constexpr int NUM_P_BUFFERS = BATCH * GRID_M * GRID_N;
+
+constexpr int DEV_A = 0;
+constexpr int DEV_B = 1;
+constexpr int DEV_C = 2;
+constexpr int ARG_SIZE = 6;
+}  // namespace
+
+extern "C" int orchestration(Runtime* runtime) {
+    if (runtime == nullptr) {
+        return -1;
+    }
+
+    if (runtime->orch_argc < ARG_SIZE + 1) {
+        return -1;
+    }
+
+    const uint64_t dev_A = runtime->orch_args[DEV_A];
+    const uint64_t dev_B = runtime->orch_args[DEV_B];
+    const uint64_t dev_C = runtime->orch_args[DEV_C];
+
+    if (dev_A == 0 || dev_B == 0 || dev_C == 0) {
+        return -1;
+    }
+
+    const AicpuBuildApi& api = runtime->aicpu_build_api;
+    if (api.add_task == nullptr || api.add_successor_conditional == nullptr ||
+        api.publish_task == nullptr || api.device_malloc == nullptr) {
+        return -1;
+    }
+
+    // Allocate intermediate P buffers (one per C tile)
+    void* dev_P[NUM_P_BUFFERS];
+    for (int i = 0; i < NUM_P_BUFFERS; i++) {
+        dev_P[i] = api.device_malloc(TILE_BYTES);
+        if (dev_P[i] == nullptr) {
+            return -1;
+        }
+    }
+
+    // Track last add task for each C tile (for K accumulation dependency)
+    int last_add_task[NUM_P_BUFFERS];
+    for (int i = 0; i < NUM_P_BUFFERS; i++) {
+        last_add_task[i] = -1;
+    }
+
+    // Build task graph: 4-level tiling loop
+    for (int batch = 0; batch < BATCH; batch++) {
+        for (int m_idx = 0; m_idx < GRID_M; m_idx++) {
+            for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
+                for (int k_idx = 0; k_idx < GRID_K; k_idx++) {
+                    // Calculate tile offsets
+                    size_t A_offset = (batch * GRID_M * GRID_K + m_idx * GRID_K + k_idx) * TILE_BYTES;
+                    size_t B_offset = (batch * GRID_K * GRID_N + k_idx * GRID_N + n_idx) * TILE_BYTES;
+                    size_t C_offset = (batch * GRID_M * GRID_N + m_idx * GRID_N + n_idx) * TILE_BYTES;
+
+                    int c_tile_idx = batch * GRID_M * GRID_N + m_idx * GRID_N + n_idx;
+
+                    if (k_idx == 0) {
+                        // First k iteration: C[m,n] = A[m,0] @ B[0,n]
+                        // Write gemm result directly to C (no accumulation needed)
+                        uint64_t args_gemm[6];
+                        args_gemm[0] = dev_A + A_offset;
+                        args_gemm[1] = dev_B + B_offset;
+                        args_gemm[2] = dev_C + C_offset;  // Write directly to C
+                        args_gemm[3] = TILE;
+                        args_gemm[4] = TILE;
+                        args_gemm[5] = TILE;
+                        int t_gemm = api.add_task(runtime, args_gemm, 6, 0, CoreType::AIC, 0);
+                        if (t_gemm < 0) return -1;
+
+                        api.publish_task(runtime, t_gemm);
+                        last_add_task[c_tile_idx] = t_gemm;
+                    } else {
+                        // Subsequent k iterations: C[m,n] = C[m,n] + A[m,k] @ B[k,n]
+                        // Task 1: P = A[m,k] @ B[k,n] (gemm_tile on Cube core)
+                        uint64_t args_gemm[6];
+                        args_gemm[0] = dev_A + A_offset;
+                        args_gemm[1] = dev_B + B_offset;
+                        args_gemm[2] = reinterpret_cast<uint64_t>(dev_P[c_tile_idx]);
+                        args_gemm[3] = TILE;
+                        args_gemm[4] = TILE;
+                        args_gemm[5] = TILE;
+                        int t_gemm = api.add_task(runtime, args_gemm, 6, 0, CoreType::AIC, 0);
+                        if (t_gemm < 0) return -1;
+
+                        // Task 2: C[m,n] = C[m,n] + P (tile_add on Vector core)
+                        uint64_t args_add[5];
+                        args_add[0] = dev_C + C_offset;
+                        args_add[1] = reinterpret_cast<uint64_t>(dev_P[c_tile_idx]);
+                        args_add[2] = dev_C + C_offset;
+                        args_add[3] = TILE;
+                        args_add[4] = TILE;
+                        int t_add = api.add_task(runtime, args_add, 5, 1, CoreType::AIV, 0);
+                        if (t_add < 0) return -1;
+
+                        // Dependency: gemm must complete before add
+                        api.add_successor_conditional(runtime, t_gemm, t_add);
+
+                        // Dependency: previous task must complete before current gemm
+                        if (last_add_task[c_tile_idx] >= 0) {
+                            api.add_successor_conditional(runtime, last_add_task[c_tile_idx], t_gemm);
+                        }
+
+                        // Publish tasks after all dependencies are set
+                        api.publish_task(runtime, t_gemm);
+                        api.publish_task(runtime, t_add);
+
+                        last_add_task[c_tile_idx] = t_add;
+                    }
+                }
+            }
+        }
+    }
+
+    if (runtime->kernel_addrs[0] == 0 || runtime->kernel_addrs[1] == 0) {
+        return -1;
+    }
+
+    return 0;
+}

--- a/examples/host_build_graph/bgemm/README.md
+++ b/examples/host_build_graph/bgemm/README.md
@@ -1,0 +1,76 @@
+# BGEMM Example (Host Build Graph Runtime)
+
+Tiled matrix multiplication example demonstrating Cube (AIC) and Vector (AIV) core cooperation.
+
+## Computation
+
+```
+C = A @ B
+```
+
+Tiled computation with 4x4x4 grid:
+- Tile size: 64 x 64
+- Matrix A: 256 x 256 (4x4 tiles)
+- Matrix B: 256 x 256 (4x4 tiles)
+- Matrix C: 256 x 256 (4x4 tiles)
+
+## Task Graph
+
+For each output tile C[m,n]:
+```
+for k in [0, GRID_K):
+    P = A[m,k] @ B[k,n]    (gemm_tile on Cube core)
+    C[m,n] = C[m,n] + P    (tile_add on Vector core)
+```
+
+Dependencies:
+- gemm_tile → tile_add: P must be computed before accumulation
+- tile_add[k] → gemm_tile[k+1]: K-dimension accumulation is sequential
+
+Total tasks: 128 (64 gemm + 64 add)
+
+## Kernels
+
+| Kernel | Core Type | Function |
+|--------|-----------|----------|
+| kernel_gemm_tile | AIC (Cube) | 64x64 matrix multiplication |
+| kernel_tile_add | AIV (Vector) | 64x64 element-wise addition |
+
+## File Structure
+
+```
+bgemm/
+├── golden.py                          # Test specification
+├── README.md                          # This file
+└── kernels/
+    ├── kernel_config.py               # Kernel configuration
+    ├── orchestration/
+    │   └── bgemm_orch.cpp             # Task graph builder
+    ├── aic/
+    │   └── kernel_gemm_tile.cpp       # Cube core matmul kernel
+    └── aiv/
+        └── kernel_tile_add.cpp        # Vector core add kernel
+```
+
+## Technical Details
+
+### Memory Layout (Tile-First)
+
+```
+A: [BATCH, GRID_M, GRID_K, TILE_M, TILE_K]
+B: [BATCH, GRID_K, GRID_N, TILE_K, TILE_N]
+C: [BATCH, GRID_M, GRID_N, TILE_M, TILE_N]
+```
+
+### Kernel Implementation
+
+Both kernels use PTO ISA tile operations:
+
+- **kernel_gemm_tile**: Uses `TileLeft`, `TileRight`, `TileAcc` types with `TLOAD`, `TMOV`, `TMATMUL`, `TSTORE` instructions
+- **kernel_tile_add**: Uses `TileVec` type with `TLOAD`, `TADD`, `TSTORE` instructions
+
+### Pipeline Synchronization
+
+Kernels include proper pipeline synchronization:
+- `PIPE_MTE2` → `PIPE_M`/`PIPE_V`: After loads, before compute
+- `PIPE_M`/`PIPE_V` → `PIPE_MTE3`: After compute, before store

--- a/examples/host_build_graph/bgemm/golden.py
+++ b/examples/host_build_graph/bgemm/golden.py
@@ -1,0 +1,59 @@
+"""
+Golden test specification for BGEMM (Host Build Graph Runtime).
+
+Computation: C = A @ B (tiled matrix multiplication)
+Configuration: 4x4x4 grid, 64x64 tiles
+"""
+
+import numpy as np
+
+__outputs__ = ["C"]
+TENSOR_ORDER = ["A", "B", "C"]
+RTOL = 1e-3
+ATOL = 1e-3
+
+TILE_M = 64
+TILE_K = 64
+TILE_N = 64
+
+GRID_M = 4
+GRID_K = 4
+GRID_N = 4
+BATCH = 1
+
+M = TILE_M * GRID_M
+K = TILE_K * GRID_K
+N = TILE_N * GRID_N
+
+
+def generate_inputs(params: dict) -> dict:
+    """Generate input tensors with tile-first memory layout."""
+    A = np.random.randn(BATCH, GRID_M, GRID_K, TILE_M, TILE_K).astype(np.float32) * 0.01
+    B = np.random.randn(BATCH, GRID_K, GRID_N, TILE_K, TILE_N).astype(np.float32) * 0.01
+    C = np.zeros((BATCH, GRID_M, GRID_N, TILE_M, TILE_N), dtype=np.float32)
+
+    return {
+        "A": A.flatten(),
+        "B": B.flatten(),
+        "C": C.flatten(),
+    }
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute golden result: C[m,n] = sum(k) A[m,k] @ B[k,n]."""
+    A = tensors["A"].reshape(BATCH, GRID_M, GRID_K, TILE_M, TILE_K)
+    B = tensors["B"].reshape(BATCH, GRID_K, GRID_N, TILE_K, TILE_N)
+    C = tensors["C"].reshape(BATCH, GRID_M, GRID_N, TILE_M, TILE_N)
+
+    C[:] = 0.0
+
+    for batch in range(BATCH):
+        for m_idx in range(GRID_M):
+            for n_idx in range(GRID_N):
+                for k_idx in range(GRID_K):
+                    C[batch, m_idx, n_idx] += np.matmul(
+                        A[batch, m_idx, k_idx],
+                        B[batch, k_idx, n_idx]
+                    )
+
+    tensors["C"][:] = C.flatten()

--- a/examples/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -1,0 +1,90 @@
+/**
+ * Tile-based Matrix Multiplication Kernel (Cube Core)
+ *
+ * Computes: output = input_a @ input_b (64x64 tile matmul)
+ * Uses TMATMUL instruction
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <typename T>
+AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
+    if (num_2 == 0) {
+        return 0;
+    }
+    return (num_1 + num_2 - 1) / num_2 * num_2;
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(args[0]);
+    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(args[1]);
+    __gm__ float* output = reinterpret_cast<__gm__ float*>(args[2]);
+
+    constexpr int TILE = 64;
+    constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
+    constexpr int M = CeilAlign<int>(TILE, 16);
+    constexpr int K = CeilAlign<int>(TILE, blockAlign);
+    constexpr int N = CeilAlign<int>(TILE, blockAlign);
+
+    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+
+    GlobalDataA src0Global(input_a);
+    GlobalDataB src1Global(input_b);
+    GlobalDataC dstGlobal(output);
+
+    using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+
+    using LeftTile = TileLeft<float, M, K, TILE, TILE>;
+    using RightTile = TileRight<float, K, N, TILE, TILE>;
+    using AccTile = TileAcc<float, M, N, TILE, TILE>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    TLOAD(aMatTile, src0Global);
+    TLOAD(bMatTile, src1Global);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(dstGlobal, cTile);
+}

--- a/examples/host_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/host_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -1,0 +1,53 @@
+/**
+ * Tile-based Element-wise Addition Kernel (Vector Core)
+ *
+ * Computes: output = input_a + input_b (64x64 tile addition)
+ * Uses TADD instruction
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(args[0]);
+    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(args[1]);
+    __gm__ float* output = reinterpret_cast<__gm__ float*>(args[2]);
+
+    constexpr int TILE = 64;
+
+    using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
+    using DynStridDim5 = Stride<1, 1, 1, TILE, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, TILE, TILE, BLayout::RowMajor, -1, -1>;
+
+    TileData aTile(TILE, TILE);
+    TileData bTile(TILE, TILE);
+    TileData outTile(TILE, TILE);
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x10000);
+    TASSIGN(outTile, 0x20000);
+
+    GlobalData aGlobal(input_a);
+    GlobalData bGlobal(input_b);
+    GlobalData outGlobal(output);
+
+    TLOAD(aTile, aGlobal);
+    TLOAD(bTile, bGlobal);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(outTile, aTile, bTile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(outGlobal, outTile);
+}

--- a/examples/host_build_graph/bgemm/kernels/kernel_config.py
+++ b/examples/host_build_graph/bgemm/kernels/kernel_config.py
@@ -1,0 +1,27 @@
+"""
+Kernel configuration for BGEMM (Host Build Graph Runtime).
+
+Cube core (AIC) for matrix multiplication, Vector core (AIV) for element-wise addition.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "bgemm_orch.cpp"),
+    "function_name": "build_bgemm_graph",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_gemm_tile.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_tile_add.cpp"),
+        "core_type": "aiv",
+    },
+]

--- a/examples/host_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/host_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -1,0 +1,139 @@
+/**
+ * BGEMM Orchestration Function (Host Build Graph Runtime)
+ *
+ * Builds the task graph for tiled matrix multiplication: C = A @ B
+ *
+ * Configuration:
+ *   - Tile size: 64 x 64
+ *   - Grid: 4 x 4 x 4 (GRID_M x GRID_K x GRID_N)
+ *
+ * Memory layout (tile-first):
+ *   A: [BATCH, GRID_M, GRID_K, TILE_M, TILE_K]
+ *   B: [BATCH, GRID_K, GRID_N, TILE_K, TILE_N]
+ *   C: [BATCH, GRID_M, GRID_N, TILE_M, TILE_N]
+ *
+ * Task graph per output tile:
+ *   for k in [0, GRID_K):
+ *     P = A[m,k] @ B[k,n]    (gemm_tile on Cube core)
+ *     C[m,n] = C[m,n] + P    (tile_add on Vector core)
+ */
+
+#include "runtime.h"
+#include <iostream>
+#include <vector>
+
+extern "C" {
+
+constexpr int TILE = 64;
+constexpr int GRID_M = 4;
+constexpr int GRID_K = 4;
+constexpr int GRID_N = 4;
+constexpr int BATCH = 1;
+
+constexpr size_t TILE_BYTES = TILE * TILE * sizeof(float);
+
+int build_bgemm_graph(Runtime* runtime, uint64_t* args, int arg_count) {
+    if (arg_count < 7) {
+        std::cerr << "build_bgemm_graph: Expected at least 7 args, got " << arg_count << '\n';
+        return -1;
+    }
+
+    void* host_A = reinterpret_cast<void*>(args[0]);
+    void* host_B = reinterpret_cast<void*>(args[1]);
+    void* host_C = reinterpret_cast<void*>(args[2]);
+    size_t size_A = static_cast<size_t>(args[3]);
+    size_t size_B = static_cast<size_t>(args[4]);
+    size_t size_C = static_cast<size_t>(args[5]);
+
+    std::cout << "\n=== build_bgemm_graph ===" << '\n';
+    std::cout << "Grid: " << GRID_M << " x " << GRID_K << " x " << GRID_N << '\n';
+
+    // Allocate device memory and copy inputs
+    void* dev_A = runtime->host_api.device_malloc(size_A);
+    if (!dev_A) return -1;
+    runtime->host_api.copy_to_device(dev_A, host_A, size_A);
+
+    void* dev_B = runtime->host_api.device_malloc(size_B);
+    if (!dev_B) {
+        runtime->host_api.device_free(dev_A);
+        return -1;
+    }
+    runtime->host_api.copy_to_device(dev_B, host_B, size_B);
+
+    void* dev_C = runtime->host_api.device_malloc(size_C);
+    if (!dev_C) {
+        runtime->host_api.device_free(dev_A);
+        runtime->host_api.device_free(dev_B);
+        return -1;
+    }
+    runtime->host_api.copy_to_device(dev_C, host_C, size_C);
+    runtime->record_tensor_pair(host_C, dev_C, size_C);
+
+    // Allocate intermediate P buffers (one per C tile)
+    constexpr int NUM_P_BUFFERS = BATCH * GRID_M * GRID_N;
+    std::vector<void*> dev_P(NUM_P_BUFFERS, nullptr);
+    for (int i = 0; i < NUM_P_BUFFERS; i++) {
+        dev_P[i] = runtime->host_api.device_malloc(TILE_BYTES);
+        if (!dev_P[i]) {
+            for (int j = 0; j < i; j++) {
+                runtime->host_api.device_free(dev_P[j]);
+            }
+            runtime->host_api.device_free(dev_A);
+            runtime->host_api.device_free(dev_B);
+            runtime->host_api.device_free(dev_C);
+            return -1;
+        }
+    }
+
+    // Track last add task for each C tile (for K accumulation dependency)
+    std::vector<int> last_add_task(BATCH * GRID_M * GRID_N, -1);
+
+    // Build task graph: 4-level tiling loop
+    for (int batch = 0; batch < BATCH; batch++) {
+        for (int m_idx = 0; m_idx < GRID_M; m_idx++) {
+            for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
+                for (int k_idx = 0; k_idx < GRID_K; k_idx++) {
+                    // Calculate tile offsets
+                    size_t A_offset = (batch * GRID_M * GRID_K + m_idx * GRID_K + k_idx) * TILE_BYTES;
+                    size_t B_offset = (batch * GRID_K * GRID_N + k_idx * GRID_N + n_idx) * TILE_BYTES;
+                    size_t C_offset = (batch * GRID_M * GRID_N + m_idx * GRID_N + n_idx) * TILE_BYTES;
+
+                    int c_tile_idx = batch * GRID_M * GRID_N + m_idx * GRID_N + n_idx;
+
+                    // Task 1: P = A[m,k] @ B[k,n] (gemm_tile on Cube core)
+                    uint64_t args_gemm[6];
+                    args_gemm[0] = reinterpret_cast<uint64_t>(static_cast<char*>(dev_A) + A_offset);
+                    args_gemm[1] = reinterpret_cast<uint64_t>(static_cast<char*>(dev_B) + B_offset);
+                    args_gemm[2] = reinterpret_cast<uint64_t>(dev_P[c_tile_idx]);
+                    args_gemm[3] = TILE;
+                    args_gemm[4] = TILE;
+                    args_gemm[5] = TILE;
+                    int t_gemm = runtime->add_task(args_gemm, 6, 0, CoreType::AIC);
+
+                    // Task 2: C[m,n] = C[m,n] + P (tile_add on Vector core)
+                    uint64_t args_add[5];
+                    args_add[0] = reinterpret_cast<uint64_t>(static_cast<char*>(dev_C) + C_offset);
+                    args_add[1] = reinterpret_cast<uint64_t>(dev_P[c_tile_idx]);
+                    args_add[2] = reinterpret_cast<uint64_t>(static_cast<char*>(dev_C) + C_offset);
+                    args_add[3] = TILE;
+                    args_add[4] = TILE;
+                    int t_add = runtime->add_task(args_add, 5, 1, CoreType::AIV);
+
+                    // Dependency: gemm must complete before add
+                    runtime->add_successor(t_gemm, t_add);
+
+                    // Dependency: previous add must complete before current gemm (K accumulation)
+                    if (last_add_task[c_tile_idx] >= 0) {
+                        runtime->add_successor(last_add_task[c_tile_idx], t_gemm);
+                    }
+                    last_add_task[c_tile_idx] = t_add;
+                }
+            }
+        }
+    }
+
+    std::cout << "Created " << runtime->get_task_count() << " tasks\n";
+    return 0;
+}
+
+}  // extern "C"


### PR DESCRIPTION
  Add BGEMM (Batched General Matrix Multiplication) example demonstrating
  Cube (AIC) and Vector (AIV) core cooperation with tile-based computation.

  - Add examples/aicpu_build_graph/bgemm/
    - Task graph built on AICPU with AicpuBuildApi
    - Supports 4x4x4 grid with 64x64 tiles (256x256 matrices)

  - Add examples/host_build_graph/bgemm/
    - Same computation with host-side graph building

  - Both examples include:
    - golden.py: Test specification with tile-first memory layout
    - kernel_config.py: Runtime and kernel configuration
    - kernels/aic/kernel_gemm_tile.cpp: Cube core matmul kernel
    - kernels/aiv/kernel_tile_add.cpp: Vector core add kernel
    - kernels/orchestration/bgemm_orch.cpp: Task graph builder

  Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>