### PR TITLE
Feature: add batch paged attention example

### DIFF
--- a/examples/tensormap_and_ringbuffer/batch_paged_attention/golden.py
+++ b/examples/tensormap_and_ringbuffer/batch_paged_attention/golden.py
@@ -1,0 +1,284 @@
+"""
+Paged Attention Golden Implementation - Small Scale (16x16)
+
+Implements the online softmax algorithm for paged attention with:
+- float16 Q/K/V inputs (sim-compatible)
+- Non-transposed K storage: (total_blocks, block_size, kv_head_num, head_dim)
+- GQA support (kv_head_num=1)
+- 16x16 tile dimensions
+
+Args layout: [ptr_query, ..., ptr_config, size_query, size_key_cache, size_value_cache]
+"""
+
+import ctypes
+import struct
+import torch
+
+__outputs__ = ["out"]
+
+RTOL = 1e-2
+ATOL = 1e-2
+
+
+# All test cases - small scale (16x16 tiles)
+ALL_CASES = {
+    "Case1": {
+        "batch": 1,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 16,
+        "block_size": 16,
+        "context_len": 33,
+        "max_model_len": 256,
+    },
+    "Case2": {
+        "batch": 1,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 16,
+        "block_size": 16,
+        "context_len": 31,
+        "max_model_len": 256,
+    },
+    "Case3": {
+        "batch": 1,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 16,
+        "block_size": 16,
+        "context_len": 128,
+        "max_model_len": 256,
+    },
+}
+
+DEFAULT_CASE = "Case1"
+
+
+def generate_inputs(params: dict) -> list:
+    """Generate input tensors and zeroed output tensor."""
+    batch = params["batch"]
+    num_heads = params["num_heads"]
+    kv_head_num = params["kv_head_num"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    context_len = params["context_len"]
+    max_model_len = params["max_model_len"]
+
+    assert context_len >= 1, "context_len must be >= 1 to avoid division by zero in attention"
+
+    max_num_blocks_per_req = max_model_len // block_size
+    cur_valid_blocks = (context_len + block_size - 1) // block_size
+    total_blocks = batch * cur_valid_blocks
+    scale_value = 1.0
+    scale_bits = struct.unpack('I', struct.pack('f', scale_value))[0]
+
+    # Random block table: (batch, max_num_blocks_per_req) int32 since torch does not support uint32
+    # Values are always non-negative (physical block indices)
+    block_table = torch.randint(
+        0,
+        max(total_blocks, 1),
+        size=(batch, max_num_blocks_per_req),
+        dtype=torch.int32,
+    )
+
+    # Context lens: all = context_len
+    context_lens = torch.full((batch,), context_len, dtype=torch.int32)
+
+    config = torch.tensor(
+        [batch, num_heads, kv_head_num, head_dim, block_size,
+         max_num_blocks_per_req, scale_bits],
+        dtype=torch.int64,
+    )
+
+    # Query: (batch, 1, num_heads * head_dim) -> (batch, num_heads, head_dim) float16
+    query_fp16 = torch.empty(batch, 1, num_heads * head_dim).uniform_(-0.5, 0.5).to(torch.float16)
+    query_fp16 = query_fp16.reshape(batch, num_heads, head_dim)
+
+    # Key cache: (total_blocks, block_size, kv_head_num, head_dim) float16
+    key_fp16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-0.5, 0.5).to(torch.float16)
+
+    # Value cache: (total_blocks, block_size, kv_head_num, head_dim) float16
+    value_fp16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-1, 1).to(torch.float16)
+
+    query = query_fp16.flatten()
+    key_cache = key_fp16.flatten()
+    value_cache = value_fp16.flatten()
+    block_table_flat = block_table.flatten()
+    out = torch.zeros(batch * num_heads * head_dim, dtype=torch.float32)
+
+    return [
+        ("query", query),
+        ("key_cache", key_cache),
+        ("value_cache", value_cache),
+        ("block_table", block_table_flat),
+        ("context_lens", context_lens),
+        ("out", out),
+        ("config", config),
+        ("size_query", ctypes.c_int64(query.nbytes)),
+        ("size_key_cache", ctypes.c_int64(key_cache.nbytes)),
+        ("size_value_cache", ctypes.c_int64(value_cache.nbytes)),
+    ]
+
+
+def paged_attention(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    num_kv_heads: int,
+    num_heads: int,
+    scale_value: float,
+    block_table: torch.Tensor,
+    context_lens: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Compute paged attention using online softmax with head tiling and GQA.
+
+    Vectorized across the batch dimension for performance.
+    Supports different context_lens per batch via masking.
+
+    Args:
+        query: (batch, num_heads, head_dim) float16
+        key_cache: (total_blocks, block_size, num_kv_heads, head_dim) float16
+        value_cache: (total_blocks, block_size, num_kv_heads, head_dim) float16
+        num_kv_heads: int
+        num_heads: int
+        scale_value: float
+        block_table: (batch, block_num) int32 (non-negative)
+        context_lens: (batch,) int32
+
+    Returns:
+        out: (batch * num_heads, head_dim) float32
+    """
+    assert num_kv_heads == 1
+    batch, num_heads_dim, head_dim = query.shape
+    _, block_size, _, _ = key_cache.shape
+
+    # Reshape for batched computation
+    key_cache_flat = key_cache.reshape(-1, block_size, head_dim)
+    value_cache_flat = value_cache.reshape(-1, block_size, head_dim)
+
+    out = torch.zeros((batch, num_heads_dim, head_dim), dtype=torch.float32)
+
+    q_tile = min(num_heads_dim, 128)
+
+    # Max blocks across all batches (each batch may have different context_len)
+    max_bn = int(((context_lens.max().item()) + block_size - 1) // block_size)
+
+    for q_offset in range(0, num_heads_dim, q_tile):
+        q_tile_size = min(q_tile, num_heads_dim - q_offset)
+        # qi: (batch, q_tile_size, head_dim)
+        qi = query[:, q_offset:q_offset + q_tile_size, :].to(torch.float32)
+
+        oi = None  # (batch, q_tile_size, head_dim)
+        li = None  # (batch, q_tile_size, 1)
+        mi = None  # (batch, q_tile_size, 1)
+
+        for bn in range(max_bn):
+            # valid_len per batch for this block position
+            valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+            active_mask = valid_lens > 0  # (batch,)
+
+            if not active_mask.any():
+                break
+
+            # Gather block indices for all batches
+            block_indices = block_table[:, bn]  # (batch,)
+
+            # Gather K and V: (batch, block_size, head_dim)
+            kj_all = key_cache_flat[block_indices].to(torch.float32)
+            vj_all = value_cache_flat[block_indices].to(torch.float32)
+
+            # QK matmul: (batch, q_tile_size, block_size)
+            sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale_value
+
+            # Mask out invalid positions (beyond valid_len per batch)
+            pos = torch.arange(block_size, device=sij.device).unsqueeze(0)  # (1, block_size)
+            valid_mask = pos < valid_lens.unsqueeze(1)  # (batch, block_size)
+            valid_mask = valid_mask.unsqueeze(1)  # (batch, 1, block_size)
+            sij = sij.masked_fill(~valid_mask, float('-inf'))
+
+            # Also mask inactive batches (no blocks at this position)
+            batch_mask = active_mask.view(-1, 1, 1)  # (batch, 1, 1)
+            sij = sij.masked_fill(~batch_mask, float('-inf'))
+
+            mij = sij.max(dim=-1, keepdim=True)[0]  # (batch, q_tile_size, 1)
+            mij = mij.clamp(min=-1e30)
+            pij = torch.exp(sij - mij)
+            pij = pij.masked_fill(~valid_mask, 0.0)
+            pij = pij.masked_fill(~batch_mask, 0.0)
+            pij = pij.to(torch.float16).to(torch.float32)
+            lij = pij.sum(dim=-1, keepdim=True)  # (batch, q_tile_size, 1)
+
+            # PV matmul: (batch, q_tile_size, head_dim)
+            oi_new = torch.bmm(pij, vj_all)
+
+            if bn == 0:
+                oi = oi_new
+                li = lij
+                mi = mij
+            else:
+                mi_new = torch.maximum(mi, mij)
+                alpha = torch.exp(mi - mi_new)
+                beta = torch.exp(mij - mi_new)
+                li = alpha * li + beta * lij
+                oi = alpha * oi + beta * oi_new
+                mi = mi_new
+
+        # Final normalization
+        out[:, q_offset:q_offset + q_tile_size, :] = oi / li
+
+    return out.reshape(-1, head_dim)
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute expected output in-place using online softmax paged attention."""
+    batch = params["batch"]
+    num_heads = params["num_heads"]
+    kv_head_num = params["kv_head_num"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    max_model_len = params["max_model_len"]
+
+    max_num_blocks_per_req = max_model_len // block_size
+
+    # Reconstruct shaped tensors from flat tensors
+    query = tensors["query"].reshape(batch, num_heads, head_dim)
+    key_cache = tensors["key_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    value_cache = tensors["value_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    block_table = tensors["block_table"].reshape(batch, max_num_blocks_per_req)
+    context_lens = tensors["context_lens"]
+
+    out = paged_attention(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        num_kv_heads=kv_head_num,
+        num_heads=num_heads,
+        scale_value=1.0,
+        block_table=block_table,
+        context_lens=context_lens,
+    )
+
+    tensors["out"][:] = out.flatten()
+
+
+if __name__ == "__main__":
+    params = {"name": DEFAULT_CASE, **ALL_CASES[DEFAULT_CASE]}
+    result = generate_inputs(params)
+    tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
+    compute_golden(tensors, params)
+
+    print(f"=== Paged Attention Golden Test ({params['name']}) ===")
+    print(f"batch={params['batch']}, num_heads={params['num_heads']}, head_dim={params['head_dim']}")
+    print(f"kv_head_num={params['kv_head_num']}, block_size={params['block_size']}")
+    print(f"context_len={params['context_len']}")
+
+    max_num_blocks = params['max_model_len'] // params['block_size']
+    q_tile = min(params['num_heads'], 128)
+    print(f"max_num_blocks_per_req={max_num_blocks}, q_tile_size={q_tile}")
+
+    out = tensors["out"].reshape(params["batch"] * params["num_heads"], params["head_dim"])
+    print(f"Output shape: {out.shape}")
+    print(f"Output range: [{out.min():.4f}, {out.max():.4f}]")
+    print(f"Output mean: {out.mean():.4f}")
+    print("Golden test passed!")

--- a/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_hub.cpp
+++ b/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_hub.cpp
@@ -1,0 +1,14 @@
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}

--- a/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,0 +1,109 @@
+// Batched PV Matmul Kernel: for each batch b, pij(M, K) @ vj(K, N) -> oi_new(M, N)
+//
+// Processes batch_count batches in a single kernel invocation.
+// Per-batch addresses are computed from global tensor bases + block_table lookup.
+//
+// Template: M=q_tile, K=block_size, N=head_dim
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int K, int N>
+static __aicore__ void pv_matmul_batch_impl(
+    __gm__ TensorData* pij_batch,
+    __gm__ TensorData* value_cache,
+    __gm__ TensorData* oi_new_batch,
+    uint64_t block_table_ptr,
+    uint64_t batch_count,
+    uint64_t block_idx,
+    uint64_t block_num) {
+
+    __gm__ half* pij_base = reinterpret_cast<__gm__ half*>(pij_batch->buffer.addr);
+    __gm__ half* val_base = reinterpret_cast<__gm__ half*>(value_cache->buffer.addr);
+    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new_batch->buffer.addr);
+    // Block table values are always non-negative (physical block indices)
+    __gm__ int32_t* bt = reinterpret_cast<__gm__ int32_t*>(block_table_ptr);
+
+    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
+
+    using TileMatA = Tile<TileType::Mat, half, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
+
+    using LeftTile = TileLeft<half, M, K, M, K>;
+    using RightTile = TileRight<half, K, N, K, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    for (uint64_t b = 0; b < batch_count; b++) {
+        __gm__ half* pij_addr = pij_base + b * M * K;
+        int32_t phys_block = bt[b * block_num + block_idx];
+        __gm__ half* vj_addr = val_base + (uint64_t)phys_block * K * N;
+        __gm__ float* oi_addr = oi_base + b * M * N;
+
+        GlobalA pijGlobal(pij_addr);
+        GlobalB vjGlobal(vj_addr);
+        GlobalOut oiGlobal(oi_addr);
+
+        TLOAD(aMatTile, pijGlobal);
+        TLOAD(bMatTile, vjGlobal);
+
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+        TMOV(aTile, aMatTile);
+        TMOV(bTile, bMatTile);
+
+        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+        TMATMUL(cTile, aTile, bTile);
+
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+        TSTORE(oiGlobal, cTile);
+
+        if (b + 1 < batch_count) {
+            pipe_barrier(PIPE_ALL);
+        }
+    }
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* pij_batch = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* value_cache = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* oi_new_batch = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    uint64_t block_table_ptr = static_cast<uint64_t>(args[3]);
+    uint64_t batch_count = static_cast<uint64_t>(args[4]);
+    uint64_t block_idx = static_cast<uint64_t>(args[5]);
+    uint64_t block_num = static_cast<uint64_t>(args[6]);
+
+    pv_matmul_batch_impl<16, 16, 16>(
+        pij_batch, value_cache, oi_new_batch,
+        block_table_ptr, batch_count, block_idx, block_num);
+}

--- a/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,0 +1,113 @@
+// Batched QK Matmul Kernel: for each batch b, qi(M, K) @ kj.T(K, N) -> sij(M, N)
+//
+// Processes batch_count batches in a single kernel invocation.
+// Per-batch addresses are computed from global tensor bases + block_table lookup.
+//
+// Template: M=q_tile, K=head_dim, N=block_size
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int K, int N>
+static __aicore__ void qk_matmul_batch_impl(
+    __gm__ TensorData* query,
+    __gm__ TensorData* key_cache,
+    __gm__ TensorData* sij_batch,
+    uint64_t block_table_ptr,
+    uint64_t batch_count,
+    uint64_t block_idx,
+    uint64_t q_offset,
+    uint64_t block_num,
+    uint64_t num_heads) {
+
+    __gm__ half* query_base = reinterpret_cast<__gm__ half*>(query->buffer.addr);
+    __gm__ half* key_base = reinterpret_cast<__gm__ half*>(key_cache->buffer.addr);
+    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_batch->buffer.addr);
+    // Block table values are always non-negative (physical block indices)
+    __gm__ int32_t* bt = reinterpret_cast<__gm__ int32_t*>(block_table_ptr);
+
+    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
+
+    using TileMatA = Tile<TileType::Mat, half, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
+
+    using LeftTile = TileLeft<half, M, K, M, K>;
+    using RightTile = TileRight<half, K, N, K, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    for (uint64_t b = 0; b < batch_count; b++) {
+        __gm__ half* qi_addr = query_base + (b * num_heads + q_offset) * K;
+        int32_t phys_block = bt[b * block_num + block_idx];
+        __gm__ half* kj_addr = key_base + (uint64_t)phys_block * N * K;
+        __gm__ float* sij_addr = sij_base + b * M * N;
+
+        GlobalA qiGlobal(qi_addr);
+        GlobalB kjGlobal(kj_addr);
+        GlobalOut sijGlobal(sij_addr);
+
+        TLOAD(aMatTile, qiGlobal);
+        TLOAD(bMatTile, kjGlobal);
+
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+        TMOV(aTile, aMatTile);
+        TMOV(bTile, bMatTile);
+
+        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+        TMATMUL(cTile, aTile, bTile);
+
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+        TSTORE(sijGlobal, cTile);
+
+        if (b + 1 < batch_count) {
+            pipe_barrier(PIPE_ALL);
+        }
+    }
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* query = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* key_cache = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* sij_batch = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    uint64_t block_table_ptr = static_cast<uint64_t>(args[3]);
+    uint64_t batch_count = static_cast<uint64_t>(args[4]);
+    uint64_t block_idx = static_cast<uint64_t>(args[5]);
+    uint64_t q_offset = static_cast<uint64_t>(args[6]);
+    uint64_t block_num = static_cast<uint64_t>(args[7]);
+    uint64_t num_heads = static_cast<uint64_t>(args[8]);
+
+    qk_matmul_batch_impl<16, 16, 16>(
+        query, key_cache, sij_batch,
+        block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads);
+}

--- a/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_hub.cpp
+++ b/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_hub.cpp
@@ -1,0 +1,14 @@
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}

--- a/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,0 +1,222 @@
+// Batched Online Softmax Update + Normalize Kernel (AIV)
+//
+// Processes batch_count batches in a single kernel invocation.
+// For each batch b, updates accumulators mi/li/oi with new block's mij/lij/oi_new.
+// On is_last, normalizes and writes to the output tensor at the correct batch offset.
+//
+// Scalar layout strategy (unchanged from unbatched version):
+//   M scalar floats stored contiguously in GM can be loaded as either:
+//   - ND (kScalarRows, kScalarCols) RowMajor for element-wise ops
+//   - DN (kAlignedRows, 1) ColMajor for row-broadcast ops
+//   Conversion between layouts uses GM round-trip: ND TSTORE -> DN TLOAD.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int N>
+static __aicore__ void online_update_batch_impl(
+    __gm__ TensorData* mij_batch,
+    __gm__ TensorData* lij_batch,
+    __gm__ TensorData* oi_new_batch,
+    __gm__ TensorData* mi_batch,
+    __gm__ TensorData* li_batch,
+    __gm__ TensorData* oi_batch,
+    __gm__ TensorData* out,
+    uint64_t is_first,
+    uint64_t is_last,
+    uint64_t batch_count,
+    uint64_t q_offset,
+    uint64_t num_heads) {
+
+    __gm__ float* mij_base = reinterpret_cast<__gm__ float*>(mij_batch->buffer.addr);
+    __gm__ float* lij_base = reinterpret_cast<__gm__ float*>(lij_batch->buffer.addr);
+    __gm__ float* oi_new_base = reinterpret_cast<__gm__ float*>(oi_new_batch->buffer.addr);
+    __gm__ float* mi_base = reinterpret_cast<__gm__ float*>(mi_batch->buffer.addr);
+    __gm__ float* li_base = reinterpret_cast<__gm__ float*>(li_batch->buffer.addr);
+    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_batch->buffer.addr);
+    __gm__ float* out_base = reinterpret_cast<__gm__ float*>(out->buffer.addr);
+
+    constexpr int kScalarCols = 32 / sizeof(float);
+    constexpr int kScalarRows = M / kScalarCols;
+    constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+
+    using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+
+    constexpr int kDataBytes = M * N * sizeof(float);
+    constexpr int kScalarNDBytes = kScalarRows * kScalarCols * sizeof(float);
+    constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
+
+    TileDataMxN oiNewTile;
+    TileDataMxN oiTile;
+
+    TileScalarND mijND, lijND, miND, liND;
+    TileScalarND miNewND, alphaND, betaND, tmpND;
+
+    TileScalarDN alphaDN, betaDN, liDN;
+
+    TASSIGN(oiNewTile, 0);
+    TASSIGN(oiTile, kDataBytes);
+    TASSIGN(mijND, 2 * kDataBytes);
+    TASSIGN(lijND, 2 * kDataBytes + kScalarNDBytes);
+    TASSIGN(miND, 2 * kDataBytes + 2 * kScalarNDBytes);
+    TASSIGN(liND, 2 * kDataBytes + 3 * kScalarNDBytes);
+    TASSIGN(miNewND, 2 * kDataBytes + 4 * kScalarNDBytes);
+    TASSIGN(alphaND, 2 * kDataBytes + 5 * kScalarNDBytes);
+    TASSIGN(betaND, 2 * kDataBytes + 6 * kScalarNDBytes);
+    TASSIGN(tmpND, 2 * kDataBytes + 7 * kScalarNDBytes);
+    TASSIGN(alphaDN, 2 * kDataBytes + 8 * kScalarNDBytes);
+    TASSIGN(betaDN, 2 * kDataBytes + 8 * kScalarNDBytes + kScalarDNBytes);
+    TASSIGN(liDN, 2 * kDataBytes + 8 * kScalarNDBytes + 2 * kScalarDNBytes);
+
+    for (uint64_t b = 0; b < batch_count; b++) {
+        __gm__ float* mij_ptr = mij_base + b * M;
+        __gm__ float* lij_ptr = lij_base + b * M;
+        __gm__ float* oi_new_ptr = oi_new_base + b * M * N;
+        __gm__ float* mi_ptr = mi_base + b * M;
+        __gm__ float* li_ptr = li_base + b * M;
+        __gm__ float* oi_ptr = oi_base + b * M * N;
+        __gm__ float* dst_ptr = out_base + (b * num_heads + q_offset) * N;
+
+        GlobalDataMxN oiNewGlobal(oi_new_ptr);
+        GlobalDataMxN oiGlobal(oi_ptr);
+        GlobalDataMxN dstGlobal(dst_ptr);
+
+        GlobalScalarND mijGlobalND(mij_ptr);
+        GlobalScalarND lijGlobalND(lij_ptr);
+        GlobalScalarND miGlobalND(mi_ptr);
+        GlobalScalarND liGlobalND(li_ptr);
+
+        GlobalScalarDN mijGlobalDN(mij_ptr);
+        GlobalScalarDN lijGlobalDN(lij_ptr);
+        GlobalScalarDN liGlobalDN(li_ptr);
+
+        if (is_first) {
+            TLOAD(oiNewTile, oiNewGlobal);
+            TLOAD(mijND, mijGlobalND);
+            TLOAD(lijND, lijGlobalND);
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(miGlobalND, mijND);
+            TSTORE(liGlobalND, lijND);
+            TSTORE(oiGlobal, oiNewTile);
+
+            if (is_last) {
+                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+                TLOAD(liDN, liGlobalDN);
+                set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+                wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+                TROWEXPANDDIV(oiNewTile, oiNewTile, liDN);
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                TSTORE(dstGlobal, oiNewTile);
+            }
+        } else {
+            TLOAD(oiNewTile, oiNewGlobal);
+            TLOAD(oiTile, oiGlobal);
+            TLOAD(mijND, mijGlobalND);
+            TLOAD(lijND, lijGlobalND);
+            TLOAD(miND, miGlobalND);
+            TLOAD(liND, liGlobalND);
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+            TMAX(miNewND, miND, mijND);
+            pipe_barrier(PIPE_V);
+            TSUB(alphaND, miND, miNewND);
+            pipe_barrier(PIPE_V);
+            TEXP(alphaND, alphaND);
+            pipe_barrier(PIPE_V);
+            TSUB(betaND, mijND, miNewND);
+            pipe_barrier(PIPE_V);
+            TEXP(betaND, betaND);
+            pipe_barrier(PIPE_V);
+            TMUL(liND, alphaND, liND);
+            pipe_barrier(PIPE_V);
+            TMUL(tmpND, betaND, lijND);
+            pipe_barrier(PIPE_V);
+            TADD(liND, liND, tmpND);
+
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(miGlobalND, miNewND);
+            TSTORE(liGlobalND, liND);
+            TSTORE(mijGlobalND, alphaND);
+            TSTORE(lijGlobalND, betaND);
+
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            TLOAD(alphaDN, mijGlobalDN);
+            TLOAD(betaDN, lijGlobalDN);
+            if (is_last) {
+                TLOAD(liDN, liGlobalDN);
+            }
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+
+            TROWEXPANDMUL(oiTile, oiTile, alphaDN);
+            TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);
+            pipe_barrier(PIPE_V);
+            TADD(oiTile, oiTile, oiNewTile);
+
+            if (is_last) {
+                pipe_barrier(PIPE_V);
+                TROWEXPANDDIV(oiTile, oiTile, liDN);
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                TSTORE(dstGlobal, oiTile);
+            } else {
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+                TSTORE(oiGlobal, oiTile);
+            }
+        }
+
+        if (b + 1 < batch_count) {
+            pipe_barrier(PIPE_ALL);
+        }
+    }
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* mij_batch = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* lij_batch = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* oi_new_batch = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    __gm__ TensorData* mi_batch = reinterpret_cast<__gm__ TensorData*>(args[3]);
+    __gm__ TensorData* li_batch = reinterpret_cast<__gm__ TensorData*>(args[4]);
+    __gm__ TensorData* oi_batch = reinterpret_cast<__gm__ TensorData*>(args[5]);
+    __gm__ TensorData* out = reinterpret_cast<__gm__ TensorData*>(args[6]);
+    uint64_t is_first = static_cast<uint64_t>(args[7]);
+    uint64_t is_last = static_cast<uint64_t>(args[8]);
+    uint64_t batch_count = static_cast<uint64_t>(args[9]);
+    uint64_t q_offset = static_cast<uint64_t>(args[10]);
+    uint64_t num_heads = static_cast<uint64_t>(args[11]);
+
+    online_update_batch_impl<16, 16>(
+        mij_batch, lij_batch, oi_new_batch,
+        mi_batch, li_batch, oi_batch, out,
+        is_first, is_last, batch_count, q_offset, num_heads);
+}

--- a/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,0 +1,148 @@
+// Batched Softmax Preparation Kernel (AIV)
+//
+// Processes batch_count batches in a single kernel invocation.
+// For each batch b at block_idx bn:
+//   valid_len = min(N, context_lens[b] - bn * N)
+//   sij_masked = pad(sij[b], valid_len, -inf)
+//   sij_scale  = sij_masked * scale
+//   mij[b]     = row_max(sij_scale)
+//   pij[b]     = exp(sij_scale - mij[b])  (truncated to fp16 then back)
+//   lij[b]     = row_sum(pij[b])
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int N>
+static __aicore__ void softmax_prepare_batch_impl(
+    __gm__ TensorData* sij_batch,
+    __gm__ TensorData* pij_batch,
+    __gm__ TensorData* mij_batch,
+    __gm__ TensorData* lij_batch,
+    float scale_value,
+    uint64_t context_lens_ptr,
+    uint64_t batch_count,
+    uint64_t block_idx) {
+
+    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_batch->buffer.addr);
+    __gm__ half* pij_base = reinterpret_cast<__gm__ half*>(pij_batch->buffer.addr);
+    __gm__ float* mij_base = reinterpret_cast<__gm__ float*>(mij_batch->buffer.addr);
+    __gm__ float* lij_base = reinterpret_cast<__gm__ float*>(lij_batch->buffer.addr);
+    __gm__ int32_t* ctx_lens = reinterpret_cast<__gm__ int32_t*>(context_lens_ptr);
+
+    constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalDataMxN_f16 = GlobalTensor<half, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+
+    using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N, SLayout::NoneBox, 512, PadValue::Min>;
+
+    using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileVecMxN_f16 = Tile<TileType::Vec, half, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+
+    TileVecMxN sijTile;
+    TileSijPad sijPadTile;
+    TileVecMxN pijTile;
+    TileVecMxN tmpTile;
+    TileScalarDN maxTile;
+    TileScalarDN sumTile;
+    TileVecMxN_f16 pijF16Tile;
+
+    TASSIGN(sijTile, 0x0);
+    TASSIGN(sijPadTile, 0x0);
+    TASSIGN(pijTile, M * N * sizeof(float));
+    TASSIGN(tmpTile, 2 * M * N * sizeof(float));
+    TASSIGN(maxTile, 3 * M * N * sizeof(float));
+    TASSIGN(sumTile, 3 * M * N * sizeof(float) + kAlignedRows * sizeof(float));
+    TASSIGN(pijF16Tile, 3 * M * N * sizeof(float) + 2 * kAlignedRows * sizeof(float));
+
+    for (uint64_t b = 0; b < batch_count; b++) {
+        int32_t cur_seq = ctx_lens[b];
+        uint64_t start = block_idx * N;
+        uint64_t valid_len = 0;
+        if (start < (uint64_t)cur_seq) {
+            uint64_t remaining = (uint64_t)cur_seq - start;
+            valid_len = (remaining < N) ? remaining : N;
+        }
+
+        __gm__ float* sij_addr = sij_base + b * M * N;
+        __gm__ half* pij_addr = pij_base + b * M * N;
+        __gm__ float* mij_addr = mij_base + b * M;
+        __gm__ float* lij_addr = lij_base + b * M;
+
+        GlobalDataMxN sijGlobal(sij_addr);
+        GlobalDataMxN_f16 pijGlobal(pij_addr);
+        GlobalScalarDN mijGlobal(mij_addr);
+        GlobalScalarDN lijGlobal(lij_addr);
+
+        TLOAD(sijTile, sijGlobal);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        TileSijDyn sijDynTile(static_cast<size_t>(valid_len));
+        TASSIGN(sijDynTile, 0x0);
+        // TFILLPAD_INPLACE alone is insufficient at small N (block_size<=32);
+        // manually fill invalid columns with -inf as a workaround.
+        TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+        if (valid_len < static_cast<uint64_t>(N)) {
+            constexpr float NEG_INF = -__builtin_huge_valf();
+            for (int r = 0; r < M; r++) {
+                for (uint64_t c = valid_len; c < N; c++) {
+                    sijTile.SetValue(static_cast<uint32_t>(r * N + c), NEG_INF);
+                }
+            }
+        }
+
+        TMULS(sijTile, sijTile, scale_value);
+        pipe_barrier(PIPE_V);
+        TROWMAX(maxTile, sijTile, tmpTile);
+        pipe_barrier(PIPE_V);
+        TROWEXPANDSUB(pijTile, sijTile, maxTile);
+        pipe_barrier(PIPE_V);
+        TEXP(pijTile, pijTile);
+        TCVT(pijF16Tile, pijTile, RoundMode::CAST_ROUND);
+        TCVT(pijTile, pijF16Tile, RoundMode::CAST_ROUND);
+        TROWSUM(sumTile, pijTile, tmpTile);
+
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(mijGlobal, maxTile);
+        TSTORE(lijGlobal, sumTile);
+        TSTORE(pijGlobal, pijF16Tile);
+
+        if (b + 1 < batch_count) {
+            pipe_barrier(PIPE_ALL);
+        }
+    }
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* sij_batch = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* pij_batch = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* mij_batch = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    __gm__ TensorData* lij_batch = reinterpret_cast<__gm__ TensorData*>(args[3]);
+    union { uint64_t u; float f; } scale_conv;
+    scale_conv.u = static_cast<uint64_t>(args[4]);
+    float scale_value = scale_conv.f;
+    uint64_t context_lens_ptr = static_cast<uint64_t>(args[5]);
+    uint64_t batch_count = static_cast<uint64_t>(args[6]);
+    uint64_t block_idx = static_cast<uint64_t>(args[7]);
+
+    softmax_prepare_batch_impl<16, 16>(
+        sij_batch, pij_batch, mij_batch, lij_batch,
+        scale_value, context_lens_ptr, batch_count, block_idx);
+}

--- a/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/kernel_config.py
+++ b/examples/tensormap_and_ringbuffer/batch_paged_attention/kernels/kernel_config.py
@@ -1,0 +1,45 @@
+"""
+Paged Attention Kernel and Orchestration Configuration
+
+Defines the kernels and orchestration function for paged attention
+with AIC/AIV subgraph splitting:
+
+AIC Kernels (Matrix Multiplication):
+  - aic_qk_matmul: Q @ K^T computation
+  - aic_pv_matmul: P @ V computation
+
+AIV Kernels (Vector Operations):
+  - aiv_softmax_prepare: scale, rowmax, exp, rowsum
+  - aiv_online_update: online softmax accumulation + fused normalization
+
+Note: aiv_normalize has been merged into aiv_online_update for efficiency.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+# Orchestration config
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "paged_attention_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+# Kernel configs (aiv_normalize removed - merged into aiv_online_update)
+KERNELS = [
+    # AIC kernels (matrix multiplication using Cube unit)
+    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),       "core_type": "aic"},
+    # AIV kernels (vector operations)
+    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
+    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
+    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),       "core_type": "aiv"},
+]
+
+# Runtime configuration
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 24,
+}


### PR DESCRIPTION
Add batch_paged_attention under tensormap_and_ringbuffer examples.
The orchestrator submits a fixed number of tasks (1 + max_bn * 4)
regardless of batch size; each kernel processes all batches internally
via pointer arithmetic, avoiding per-batch task submission overhead.

Key details:
- Online softmax with GQA support (kv_head_num=1)
- 16x16 tile dimensions, head_dim=16, block_size=16
- Non-transposed K storage: (total_blocks, block_size, kv_head_num, head_dim)
- Fix softmax valid_len init and manual -inf padding for small block sizes
- Golden covers 3 cases with varying context lengths (33, 31, 128)