### PR TITLE
Support: integrate auto device-log resolution for profiling

### DIFF
--- a/.codex/rules.md
+++ b/.codex/rules.md
@@ -1,0 +1,15 @@
+# Codex Rules
+
+Before doing any work in this repository, read `CLAUDE.md` first.
+
+## Required startup sequence
+
+1. Read `CLAUDE.md` completely before running commands, analyzing code, or editing files.
+2. Follow role boundaries and rules from `CLAUDE.md`.
+3. Read only the relevant files under `.ai-instructions/` for the current task.
+
+## Additional rules
+
+- If `CLAUDE.md` changes, re-read it before continuing.
+- If user instructions conflict with repository conventions, follow user intent for that task.
+- Higher-priority system/developer/user instructions override this file.

--- a/examples/host_build_graph/vector_example/README.md
+++ b/examples/host_build_graph/vector_example/README.md
@@ -78,7 +78,7 @@ python examples/scripts/run_example.py \
   -k examples/host_build_graph/vector_example/kernels \
   -g examples/host_build_graph/vector_example/golden.py \
   -p a2a3 \
-  -d 9
+  -d 0
 
 # With verbose output
 python examples/scripts/run_example.py \
@@ -176,8 +176,7 @@ export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
 # Or you can set it manually if you have it elsewhere:
 # export PTO_ISA_ROOT=/path/to/pto-isa
 
-# Optional
-export PTO_DEVICE_ID=0
+# Optional: choose device via CLI, e.g. `-d 0`
 ```
 
 ### For Simulation Platform (a2a3sim)

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -299,8 +299,7 @@ export ASCEND_HOME_PATH=/usr/local/Ascend/cann-8.5.0
 # Override if needed:
 # export PTO_ISA_ROOT=/path/to/pto-isa
 
-# Optional
-export PTO_DEVICE_ID=0
+# Optional: choose device via CLI, e.g. `-d 0`
 ```
 
 ### a2a3sim Platform (Simulation)

--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -324,7 +324,7 @@ class CodeRunner:
     Args:
         kernels_dir: Path to kernels directory containing kernel_config.py
         golden_path: Path to golden.py script
-        device_id: Device ID (defaults to PTO_DEVICE_ID env var or 0)
+        device_id: Device ID (defaults to 0)
         platform: Platform name ("a2a3" for hardware, "a2a3sim" for simulation, default: "a2a3")
     """
 

--- a/examples/scripts/run_example.py
+++ b/examples/scripts/run_example.py
@@ -82,8 +82,8 @@ Golden.py interface:
     parser.add_argument(
         "-d", "--device",
         type=int,
-        default=None,
-        help="Device ID (default: from PTO_DEVICE_ID env or 0)"
+        default=0,
+        help="Device ID (default: 0)"
     )
 
     parser.add_argument(
@@ -196,7 +196,14 @@ Golden.py interface:
                 import subprocess
                 try:
                     # Call swimlane_converter.py with kernel_config.py path
-                    cmd = [sys.executable, str(swimlane_script), "-k", str(kernel_config_path)]
+                    cmd = [
+                        sys.executable,
+                        str(swimlane_script),
+                        "-k",
+                        str(kernel_config_path),
+                        "-d",
+                        str(args.device),
+                    ]
                     if log_level_str == "debug":
                         cmd.append("-v")
 

--- a/tools/device_log_resolver.py
+++ b/tools/device_log_resolver.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Resolve Ascend device log files with deterministic precedence."""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def get_log_root() -> Path:
+    """Return log root: ASCEND_WORK_PATH first, then ~/ascend fallback."""
+    ascend_work_path = os.environ.get("ASCEND_WORK_PATH")
+    if ascend_work_path:
+        env_root = Path(ascend_work_path).expanduser() / "log" / "debug"
+        if env_root.exists():
+            return env_root
+    return Path.home() / "ascend" / "log" / "debug"
+
+
+def infer_device_id_from_log_path(log_path: Path) -> Optional[str]:
+    """Infer device id from any path segment like device-0."""
+    for part in log_path.parts:
+        match = re.fullmatch(r"device-(\d+)", part)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _latest_log_from_dir(log_dir: Path) -> Optional[Path]:
+    if not log_dir.exists() or not log_dir.is_dir():
+        return None
+
+    candidates = sorted(log_dir.glob("*.log"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not candidates:
+        return None
+    return candidates[0]
+
+
+def _extract_perf_timestamp(perf_path: Optional[Path]) -> Optional[datetime]:
+    if perf_path is None:
+        return None
+
+    filename_match = re.search(r"perf_swimlane_(\d{8}_\d{6})", perf_path.name)
+    if filename_match:
+        try:
+            return datetime.strptime(filename_match.group(1), "%Y%m%d_%H%M%S")
+        except ValueError:
+            pass
+
+    if perf_path.exists():
+        return datetime.fromtimestamp(perf_path.stat().st_mtime)
+    return None
+
+
+def _resolve_explicit_device_log(device_log: str) -> Tuple[Optional[Path], str]:
+    if glob.has_magic(device_log):
+        # Expand "~" before globbing; glob.glob does not expand it.
+        expanded_pattern = str(Path(device_log).expanduser())
+        matches = [Path(m) for m in glob.glob(expanded_pattern)]
+        matches = [p for p in matches if p.is_file()]
+        if not matches:
+            return None, f"explicit --device-log glob had no matches: {device_log}"
+        best = max(matches, key=lambda p: p.stat().st_mtime)
+        return best, f"explicit --device-log glob: {device_log}"
+
+    path = Path(device_log).expanduser()
+    if path.exists() and path.is_file():
+        return path, "explicit --device-log file"
+
+    if path.exists() and path.is_dir():
+        best = _latest_log_from_dir(path)
+        if best is None:
+            return None, f"explicit --device-log directory has no .log files: {path}"
+        return best, f"explicit --device-log directory: {path}"
+
+    return None, f"explicit --device-log path not found: {path}"
+
+
+def _resolve_nearest_log(root: Path, perf_path: Optional[Path]) -> Tuple[Optional[Path], str]:
+    device_dirs = sorted([p for p in root.glob("device-*") if p.is_dir()])
+    if not device_dirs:
+        return None, f"no device-* directories found under {root}"
+
+    candidates = []
+    for device_dir in device_dirs:
+        for log_file in device_dir.glob("*.log"):
+            candidates.append(log_file)
+
+    if not candidates:
+        return None, f"no .log files found under {root}/device-*"
+
+    perf_dt = _extract_perf_timestamp(perf_path)
+    if perf_dt is None:
+        best = max(candidates, key=lambda p: p.stat().st_mtime)
+        return best, "auto-scan device-* (newest log)"
+
+    perf_ts = perf_dt.timestamp()
+    best = min(candidates, key=lambda p: abs(p.stat().st_mtime - perf_ts))
+    return best, f"auto-scan device-* (closest log to perf timestamp {perf_dt:%Y-%m-%d %H:%M:%S})"
+
+
+def resolve_device_log_path(
+    device_id: Optional[str] = None,
+    device_log: Optional[str] = None,
+    perf_path: Optional[Path] = None,
+) -> Tuple[Optional[Path], str]:
+    """Resolve device log path with deterministic precedence.
+
+    Priority:
+      1) --device-log explicit path/dir/glob
+      2) --device-id -> <log_root>/device-<id>/ newest .log
+      3) auto-scan all device-* and choose nearest to perf timestamp
+    """
+    if device_log:
+        return _resolve_explicit_device_log(device_log)
+
+    root = get_log_root()
+
+    if device_id is not None:
+        device_dir = root / f"device-{device_id}"
+        best = _latest_log_from_dir(device_dir)
+        if best is None:
+            return None, f"device-id selection failed: no .log files in {device_dir}"
+        return best, f"device-id selection: device-{device_id} under {root}"
+
+    return _resolve_nearest_log(root, perf_path)

--- a/tools/sched_overhead_analysis.py
+++ b/tools/sched_overhead_analysis.py
@@ -9,6 +9,7 @@ Usage:
     python sched_overhead_analysis.py                          # auto-select latest files
     python sched_overhead_analysis.py --perf-json <path>       # specify perf data
     python sched_overhead_analysis.py --device-log <path>      # specify device log
+    python sched_overhead_analysis.py --perf-json <path> -d 0  # resolve from device-0
 """
 import argparse
 import json
@@ -16,27 +17,18 @@ import re
 import sys
 from pathlib import Path
 
+try:
+    from device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
+except ImportError:
+    from tools.device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
+
 
 def auto_select_perf_json():
     """Find the latest perf_swimlane_*.json in outputs/ directory."""
     outputs_dir = Path(__file__).parent.parent / 'outputs'
     files = sorted(outputs_dir.glob('perf_swimlane_*.json'), key=lambda p: p.stat().st_mtime, reverse=True)
     if not files:
-        print(f"Error: No perf_swimlane_*.json files found in {outputs_dir}", file=sys.stderr)
-        sys.exit(1)
-    return files[0]
-
-
-def auto_select_device_log():
-    """Find the latest .log in ~/ascend/log/debug/device-0/."""
-    log_dir = Path.home() / 'ascend' / 'log' / 'debug' / 'device-0'
-    if not log_dir.exists():
-        print(f"Error: Device log directory not found: {log_dir}", file=sys.stderr)
-        sys.exit(1)
-    files = sorted(log_dir.glob('*.log'), key=lambda p: p.stat().st_mtime, reverse=True)
-    if not files:
-        print(f"Error: No .log files found in {log_dir}", file=sys.stderr)
-        sys.exit(1)
+        raise FileNotFoundError(f"No perf_swimlane_*.json files found in {outputs_dir}")
     return files[0]
 
 
@@ -170,24 +162,68 @@ def parse_scheduler_threads(log_path):
     return threads
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description='Scheduler overhead analysis for PTO2',
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  %(prog)s                                          # auto-select latest files
-  %(prog)s --perf-json outputs/perf_swimlane_*.json
-  %(prog)s --device-log ~/ascend/log/debug/device-0/device-*.log
-        """
-    )
-    parser.add_argument('--perf-json', help='Path to perf_swimlane_*.json file. If not specified, uses the latest in outputs/')
-    parser.add_argument('--device-log', help='Path to device log file. If not specified, uses the latest in ~/ascend/log/debug/device-0/')
-    args = parser.parse_args()
+def validate_perf_tasks_for_overhead_analysis(tasks):
+    """Validate required per-task fields for overhead deep-dive analysis.
 
-    # Resolve input paths
-    perf_path = Path(args.perf_json) if args.perf_json else auto_select_perf_json()
-    log_path = Path(args.device_log) if args.device_log else auto_select_device_log()
+    Returns:
+        tuple[bool, str]: (is_valid, error_message)
+    """
+    required_fields = [
+        "duration_us",
+        "start_time_us",
+        "end_time_us",
+        "dispatch_time_us",
+        "finish_time_us",
+    ]
+
+    missing = []
+    for idx, task in enumerate(tasks):
+        missing_fields = [field for field in required_fields if field not in task]
+        if missing_fields:
+            task_label = task.get("task_id", idx)
+            missing.append(f"task={task_label} missing={','.join(missing_fields)}")
+            if len(missing) >= 5:
+                break
+
+    if missing:
+        detail = "; ".join(missing)
+        # These fields are produced by runtime-side JSON export in:
+        # src/platform/src/host/performance_collector.cpp (dispatch_time_us, finish_time_us)
+        msg = "\n".join([
+            "Perf JSON is incompatible with scheduler overhead deep-dive analysis.",
+            f"Missing required fields (showing up to 5 tasks): {detail}",
+            "",
+            "Why this happens:",
+            "  - The input is not a runtime-generated perf_swimlane_*.json, OR",
+            "  - The runtime binary does not include / emit dispatch+finish timestamps.",
+            "",
+            "How to fix:",
+            "  1) Re-run workload with profiling enabled (e.g. run_example.py --enable-profiling).",
+            "  2) Use the newly generated outputs/perf_swimlane_*.json as --perf-json input.",
+            "  3) Verify each task includes dispatch_time_us and finish_time_us.",
+            "",
+            "Note:",
+            "  - swimlane_converter conversion can still succeed; only deep-dive analysis requires these fields.",
+        ])
+        return False, msg
+
+    return True, ""
+
+
+def run_analysis(perf_path, log_path, print_sources=True, selection_strategy=None):
+    """Run scheduler overhead analysis report.
+
+    Args:
+        perf_path: Path to perf_swimlane_*.json.
+        log_path: Path to selected device log file.
+        print_sources: Whether to print selected input files.
+        selection_strategy: Optional human-readable device-log selection strategy.
+
+    Returns:
+        int: 0 on success, non-zero on failure.
+    """
+    perf_path = Path(perf_path)
+    log_path = Path(log_path)
 
     if not perf_path.exists():
         print(f"Error: Perf JSON not found: {perf_path}", file=sys.stderr)
@@ -196,14 +232,29 @@ Examples:
         print(f"Error: Device log not found: {log_path}", file=sys.stderr)
         return 1
 
-    print(f"Perf data:  {perf_path}")
-    print(f"Device log: {log_path}")
+    if print_sources:
+        print(f"Perf data:  {perf_path}")
+        print(f"Device log: {log_path}")
+        if selection_strategy:
+            print(f"Selection:  {selection_strategy}")
+        inferred_device_id = infer_device_id_from_log_path(log_path)
+        if inferred_device_id is not None:
+            print(f"Device ID:  {inferred_device_id}")
 
     # === Part 1: Per-task time breakdown from perf data ===
     with open(perf_path) as f:
         data = json.load(f)
     tasks = data['tasks']
     n_total = len(tasks)
+
+    if n_total == 0:
+        print("Error: No tasks found in perf data", file=sys.stderr)
+        return 1
+
+    valid, err = validate_perf_tasks_for_overhead_analysis(tasks)
+    if not valid:
+        print(f"Error: {err}", file=sys.stderr)
+        return 1
 
     all_exec = sum(t['duration_us'] for t in tasks)
     all_head = sum(t['start_time_us'] - t['dispatch_time_us'] for t in tasks)
@@ -323,6 +374,10 @@ Examples:
     tails = [t['finish_time_us'] - t['end_time_us'] for t in tasks]
     tails.sort()
     n = len(tails)
+    if n == 0:
+        print('Error: Empty tail-overhead set', file=sys.stderr)
+        return 1
+
     print(f'  Tail OH distribution (N={n}):')
     for pct_val in [10, 25, 50, 75, 90, 95, 99]:
         idx = min(int(n * pct_val / 100), n - 1)
@@ -335,7 +390,7 @@ Examples:
     avg_loop_us = total_us / total_loops if total_loops > 0 else 0
     avg_tail_oh = sum(tails) / n
     loop_ratio = avg_tail_oh / avg_loop_us if avg_loop_us > 0 else 0
-    print(f'  Avg scheduler loop iteration: {avg_loop_us:.1f} us (\u2248 avg polling interval per loop)')
+    print(f'  Avg scheduler loop iteration: {avg_loop_us:.1f} us (approx avg polling interval per loop)')
     if n_threads > 0:
         print(f'  With {n_threads} threads sharing {total_loops} loops over {total_us/n_threads:.0f} us wall each:')
     print()
@@ -373,7 +428,7 @@ Examples:
     }
 
     # Sort by total descending
-    for p, detail in sorted(phase_details.items(), key=lambda x: x[1]['total'], reverse=True):
+    for _, detail in sorted(phase_details.items(), key=lambda x: x[1]['total'], reverse=True):
         per_task = detail['total'] / total_completed if total_completed > 0 else 0
         pct = detail['total'] / total_us * 100 if total_us > 0 else 0
         print(f'    - {detail["label"]:<50} {per_task:.2f} us/task  ({pct:.1f}% of scheduler CPU)')
@@ -382,8 +437,8 @@ Examples:
             print(f'        {sub_label:<48} {sub_per_task:.2f} us/task')
 
     print()
-    print(f'  Avg Tail OH = {avg_tail_oh:.1f} us \u2248 {loop_ratio:.1f} \u00d7 avg loop iteration ({avg_loop_us:.1f} us)')
-    print(f'  \u2192 on average, a completed task waits ~{loop_ratio:.1f} loop iterations before being detected')
+    print(f'  Avg Tail OH = {avg_tail_oh:.1f} us ~= {loop_ratio:.1f} x avg loop iteration ({avg_loop_us:.1f} us)')
+    print(f'  -> On average, a completed task waits ~{loop_ratio:.1f} loop iterations before being detected')
     print()
 
     # Data-driven insight: find the dominant phase (excluding early_ready which is typically trivial)
@@ -392,20 +447,67 @@ Examples:
     dominant_pct = work_phases[dominant_phase] / total_us * 100 if total_us > 0 else 0
     print(f'  Key insight: {phase_labels[dominant_phase].split(" (")[0]} phase consumes ~{dominant_pct:.0f}% of scheduler CPU.')
     if dominant_phase == 'dispatch':
-        dispatch_lock_pct = sum(t.get('lock_dispatch_wait', 0) for t in threads.values()) / phase_totals.get('dispatch', 1) * 100
+        dispatch_total = phase_totals.get('dispatch', 0)
+        dispatch_lock_pct = sum(t.get('lock_dispatch_wait', 0) for t in threads.values()) / dispatch_total * 100 if dispatch_total > 0 else 0
         print(f'  Within dispatch, lock contention accounts for {dispatch_lock_pct:.0f}% of time.')
         if miss_w > hit_w:
             print(f'  Dispatch miss (empty queue) dominates lock wait: miss={miss_w}us vs hit={hit_w}us.')
-        print(f'  Cache flush (dc cvac + dsb sy) is the dominant non-lock cost.')
+        print('  Cache flush (dc cvac + dsb sy) is the dominant non-lock cost.')
     elif dominant_phase == 'complete':
-        complete_lock_pct = sum(t.get('lock_complete_wait', 0) for t in threads.values()) / phase_totals.get('complete', 1) * 100
+        complete_total = phase_totals.get('complete', 0)
+        complete_lock_pct = sum(t.get('lock_complete_wait', 0) for t in threads.values()) / complete_total * 100 if complete_total > 0 else 0
         print(f'  Within complete, lock contention accounts for {complete_lock_pct:.0f}% of time.')
-        print(f'  Fanout traversal and atomic ops dominate the non-lock cost.')
+        print('  Fanout traversal and atomic ops dominate the non-lock cost.')
     elif dominant_phase == 'scan':
-        print(f'  Scan phase overhead indicates too many root tasks or inefficient task graph traversal.')
+        print('  Scan phase overhead indicates too many root tasks or inefficient task graph traversal.')
     print('=' * 90)
 
     return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Scheduler overhead analysis for PTO2',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s                                          # auto-select latest files
+  %(prog)s --perf-json outputs/perf_swimlane_*.json
+  %(prog)s --device-log ~/ascend/log/debug/device-0/device-*.log
+  %(prog)s --perf-json outputs/perf_swimlane_*.json -d 0
+        """
+    )
+    parser.add_argument('--perf-json', help='Path to perf_swimlane_*.json file. If not specified, uses the latest in outputs/')
+    parser.add_argument('--device-log', help='Path to device log file/path/glob. Overrides auto-resolution when provided')
+    parser.add_argument('-d', '--device-id', help='Device id for auto-selection from device-<id>')
+    args = parser.parse_args()
+
+    # Resolve perf path
+    try:
+        perf_path = Path(args.perf_json) if args.perf_json else auto_select_perf_json()
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    if not perf_path.exists():
+        print(f"Error: Perf JSON not found: {perf_path}", file=sys.stderr)
+        return 1
+
+    # Resolve device log path (strict in this standalone CLI)
+    log_path, strategy = resolve_device_log_path(
+        device_id=args.device_id,
+        device_log=args.device_log,
+        perf_path=perf_path,
+    )
+    if log_path is None:
+        print(f"Error: Failed to resolve device log ({strategy})", file=sys.stderr)
+        return 1
+
+    if not log_path.exists():
+        print(f"Error: Device log not found: {log_path}", file=sys.stderr)
+        return 1
+
+    return run_analysis(perf_path, log_path, print_sources=True, selection_strategy=strategy)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Add shared device_log_resolver for --device-log, --device-id, and auto-scan selection.
- Wire run_example.py to pass device id into swimlane_converter.py during profiling flow.
- Invoke scheduler overhead deep-dive from swimlane_converter when a device log is resolved.
- Improve diagnostics for missing dispatch_time_us/finish_time_us with fix steps.
- Update docs/examples and remove PTO_DEVICE_ID references from comments/docs.