### PR TITLE
Fix: add partial block masking to paged attention softmax

### DIFF
--- a/examples/tensormap_and_ringbuffer/paged_attention/TFILLPAD_INPLACE_BUG.md
+++ b/examples/tensormap_and_ringbuffer/paged_attention/TFILLPAD_INPLACE_BUG.md
@@ -1,0 +1,205 @@
+# TFILLPAD_INPLACE Bug at Small Tile Width (N ≤ 16)
+
+## Summary
+
+`TFILLPAD_INPLACE` produces incorrect padding results on Ascend A2/A3 hardware when
+the tile column count `N` is small (e.g. N=16 for float32). The bug manifests as
+corrupted data in the padded region for certain `valid_len` values, causing downstream
+softmax and attention computations to produce wrong results.
+
+## Affected Configuration
+
+- **Platform**: Ascend A2/A3 (tested on hardware, also reproduces on simulator)
+- **Data type**: float32 (sizeof=4)
+- **Tile shape**: (M, N) = (16, 16) — i.e. 2 × 32-byte blocks per row
+- **PTO source**: `include/pto/npu/a2a3/TFillPad.hpp`
+
+The bug does NOT reproduce at larger N values (N=32, 64, 128) where the same
+`valid_len` values work correctly.
+
+## Reproduction
+
+In the paged attention example (`examples/tensormap_and_ringbuffer/paged_attention/`),
+the softmax preparation kernel uses `TFILLPAD_INPLACE` to mask invalid key positions
+with `-inf` before computing softmax:
+
+```cpp
+// Tile types
+using TileSijDyn = Tile<TileType::Vec, float, 16, 16, BLayout::RowMajor, 16, -1>;
+using TileSijPad = Tile<TileType::Vec, float, 16, 16, BLayout::RowMajor, 16, 16,
+                        SLayout::NoneBox, 512, PadValue::Min>;
+
+TileSijDyn sijDynTile(valid_len);  // valid_len = number of valid columns
+TileSijPad sijPadTile;
+// Both assigned to same UB address (in-place)
+TASSIGN(sijDynTile, 0x0);
+TASSIGN(sijPadTile, 0x0);
+
+// After loading sij from GM:
+TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+// Expected: columns [valid_len, 16) filled with -inf (0xff800000)
+// Actual:   corrupted for certain valid_len values
+```
+
+### Test Matrix (N=16, float32, on hardware)
+
+| valid_len | context_len | blocks | TFILLPAD_INPLACE only | SetValue only | TFILLPAD + SetValue |
+|-----------|-------------|--------|-----------------------|---------------|---------------------|
+| 1         | 17          | 2      | FAIL (27/256)         | PASS          | PASS                |
+| 7         | 23          | 2      | FAIL (29/256)         | PASS          | PASS                |
+| 8         | 24          | 2      | FAIL (28/256)         | FAIL (182/256)| PASS                |
+| 9         | 25          | 2      | PASS                  | PASS          | PASS                |
+| 12        | 28          | 2      | PASS                  | PASS          | PASS                |
+| 15        | 31          | 2      | PASS                  | PASS          | PASS                |
+| 16 (full) | 32          | 2      | PASS                  | PASS          | PASS                |
+| 1         | 33          | 3      | FAIL (25/256)         | FAIL (88/256) | PASS                |
+
+### Cross-dimension validation (confirming N=16 is the trigger)
+
+| num_heads | head_dim | block_size (=N) | context_len | valid_len | Result |
+|-----------|----------|-----------------|-------------|-----------|--------|
+| 16        | 16       | **16**          | 33          | 1         | FAIL   |
+| 16        | 16       | **32**          | 33          | 1         | PASS   |
+| 16        | **32**   | **16**          | 33          | 1         | FAIL   |
+
+block_size determines N in the softmax tile (M, N). When block_size=32 (N=32),
+the same valid_len=1 passes. When block_size=16 (N=16), it fails regardless of
+head_dim.
+
+## Root Cause Analysis
+
+The bug is in the `TFillPad` function in `include/pto/npu/a2a3/TFillPad.hpp`.
+The function has two internal code paths for filling padding:
+
+### Path A: `Handle32BAlignedPad_Other` (lines 103-134)
+
+Fills the **partial 32-byte block** at the boundary using `vector_dup` with a
+norm-mode bitmask. This path is reliable.
+
+### Path B: `PadRightSingleRow` + `PadRightRemainingRows` (lines 136-167)
+
+Fills **complete 32-byte blocks** to the right of the boundary. Uses `vector_dup`
+for row 0, then `vcopy` with `srcRepeatStride=0` (broadcast) to replicate to
+remaining rows. **This path has the bug.**
+
+### Which path runs depends on `valid_len`
+
+The key variable is `srcValidCol32B` — the valid_len rounded up to the next
+32-byte-aligned element count:
+
+```
+elements_per_block = 32 / sizeof(float) = 8
+srcValidCol32B = ceil(valid_len / 8) * 8
+padOffset = srcValidCol32B
+padCols = N - srcValidCol32B        // columns for Path B
+pad_32B = srcValidCol32B - valid_len // columns for Path A
+```
+
+For N=16 (2 blocks of 8 elements each):
+
+```
+valid_len ∈ [1, 8]:
+    srcValidCol32B = 8
+    padOffset = 8,  padCols = 8   → Path B runs (fills block 1)
+    pad_32B = 8 - valid_len       → Path A runs if valid_len < 8
+
+valid_len ∈ [9, 15]:
+    srcValidCol32B = 16
+    padOffset = 16, padCols = 0   → Path B is a NO-OP
+    pad_32B = 16 - valid_len      → Path A runs (fills within block 1)
+
+valid_len = 16:
+    No padding needed (full block)
+```
+
+**Pattern: valid_len ≤ 8 → Path B runs → BUG. valid_len ≥ 9 → only Path A → OK.**
+
+### Path B code trace (the buggy path)
+
+```cpp
+// PadRightSingleRow: fill row 0's right padding
+set_mask_count();
+set_vector_mask(0, padCols);  // padCols = 8
+vector_dup(dstPtr + padOffset, dupPadValue, 1, 1, 1, 8, 0);
+//         ^-- dstPtr + 8 (element 8 of row 0)
+pipe_barrier(PIPE_V);
+
+// PadRightRemainingRows: broadcast row 0's pattern to rows 1..M-1
+dstRepeatStride = N * sizeof(float) / 32;  // = 16 * 4 / 32 = 2
+_dstPtr = dstPtr + padOffset + copyDstCols; // = dstPtr + 8 + 16 = dstPtr + 24
+fillRow = M - 1;  // = 15
+
+vcopy(_dstPtr, dstPtr + padOffset, 15, 1, 0, 2, 0);
+//    dst       src                rep  dB sB dR sR
+//    row1:8    row0:8             15   1  0  2  0
+//
+// dstRepeatStride=2 (64 bytes = 1 row), srcRepeatStride=0 (broadcast)
+// mask: counter mode, 8 elements (inherited from PadRightSingleRow)
+```
+
+The `vcopy` with `srcRepeatStride=0` and `dstRepeatStride=2` at N=16 appears to
+produce incorrect results on hardware. The exact hardware failure mode is unclear,
+but it consistently corrupts the padding data.
+
+### Why valid_len=8 is special
+
+When `valid_len=8`:
+- `pad_32B = 8 - 8 = 0` → Path A computes `mask = 0xff >> 8 << 8 = 0`
+- `set_vector_mask(0, 0)` is called, then `vector_dup` with zero mask
+- This is effectively a no-op, but may have undefined behavior on hardware
+- Path B still runs and produces incorrect results
+- Additionally, `SetValue`-only workaround also fails for valid_len=8,
+  suggesting the zero-mask `vector_dup` in Path A corrupts pipeline state
+
+## Workaround
+
+The working fix uses **both** `TFILLPAD_INPLACE` and scalar `SetValue` writes:
+
+```cpp
+// Step 1: TFILLPAD_INPLACE sets up vector pipeline state correctly
+//         (mask modes, barriers, etc.) even though its data output is buggy
+TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+
+// Step 2: SetValue patches the actual data with correct -inf values
+if (valid_len < static_cast<uint64_t>(N)) {
+    constexpr float NEG_INF = -__builtin_huge_valf();
+    for (int r = 0; r < M; r++) {
+        for (uint64_t c = valid_len; c < N; c++) {
+            sijTile.SetValue(static_cast<uint32_t>(r * N + c), NEG_INF);
+        }
+    }
+}
+```
+
+**Why both are needed:**
+
+| Approach               | valid_len=1 | valid_len=7 | valid_len=8 |
+|------------------------|-------------|-------------|-------------|
+| TFILLPAD_INPLACE only  | FAIL        | FAIL        | FAIL        |
+| SetValue only          | PASS        | PASS        | FAIL        |
+| TFILLPAD + SetValue    | PASS        | PASS        | PASS        |
+
+- `TFILLPAD_INPLACE` alone: Path B produces wrong data
+- `SetValue` alone: works for most cases, but valid_len=8 fails because
+  Path A's zero-mask `vector_dup` (which runs before SetValue in the
+  TFILLPAD-only case) apparently sets up necessary pipeline state that
+  subsequent vector operations depend on
+- Both together: TFILLPAD handles pipeline state, SetValue fixes the data
+
+## Scope
+
+- **Affected**: Any `TFILLPAD_INPLACE` call with float32 tiles where
+  `N ≤ 16` and `valid_len ≤ N/2` (i.e. valid data fits within the first
+  32-byte block of each row)
+- **Not affected**: N ≥ 32 (tested with N=32, 64, 128 — all pass)
+- **Not affected**: Full tiles (valid_len == N)
+- **Likely affected**: float16/bfloat16 tiles with N ≤ 32 (untested, but
+  the same code path would be triggered since elements_per_block=16 for
+  16-bit types, and the same vcopy broadcast pattern is used)
+
+## Files
+
+- Bug location: `include/pto/npu/a2a3/TFillPad.hpp`, functions
+  `PadRightSingleRow` (line 136) and `PadRightRemainingRows` (line 146)
+- Workaround applied in: `examples/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp`
+- Test configuration: `examples/tensormap_and_ringbuffer/paged_attention/golden.py`

--- a/examples/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -21,8 +21,7 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-constexpr int M = 16, K = 16, N = 16;
-
+template <int M, int K, int N>
 static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __gm__ Tensor* oi) {
     __gm__ half* pij_addr = reinterpret_cast<__gm__ half*>(pij->buffer.addr);
     __gm__ half* vj_addr = reinterpret_cast<__gm__ half*>(vj->buffer.addr);
@@ -86,5 +85,5 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* vj = reinterpret_cast<__gm__ Tensor*>(args[1]);
     __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
 
-    pv_matmul_impl(pij, vj, oi_new);
+    pv_matmul_impl<16, 16, 16>(pij, vj, oi_new);
 }

--- a/examples/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -21,8 +21,7 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-constexpr int M = 16, K = 16, N = 16;
-
+template <int M, int K, int N>
 static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm__ Tensor* sij) {
     __gm__ half* qi_addr = reinterpret_cast<__gm__ half*>(qi->buffer.addr);
     __gm__ half* kj_addr = reinterpret_cast<__gm__ half*>(kj->buffer.addr);
@@ -87,5 +86,5 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* kj = reinterpret_cast<__gm__ Tensor*>(args[1]);
     __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[2]);
 
-    qk_matmul_impl(qi, kj, sij);
+    qk_matmul_impl<16, 16, 16>(qi, kj, sij);
 }

--- a/examples/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -23,8 +23,7 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-constexpr int M = 16, N = 16;
-
+template <int M, int N>
 static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     __gm__ Tensor* lij,
     __gm__ Tensor* oi_new,
@@ -231,5 +230,5 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
 
-    online_update_impl(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    online_update_impl<16, 16>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
 }

--- a/examples/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,9 +1,18 @@
-// Softmax Preparation Kernel (AIV)
+// Softmax Preparation Kernel (AIV) with partial block masking
 //
 // Fixed tile size: sij is (16, 16)
 //
+// For partial blocks (valid_len < N), positions [valid_len, N) in sij are
+// filled with -inf before softmax, ensuring exp(-inf)=0 so that invalid
+// key positions contribute zero attention weight.
+//
+// Uses TFILLPAD_INPLACE for vector pipeline state setup, then patches with
+// scalar SetValue writes to fix a hardware bug in TFILLPAD's vcopy broadcast
+// path at small N (N=16).
+//
 // Computes:
-//   sij_scale = sij * scale
+//   sij_masked = pad(sij, valid_len, -inf)
+//   sij_scale = sij_masked * scale
 //   mij = row_max(sij_scale)        -> (M, 1)
 //   pij = exp(sij_scale - mij)      -> (M, N)
 //   lij = row_sum(pij)              -> (M, 1)
@@ -23,13 +32,13 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-constexpr int M = 16, N = 16;
-
+template <int M, int N>
 static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     float scale_value,
     __gm__ Tensor* pij,
     __gm__ Tensor* mij,
     __gm__ Tensor* lij) {
+    uint64_t valid_len = static_cast<uint64_t>(sij->repeats[1]);
     __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
     __gm__ half* pij_addr = reinterpret_cast<__gm__ half*>(pij->buffer.addr);
     __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
@@ -46,11 +55,18 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     GlobalScalarDN mijGlobal(mij_addr + mij->start_offset);
     GlobalScalarDN lijGlobal(lij_addr + lij->start_offset);
 
+    // Dynamic-cols tile: marks which columns are valid for TFILLPAD boundary
+    using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
+    // Padded tile: TFILLPAD_INPLACE fills positions [valid_len, N) with -inf
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N, SLayout::NoneBox, 512, PadValue::Min>;
+
     using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
     using TileVecMxN_f16 = Tile<TileType::Vec, half, M, N, BLayout::RowMajor, M, N>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     TileVecMxN sijTile;
+    TileSijDyn sijDynTile(static_cast<size_t>(valid_len));
+    TileSijPad sijPadTile;
     TileVecMxN pijTile;
     TileVecMxN tmpTile;
     TileScalarDN maxTile;
@@ -58,19 +74,40 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     TileVecMxN_f16 pijF16Tile;
 
     TASSIGN(sijTile, 0x0);
+    TASSIGN(sijDynTile, 0x0);
+    TASSIGN(sijPadTile, 0x0);
     TASSIGN(pijTile, M * N * sizeof(float));
     TASSIGN(tmpTile, 2 * M * N * sizeof(float));
     TASSIGN(maxTile, 3 * M * N * sizeof(float));
     TASSIGN(sumTile, 3 * M * N * sizeof(float) + kAlignedRows * sizeof(float));
     TASSIGN(pijF16Tile, 3 * M * N * sizeof(float) + 2 * kAlignedRows * sizeof(float));
 
+    // Load full sij (M, N) tile from GM - all N columns including garbage for partial blocks
     TLOAD(sijTile, sijGlobal);
     set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
     wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
+    // Mask columns [valid_len, N) with -inf.
+    // Use TFILLPAD_INPLACE for the main fill, then patch with SetValue for
+    // cases where TFILLPAD's vcopy broadcast path fails at small N.
+    TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+    // Patch: SetValue ensures correctness for valid_len <= N/2 where
+    // TFILLPAD's PadRightRemainingRows vcopy has a hardware issue.
+    if (valid_len < static_cast<uint64_t>(N)) {
+        constexpr float NEG_INF = -__builtin_huge_valf();
+        for (int r = 0; r < M; r++) {
+            for (uint64_t c = valid_len; c < N; c++) {
+                sijTile.SetValue(static_cast<uint32_t>(r * N + c), NEG_INF);
+            }
+        }
+    }
+
     TMULS(sijTile, sijTile, scale_value);
+    pipe_barrier(PIPE_V);
     TROWMAX(maxTile, sijTile, tmpTile);
+    pipe_barrier(PIPE_V);
     TROWEXPANDSUB(pijTile, sijTile, maxTile);
+    pipe_barrier(PIPE_V);
     TEXP(pijTile, pijTile);
     // Truncate pij to fp16 first, then compute lij from truncated values (matches golden)
     TCVT(pijF16Tile, pijTile, RoundMode::CAST_ROUND);
@@ -96,5 +133,5 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[3]);
     __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[4]);
 
-    softmax_prepare_impl(sij, scale_value, pij, mij, lij);
+    softmax_prepare_impl<16, 16>(sij, scale_value, pij, mij, lij);
 }

--- a/examples/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -135,10 +135,10 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                     Tensor qi = query.view({q_tile, head_dim}, {cur_offset, 0});
                     uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
                     uint64_t valid_len = block_size < (cur_seq - bn * block_size) ? block_size : (cur_seq - bn * block_size);
-                    Tensor kj = key_cache.view({valid_len, head_dim}, {cur_block_idx * block_size, 0});
-                    Tensor vj = value_cache.view({valid_len, head_dim}, {cur_block_idx * block_size, 0});
+                    Tensor kj = key_cache.view({block_size, head_dim}, {cur_block_idx * block_size, 0});
+                    Tensor vj = value_cache.view({block_size, head_dim}, {cur_block_idx * block_size, 0});
 
-                    uint64_t sij_shapes[2] = {q_tile, valid_len};
+                    uint64_t sij_shapes[2] = {q_tile, block_size};
                     Tensor sij = make_tensor(sij_shapes, 2, DataType::FLOAT32);
                     Tensor pij_f16 = make_tensor(sij_shapes, 2, data_type);
 
@@ -149,10 +149,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                     };
                     pto2_rt_submit_task(rt, FUNC_QK_MATMUL, PTO2_WORKER_CUBE, "c1", params_qk, 3);
 
+                    Tensor sij_valid = sij.view({q_tile, valid_len}, {0, 0});
                     Tensor li = make_tensor(li_shapes, 1, DataType::FLOAT32);
                     Tensor mi = make_tensor(mi_shapes, 1, DataType::FLOAT32);
                     PTOParam params_sf[] = {
-                        make_input_param(sij),
+                        make_input_param(sij_valid),
                         make_scalar_param(float_to_u64(scale_value)),
                         make_output_param(pij_f16),
                         make_output_param(mi),


### PR DESCRIPTION
Add -inf masking for invalid key positions in partial blocks by using TFILLPAD_INPLACE + scalar SetValue workaround for a hardware bug in TFILLPAD's vcopy broadcast path at small tile width (N=16). Pass valid_len through sij tensor view so softmax_prepare can apply the mask.

- Templatize M/N/K in AIC/AIV kernels replacing module-level constexpr
- Always load full block_size K/V tiles; convey valid_len via sij view
- Add pipe_barrier calls between dependent vector ops in softmax_prepare
- Update golden.py test cases to exercise partial blocks (context_len=33,128)
- Add TFILLPAD_INPLACE_BUG.md documenting the hardware bug and workaround