### PR TITLE
fixed: fix free error 507899 in enable profiling

### DIFF
--- a/src/platform/a2a3/host/device_runner.cpp
+++ b/src/platform/a2a3/host/device_runner.cpp
@@ -488,11 +488,11 @@ int DeviceRunner::finalize() {
 
     // Cleanup performance profiling
     if (perf_collector_.is_initialized()) {
-        auto unregister_cb = [](void* host_ptr, int device_id, void* user_data) -> int {
+        auto unregister_cb = [](void* dev_ptr, int device_id, void* user_data) -> int {
             (void)user_data;
             HalHostUnregisterFn fn = get_halHostUnregister();
             if (fn != nullptr) {
-                return fn(host_ptr, device_id);
+                return fn(dev_ptr, device_id);
             }
             return 0;
         };

--- a/src/platform/include/host/performance_collector.h
+++ b/src/platform/include/host/performance_collector.h
@@ -48,12 +48,12 @@ using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id,
 /**
  * Memory unregister callback
  *
- * @param host_ptr Host-mapped pointer
+ * @param dev_ptr Device memory pointer
  * @param device_id Device ID
  * @param user_data User-provided context pointer
  * @return 0 on success, error code on failure
  */
-using PerfUnregisterCallback = int (*)(void* host_ptr, int device_id, void* user_data);
+using PerfUnregisterCallback = int (*)(void* dev_ptr, int device_id, void* user_data);
 
 /**
  * Memory free callback
@@ -145,6 +145,7 @@ private:
     // Shared memory pointers
     void* perf_shared_mem_dev_{nullptr};   // Device memory pointer
     void* perf_shared_mem_host_{nullptr};  // Host-mapped pointer
+    bool was_registered_{false};           // True if register_cb was called successfully
     int device_id_{-1};
 
     // Collected data


### PR DESCRIPTION
The halHostUnregister function was never called, resulting in the SVM mapping not being released and the rtFree operation failing.