### PR TITLE
docs: add AI-assisted development guides, commands, and architecture reference

### DIFF
--- a/.ai-instructions/coding/architecture.md
+++ b/.ai-instructions/coding/architecture.md
@@ -1,0 +1,51 @@
+# Architecture Quick Reference
+
+## Three-Program Model
+
+PTO Runtime compiles three separate programs per invocation:
+- **Host** (`.so`): Runs on host CPU. Manages device memory, builds the task graph, launches execution.
+- **AICPU** (`.so`): Runs on AICPU processor. Schedules tasks to AICore via handshake buffers.
+- **AICore** (`.o`): Runs on AICore compute cores. Executes computation kernels (add, mul, matmul, etc.).
+
+Each program is compiled independently with its own toolchain and linked at runtime.
+
+## Runtime Variants
+
+Three runtimes under `src/runtime/`, each providing a different graph-building strategy:
+- **`host_build_graph`** -- Host CPU builds the full task dependency graph before launching
+- **`aicpu_build_graph`** -- AICPU builds and manages the graph on-device
+- **`tensormap_and_ringbuffer`** -- Advanced runtime with tensor maps, ring buffers, shared memory, and multi-core orchestration
+
+Each runtime has a `build_config.py` declaring its include/source directories for the three components (host, aicpu, aicore). The `RUNTIME_CONFIG.runtime` field in `kernel_config.py` selects which runtime to use.
+
+## Platform Backends
+
+Two backends under `src/platform/`:
+- **`a2a3`** -- Real Ascend hardware (requires CANN toolkit, `ccec` compiler for AICore, aarch64 cross-compiler for AICPU)
+- **`a2a3sim`** -- Thread-based simulation (g++ only, no device required, runs on Linux and macOS)
+
+Shared interfaces live in `src/platform/include/` (split into `host/`, `aicpu/`, `aicore/`, `common/`).
+Platform-specific implementations live in `src/platform/src/` and `src/platform/a2a3/` or `src/platform/a2a3sim/`.
+
+## Compilation Pipeline
+
+Python modules under `python/` drive the build:
+1. `kernel_compiler.py` -- compiles user-written kernel `.cpp` files (one per `func_id`)
+2. `runtime_compiler.py` -- compiles runtime sources for each component (host, aicpu, aicore)
+3. `runtime_builder.py` -- orchestrates the full build pipeline (compile + link)
+4. `bindings.py` -- provides ctypes wrappers for calling the host `.so` from Python
+
+## Example / Test Directory Layout
+
+Every example and device test follows this structure:
+```
+my_example/
+  golden.py              # generate_inputs() + compute_golden()
+  kernels/
+    kernel_config.py     # KERNELS list + ORCHESTRATION dict + RUNTIME_CONFIG
+    aic/                 # AICore kernel sources (optional)
+    aiv/                 # AIV kernel sources (optional)
+    orchestration/       # Orchestration C++ source
+```
+
+Run with: `python examples/scripts/run_example.py -k <kernels_dir> -g <golden.py> -p <platform>`

--- a/.ai-instructions/coding/testing.md
+++ b/.ai-instructions/coding/testing.md
@@ -1,0 +1,75 @@
+# Testing Guide
+
+## Test Types
+
+1. **Python unit tests** (`tests/test_runtime_builder.py`): Standard pytest tests for the Python compilation pipeline. Run with `pytest tests -v`.
+2. **Simulation examples** (`examples/*/`): Full end-to-end tests running on `a2a3sim`. No hardware required, works on Linux and macOS.
+3. **Device tests** (`tests/device_tests/*/`): Hardware-only tests running on real Ascend devices via `a2a3`. Requires CANN toolkit.
+
+## Running Tests
+
+```bash
+# Python unit tests
+pytest tests -v
+
+# All simulation tests
+./ci.sh -p a2a3sim
+
+# All hardware tests (specify device range)
+./ci.sh -p a2a3 -d 4-7 --parallel
+
+# Single example
+python examples/scripts/run_example.py \
+    -k examples/host_build_graph/vector_example/kernels \
+    -g examples/host_build_graph/vector_example/golden.py \
+    -p a2a3sim
+```
+
+## Adding a New Example or Device Test
+
+1. Create a directory under the appropriate runtime:
+   - Examples: `examples/<runtime>/<name>/`
+   - Device tests: `tests/device_tests/<runtime>/<name>/`
+2. Add `golden.py` implementing `generate_inputs(params)` and `compute_golden(tensors, params)`
+3. Add `kernels/kernel_config.py` with `KERNELS` list, `ORCHESTRATION` dict, and `RUNTIME_CONFIG`
+4. Add kernel source files under `kernels/aic/`, `kernels/aiv/`, and/or `kernels/orchestration/`
+5. The CI script (`ci.sh`) auto-discovers examples and device tests -- no registration needed
+
+## Golden Test Pattern
+
+### `golden.py` required functions
+
+- **`generate_inputs(params)`** -- Returns a dict of torch tensors (inputs + zero-initialized outputs)
+- **`compute_golden(tensors, params)`** -- Computes expected outputs in-place by writing to output tensors
+
+### Declaring outputs
+
+Output tensors are identified by one of:
+- `__outputs__` list: e.g., `__outputs__ = ["f"]`
+- `out_` prefix convention: any tensor named `out_*` is treated as output
+
+### Optional configuration
+
+- `TENSOR_ORDER`: List of tensor names defining the argument order for the orchestration function
+- `RTOL` / `ATOL`: Comparison tolerances (default: `1e-5`)
+- `PARAMS_LIST`: List of parameter dicts for parameterized tests
+
+### `kernel_config.py` structure
+
+```python
+ORCHESTRATION = {
+    "source": "path/to/orchestration.cpp",
+    "function_name": "build_example_graph",
+}
+
+KERNELS = [
+    {"func_id": 0, "source": "path/to/kernel.cpp", "core_type": "aiv"},
+    {"func_id": 1, "source": "path/to/kernel2.cpp", "core_type": "aic"},
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "host_build_graph",  # or "aicpu_build_graph", "tensormap_and_ringbuffer"
+    "aicpu_thread_num": 3,
+    "block_dim": 3,
+}
+```

--- a/.claude/commands/profile.md
+++ b/.claude/commands/profile.md
@@ -1,0 +1,6 @@
+Run the example at $ARGUMENTS with profiling enabled on hardware.
+
+1. Verify the directory exists and contains `kernels/kernel_config.py` and `golden.py`
+2. Run: `python examples/scripts/run_example.py -k $ARGUMENTS/kernels -g $ARGUMENTS/golden.py -p a2a3 --enable-profiling`
+3. If the test passes, report the swimlane output file location in `outputs/`
+4. Summarize the task statistics from the console output (per-function timing breakdown)

--- a/.claude/commands/test-all-device.md
+++ b/.claude/commands/test-all-device.md
@@ -1,0 +1,5 @@
+Run the full hardware CI pipeline across multiple NPU devices.
+
+1. Run: `./ci.sh -p a2a3 -d 4-7 --parallel`
+2. Report the results summary (pass/fail counts per task)
+3. If any tests fail, show the relevant error output and which device/round failed

--- a/.claude/commands/test-all-sim.md
+++ b/.claude/commands/test-all-sim.md
@@ -1,0 +1,5 @@
+Run the full simulation CI pipeline.
+
+1. Run: `./ci.sh -p a2a3sim`
+2. Report the results summary (pass/fail counts)
+3. If any tests fail, show the relevant error output

--- a/.claude/commands/test-device.md
+++ b/.claude/commands/test-device.md
@@ -1,0 +1,5 @@
+Run the hardware device test for the example at $ARGUMENTS.
+
+1. Verify the directory exists and contains `kernels/kernel_config.py` and `golden.py`
+2. Run: `python examples/scripts/run_example.py -k $ARGUMENTS/kernels -g $ARGUMENTS/golden.py -p a2a3`
+3. Report pass/fail status with any error output

--- a/.claude/commands/test-sim.md
+++ b/.claude/commands/test-sim.md
@@ -1,0 +1,5 @@
+Run the simulation test for the example at $ARGUMENTS.
+
+1. Verify the directory exists and contains `kernels/kernel_config.py` and `golden.py`
+2. Run: `python examples/scripts/run_example.py -k $ARGUMENTS/kernels -g $ARGUMENTS/golden.py -p a2a3sim`
+3. Report pass/fail status with any error output

--- a/.gitignore
+++ b/.gitignore
@@ -10,19 +10,12 @@ build/
 .venv/
 venv/
 .cache
-.claude
 .vscode
 *bak
 outputs
 
-# Generated example outputs (Ascend header backends)
-examples/output_ascend_a2a3/
-examples/output_ascend_a5/
-
-# Ascend simulator debug dumps
-core*_*.dump
-profile_*_log*.toml
-
 # Git cloned dependencies (not tracked in repo)
 examples/scripts/_deps/
+
+# Profiling files
 outputs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,40 @@ Each developer role has a designated working directory. Stay within your assigne
 - **Working directory**: `examples/`
 - Write code generation examples and kernel implementations here
 
+## Architecture
+
+PTO Runtime compiles three independent programs (Host `.so`, AICPU `.so`, AICore `.o`) that communicate through handshake buffers on Ascend NPU devices. Three runtime variants live under `src/runtime/` (`host_build_graph`, `aicpu_build_graph`, `tensormap_and_ringbuffer`), two platform backends under `src/platform/` (`a2a3` = hardware, `a2a3sim` = simulation). See `README.md` for the full architecture diagram.
+
+## Common Commands
+
+### Simulation tests (no hardware required)
+```bash
+./ci.sh -p a2a3sim
+```
+
+### Hardware tests (requires Ascend device)
+```bash
+./ci.sh -p a2a3 -d 4-7 --parallel
+```
+
+### Run a single example
+```bash
+python examples/scripts/run_example.py \
+    -k examples/host_build_graph/vector_example/kernels \
+    -g examples/host_build_graph/vector_example/golden.py \
+    -p a2a3sim
+```
+
+### Python unit tests
+```bash
+pytest tests -v
+```
+
+### Format C++ code
+```bash
+clang-format -i <file>
+```
+
 ## Important Rules
 
 1. **Consult `.ai-instructions/` for task-specific rules.** The directory contains topic-based guides — read the ones relevant to your current task (e.g., `coding/` when writing code, `git-commit/` when committing, `terminologies/` when unsure about domain terms). You do not need to read all files upfront


### PR DESCRIPTION
Add architecture quick reference and testing guide under .ai-instructions/, Claude Code slash commands for common CI workflows, and expand CLAUDE.md with architecture overview and common commands. Track .claude/ directory by removing it from .gitignore.