### PR TITLE
Refactor: implement ACK/FIN dual-state handshake protocol for task scheduling

### DIFF
--- a/src/platform/a2a3/aicore/inner_kernel.h
+++ b/src/platform/a2a3/aicore/inner_kernel.h
@@ -48,7 +48,7 @@ __aicore__ inline uint64_t read_reg(RegId reg) {
 __aicore__ inline void write_reg(RegId reg, uint64_t value) {
     switch (reg) {
         case RegId::COND:
-            set_cond(static_cast<AICoreStatus>(static_cast<uint32_t>(value)));
+            set_cond(static_cast<uint32_t>(value));
             break;
         case RegId::DATA_MAIN_BASE:
         case RegId::FAST_PATH_ENABLE:

--- a/src/platform/include/common/platform_config.h
+++ b/src/platform/include/common/platform_config.h
@@ -179,4 +179,40 @@ namespace DAV_2201 {
 constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = 25;
 }
 
+// =============================================================================
+// ACK/FIN Dual-State Register Protocol
+// =============================================================================
+
+/**
+ * AICPU-AICore task handshake protocol via COND register
+ *
+ * Register format: [bit 31: state | low 31 bits: task_id]
+ * State: ACK (0) = task received, FIN (1) = task completed
+ */
+
+#define TASK_ID_MASK       0x7FFFFFFFU
+#define TASK_STATE_MASK    0x80000000U
+
+#define TASK_ACK_STATE     0
+#define TASK_FIN_STATE     1
+
+#define EXTRACT_TASK_ID(regval)    ((int)((regval) & TASK_ID_MASK))
+#define EXTRACT_TASK_STATE(regval) ((int)(((regval) & TASK_STATE_MASK) >> 31))
+#define MAKE_ACK_VALUE(task_id)    ((uint64_t)((task_id) & TASK_ID_MASK))
+#define MAKE_FIN_VALUE(task_id)    ((uint64_t)(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
+
+// This value is RESERVED and must never be used as a real task ID.
+#define AICORE_IDLE_TASK_ID        0x7FFFFFFFU
+#define AICORE_IDLE_VALUE          MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
+
+// =============================================================================
+// Task State Constants
+// =============================================================================
+
+/**
+ * Invalid task ID sentinel value
+ * Used to indicate that pending_task_ids_ or running_task_ids_ slot is empty.
+ */
+constexpr int AICPU_TASK_INVALID = -1;
+
 #endif  // PLATFORM_COMMON_PLATFORM_CONFIG_H_


### PR DESCRIPTION
Refactor: implement ACK/FIN dual-state handshake protocol for task scheduling
Platform changes:
- Add ACK/FIN protocol macros and constants to platform_config.h
  (TASK_ID_MASK, MAKE_ACK_VALUE, MAKE_FIN_VALUE, etc.)
- Simplify COND register write in aicore inner_kernel.h

Runtime changes:
- Implement two-slot task tracking (pending + running) in AICPU executor
- Add thread-local ready queues to reduce lock contention
- Refactor initial task distribution with round-robin assignment
- Update AICore executor to use ACK/FIN protocol macros

This enables pipelined task execution where AICore can acknowledge task
receipt while executing previous task, improving scheduling efficiency.