### PR TITLE
Fix: replace dcci no-op with acquire fence in a2a3sim

### DIFF
--- a/src/platform/a2a3sim/aicore/inner_kernel.h
+++ b/src/platform/a2a3sim/aicore/inner_kernel.h
@@ -9,6 +9,7 @@
 #ifndef PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
 #define PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 
@@ -19,9 +20,11 @@
 #define __aicore__
 #endif
 
-// dcci (Data Cache Clean and Invalidate) - no-op in simulation
-// Use variadic macro to support both 2-arg and 3-arg calls
-#define dcci(...) ((void)0)
+// dcci (Data Cache Clean and Invalidate) - acquire fence in simulation
+// Hardware dcci invalidates cache to ensure fresh reads from shared memory.
+// In simulation, an acquire fence provides the equivalent ordering guarantee.
+// Use variadic macro to support both 2-arg and 3-arg calls.
+#define dcci(...) std::atomic_thread_fence(std::memory_order_acquire)
 
 // Cache coherency constants (no-op in simulation)
 #define ENTIRE_DATA_CACHE 0


### PR DESCRIPTION
## Summary
- Fix intermittent data race in AICPU-AICore handshake under simulation (a2a3sim) causing 2/100 bgemm test failures
- Replace `dcci` no-op with acquire fence to ensure correct ordering of shared memory reads

## Root Cause
`dcci` was defined as `((void)0)` in sim mode, providing no ordering guarantee for AICore's polling loop. On aarch64 weak memory model, this allowed AICore to read stale task payload after seeing `task_status==1`.

## Changes
- **inner_kernel.h**: `dcci` from no-op to `__atomic_thread_fence(__ATOMIC_ACQUIRE)`, matching hardware cache-invalidate semantics

## Test
- [x] `sh bgemm_a2a3sim.sh`: before fix 98/100 PASSED, after fix 100/100 PASSED

## Additional Context
bgemm_a2a3sim.sh：
```bash
#!/bin/bash

TOTAL=100
PASS=0
FAIL=0

LOGFILE="batch_run_$(date '+%Y%m%d_%H%M%S')-bgemm_a2a3sim.txt"

CMD="python examples/scripts/run_example.py \
    -k examples/tensormap_and_ringbuffer/bgemm/kernels \
    -g examples/tensormap_and_ringbuffer/bgemm/golden.py \
    -p a2a3sim"

echo "Log file: $LOGFILE"
echo "Batch run started at $(date)" | tee "$LOGFILE"
echo "" | tee -a "$LOGFILE"

for i in $(seq 1 $TOTAL); do
    echo "=== Run $i / $TOTAL ===" | tee -a "$LOGFILE"
    output=$($CMD 2>&1)
    echo "$output" >> "$LOGFILE"
    if echo "$output" | grep -q "TEST PASSED"; then
        PASS=$((PASS + 1))
        echo "[Run $i] PASSED" | tee -a "$LOGFILE"
    else
        FAIL=$((FAIL + 1))
        echo "[Run $i] FAILED" | tee -a "$LOGFILE"
    fi
    echo "" >> "$LOGFILE"
done

echo "" | tee -a "$LOGFILE"
echo "==============================" | tee -a "$LOGFILE"
echo "Results: $PASS / $TOTAL PASSED" | tee -a "$LOGFILE"
echo "Batch run finished at $(date)" | tee -a "$LOGFILE"
echo "==============================" | tee -a "$LOGFILE"
echo "Full log saved to: $LOGFILE"
```

Closes #110 
