### PR TITLE
Add: pass unified logging to orchestration via ops table

### DIFF
--- a/examples/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -26,7 +26,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include "pto_orchestration_api.h"
 
@@ -73,8 +72,8 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
     size_t size_B = (size_t)args[ARG_SIZE_B];
     size_t size_C = (size_t)args[ARG_SIZE_C];
 
-    printf("[bgemm_orch] Grid: %dx%dx%d, Batch: %d, Tile: %d\n",
-           GRID_M, GRID_K, GRID_N, BATCH, TILE);
+    LOG_INFO(rt, "[bgemm_orch] Grid: %dx%dx%d, Batch: %d, Tile: %d",
+                  GRID_M, GRID_K, GRID_N, BATCH, TILE);
 
     // Create 1D external tensors for the full A, B, C arrays
     Tensor ext_A = make_tensor_external(dev_A, size_A);
@@ -127,8 +126,8 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
         }
     }
 
-    printf("[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each\n",
-           BATCH, GRID_M, GRID_N, GRID_K);
+    LOG_INFO(rt, "[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each",
+                  BATCH, GRID_M, GRID_N, GRID_K);
 }
 
 }  // extern "C"

--- a/examples/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -15,7 +15,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include "pto_orchestration_api.h"
 
@@ -94,7 +93,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
 
     (void)kv_head_num;
 
-    printf("batch = %lu\n", (unsigned long)batch);
+    LOG_INFO(rt, "batch = %lu", (unsigned long)batch);
 
     // Compute actual tensor shapes from buffer sizes (not from max block_num)
     uint64_t query_shapes[2] = {batch * num_heads, head_dim};
@@ -106,10 +105,10 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
     Tensor key_cache = make_tensor_external(host_key_cache, key_cache_shapes, 2, data_type);
     Tensor value_cache = make_tensor_external(host_value_cache, value_cache_shapes, 2, data_type);
     Tensor out = make_tensor_external(host_out, out_shapes, 2, DataType::FLOAT32);
-    printf("query=%s\n", query.dump().c_str());
-    printf("key_cache=%s\n", key_cache.dump().c_str());
-    printf("value_cache=%s\n", value_cache.dump().c_str());
-    printf("out=%s\n", out.dump().c_str());
+    LOG_DEBUG(rt, "query=%s", query.dump().c_str());
+    LOG_DEBUG(rt, "key_cache=%s", key_cache.dump().c_str());
+    LOG_DEBUG(rt, "value_cache=%s", value_cache.dump().c_str());
+    LOG_DEBUG(rt, "out=%s", out.dump().c_str());
 
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
         uint64_t cur_seq = host_context_lens[b_idx];
@@ -192,8 +191,8 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
         }
     }
 
-    printf("[orch] tasks submitted for batch=%lu, num_heads=%lu\n",
-           (unsigned long)batch, (unsigned long)num_heads);
+    LOG_INFO(rt, "tasks submitted for batch=%lu, num_heads=%lu",
+                  (unsigned long)batch, (unsigned long)num_heads);
 }
 
 }  // extern "C"

--- a/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -20,7 +20,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include "pto_orchestration_api.h"
 
@@ -93,7 +92,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
     size_t size_f = (size_t)args[ARG_SIZE_F];
     int SIZE = (int)(args[ARG_SIZE] & 0x7FFFFFFF);
 
-    printf("===============SIZE=%d\n", SIZE);
+    LOG_INFO(rt, "===============SIZE=%d", SIZE);
 
     size_t BYTES = (size_t)SIZE * sizeof(float);
 

--- a/src/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -57,6 +57,12 @@ typedef struct PTO2RuntimeOps {
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
     void (*orchestration_done)(PTO2Runtime* rt);
+
+    // Logging (populated by runtime, called by orchestration)
+    void (*log_error)(const char* func, const char* fmt, ...);
+    void (*log_warn)(const char* func, const char* fmt, ...);
+    void (*log_info)(const char* func, const char* fmt, ...);
+    void (*log_debug)(const char* func, const char* fmt, ...);
 } PTO2RuntimeOps;
 
 /**
@@ -91,6 +97,15 @@ static inline void pto2_rt_scope_end(PTO2Runtime* rt) {
 static inline void pto2_rt_orchestration_done(PTO2Runtime* rt) {
     rt->ops->orchestration_done(rt);
 }
+
+// =============================================================================
+// Logging Macros for Orchestration (call through ops table)
+// =============================================================================
+
+#define LOG_ERROR(rt, fmt, ...) (rt)->ops->log_error(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_WARN(rt, fmt, ...)  (rt)->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_INFO(rt, fmt, ...)  (rt)->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_DEBUG(rt, fmt, ...) (rt)->ops->log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
 
 // =============================================================================
 // C++ Scope Guards and Macros

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -10,35 +10,40 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "common/unified_log.h"
 
 // =============================================================================
-// Ops Table (function-pointer dispatch for orchestration .so)
+// Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
 static void submit_task_impl(PTO2Runtime* rt, int32_t kernel_id,
-                              PTO2WorkerType worker_type,
-                              PTOParam* params, int32_t num_params) {
+                             PTO2WorkerType worker_type,
+                             PTOParam* params, int32_t num_params) {
     pto2_submit_task(&rt->orchestrator, kernel_id, worker_type,
                      params, num_params);
 }
 
-static void scope_begin_impl(PTO2Runtime* rt) {
+void pto2_rt_scope_begin(PTO2Runtime* rt) {
     pto2_scope_begin(&rt->orchestrator);
 }
 
-static void scope_end_impl(PTO2Runtime* rt) {
+void pto2_rt_scope_end(PTO2Runtime* rt) {
     pto2_scope_end(&rt->orchestrator);
 }
 
-static void orchestration_done_impl(PTO2Runtime* rt) {
+void pto2_rt_orchestration_done(PTO2Runtime* rt) {
     pto2_orchestrator_done(&rt->orchestrator);
 }
 
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task        = submit_task_impl,
-    .scope_begin        = scope_begin_impl,
-    .scope_end          = scope_end_impl,
-    .orchestration_done = orchestration_done_impl,
+    .scope_begin        = pto2_rt_scope_begin,
+    .scope_end          = pto2_rt_scope_end,
+    .orchestration_done = pto2_rt_orchestration_done,
+    .log_error          = unified_log_error,
+    .log_warn           = unified_log_warn,
+    .log_info           = unified_log_info,
+    .log_debug          = unified_log_debug,
 };
 
 // =============================================================================
@@ -177,20 +182,4 @@ void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;
     }
-}
-
-// =============================================================================
-// Orchestration API
-// =============================================================================
-
-void pto2_rt_scope_begin(PTO2Runtime* rt) {
-    scope_begin_impl(rt);
-}
-
-void pto2_rt_scope_end(PTO2Runtime* rt) {
-    scope_end_impl(rt);
-}
-
-void pto2_rt_orchestration_done(PTO2Runtime* rt) {
-    orchestration_done_impl(rt);
 }

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -61,6 +61,12 @@ typedef struct PTO2RuntimeOps {
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
     void (*orchestration_done)(PTO2Runtime* rt);
+
+    // Logging (populated by runtime, called by orchestration)
+    void (*log_error)(const char* func, const char* fmt, ...);
+    void (*log_warn)(const char* func, const char* fmt, ...);
+    void (*log_info)(const char* func, const char* fmt, ...);
+    void (*log_debug)(const char* func, const char* fmt, ...);
 } PTO2RuntimeOps;
 
 /**


### PR DESCRIPTION
Extend PTO2RuntimeOps with log function pointers so orchestration .so files can use ORCH_LOG_* macros instead of printf, with zero new link dependencies. Migrate existing printf calls in examples.