### PR TITLE
Refactor: modularize performance collector into platform host/aicpu/aicore components

### DIFF
--- a/src/platform/a2a3/aicore/inner_kernel.h
+++ b/src/platform/a2a3/aicore/inner_kernel.h
@@ -65,4 +65,17 @@ __aicore__ inline uint32_t get_physical_core_id() {
     return static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK;
 }
 
+// =============================================================================
+// System Counter
+// =============================================================================
+
+/**
+ * Get AICore system counter
+ *
+ * @return Hardware counter value (ticks)
+ */
+__aicore__ __attribute__((always_inline)) inline uint64_t get_sys_cnt_aicore() {
+    return get_sys_cnt();
+}
+
 #endif  // PLATFORM_A2A3_AICORE_INNER_KERNEL_H_

--- a/src/platform/a2a3/host/CMakeLists.txt
+++ b/src/platform/a2a3/host/CMakeLists.txt
@@ -27,7 +27,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/host_log.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/unified_log_host.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/performance_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/performance_collector.cpp"
 )
 if(DEFINED CUSTOM_SOURCE_DIRS)
     foreach(SRC_DIR ${CUSTOM_SOURCE_DIRS})

--- a/src/platform/a2a3sim/aicore/inner_kernel.h
+++ b/src/platform/a2a3sim/aicore/inner_kernel.h
@@ -20,7 +20,8 @@
 #endif
 
 // dcci (Data Cache Clean and Invalidate) - no-op in simulation
-#define dcci(addr, mode, opt) ((void)0)
+// Use variadic macro to support both 2-arg and 3-arg calls
+#define dcci(...) ((void)0)
 
 // Cache coherency constants (no-op in simulation)
 #define ENTIRE_DATA_CACHE 0
@@ -36,21 +37,17 @@
 // =============================================================================
 
 /**
- * Simulated system counter for performance profiling
+ * Get simulated AICore system counter
  *
- * Returns monotonic counter value at 1850 MHz frequency.
- * Uses std::chrono::high_resolution_clock and converts to counter ticks.
- *
- * @return Simulated counter value (ticks since epoch)
+ * @return Simulated counter value (ticks)
  */
-inline uint64_t get_sys_cnt() {
+inline uint64_t get_sys_cnt_aicore() {
     auto now = std::chrono::high_resolution_clock::now();
     uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
         now.time_since_epoch()
     ).count();
 
-    // Convert nanoseconds to counter ticks at PLATFORM_PROF_SYS_CNT_FREQ
-    // Split elapsed_ns into seconds and remainder to avoid overflow
+    // Convert nanoseconds to counter ticks
     constexpr uint64_t kNsPerSec = std::nano::den;
     uint64_t seconds = elapsed_ns / kNsPerSec;
     uint64_t remaining_ns = elapsed_ns % kNsPerSec;

--- a/src/platform/a2a3sim/host/CMakeLists.txt
+++ b/src/platform/a2a3sim/host/CMakeLists.txt
@@ -31,7 +31,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/host_log.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/unified_log_host.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/performance_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/performance_collector.cpp"
 )
 
 if(DEFINED CUSTOM_SOURCE_DIRS)

--- a/src/platform/include/aicore/performance_collector_aicore.h
+++ b/src/platform/include/aicore/performance_collector_aicore.h
@@ -1,0 +1,76 @@
+/**
+ * @file performance_collector_aicore.h
+ * @brief AICore performance data collection interface
+ *
+ * Provides lightweight performance recording interface for AICore kernels.
+ * Uses dcci for efficient cache management instead of memory barriers.
+ */
+
+#ifndef PLATFORM_AICORE_PERFORMANCE_COLLECTOR_AICORE_H_
+#define PLATFORM_AICORE_PERFORMANCE_COLLECTOR_AICORE_H_
+
+#include "common/perf_profiling.h"
+#include "aicore/aicore.h"
+
+// Include platform-specific timestamp implementation
+// Build system selects the correct inner_kernel.h based on platform:
+// - src/platform/a2a3/aicore/inner_kernel.h (real hardware)
+// - src/platform/a2a3sim/aicore/inner_kernel.h (simulation)
+// Both provide unified get_sys_cnt_aicore() interface
+#include "inner_kernel.h"
+
+// ============= Public Interface =============
+
+/**
+ * Record task execution performance data
+ *
+ * Writes performance metrics to the provided buffer. Buffer management
+ * and status tracking are handled by AICPU.
+ *
+ * @param perf_buf Performance buffer pointer
+ * @param task_id Task ID
+ * @param func_id Function ID
+ * @param start_time Start timestamp
+ * @param end_time End timestamp
+ * @param kernel_ready_time Kernel ready timestamp
+ * @param core_id Core ID
+ * @param core_type Core type (AIC/AIV)
+ */
+__aicore__ __attribute__((always_inline))
+static inline void perf_aicore_record_task(
+    __gm__ PerfBuffer* perf_buf,
+    uint32_t task_id,
+    uint32_t func_id,
+    uint64_t start_time,
+    uint64_t end_time,
+    uint64_t kernel_ready_time,
+    int core_id,
+    CoreType core_type) {
+
+    // Read current buffer count
+    dcci(&perf_buf->count, SINGLE_CACHE_LINE);
+    uint32_t idx = perf_buf->count;
+
+    if (idx >= PLATFORM_PROF_BUFFER_SIZE) {
+        return;
+    }
+
+    __gm__ PerfRecord* record = &perf_buf->records[idx];
+
+    // Write record data
+    record->start_time = start_time;
+    record->end_time = end_time;
+    record->kernel_ready_time = kernel_ready_time;
+    record->task_id = task_id;
+    record->func_id = func_id;
+    record->core_id = core_id;
+    record->core_type = core_type;
+
+    perf_buf->count = idx + 1;
+
+    // Flush cache to make data visible
+    dcci(&perf_buf->count, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    dcci(record, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+}
+
+#endif  // PLATFORM_AICORE_PERFORMANCE_COLLECTOR_AICORE_H_

--- a/src/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/platform/include/aicpu/performance_collector_aicpu.h
@@ -1,0 +1,81 @@
+/**
+ * @file performance_collector_aicpu.h
+ * @brief AICPU performance data collection interface
+ *
+ * Provides performance profiling management interface for AICPU side.
+ * Handles buffer initialization, switching, and flushing.
+ */
+
+#ifndef PLATFORM_AICPU_PERFORMANCE_COLLECTOR_AICPU_H_
+#define PLATFORM_AICPU_PERFORMANCE_COLLECTOR_AICPU_H_
+
+#include "common/perf_profiling.h"
+#include "runtime.h"
+
+// Include platform-specific timestamp implementation
+// Build system selects the correct inner_aicpu.h based on platform:
+// Both provide unified get_sys_cnt_aicpu() interface
+#include "device_time.h"
+
+// ============= Public Interface =============
+
+/**
+ * Initialize performance profiling
+ *
+ * Sets up double buffers for each core and initializes tracking state.
+ *
+ * @param runtime Runtime instance pointer
+ */
+void perf_aicpu_init_profiling(Runtime* runtime);
+
+/**
+ * Record dispatch and finish timestamps
+ *
+ * Updates task record with AICPU-side timing information.
+ *
+ * @param record PerfRecord pointer to update
+ * @param dispatch_time Dispatch timestamp
+ * @param finish_time Finish timestamp
+ */
+void perf_aicpu_record_dispatch_and_finish_time(PerfRecord* record,
+                                                 uint64_t dispatch_time,
+                                                 uint64_t finish_time);
+
+/**
+ * Switch performance buffer when current buffer is full
+ *
+ * Checks buffer capacity and switches to alternate buffer if needed.
+ *
+ * @param runtime Runtime instance pointer
+ * @param core_id Core ID
+ * @param thread_idx Thread index
+ */
+void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx);
+
+/**
+ * Flush remaining performance data
+ *
+ * Marks non-empty buffers as ready and enqueues them for host collection.
+ *
+ * @param runtime Runtime instance pointer
+ * @param thread_idx Thread index
+ * @param cur_thread_cores Array of core IDs managed by this thread
+ * @param core_num Number of cores managed by this thread
+ */
+void perf_aicpu_flush_buffers(Runtime* runtime,
+                               int thread_idx,
+                               const int* cur_thread_cores,
+                               int core_num);
+
+/**
+ * Update total task count in performance header
+ *
+ * Allows dynamic update of total_tasks as orchestrator makes progress.
+ * Used by tensormap_and_ringbuffer runtime where task count grows incrementally.
+ *
+ * @param runtime Runtime instance pointer
+ * @param total_tasks Current total task count
+ */
+void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks);
+
+#endif  // PLATFORM_AICPU_PERFORMANCE_COLLECTOR_AICPU_H_

--- a/src/platform/include/common/platform_config.h
+++ b/src/platform/include/common/platform_config.h
@@ -76,7 +76,7 @@ constexpr int PLATFORM_MAX_CORES =
  * Performance buffer capacity for each double buffer
  * Number of PerfRecord entries per buffer (ping or pong)
  */
-constexpr int PLATFORM_PROF_BUFFER_SIZE = 20;
+constexpr int PLATFORM_PROF_BUFFER_SIZE = 1000;
 
 /**
  * Ready queue capacity for performance data collection
@@ -94,7 +94,7 @@ constexpr uint64_t PLATFORM_PROF_SYS_CNT_FREQ = 50000000;  // 50 MHz
 /**
  * Timeout duration for performance data collection (seconds)
  */
-constexpr int PLATFORM_PROF_TIMEOUT_SECONDS = 2;
+constexpr int PLATFORM_PROF_TIMEOUT_SECONDS = 30;
 
 /**
  * Number of empty polling iterations before checking timeout

--- a/src/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -1,0 +1,292 @@
+/**
+ * @file performance_collector_aicpu.cpp
+ * @brief AICPU performance data collection implementation
+ */
+
+#include "aicpu/performance_collector_aicpu.h"
+#include "common/memory_barrier.h"
+#include "common/unified_log.h"
+#include "common/platform_config.h"
+
+/**
+ * Enqueue ready buffer to per-thread queue
+ *
+ * @param header PerfDataHeader pointer
+ * @param thread_idx Thread index
+ * @param core_index Core index
+ * @param buffer_id Buffer ID (1 or 2)
+ * @return 0 on success, -1 if queue full
+ */
+static int enqueue_ready_buffer(PerfDataHeader* header,
+                                 int thread_idx,
+                                 uint32_t core_index,
+                                 uint32_t buffer_id) {
+    uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
+    uint32_t current_tail = header->queue_tails[thread_idx];
+    uint32_t current_head = header->queue_heads[thread_idx];
+
+    // Check if queue is full
+    uint32_t next_tail = (current_tail + 1) % capacity;
+    if (next_tail == current_head) {
+        return -1;
+    }
+
+    header->queues[thread_idx][current_tail].core_index = core_index;
+    header->queues[thread_idx][current_tail].buffer_id = buffer_id;
+    header->queue_tails[thread_idx] = next_tail;
+
+    return 0;
+}
+
+void perf_aicpu_init_profiling(Runtime* runtime) {
+    void* perf_base = (void*)runtime->perf_data_base;
+    if (perf_base == nullptr) {
+        LOG_ERROR("perf_data_base is NULL, cannot initialize profiling");
+        return;
+    }
+
+    PerfDataHeader* header = get_perf_header(perf_base);
+    DoubleBuffer* buffers = get_double_buffers(perf_base);
+
+    int32_t task_count = runtime->get_task_count();
+    header->total_tasks = static_cast<uint32_t>(task_count);
+
+    LOG_INFO("Initializing performance profiling for %d cores", runtime->worker_count);
+
+    // Assign buffer1 to each core for initial writing
+    for (int i = 0; i < runtime->worker_count; i++) {
+        Handshake* h = &runtime->workers[i];
+        DoubleBuffer* db = &buffers[i];
+
+        h->perf_records_addr = (uint64_t)&db->buffer1;
+        db->buffer1_status = BufferStatus::WRITING;
+
+        LOG_DEBUG("Core %d: assigned buffer1 (addr=0x%lx)", i, h->perf_records_addr);
+    }
+
+    wmb();
+
+    LOG_INFO("Performance profiling initialized for %d cores", runtime->worker_count);
+}
+
+void perf_aicpu_record_dispatch_and_finish_time(PerfRecord* record,
+                                                 uint64_t dispatch_time,
+                                                 uint64_t finish_time) {
+    rmb();
+
+    record->dispatch_time = dispatch_time;
+    record->finish_time = finish_time;
+
+    wmb();
+}
+
+
+void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
+    void* perf_base = (void*)runtime->perf_data_base;
+    if (perf_base == nullptr) {
+        return;
+    }
+
+    rmb();
+
+    Handshake* h = &runtime->workers[core_id];
+    PerfDataHeader* header = get_perf_header(perf_base);
+    DoubleBuffer* db = get_core_double_buffer(perf_base, core_id);
+
+    uint64_t current_addr = h->perf_records_addr;
+    uint64_t buffer1_addr = (uint64_t)&db->buffer1;
+    uint64_t buffer2_addr = (uint64_t)&db->buffer2;
+
+    uint32_t full_buffer_id = 0;
+    PerfBuffer* full_buf = nullptr;
+    volatile BufferStatus* full_status_ptr = nullptr;
+    PerfBuffer* alternate_buf = nullptr;
+    volatile BufferStatus* alternate_status_ptr = nullptr;
+    uint32_t alternate_buffer_id = 0;
+
+    if (current_addr == buffer1_addr) {
+        full_buffer_id = 1;
+        full_buf = &db->buffer1;
+        full_status_ptr = &db->buffer1_status;
+        alternate_buf = &db->buffer2;
+        alternate_status_ptr = &db->buffer2_status;
+        alternate_buffer_id = 2;
+    } else if (current_addr == buffer2_addr) {
+        full_buffer_id = 2;
+        full_buf = &db->buffer2;
+        full_status_ptr = &db->buffer2_status;
+        alternate_buf = &db->buffer1;
+        alternate_status_ptr = &db->buffer1_status;
+        alternate_buffer_id = 1;
+    } else {
+        LOG_ERROR("Thread %d: Core %d has invalid perf_records_addr=0x%lx",
+                  thread_idx, core_id, current_addr);
+        return;
+    }
+
+    LOG_INFO("Thread %d: Core %d buffer%u is full (count=%u)",
+             thread_idx, core_id, full_buffer_id, full_buf->count);
+
+    // Complete performance records by filling fanout information
+    // Use Runtime's method - each runtime provides its own implementation
+    runtime->complete_perf_records(full_buf);
+
+    BufferStatus alternate_status = *alternate_status_ptr;
+
+    // Wait if alternate buffer is not ready
+    if (alternate_status != BufferStatus::IDLE) {
+        LOG_WARN("Thread %d: Core %d cannot switch, buffer%u status=%u, spinning until Host reads it",
+                 thread_idx, core_id, alternate_buffer_id, static_cast<uint32_t>(alternate_status));
+
+        constexpr uint64_t TIMEOUT_SECONDS = 2;
+
+        uint64_t start_time = get_sys_cnt_aicpu();
+        bool timeout = false;
+
+        while (true) {
+            rmb();
+            alternate_status = *alternate_status_ptr;
+            uint64_t current_time = get_sys_cnt_aicpu();
+            uint64_t elapsed = current_time - start_time;
+
+            if (alternate_status == BufferStatus::IDLE) {
+                LOG_INFO("Thread %d: Core %d buffer%u now idle, proceeding with switch",
+                         thread_idx, core_id, alternate_buffer_id);
+                break;
+            } 
+
+            if (elapsed >= TIMEOUT_SECONDS * PLATFORM_PROF_SYS_CNT_FREQ) {
+                LOG_ERROR("Thread %d: Core %d buffer%u timeout after %lu seconds (status=%u)",
+                         thread_idx, core_id, alternate_buffer_id, TIMEOUT_SECONDS,
+                         static_cast<uint32_t>(alternate_status));
+                LOG_ERROR("Forcing buffer%u to IDLE and discarding performance data to prevent deadlock",
+                         alternate_buffer_id);
+                timeout = true;
+                break;
+            }
+        }
+
+        // Discard full buffer data on timeout to avoid deadlock
+        if (timeout) {
+            full_buf->count = 0;
+            *full_status_ptr = BufferStatus::WRITING;
+
+            wmb();
+
+            LOG_ERROR("Thread %d: Core %d timeout - discarded buffer%u data, reusing it for writing",
+                     thread_idx, core_id, full_buffer_id);
+
+            return;
+        }
+    }
+
+    *full_status_ptr = BufferStatus::READY;
+    *alternate_status_ptr = BufferStatus::WRITING;
+
+    // Enqueue full buffer 
+    int enqueue_result = enqueue_ready_buffer(header, thread_idx, core_id, full_buffer_id);
+    if (enqueue_result != 0) {
+        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer%u (queue full), data lost!",
+                 thread_idx, core_id, full_buffer_id);
+        // Revert status changes since we failed to enqueue
+        *full_status_ptr = BufferStatus::WRITING;
+        *alternate_status_ptr = BufferStatus::IDLE;
+        return;
+    }
+
+    LOG_INFO("Thread %d: Core %d enqueued buffer%u", thread_idx, core_id, full_buffer_id);
+
+    h->perf_records_addr = (uint64_t)alternate_buf;
+
+    LOG_INFO("Thread %d: Core %d switched to buffer%u",
+             thread_idx, core_id, alternate_buffer_id);
+}
+
+void perf_aicpu_flush_buffers(Runtime* runtime,
+                               int thread_idx,
+                               const int* cur_thread_cores,
+                               int core_num) {
+    if (!runtime->enable_profiling) {
+        return;
+    }
+
+    void* perf_base = (void*)runtime->perf_data_base;
+    if (perf_base == nullptr) {
+        return;
+    }
+
+    rmb();
+
+    PerfDataHeader* header = get_perf_header(perf_base);
+    DoubleBuffer* buffers = get_double_buffers(perf_base);
+
+    LOG_INFO("Thread %d: Flushing performance buffers for %d cores", thread_idx, core_num);
+
+    int flushed_count = 0;
+
+    for (int i = 0; i < core_num; i++) {
+        int core_id = cur_thread_cores[i];
+        Handshake* h = &runtime->workers[core_id];
+        DoubleBuffer* db = &buffers[core_id];
+
+        uint64_t current_addr = h->perf_records_addr;
+        if (current_addr == 0) {
+            continue;
+        }
+
+        uint64_t buf1_addr = (uint64_t)&db->buffer1;
+        uint64_t buf2_addr = (uint64_t)&db->buffer2;
+
+        PerfBuffer* current_buf = nullptr;
+        volatile BufferStatus* current_status = nullptr;
+        uint32_t buffer_id = 0;
+
+        if (current_addr == buf1_addr) {
+            current_buf = &db->buffer1;
+            current_status = &db->buffer1_status;
+            buffer_id = 1;
+        } else if (current_addr == buf2_addr) {
+            current_buf = &db->buffer2;
+            current_status = &db->buffer2_status;
+            buffer_id = 2;
+        } else {
+            LOG_WARN("Thread %d: Core %d perf_records_addr=0x%lx doesn't match buffer1=0x%lx or buffer2=0x%lx",
+                     thread_idx, core_id, current_addr, buf1_addr, buf2_addr);
+            continue;
+        }
+
+        uint32_t count = current_buf->count;
+
+        if (count > 0) {
+            runtime->complete_perf_records(current_buf);
+
+            *current_status = BufferStatus::READY;
+
+            int rc = enqueue_ready_buffer(header, thread_idx, core_id, buffer_id);
+            if (rc == 0) {
+                LOG_INFO("Thread %d: Core %d flushed buffer%d with %u records",
+                         thread_idx, core_id, buffer_id, count);
+                flushed_count++;
+            } else {
+                LOG_ERROR("Thread %d: Core %d failed to enqueue buffer%d (queue full), data lost!",
+                         thread_idx, core_id, buffer_id);
+                // Revert status since we failed to enqueue
+                *current_status = BufferStatus::WRITING;
+            }
+        }
+    }
+
+    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed",
+             thread_idx, flushed_count);
+}
+
+void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
+    void* perf_base = (void*)runtime->perf_data_base;
+    if (perf_base == nullptr) {
+        return;
+    }
+
+    PerfDataHeader* header = get_perf_header(perf_base);
+    header->total_tasks = total_tasks;
+    wmb();
+}

--- a/src/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -44,6 +44,9 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
     // All kernels have signature: void kernel(__gm__ int64_t* args)
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)task->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
+
+    // Ensure all memory writes are visible to other cores
+    pipe_barrier(PIPE_ALL);
 }
 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {

--- a/src/runtime/aicpu_build_graph/runtime/runtime.cpp
+++ b/src/runtime/aicpu_build_graph/runtime/runtime.cpp
@@ -295,3 +295,14 @@ int Runtime::get_device_alloc_count() const { return device_alloc_count; }
 void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 
 void Runtime::clear_device_allocs() { device_alloc_count = 0; }
+
+// =============================================================================
+// Performance Profiling
+// =============================================================================
+
+void Runtime::complete_perf_records(PerfBuffer* perf_buf) {
+    // No-op for aicpu_build_graph.
+    // Task graph is managed by AICPU orchestration plugin, which handles
+    // performance record completion.
+    (void)perf_buf;
+}

--- a/src/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/runtime/aicpu_build_graph/runtime/runtime.h
@@ -26,6 +26,7 @@
 #include <atomic>
 
 #include "common/core_type.h"
+#include "common/perf_profiling.h"
 #include "common/platform_config.h"
 
 // =============================================================================
@@ -512,6 +513,20 @@ public:
      * Clear all recorded device allocations.
      */
     void clear_device_allocs();
+
+    // =========================================================================
+    // Performance Profiling
+    // =========================================================================
+
+    /**
+     * Fill fanout information for performance records (stub for API compatibility)
+     *
+     * This is a no-op for aicpu_build_graph. Task graph is managed by the
+     * AICPU orchestration plugin, which handles performance record completion.
+     *
+     * @param perf_buf Performance buffer containing records to complete
+     */
+    void complete_perf_records(PerfBuffer* perf_buf);
 
     // =========================================================================
     // Host API (host-only, not copied to device)

--- a/src/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -1,65 +1,10 @@
 #include "aicore/aicore.h"
 #include "runtime.h"
 #include "common/perf_profiling.h"
+#include "aicore/performance_collector_aicore.h"
 #include "common/platform_config.h"  // Platform configuration (C/C++ compatible)
 
 typedef void (*KernelFunc)(__gm__ int64_t*);
-
-/**
- * @brief Record task execution performance data
- *
- * This function records the performance metrics of a task execution to the profiling buffer.
- * It writes the task timing data, metadata, and marks the buffer as full when needed.
- *
- * @param my_hank Pointer to the handshake structure containing perf buffer info
- * @param task_ptr Pointer to the executed task
- * @param start_time Task start timestamp
- * @param end_time Task end timestamp
- * @param block_idx AICore block index
- * @param core_type Core type (AIC or AIV)
- * @param kernel_ready_time Kernel ready timestamp (when AICore entered main loop)
- */
-__aicore__ __attribute__((always_inline)) static void record_task_performance(
-    __gm__ Handshake* my_hank,
-    __gm__ Task* task_ptr,
-    uint64_t start_time,
-    uint64_t end_time,
-    int block_idx,
-    CoreType core_type,
-    uint64_t kernel_ready_time) {
-
-    // dcci() for handshake visibility during profiling
-    dcci((__gm__ uint32_t*)&my_hank->perf_buffer_status, SINGLE_CACHE_LINE, CACHELINE_OUT);
-
-    if (my_hank->perf_buffer_status != 0) {
-        return;
-    }
-
-    __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-    uint32_t idx = perf_buf->count;
-
-    if (idx < PLATFORM_PROF_BUFFER_SIZE) {
-        __gm__ PerfRecord* record = (__gm__ PerfRecord*)&perf_buf->records[idx];
-
-        record->start_time = start_time;
-        record->end_time = end_time;
-        record->kernel_ready_time = kernel_ready_time;
-        record->task_id = task_ptr->task_id;
-        record->func_id = task_ptr->func_id;
-        record->core_id = block_idx;
-        record->core_type = core_type;
-
-        perf_buf->count = idx + 1;
-        dcci(record, ENTIRE_DATA_CACHE, CACHELINE_OUT);
-        if (perf_buf->count >= PLATFORM_PROF_BUFFER_SIZE) {
-            my_hank->perf_buffer_status = 1;
-        }
-    } else {
-        my_hank->perf_buffer_status = 1;
-    }
-    // dcci() for handshake visibility during profiling
-    dcci((__gm__ uint32_t*)&my_hank->perf_buffer_status, SINGLE_CACHE_LINE, CACHELINE_OUT);
-}
 
 __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task) {
     if (task->function_bin_addr == 0) {
@@ -91,7 +36,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     write_reg(RegId::COND, static_cast<uint64_t>(AICoreStatus::IDLE));
 
     bool profiling_enabled = runtime->enable_profiling;
-    uint64_t kernel_ready_time = get_sys_cnt();
+    uint64_t kernel_ready_time = get_sys_cnt_aicore();
 
     // Main loop: poll DATA_MAIN_BASE for task_id
     volatile uint32_t task_id = 0;
@@ -107,14 +52,16 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
         if (task_id != 0 && task_id != last_task_id) {
             write_reg(RegId::COND, static_cast<uint64_t>(AICoreStatus::BUSY));
             __gm__ Task* task_ptr = &(runtime->tasks[task_id - 1]);
-            uint64_t start_time = get_sys_cnt();
+            uint64_t start_time = get_sys_cnt_aicore();
             
             execute_task(task_ptr);
 
             if (profiling_enabled) {
-                uint64_t end_time = get_sys_cnt();
-                record_task_performance(my_hank, task_ptr, start_time, end_time,
-                                      block_idx, core_type, kernel_ready_time);
+                uint64_t end_time = get_sys_cnt_aicore();
+                __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
+                perf_aicore_record_task(perf_buf, task_ptr->task_id, task_ptr->func_id,
+                                      start_time, end_time, kernel_ready_time,
+                                      block_idx, core_type);
             }
 
             last_task_id = task_id;

--- a/src/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/runtime/host_build_graph/runtime/runtime.cpp
@@ -215,3 +215,28 @@ int Runtime::get_tensor_pair_count() const {
 void Runtime::clear_tensor_pairs() {
     tensor_pair_count = 0;
 }
+
+// =============================================================================
+// Performance Profiling
+// =============================================================================
+
+void Runtime::complete_perf_records(PerfBuffer* perf_buf) {
+    uint32_t count = perf_buf->count;
+
+    for (uint32_t i = 0; i < count; i++) {
+        PerfRecord* record = &perf_buf->records[i];
+        uint32_t task_id = record->task_id;
+
+        // Query Task by task_id (O(1) array indexing)
+        Task* task = get_task(task_id);
+        if (task != nullptr) {
+            record->fanout_count = task->fanout_count;
+
+            for (int32_t j = 0; j < task->fanout_count; j++) {
+                record->fanout[j] = task->fanout[j];
+            }
+        } else {
+            record->fanout_count = 0;
+        }
+    }
+}

--- a/src/runtime/host_build_graph/runtime/runtime.h
+++ b/src/runtime/host_build_graph/runtime/runtime.h
@@ -26,6 +26,7 @@
 #include <atomic>
 
 #include "common/core_type.h"
+#include "common/perf_profiling.h"
 #include "common/platform_config.h"
 
 // Logging macros using unified logging interface
@@ -313,6 +314,20 @@ public:
      * Clear all recorded tensor pairs.
      */
     void clear_tensor_pairs();
+
+    // =========================================================================
+    // Performance Profiling
+    // =========================================================================
+
+    /**
+     * Fill fanout information for performance records
+     *
+     * Extracts task dependency data from the task graph and populates
+     * fanout arrays in performance records.
+     *
+     * @param perf_buf Performance buffer containing records to complete
+     */
+    void complete_perf_records(PerfBuffer* perf_buf);
 
     // =========================================================================
     // Device Orchestration (stub for API compatibility)

--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -22,6 +22,7 @@
 #include <string.h>  // for memset
 
 #include "common/core_type.h"
+#include "common/perf_profiling.h"
 #include "pto2_dispatch_payload.h"
 
 // =============================================================================
@@ -192,6 +193,20 @@ public:
      * Clear all recorded tensor pairs.
      */
     void clear_tensor_pairs();
+
+    // =========================================================================
+    // Performance Profiling
+    // =========================================================================
+
+    /**
+     * Fill fanout information for performance records
+     *
+     * Extracts task dependency data from the task graph and populates
+     * fanout arrays in performance records.
+     *
+     * @param perf_buf Performance buffer containing records to complete
+     */
+    void complete_perf_records(PerfBuffer* perf_buf);
 
     // =========================================================================
     // Device orchestration (for AICPU thread 3)


### PR DESCRIPTION
Refactor: modularize performance collector into platform host/aicpu/aicore components
Separate performance profiling logic from executors into dedicated modules:
- Add performance_collector_aicore.h for AICore-side recording interface
- Add performance_collector_aicpu.h/.cpp for AICPU-side buffer management
- Move performance_collector.cpp to host/ directory for host-side collection
- Add get_sys_cnt_aicore() to unify timestamp access across platforms
- Simplify aicpu/aicore executors by removing duplicated profiling code
- Update swimlane_converter.py to support new performance data structure

This refactoring reduces code duplication and avoids lock contention,
minimizing the performance overhead of profiling on task scheduling.