### PR TITLE
Refactor: make ready queue shards runtime-configurable

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -21,6 +21,7 @@ Runtime::Runtime() {
     memset(workers, 0, sizeof(workers));
     worker_count = 0;
     sche_cpu_num = 1;
+    ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
 
     // Initialize tensor pairs
     tensor_pair_count = 0;

--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -23,6 +23,7 @@
 
 #include "common/core_type.h"
 #include "common/perf_profiling.h"
+#include "common/platform_config.h"
 #include "pto2_dispatch_payload.h"
 
 // =============================================================================
@@ -34,6 +35,9 @@
 #define RUNTIME_MAX_TENSOR_PAIRS 64
 #define RUNTIME_MAX_FUNC_ID 32
 #define RUNTIME_MAX_ORCH_SO_SIZE (4 * 1024 * 1024)  // 1MB max for orchestration SO
+
+// Default ready queue shards: one shard per worker thread (total minus orchestrator)
+constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 1;
 
 // =============================================================================
 // Data Structures
@@ -137,6 +141,7 @@ public:
 
     // Execution parameters for AICPU scheduling
     int sche_cpu_num;  // Number of AICPU threads for scheduling
+    int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
     // NOTE: Made public for direct access from aicore code


### PR DESCRIPTION
Replace compile-time PTO2_READY_QUEUE_SHARDS with runtime-configurable active_shards_ (1..16, default 3) via PTO2_READY_QUEUE_SHARDS env var.

- aicpu_executor.cpp: PTO2_MAX_READY_QUEUE_SHARDS=16 for array sizing, active_shards_ member for runtime shard count
- runtime_maker.cpp: parse PTO2_READY_QUEUE_SHARDS env var
- runtime.h/cpp: add ready_queue_shards field (default 3)