### PR TITLE
Refactor: replace physical_core_id argument with platform getter

### DIFF
--- a/.claude/commands/test-all-sim.md
+++ b/.claude/commands/test-all-sim.md
@@ -1,5 +1,5 @@
 Run the full simulation CI pipeline.
 
-1. Run: `./ci.sh -p a2a3sim`
+1. Run: `./ci.sh -p a2a3sim --parallel`
 2. Report the results summary (pass/fail counts)
 3. If any tests fail, show the relevant error output

--- a/src/platform/a2a3/aicore/inner_kernel.h
+++ b/src/platform/a2a3/aicore/inner_kernel.h
@@ -56,4 +56,13 @@ __aicore__ inline void write_reg(RegId reg, uint64_t value) {
     }
 }
 
+/**
+ * Get the physical core ID from hardware
+ *
+ * @return Physical core ID (masked to 12 bits)
+ */
+__aicore__ inline uint32_t get_physical_core_id() {
+    return static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK;
+}
+
 #endif  // PLATFORM_A2A3_AICORE_INNER_KERNEL_H_

--- a/src/platform/a2a3/aicore/kernel.cpp
+++ b/src/platform/a2a3/aicore/kernel.cpp
@@ -1,8 +1,6 @@
 /**
  * Minimal AICore Kernel
  */
-#include <cstdint>
-
 #include "aicore/aicore.h"
 #include "common/core_type.h"
 
@@ -23,7 +21,7 @@ class Runtime;
 [[block_local]] int block_idx;
 [[block_local]] CoreType core_type;
 
-extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id);
+extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
 
 /**
  * Kernel entry point with control loop
@@ -49,6 +47,5 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime
     block_idx = get_block_idx();
     core_type = CoreType::AIC;
 #endif
-    uint32_t physical_core_id = static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK;
-    aicore_execute(runtime, block_idx, core_type, physical_core_id);
+    aicore_execute(runtime, block_idx, core_type);
 }

--- a/src/platform/a2a3sim/aicore/inner_kernel.h
+++ b/src/platform/a2a3sim/aicore/inner_kernel.h
@@ -73,6 +73,12 @@ inline uint64_t get_sys_cnt() {
 extern thread_local volatile uint8_t* g_sim_reg_base;
 
 /**
+ * Per-thread simulated physical core ID.
+ * Set by the kernel wrapper before calling aicore_execute().
+ */
+extern thread_local uint32_t g_sim_physical_core_id;
+
+/**
  * Read an AICore register from simulated register memory
  *
  * @param reg  Register identifier
@@ -96,6 +102,15 @@ inline void write_reg(RegId reg, uint64_t value) {
     *reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset) =
         static_cast<uint32_t>(value);
     __sync_synchronize();
+}
+
+/**
+ * Get the physical core ID from simulation state
+ *
+ * @return Physical core ID for the current simulated core
+ */
+inline uint32_t get_physical_core_id() {
+    return g_sim_physical_core_id;
 }
 
 #endif  // PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_

--- a/src/platform/a2a3sim/aicore/kernel.cpp
+++ b/src/platform/a2a3sim/aicore/kernel.cpp
@@ -14,10 +14,14 @@
 // Thread-local simulated register base (declared in inner_kernel.h)
 thread_local volatile uint8_t* g_sim_reg_base = nullptr;
 
+// Thread-local simulated physical core ID (declared in inner_kernel.h)
+thread_local uint32_t g_sim_physical_core_id = 0;
+
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
-void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id);
+void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
 
 // Wrapper with extern "C" for dlsym lookup
+// NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
 extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs) {
     // Set up simulated register base for this thread.
     // regs points to an array of uint64_t base addresses (one per core).
@@ -27,5 +31,7 @@ extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, C
         g_sim_reg_base = reinterpret_cast<volatile uint8_t*>(regs_array[physical_core_id]);
     }
 
-    aicore_execute(runtime, block_idx, core_type, physical_core_id);
+    g_sim_physical_core_id = physical_core_id;
+
+    aicore_execute(runtime, block_idx, core_type);
 }

--- a/src/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -46,7 +46,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
     kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
 }
 
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal

--- a/src/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -72,7 +72,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
     pipe_barrier(PIPE_ALL);
 }
 
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
@@ -81,7 +81,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     }
 
     // Report physical core ID and core type for AICPU
-    my_hank->physical_core_id = physical_core_id;
+    my_hank->physical_core_id = get_physical_core_id();
     my_hank->core_type = core_type;
     my_hank->aicore_done = block_idx + 1;
 

--- a/src/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -111,9 +111,8 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* 
  * @param runtime Pointer to Runtime in global memory
  * @param block_idx Block index (core ID)
  * @param core_type Core type (AIC or AIV)
- * @param physical_core_id Physical core ID from hardware
  */
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal


### PR DESCRIPTION
Remove physical_core_id from the aicore_execute() signature and provide get_physical_core_id() in each platform's inner_kernel.h instead.  This keeps platform-specific details out of the runtime interface — only host_build_graph actually uses the value, while the other two runtimes ignored the parameter entirely.

Platform layer:
- a2a3: add get_physical_core_id() reading hardware via get_coreid()
- a2a3sim: add thread_local g_sim_physical_core_id set by the wrapper before calling aicore_execute(); getter reads it

Runtime layer:
- host_build_graph: use get_physical_core_id() for handshake
- aicpu_build_graph / tensormap_and_ringbuffer: drop unused param