### PR TITLE
Add: BGEMM example for tensormap_and_ringbuffer runtime

### DIFF
--- a/examples/tensormap_and_ringbuffer/bgemm/golden.py
+++ b/examples/tensormap_and_ringbuffer/bgemm/golden.py
@@ -1,0 +1,59 @@
+"""
+Golden test specification for BGEMM (tensormap_and_ringbuffer Runtime).
+
+Computation: C = A @ B (tiled matrix multiplication)
+Configuration: 4x4x4 grid, 64x64 tiles
+"""
+
+import torch
+
+__outputs__ = ["C"]
+TENSOR_ORDER = ["A", "B", "C"]
+RTOL = 1e-3
+ATOL = 1e-3
+
+TILE_M = 64
+TILE_K = 64
+TILE_N = 64
+
+GRID_M = 4
+GRID_K = 4
+GRID_N = 4
+BATCH = 2
+
+M = TILE_M * GRID_M
+K = TILE_K * GRID_K
+N = TILE_N * GRID_N
+
+
+def generate_inputs(params: dict) -> dict:
+    """Generate input tensors with tile-first memory layout."""
+    A = torch.randn(BATCH, GRID_M, GRID_K, TILE_M, TILE_K, dtype=torch.float32) * 0.01
+    B = torch.randn(BATCH, GRID_K, GRID_N, TILE_K, TILE_N, dtype=torch.float32) * 0.01
+    C = torch.zeros(BATCH, GRID_M, GRID_N, TILE_M, TILE_N, dtype=torch.float32)
+
+    return {
+        "A": A.flatten(),
+        "B": B.flatten(),
+        "C": C.flatten(),
+    }
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute golden result: C[m,n] = sum(k) A[m,k] @ B[k,n]."""
+    A = torch.as_tensor(tensors["A"]).reshape(BATCH, GRID_M, GRID_K, TILE_M, TILE_K)
+    B = torch.as_tensor(tensors["B"]).reshape(BATCH, GRID_K, GRID_N, TILE_K, TILE_N)
+    C = torch.as_tensor(tensors["C"]).reshape(BATCH, GRID_M, GRID_N, TILE_M, TILE_N)
+
+    C[:] = 0.0
+
+    for batch in range(BATCH):
+        for m_idx in range(GRID_M):
+            for n_idx in range(GRID_N):
+                for k_idx in range(GRID_K):
+                    C[batch, m_idx, n_idx] += torch.matmul(
+                        A[batch, m_idx, k_idx],
+                        B[batch, k_idx, n_idx]
+                    )
+
+    tensors["C"][:] = C.flatten()

--- a/examples/tensormap_and_ringbuffer/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/tensormap_and_ringbuffer/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -1,0 +1,109 @@
+/**
+ * Tile-based Matrix Multiplication Kernel (Cube Core)
+ *
+ * Computes: output = input_a @ input_b (64x64 tile matmul)
+ * Uses TMATMUL instruction
+ *
+ * Args (Tensor*):
+ *   args[0] = input_a (INPUT)
+ *   args[1] = input_b (INPUT)
+ *   args[2] = output  (OUTPUT)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <typename T>
+AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
+    if (num_2 == 0) {
+        return 0;
+    }
+    return (num_1 + num_2 - 1) / num_2 * num_2;
+}
+
+static __aicore__ void gemm_tile_impl(
+    __gm__ Tensor* input_a_tensor,
+    __gm__ Tensor* input_b_tensor,
+    __gm__ Tensor* output_tensor) {
+
+    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
+    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
+    __gm__ float* output  = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr)  + output_tensor->start_offset;
+
+    constexpr int TILE = 64;
+    constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
+    constexpr int M = CeilAlign<int>(TILE, 16);
+    constexpr int K = CeilAlign<int>(TILE, blockAlign);
+    constexpr int N = CeilAlign<int>(TILE, blockAlign);
+
+    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+
+    GlobalDataA src0Global(input_a);
+    GlobalDataB src1Global(input_b);
+    GlobalDataC dstGlobal(output);
+
+    using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+
+    using LeftTile = TileLeft<float, M, K, TILE, TILE>;
+    using RightTile = TileRight<float, K, N, TILE, TILE>;
+    using AccTile = TileAcc<float, M, N, TILE, TILE>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    TLOAD(aMatTile, src0Global);
+    TLOAD(bMatTile, src1Global);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(dstGlobal, cTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* input_a = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* input_b = reinterpret_cast<__gm__ Tensor*>(args[1]);
+    __gm__ Tensor* output  = reinterpret_cast<__gm__ Tensor*>(args[2]);
+
+    gemm_tile_impl(input_a, input_b, output);
+}

--- a/examples/tensormap_and_ringbuffer/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/tensormap_and_ringbuffer/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -1,0 +1,61 @@
+/**
+ * Tile-based Element-wise Addition Kernel (Vector Core) - INOUT Pattern
+ *
+ * Computes: C_tile = C_tile + P (64x64 tile accumulation)
+ * Uses TADD instruction
+ *
+ * Args (Tensor*):
+ *   args[0] = C_tile (INOUT: read + write accumulator)
+ *   args[1] = P      (INPUT: matmul result to accumulate)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* c_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* p_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
+
+    __gm__ float* c_ptr = reinterpret_cast<__gm__ float*>(c_tensor->buffer.addr) + c_tensor->start_offset;
+    __gm__ float* p_ptr = reinterpret_cast<__gm__ float*>(p_tensor->buffer.addr) + p_tensor->start_offset;
+
+    constexpr int TILE = 64;
+
+    using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
+    using DynStridDim5 = Stride<1, 1, 1, TILE, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, TILE, TILE, BLayout::RowMajor, -1, -1>;
+
+    TileData cTile(TILE, TILE);
+    TileData pTile(TILE, TILE);
+    TileData outTile(TILE, TILE);
+    TASSIGN(cTile, 0x0);
+    TASSIGN(pTile, 0x10000);
+    TASSIGN(outTile, 0x20000);
+
+    GlobalData cGlobal(c_ptr);
+    GlobalData pGlobal(p_ptr);
+    GlobalData outGlobal(c_ptr);  // write back to same C location
+
+    TLOAD(cTile, cGlobal);
+    TLOAD(pTile, pGlobal);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(outTile, cTile, pTile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(outGlobal, outTile);
+}

--- a/examples/tensormap_and_ringbuffer/bgemm/kernels/kernel_config.py
+++ b/examples/tensormap_and_ringbuffer/bgemm/kernels/kernel_config.py
@@ -1,0 +1,35 @@
+"""
+Kernel configuration for BGEMM (tensormap_and_ringbuffer Runtime).
+
+Cube core (AIC) for matrix multiplication, Vector core (AIV) for element-wise addition.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "bgemm_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "GEMM",
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_gemm_tile.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "ADD",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_tile_add.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 3,
+}

--- a/examples/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -1,0 +1,134 @@
+/**
+ * BGEMM Orchestration Function (tensormap_and_ringbuffer Runtime)
+ *
+ * Builds the task graph for tiled matrix multiplication: C = A @ B
+ *
+ * Configuration:
+ *   - Tile size: 64 x 64
+ *   - Grid: 4 x 4 x 4 (GRID_M x GRID_K x GRID_N)
+ *   - Batch: 2
+ *
+ * Memory layout (tile-first, 5D flattened):
+ *   A: [BATCH, GRID_M, GRID_K, TILE, TILE]
+ *   B: [BATCH, GRID_K, GRID_N, TILE, TILE]
+ *   C: [BATCH, GRID_M, GRID_N, TILE, TILE]
+ *
+ * Task graph per output tile C[batch, m, n]:
+ *   for k in [0, GRID_K):
+ *     P = A[m,k] @ B[k,n]    (gemm_tile on Cube core, func_id=0)
+ *     C[m,n] = C[m,n] + P    (tile_add on Vector core, func_id=1)
+ *
+ * Dependencies are automatic via TensorMap overlap detection.
+ *
+ * This file compiles as a standalone .so with zero runtime link dependencies.
+ * All runtime calls go through the PTO2RuntimeOps function-pointer table.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_GEMM_TILE 0
+#define FUNC_TILE_ADD  1
+
+// Grid and tile constants
+static constexpr int TILE = 64;
+static constexpr int GRID_M = 4;
+static constexpr int GRID_K = 4;
+static constexpr int GRID_N = 4;
+static constexpr int BATCH = 2;
+
+static constexpr uint64_t TILE_ELEMS = TILE * TILE;           // 4096 elements
+static constexpr uint64_t TILE_BYTES = TILE_ELEMS * sizeof(float);  // 16384 bytes
+
+// Args layout: [ptr_A, ptr_B, ptr_C, size_A, size_B, size_C, elem_count]
+#define ARG_PTR_A   0
+#define ARG_PTR_B   1
+#define ARG_PTR_C   2
+#define ARG_SIZE_A  3
+#define ARG_SIZE_B  4
+#define ARG_SIZE_C  5
+
+extern "C" {
+
+__attribute__((visibility("default")))
+PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count) {
+    (void)args;
+    (void)arg_count;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 7,
+    };
+}
+
+__attribute__((visibility("default")))
+void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
+    (void)arg_count;
+
+    void* dev_A = (void*)(uintptr_t)args[ARG_PTR_A];
+    void* dev_B = (void*)(uintptr_t)args[ARG_PTR_B];
+    void* dev_C = (void*)(uintptr_t)args[ARG_PTR_C];
+    size_t size_A = (size_t)args[ARG_SIZE_A];
+    size_t size_B = (size_t)args[ARG_SIZE_B];
+    size_t size_C = (size_t)args[ARG_SIZE_C];
+
+    printf("[bgemm_orch] Grid: %dx%dx%d, Batch: %d, Tile: %d\n",
+           GRID_M, GRID_K, GRID_N, BATCH, TILE);
+
+    // Create 1D external tensors for the full A, B, C arrays
+    Tensor ext_A = make_tensor_external(dev_A, size_A);
+    Tensor ext_B = make_tensor_external(dev_B, size_B);
+    Tensor ext_C = make_tensor_external(dev_C, size_C);
+
+    for (int batch = 0; batch < BATCH; batch++) {
+        for (int m_idx = 0; m_idx < GRID_M; m_idx++) {
+            for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
+                PTO2_SCOPE(rt) {
+                    uint64_t c_elem_offset =
+                        ((uint64_t)batch * GRID_M * GRID_N +
+                         (uint64_t)m_idx * GRID_N +
+                         (uint64_t)n_idx) * TILE_ELEMS;
+                    Tensor C_view = ext_C.view({TILE_ELEMS}, {c_elem_offset});
+
+                    for (int k_idx = 0; k_idx < GRID_K; k_idx++) {
+                        uint64_t a_elem_offset =
+                            ((uint64_t)batch * GRID_M * GRID_K +
+                             (uint64_t)m_idx * GRID_K +
+                             (uint64_t)k_idx) * TILE_ELEMS;
+                        uint64_t b_elem_offset =
+                            ((uint64_t)batch * GRID_K * GRID_N +
+                             (uint64_t)k_idx * GRID_N +
+                             (uint64_t)n_idx) * TILE_ELEMS;
+
+                        Tensor A_view = ext_A.view({TILE_ELEMS}, {a_elem_offset});
+                        Tensor B_view = ext_B.view({TILE_ELEMS}, {b_elem_offset});
+                        Tensor P = make_tensor(TILE_BYTES);
+
+                        // P = A[m,k] @ B[k,n]
+                        PTOParam params_gemm[] = {
+                            make_input_param(A_view),
+                            make_input_param(B_view),
+                            make_output_param(P),
+                        };
+                        pto2_rt_submit_task(rt, FUNC_GEMM_TILE, PTO2_WORKER_CUBE,
+                                           "gemm", params_gemm, 3);
+
+                        // C[m,n] += P
+                        PTOParam params_add[] = {
+                            make_inout_param(C_view),
+                            make_input_param(P),
+                        };
+                        pto2_rt_submit_task(rt, FUNC_TILE_ADD, PTO2_WORKER_VECTOR,
+                                           "add", params_add, 2);
+                    }
+                }
+            }
+        }
+    }
+
+    printf("[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each\n",
+           BATCH, GRID_M, GRID_N, GRID_K);
+}
+
+}  // extern "C"


### PR DESCRIPTION
Add BGEMM (Batched General Matrix Multiplication) example demonstrating
Cube (AIC) and Vector (AIV) core cooperation with tile-based computation
using the tensormap_and_ringbuffer runtime.

Add examples/tensormap_and_ringbuffer/bgemm/

- Task dependencies resolved automatically via TensorMap overlap detection
- Supports 4x4x4 grid with 64x64 tiles (256x256 matrices, batch=2)

Example includes:

- golden.py: Test specification with tile-first 5D memory layout
- kernel_config.py: Runtime and kernel configuration
- kernels/aic/kernel_gemm_tile.cpp: Cube core matmul kernel (TMATMUL)
- kernels/aiv/kernel_tile_add.cpp: Vector core accumulation kernel (TADD)
- kernels/orchestration/bgemm_orch.cpp: Task graph builder

Closes #84