### PR TITLE
Refactor: remove unused func_name parameter from pto2_rt_submit_task

### DIFF
--- a/examples/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -112,7 +112,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                             make_output_param(P),
                         };
                         pto2_rt_submit_task(rt, FUNC_GEMM_TILE, PTO2_WORKER_CUBE,
-                                           "gemm", params_gemm, 3);
+                                           params_gemm, 3); // gemm
 
                         // C[m,n] += P
                         PTOParam params_add[] = {
@@ -120,7 +120,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                             make_input_param(P),
                         };
                         pto2_rt_submit_task(rt, FUNC_TILE_ADD, PTO2_WORKER_VECTOR,
-                                           "add", params_add, 2);
+                                           params_add, 2); // add
                     }
                 }
             }

--- a/examples/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -129,7 +129,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                     make_output_param(li_update),
                     make_output_param(mi_update),
                 };
-                pto2_rt_submit_task(rt, FUNC_AIV_HUB, PTO2_WORKER_VECTOR, "create_inplace", params_inplace, 3);
+                pto2_rt_submit_task(rt, FUNC_AIV_HUB, PTO2_WORKER_VECTOR, params_inplace, 3); // create_inplace
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
                     Tensor qi = query.view({q_tile, head_dim}, {cur_offset, 0});
@@ -147,7 +147,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                         make_input_param(kj),
                         make_output_param(sij),
                     };
-                    pto2_rt_submit_task(rt, FUNC_QK_MATMUL, PTO2_WORKER_CUBE, "c1", params_qk, 3);
+                    pto2_rt_submit_task(rt, FUNC_QK_MATMUL, PTO2_WORKER_CUBE, params_qk, 3); // c1
 
                     Tensor sij_valid = sij.view({q_tile, valid_len}, {0, 0});
                     Tensor li = make_tensor(li_shapes, 1, DataType::FLOAT32);
@@ -159,7 +159,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                         make_output_param(mi),
                         make_output_param(li),
                     };
-                    pto2_rt_submit_task(rt, FUNC_SOFTMAX_PREPARE, PTO2_WORKER_VECTOR, "v1", params_sf, 5);
+                    pto2_rt_submit_task(rt, FUNC_SOFTMAX_PREPARE, PTO2_WORKER_VECTOR, params_sf, 5); // v1
 
                     uint64_t oi_tmp_shapes[2] = {q_tile, head_dim};
                     Tensor oi_tmp = make_tensor(oi_tmp_shapes, 2, DataType::FLOAT32);
@@ -169,7 +169,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                         make_input_param(vj),
                         make_output_param(oi_tmp),
                     };
-                    pto2_rt_submit_task(rt, FUNC_PV_MATMUL, PTO2_WORKER_CUBE, "c2", params_pv, 3);
+                    pto2_rt_submit_task(rt, FUNC_PV_MATMUL, PTO2_WORKER_CUBE, params_pv, 3); // c2
 
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
@@ -186,7 +186,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                         make_scalar_param(is_first),
                         make_scalar_param(is_last),
                     };
-                    pto2_rt_submit_task(rt, FUNC_ONLINE_UPDATE, PTO2_WORKER_VECTOR, "v2", params_up, 9);
+                    pto2_rt_submit_task(rt, FUNC_ONLINE_UPDATE, PTO2_WORKER_VECTOR, params_up, 9); // v2
                 }
             }
         }

--- a/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -109,7 +109,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
         make_input_param(ext_b),
         make_output_param(c),
     };
-    pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t0, 3);
+    pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, params_t0, 3); // kernel_add
 
     // Inner scope: owns t1, t2, t3, t4; intermediates d, e, g release on scope end.
     // c flows in from outer scope (outer-scope tensors are visible to inner scopes).
@@ -125,7 +125,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
             make_output_param(d),
             make_scalar_param((uint64_t)3),
         };
-        pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t1, 3);
+        pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, params_t1, 3); // kernel_add_scalar
 
         // t2: e = c + 2 (kernel_id=1, kernel_add_scalar)
         PTOParam params_t2[] = {
@@ -134,7 +134,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
             make_output_param(e),
             make_scalar_param((uint64_t)3),
         };
-        pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, "kernel_add_scalar", params_t2, 3);
+        pto2_rt_submit_task(rt, 1, PTO2_WORKER_VECTOR, params_t2, 3); // kernel_add_scalar
 
         // t3: g = d * e (kernel_id=2, kernel_mul)
         PTOParam params_t3[] = {
@@ -143,7 +143,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
             make_output_param(g),
             make_scalar_param((uint64_t)3),
         };
-        pto2_rt_submit_task(rt, 2, PTO2_WORKER_VECTOR, "kernel_mul", params_t3, 3);
+        pto2_rt_submit_task(rt, 2, PTO2_WORKER_VECTOR, params_t3, 3); // kernel_mul
 
         // t4: f = g + c (kernel_id=0, kernel_add)
         PTOParam params_t4[] = {
@@ -151,7 +151,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
             make_input_param(c),
             make_output_param(ext_f),
         };
-        pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, "kernel_add", params_t4, 3);
+        pto2_rt_submit_task(rt, 0, PTO2_WORKER_VECTOR, params_t4, 3); // kernel_add
     }  // inner scope ends: releases d, e, g
 }
 

--- a/src/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -52,7 +52,7 @@ typedef struct PTO2Runtime PTO2Runtime;
  */
 typedef struct PTO2RuntimeOps {
     void (*submit_task)(PTO2Runtime* rt, int32_t kernel_id,
-                        PTO2WorkerType worker_type, const char* func_name,
+                        PTO2WorkerType worker_type,
                         PTOParam* params, int32_t num_params);
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
@@ -76,9 +76,8 @@ struct PTO2Runtime {
 
 static inline void pto2_rt_submit_task(PTO2Runtime* rt, int32_t kernel_id,
                                         PTO2WorkerType worker_type,
-                                        const char* func_name,
                                         PTOParam* params, int32_t num_params) {
-    rt->ops->submit_task(rt, kernel_id, worker_type, func_name, params, num_params);
+    rt->ops->submit_task(rt, kernel_id, worker_type, params, num_params);
 }
 
 static inline void pto2_rt_scope_begin(PTO2Runtime* rt) {

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -262,7 +262,6 @@ void* pto2_alloc_packed_buffer(PTO2OrchestratorState* orch, int32_t total_size) 
 void pto2_submit_task(PTO2OrchestratorState* orch,
     int32_t kernel_id,
     PTO2WorkerType worker_type,
-    const char* func_name,
     PTOParam* params,
     int32_t num_params) {
     ORCH_PROF_START();
@@ -286,7 +285,6 @@ void pto2_submit_task(PTO2OrchestratorState* orch,
     task->task_id = task_id;
     task->kernel_id = kernel_id;
     task->worker_type = worker_type;
-    task->func_name = func_name;
     task->fanin_head = 0;
     task->fanin_count = 0;
     task->fanout_head = 0;

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -173,14 +173,12 @@ void pto2_scope_end(PTO2OrchestratorState* orch);
  * @param orch        Orchestrator state
  * @param kernel_id   InCore function ID
  * @param worker_type Target worker type (CUBE, VECTOR, AI_CPU, ACCELERATOR)
- * @param func_name   Function name (for debugging)
  * @param params      Array of task parameters
  * @param num_params  Number of parameters
  */
 void pto2_submit_task(PTO2OrchestratorState* orch,
     int32_t kernel_id,
     PTO2WorkerType worker_type,
-    const char* func_name,
     PTOParam* params,
     int32_t num_params);
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -16,10 +16,10 @@
 // =============================================================================
 
 static void submit_task_impl(PTO2Runtime* rt, int32_t kernel_id,
-                              PTO2WorkerType worker_type, const char* func_name,
+                              PTO2WorkerType worker_type,
                               PTOParam* params, int32_t num_params) {
     pto2_submit_task(&rt->orchestrator, kernel_id, worker_type,
-                     func_name, params, num_params);
+                     params, num_params);
 }
 
 static void scope_begin_impl(PTO2Runtime* rt) {
@@ -189,16 +189,6 @@ void pto2_rt_scope_begin(PTO2Runtime* rt) {
 
 void pto2_rt_scope_end(PTO2Runtime* rt) {
     scope_end_impl(rt);
-}
-
-void pto2_rt_submit_task(PTO2Runtime* rt,
-                         int32_t kernel_id,
-                         PTO2WorkerType worker_type,
-                         const char* func_name,
-                         PTOParam* params,
-                         int32_t num_params) {
-    submit_task_impl(rt, kernel_id, worker_type,
-                     func_name, params, num_params);
 }
 
 void pto2_rt_orchestration_done(PTO2Runtime* rt) {

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -56,7 +56,7 @@ typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 typedef struct PTO2RuntimeOps {
     void (*submit_task)(PTO2Runtime* rt, int32_t kernel_id,
-                        PTO2WorkerType worker_type, const char* func_name,
+                        PTO2WorkerType worker_type,
                         PTOParam* params, int32_t num_params);
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
@@ -166,23 +166,6 @@ void pto2_rt_scope_begin(PTO2Runtime* rt);
  * Tasks whose refcount reaches zero will have their buffers released.
  */
 void pto2_rt_scope_end(PTO2Runtime* rt);
-
-/**
- * Submit a task
- *
- * @param rt          Runtime context
- * @param kernel_id   InCore function ID
- * @param worker_type Target worker type
- * @param func_name   Function name (for debugging)
- * @param params      Array of task parameters
- * @param num_params  Number of parameters
- */
-void pto2_rt_submit_task(PTO2Runtime* rt,
-                         int32_t kernel_id,
-                         PTO2WorkerType worker_type,
-                         const char* func_name,
-                         PTOParam* params,
-                         int32_t num_params);
 
 /**
  * Mark orchestration as complete

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -269,9 +269,6 @@ typedef struct {
     int32_t  output_index[PTO2_MAX_OUTPUTS]; // Offset of each output in params;
     int32_t  num_outputs;         // Number of output buffers
 
-    // Function name (for debugging/tracing)
-    const char* func_name;        // Function name (for debugging/tracing)
-    
     // Status flags
     bool     is_active;           // Task slot is in use
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -51,7 +51,7 @@ enum class PTOParamType : int32_t {
  *       make_input_param(td_a),
  *       make_output_param(td_c),
  *   };
- *   pto2_rt_submit_task(rt, func_id, worker_type, name, params, 2);
+ *   pto2_rt_submit_task(rt, func_id, worker_type, params, 2);
  *   // td_c.buffer.addr is already updated - no explicit sync needed
  */
 struct PTOParam {


### PR DESCRIPTION
The func_name parameter was originally intended for debugging but was stored in PTO2TaskDescriptor and never consumed by the runtime. Remove it from the entire call chain and replace the string literals at call sites with trailing comments to preserve readability.

Changes:
- Drop const char* func_name from PTO2RuntimeOps.submit_task, the pto2_rt_submit_task inline wrapper, pto2_submit_task, and submit_task_impl throughout the tensormap_and_ringbuffer runtime
- Remove PTO2TaskDescriptor::func_name field and the assignment in pto2_submit_task
- Delete the now-dead non-inline pto2_rt_submit_task exported function from pto_runtime2.cpp/.h (all callers use the inline in pto_orchestration_api.h)
- Update all call sites in examples/ and tests/ to drop the string argument and add it as a // comment
- Fix stale signature in pto_types.h doc comment