### PR TITLE
Refactor: replace auto-generated scalar args with explicit ctypes scalars in golden files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ examples/scripts/_deps/
 
 # Profiling files
 outputs
+
+# Mid-work documentation
+.docs

--- a/examples/aicpu_build_graph/bgemm/golden.py
+++ b/examples/aicpu_build_graph/bgemm/golden.py
@@ -3,12 +3,14 @@ Golden test specification for BGEMM (AICPU Build Graph Runtime).
 
 Computation: C = A @ B (tiled matrix multiplication)
 Configuration: 4x4x4 grid, 64x64 tiles
+
+Args layout: [ptr_A, ptr_B, ptr_C]
 """
 
+import ctypes
 import numpy as np
 
 __outputs__ = ["C"]
-TENSOR_ORDER = ["A", "B", "C"]
 RTOL = 1e-3
 ATOL = 1e-3
 
@@ -26,17 +28,21 @@ K = TILE_K * GRID_K
 N = TILE_N * GRID_N
 
 
-def generate_inputs(params: dict) -> dict:
+def generate_inputs(params: dict) -> list:
     """Generate input tensors with tile-first memory layout."""
     A = np.random.randn(BATCH, GRID_M, GRID_K, TILE_M, TILE_K).astype(np.float32) * 0.01
     B = np.random.randn(BATCH, GRID_K, GRID_N, TILE_K, TILE_N).astype(np.float32) * 0.01
     C = np.zeros((BATCH, GRID_M, GRID_N, TILE_M, TILE_N), dtype=np.float32)
 
-    return {
-        "A": A.flatten(),
-        "B": B.flatten(),
-        "C": C.flatten(),
-    }
+    A_flat = A.flatten()
+    B_flat = B.flatten()
+    C_flat = C.flatten()
+
+    return [
+        ("A", A_flat),
+        ("B", B_flat),
+        ("C", C_flat),
+    ]
 
 
 def compute_golden(tensors: dict, params: dict) -> None:

--- a/examples/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -35,7 +35,7 @@ constexpr int NUM_P_BUFFERS = BATCH * GRID_M * GRID_N;
 constexpr int DEV_A = 0;
 constexpr int DEV_B = 1;
 constexpr int DEV_C = 2;
-constexpr int ARG_SIZE = 6;
+constexpr int ARG_SIZE = 2;
 }  // namespace
 
 extern "C" int orchestration(Runtime* runtime) {

--- a/examples/aicpu_build_graph/vector_example/golden.py
+++ b/examples/aicpu_build_graph/vector_example/golden.py
@@ -4,33 +4,37 @@ Golden script for aicpu_build_graph example.
 Computation:
     f = (a + b + 1) * (a + b + 2)
     where a=2.0, b=3.0, so f=42.0
+
+Args layout: [ptr_a, ptr_b, ptr_f, SIZE]
 """
 
+import ctypes
 import torch
 
 __outputs__ = ["f"]
-
-# Args layout (host orchestration): [ptr_a, ptr_b, ptr_f, size_a, size_b, size_f, SIZE]
-TENSOR_ORDER = ["a", "b", "f"]
 
 RTOL = 1e-5
 ATOL = 1e-5
 
 
-def generate_inputs(params: dict) -> dict:
+def generate_inputs(params: dict) -> list:
     ROWS = 128
     COLS = 128
     SIZE = ROWS * COLS
 
-    return {
-        "a": torch.full((SIZE,), 2.0, dtype=torch.float32),
-        "b": torch.full((SIZE,), 3.0, dtype=torch.float32),
-        "f": torch.zeros(SIZE, dtype=torch.float32),
-    }
+    a = torch.full((SIZE,), 2.0, dtype=torch.float32)
+    b = torch.full((SIZE,), 3.0, dtype=torch.float32)
+    f = torch.zeros(SIZE, dtype=torch.float32)
+
+    return [
+        ("a", a),
+        ("b", b),
+        ("f", f),
+        ("SIZE", ctypes.c_int64(SIZE)),
+    ]
 
 
 def compute_golden(tensors: dict, params: dict) -> None:
     a = tensors["a"]
     b = tensors["b"]
     tensors["f"][:] = (a + b + 1) * (a + b + 2)
-

--- a/examples/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
+++ b/examples/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
@@ -7,10 +7,7 @@
  *   orch_args[0] = dev_a      (input,  float[SIZE])
  *   orch_args[1] = dev_b      (input,  float[SIZE])
  *   orch_args[2] = dev_f      (output, float[SIZE])
- *   orch_args[3] = nbytes_a   (scalar)
- *   orch_args[4] = nbytes_b   (scalar)
- *   orch_args[5] = nbytes_f   (scalar)
- *   orch_args[6] = SIZE        (element count, scalar)
+ *   orch_args[3] = SIZE        (element count, scalar)
  *
  * This function allocates intermediate tensors via api.device_malloc() (HBM)
  * and builds the task dependency graph:
@@ -34,7 +31,7 @@ union ScalarConverter {
 constexpr int DEV_A = 0;
 constexpr int DEV_B = 1;
 constexpr int DEV_F = 2;
-constexpr int SIZE  = 6;
+constexpr int SIZE  = 3;
 }  // namespace
 
 extern "C" int orchestration(Runtime* runtime) {

--- a/examples/host_build_graph/bgemm/golden.py
+++ b/examples/host_build_graph/bgemm/golden.py
@@ -3,12 +3,14 @@ Golden test specification for BGEMM (Host Build Graph Runtime).
 
 Computation: C = A @ B (tiled matrix multiplication)
 Configuration: 4x4x4 grid, 64x64 tiles
+
+Args layout: [ptr_A, ptr_B, ptr_C, size_A, size_B, size_C]
 """
 
+import ctypes
 import numpy as np
 
 __outputs__ = ["C"]
-TENSOR_ORDER = ["A", "B", "C"]
 RTOL = 1e-3
 ATOL = 1e-3
 
@@ -26,17 +28,24 @@ K = TILE_K * GRID_K
 N = TILE_N * GRID_N
 
 
-def generate_inputs(params: dict) -> dict:
+def generate_inputs(params: dict) -> list:
     """Generate input tensors with tile-first memory layout."""
     A = np.random.randn(BATCH, GRID_M, GRID_K, TILE_M, TILE_K).astype(np.float32) * 0.01
     B = np.random.randn(BATCH, GRID_K, GRID_N, TILE_K, TILE_N).astype(np.float32) * 0.01
     C = np.zeros((BATCH, GRID_M, GRID_N, TILE_M, TILE_N), dtype=np.float32)
 
-    return {
-        "A": A.flatten(),
-        "B": B.flatten(),
-        "C": C.flatten(),
-    }
+    A_flat = A.flatten()
+    B_flat = B.flatten()
+    C_flat = C.flatten()
+
+    return [
+        ("A", A_flat),
+        ("B", B_flat),
+        ("C", C_flat),
+        ("size_A", ctypes.c_int64(A_flat.nbytes)),
+        ("size_B", ctypes.c_int64(B_flat.nbytes)),
+        ("size_C", ctypes.c_int64(C_flat.nbytes)),
+    ]
 
 
 def compute_golden(tensors: dict, params: dict) -> None:

--- a/examples/host_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/host_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -33,8 +33,8 @@ constexpr int BATCH = 1;
 constexpr size_t TILE_BYTES = TILE * TILE * sizeof(float);
 
 int build_bgemm_graph(Runtime* runtime, uint64_t* args, int arg_count) {
-    if (arg_count < 7) {
-        std::cerr << "build_bgemm_graph: Expected at least 7 args, got " << arg_count << '\n';
+    if (arg_count < 6) {
+        std::cerr << "build_bgemm_graph: Expected at least 6 args, got " << arg_count << '\n';
         return -1;
     }
 

--- a/examples/host_build_graph/matmul/golden.py
+++ b/examples/host_build_graph/matmul/golden.py
@@ -1,9 +1,6 @@
 """
 Golden script for matmul example.
 
-This script defines the input data generation and expected output computation
-for the matmul example (both a2a3 and a2a3sim platforms).
-
 Computation:
     F = exp(sqrt(log(A)) @ W1 + sqrt(log(A)) @ W2)
 
@@ -17,91 +14,57 @@ Computation:
           t3: F = exp(C + D)        [AIV, float->float]
 
     where A = e^4 (128x128, float16), W1 = W2 = 1/256 (128x128, float16)
-    Result: F = exp(2) ≈ 7.389
+    Result: F = exp(2) ~ 7.389
+
+Args layout: [ptr_a, ptr_w1, ptr_w2, ptr_f, size_a, size_w1, size_w2, size_f, SIZE]
 """
 
+import ctypes
 import torch
 
-# Output tensor names (alternatively, use 'out_' prefix convention)
 __outputs__ = ["f"]
 
-# Tensor order for orchestration function arguments
-# This MUST match the order expected by build_matmul_graph in matmul_orch.cpp
-# Args layout: [ptr_a, ptr_w1, ptr_w2, ptr_f, size_a, size_w1, size_w2, size_f, SIZE]
-TENSOR_ORDER = ["a", "w1", "w2", "f"]
-
-# Comparison tolerances (slightly relaxed for half precision intermediate)
 RTOL = 1e-2
 ATOL = 1e-2
 
 
-def generate_inputs(params: dict) -> dict:
-    """
-    Generate input and output tensors.
-
-    Creates:
-    - a:  128x128 matrix, all e^4 ≈ 54.598 (float32, so log(a) = 4)
-    - w1: 128x128 matrix, all 1/256 (float16, weight matrix for first matmul)
-    - w2: 128x128 matrix, all 1/256 (float16, weight matrix for second matmul)
-    - f:  128x128 matrix, zeros (float32, output)
-
-    Returns:
-        Dict of torch tensors with tensor names as keys
-    """
+def generate_inputs(params: dict) -> list:
     ROWS = 128
     COLS = 128
-    SIZE = ROWS * COLS  # 16384 elements
+    SIZE = ROWS * COLS
 
-    # Input value: e^4 so that log(A) = 4, sqrt(4) = 2
     input_value = torch.exp(torch.tensor(4.0)).item()
-
-    # Weight matrices: 1/256 each, so that after two matmuls and addition:
-    #   C = B @ W1: each element = 2 * (1/256) * 128 = 1
-    #   D = B @ W2: each element = 2 * (1/256) * 128 = 1
-    #   C + D = 2
-    #   exp(2) ≈ 7.389
     weight_value = 1.0 / (2 * COLS)
 
-    return {
-        "a":  torch.full((SIZE,), input_value, dtype=torch.float16),   # half precision input
-        "w1": torch.full((SIZE,), weight_value, dtype=torch.float16),  # half precision weight
-        "w2": torch.full((SIZE,), weight_value, dtype=torch.float16),  # half precision weight
-        "f":  torch.zeros(SIZE, dtype=torch.float32),               # float output
-    }
+    a = torch.full((SIZE,), input_value, dtype=torch.float16)
+    w1 = torch.full((SIZE,), weight_value, dtype=torch.float16)
+    w2 = torch.full((SIZE,), weight_value, dtype=torch.float16)
+    f = torch.zeros(SIZE, dtype=torch.float32)
+
+    return [
+        ("a", a),
+        ("w1", w1),
+        ("w2", w2),
+        ("f", f),
+        ("size_a", ctypes.c_int64(a.nbytes)),
+        ("size_w1", ctypes.c_int64(w1.nbytes)),
+        ("size_w2", ctypes.c_int64(w2.nbytes)),
+        ("size_f", ctypes.c_int64(f.nbytes)),
+        ("SIZE", ctypes.c_int64(SIZE)),
+    ]
 
 
 def compute_golden(tensors: dict, params: dict) -> None:
-    """
-    Compute expected output in-place.
-
-    F = exp(sqrt(log(A)) @ W1 + sqrt(log(A)) @ W2)
-
-    Step by step:
-    1. B = sqrt(log(A)) = sqrt(log(e^4)) = sqrt(4) = 2  (all elements, half precision)
-    2. C = B @ W1 (matrix multiplication)
-       - B is 128x128 with all 2s (half), W1 is 128x128 with all 1/256 (half)
-       - C[i,j] = sum(B[i,k] * W1[k,j]) = 2 * (1/256) * 128 = 1 (float output)
-    3. D = B @ W2 (matrix multiplication)
-       - Same as C: D[i,j] = 1 (float output)
-    4. F = exp(C + D) = exp(1 + 1) = exp(2) ≈ 7.389
-
-    Args:
-        tensors: Dict containing all tensors (inputs and outputs)
-        params: Parameter dict (unused in this example)
-    """
     ROWS = 128
     COLS = 128
 
-    # Use float32 for computation accuracy in golden
-    # Convert to torch tensors (handles both array types)
-    a  = torch.as_tensor(tensors["a"]).reshape(ROWS, COLS).to(torch.float32)
+    a = torch.as_tensor(tensors["a"]).reshape(ROWS, COLS).to(torch.float32)
     w1 = torch.as_tensor(tensors["w1"]).reshape(ROWS, COLS).to(torch.float32)
     w2 = torch.as_tensor(tensors["w2"]).reshape(ROWS, COLS).to(torch.float32)
 
-    # F = exp(sqrt(log(A)) @ W1 + sqrt(log(A)) @ W2)
-    b = torch.sqrt(torch.log(a))          # B = sqrt(log(A))
-    c = torch.matmul(b, w1)            # C = B @ W1
-    d = torch.matmul(b, w2)            # D = B @ W2
-    f = torch.exp(c + d)               # F = exp(C + D)
+    b = torch.sqrt(torch.log(a))
+    c = torch.matmul(b, w1)
+    d = torch.matmul(b, w2)
+    f = torch.exp(c + d)
 
     tensors["f"][:] = f.flatten().to(torch.float32)

--- a/examples/host_build_graph/paged_attention/golden.py
+++ b/examples/host_build_graph/paged_attention/golden.py
@@ -6,19 +6,17 @@ Implements the online softmax algorithm for paged attention with:
 - Non-transposed K storage: (total_blocks, block_size, kv_head_num, head_dim)
 - GQA support (kv_head_num=1)
 - 16x16 tile dimensions for fast simulation
+
+Args layout: [ptr_query, ..., ptr_config, size_query, ..., size_config]
 """
 
+import ctypes
 import os
 import struct
 import torch
 
-# Output tensor names
 __outputs__ = ["out"]
 
-# Tensor order matching orchestration function parameter order
-TENSOR_ORDER = ["query", "key_cache", "value_cache", "block_table", "context_lens", "out", "config"]
-
-# Comparison tolerances
 RTOL = 1e-2
 ATOL = 1e-2
 
@@ -50,7 +48,7 @@ _selected = os.environ.get("PA_CASE", "Case1")
 PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
 
 
-def generate_inputs(params: dict) -> dict:
+def generate_inputs(params: dict) -> list:
     """Generate input tensors and zeroed output tensor."""
     batch = params["batch"]
     num_heads = params["num_heads"]
@@ -60,16 +58,12 @@ def generate_inputs(params: dict) -> dict:
     context_len = params["context_len"]
     max_model_len = params["max_model_len"]
 
-    # Random seed will be different each time (torch default behavior)
-
     max_num_blocks_per_req = max_model_len // block_size
     cur_valid_blocks = (context_len + block_size - 1) // block_size
     total_blocks = batch * cur_valid_blocks
     scale_value = 1.0
     scale_bits = struct.unpack('I', struct.pack('f', scale_value))[0]
 
-    # Random block table: (batch, max_num_blocks_per_req) int32
-    # randint is [low, high), so high=total_blocks covers indices [0, total_blocks)
     block_table = torch.randint(
         0,
         max(total_blocks, 1),
@@ -77,7 +71,6 @@ def generate_inputs(params: dict) -> dict:
         dtype=torch.int32,
     )
 
-    # Context lens: all = context_len
     context_lens = torch.full((batch,), context_len, dtype=torch.int32)
 
     config = torch.tensor(
@@ -86,25 +79,34 @@ def generate_inputs(params: dict) -> dict:
         dtype=torch.int64,
     )
 
-    # Query: (batch, 1, num_heads * head_dim) -> (batch, num_heads, head_dim) float16
     query_fp16 = (torch.rand(batch, 1, num_heads * head_dim) - 0.5).to(torch.float16)
     query_fp16 = query_fp16.reshape(batch, num_heads, head_dim)
 
-    # Key cache: (total_blocks, block_size, kv_head_num, head_dim) float16
     key_fp16 = (torch.rand(total_blocks, block_size, kv_head_num, head_dim) - 0.5).to(torch.float16)
-
-    # Value cache: (total_blocks, block_size, kv_head_num, head_dim) float16
     value_fp16 = (torch.rand(total_blocks, block_size, kv_head_num, head_dim) * 2 - 1).to(torch.float16)
 
-    return {
-        "query": query_fp16.flatten(),
-        "key_cache": key_fp16.flatten(),
-        "value_cache": value_fp16.flatten(),
-        "block_table": block_table.flatten(),
-        "context_lens": context_lens,
-        "out": torch.zeros(batch * num_heads * head_dim, dtype=torch.float32),
-        "config": config,
-    }
+    query = query_fp16.flatten()
+    key_cache = key_fp16.flatten()
+    value_cache = value_fp16.flatten()
+    block_table_flat = block_table.flatten()
+    out = torch.zeros(batch * num_heads * head_dim, dtype=torch.float32)
+
+    return [
+        ("query", query),
+        ("key_cache", key_cache),
+        ("value_cache", value_cache),
+        ("block_table", block_table_flat),
+        ("context_lens", context_lens),
+        ("out", out),
+        ("config", config),
+        ("size_query", ctypes.c_int64(query.nbytes)),
+        ("size_key_cache", ctypes.c_int64(key_cache.nbytes)),
+        ("size_value_cache", ctypes.c_int64(value_cache.nbytes)),
+        ("size_block_table", ctypes.c_int64(block_table_flat.nbytes)),
+        ("size_context_lens", ctypes.c_int64(context_lens.nbytes)),
+        ("size_out", ctypes.c_int64(out.nbytes)),
+        ("size_config", ctypes.c_int64(config.nbytes)),
+    ]
 
 
 def paged_attention(
@@ -140,7 +142,6 @@ def paged_attention(
     batch, num_heads_dim, head_dim = query.shape
     _, block_size, _, _ = key_cache.shape
 
-    # Reshape for batched computation
     key_cache_flat = key_cache.reshape(-1, block_size, head_dim)
     value_cache_flat = value_cache.reshape(-1, block_size, head_dim)
 
@@ -148,55 +149,46 @@ def paged_attention(
 
     q_tile = min(num_heads_dim, 128)
 
-    # Max blocks across all batches (each batch may have different context_len)
     max_bn = int(((context_lens.max().item()) + block_size - 1) // block_size)
 
     for q_offset in range(0, num_heads_dim, q_tile):
         q_tile_size = min(q_tile, num_heads_dim - q_offset)
-        # qi: (batch, q_tile_size, head_dim)
         qi = query[:, q_offset:q_offset + q_tile_size, :].to(torch.float32)
 
-        oi = None  # (batch, q_tile_size, head_dim)
-        li = None  # (batch, q_tile_size, 1)
-        mi = None  # (batch, q_tile_size, 1)
+        oi = None
+        li = None
+        mi = None
 
         for bn in range(max_bn):
-            # valid_len per batch for this block position
             valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
-            active_mask = valid_lens > 0  # (batch,)
+            active_mask = valid_lens > 0
 
             if not active_mask.any():
                 break
 
-            # Gather block indices for all batches
-            block_indices = block_table[:, bn]  # (batch,)
+            block_indices = block_table[:, bn]
 
-            # Gather K and V: (batch, block_size, head_dim)
             kj_all = key_cache_flat[block_indices].to(torch.float32)
             vj_all = value_cache_flat[block_indices].to(torch.float32)
 
-            # QK matmul: (batch, q_tile_size, block_size)
             sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale_value
 
-            # Mask out invalid positions (beyond valid_len per batch)
-            pos = torch.arange(block_size, device=sij.device).unsqueeze(0)  # (1, block_size)
-            valid_mask = pos < valid_lens.unsqueeze(1)  # (batch, block_size)
-            valid_mask = valid_mask.unsqueeze(1)  # (batch, 1, block_size)
+            pos = torch.arange(block_size, device=sij.device).unsqueeze(0)
+            valid_mask = pos < valid_lens.unsqueeze(1)
+            valid_mask = valid_mask.unsqueeze(1)
             sij = sij.masked_fill(~valid_mask, float('-inf'))
 
-            # Also mask inactive batches (no blocks at this position)
-            batch_mask = active_mask.view(-1, 1, 1)  # (batch, 1, 1)
+            batch_mask = active_mask.view(-1, 1, 1)
             sij = sij.masked_fill(~batch_mask, float('-inf'))
 
-            mij = sij.max(dim=-1, keepdim=True)[0]  # (batch, q_tile_size, 1)
+            mij = sij.max(dim=-1, keepdim=True)[0]
             mij = mij.clamp(min=-1e30)
             pij = torch.exp(sij - mij)
             pij = pij.masked_fill(~valid_mask, 0.0)
             pij = pij.masked_fill(~batch_mask, 0.0)
             pij = pij.to(torch.bfloat16).to(torch.float32)
-            lij = pij.sum(dim=-1, keepdim=True)  # (batch, q_tile_size, 1)
+            lij = pij.sum(dim=-1, keepdim=True)
 
-            # PV matmul: (batch, q_tile_size, head_dim)
             oi_new = torch.bmm(pij, vj_all)
 
             if bn == 0:
@@ -211,7 +203,6 @@ def paged_attention(
                 oi = alpha * oi + beta * oi_new
                 mi = mi_new
 
-        # Final normalization
         out[:, q_offset:q_offset + q_tile_size, :] = oi / li
 
     return out.reshape(-1, head_dim)
@@ -228,7 +219,6 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
     max_num_blocks_per_req = max_model_len // block_size
 
-    # Reconstruct shaped tensors from flat tensors
     query = tensors["query"].reshape(batch, num_heads, head_dim)
     key_cache = tensors["key_cache"].reshape(-1, block_size, kv_head_num, head_dim)
     value_cache = tensors["value_cache"].reshape(-1, block_size, kv_head_num, head_dim)
@@ -251,7 +241,8 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
 if __name__ == "__main__":
     params = PARAMS_LIST[0]
-    tensors = generate_inputs(params)
+    result = generate_inputs(params)
+    tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
     compute_golden(tensors, params)
 
     print(f"=== Paged Attention Golden Test ({params['name']}) ===")

--- a/examples/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -24,8 +24,8 @@
 extern "C" {
 
 int build_paged_attention_graph(Runtime* runtime, uint64_t* args, int arg_count) {
-    if (arg_count < 15) {
-        std::cerr << "Expected at least 15 args, got " << arg_count << '\n';
+    if (arg_count < 14) {
+        std::cerr << "Expected at least 14 args, got " << arg_count << '\n';
         return -1;
     }
 

--- a/examples/host_build_graph/vector_example/golden.py
+++ b/examples/host_build_graph/vector_example/golden.py
@@ -1,66 +1,43 @@
 """
 Golden script for host_build_graph example.
 
-This script defines the input data generation and expected output computation
-for the host_build_graph example (both a2a3 and a2a3sim platforms).
-
 Computation:
     f = (a + b + 1) * (a + b + 2)
     where a=2.0, b=3.0, so f=42.0
+
+Args layout: [ptr_a, ptr_b, ptr_f, size_a, size_b, size_f, SIZE]
 """
 
+import ctypes
 import torch
 
-# Output tensor names (alternatively, use 'out_' prefix convention)
 __outputs__ = ["f"]
 
-# Tensor order for orchestration function arguments
-# This MUST match the order expected by BuildExampleGraph in example_orch.cpp
-# Args layout: [ptr_a, ptr_b, ptr_f, size_a, size_b, size_f, SIZE]
-TENSOR_ORDER = ["a", "b", "f"]
-
-# Comparison tolerances
 RTOL = 1e-5
 ATOL = 1e-5
 
 
-def generate_inputs(params: dict) -> dict:
-    """
-    Generate input and output tensors.
-
-    Creates:
-    - a: 16384 elements, all 2.0
-    - b: 16384 elements, all 3.0
-    - f: 16384 elements, zeros (output)
-
-    Returns:
-        Dict of torch tensors with tensor names as keys
-    """
+def generate_inputs(params: dict) -> list:
     ROWS = 128
     COLS = 128
-    SIZE = ROWS * COLS  # 16384 elements
+    SIZE = ROWS * COLS
 
-    return {
-        "a": torch.full((SIZE,), 2.0, dtype=torch.float32),
-        "b": torch.full((SIZE,), 3.0, dtype=torch.float32),
-        "f": torch.zeros(SIZE, dtype=torch.float32),
-    }
+    a = torch.full((SIZE,), 2.0, dtype=torch.float32)
+    b = torch.full((SIZE,), 3.0, dtype=torch.float32)
+    f = torch.zeros(SIZE, dtype=torch.float32)
+
+    return [
+        ("a", a),
+        ("b", b),
+        ("f", f),
+        ("size_a", ctypes.c_int64(a.nbytes)),
+        ("size_b", ctypes.c_int64(b.nbytes)),
+        ("size_f", ctypes.c_int64(f.nbytes)),
+        ("SIZE", ctypes.c_int64(SIZE)),
+    ]
 
 
 def compute_golden(tensors: dict, params: dict) -> None:
-    """
-    Compute expected output in-place.
-
-    f = (a + b + 1) * (a + b + 2)
-      = (2 + 3 + 1) * (2 + 3 + 2)
-      = 6 * 7
-      = 42
-
-    Args:
-        tensors: Dict containing all tensors (inputs and outputs)
-        params: Parameter dict (unused in this example)
-    """
-    # Convert to torch tensors (handles both array types)
     a = torch.as_tensor(tensors["a"])
     b = torch.as_tensor(tensors["b"])
     tensors["f"][:] = (a + b + 1) * (a + b + 2)

--- a/examples/tensormap_and_ringbuffer/bgemm/golden.py
+++ b/examples/tensormap_and_ringbuffer/bgemm/golden.py
@@ -3,12 +3,14 @@ Golden test specification for BGEMM (tensormap_and_ringbuffer Runtime).
 
 Computation: C = A @ B (tiled matrix multiplication)
 Configuration: 4x4x4 grid, 64x64 tiles
+
+Args layout: [ptr_A, ptr_B, ptr_C, size_A, size_B, size_C]
 """
 
+import ctypes
 import torch
 
 __outputs__ = ["C"]
-TENSOR_ORDER = ["A", "B", "C"]
 RTOL = 1e-3
 ATOL = 1e-3
 
@@ -26,17 +28,24 @@ K = TILE_K * GRID_K
 N = TILE_N * GRID_N
 
 
-def generate_inputs(params: dict) -> dict:
+def generate_inputs(params: dict) -> list:
     """Generate input tensors with tile-first memory layout."""
     A = torch.randn(BATCH, GRID_M, GRID_K, TILE_M, TILE_K, dtype=torch.float32) * 0.01
     B = torch.randn(BATCH, GRID_K, GRID_N, TILE_K, TILE_N, dtype=torch.float32) * 0.01
     C = torch.zeros(BATCH, GRID_M, GRID_N, TILE_M, TILE_N, dtype=torch.float32)
 
-    return {
-        "A": A.flatten(),
-        "B": B.flatten(),
-        "C": C.flatten(),
-    }
+    A_flat = A.flatten()
+    B_flat = B.flatten()
+    C_flat = C.flatten()
+
+    return [
+        ("A", A_flat),
+        ("B", B_flat),
+        ("C", C_flat),
+        ("size_A", ctypes.c_int64(A_flat.nbytes)),
+        ("size_B", ctypes.c_int64(B_flat.nbytes)),
+        ("size_C", ctypes.c_int64(C_flat.nbytes)),
+    ]
 
 
 def compute_golden(tensors: dict, params: dict) -> None:

--- a/examples/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -57,7 +57,7 @@ PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count
     (void)args;
     (void)arg_count;
     return PTO2OrchestrationConfig{
-        .expected_arg_count = 7,
+        .expected_arg_count = 6,
     };
 }
 

--- a/examples/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -47,7 +47,7 @@ PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count
     (void)args;
     (void)arg_count;
     return PTO2OrchestrationConfig{
-        .expected_arg_count = 7,
+        .expected_arg_count = 10,
     };
 }
 
@@ -69,7 +69,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
     void* host_out = (void*)(uintptr_t)args[5];             // [batch, num_heads, head_dim]
     int64_t* host_config = (int64_t*)(uintptr_t)args[6];
 
-    // Extract sizes (next 7 args after pointers)
+    // Extract sizes (next 3 args after pointers)
     size_t query_size = (size_t)args[7];
     size_t key_cache_size = (size_t)args[8];
     size_t value_cache_size = (size_t)args[9];

--- a/tests/device_tests/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -63,7 +63,7 @@ extern "C" int orchestration(Runtime* runtime) {
         return -1;
     }
 
-    if (runtime->orch_argc < 15) {
+    if (runtime->orch_argc < 14) {
         return -1;
     }
 

--- a/tests/device_tests/host_build_graph/paged_attention/golden.py
+++ b/tests/device_tests/host_build_graph/paged_attention/golden.py
@@ -7,19 +7,17 @@ Implements the online softmax algorithm for paged attention with:
 - GQA support (kv_head_num=1)
 - Head tiling: q_tile = min(q_head_num, 128)
 - Random block table mapping
+
+Args layout: [ptr_query, ..., ptr_config, size_query, ..., size_config]
 """
 
+import ctypes
 import os
 import struct
 import torch
 
-# Output tensor names
 __outputs__ = ["out"]
 
-# Tensor order matching orchestration function parameter order
-TENSOR_ORDER = ["query", "key_cache", "value_cache", "block_table", "context_lens", "out", "config"]
-
-# Comparison tolerances
 RTOL = 1e-3
 ATOL = 1e-3
 
@@ -51,7 +49,7 @@ _selected = os.environ.get("PA_CASE", "Case1")
 PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
 
 
-def generate_inputs(params: dict) -> dict:
+def generate_inputs(params: dict) -> list:
     """Generate input tensors and zeroed output tensor."""
     batch = params["batch"]
     num_heads = params["num_heads"]
@@ -67,7 +65,6 @@ def generate_inputs(params: dict) -> dict:
     scale_value = 1.0
     scale_bits = struct.unpack('I', struct.pack('f', scale_value))[0]
 
-    # Random block table: (batch, max_num_blocks_per_req) int32
     block_table = torch.randint(
         0,
         max(total_blocks, 1),
@@ -75,7 +72,6 @@ def generate_inputs(params: dict) -> dict:
         dtype=torch.int32,
     )
 
-    # Context lens: all = context_len
     context_lens = torch.full((batch,), context_len, dtype=torch.int32)
 
     config = torch.tensor(
@@ -84,25 +80,34 @@ def generate_inputs(params: dict) -> dict:
         dtype=torch.int64,
     )
 
-    # Query: (batch, 1, num_heads * head_dim) -> (batch, num_heads, head_dim) bfloat16
     query_bf16 = torch.empty(batch, 1, num_heads * head_dim).uniform_(-0.5, 0.5).to(torch.bfloat16)
     query_bf16 = query_bf16.reshape(batch, num_heads, head_dim)
 
-    # Key cache: (total_blocks, block_size, kv_head_num, head_dim) bfloat16
     key_bf16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-0.5, 0.5).to(torch.bfloat16)
-
-    # Value cache: (total_blocks, block_size, kv_head_num, head_dim) bfloat16
     value_bf16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-1, 1).to(torch.bfloat16)
 
-    return {
-        "query": query_bf16.flatten(),
-        "key_cache": key_bf16.flatten(),
-        "value_cache": value_bf16.flatten(),
-        "block_table": block_table.flatten(),
-        "context_lens": context_lens,
-        "out": torch.zeros(batch * num_heads * head_dim, dtype=torch.float32),
-        "config": config,
-    }
+    query = query_bf16.flatten()
+    key_cache = key_bf16.flatten()
+    value_cache = value_bf16.flatten()
+    block_table_flat = block_table.flatten()
+    out = torch.zeros(batch * num_heads * head_dim, dtype=torch.float32)
+
+    return [
+        ("query", query),
+        ("key_cache", key_cache),
+        ("value_cache", value_cache),
+        ("block_table", block_table_flat),
+        ("context_lens", context_lens),
+        ("out", out),
+        ("config", config),
+        ("size_query", ctypes.c_int64(query.nbytes)),
+        ("size_key_cache", ctypes.c_int64(key_cache.nbytes)),
+        ("size_value_cache", ctypes.c_int64(value_cache.nbytes)),
+        ("size_block_table", ctypes.c_int64(block_table_flat.nbytes)),
+        ("size_context_lens", ctypes.c_int64(context_lens.nbytes)),
+        ("size_out", ctypes.c_int64(out.nbytes)),
+        ("size_config", ctypes.c_int64(config.nbytes)),
+    ]
 
 
 def paged_attention(
@@ -138,7 +143,6 @@ def paged_attention(
     batch, num_heads_dim, head_dim = query.shape
     _, block_size, _, _ = key_cache.shape
 
-    # Reshape for batched computation
     key_cache_flat = key_cache.reshape(-1, block_size, head_dim)
     value_cache_flat = value_cache.reshape(-1, block_size, head_dim)
 
@@ -146,55 +150,46 @@ def paged_attention(
 
     q_tile = min(num_heads_dim, 128)
 
-    # Max blocks across all batches (each batch may have different context_len)
     max_bn = int(((context_lens.max().item()) + block_size - 1) // block_size)
 
     for q_offset in range(0, num_heads_dim, q_tile):
         q_tile_size = min(q_tile, num_heads_dim - q_offset)
-        # qi: (batch, q_tile_size, head_dim)
         qi = query[:, q_offset:q_offset + q_tile_size, :].to(torch.float32)
 
-        oi = None  # (batch, q_tile_size, head_dim)
-        li = None  # (batch, q_tile_size, 1)
-        mi = None  # (batch, q_tile_size, 1)
+        oi = None
+        li = None
+        mi = None
 
         for bn in range(max_bn):
-            # valid_len per batch for this block position
             valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
-            active_mask = valid_lens > 0  # (batch,)
+            active_mask = valid_lens > 0
 
             if not active_mask.any():
                 break
 
-            # Gather block indices for all batches
-            block_indices = block_table[:, bn]  # (batch,)
+            block_indices = block_table[:, bn]
 
-            # Gather K and V: (batch, block_size, head_dim)
             kj_all = key_cache_flat[block_indices].to(torch.float32)
             vj_all = value_cache_flat[block_indices].to(torch.float32)
 
-            # QK matmul: (batch, q_tile_size, block_size)
             sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale_value
 
-            # Mask out invalid positions (beyond valid_len per batch)
-            pos = torch.arange(block_size, device=sij.device).unsqueeze(0)  # (1, block_size)
-            valid_mask = pos < valid_lens.unsqueeze(1)  # (batch, block_size)
-            valid_mask = valid_mask.unsqueeze(1)  # (batch, 1, block_size)
+            pos = torch.arange(block_size, device=sij.device).unsqueeze(0)
+            valid_mask = pos < valid_lens.unsqueeze(1)
+            valid_mask = valid_mask.unsqueeze(1)
             sij = sij.masked_fill(~valid_mask, float('-inf'))
 
-            # Also mask inactive batches (no blocks at this position)
-            batch_mask = active_mask.view(-1, 1, 1)  # (batch, 1, 1)
+            batch_mask = active_mask.view(-1, 1, 1)
             sij = sij.masked_fill(~batch_mask, float('-inf'))
 
-            mij = sij.max(dim=-1, keepdim=True)[0]  # (batch, q_tile_size, 1)
+            mij = sij.max(dim=-1, keepdim=True)[0]
             mij = mij.clamp(min=-1e30)
             pij = torch.exp(sij - mij)
             pij = pij.masked_fill(~valid_mask, 0.0)
             pij = pij.masked_fill(~batch_mask, 0.0)
             pij = pij.to(torch.bfloat16).to(torch.float32)
-            lij = pij.sum(dim=-1, keepdim=True)  # (batch, q_tile_size, 1)
+            lij = pij.sum(dim=-1, keepdim=True)
 
-            # PV matmul: (batch, q_tile_size, head_dim)
             oi_new = torch.bmm(pij, vj_all)
 
             if bn == 0:
@@ -209,7 +204,6 @@ def paged_attention(
                 oi = alpha * oi + beta * oi_new
                 mi = mi_new
 
-        # Final normalization
         out[:, q_offset:q_offset + q_tile_size, :] = oi / li
 
     return out.reshape(-1, head_dim)
@@ -226,7 +220,6 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
     max_num_blocks_per_req = max_model_len // block_size
 
-    # Reconstruct shaped tensors from flat tensors
     query = tensors["query"].reshape(batch, num_heads, head_dim)
     key_cache = tensors["key_cache"].reshape(-1, block_size, kv_head_num, head_dim)
     value_cache = tensors["value_cache"].reshape(-1, block_size, kv_head_num, head_dim)
@@ -249,7 +242,8 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
 if __name__ == "__main__":
     params = PARAMS_LIST[0]
-    tensors = generate_inputs(params)
+    result = generate_inputs(params)
+    tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
     compute_golden(tensors, params)
 
     print(f"=== Paged Attention Golden Test ({params['name']}) ===")

--- a/tests/device_tests/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -24,8 +24,8 @@
 extern "C" {
 
 int build_paged_attention_graph(Runtime* runtime, uint64_t* args, int arg_count) {
-    if (arg_count < 15) {
-        std::cerr << "Expected at least 15 args, got " << arg_count << '\n';
+    if (arg_count < 14) {
+        std::cerr << "Expected at least 14 args, got " << arg_count << '\n';
         return -1;
     }
 

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -7,19 +7,17 @@ Implements the online softmax algorithm for paged attention with:
 - GQA support (kv_head_num=1)
 - Head tiling: q_tile = min(q_head_num, 128)
 - Random block table mapping
+
+Args layout: [ptr_query, ..., ptr_config, size_query, size_key_cache, size_value_cache]
 """
 
+import ctypes
 import os
 import struct
 import torch
 
-# Output tensor names
 __outputs__ = ["out"]
 
-# Tensor order matching orchestration function parameter order
-TENSOR_ORDER = ["query", "key_cache", "value_cache", "block_table", "context_lens", "out", "config"]
-
-# Comparison tolerances
 RTOL = 1e-3
 ATOL = 1e-3
 
@@ -51,7 +49,7 @@ _selected = os.environ.get("PA_CASE", "Case1")
 PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
 
 
-def generate_inputs(params: dict) -> dict:
+def generate_inputs(params: dict) -> list:
     """Generate input tensors and zeroed output tensor."""
     batch = params["batch"]
     num_heads = params["num_heads"]
@@ -67,7 +65,6 @@ def generate_inputs(params: dict) -> dict:
     scale_value = 1.0
     scale_bits = struct.unpack('I', struct.pack('f', scale_value))[0]
 
-    # Random block table: (batch, max_num_blocks_per_req) int32
     block_table = torch.randint(
         0,
         max(total_blocks, 1),
@@ -75,7 +72,6 @@ def generate_inputs(params: dict) -> dict:
         dtype=torch.int32,
     )
 
-    # Context lens: all = context_len
     context_lens = torch.full((batch,), context_len, dtype=torch.int32)
 
     config = torch.tensor(
@@ -84,25 +80,30 @@ def generate_inputs(params: dict) -> dict:
         dtype=torch.int64,
     )
 
-    # Query: (batch, 1, num_heads * head_dim) -> (batch, num_heads, head_dim) bfloat16
     query_bf16 = torch.empty(batch, 1, num_heads * head_dim).uniform_(-0.5, 0.5).to(torch.bfloat16)
     query_bf16 = query_bf16.reshape(batch, num_heads, head_dim)
 
-    # Key cache: (total_blocks, block_size, kv_head_num, head_dim) bfloat16
     key_bf16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-0.5, 0.5).to(torch.bfloat16)
-
-    # Value cache: (total_blocks, block_size, kv_head_num, head_dim) bfloat16
     value_bf16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-1, 1).to(torch.bfloat16)
 
-    return {
-        "query": query_bf16.flatten(),
-        "key_cache": key_bf16.flatten(),
-        "value_cache": value_bf16.flatten(),
-        "block_table": block_table.flatten(),
-        "context_lens": context_lens,
-        "out": torch.zeros(batch * num_heads * head_dim, dtype=torch.float32),
-        "config": config,
-    }
+    query = query_bf16.flatten()
+    key_cache = key_bf16.flatten()
+    value_cache = value_bf16.flatten()
+    block_table_flat = block_table.flatten()
+    out = torch.zeros(batch * num_heads * head_dim, dtype=torch.float32)
+
+    return [
+        ("query", query),
+        ("key_cache", key_cache),
+        ("value_cache", value_cache),
+        ("block_table", block_table_flat),
+        ("context_lens", context_lens),
+        ("out", out),
+        ("config", config),
+        ("size_query", ctypes.c_int64(query.nbytes)),
+        ("size_key_cache", ctypes.c_int64(key_cache.nbytes)),
+        ("size_value_cache", ctypes.c_int64(value_cache.nbytes)),
+    ]
 
 
 def paged_attention(
@@ -249,7 +250,8 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
 if __name__ == "__main__":
     params = PARAMS_LIST[0]
-    tensors = generate_inputs(params)
+    result = generate_inputs(params)
+    tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
     compute_golden(tensors, params)
 
     print(f"=== Paged Attention Golden Test ({params['name']}) ===")

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -44,7 +44,7 @@ __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestrati
     (void)args;
     (void)arg_count;
     return PTO2OrchestrationConfig{
-        .expected_arg_count = 15,
+        .expected_arg_count = 10,
     };
 }
 
@@ -72,14 +72,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     void* host_out = reinterpret_cast<void*>(args[5]);          // [batch, num_heads, head_dim]
     int64_t* host_config = reinterpret_cast<int64_t*>(args[6]);
 
-    // Extract sizes (next 7)
+    // Extract sizes (next 3)
     size_t query_size = static_cast<size_t>(args[7]);
     size_t key_cache_size = static_cast<size_t>(args[8]);
     size_t value_cache_size = static_cast<size_t>(args[9]);
-    size_t block_table_size = static_cast<size_t>(args[10]);
-    size_t context_lens_size = static_cast<size_t>(args[11]);
-    size_t out_size = static_cast<size_t>(args[12]);
-    size_t config_size = static_cast<size_t>(args[13]);
 
     // Extract config parameters
     uint64_t batch = static_cast<uint64_t>(static_cast<int>(host_config[0]));


### PR DESCRIPTION
The framework no longer silently appends scalar arguments (tensor byte sizes + element count). Golden authors now specify the full args layout explicitly via a list of (name, value) pairs, using ctypes for typed scalars. This makes the args array transparent and gives golden authors full control over what gets passed to orchestration functions.