### PR TITLE
Fix: add memory barriers to AICPU-AICore handshake to eliminate data race in simulation

### DIFF
--- a/src/platform/a2a3sim/aicore/inner_kernel.h
+++ b/src/platform/a2a3sim/aicore/inner_kernel.h
@@ -21,7 +21,7 @@
 
 // dcci (Data Cache Clean and Invalidate) - no-op in simulation
 // Use variadic macro to support both 2-arg and 3-arg calls
-#define dcci(...) ((void)0)
+#define dcci(...) __atomic_thread_fence(__ATOMIC_ACQUIRE)
 
 // Cache coherency constants (no-op in simulation)
 #define ENTIRE_DATA_CACHE 0

--- a/src/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -72,9 +72,11 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
 
         // Execute task if assigned (task != 0 means valid Task* pointer)
         if (my_hank->task_status == 1 && my_hank->task != 0) {
+            pipe_barrier(PIPE_ALL);  // Acquire: ensure subsequent reads of payload see latest data
             __gm__ Task* task_ptr = reinterpret_cast<__gm__ Task*>(my_hank->task);
             execute_task(task_ptr);
             // Mark task as complete (task_status: 0=idle, 1=busy)
+            pipe_barrier(PIPE_ALL);  // Release: ensure kernel output writes visible before signaling completion
             my_hank->task_status = 0;
         }
     }

--- a/src/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -630,7 +630,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             int core_id = cur_thread_cores[i];
             Handshake* h = &hank[core_id];
 
-            if (h->task_status == 0 && h->task != 0) {
+            if (__atomic_load_n(const_cast<int32_t*>(&h->task_status), __ATOMIC_ACQUIRE) == 0 && h->task != 0) {
                 Task* task = reinterpret_cast<Task*>(h->task);
                 h->task = 0;
 
@@ -698,7 +698,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         task_id,
                         core_id);
                     h->task = reinterpret_cast<uint64_t>(task);
-                    h->task_status = 1;
+                    __atomic_store_n(const_cast<int32_t*>(&h->task_status), 1, __ATOMIC_RELEASE);
                     cur_thread_tasks_in_flight++;
                     made_progress = true;
                 }


### PR DESCRIPTION
## Summary
- Fix intermittent data race in AICPU-AICore handshake under simulation (a2a3sim) causing 2/100 bgemm test failures
- Add acquire-release memory barriers at all four synchronization points to ensure correct ordering of task payload and status flag visibility

## Root Cause
The `Handshake.task_status` field used `volatile` reads/writes without memory barriers. On aarch64 weak memory model, this allowed:
1. AICore to read stale task payload after seeing `task_status==1`
2. AICPU to read stale kernel output after seeing `task_status==0`

Additionally, `dcci` was defined as `((void)0)` in sim mode, providing no ordering guarantee for AICore's polling loop.

## Changes
- **inner_kernel.h**: `dcci` from no-op to `__atomic_thread_fence(__ATOMIC_ACQUIRE)`, matching hardware cache-invalidate semantics
- **aicore_executor.cpp**: Add `pipe_barrier(PIPE_ALL)` as acquire barrier after reading `task_status==1` and release barrier before writing `task_status=0`
- **aicpu_executor.cpp**: Replace plain volatile read/write of `task_status` with `__atomic_load_n(__ATOMIC_ACQUIRE)` / `__atomic_store_n(__ATOMIC_RELEASE)`

## Test 
- [x] `sh bgemm_a2a3sim.sh`: before fix 98/100 PASSED, after fix 100/100 PASSED

## Additional Context
bgemm_a2a3sim.sh：
```
#!/bin/bash

TOTAL=100
PASS=0
FAIL=0

LOGFILE="batch_run_$(date '+%Y%m%d_%H%M%S')-bgemm_a2a3sim.txt"

CMD="python examples/scripts/run_example.py \
    -k examples/tensormap_and_ringbuffer/bgemm/kernels \
    -g examples/tensormap_and_ringbuffer/bgemm/golden.py \
    -p a2a3sim"

echo "Log file: $LOGFILE"
echo "Batch run started at $(date)" | tee "$LOGFILE"
echo "" | tee -a "$LOGFILE"

for i in $(seq 1 $TOTAL); do
    echo "=== Run $i / $TOTAL ===" | tee -a "$LOGFILE"
    output=$($CMD 2>&1)
    echo "$output" >> "$LOGFILE"
    if echo "$output" | grep -q "TEST PASSED"; then
        PASS=$((PASS + 1))
        echo "[Run $i] PASSED" | tee -a "$LOGFILE"
    else
        FAIL=$((FAIL + 1))
        echo "[Run $i] FAILED" | tee -a "$LOGFILE"
    fi
    echo "" >> "$LOGFILE"
done

echo "" | tee -a "$LOGFILE"
echo "==============================" | tee -a "$LOGFILE"
echo "Results: $PASS / $TOTAL PASSED" | tee -a "$LOGFILE"
echo "Batch run finished at $(date)" | tee -a "$LOGFILE"
echo "==============================" | tee -a "$LOGFILE"
echo "Full log saved to: $LOGFILE"
```

Closes #110 