### PR TITLE
Refactor aicpu logical

### DIFF
--- a/examples/host_build_graph/paged_attention/golden.py
+++ b/examples/host_build_graph/paged_attention/golden.py
@@ -120,10 +120,13 @@ def paged_attention(
     """
     Compute paged attention using online softmax with head tiling and GQA.
 
+    Vectorized across the batch dimension for performance.
+    Supports different context_lens per batch via masking.
+
     Args:
-        query: (batch, num_heads, head_dim) float16
-        key_cache: (total_blocks, block_size, num_kv_heads, head_dim) float16
-        value_cache: (total_blocks, block_size, num_kv_heads, head_dim) float16
+        query: (batch, num_heads, head_dim) bfloat16
+        key_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
+        value_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
         num_kv_heads: int
         num_heads: int
         scale_value: float
@@ -131,65 +134,87 @@ def paged_attention(
         context_lens: (batch,) int32
 
     Returns:
-        out: (batch, num_heads, head_dim) float32
+        out: (batch * num_heads, head_dim) float32
     """
     assert num_kv_heads == 1
-    batch, num_heads, head_dim = query.shape
+    batch, num_heads_dim, head_dim = query.shape
     _, block_size, _, _ = key_cache.shape
-    _, block_num = block_table.shape
 
-    query = query.reshape(-1, head_dim)
-    key_cache = key_cache.reshape(-1, block_size, head_dim)
-    value_cache = value_cache.reshape(-1, block_size, head_dim)
+    # Reshape for batched computation
+    key_cache_flat = key_cache.reshape(-1, block_size, head_dim)
+    value_cache_flat = value_cache.reshape(-1, block_size, head_dim)
 
-    out = torch.zeros((batch * num_heads, head_dim), dtype=torch.float32)
+    out = torch.zeros((batch, num_heads_dim, head_dim), dtype=torch.float32)
 
-    for b_idx in range(batch):
-        cur_seq = int(context_lens[b_idx])
-        bn_this_batch = (cur_seq + block_size - 1) // block_size
-        assert bn_this_batch <= block_num
+    q_tile = min(num_heads_dim, 128)
 
-        q_tile = min(num_heads, 128)
-        for cur_offset in range(0, num_heads, q_tile):
-            q_tile_size = min(q_tile, num_heads - cur_offset)
-            base_idx = b_idx * num_heads + cur_offset
-            qi = query[base_idx : base_idx + q_tile_size].to(torch.float32)
+    # Max blocks across all batches (each batch may have different context_len)
+    max_bn = int(((context_lens.max().item()) + block_size - 1) // block_size)
 
-            oi = None
-            li = None
-            mi = None
+    for q_offset in range(0, num_heads_dim, q_tile):
+        q_tile_size = min(q_tile, num_heads_dim - q_offset)
+        # qi: (batch, q_tile_size, head_dim)
+        qi = query[:, q_offset:q_offset + q_tile_size, :].to(torch.float32)
 
-            for bn in range(bn_this_batch):
-                cur_block_idx = block_table[b_idx, bn]
-                valid_len = min(block_size, cur_seq - bn * block_size)
-                kj = key_cache[cur_block_idx, :valid_len, :].to(torch.float32)
-                vj = value_cache[cur_block_idx, :valid_len, :].to(torch.float32)
+        oi = None  # (batch, q_tile_size, head_dim)
+        li = None  # (batch, q_tile_size, 1)
+        mi = None  # (batch, q_tile_size, 1)
 
-                sij = (qi @ kj.T) * scale_value
-                mij = sij.max(dim=-1, keepdim=True)[0]
-                pij = torch.exp(sij - mij).to(torch.float16).to(torch.float32)
-                lij = torch.sum(pij, dim=1, keepdim=True)
+        for bn in range(max_bn):
+            # valid_len per batch for this block position
+            valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+            active_mask = valid_lens > 0  # (batch,)
 
-                if bn == 0:
-                    oi = pij @ vj
-                    li = lij
-                    mi = mij
-                else:
-                    mi_new = torch.maximum(mi, mij)
-                    alpha = torch.exp(mi - mi_new)
-                    beta = torch.exp(mij - mi_new)
-                    li_new = alpha * li + beta * lij
-                    oi_new = pij @ vj
-                    oi = alpha * oi + beta * oi_new
-                    li = li_new
-                    mi = mi_new
+            if not active_mask.any():
+                break
 
-                if bn == bn_this_batch - 1:
-                    oi = oi / li
+            # Gather block indices for all batches
+            block_indices = block_table[:, bn]  # (batch,)
 
-            out[base_idx : base_idx + q_tile_size] = oi
+            # Gather K and V: (batch, block_size, head_dim)
+            kj_all = key_cache_flat[block_indices].to(torch.float32)
+            vj_all = value_cache_flat[block_indices].to(torch.float32)
 
-    return out
+            # QK matmul: (batch, q_tile_size, block_size)
+            sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale_value
+
+            # Mask out invalid positions (beyond valid_len per batch)
+            pos = torch.arange(block_size, device=sij.device).unsqueeze(0)  # (1, block_size)
+            valid_mask = pos < valid_lens.unsqueeze(1)  # (batch, block_size)
+            valid_mask = valid_mask.unsqueeze(1)  # (batch, 1, block_size)
+            sij = sij.masked_fill(~valid_mask, float('-inf'))
+
+            # Also mask inactive batches (no blocks at this position)
+            batch_mask = active_mask.view(-1, 1, 1)  # (batch, 1, 1)
+            sij = sij.masked_fill(~batch_mask, float('-inf'))
+
+            mij = sij.max(dim=-1, keepdim=True)[0]  # (batch, q_tile_size, 1)
+            mij = mij.clamp(min=-1e30)
+            pij = torch.exp(sij - mij)
+            pij = pij.masked_fill(~valid_mask, 0.0)
+            pij = pij.masked_fill(~batch_mask, 0.0)
+            pij = pij.to(torch.bfloat16).to(torch.float32)
+            lij = pij.sum(dim=-1, keepdim=True)  # (batch, q_tile_size, 1)
+
+            # PV matmul: (batch, q_tile_size, head_dim)
+            oi_new = torch.bmm(pij, vj_all)
+
+            if bn == 0:
+                oi = oi_new
+                li = lij
+                mi = mij
+            else:
+                mi_new = torch.maximum(mi, mij)
+                alpha = torch.exp(mi - mi_new)
+                beta = torch.exp(mij - mi_new)
+                li = alpha * li + beta * lij
+                oi = alpha * oi + beta * oi_new
+                mi = mi_new
+
+        # Final normalization
+        out[:, q_offset:q_offset + q_tile_size, :] = oi / li
+
+    return out.reshape(-1, head_dim)
 
 
 def compute_golden(tensors: dict, params: dict) -> None:
@@ -203,13 +228,12 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
     max_num_blocks_per_req = max_model_len // block_size
 
-    # Reconstruct shaped arrays from flat float16 tensors
-    # Convert to torch tensors (handles both array types)
-    query = torch.as_tensor(tensors["query"]).reshape(batch, num_heads, head_dim)
-    key_cache = torch.as_tensor(tensors["key_cache"]).reshape(-1, block_size, kv_head_num, head_dim)
-    value_cache = torch.as_tensor(tensors["value_cache"]).reshape(-1, block_size, kv_head_num, head_dim)
-    block_table = torch.as_tensor(tensors["block_table"]).reshape(batch, max_num_blocks_per_req)
-    context_lens = torch.as_tensor(tensors["context_lens"])
+    # Reconstruct shaped tensors from flat tensors
+    query = tensors["query"].reshape(batch, num_heads, head_dim)
+    key_cache = tensors["key_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    value_cache = tensors["value_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    block_table = tensors["block_table"].reshape(batch, max_num_blocks_per_req)
+    context_lens = tensors["context_lens"]
 
     out = paged_attention(
         query=query,

--- a/examples/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/examples/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -117,10 +117,13 @@ def paged_attention(
     """
     Compute paged attention using online softmax with head tiling and GQA.
 
+    Vectorized across the batch dimension for performance.
+    Supports different context_lens per batch via masking.
+
     Args:
-        query: (batch, num_heads, head_dim) float16
-        key_cache: (total_blocks, block_size, num_kv_heads, head_dim) float16
-        value_cache: (total_blocks, block_size, num_kv_heads, head_dim) float16
+        query: (batch, num_heads, head_dim) bfloat16
+        key_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
+        value_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
         num_kv_heads: int
         num_heads: int
         scale_value: float
@@ -128,65 +131,87 @@ def paged_attention(
         context_lens: (batch,) int32
 
     Returns:
-        out: (batch, num_heads, head_dim) float32
+        out: (batch * num_heads, head_dim) float32
     """
     assert num_kv_heads == 1
-    batch, num_heads, head_dim = query.shape
+    batch, num_heads_dim, head_dim = query.shape
     _, block_size, _, _ = key_cache.shape
-    _, block_num = block_table.shape
 
-    query = query.reshape(-1, head_dim)
-    key_cache = key_cache.reshape(-1, block_size, head_dim)
-    value_cache = value_cache.reshape(-1, block_size, head_dim)
+    # Reshape for batched computation
+    key_cache_flat = key_cache.reshape(-1, block_size, head_dim)
+    value_cache_flat = value_cache.reshape(-1, block_size, head_dim)
 
-    out = torch.zeros((batch * num_heads, head_dim), dtype=torch.float32)
+    out = torch.zeros((batch, num_heads_dim, head_dim), dtype=torch.float32)
 
-    for b_idx in range(batch):
-        cur_seq = int(context_lens[b_idx])
-        bn_this_batch = (cur_seq + block_size - 1) // block_size
-        assert bn_this_batch <= block_num
+    q_tile = min(num_heads_dim, 128)
 
-        q_tile = min(num_heads, 128)
-        for cur_offset in range(0, num_heads, q_tile):
-            q_tile_size = min(q_tile, num_heads - cur_offset)
-            base_idx = b_idx * num_heads + cur_offset
-            qi = query[base_idx : base_idx + q_tile_size].to(torch.float32)
+    # Max blocks across all batches (each batch may have different context_len)
+    max_bn = int(((context_lens.max().item()) + block_size - 1) // block_size)
 
-            oi = None
-            li = None
-            mi = None
+    for q_offset in range(0, num_heads_dim, q_tile):
+        q_tile_size = min(q_tile, num_heads_dim - q_offset)
+        # qi: (batch, q_tile_size, head_dim)
+        qi = query[:, q_offset:q_offset + q_tile_size, :].to(torch.float32)
 
-            for bn in range(bn_this_batch):
-                cur_block_idx = block_table[b_idx, bn]
-                valid_len = min(block_size, cur_seq - bn * block_size)
-                kj = key_cache[cur_block_idx, :valid_len, :].to(torch.float32)
-                vj = value_cache[cur_block_idx, :valid_len, :].to(torch.float32)
+        oi = None  # (batch, q_tile_size, head_dim)
+        li = None  # (batch, q_tile_size, 1)
+        mi = None  # (batch, q_tile_size, 1)
 
-                sij = (qi @ kj.T) * scale_value
-                mij = sij.max(dim=-1, keepdim=True)[0]
-                pij = torch.exp(sij - mij).to(torch.float16).to(torch.float32)
-                lij = pij.sum(dim=1, keepdim=True)
+        for bn in range(max_bn):
+            # valid_len per batch for this block position
+            valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+            active_mask = valid_lens > 0  # (batch,)
 
-                if bn == 0:
-                    oi = pij @ vj
-                    li = lij
-                    mi = mij
-                else:
-                    mi_new = torch.maximum(mi, mij)
-                    alpha = torch.exp(mi - mi_new)
-                    beta = torch.exp(mij - mi_new)
-                    li_new = alpha * li + beta * lij
-                    oi_new = pij @ vj
-                    oi = alpha * oi + beta * oi_new
-                    li = li_new
-                    mi = mi_new
+            if not active_mask.any():
+                break
 
-                if bn == bn_this_batch - 1:
-                    oi = oi / li
+            # Gather block indices for all batches
+            block_indices = block_table[:, bn]  # (batch,)
 
-            out[base_idx : base_idx + q_tile_size] = oi
+            # Gather K and V: (batch, block_size, head_dim)
+            kj_all = key_cache_flat[block_indices].to(torch.float32)
+            vj_all = value_cache_flat[block_indices].to(torch.float32)
 
-    return out
+            # QK matmul: (batch, q_tile_size, block_size)
+            sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale_value
+
+            # Mask out invalid positions (beyond valid_len per batch)
+            pos = torch.arange(block_size, device=sij.device).unsqueeze(0)  # (1, block_size)
+            valid_mask = pos < valid_lens.unsqueeze(1)  # (batch, block_size)
+            valid_mask = valid_mask.unsqueeze(1)  # (batch, 1, block_size)
+            sij = sij.masked_fill(~valid_mask, float('-inf'))
+
+            # Also mask inactive batches (no blocks at this position)
+            batch_mask = active_mask.view(-1, 1, 1)  # (batch, 1, 1)
+            sij = sij.masked_fill(~batch_mask, float('-inf'))
+
+            mij = sij.max(dim=-1, keepdim=True)[0]  # (batch, q_tile_size, 1)
+            mij = mij.clamp(min=-1e30)
+            pij = torch.exp(sij - mij)
+            pij = pij.masked_fill(~valid_mask, 0.0)
+            pij = pij.masked_fill(~batch_mask, 0.0)
+            pij = pij.to(torch.bfloat16).to(torch.float32)
+            lij = pij.sum(dim=-1, keepdim=True)  # (batch, q_tile_size, 1)
+
+            # PV matmul: (batch, q_tile_size, head_dim)
+            oi_new = torch.bmm(pij, vj_all)
+
+            if bn == 0:
+                oi = oi_new
+                li = lij
+                mi = mij
+            else:
+                mi_new = torch.maximum(mi, mij)
+                alpha = torch.exp(mi - mi_new)
+                beta = torch.exp(mij - mi_new)
+                li = alpha * li + beta * lij
+                oi = alpha * oi + beta * oi_new
+                mi = mi_new
+
+        # Final normalization
+        out[:, q_offset:q_offset + q_tile_size, :] = oi / li
+
+    return out.reshape(-1, head_dim)
 
 
 def compute_golden(tensors: dict, params: dict) -> None:

--- a/src/platform/a2a3/aicpu/device_log.cpp
+++ b/src/platform/a2a3/aicpu/device_log.cpp
@@ -61,3 +61,12 @@ void dev_log_error(const char* func, const char* fmt, ...) {
     va_end(args);
     dlog_error(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
 }
+
+void dev_log_always(const char* func, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    char buffer[2048];
+    vsnprintf(buffer, sizeof(buffer), fmt, args);
+    va_end(args);
+    dlog_error(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
+}

--- a/src/platform/a2a3sim/aicpu/device_log.cpp
+++ b/src/platform/a2a3sim/aicpu/device_log.cpp
@@ -120,3 +120,12 @@ void dev_log_error(const char* func, const char* fmt, ...) {
     printf("\n");
     va_end(args);
 }
+
+void dev_log_always(const char* func, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    printf("[ALWAYS] %s: ", func);
+    vprintf(fmt, args);
+    printf("\n");
+    va_end(args);
+}

--- a/src/platform/include/aicpu/device_log.h
+++ b/src/platform/include/aicpu/device_log.h
@@ -51,6 +51,7 @@ void dev_log_debug(const char* func, const char* fmt, ...);
 void dev_log_info(const char* func, const char* fmt, ...);
 void dev_log_warn(const char* func, const char* fmt, ...);
 void dev_log_error(const char* func, const char* fmt, ...);
+void dev_log_always(const char* func, const char* fmt, ...);
 
 // =============================================================================
 // High-Level Logging Macros (Platform-Independent Layer)
@@ -92,6 +93,7 @@ void dev_log_error(const char* func, const char* fmt, ...);
 #define DEV_INFO(fmt, args...)  D_DEV_LOGI(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
 #define DEV_WARN(fmt, args...)  D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
 #define DEV_ERROR(fmt, args...) D_DEV_LOGE(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
+#define DEV_ALWAYS(fmt, args...) dev_log_always(__FUNCTION__, fmt, ##args)
 
 // =============================================================================
 // Platform-Specific Assertion

--- a/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -28,6 +28,14 @@
 #include "common/perf_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
+
+// Scheduler profiling helper
+#include <time.h>
+static inline uint64_t _orch_now_ns() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
 #include "inner_aicpu.h"
 
 // Device orchestration function signature (loaded via dlopen).
@@ -45,6 +53,14 @@ constexpr int MAX_CORES_PER_THREAD = MAX_AIC_PER_THREAD + MAX_AIV_PER_THREAD;
 
 // Maximum tasks for ready queue (PTO2 mode uses shared memory task count)
 constexpr int AICPU_MAX_READY_TASKS = 16384;
+constexpr int AICPU_READY_MASK = AICPU_MAX_READY_TASKS - 1;
+
+// Lightweight spinlock (avoids futex syscall overhead of std::mutex)
+struct SpinLock {
+    std::atomic<int> flag{0};
+    void lock() { while (flag.exchange(1, std::memory_order_acquire) != 0) { PTO2_SPIN_PAUSE_LIGHT(); } }
+    void unlock() { flag.store(0, std::memory_order_release); }
+};
 
 // Core information for discovery (aligned with host_build_graph)
 struct CoreInfo {
@@ -73,17 +89,16 @@ struct AicpuExecutor {
     int aiv_count_{0};
 
     // ===== Task queue state (FIFO circular queue, aligned with host_build_graph) =====
-    std::mutex ready_queue_aic_mutex_;
+    // ===== Spinlock-based MPMC ready queues (lighter than std::mutex) =====
+    SpinLock ready_queue_aic_lock_;
     int ready_queue_aic_[AICPU_MAX_READY_TASKS];
-    std::atomic<int> ready_count_aic_{0};
-    int ready_queue_aic_head_{0};  // Circular queue: read position (front)
-    int ready_queue_aic_tail_{0};  // Circular queue: write position (back)
+    int ready_queue_aic_head_{0};
+    int ready_queue_aic_tail_{0};
 
-    std::mutex ready_queue_aiv_mutex_;
+    SpinLock ready_queue_aiv_lock_;
     int ready_queue_aiv_[AICPU_MAX_READY_TASKS];
-    std::atomic<int> ready_count_aiv_{0};
-    int ready_queue_aiv_head_{0};  // Circular queue: read position (front)
-    int ready_queue_aiv_tail_{0};  // Circular queue: write position (back)
+    int ready_queue_aiv_head_{0};
+    int ready_queue_aiv_tail_{0};
 
     // Task execution tracking
     std::atomic<int> completed_tasks_{0};
@@ -96,6 +111,12 @@ struct AicpuExecutor {
     std::atomic<int> next_scan_index_{0};
     std::atomic<bool> perf_init_done_{false};
     std::atomic<bool> sm_header_ready_{false};  // Thread 3 sets after SM header init
+
+    // Orchestrator ready queue pointers (set by Thread 3, read by scheduler threads)
+    volatile int32_t* orch_ready_queue_{nullptr};
+    volatile int32_t* orch_ready_tail_{nullptr};
+    volatile int32_t* orch_ready_head_{nullptr};
+    int32_t orch_ready_capacity_{0};
 
     // Orchestration SO handle - defer dlclose until all tasks complete
     void* orch_so_handle_{nullptr};
@@ -292,8 +313,6 @@ int AicpuExecutor::init(Runtime* runtime) {
     orchestrator_done_.store(orch_on_host, std::memory_order_release);
 
     // Initial ready tasks will be populated from PTO2 shared memory in resolve_and_dispatch_pto2
-    ready_count_aic_.store(0, std::memory_order_release);
-    ready_count_aiv_.store(0, std::memory_order_release);
     ready_queue_aic_head_ = 0;
     ready_queue_aic_tail_ = 0;
     ready_queue_aiv_head_ = 0;
@@ -357,14 +376,6 @@ static void build_pto2_payload(PTO2DispatchPayload* out, Runtime* runtime,
     }
 
     out->num_args = n;
-    DEV_INFO("build_pto2_payload ok");
-    for (int i = 0; i < task->param_count; i++) {
-        if (task->params[i].type == PTOParamType::SCALAR) {
-            DEV_INFO("build_pto2_payload param %d scalar: %d", i, out->args[i]);
-        } else {
-            DEV_INFO("build_pto2_payload param %d addr: %x", i, out->args[i]);
-        }
-    }
 }
 
 int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
@@ -433,7 +444,17 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
     const int WARN_INTERVAL = 1000000;
     bool profiling_enabled = runtime->enable_profiling;
 
+    // Scheduler profiling counters
+    uint64_t sched_scan_ns = 0, sched_orch_drain_ns = 0;
+    uint64_t sched_complete_ns = 0, sched_dispatch_ns = 0, sched_yield_ns = 0;
+    uint64_t sched_loop_count = 0, sched_yield_count = 0;
+    // Fanout traversal statistics
+    uint64_t total_fanout_traversed = 0;
+    int32_t max_fanout_len = 0;
+
     while (true) {
+        sched_loop_count++;
+        uint64_t _phase_t0 = _orch_now_ns(), _phase_t1;
         // Dynamic task_count (Thread 3 sets total_tasks_ when orchestration completes)
         int32_t task_count = total_tasks_.load(std::memory_order_acquire);
         bool orch_done = orchestrator_done_.load(std::memory_order_acquire);
@@ -481,57 +502,57 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                     __atomic_store_n(&s_pto2_task_completed[slot], 1, __ATOMIC_RELEASE);
                     int32_t wt = t->worker_type;
                     if (wt == PTO2_WORKER_CUBE) {
-                        std::lock_guard<std::mutex> lock(ready_queue_aic_mutex_);
-                        ready_queue_aic_[ready_queue_aic_tail_] = idx;
-                        ready_queue_aic_tail_ = (ready_queue_aic_tail_ + 1) % AICPU_MAX_READY_TASKS;
-                        ready_count_aic_.fetch_add(1, std::memory_order_release);
+                        ready_queue_aic_lock_.lock();
+                        ready_queue_aic_[ready_queue_aic_tail_++ & AICPU_READY_MASK] = idx;
+                        ready_queue_aic_lock_.unlock();
                     } else {
-                        std::lock_guard<std::mutex> lock(ready_queue_aiv_mutex_);
-                        ready_queue_aiv_[ready_queue_aiv_tail_] = idx;
-                        ready_queue_aiv_tail_ = (ready_queue_aiv_tail_ + 1) % AICPU_MAX_READY_TASKS;
-                        ready_count_aiv_.fetch_add(1, std::memory_order_release);
+                        ready_queue_aiv_lock_.lock();
+                        ready_queue_aiv_[ready_queue_aiv_tail_++ & AICPU_READY_MASK] = idx;
+                        ready_queue_aiv_lock_.unlock();
                     }
                     made_progress = true;
                 }
             }
         }
+        _phase_t1 = _orch_now_ns(); sched_scan_ns += (_phase_t1 - _phase_t0); _phase_t0 = _phase_t1;
 
-        // Readiness scan: enqueue tasks made ready by orchestrator's early-return path
-        // (producer already completed → refcount incremented directly, but not enqueued)
-        {
-            int32_t scanned = next_scan_index_.load(std::memory_order_acquire);
-            for (int32_t idx = 0; idx < scanned; idx++) {
-                int32_t slot = idx & window_mask;
-                int32_t state = __atomic_load_n(&s_pto2_task_completed[slot], __ATOMIC_ACQUIRE);
-                if (state != 0) continue;  // already enqueued (1) or completed (2)
 
-                PTO2TaskDescriptor* t = &task_descriptors[slot];
-                int32_t fanin_count = __atomic_load_n(&t->fanin_count, __ATOMIC_ACQUIRE);
-                if (fanin_count <= 0) continue;  // root tasks handled by incremental scan
+        // Drain orchestrator ready queue: tasks made ready by orchestrator's early-return path
+        // (producer already completed → refcount incremented directly, consumer pushed to queue)
+        if (orch_ready_queue_ != nullptr) {
+            while (true) {
+                int32_t head = __atomic_load_n(orch_ready_head_, __ATOMIC_ACQUIRE);
+                int32_t tail = __atomic_load_n(orch_ready_tail_, __ATOMIC_ACQUIRE);
+                if (head == tail) break;  // queue empty
 
-                int32_t refcount = __atomic_load_n(&s_pto2_fanin_refcount[slot], __ATOMIC_ACQUIRE);
-                if (refcount < fanin_count) continue;
+                // CAS to claim this slot (multiple scheduler threads compete)
+                if (!__atomic_compare_exchange_n(orch_ready_head_, &head, head + 1,
+                        false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) continue;
 
-                // CAS from 0 → 1 to claim enqueue rights
+                int32_t task_id = orch_ready_queue_[head & (orch_ready_capacity_ - 1)];
+                int32_t slot = task_id & window_mask;
+
+                // CAS from 0 → 1 to claim enqueue rights (may already be enqueued by fanout path)
                 int32_t expected = 0;
                 if (!__atomic_compare_exchange_n(&s_pto2_task_completed[slot], &expected, 1,
                         false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) continue;
 
+                PTO2TaskDescriptor* t = &task_descriptors[slot];
                 int32_t wt = t->worker_type;
                 if (wt == PTO2_WORKER_CUBE) {
-                    std::lock_guard<std::mutex> lock(ready_queue_aic_mutex_);
-                    ready_queue_aic_[ready_queue_aic_tail_] = idx;
-                    ready_queue_aic_tail_ = (ready_queue_aic_tail_ + 1) % AICPU_MAX_READY_TASKS;
-                    ready_count_aic_.fetch_add(1, std::memory_order_release);
+                    ready_queue_aic_lock_.lock();
+                    ready_queue_aic_[ready_queue_aic_tail_++ & AICPU_READY_MASK] = task_id;
+                    ready_queue_aic_lock_.unlock();
                 } else {
-                    std::lock_guard<std::mutex> lock(ready_queue_aiv_mutex_);
-                    ready_queue_aiv_[ready_queue_aiv_tail_] = idx;
-                    ready_queue_aiv_tail_ = (ready_queue_aiv_tail_ + 1) % AICPU_MAX_READY_TASKS;
-                    ready_count_aiv_.fetch_add(1, std::memory_order_release);
+                    ready_queue_aiv_lock_.lock();
+                    ready_queue_aiv_[ready_queue_aiv_tail_++ & AICPU_READY_MASK] = task_id;
+                    ready_queue_aiv_lock_.unlock();
                 }
                 made_progress = true;
             }
         }
+        _phase_t1 = _orch_now_ns(); sched_orch_drain_ns += (_phase_t1 - _phase_t0); _phase_t0 = _phase_t1;
+
 
         // Phase 1: Process completed tasks (Handshake.task = PTO2DispatchPayload*)
         for (int i = 0; i < core_num; i++) {
@@ -566,17 +587,19 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                 int32_t task_id = payload->task_id;
                 PTO2TaskDescriptor* pto2_task = &task_descriptors[task_id & window_mask];
 
-                DEV_INFO("Thread %d: Core %d completed PTO2 task %d", thread_idx, core_id, task_id);
+                DEV_DEBUG("Thread %d: Core %d completed PTO2 task %d", thread_idx, core_id, task_id);
 
                 // Acquire fanout_lock, mark completed (state=2), snapshot fanout_head
-                while (PTO2_EXCHANGE(&pto2_task->fanout_lock, 1) != 0) { PTO2_SPIN_PAUSE(); }
+                while (PTO2_EXCHANGE(&pto2_task->fanout_lock, 1) != 0) { PTO2_SPIN_PAUSE_LIGHT(); }
                 __atomic_store_n(&s_pto2_task_completed[task_id & window_mask], 2, __ATOMIC_RELEASE);
                 int32_t fanout_head = pto2_task->fanout_head;
                 PTO2_STORE_RELEASE(&pto2_task->fanout_lock, 0);
 
                 // Traverse fanout outside lock
+                int32_t fanout_len = 0;
                 int32_t current = fanout_head;
                 while (current > 0) {
+                    fanout_len++;
                     PTO2DepListEntry* entry = &dep_list_pool[current];
                     int32_t consumer_id = entry->task_id;
                     int32_t consumer_slot = consumer_id & window_mask;
@@ -587,21 +610,19 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                         __atomic_store_n(&s_pto2_task_completed[consumer_slot], 1, __ATOMIC_RELEASE);
                         int32_t wt = consumer_desc->worker_type;
                         if (wt == PTO2_WORKER_CUBE) {
-                            std::lock_guard<std::mutex> lock(ready_queue_aic_mutex_);
-                            // FIFO: enqueue to tail
-                            ready_queue_aic_[ready_queue_aic_tail_] = consumer_id;
-                            ready_queue_aic_tail_ = (ready_queue_aic_tail_ + 1) % AICPU_MAX_READY_TASKS;
-                            ready_count_aic_.fetch_add(1, std::memory_order_release);
+                            ready_queue_aic_lock_.lock();
+                            ready_queue_aic_[ready_queue_aic_tail_++ & AICPU_READY_MASK] = consumer_id;
+                            ready_queue_aic_lock_.unlock();
                         } else {
-                            std::lock_guard<std::mutex> lock(ready_queue_aiv_mutex_);
-                            // FIFO: enqueue to tail
-                            ready_queue_aiv_[ready_queue_aiv_tail_] = consumer_id;
-                            ready_queue_aiv_tail_ = (ready_queue_aiv_tail_ + 1) % AICPU_MAX_READY_TASKS;
-                            ready_count_aiv_.fetch_add(1, std::memory_order_release);
+                            ready_queue_aiv_lock_.lock();
+                            ready_queue_aiv_[ready_queue_aiv_tail_++ & AICPU_READY_MASK] = consumer_id;
+                            ready_queue_aiv_lock_.unlock();
                         }
                     }
                     current = entry->next_offset;
                 }
+                total_fanout_traversed += fanout_len;
+                if (fanout_len > max_fanout_len) max_fanout_len = fanout_len;
 
                 cur_thread_tasks_in_flight--;
                 cur_thread_completed++;
@@ -609,6 +630,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                 completed_tasks_.fetch_add(1, std::memory_order_release);
             }
         }
+        _phase_t1 = _orch_now_ns(); sched_complete_ns += (_phase_t1 - _phase_t0); _phase_t0 = _phase_t1;
 
         // Phase 2: Dispatch ready tasks to idle cores (build PTO2DispatchPayload)
         if (cur_thread_tasks_in_flight < core_num) {
@@ -616,53 +638,37 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                 int core_id = cur_thread_cores[i];
                 Handshake* h = &hank[core_id];
                 if (h->task_status == 0 && h->task == 0) {
-                    bool dispatched = false;
-                    if (h->core_type == CoreType::AIC && ready_count_aic_.load(std::memory_order_acquire) > 0) {
-                        std::lock_guard<std::mutex> lock(ready_queue_aic_mutex_);
-                        int count = ready_count_aic_.load(std::memory_order_relaxed);
-                        if (count > 0) {
-                            // FIFO: dequeue from head
-                            int32_t task_id = ready_queue_aic_[ready_queue_aic_head_];
-                            ready_queue_aic_head_ = (ready_queue_aic_head_ + 1) % AICPU_MAX_READY_TASKS;
-                            ready_count_aic_.fetch_sub(1, std::memory_order_release);
-                            PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
-                            PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
-                            build_pto2_payload(payload, runtime, task, task_descriptors, dep_list_pool, window_size);
-                            h->task = reinterpret_cast<uint64_t>(payload);
-                            if (runtime->enable_profiling) {
-                                dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
-                            }
-                            h->task_status = 1;
-                            cur_thread_tasks_in_flight++;
-                            made_progress = true;
-                            dispatched = true;
-                            DEV_INFO("Thread %d: Dispatching PTO2 AIC task %d to core %d", thread_idx, task_id, core_id);
+                    int32_t task_id = -1;
+                    if (h->core_type == CoreType::AIC) {
+                        ready_queue_aic_lock_.lock();
+                        if (ready_queue_aic_head_ < ready_queue_aic_tail_) {
+                            task_id = ready_queue_aic_[ready_queue_aic_head_++ & AICPU_READY_MASK];
                         }
+                        ready_queue_aic_lock_.unlock();
+                    } else {
+                        ready_queue_aiv_lock_.lock();
+                        if (ready_queue_aiv_head_ < ready_queue_aiv_tail_) {
+                            task_id = ready_queue_aiv_[ready_queue_aiv_head_++ & AICPU_READY_MASK];
+                        }
+                        ready_queue_aiv_lock_.unlock();
                     }
-                    if (!dispatched && h->core_type == CoreType::AIV && ready_count_aiv_.load(std::memory_order_acquire) > 0) {
-                        std::lock_guard<std::mutex> lock(ready_queue_aiv_mutex_);
-                        int count = ready_count_aiv_.load(std::memory_order_relaxed);
-                        if (count > 0) {
-                            // FIFO: dequeue from head
-                            int32_t task_id = ready_queue_aiv_[ready_queue_aiv_head_];
-                            ready_queue_aiv_head_ = (ready_queue_aiv_head_ + 1) % AICPU_MAX_READY_TASKS;
-                            ready_count_aiv_.fetch_sub(1, std::memory_order_release);
-                            PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
-                            PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
-                            build_pto2_payload(payload, runtime, task, task_descriptors, dep_list_pool, window_size);
-                            h->task = reinterpret_cast<uint64_t>(payload);
-                            if (runtime->enable_profiling) {
-                                dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
-                            }
-                            h->task_status = 1;
-                            cur_thread_tasks_in_flight++;
-                            made_progress = true;
-                            DEV_INFO("Thread %d: Dispatching PTO2 AIV task %d to core %d", thread_idx, task_id, core_id);
+                    if (task_id >= 0) {
+                        PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
+                        PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
+                        build_pto2_payload(payload, runtime, task, task_descriptors, dep_list_pool, window_size);
+                        h->task = reinterpret_cast<uint64_t>(payload);
+                        if (runtime->enable_profiling) {
+                            dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                         }
+                        h->task_status = 1;
+                        cur_thread_tasks_in_flight++;
+                        made_progress = true;
+                        DEV_DEBUG("Thread %d: Dispatching PTO2 task %d to core %d", thread_idx, task_id, core_id);
                     }
                 }
             }
         }
+        _phase_t1 = _orch_now_ns(); sched_dispatch_ns += (_phase_t1 - _phase_t0); _phase_t0 = _phase_t1;
 
         if (!made_progress) {
             idle_iterations++;
@@ -675,12 +681,32 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                 return -1;
             }
             std::this_thread::yield();
+            sched_yield_count++;
+            _phase_t1 = _orch_now_ns(); sched_yield_ns += (_phase_t1 - _phase_t0);
         } else {
             idle_iterations = 0;
         }
     }
 
-    DEV_INFO("Thread %d: PTO2 execution complete, completed %d tasks", thread_idx, cur_thread_completed);
+    uint64_t sched_total = sched_scan_ns + sched_orch_drain_ns + sched_complete_ns + sched_dispatch_ns + sched_yield_ns;
+    if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
+    DEV_ALWAYS("Thread %d: PTO2 scheduler stats: loops=%llu, completed=%d, total=%.3fms",
+             thread_idx, (unsigned long long)sched_loop_count, cur_thread_completed, sched_total/1e6);
+    DEV_ALWAYS("Thread %d:   scan=%.3fms (%.1f%%), orch_drain=%.3fms (%.1f%%), complete=%.3fms (%.1f%%), dispatch=%.3fms (%.1f%%)",
+             thread_idx,
+             sched_scan_ns/1e6, sched_scan_ns*100.0/sched_total,
+             sched_orch_drain_ns/1e6, sched_orch_drain_ns*100.0/sched_total,
+             sched_complete_ns/1e6, sched_complete_ns*100.0/sched_total,
+             sched_dispatch_ns/1e6, sched_dispatch_ns*100.0/sched_total);
+    DEV_ALWAYS("Thread %d:   yield=%.3fms (%.1f%%, %llu calls, avg=%.1fus)",
+             thread_idx, sched_yield_ns/1e6, sched_yield_ns*100.0/sched_total,
+             (unsigned long long)sched_yield_count,
+             sched_yield_count > 0 ? sched_yield_ns/1e3/sched_yield_count : 0.0);
+    DEV_ALWAYS("Thread %d:   fanout: total_traversed=%llu, max_len=%d, avg=%.1f",
+             thread_idx, (unsigned long long)total_fanout_traversed, max_fanout_len,
+             cur_thread_completed > 0 ? (double)total_fanout_traversed / cur_thread_completed : 0.0);
+
+    DEV_ALWAYS("Thread %d: PTO2 execution complete, completed %d tasks", thread_idx, cur_thread_completed);
 
     // Flush performance buffers for cores managed by this thread
     if (profiling_enabled) {
@@ -860,12 +886,40 @@ int AicpuExecutor::run(Runtime* runtime) {
             rt->orchestrator.aicpu_task_completed = s_pto2_task_completed;
             rt->orchestrator.aicpu_window_mask = ws - 1;
 
+            // Expose orchestrator ready queue to scheduler threads
+            orch_ready_queue_ = rt->orchestrator.orch_ready_queue;
+            orch_ready_tail_ = &rt->orchestrator.orch_ready_tail;
+            orch_ready_head_ = &rt->orchestrator.orch_ready_head;
+            orch_ready_capacity_ = PTO2OrchestratorState::ORCH_READY_QUEUE_SIZE;
+
             // Call orchestration wrapped in outer scope (matches old PTO2_ORCHESTRATION behavior)
             DEV_INFO("Thread 3: Calling aicpu_orchestration_entry from SO");
             PTO2_SCOPE(rt) {
                 orch_func(rt, args, arg_count);
             }
             DEV_INFO("Thread 3: aicpu_orchestration_entry returned");
+
+            // Print orchestrator profiling data
+#if PTO2_ORCH_PROFILING
+            {
+                PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
+                uint64_t total = p.sync_ns + p.alloc_ns + p.params_ns +
+                                 p.lookup_ns + p.heap_ns + p.insert_ns +
+                                 p.fanin_ns + p.finalize_ns;
+                DEV_INFO("=== Orchestrator Profiling: %lld tasks, total=%.3fms ===",
+                         (long long)p.submit_count, total / 1e6);
+                DEV_INFO("  sync_tensormap : %.3fms (%.1f%%)", p.sync_ns / 1e6, p.sync_ns * 100.0 / total);
+                DEV_INFO("  task_ring_alloc: %.3fms (%.1f%%)", p.alloc_ns / 1e6, p.alloc_ns * 100.0 / total);
+                DEV_INFO("  param_copy     : %.3fms (%.1f%%)", p.params_ns / 1e6, p.params_ns * 100.0 / total);
+                DEV_INFO("  lookup+dep     : %.3fms (%.1f%%)", p.lookup_ns / 1e6, p.lookup_ns * 100.0 / total);
+                DEV_INFO("  heap_alloc     : %.3fms (%.1f%%)", p.heap_ns / 1e6, p.heap_ns * 100.0 / total);
+                DEV_INFO("  tensormap_ins  : %.3fms (%.1f%%)", p.insert_ns / 1e6, p.insert_ns * 100.0 / total);
+                DEV_INFO("  fanin+ready    : %.3fms (%.1f%%)", p.fanin_ns / 1e6, p.fanin_ns * 100.0 / total);
+                DEV_INFO("  finalize+SM    : %.3fms (%.1f%%)", p.finalize_ns / 1e6, p.finalize_ns * 100.0 / total);
+                DEV_INFO("  scope_end      : %.3fms", p.scope_end_ns / 1e6);
+                DEV_INFO("  avg/task       : %.3fus", total / 1e3 / p.submit_count);
+            }
+#endif
 
             // Teardown runtime
             pto2_rt_orchestration_done(rt);
@@ -913,8 +967,6 @@ int AicpuExecutor::run(Runtime* runtime) {
 
 void AicpuExecutor::deinit() {
     // Cleanup runtime execution state
-    ready_count_aic_.store(0, std::memory_order_release);
-    ready_count_aiv_.store(0, std::memory_order_release);
     ready_queue_aic_head_ = 0;
     ready_queue_aic_tail_ = 0;
     ready_queue_aiv_head_ = 0;
@@ -954,22 +1006,22 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int thread_idx,
                                          const int* cur_thread_cores, int core_num,
                                          Handshake* hank) {
     (void)runtime;  // Reserved for future use
-    DEV_ERROR("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
+    DEV_ALWAYS("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
 
     int completed = completed_tasks_.load(std::memory_order_acquire);
     int total = total_tasks_.load(std::memory_order_acquire);
-    DEV_ERROR("Progress: %d/%d tasks (%.1f%%)",
+    DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)",
              completed, total, total > 0 ? completed * 100.0 / total : 0.0);
 
-    int aic_ready = ready_count_aic_.load(std::memory_order_acquire);
-    int aiv_ready = ready_count_aiv_.load(std::memory_order_acquire);
-    DEV_ERROR("Ready Queues: AIC=%d, AIV=%d", aic_ready, aiv_ready);
+    int aic_ready = ready_queue_aic_tail_ - ready_queue_aic_head_;
+    int aiv_ready = ready_queue_aiv_tail_ - ready_queue_aiv_head_;
+    DEV_ALWAYS("Ready Queues: AIC=%d, AIV=%d", aic_ready, aiv_ready);
 
     int busy_cores = 0;
     int idle_cores = 0;
     int anomaly_cores = 0;
 
-    DEV_ERROR("Core Status:");
+    DEV_ALWAYS("Core Status:");
     for (int i = 0; i < core_num; i++) {
         int core_id = cur_thread_cores[i];
         Handshake* h = &hank[core_id];
@@ -980,30 +1032,30 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int thread_idx,
             PTO2DispatchPayload* payload = reinterpret_cast<PTO2DispatchPayload*>(h->task);
             busy_cores++;
 
-            DEV_ERROR("  Core %d [%s, BUSY]: task_id=%d, kernel_id=%d",
+            DEV_ALWAYS("  Core %d [%s, BUSY]: task_id=%d, kernel_id=%d",
                      core_id, core_type_str,
                      payload->task_id, payload->kernel_id);
         } else if (h->task_status != 0) {
             anomaly_cores++;
-            DEV_ERROR("  Core %d [%s, ANOMALY]: status=BUSY but task=NULL", core_id, core_type_str);
+            DEV_ALWAYS("  Core %d [%s, ANOMALY]: status=BUSY but task=NULL", core_id, core_type_str);
         } else {
             idle_cores++;
         }
     }
 
-    DEV_ERROR("Summary: %d busy, %d idle, %d anomaly", busy_cores, idle_cores, anomaly_cores);
+    DEV_ALWAYS("Summary: %d busy, %d idle, %d anomaly", busy_cores, idle_cores, anomaly_cores);
 
     // Diagnose deadlock vs livelock
     if (busy_cores == 0 && aic_ready == 0 && aiv_ready == 0 && completed < total) {
-        DEV_ERROR("*** DEADLOCK DETECTED ***");
-        DEV_ERROR("All cores idle, no ready tasks, but %d tasks incomplete", total - completed);
-        DEV_ERROR("Check PTO2 shared memory for task dependency state");
+        DEV_ALWAYS("*** DEADLOCK DETECTED ***");
+        DEV_ALWAYS("All cores idle, no ready tasks, but %d tasks incomplete", total - completed);
+        DEV_ALWAYS("Check PTO2 shared memory for task dependency state");
     } else if (busy_cores > 0) {
-        DEV_ERROR("*** LIVELOCK / HUNG TASK ***");
-        DEV_ERROR("%d cores executing but no progress", busy_cores);
+        DEV_ALWAYS("*** LIVELOCK / HUNG TASK ***");
+        DEV_ALWAYS("%d cores executing but no progress", busy_cores);
     }
 
-    DEV_ERROR("========== END DIAGNOSTIC ==========");
+    DEV_ALWAYS("========== END DIAGNOSTIC ==========");
 }
 
 // =============================================================================

--- a/src/runtime/tensormap_and_ringbuffer/orchestration/tensor_orch.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/orchestration/tensor_orch.cpp
@@ -54,32 +54,7 @@ Tensor::Tensor(Tensor&& other)
     }
 }
 
-Tensor::Tensor(const Tensor& other)
-    : buffer(other.buffer),
-      start_offset(other.start_offset),
-      ndims(other.ndims),
-      dtype(other.dtype),
-      version(other.version),
-      overlap_type(other.overlap_type) {
-    for (uint64_t i = 0; i < ndims; i++) {
-        strides[i] = other.strides[i];
-        repeats[i] = other.repeats[i];
-    }
-}
-
-Tensor& Tensor::operator=(const Tensor& other) {
-    buffer = other.buffer;
-    start_offset = other.start_offset;
-    ndims = other.ndims;
-    dtype = other.dtype;
-    version = other.version;
-    overlap_type = other.overlap_type;
-    for (uint64_t i = 0; i < ndims; i++) {
-        strides[i] = other.strides[i];
-        repeats[i] = other.repeats[i];
-    }
-    return *this;
-}
+// Copy constructor and operator= are now inline in tensor.h
 
 // =============================================================================
 // Validation and optimization (called by constructor's debug_assert)

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -272,9 +272,9 @@ int32_t pto2_task_ring_try_alloc(PTO2TaskRing* ring) {
         int32_t task_id = current;
         int32_t slot = task_id & (ring->window_size - 1);
         
-        // Initialize task descriptor
+        // Mark slot as occupied (skip full memset — pto2_submit_task
+        // explicitly initializes all fields it needs)
         PTO2TaskDescriptor* task = &ring->descriptors[slot];
-        memset(task, 0, sizeof(PTO2TaskDescriptor));
         task->task_id = task_id;
         task->is_active = true;
         

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -279,7 +279,6 @@ typedef struct {
     PTOParam params[16];
     Tensor tensor_copies[16];  // Owned tensor data (params[i].tensor points here)
     int param_count{0};
-    
 } PTO2TaskDescriptor;
 
 // =============================================================================
@@ -378,10 +377,13 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 #include <sched.h>
 #if defined(__aarch64__)
     #define PTO2_SPIN_PAUSE()         do { __asm__ __volatile__("yield" ::: "memory"); sched_yield(); } while(0)
+    #define PTO2_SPIN_PAUSE_LIGHT()   __asm__ __volatile__("yield" ::: "memory")
 #elif defined(__x86_64__)
     #define PTO2_SPIN_PAUSE()         do { __builtin_ia32_pause(); sched_yield(); } while(0)
+    #define PTO2_SPIN_PAUSE_LIGHT()   __builtin_ia32_pause()
 #else
     #define PTO2_SPIN_PAUSE()         sched_yield()
+    #define PTO2_SPIN_PAUSE_LIGHT()   ((void)0)
 #endif
 
 /**

--- a/src/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -132,9 +132,33 @@ struct Tensor {
         OverlapType overlap_type = OverlapType::Accurate);
 
     Tensor(Tensor&& other);
-    Tensor(const Tensor& other);
 
-    Tensor& operator=(const Tensor& other);
+    Tensor(const Tensor& other)
+        : buffer(other.buffer),
+          start_offset(other.start_offset),
+          ndims(other.ndims),
+          dtype(other.dtype),
+          version(other.version),
+          overlap_type(other.overlap_type) {
+        for (uint64_t i = 0; i < ndims; i++) {
+            strides[i] = other.strides[i];
+            repeats[i] = other.repeats[i];
+        }
+    }
+
+    Tensor& operator=(const Tensor& other) {
+        buffer = other.buffer;
+        start_offset = other.start_offset;
+        ndims = other.ndims;
+        dtype = other.dtype;
+        version = other.version;
+        overlap_type = other.overlap_type;
+        for (uint64_t i = 0; i < ndims; i++) {
+            strides[i] = other.strides[i];
+            repeats[i] = other.repeats[i];
+        }
+        return *this;
+    }
 
     std::string dump() const;
 

--- a/tests/device_tests/host_build_graph/paged_attention/golden.py
+++ b/tests/device_tests/host_build_graph/paged_attention/golden.py
@@ -118,6 +118,9 @@ def paged_attention(
     """
     Compute paged attention using online softmax with head tiling and GQA.
 
+    Vectorized across the batch dimension for performance.
+    Supports different context_lens per batch via masking.
+
     Args:
         query: (batch, num_heads, head_dim) bfloat16
         key_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
@@ -129,65 +132,87 @@ def paged_attention(
         context_lens: (batch,) int32
 
     Returns:
-        out: (batch, num_heads, head_dim) float32
+        out: (batch * num_heads, head_dim) float32
     """
     assert num_kv_heads == 1
-    batch, num_heads, head_dim = query.shape
+    batch, num_heads_dim, head_dim = query.shape
     _, block_size, _, _ = key_cache.shape
-    _, block_num = block_table.shape
 
-    query = query.reshape(-1, head_dim)
-    key_cache = key_cache.reshape(-1, block_size, head_dim)
-    value_cache = value_cache.reshape(-1, block_size, head_dim)
+    # Reshape for batched computation
+    key_cache_flat = key_cache.reshape(-1, block_size, head_dim)
+    value_cache_flat = value_cache.reshape(-1, block_size, head_dim)
 
-    out = torch.zeros((batch * num_heads, head_dim), dtype=torch.float32)
+    out = torch.zeros((batch, num_heads_dim, head_dim), dtype=torch.float32)
 
-    for b_idx in range(batch):
-        cur_seq = int(context_lens[b_idx])
-        bn_this_batch = (cur_seq + block_size - 1) // block_size
-        assert bn_this_batch <= block_num
+    q_tile = min(num_heads_dim, 128)
 
-        q_tile = min(num_heads, 128)
-        for cur_offset in range(0, num_heads, q_tile):
-            q_tile_size = min(q_tile, num_heads - cur_offset)
-            base_idx = b_idx * num_heads + cur_offset
-            qi = query[base_idx : base_idx + q_tile_size].to(torch.float32)
+    # Max blocks across all batches (each batch may have different context_len)
+    max_bn = int(((context_lens.max().item()) + block_size - 1) // block_size)
 
-            oi = None
-            li = None
-            mi = None
+    for q_offset in range(0, num_heads_dim, q_tile):
+        q_tile_size = min(q_tile, num_heads_dim - q_offset)
+        # qi: (batch, q_tile_size, head_dim)
+        qi = query[:, q_offset:q_offset + q_tile_size, :].to(torch.float32)
 
-            for bn in range(bn_this_batch):
-                cur_block_idx = block_table[b_idx, bn]
-                valid_len = min(block_size, cur_seq - bn * block_size)
-                kj = key_cache[cur_block_idx, :valid_len, :].to(torch.float32)
-                vj = value_cache[cur_block_idx, :valid_len, :].to(torch.float32)
+        oi = None  # (batch, q_tile_size, head_dim)
+        li = None  # (batch, q_tile_size, 1)
+        mi = None  # (batch, q_tile_size, 1)
 
-                sij = (qi @ kj.T) * scale_value
-                mij = sij.max(dim=-1, keepdim=True)[0]
-                pij = torch.exp(sij - mij).to(torch.bfloat16).to(torch.float32)
-                lij = pij.sum(dim=1, keepdim=True)
+        for bn in range(max_bn):
+            # valid_len per batch for this block position
+            valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+            active_mask = valid_lens > 0  # (batch,)
 
-                if bn == 0:
-                    oi = pij @ vj
-                    li = lij
-                    mi = mij
-                else:
-                    mi_new = torch.maximum(mi, mij)
-                    alpha = torch.exp(mi - mi_new)
-                    beta = torch.exp(mij - mi_new)
-                    li_new = alpha * li + beta * lij
-                    oi_new = pij @ vj
-                    oi = alpha * oi + beta * oi_new
-                    li = li_new
-                    mi = mi_new
+            if not active_mask.any():
+                break
 
-                if bn == bn_this_batch - 1:
-                    oi = oi / li
+            # Gather block indices for all batches
+            block_indices = block_table[:, bn]  # (batch,)
 
-            out[base_idx : base_idx + q_tile_size] = oi
+            # Gather K and V: (batch, block_size, head_dim)
+            kj_all = key_cache_flat[block_indices].to(torch.float32)
+            vj_all = value_cache_flat[block_indices].to(torch.float32)
 
-    return out
+            # QK matmul: (batch, q_tile_size, block_size)
+            sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale_value
+
+            # Mask out invalid positions (beyond valid_len per batch)
+            pos = torch.arange(block_size, device=sij.device).unsqueeze(0)  # (1, block_size)
+            valid_mask = pos < valid_lens.unsqueeze(1)  # (batch, block_size)
+            valid_mask = valid_mask.unsqueeze(1)  # (batch, 1, block_size)
+            sij = sij.masked_fill(~valid_mask, float('-inf'))
+
+            # Also mask inactive batches (no blocks at this position)
+            batch_mask = active_mask.view(-1, 1, 1)  # (batch, 1, 1)
+            sij = sij.masked_fill(~batch_mask, float('-inf'))
+
+            mij = sij.max(dim=-1, keepdim=True)[0]  # (batch, q_tile_size, 1)
+            mij = mij.clamp(min=-1e30)
+            pij = torch.exp(sij - mij)
+            pij = pij.masked_fill(~valid_mask, 0.0)
+            pij = pij.masked_fill(~batch_mask, 0.0)
+            pij = pij.to(torch.bfloat16).to(torch.float32)
+            lij = pij.sum(dim=-1, keepdim=True)  # (batch, q_tile_size, 1)
+
+            # PV matmul: (batch, q_tile_size, head_dim)
+            oi_new = torch.bmm(pij, vj_all)
+
+            if bn == 0:
+                oi = oi_new
+                li = lij
+                mi = mij
+            else:
+                mi_new = torch.maximum(mi, mij)
+                alpha = torch.exp(mi - mi_new)
+                beta = torch.exp(mij - mi_new)
+                li = alpha * li + beta * lij
+                oi = alpha * oi + beta * oi_new
+                mi = mi_new
+
+        # Final normalization
+        out[:, q_offset:q_offset + q_tile_size, :] = oi / li
+
+    return out.reshape(-1, head_dim)
 
 
 def compute_golden(tensors: dict, params: dict) -> None:

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -118,6 +118,9 @@ def paged_attention(
     """
     Compute paged attention using online softmax with head tiling and GQA.
 
+    Vectorized across the batch dimension for performance.
+    Supports different context_lens per batch via masking.
+
     Args:
         query: (batch, num_heads, head_dim) bfloat16
         key_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
@@ -129,65 +132,87 @@ def paged_attention(
         context_lens: (batch,) int32
 
     Returns:
-        out: (batch, num_heads, head_dim) float32
+        out: (batch * num_heads, head_dim) float32
     """
     assert num_kv_heads == 1
-    batch, num_heads, head_dim = query.shape
+    batch, num_heads_dim, head_dim = query.shape
     _, block_size, _, _ = key_cache.shape
-    _, block_num = block_table.shape
 
-    query = query.reshape(-1, head_dim)
-    key_cache = key_cache.reshape(-1, block_size, head_dim)
-    value_cache = value_cache.reshape(-1, block_size, head_dim)
+    # Reshape for batched computation
+    key_cache_flat = key_cache.reshape(-1, block_size, head_dim)
+    value_cache_flat = value_cache.reshape(-1, block_size, head_dim)
 
-    out = torch.zeros((batch * num_heads, head_dim), dtype=torch.float32)
+    out = torch.zeros((batch, num_heads_dim, head_dim), dtype=torch.float32)
 
-    for b_idx in range(batch):
-        cur_seq = int(context_lens[b_idx])
-        bn_this_batch = (cur_seq + block_size - 1) // block_size
-        assert bn_this_batch <= block_num
+    q_tile = min(num_heads_dim, 128)
 
-        q_tile = min(num_heads, 128)
-        for cur_offset in range(0, num_heads, q_tile):
-            q_tile_size = min(q_tile, num_heads - cur_offset)
-            base_idx = b_idx * num_heads + cur_offset
-            qi = query[base_idx : base_idx + q_tile_size].to(torch.float32)
+    # Max blocks across all batches (each batch may have different context_len)
+    max_bn = int(((context_lens.max().item()) + block_size - 1) // block_size)
 
-            oi = None
-            li = None
-            mi = None
+    for q_offset in range(0, num_heads_dim, q_tile):
+        q_tile_size = min(q_tile, num_heads_dim - q_offset)
+        # qi: (batch, q_tile_size, head_dim)
+        qi = query[:, q_offset:q_offset + q_tile_size, :].to(torch.float32)
 
-            for bn in range(bn_this_batch):
-                cur_block_idx = block_table[b_idx, bn]
-                valid_len = min(block_size, cur_seq - bn * block_size)
-                kj = key_cache[cur_block_idx, :valid_len, :].to(torch.float32)
-                vj = value_cache[cur_block_idx, :valid_len, :].to(torch.float32)
+        oi = None  # (batch, q_tile_size, head_dim)
+        li = None  # (batch, q_tile_size, 1)
+        mi = None  # (batch, q_tile_size, 1)
 
-                sij = (qi @ kj.T) * scale_value
-                mij = sij.max(dim=-1, keepdim=True)[0]
-                pij = torch.exp(sij - mij).to(torch.bfloat16).to(torch.float32)
-                lij = pij.sum(dim=1, keepdim=True)
+        for bn in range(max_bn):
+            # valid_len per batch for this block position
+            valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+            active_mask = valid_lens > 0  # (batch,)
 
-                if bn == 0:
-                    oi = pij @ vj
-                    li = lij
-                    mi = mij
-                else:
-                    mi_new = torch.maximum(mi, mij)
-                    alpha = torch.exp(mi - mi_new)
-                    beta = torch.exp(mij - mi_new)
-                    li_new = alpha * li + beta * lij
-                    oi_new = pij @ vj
-                    oi = alpha * oi + beta * oi_new
-                    li = li_new
-                    mi = mi_new
+            if not active_mask.any():
+                break
 
-                if bn == bn_this_batch - 1:
-                    oi = oi / li
+            # Gather block indices for all batches
+            block_indices = block_table[:, bn]  # (batch,)
 
-            out[base_idx : base_idx + q_tile_size] = oi
+            # Gather K and V: (batch, block_size, head_dim)
+            kj_all = key_cache_flat[block_indices].to(torch.float32)
+            vj_all = value_cache_flat[block_indices].to(torch.float32)
 
-    return out
+            # QK matmul: (batch, q_tile_size, block_size)
+            sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale_value
+
+            # Mask out invalid positions (beyond valid_len per batch)
+            pos = torch.arange(block_size, device=sij.device).unsqueeze(0)  # (1, block_size)
+            valid_mask = pos < valid_lens.unsqueeze(1)  # (batch, block_size)
+            valid_mask = valid_mask.unsqueeze(1)  # (batch, 1, block_size)
+            sij = sij.masked_fill(~valid_mask, float('-inf'))
+
+            # Also mask inactive batches (no blocks at this position)
+            batch_mask = active_mask.view(-1, 1, 1)  # (batch, 1, 1)
+            sij = sij.masked_fill(~batch_mask, float('-inf'))
+
+            mij = sij.max(dim=-1, keepdim=True)[0]  # (batch, q_tile_size, 1)
+            mij = mij.clamp(min=-1e30)
+            pij = torch.exp(sij - mij)
+            pij = pij.masked_fill(~valid_mask, 0.0)
+            pij = pij.masked_fill(~batch_mask, 0.0)
+            pij = pij.to(torch.bfloat16).to(torch.float32)
+            lij = pij.sum(dim=-1, keepdim=True)  # (batch, q_tile_size, 1)
+
+            # PV matmul: (batch, q_tile_size, head_dim)
+            oi_new = torch.bmm(pij, vj_all)
+
+            if bn == 0:
+                oi = oi_new
+                li = lij
+                mi = mij
+            else:
+                mi_new = torch.maximum(mi, mij)
+                alpha = torch.exp(mi - mi_new)
+                beta = torch.exp(mij - mi_new)
+                li = alpha * li + beta * lij
+                oi = alpha * oi + beta * oi_new
+                mi = mi_new
+
+        # Final normalization
+        out[:, q_offset:q_offset + q_tile_size, :] = oi / li
+
+    return out.reshape(-1, head_dim)
 
 
 def compute_golden(tensors: dict, params: dict) -> None:


### PR DESCRIPTION
- Replace std::mutex with spinlocks and bitmask circular queues in
  AICPU scheduler ready queues; remove redundant atomic counters
- Add orchestrator ready queue (SPSC ring) to push early-return ready
  tasks directly, replacing O(N) readiness scan in scheduler
- Stack-allocate tensormap lookup results (PTO2LookupResult) to avoid
  per-lookup heap allocation from std::vector
- Inline Tensor copy ctor/operator= into header; skip memset on task
  ring slot allocation; bulk memcpy params in submit_task
- Add PTO2_SPIN_PAUSE_LIGHT() (yield without sched_yield) for
  tight spinloops on aarch64/x86_64
- Add DEV_ALWAYS log level for diagnostics; change diagnostic reports
  from DEV_ERROR to DEV_ALWAYS, per-task logs from DEV_INFO to DEV_DEBUG
- Add profiling instrumentation to scheduler, orchestrator, and host
  runtime init
- Vectorize paged attention golden computation across batch dimension
- 修复64batch卡死的问题，暂时将window大小改成65536，后面再支持task ring的环形分配
- replace pa golden