### PR TITLE
Refactor: clarify no-copy semantics in tensor and param docstrings

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -41,8 +41,9 @@ enum class PTOParamType : int32_t {
  * automatic dependency detection via TensorMap overlap checking.
  *
  * For OUTPUT params with tensor->buffer.addr == 0, the runtime allocates
- * a buffer and writes the address back through the pointer, implicitly
- * updating the caller's local Tensor. No manual sync needed.
+ * from the heap ring in pto2_submit_task (not in make_tensor) and writes the
+ * address back through the pointer. No buffer content is copied; input/inout
+ * tensors already point to their storage, so no memcpy on submit.
  *
  * Example:
  *   Tensor td_a = make_tensor_external(dev_a, size);

--- a/src/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -251,7 +251,9 @@ static inline Tensor make_tensor_external(
 
 /**
  * Create a Tensor for runtime-allocated output (addr=0).
- * The runtime fills in the actual address during pto2_submit_task.
+ * NO memory allocation: only records dtype, shape, and buffer.size in the Tensor struct.
+ * The runtime allocates from the heap ring and fills buffer.addr during pto2_submit_task
+ * when this tensor is passed as OUTPUT param. No buffer content is ever copied.
  */
 static inline Tensor make_tensor(uint64_t size_bytes, DataType dtype = DataType::FLOAT32, int32_t version = 0) {
     return Tensor::make_1d_contiguous(0, size_bytes, dtype, version);
@@ -259,7 +261,9 @@ static inline Tensor make_tensor(uint64_t size_bytes, DataType dtype = DataType:
 
 /**
  * Create a Tensor for runtime-allocated output (addr=0).
- * The runtime fills in the actual address during pto2_submit_task.
+ * NO memory allocation: only records dtype, shape, and buffer.size in the Tensor struct.
+ * The runtime allocates from the heap ring and fills buffer.addr during pto2_submit_task
+ * when this tensor is passed as OUTPUT param. No buffer content is ever copied.
  */
 static inline Tensor make_tensor(
     const uint64_t shapes[], uint64_t ndims, DataType dtype = DataType::FLOAT32, int32_t version = 0) {


### PR DESCRIPTION
Clarify that make_tensor only records dtype/shape/size without allocating memory, and pto2_submit_task copies only tensor descriptors (metadata), never buffer content. Add OUTPUT param assert in orchestrator.