### PR TITLE
Refactor: replace PARAMS_LIST with ALL_CASES/DEFAULT_CASE and add --all/--case CLI flags

### DIFF
--- a/.ai-instructions/coding/testing.md
+++ b/.ai-instructions/coding/testing.md
@@ -80,7 +80,8 @@ Output tensors are identified by one of:
 ### Optional configuration
 
 - `RTOL` / `ATOL`: Comparison tolerances (default: `1e-5`)
-- `PARAMS_LIST`: List of parameter dicts for parameterized tests
+- `ALL_CASES`: Dict of named parameter sets for parameterized tests
+- `DEFAULT_CASE`: Name of the default case to run
 
 ### `kernel_config.py` structure
 

--- a/examples/host_build_graph/paged_attention/golden.py
+++ b/examples/host_build_graph/paged_attention/golden.py
@@ -11,7 +11,6 @@ Args layout: [ptr_query, ..., ptr_config, size_query, ..., size_config]
 """
 
 import ctypes
-import os
 import struct
 import torch
 
@@ -43,9 +42,7 @@ ALL_CASES = {
     },
 }
 
-# Select case by env var PA_CASE, default to Case1
-_selected = os.environ.get("PA_CASE", "Case1")
-PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
+DEFAULT_CASE = "Case1"
 
 
 def generate_inputs(params: dict) -> list:
@@ -240,7 +237,7 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
 
 if __name__ == "__main__":
-    params = PARAMS_LIST[0]
+    params = {"name": DEFAULT_CASE, **ALL_CASES[DEFAULT_CASE]}
     result = generate_inputs(params)
     tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
     compute_golden(tensors, params)

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -180,7 +180,7 @@ def generate_inputs(params: dict) -> dict:
     Generate input and output tensors.
 
     Args:
-        params: Parameter dictionary (from PARAMS_LIST)
+        params: Parameter dictionary (from ALL_CASES)
 
     Returns:
         Dictionary containing all tensors (inputs + outputs)
@@ -205,10 +205,11 @@ def compute_golden(tensors: dict, params: dict) -> None:
     tensors["f"][:] = (a + b + 1) * (a + b + 2)
 
 # Optional: Multiple test cases
-PARAMS_LIST = [
-    {},  # Default parameters
-    # {"size": 1024},  # Other test cases
-]
+ALL_CASES = {
+    "Default": {},
+    # "Large": {"size": 1024},  # Other test cases
+}
+DEFAULT_CASE = "Default"
 ```
 
 ### Golden Script Interface Description
@@ -230,7 +231,8 @@ PARAMS_LIST = [
 #### Optional Configuration
 
 - **`__outputs__`**: Output tensor names list (or use `out_` prefix convention)
-- **`PARAMS_LIST`**: Test parameters list (default `[{}]`)
+- **`ALL_CASES`**: Dict of named parameter sets for parameterized tests
+- **`DEFAULT_CASE`**: Name of the default case to run
 - **`RTOL`**: Relative tolerance (default `1e-5`)
 - **`ATOL`**: Absolute tolerance (default `1e-5`)
 
@@ -402,14 +404,15 @@ Solutions:
 
 ### Q: How to add multiple test cases?
 
-Define `PARAMS_LIST` in `golden.py`:
+Define `ALL_CASES` and `DEFAULT_CASE` in `golden.py`:
 
 ```python
-PARAMS_LIST = [
-    {"size": 1024},
-    {"size": 2048},
-    {"size": 4096},
-]
+ALL_CASES = {
+    "Small": {"size": 1024},
+    "Medium": {"size": 2048},
+    "Large": {"size": 4096},
+}
+DEFAULT_CASE = "Small"
 
 def generate_inputs(params: dict) -> dict:
     size = params["size"]
@@ -419,6 +422,8 @@ def generate_inputs(params: dict) -> dict:
         "out_f": torch.zeros(size, dtype=torch.float32),
     }
 ```
+
+Then use `--all` to run all cases or `--case Medium` to run a specific one.
 
 ### Q: Are PyTorch tensors supported?
 

--- a/examples/scripts/run_example.py
+++ b/examples/scripts/run_example.py
@@ -59,8 +59,9 @@ Golden.py interface:
         '''Compute expected outputs in-place'''
         tensors["out_f"][:] = tensors["a"] + 1
 
-    # Optional
-    PARAMS_LIST = [{"size": 1024}]  # Multiple test cases
+    # Optional — for parameterized test cases:
+    ALL_CASES = {"Case1": {"size": 1024}, "Case2": {"size": 2048}}
+    DEFAULT_CASE = "Case1"
     RTOL = 1e-5  # Relative tolerance
     ATOL = 1e-5  # Absolute tolerance
     __outputs__ = ["out_f"]  # Or use 'out_' prefix
@@ -117,7 +118,23 @@ Golden.py interface:
         help="Enable profiling and generate swimlane.json"
     )
 
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run all test cases defined in ALL_CASES (default: run only DEFAULT_CASE)"
+    )
+
+    parser.add_argument(
+        "--case",
+        type=str,
+        default=None,
+        help="Run a specific test case by name (e.g., --case Case2)"
+    )
+
     args = parser.parse_args()
+
+    if args.all and args.case:
+        parser.error("--all and --case are mutually exclusive")
 
     # Determine log level from arguments
     log_level_str = None
@@ -179,6 +196,8 @@ Golden.py interface:
             device_id=args.device,
             platform=args.platform,
             enable_profiling=args.enable_profiling,
+            run_all_cases=args.all,
+            case_name=args.case,
         )
 
         runner.run()

--- a/examples/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/examples/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -11,7 +11,6 @@ Args layout: [ptr_query, ..., ptr_config, size_query, size_key_cache, size_value
 """
 
 import ctypes
-import os
 import struct
 import torch
 
@@ -43,9 +42,7 @@ ALL_CASES = {
     },
 }
 
-# Select case by env var PA_CASE, default to Case1
-_selected = os.environ.get("PA_CASE", "Case1")
-PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
+DEFAULT_CASE = "Case1"
 
 
 def generate_inputs(params: dict) -> list:
@@ -236,7 +233,7 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
 
 if __name__ == "__main__":
-    params = PARAMS_LIST[0]
+    params = {"name": DEFAULT_CASE, **ALL_CASES[DEFAULT_CASE]}
     result = generate_inputs(params)
     tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
     compute_golden(tensors, params)

--- a/tests/device_tests/aicpu_build_graph/paged_attention/golden.py
+++ b/tests/device_tests/aicpu_build_graph/paged_attention/golden.py
@@ -12,7 +12,6 @@ Args layout: [ptr_query, ..., ptr_config, size_query, ..., size_config]
 """
 
 import ctypes
-import os
 import struct
 import torch
 
@@ -44,9 +43,7 @@ ALL_CASES = {
     },
 }
 
-# Select case by env var PA_CASE, default to Case1
-_selected = os.environ.get("PA_CASE", "Case1")
-PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
+DEFAULT_CASE = "Case1"
 
 
 def generate_inputs(params: dict) -> list:
@@ -253,7 +250,7 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
 
 if __name__ == "__main__":
-    params = PARAMS_LIST[0]
+    params = {"name": DEFAULT_CASE, **ALL_CASES[DEFAULT_CASE]}
     result = generate_inputs(params)
     tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
     compute_golden(tensors, params)

--- a/tests/device_tests/host_build_graph/paged_attention/golden.py
+++ b/tests/device_tests/host_build_graph/paged_attention/golden.py
@@ -12,7 +12,6 @@ Args layout: [ptr_query, ..., ptr_config, size_query, ..., size_config]
 """
 
 import ctypes
-import os
 import struct
 import torch
 
@@ -44,9 +43,7 @@ ALL_CASES = {
     },
 }
 
-# Select case by env var PA_CASE, default to Case1
-_selected = os.environ.get("PA_CASE", "Case1")
-PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
+DEFAULT_CASE = "Case1"
 
 
 def generate_inputs(params: dict) -> list:
@@ -241,7 +238,7 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
 
 if __name__ == "__main__":
-    params = PARAMS_LIST[0]
+    params = {"name": DEFAULT_CASE, **ALL_CASES[DEFAULT_CASE]}
     result = generate_inputs(params)
     tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
     compute_golden(tensors, params)

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -12,7 +12,6 @@ Args layout: [ptr_query, ..., ptr_config, size_query, size_key_cache, size_value
 """
 
 import ctypes
-import os
 import struct
 import torch
 
@@ -44,9 +43,7 @@ ALL_CASES = {
     },
 }
 
-# Select case by env var PA_CASE, default to Case1
-_selected = os.environ.get("PA_CASE", "Case1")
-PARAMS_LIST = [{"name": _selected, **ALL_CASES[_selected]}]
+DEFAULT_CASE = "Case1"
 
 
 def generate_inputs(params: dict) -> list:
@@ -249,7 +246,7 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
 
 if __name__ == "__main__":
-    params = PARAMS_LIST[0]
+    params = {"name": DEFAULT_CASE, **ALL_CASES[DEFAULT_CASE]}
     result = generate_inputs(params)
     tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
     compute_golden(tensors, params)


### PR DESCRIPTION
Replace the fragile PA_CASE env var hack in golden.py with a clean ALL_CASES + DEFAULT_CASE interface. Add --all and --case flags to run_example.py so users can run all test cases or select a specific one from the command line.