### PR TITLE
Fix intermittent data mismatch in tensormap_and_ringbuffer by adding memory barriers to AICPU-AICore handshake

### DIFF
--- a/src/platform/a2a3sim/aicore/inner_kernel.h
+++ b/src/platform/a2a3sim/aicore/inner_kernel.h
@@ -21,7 +21,7 @@
 
 // dcci (Data Cache Clean and Invalidate) - no-op in simulation
 // Use variadic macro to support both 2-arg and 3-arg calls
-#define dcci(...) ((void)0)
+#define dcci(...) __atomic_thread_fence(__ATOMIC_ACQUIRE)
 
 // Cache coherency constants (no-op in simulation)
 #define ENTIRE_DATA_CACHE 0

--- a/src/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -83,6 +83,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
 
         // Execute task if assigned (task != 0)
         if (my_hank->task_status == 1 && my_hank->task != 0) {
+            pipe_barrier(PIPE_ALL);  // Acquire: ensure subsequent reads of payload see latest data
             __gm__ PTO2DispatchPayload* payload =
                 reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
 
@@ -105,6 +106,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             }
 
             // Mark task as complete (task_status: 0=idle, 1=busy)
+            pipe_barrier(PIPE_ALL);  // Release: ensure kernel output writes visible before signaling completion
             my_hank->task_status = 0;
         }
     }

--- a/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -554,7 +554,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
         for (int i = 0; i < core_num; i++) {
             int core_id = cur_thread_cores[i];
             Handshake* h = &hank[core_id];
-            if (h->task_status == 0 && h->task != 0) {
+            if (__atomic_load_n(const_cast<int32_t*>(&h->task_status), __ATOMIC_ACQUIRE) == 0 && h->task != 0) {
                 PTO2DispatchPayload* payload = reinterpret_cast<PTO2DispatchPayload*>(h->task);
                 h->task = 0;
 
@@ -656,7 +656,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                             }
                             core_dispatch_counts_[core_id]++;
                         }
-                        h->task_status = 1;
+                        __atomic_store_n(const_cast<int32_t*>(&h->task_status), 1, __ATOMIC_RELEASE);
                         cur_thread_tasks_in_flight++;
                         made_progress = true;
                         DEV_DEBUG("Thread %d: Dispatching PTO2 task %d to core %d", thread_idx, task_id, core_id);


### PR DESCRIPTION
## Summary

- Fix ~5% intermittent data mismatch ("output does not match golden") in tensormap_and_ringbuffer BGEMM/PA tests caused by missing memory barriers in the AICPU-AICore Handshake protocol on ARM aarch64 weak memory ordering
- Add release-acquire barrier pairs on task_status signaling path, using platform-appropriate primitives for g++ (AICPU) and CANN compiler (AICore)

## Root Cause

The Handshake struct uses `volatile` fields for cross-thread AICPU↔AICore communication. On ARM aarch64, `volatile` only prevents compiler elision — it does **not** prevent CPU store/load reordering. This allows AICore to observe `task_status == 1` while `payload->args[]` data from `build_pto2_payload()` has not yet propagated, causing the kernel to execute with stale arguments.

The race window is narrow (tens to hundreds of nanoseconds for ARM store buffer flush), matching the observed failure rates.

## Changes

### aicpu_executor.cpp (compiled by g++)
- **line ~659**: `h->task_status = 1` → `__atomic_store_n(&task_status, 1, __ATOMIC_RELEASE)` — ensures payload writes are visible before signaling task ready
- **line ~557**: `h->task_status == 0` → `__atomic_load_n(&task_status, __ATOMIC_ACQUIRE)` — ensures subsequent reads of kernel output see latest values

### aicore_executor.cpp (compiled by CANN compiler)
- **line ~86**: add `pipe_barrier(PIPE_ALL)` after `task_status == 1` check — acquire barrier before reading payload
- **line ~109**: add `pipe_barrier(PIPE_ALL)` before `task_status = 0` write — release barrier after kernel execution

> `__atomic_store_n`/`__atomic_load_n` cannot be used on AICore side because CANN compiler rejects `const_cast` that strips `__gm__` address-space qualifier from `volatile __gm__ int32_t*`.

### a2a3sim/inner_kernel.h
- **line 24**: `#define dcci(...) ((void)0)` → `#define dcci(...) __atomic_thread_fence(__ATOMIC_ACQUIRE)` — provide acquire semantics in simulation mode where hardware `dcci` is unavailable

## Test Plan

- [ ] `sh bgemm_a2a3sim.sh` — simulation BGEMM 100/100 PASSED
- [ ] `sh bgemm_a2a3.sh` — on-board BGEMM 100/100 PASSED (also verifies CANN compilation)
- [ ] Extended run (500+ iterations) to confirm elimination of intermittent failures