### PR TITLE
Fix: compute heap_tail as offset from heap base instead of absolute pointer cast

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -105,7 +105,7 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
 
     // Initialize scheduler
     if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle,
-                              &rt->orchestrator.dep_pool)) {
+                              &rt->orchestrator.dep_pool, rt->gm_heap)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
@@ -142,7 +142,7 @@ PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
     }
 
     if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle,
-                             &rt->orchestrator.dep_pool)) {
+                             &rt->orchestrator.dep_pool, rt->gm_heap)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt);
         return NULL;

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -54,7 +54,10 @@ typedef struct PTO2SchedulerState {
 
     // Local copies of ring pointers (written to shared memory after update)
     int32_t last_task_alive;      // Task ring tail
-    uint64_t heap_tail;           // Heap ring tail
+    uint64_t heap_tail;           // Heap ring tail (offset from heap_base)
+
+    // Heap base address (for converting absolute pointers to offsets)
+    void* heap_base;
 
     // === DYNAMIC CONFIGURATION ===
     uint64_t task_window_size;    // Task window size (power of 2)
@@ -98,11 +101,13 @@ static inline int32_t pto2_task_slot(PTO2SchedulerState* sched, int32_t task_id)
  * @param sched      Scheduler state to initialize
  * @param sm_handle  Shared memory handle
  * @param dep_pool   Dependency list pool
+ * @param heap_base  Base address of GM heap (for pointer-to-offset conversion)
  * @return true on success
  */
 bool pto2_scheduler_init(PTO2SchedulerState* sched,
                           PTO2SharedMemoryHandle* sm_handle,
-                          PTO2DepListPool* dep_pool);
+                          PTO2DepListPool* dep_pool,
+                          void* heap_base);
 
 /**
  * Destroy scheduler state and free resources


### PR DESCRIPTION
The scheduler's heap_tail must be an offset into the heap ring buffer, but it was being set by casting an absolute pointer to an integer. This produces a garbage value that breaks heap reclamation when the ring wraps around.

Store heap_base in PTO2SchedulerState and compute the offset correctly as (packed_buffer_end - heap_base).