### PR TITLE
Fix: resolve sporadic paged attention FAIL due to cross-pipeline race and precision mismatch

### DIFF
--- a/examples/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/examples/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -179,7 +179,7 @@ def paged_attention(
             pij = torch.exp(sij - mij)
             pij = pij.masked_fill(~valid_mask, 0.0)
             pij = pij.masked_fill(~batch_mask, 0.0)
-            pij = pij.to(torch.bfloat16).to(torch.float32)
+            pij = pij.to(torch.float16).to(torch.float32)
             lij = pij.sum(dim=-1, keepdim=True)
 
             oi_new = torch.bmm(pij, vj_all)

--- a/examples/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -94,12 +94,25 @@ static __aicore__ void softmax_prepare_impl(__gm__ TensorData* sij,
     // Patch: SetValue ensures correctness for valid_len <= N/2 where
     // TFILLPAD's PadRightRemainingRows vcopy has a hardware issue.
     if (valid_len < static_cast<uint64_t>(N)) {
+        // Cross-pipeline sync: wait for PIPE_V vcopy in TFILLPAD to complete
+        // before PIPE_S scalar SetValue writes to the same UB addresses.
+        // Without this, PIPE_V vcopy and PIPE_S SetValue race on UB memory,
+        // causing sporadic FAIL when vcopy finishes after SetValue.
+        // Pattern from TFillPad.hpp Handle32BAlignedPad_Byte (PtoSetWaitFlag).
+        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
         constexpr float NEG_INF = -__builtin_huge_valf();
         for (int r = 0; r < M; r++) {
             for (uint64_t c = valid_len; c < N; c++) {
                 sijTile.SetValue(static_cast<uint32_t>(r * N + c), NEG_INF);
             }
         }
+        // Ensure PIPE_S scalar UB writes are visible to subsequent PIPE_V ops.
+        // dsb(DSB_UB) is a hardware-only intrinsic; in simulation there are no
+        // real pipelines so the barrier is unnecessary and DSB_UB is undefined.
+#ifdef DSB_UB
+        dsb(DSB_UB);
+#endif
     }
 
     TMULS(sijTile, sijTile, scale_value);


### PR DESCRIPTION
## Summary

- Add cross-pipeline synchronization in `aiv_softmax_prepare.cpp` to fix a
  sporadic FAIL caused by a PIPE_V / PIPE_S race condition on UB memory
- Align `golden.py` pij truncation precision from `bfloat16` to `float16` to
  match device-side `half` (IEEE fp16) conversion

## Root Cause

**Primary — Cross-pipeline race (non-deterministic FAIL):**
`TFILLPAD_INPLACE` emits a `vcopy` on PIPE_V (via `PadRightRemainingRows`) to
broadcast padding rows into the UB tile. Due to a known hardware bug at N=16,
this vcopy produces incorrect data, so the subsequent `SetValue` loop overwrites
the padding region with the correct `-inf` values. However, `SetValue` runs on
PIPE_S (scalar pointer dereference), and `PadRightRemainingRows` returns
**without any pipeline barrier** — unlike `PadRightSingleRow` and
`Handle32BAlignedPad_Other` which both issue `pipe_barrier(PIPE_V)`.

This creates a race window: PIPE_V vcopy and PIPE_S SetValue write to the same
UB addresses concurrently. When vcopy finishes after SetValue (~6% of runs),
the incorrect vcopy data overwrites the correct `-inf`, causing mismatch in the
final attention output. A single `pipe_barrier(PIPE_V)` is insufficient because
it only serializes PIPE_V-internal ordering without blocking PIPE_S execution.

**Secondary — Precision mismatch (deterministic error accumulation):**
`golden.py` truncated pij via `torch.bfloat16` (7-bit mantissa), while the
device uses `TCVT` to fp16/half (10-bit mantissa).

## Fix

1. **`aiv_softmax_prepare.cpp`**: Insert `set_flag(PIPE_V, PIPE_S, EVENT_ID0)`
   + `wait_flag(PIPE_V, PIPE_S, EVENT_ID0)` before the SetValue loop to ensure
   PIPE_V vcopy completes before PIPE_S begins writing. Add `dsb(DSB_UB)` after
   the loop to guarantee scalar UB writes are visible to subsequent PIPE_V
   operations (TMULS). This pattern follows `Handle32BAlignedPad_Byte` in
   `TFillPad.hpp` which uses the same `PtoSetWaitFlag<PIPE_V, PIPE_S>()` +
   `dsb(DSB_UB)` idiom.

2. **`golden.py`**: Change `pij.to(torch.bfloat16)` → `pij.to(torch.float16)`
   to match device-side half-precision truncation.

## Test

- [x] Batch run paged attention 100× with config `batch=1, num_heads=16,
      head_dim=16, block_size=16, context_len=33` — 100/100 PASS
      (previously ~94/100)

Closes #139 