### PR TITLE
Refactor: pipeline AICPU dispatch with incremental task scanning

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -72,6 +72,11 @@ struct PTO2OrchestratorState {
     int64_t tasks_submitted;
     int64_t buffers_allocated;
     int64_t bytes_allocated;
+
+    // === AICPU PARALLEL MODE (set by aicpu_executor, NULL when unused) ===
+    int32_t* aicpu_fanin_refcount;
+    volatile int32_t* aicpu_task_completed;
+    int32_t aicpu_window_mask;
 };
 
 // =============================================================================

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -27,13 +27,13 @@ ATOL = 1e-3
 # All test cases - production scale
 ALL_CASES = {
     "Case1": {
-        "batch": 2,
+        "batch": 16,
         "num_heads": 16,
         "kv_head_num": 1,
         "head_dim": 128,
         "block_size": 128,
-        "context_len": 2048,
-        "max_model_len": 4096,
+        "context_len": 8192,
+        "max_model_len": 32768,
     },
     "Case2": {
         "batch": 64,


### PR DESCRIPTION
Replace batch ready-queue init with incremental scan driven by current_task_index, add readiness scan for orchestrator early-return path, and wire aicpu_fanin_refcount/task_completed into orchestrator so producer completion is visible across threads. Scale PA Case1 to production parameters.