### PR TITLE
Support: configurable ring buffer sizes via environment variables

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1131,6 +1131,19 @@ int AicpuExecutor::run(Runtime* runtime) {
                 DEV_INFO("Thread 3: No config function, using defaults");
             }
 
+            // Apply ring buffer size overrides from Runtime (set by host env vars)
+            if (runtime->pto2_task_window_size > 0) {
+                task_window_size = runtime->pto2_task_window_size;
+            }
+            if (runtime->pto2_heap_size > 0) {
+                heap_size = runtime->pto2_heap_size;
+            }
+            if (runtime->pto2_dep_list_pool_size > 0) {
+                dep_list_pool_size = runtime->pto2_dep_list_pool_size;
+            }
+            DEV_INFO("Thread 3: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%lu",
+                     (unsigned long)task_window_size, (unsigned long)heap_size, (unsigned long)dep_list_pool_size);
+
             if (expected_arg_count > 0 && arg_count < expected_arg_count) {
                 DEV_ERROR("Thread 3: arg_count %d < expected %d", arg_count, expected_arg_count);
                 dlclose(handle);

--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -22,6 +22,9 @@ Runtime::Runtime() {
     worker_count = 0;
     sche_cpu_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
+    pto2_task_window_size = 0;
+    pto2_heap_size = 0;
+    pto2_dep_list_pool_size = 0;
 
     // Initialize tensor pairs
     tensor_pair_count = 0;

--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -143,6 +143,11 @@ public:
     int sche_cpu_num;  // Number of AICPU threads for scheduling
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
+    // Ring buffer size overrides (0 = use compile-time defaults)
+    uint64_t pto2_task_window_size;
+    uint64_t pto2_heap_size;
+    uint64_t pto2_dep_list_pool_size;
+
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
     // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];


### PR DESCRIPTION
Add PTO2_RING_TASK_WINDOW, PTO2_RING_HEAP, PTO2_RING_DEP_POOL env vars to override compile-time ring buffer defaults at runtime.

- runtime.h/cpp: add pto2_task_window_size, pto2_heap_size, pto2_dep_list_pool_size fields (0 = use compile-time defaults)
- runtime_maker.cpp: parse and validate env vars
- aicpu_executor.cpp: apply overrides in Thread 3 before SM init