### PR TITLE
Fix: add clean_cache() to clear test-specific resources between tests

### DIFF
--- a/src/platform/a2a3/host/device_runner.cpp
+++ b/src/platform/a2a3/host/device_runner.cpp
@@ -455,6 +455,20 @@ void DeviceRunner::print_handshake_results() {
     }
 }
 
+int DeviceRunner::clean_cache() {
+    if (stream_aicpu_ == nullptr) {
+        return 0;  // Nothing to cleanup if device not initialized
+    }
+    for (const auto& [func_id, addr] : func_id_to_addr_) {
+        void* gm_addr = reinterpret_cast<void*>(addr - sizeof(uint64_t));
+        mem_alloc_.free(gm_addr);
+    }
+    func_id_to_addr_.clear();
+
+    LOG_INFO("DeviceRunner: cache cleaned (test-specific resources only)");
+    return 0;
+}
+
 int DeviceRunner::finalize() {
     if (stream_aicpu_ == nullptr) {
         return 0;

--- a/src/platform/a2a3/host/device_runner.h
+++ b/src/platform/a2a3/host/device_runner.h
@@ -250,9 +250,21 @@ public:
     int export_swimlane_json(const std::string& output_path = "outputs");
 
     /**
+     * Clean cached resources - lightweight cleanup between tests
+     *
+     * Cleans up test-specific resources while preserving device resources for reuse:
+     * - Frees kernel memory from global memory allocator
+     * - Clears kernel address cache
+     *
+     * @return 0 on success, error code on failure
+     */
+    int clean_cache();
+
+    /**
      * Cleanup all resources
      *
      * Frees all device memory, destroys streams, and resets state.
+     * Use this for final cleanup when no more tests will run.
      *
      * @return 0 on success, error code on failure
      */

--- a/src/platform/a2a3/host/pto_runtime_c_api.cpp
+++ b/src/platform/a2a3/host/pto_runtime_c_api.cpp
@@ -193,6 +193,11 @@ int finalize_runtime(RuntimeHandle runtime) {
     try {
         Runtime* r = static_cast<Runtime*>(runtime);
         int rc = validate_runtime_impl(r);
+
+        // Clean cached resources to prepare for next test
+        DeviceRunner& runner = DeviceRunner::get();
+        runner.clean_cache();
+        
         // Call destructor (user will call free())
         r->~Runtime();
         return rc;

--- a/src/platform/a2a3sim/host/device_runner.cpp
+++ b/src/platform/a2a3sim/host/device_runner.cpp
@@ -321,6 +321,30 @@ void DeviceRunner::print_handshake_results() {
     }
 }
 
+int DeviceRunner::clean_cache() {
+    // Skip if not initialized
+    if (device_id_ == -1) {
+        return 0;
+    }
+
+    // Only cleanup test-specific resources:
+
+    // 1. Close dlopen'd kernel libraries (different tests may have different kernels)
+    for (auto& pair : func_id_to_addr_) {
+        MappedKernel& kernel = pair.second;
+        if (kernel.dl_handle != nullptr) {
+            dlclose(kernel.dl_handle);
+            LOG_DEBUG("Closed dlopen kernel: func_id=%d", pair.first);
+            kernel.dl_handle = nullptr;
+            kernel.func_addr = 0;
+        }
+    }
+    func_id_to_addr_.clear();
+
+    LOG_INFO("DeviceRunner(sim): cache cleaned (test-specific resources only)");
+    return 0;
+}
+
 int DeviceRunner::finalize() {
     // Skip if already finalized
     if (device_id_ == -1 && aicpu_so_handle_ == nullptr && aicore_so_handle_ == nullptr) {

--- a/src/platform/a2a3sim/host/device_runner.h
+++ b/src/platform/a2a3sim/host/device_runner.h
@@ -158,7 +158,20 @@ public:
     int export_swimlane_json(const std::string& output_path = "outputs");
 
     /**
+     * Clean cached resources - lightweight cleanup between tests
+     *
+     * Cleans up test-specific resources while preserving device resources for reuse:
+     * - Closes dlopen'd kernel libraries (different tests may have different kernels)
+     * - Clears kernel address cache
+     *
+     * @return 0 on success, error code on failure
+     */
+    int clean_cache();
+
+    /**
      * Cleanup all resources
+     *
+     * Use this for final cleanup when no more tests will run.
      *
      * @return 0 on success
      */

--- a/src/platform/a2a3sim/host/pto_runtime_c_api.cpp
+++ b/src/platform/a2a3sim/host/pto_runtime_c_api.cpp
@@ -197,8 +197,11 @@ int finalize_runtime(RuntimeHandle runtime) {
         Runtime* r = static_cast<Runtime*>(runtime);
         int rc = validate_runtime_impl(r);
 
-        // Finalize DeviceRunner (clears last_runtime_ to avoid dangling pointer)
+        // Clean cached resources before finalization
         DeviceRunner& runner = DeviceRunner::get();
+        runner.clean_cache();
+
+        // Finalize DeviceRunner (clears last_runtime_ to avoid dangling pointer)
         runner.finalize();
 
         // Call destructor (user will call free())


### PR DESCRIPTION
Previously, cached kernel addresses persisted across tests, causing stale
data issues when running multiple tests sequentially.

This adds a lightweight clean_cache() method to DeviceRunner that:
- On hardware: frees kernel memory and clears address cache
- On simulator: closes dlopen'd kernel libraries and clears address cache

The method is called in finalize_runtime() to ensure each test starts
with a clean cache while preserving device resources for reuse.