### PR TITLE
Feature: CAS-based watermark advancement and slot-reuse validation

### DIFF
--- a/.ai-instructions/coding/codestyle.md
+++ b/.ai-instructions/coding/codestyle.md
@@ -16,3 +16,4 @@
 
 3. Prefer `volatile` decorator on struct members rather than volatile pointer casts unless necessary.
 4. Avoid using pointer arithmetic with hardcoded offsets when `offsetof` is available.
+5. **Never use `std::this_thread::yield()` or `sched_yield()` in AICPU spin-wait loops.** On the Ascend AICPU, yielding to the OS scheduler introduces unacceptable latency for tight spin-waits (ticket locks, CAS retries, etc.). Use an empty loop body or a bare architecture hint (`__asm__ volatile("yield")`) instead.

--- a/src/platform/a2a3/aicore/inner_kernel.h
+++ b/src/platform/a2a3/aicore/inner_kernel.h
@@ -20,6 +20,9 @@
 // dcci (Data Cache Clean and Invalidate) is provided by CANN headers
 // No need to define it here - it's a hardware instruction
 
+// SPIN_WAIT_HINT - no-op on real hardware (AICore has dedicated polling support)
+#define SPIN_WAIT_HINT() ((void)0)
+
 /**
  * Read an AICore register via SPR access
  *

--- a/src/platform/a2a3/aicpu/spin_hint.h
+++ b/src/platform/a2a3/aicpu/spin_hint.h
@@ -1,0 +1,14 @@
+/**
+ * @file spin_hint.h
+ * @brief Platform-specific spin-wait hint for AICPU (real hardware)
+ *
+ * On real Ascend hardware, AICPU runs on dedicated ARM A55 cores with sufficient
+ * resources. No spin-wait hint is needed — the macro expands to a no-op.
+ */
+
+#ifndef PLATFORM_A2A3_AICPU_SPIN_HINT_H_
+#define PLATFORM_A2A3_AICPU_SPIN_HINT_H_
+
+#define SPIN_WAIT_HINT() ((void)0)
+
+#endif  // PLATFORM_A2A3_AICPU_SPIN_HINT_H_

--- a/src/platform/a2a3sim/aicpu/spin_hint.h
+++ b/src/platform/a2a3sim/aicpu/spin_hint.h
@@ -1,0 +1,29 @@
+/**
+ * @file spin_hint.h
+ * @brief Platform-specific spin-wait hint for AICPU (simulation)
+ *
+ * In simulation, all AICPU scheduler threads share a small number of host CPU
+ * cores with AICore threads. Without explicit yielding, idle scheduler threads
+ * in tight polling loops starve the AICore thread executing the actual kernel,
+ * causing iteration-based timeouts (MAX_IDLE_ITERATIONS) before the kernel can
+ * complete — especially on resource-constrained CI runners (e.g., 2 cores
+ * running 13+ threads).
+ *
+ * The CPU hint (pause/yield) reduces pipeline waste, and sched_yield() lets the
+ * OS scheduler give time slices to threads doing real work.
+ */
+
+#ifndef PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_
+#define PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_
+
+#include <sched.h>
+
+#if defined(__x86_64__)
+#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
+#elif defined(__aarch64__)
+#define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#else
+#define SPIN_WAIT_HINT() sched_yield()
+#endif
+
+#endif  // PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_

--- a/src/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -46,7 +46,12 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             break;
         }
 
-        if (task_id != 0 && task_id != last_task_id) {
+        if (task_id == 0 || task_id == last_task_id) {
+            SPIN_WAIT_HINT();
+            continue;
+        }
+
+        {
             uint32_t actual_task_id = task_id - 1;
             write_reg(RegId::COND, MAKE_ACK_VALUE(actual_task_id));
 

--- a/src/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -4,6 +4,7 @@
 
 #include "aicpu/device_log.h"
 #include "aicpu/device_time.h"
+#include "spin_hint.h"
 #include "aicpu/performance_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "common/memory_barrier.h"
@@ -953,6 +954,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 LOG_ERROR("Thread %d: Timeout after %d idle iterations!", thread_idx, idle_iterations);
                 diagnose_stuck_state(runtime, thread_idx, cur_thread_cores, core_num, hank);
                 return -1;
+            } else {
+                SPIN_WAIT_HINT();
             }
         } else {
             idle_iterations = 0;

--- a/src/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -88,7 +88,12 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
         }
 
         // Execute task if new (task_id encoding: 0=idle, task_id+1=task)
-        if (task_id != 0 && task_id != last_task_id) {
+        if (task_id == 0 || task_id == last_task_id) {
+            SPIN_WAIT_HINT();
+            continue;
+        }
+
+        {
             // Invalidate cache to read fresh payload written by AICPU
             dcci(my_payload, ENTIRE_DATA_CACHE);
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -79,6 +79,7 @@ struct PTO2OrchestratorState {
     // === AICPU PARALLEL MODE (set by aicpu_executor, NULL when unused) ===
     int32_t* aicpu_fanin_refcount;
     volatile int32_t* aicpu_task_completed;
+    int32_t* aicpu_completed_by_task;  // task_id that set the completed state (for slot-reuse validation)
     int32_t aicpu_window_mask;
 
     // === ORCHESTRATOR READY QUEUE (early-return path → scheduler) ===

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -373,9 +373,11 @@ void pto2_scheduler_advance_ring_pointers(PTO2SchedulerState* sched) {
 
 void pto2_scheduler_sync_to_sm(PTO2SchedulerState* sched) {
     PTO2SharedMemoryHeader* header = sched->sm_handle->header;
-    
+
     PTO2_STORE_RELEASE(&header->last_task_alive, sched->last_task_alive);
     PTO2_STORE_RELEASE(&header->heap_tail, sched->heap_tail);
+    // Keep generation in sync so AICPU mode sees a consistent starting state
+    PTO2_STORE_RELEASE(&header->heap_tail_gen, sched->last_task_alive);
 }
 
 // =============================================================================

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -148,6 +148,7 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
     header->orchestrator_done = 0;
     header->last_task_alive = 0;
     header->heap_tail = 0;
+    header->heap_tail_gen = 0;
 
     // Layout info
     header->task_window_size = task_window_size;
@@ -181,7 +182,8 @@ void pto2_sm_reset(PTO2SharedMemoryHandle* handle) {
     header->orchestrator_done = 0;
     header->last_task_alive = 0;
     header->heap_tail = 0;
-    
+    header->heap_tail_gen = 0;
+
     header->graph_output_ptr = 0;
     header->graph_output_size = 0;
     // Clear task descriptors

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -50,7 +50,8 @@ typedef struct {
     // Written by Scheduler, Read by Orchestrator (for back-pressure)
     volatile uint64_t heap_tail;          // Heap ring free pointer (on-device, matches pto2_heap_ring_init)
     volatile int32_t last_task_alive;     // Task ring tail (oldest active task)
-    volatile int32_t _reserved;           // Explicit padding for 8-byte alignment
+    volatile int32_t heap_tail_gen;       // Ticket counter for serialized heap_tail writes
+                                          // (ensures concurrent threads write in task order)
 
     // === LAYOUT INFO (set once at init) ===
     uint64_t task_window_size;            // PTO2_TASK_WINDOW_SIZE


### PR DESCRIPTION
Add ring buffer flow control so scheduler threads advance last_task_alive and heap_tail after consuming tasks, enabling slot reuse for long-running orchestrations.

aicpu_executor.cpp:
- orch_pointers_ready_ atomic flag: scheduler threads wait for last thread to finish pointer setup before entering main loop
- s_pto2_completed_by_task[] array: records which task_id set each slot's completion state to prevent stale state from recycled slots
- CAS watermark loop: after task completion, mark slot as state=3, then CAS-advance last_task_alive and heap_tail
- Fix heap_tail: convert absolute pointer to offset from gm_heap_base (same semantic as cda8448 fixed on scheduler side)
- Fix thread_num_ == 4 hardcoded guard to thread_num_ > 1 for general multi-thread device orchestration scenarios
- Add orch ready queue pointer cleanup in deinit() to prevent stale pointer access on deinit/re-init cycles

pto_orchestrator.h/cpp:
- Add aicpu_completed_by_task pointer to PTO2OrchestratorState
- Early-return path: verify completed_by_task matches producer_id to guard against stale state from recycled slots
- Slot reset at allocation: clear task_completed and completed_by_task
- Add RELAXED load rationale comment for completed_by_task