### PR TITLE
Support: add per-phase lock profiling and device log profiling guide

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -113,7 +113,6 @@ struct AicpuExecutor {
     // Track executing task_id per core (-1 = idle)
     int executing_task_ids_[MAX_CORES_PER_THREAD];
 
-    // ===== Task queue state (FIFO circular queue, aligned with host_build_graph) =====
     // ===== 3 shards per type: push to own shard (thread_idx % 3), pop own first + work stealing =====
     SpinLock ready_queue_aic_lock_[PTO2_READY_QUEUE_SHARDS];
     int ready_queue_aic_[PTO2_READY_QUEUE_SHARDS][AICPU_MAX_READY_TASKS];
@@ -160,6 +159,18 @@ struct AicpuExecutor {
     void deinit();
     void diagnose_stuck_state(Runtime* runtime, int thread_idx, const int* cur_thread_cores,
                               int core_num, Handshake* hank);
+
+private:
+    // Helper: enqueue a ready task to the appropriate shard with profiling
+    inline void enqueue_ready_task_with_profiling(
+        int32_t task_id,
+        int32_t worker_type,
+        int thread_idx
+#if PTO2_ORCH_PROFILING
+        , uint64_t& wait_counter,
+        uint64_t& hold_counter
+#endif
+    );
 };
 
 static AicpuExecutor g_aicpu_executor;
@@ -171,6 +182,44 @@ static volatile int32_t s_pto2_task_completed[PTO2_MAX_SLOTS];
 static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
 
 // ===== AicpuExecutor Method Implementations =====
+
+// Helper: enqueue a ready task to the appropriate shard with profiling
+inline void AicpuExecutor::enqueue_ready_task_with_profiling(
+    int32_t task_id,
+    int32_t worker_type,
+    int thread_idx
+#if PTO2_ORCH_PROFILING
+    , uint64_t& wait_counter,
+    uint64_t& hold_counter
+#endif
+) {
+    int my_shard = thread_idx % PTO2_READY_QUEUE_SHARDS;
+#if PTO2_ORCH_PROFILING
+    uint64_t _l0 = get_sys_cnt_aicpu(), _l1, _l2;
+#endif
+
+    if (worker_type == PTO2_WORKER_CUBE) {
+        ready_queue_aic_lock_[my_shard].lock();
+#if PTO2_ORCH_PROFILING
+        _l1 = get_sys_cnt_aicpu();
+#endif
+        ready_queue_aic_[my_shard][ready_queue_aic_tail_[my_shard]++ & AICPU_READY_MASK] = task_id;
+        ready_queue_aic_lock_[my_shard].unlock();
+    } else {
+        ready_queue_aiv_lock_[my_shard].lock();
+#if PTO2_ORCH_PROFILING
+        _l1 = get_sys_cnt_aicpu();
+#endif
+        ready_queue_aiv_[my_shard][ready_queue_aiv_tail_[my_shard]++ & AICPU_READY_MASK] = task_id;
+        ready_queue_aiv_lock_[my_shard].unlock();
+    }
+
+#if PTO2_ORCH_PROFILING
+    _l2 = get_sys_cnt_aicpu();
+    wait_counter += (_l1 - _l0);
+    hold_counter += (_l2 - _l1);
+#endif
+}
 
 /**
  * Handshake with all cores and discover their types
@@ -430,7 +479,6 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
     // Device orchestration: wait for Thread 3 to initialize SM header
     if (thread_num_ == 4 && !runtime->get_orch_built_on_host()) {
         while (!sm_header_ready_.load(std::memory_order_acquire)) {
-            std::this_thread::yield();
         }
     }
 
@@ -470,7 +518,6 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
         pto2_init_complete_.store(true, std::memory_order_release);
     } else {
         while (!pto2_init_complete_.load(std::memory_order_acquire)) {
-            std::this_thread::yield();
         }
     }
 
@@ -491,16 +538,20 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
     // Scheduler profiling counters
 #if PTO2_ORCH_PROFILING
     uint64_t sched_scan_cycle = 0;
-    uint64_t sched_orch_drain_cycle = 0;
+    uint64_t sched_early_ready_cycle = 0;
     uint64_t sched_complete_cycle = 0;
     uint64_t sched_dispatch_cycle = 0;
-    uint64_t sched_yield_cycle = 0;
     uint64_t sched_loop_count = 0;
-    uint64_t sched_yield_count = 0;
+    uint64_t sched_scan_ready_wait = 0, sched_scan_ready_hold = 0;
+    uint64_t sched_early_ready_wait = 0, sched_early_ready_hold = 0;
+    uint64_t sched_complete_ready_wait = 0, sched_complete_ready_hold = 0;
+    uint64_t sched_dispatch_hit_wait = 0, sched_dispatch_hit_hold = 0;
+    uint64_t sched_dispatch_miss_wait = 0, sched_dispatch_miss_hold = 0;
+    uint64_t ready_pop_own = 0, ready_pop_steal = 0;
 #endif
-    // Fanout traversal statistics
-    uint64_t total_fanout_traversed = 0;
-    int32_t max_fanout_len = 0;
+    // Fanout traversal statistics: how many downstream deps were notified after task completions
+    uint64_t fanout_edges_notified = 0;
+    int32_t fanout_max_degree = 0;
 
     while (true) {
 #if PTO2_ORCH_PROFILING
@@ -616,22 +667,17 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                     int32_t fanin_count = __atomic_load_n(&consumer_desc->fanin_count, __ATOMIC_SEQ_CST);
                     if (prev + 1 == fanin_count) {
                         __atomic_store_n(&s_pto2_task_completed[consumer_slot], 1, __ATOMIC_RELEASE);
-                        int32_t wt = consumer_desc->worker_type;
-                        int my_shard = thread_idx % PTO2_READY_QUEUE_SHARDS;
-                        if (wt == PTO2_WORKER_CUBE) {
-                            ready_queue_aic_lock_[my_shard].lock();
-                            ready_queue_aic_[my_shard][ready_queue_aic_tail_[my_shard]++ & AICPU_READY_MASK] = consumer_id;
-                            ready_queue_aic_lock_[my_shard].unlock();
-                        } else {
-                            ready_queue_aiv_lock_[my_shard].lock();
-                            ready_queue_aiv_[my_shard][ready_queue_aiv_tail_[my_shard]++ & AICPU_READY_MASK] = consumer_id;
-                            ready_queue_aiv_lock_[my_shard].unlock();
-                        }
+                        enqueue_ready_task_with_profiling(
+                            consumer_id, consumer_desc->worker_type, thread_idx
+#if PTO2_ORCH_PROFILING
+                            , sched_complete_ready_wait, sched_complete_ready_hold
+#endif
+                        );
                     }
                     current = entry->next_offset;
                 }
-                total_fanout_traversed += fanout_len;
-                if (fanout_len > max_fanout_len) max_fanout_len = fanout_len;
+                fanout_edges_notified += fanout_len;
+                if (fanout_len > fanout_max_degree) fanout_max_degree = fanout_len;
 
                 cur_thread_tasks_in_flight--;
                 cur_thread_completed++;
@@ -658,26 +704,75 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                 if (status == AICoreStatus::IDLE && executing_task_ids_[core_id] == -1) {
                     Handshake* h = &hank[core_id];
                     int32_t task_id = -1;
+#if PTO2_ORCH_PROFILING
+                    bool found_task = false;
+                    bool is_stolen = false;
+#endif
                     int my_shard = thread_idx % PTO2_READY_QUEUE_SHARDS;
                     if (h->core_type == CoreType::AIC) {
                         for (int k = 0; k < PTO2_READY_QUEUE_SHARDS && task_id < 0; k++) {
                             int shard = (my_shard + k) % PTO2_READY_QUEUE_SHARDS;
+#if PTO2_ORCH_PROFILING
+                            uint64_t _l0 = get_sys_cnt_aicpu();
+#endif
                             ready_queue_aic_lock_[shard].lock();
+#if PTO2_ORCH_PROFILING
+                            uint64_t _l1 = get_sys_cnt_aicpu();
+#endif
                             if (ready_queue_aic_head_[shard] < ready_queue_aic_tail_[shard]) {
                                 task_id = ready_queue_aic_[shard][ready_queue_aic_head_[shard]++ & AICPU_READY_MASK];
+                                ready_queue_aic_lock_[shard].unlock();
+#if PTO2_ORCH_PROFILING
+                                uint64_t _l2 = get_sys_cnt_aicpu();
+                                sched_dispatch_hit_wait += (_l1 - _l0);
+                                sched_dispatch_hit_hold += (_l2 - _l1);
+                                found_task = true;
+                                is_stolen = (k != 0);
+#endif
+                                break;
                             }
                             ready_queue_aic_lock_[shard].unlock();
+#if PTO2_ORCH_PROFILING
+                            uint64_t _l2 = get_sys_cnt_aicpu();
+                            sched_dispatch_miss_wait += (_l1 - _l0);
+                            sched_dispatch_miss_hold += (_l2 - _l1);
+#endif
                         }
                     } else {
                         for (int k = 0; k < PTO2_READY_QUEUE_SHARDS && task_id < 0; k++) {
                             int shard = (my_shard + k) % PTO2_READY_QUEUE_SHARDS;
+#if PTO2_ORCH_PROFILING
+                            uint64_t _l0 = get_sys_cnt_aicpu();
+#endif
                             ready_queue_aiv_lock_[shard].lock();
+#if PTO2_ORCH_PROFILING
+                            uint64_t _l1 = get_sys_cnt_aicpu();
+#endif
                             if (ready_queue_aiv_head_[shard] < ready_queue_aiv_tail_[shard]) {
                                 task_id = ready_queue_aiv_[shard][ready_queue_aiv_head_[shard]++ & AICPU_READY_MASK];
+                                ready_queue_aiv_lock_[shard].unlock();
+#if PTO2_ORCH_PROFILING
+                                uint64_t _l2 = get_sys_cnt_aicpu();
+                                sched_dispatch_hit_wait += (_l1 - _l0);
+                                sched_dispatch_hit_hold += (_l2 - _l1);
+                                found_task = true;
+                                is_stolen = (k != 0);
+#endif
+                                break;
                             }
                             ready_queue_aiv_lock_[shard].unlock();
+#if PTO2_ORCH_PROFILING
+                            uint64_t _l2 = get_sys_cnt_aicpu();
+                            sched_dispatch_miss_wait += (_l1 - _l0);
+                            sched_dispatch_miss_hold += (_l2 - _l1);
+#endif
                         }
                     }
+#if PTO2_ORCH_PROFILING
+                    if (found_task) {
+                        if (is_stolen) ready_pop_steal++; else ready_pop_own++;
+                    }
+#endif
                     if (task_id >= 0) {
                         PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
                         PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
@@ -733,25 +828,20 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                 if (fanin_count == 0) {
                     // Mark as enqueued (state=1) to prevent double-enqueue
                     __atomic_store_n(&s_pto2_task_completed[slot], 1, __ATOMIC_RELEASE);
-                    int32_t wt = t->worker_type;
-                    int my_shard = thread_idx % PTO2_READY_QUEUE_SHARDS;
-                    if (wt == PTO2_WORKER_CUBE) {
-                        ready_queue_aic_lock_[my_shard].lock();
-                        ready_queue_aic_[my_shard][ready_queue_aic_tail_[my_shard]++ & AICPU_READY_MASK] = idx;
-                        ready_queue_aic_lock_[my_shard].unlock();
-                    } else {
-                        ready_queue_aiv_lock_[my_shard].lock();
-                        ready_queue_aiv_[my_shard][ready_queue_aiv_tail_[my_shard]++ & AICPU_READY_MASK] = idx;
-                        ready_queue_aiv_lock_[my_shard].unlock();
-                    }
+                    enqueue_ready_task_with_profiling(
+                        idx, t->worker_type, thread_idx
+#if PTO2_ORCH_PROFILING
+                        , sched_scan_ready_wait, sched_scan_ready_hold
+#endif
+                    );
                     made_progress = true;
                 }
             }
         }
         CYCLE_COUNT_LAP(sched_scan_cycle);
 
-        // Drain orchestrator ready queue: tasks made ready by orchestrator's early-return path
-        // (producer already completed → refcount incremented directly, consumer pushed to queue)
+        // Early-ready drain: tasks whose deps were already met at submit time
+        // (orchestrator detected all producers completed → pushed to orch_ready_queue_)
         if (orch_ready_queue_ != nullptr) {
             while (true) {
                 int32_t head = __atomic_load_n(orch_ready_head_, __ATOMIC_ACQUIRE);
@@ -771,21 +861,16 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                         false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) continue;
 
                 PTO2TaskDescriptor* t = &task_descriptors[slot];
-                int32_t wt = t->worker_type;
-                int my_shard = thread_idx % PTO2_READY_QUEUE_SHARDS;
-                if (wt == PTO2_WORKER_CUBE) {
-                    ready_queue_aic_lock_[my_shard].lock();
-                    ready_queue_aic_[my_shard][ready_queue_aic_tail_[my_shard]++ & AICPU_READY_MASK] = task_id;
-                    ready_queue_aic_lock_[my_shard].unlock();
-                } else {
-                    ready_queue_aiv_lock_[my_shard].lock();
-                    ready_queue_aiv_[my_shard][ready_queue_aiv_tail_[my_shard]++ & AICPU_READY_MASK] = task_id;
-                    ready_queue_aiv_lock_[my_shard].unlock();
-                }
+                enqueue_ready_task_with_profiling(
+                    task_id, t->worker_type, thread_idx
+#if PTO2_ORCH_PROFILING
+                    , sched_early_ready_wait, sched_early_ready_hold
+#endif
+                );
                 made_progress = true;
             }
         }
-        CYCLE_COUNT_LAP(sched_orch_drain_cycle);
+        CYCLE_COUNT_LAP(sched_early_ready_cycle);
 
         if (!made_progress) {
             idle_iterations++;
@@ -844,11 +929,6 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                 DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
                 return -1;
             }
-            std::this_thread::yield();
-#if PTO2_ORCH_PROFILING
-            sched_yield_count++;
-#endif
-            CYCLE_COUNT_LAP(sched_yield_cycle);
         } else {
             idle_iterations = 0;
         }
@@ -856,38 +936,56 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
 
 #if PTO2_ORCH_PROFILING
     uint64_t sched_total =
-        sched_scan_cycle + sched_orch_drain_cycle + sched_complete_cycle + sched_dispatch_cycle + sched_yield_cycle;
+        sched_scan_cycle + sched_early_ready_cycle + sched_complete_cycle + sched_dispatch_cycle;
     if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
-    DEV_ALWAYS("Thread %d: PTO2 scheduler stats: loops=%llu, completed=%d, total=%.3fus",
-        thread_idx,
-        (unsigned long long)sched_loop_count,
-        cur_thread_completed,
-        cycles_to_us(sched_total));
-    DEV_ALWAYS(
-        "Thread %d:   scan=%.3fus (%.1f%%), orch_drain=%.3fus (%.1f%%), complete=%.3fus (%.1f%%), dispatch=%.3fus "
-        "(%.1f%%)",
-        thread_idx,
-        cycles_to_us(sched_scan_cycle),
-        sched_scan_cycle * 100.0 / sched_total,
-        cycles_to_us(sched_orch_drain_cycle),
-        sched_orch_drain_cycle * 100.0 / sched_total,
-        cycles_to_us(sched_complete_cycle),
-        sched_complete_cycle * 100.0 / sched_total,
-        cycles_to_us(sched_dispatch_cycle),
-        sched_dispatch_cycle * 100.0 / sched_total);
-    DEV_ALWAYS("Thread %d:   yield=%.3fus (%.1f%%, %llu calls, avg=%.1fus)",
-        thread_idx,
-        cycles_to_us(sched_yield_cycle),
-        sched_yield_cycle * 100.0 / sched_total,
-        (unsigned long long)sched_yield_count,
-        sched_yield_count > 0 ? cycles_to_us(sched_yield_cycle) / sched_yield_count : 0.0);
-    DEV_ALWAYS("Thread %d:   fanout: total_traversed=%llu, max_len=%d, avg=%.1f",
-        thread_idx,
-        (unsigned long long)total_fanout_traversed,
-        max_fanout_len,
-        cur_thread_completed > 0 ? (double)total_fanout_traversed / cur_thread_completed : 0.0);
+    double tasks_per_loop = sched_loop_count > 0 ? (double)cur_thread_completed / sched_loop_count : 0.0;
 
-    DEV_ALWAYS("Thread %d: PTO2 execution complete, completed %d tasks", thread_idx, cur_thread_completed);
+    // === Summary ===
+    DEV_ALWAYS("Thread %d: === PTO2 Scheduler Summary ===", thread_idx);
+    DEV_ALWAYS("Thread %d: completed=%d tasks in %.0fus (%llu loops, %.1f tasks/loop)",
+        thread_idx, cur_thread_completed, cycles_to_us(sched_total),
+        (unsigned long long)sched_loop_count, tasks_per_loop);
+
+    // --- Phase Breakdown (execution order) ---
+    DEV_ALWAYS("Thread %d: --- Phase Breakdown (execution order) ---", thread_idx);
+    DEV_ALWAYS("Thread %d:   scan:        %8.0fus (%4.1f%%)",
+        thread_idx, cycles_to_us(sched_scan_cycle), sched_scan_cycle * 100.0 / sched_total);
+    DEV_ALWAYS("Thread %d:   early_ready: %8.0fus (%4.1f%%)  (deps already met at submit time)",
+        thread_idx, cycles_to_us(sched_early_ready_cycle), sched_early_ready_cycle * 100.0 / sched_total);
+    DEV_ALWAYS("Thread %d:   complete:    %8.0fus (%4.1f%%)  [fanout: edges=%llu, max_degree=%d, avg=%.1f]",
+        thread_idx, cycles_to_us(sched_complete_cycle), sched_complete_cycle * 100.0 / sched_total,
+        (unsigned long long)fanout_edges_notified, fanout_max_degree,
+        cur_thread_completed > 0 ? (double)fanout_edges_notified / cur_thread_completed : 0.0);
+    DEV_ALWAYS("Thread %d:   dispatch:    %8.0fus (%4.1f%%)  [steal: own=%llu, steal=%llu, pct=%.1f%%]",
+        thread_idx, cycles_to_us(sched_dispatch_cycle), sched_dispatch_cycle * 100.0 / sched_total,
+        (unsigned long long)ready_pop_own, (unsigned long long)ready_pop_steal,
+        (ready_pop_own + ready_pop_steal) > 0 ? 100.0 * (double)ready_pop_steal / (double)(ready_pop_own + ready_pop_steal) : 0.0);
+
+    // --- Lock Contention (ready_q) ---
+    DEV_ALWAYS("Thread %d: --- Lock Contention (ready_q) ---", thread_idx);
+    DEV_ALWAYS("Thread %d:   total:         wait=%5.0fus hold=%5.0fus",
+        thread_idx,
+        (double)cycles_to_us(sched_scan_ready_wait + sched_early_ready_wait + sched_complete_ready_wait + sched_dispatch_hit_wait + sched_dispatch_miss_wait),
+        (double)cycles_to_us(sched_scan_ready_hold + sched_early_ready_hold + sched_complete_ready_hold + sched_dispatch_hit_hold + sched_dispatch_miss_hold));
+    DEV_ALWAYS("Thread %d:   scan:          wait=%5.0fus hold=%5.0fus",
+        thread_idx,
+        (double)cycles_to_us(sched_scan_ready_wait), (double)cycles_to_us(sched_scan_ready_hold));
+    DEV_ALWAYS("Thread %d:   early_ready:   wait=%5.0fus hold=%5.0fus",
+        thread_idx,
+        (double)cycles_to_us(sched_early_ready_wait), (double)cycles_to_us(sched_early_ready_hold));
+    DEV_ALWAYS("Thread %d:   complete:      wait=%5.0fus hold=%5.0fus",
+        thread_idx,
+        (double)cycles_to_us(sched_complete_ready_wait), (double)cycles_to_us(sched_complete_ready_hold));
+    DEV_ALWAYS("Thread %d:   dispatch:      wait=%5.0fus hold=%5.0fus",
+        thread_idx,
+        (double)cycles_to_us(sched_dispatch_hit_wait + sched_dispatch_miss_wait),
+        (double)cycles_to_us(sched_dispatch_hit_hold + sched_dispatch_miss_hold));
+    DEV_ALWAYS("Thread %d:     hit:         wait=%5.0fus hold=%5.0fus (dequeued task)",
+        thread_idx,
+        (double)cycles_to_us(sched_dispatch_hit_wait), (double)cycles_to_us(sched_dispatch_hit_hold));
+    DEV_ALWAYS("Thread %d:     miss:        wait=%5.0fus hold=%5.0fus (empty queue)",
+        thread_idx,
+        (double)cycles_to_us(sched_dispatch_miss_wait), (double)cycles_to_us(sched_dispatch_miss_hold));
 #endif
 
     // Flush performance buffers for cores managed by this thread
@@ -1057,7 +1155,6 @@ int AicpuExecutor::run(Runtime* runtime) {
 
             // Wait for scheduler's one-time init to complete (ensures memset has executed)
             while (!pto2_init_complete_.load(std::memory_order_acquire)) {
-                std::this_thread::yield();
             }
 
             // Set orchestrator's aicpu parallel mode pointers
@@ -1210,7 +1307,7 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int thread_idx,
         aic_ready += ready_queue_aic_tail_[s] - ready_queue_aic_head_[s];
         aiv_ready += ready_queue_aiv_tail_[s] - ready_queue_aiv_head_[s];
     }
-    DEV_ALWAYS("Ready Queues: AIC=%d, AIV=%d", aic_ready, aiv_ready);
+    DEV_ALWAYS("Ready Queues (3 shards, per-thread push + work-steal pop): AIC=%d, AIV=%d", aic_ready, aiv_ready);
 
     int busy_cores = 0;
     int idle_cores = 0;

--- a/src/runtime/tensormap_and_ringbuffer/doc/device_log_profiling.md
+++ b/src/runtime/tensormap_and_ringbuffer/doc/device_log_profiling.md
@@ -1,0 +1,207 @@
+# PTO2 Device Log Profiling Guide
+
+## How to Find Device Logs
+
+AICPU logs (via `DEV_ALWAYS`) are written by CANN's **dlog** subsystem and do **not** appear in the `run_example.py` terminal output. They are written to CANN's device log directory:
+
+```
+$HOME/ascend/log/debug/device-<device_id>/device-<pid>_<timestamp>.log
+```
+
+Each run produces a new log file (or appends to an existing one). Find the most recent file by modification time:
+
+```bash
+ls -lt $HOME/ascend/log/debug/device-<device_id>/ | head -5
+```
+
+## Log Structure Overview
+
+A single run produces two profiling blocks in the device log:
+
+| Block | Emitted by | Function | Content |
+|-------|-----------|----------|---------|
+| **Orchestrator Profiling** | Thread 3 (orchestrator) | `aicpu_orchestration_entry` | Time breakdown of graph construction on device |
+| **PTO2 Scheduler Summary** | Threads 0/1/2 (schedulers) | `resolve_and_dispatch_pto2` | Per-thread scheduling statistics, phase timing, and lock contention |
+
+All timing values are in microseconds (us), converted from AICPU cycle counters.
+
+---
+
+## Block 1: Orchestrator Profiling
+
+Thread 3 loads the orchestration `.so` via `dlopen`, calls `aicpu_orchestration_entry`, and prints a profiling summary after it returns.
+
+### Example (from a real run: batch=64, 16704 tasks)
+
+```
+Thread 3: Calling aicpu_orchestration_entry from SO
+aicpu_orchestration_entry ">>>>>> batch = 64"
+Thread 3: aicpu_orchestration_entry returned, cost 20943.940us
+=== Orchestrator Profiling: 16704 tasks, total=14601.580us ===
+  sync_tensormap : 286.300us (2.0%)
+  task_ring_alloc: 380.400us (2.6%)
+  param_copy     : 2147.800us (14.7%)
+  lookup+dep     : 7290.300us (49.9%)
+  heap_alloc     : 701.500us (4.8%)
+  tensormap_ins  : 1890.380us (12.9%)
+  fanin+ready    : 1207.400us (8.3%)
+  finalize+SM    : 697.500us (4.8%)
+  scope_end      : 364.080us
+  avg/task       : 0.874us
+PTO2 total submitted tasks = 16704
+```
+
+### Field Reference
+
+| Field | Source (`pto_orchestrator.cpp`) | Description |
+|-------|-------------------------------|-------------|
+| **cost** | Wall-clock around `orch_func()` call | Total time including orchestration logic + scope overhead |
+| **total** | Sum of all sub-steps below | Accumulated time inside `pto2_submit_task` across all tasks |
+| **sync_tensormap** | `g_orch_sync_cycle` | TensorMap validity sync and optional cleanup before each submission |
+| **task_ring_alloc** | `g_orch_alloc_cycle` | Allocating a task slot from the task ring buffer |
+| **param_copy** | `g_orch_params_cycle` | Copying param descriptors + tensor descriptor copies into task-owned storage |
+| **lookup+dep** | `g_orch_lookup_cycle` | TensorMap lookup for inputs/inouts + building fanin/fanout dependency edges |
+| **heap_alloc** | `g_orch_heap_cycle` | Allocating packed output buffers from the heap ring |
+| **tensormap_ins** | `g_orch_insert_cycle` | Inserting output/inout tensors into the TensorMap |
+| **fanin+ready** | `g_orch_fanin_cycle` | Building the fanin list + checking if task is already ready (Step 5/5b) |
+| **finalize+SM** | `g_orch_finalize_cycle` | Initializing task in scheduler + updating shared memory `current_task_index` |
+| **scope_end** | `g_orch_scope_end_cycle` | `pto2_scope_end` overhead (notifying scheduler of scope completion) |
+| **avg/task** | `total / submit_count` | Average orchestrator time per task submission |
+
+### Interpreting the Numbers
+
+- **cost > total**: The difference is overhead outside `pto2_submit_task` (the orchestration user code itself, scope_begin/end, make_tensor calls, etc.).
+- **lookup+dep** is typically the dominant cost (~50%) because it involves TensorMap hash lookups and building dependency edges with spinlock-protected fanout list insertions.
+- **param_copy** scales with the number of parameters per task.
+- **avg/task < 1us** indicates efficient graph construction.
+
+---
+
+## Block 2: PTO2 Scheduler Summary
+
+Each of the 3 scheduler threads (Thread 0, 1, 2) prints its own summary after completing all tasks. The output has three sub-sections: **summary**, **phase breakdown**, and **lock contention**.
+
+### Example (Thread 0, from the same run)
+
+```
+Thread 0: === PTO2 Scheduler Summary ===
+Thread 0: completed=6068 tasks in 31398us (977 loops, 6.2 tasks/loop)
+Thread 0: --- Phase Breakdown (execution order) ---
+Thread 0:   scan:            2295us ( 7.3%)
+Thread 0:   early_ready:       77us ( 0.2%)  (deps already met at submit time)
+Thread 0:   complete:       11374us (36.2%)  [fanout: edges=7578, max_degree=20, avg=1.2]
+Thread 0:   dispatch:       17651us (56.2%)  [steal: own=4443, steal=1625, pct=26.8%]
+Thread 0: --- Lock Contention (ready_q) ---
+Thread 0:   total:         wait= 8366us hold= 4144us
+Thread 0:   scan:          wait=  318us hold=  704us
+Thread 0:   early_ready:   wait=    0us hold=    0us
+Thread 0:   complete:      wait= 1374us hold=  781us
+Thread 0:   dispatch:      wait= 6674us hold= 2659us
+Thread 0:     hit:         wait= 1361us hold=  551us (dequeued task)
+Thread 0:     miss:        wait= 5313us hold= 2108us (empty queue)
+```
+
+### Summary Line
+
+```
+Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
+```
+
+| Field | Description |
+|-------|-------------|
+| **completed** | Number of tasks this thread processed to completion |
+| **Y us** | Total scheduler loop time (sum of all phase cycles) |
+| **Z loops** | Number of scheduler loop iterations |
+| **W tasks/loop** | Average tasks completed per loop iteration; higher = better throughput |
+
+### Phase Breakdown
+
+The scheduler loop runs four phases in order each iteration. Each phase's time is accumulated across all loop iterations.
+
+| Phase | What it does | Inline stats |
+|-------|-------------|-------------|
+| **scan** | Scans newly submitted tasks in shared memory; enqueues root tasks (those with `fanin_count == 0`) into the ready queue | — |
+| **early_ready** | Drains the orchestrator's ready queue (tasks whose dependencies were all satisfied at submit time, detected via Step 5b in `pto2_submit_task`) | — |
+| **complete** | Polls register `COND` on each managed core; when a core becomes `IDLE`, traverses the completed task's fanout list, increments consumer refcounts, and enqueues newly ready consumers | `edges`: total fanout edges traversed; `max_degree`: largest fanout list; `avg`: average fanout per completed task |
+| **dispatch** | For each idle core, pops a task from the ready queue (own shard first, then work-stealing from other shards), builds the dispatch payload, and writes the task to the core's register | `own`: tasks dequeued from own shard; `steal`: tasks stolen from other shards; `pct`: steal percentage |
+
+**Interpreting phase percentages:**
+
+- **dispatch** is typically the largest (~55%) because it includes both ready-queue pops (with lock contention) and the actual register writes + payload construction.
+- **complete** is the second largest (~36%) because fanout traversal involves atomic operations (`SEQ_CST` fetch_add on refcounts) and conditional ready-queue pushes.
+- **scan** is small (~7%) — it only runs until all submitted tasks have been scanned.
+- **early_ready** is negligible in most cases.
+
+### Lock Contention (ready_q)
+
+Ready queues are sharded (one shard per scheduler thread). Access is protected by per-shard spinlocks. This section reports cumulative lock **wait** (time spinning to acquire) and **hold** (time from acquire to release) for each phase.
+
+```
+Thread N:   total:         wait=Xus hold=Yus        # sum across all phases
+Thread N:   scan:          wait=Xus hold=Yus        # lock during root-task enqueue
+Thread N:   early_ready:   wait=Xus hold=Yus        # lock during orch-ready drain
+Thread N:   complete:      wait=Xus hold=Yus        # lock during fanout push
+Thread N:   dispatch:      wait=Xus hold=Yus        # lock during ready-queue pop (sum of hit+miss)
+Thread N:     hit:         wait=Xus hold=Yus        # pop attempts that dequeued a task
+Thread N:     miss:        wait=Xus hold=Yus        # pop attempts on empty queue
+```
+
+**Key observations from the example:**
+
+| Metric | Thread 0 | Thread 1 | Thread 2 |
+|--------|----------|----------|----------|
+| completed | 6068 | 5997 | 4639 |
+| total time (us) | 31398 | 31410 | 31406 |
+| dispatch % | 56.2% | 56.0% | 60.5% |
+| complete % | 36.2% | 36.7% | 35.4% |
+| steal % | 26.8% | 25.8% | 41.4% |
+| lock wait (us) | 8366 | 9176 | 8807 |
+| lock hold (us) | 4144 | 4688 | 3971 |
+
+- **Lock contention is moderate**: total wait ~8-9ms out of ~31ms total time (~27-30%).
+- **dispatch.miss dominates wait time**: most lock wait comes from polling empty queues, not actual contention. Thread 0's dispatch miss wait = 5313us vs hit wait = 1361us.
+- **Work stealing is active**: Thread 2 steals 41.4% of its tasks, indicating it finishes its own shard's tasks faster and helps drain other shards.
+- **Threads are well-balanced**: all three complete within ~31ms, despite different task counts (Thread 2 has fewer tasks but higher steal rate).
+
+### Per-Task Averages
+
+Divide each thread's phase times by its `completed` count to get per-task scheduling cost:
+
+| Metric | Formula | Typical value |
+|--------|---------|---------------|
+| Scheduling overhead per task | total_time / completed | ~5-7 us/task |
+| Lock overhead per task | (total_wait + total_hold) / completed | ~1.5-2.5 us/task |
+| Dispatch per task | dispatch_time / completed | ~3-4 us/task |
+| Complete per task | complete_time / completed | ~2-3 us/task |
+
+---
+
+## Cross-Referencing with Host Profiling
+
+When `--enable-profiling` is used, the host terminal prints a **Task Statistics by Function** table with `Total_Exec` (total AICore kernel execution time). Combined with device log data:
+
+| Metric | Source | Description |
+|--------|--------|-------------|
+| Avg kernel exec time | `Total_Exec / total_tasks` (host) | Time AICore spends executing each kernel |
+| Avg scheduling overhead | `sum(thread_total) / total_tasks` (device log) | Time AICPU spends scheduling each task |
+| Sched/Exec ratio | scheduling / execution | Scheduling overhead relative to kernel execution |
+
+A high sched/exec ratio (e.g., >3x) indicates that scheduling overhead dominates, and optimizations should target the scheduler's non-lock paths (dispatch polling, fanout traversal) before reducing lock contention.
+
+---
+
+## Quick Reference: Extracting Profiling Data
+
+```bash
+# Find the latest device log for device 2
+ls -t $HOME/ascend/log/debug/device-2/device-*.log | head -1
+
+# Extract orchestrator profiling
+grep -E "Orchestrator Profiling|sync_tensormap|task_ring_alloc|param_copy|lookup\+dep|heap_alloc|tensormap_ins|fanin\+ready|finalize\+SM|scope_end|avg/task" <logfile>
+
+# Extract scheduler summary
+grep -E "Scheduler Summary|completed=|Phase Breakdown|scan:|early_ready:|complete:|dispatch:" <logfile>
+
+# Extract lock contention
+grep -E "Lock Contention|total:|scan:|early_ready:|complete:|dispatch:|hit:|miss:" <logfile>
+```

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -407,7 +407,9 @@ void pto2_submit_task(PTO2OrchestratorState* orch,
     for (int i = 0; i < fanin_count; i++) {
         task->fanin_head = pto2_dep_list_prepend(&orch->dep_pool, task->fanin_head, fanin_temp[i]);
     }
-    // Use SEQ_CST to pair with the scheduler's SEQ_CST fetch_add + load (IRIW on ARM)
+    // SEQ_CST store: participates in the global total order with Phase 1's SEQ_CST
+    // fetch_add on s_pto2_fanin_refcount to prevent the IRIW hazard on ARM.
+    // (See comment above the fetch_add in aicpu_executor.cpp Phase 1 for details.)
     __atomic_store_n(&task->fanin_count, fanin_count, __ATOMIC_SEQ_CST);
 
     CYCLE_COUNT_LAP(g_orch_fanin_cycle);


### PR DESCRIPTION
Add per-phase ready_q lock wait/hold counters to the scheduler summary (scan, early_ready, complete, dispatch hit/miss) and document the full device log output format in a dedicated profiling guide.