### PR TITLE
Refactor: per-core perf storage and deterministic device log resolution

### DIFF
--- a/src/platform/a2a3/host/device_runner.cpp
+++ b/src/platform/a2a3/host/device_runner.cpp
@@ -407,7 +407,7 @@ int DeviceRunner::run(Runtime& runtime,
 
     // Poll and collect performance data (must be before stream sync)
     if (runtime.enable_profiling) {
-        poll_and_collect_performance_data(runtime.worker_count, runtime.get_task_count());
+        poll_and_collect_performance_data(runtime.get_task_count());
     }
 
     std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
@@ -682,8 +682,8 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
                                        alloc_cb, register_cb, &mem_alloc_);
 }
 
-void DeviceRunner::poll_and_collect_performance_data(int num_aicore, int expected_tasks) {
-    perf_collector_.poll_and_collect(num_aicore, expected_tasks);
+void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
+    perf_collector_.poll_and_collect(expected_tasks);
 }
 
 int DeviceRunner::export_swimlane_json(const std::string& output_path) {

--- a/src/platform/a2a3/host/device_runner.h
+++ b/src/platform/a2a3/host/device_runner.h
@@ -232,10 +232,9 @@ public:
      * This is a synchronous polling function that should be called after
      * launching kernels but before stream synchronization.
      *
-     * @param num_cores Number of cores
      * @param expected_tasks Expected total number of tasks (used for exit condition)
      */
-    void poll_and_collect_performance_data(int num_cores, int expected_tasks);
+    void poll_and_collect_performance_data(int expected_tasks);
 
     /**
      * Export performance data to merged_swimlane.json

--- a/src/platform/a2a3sim/host/device_runner.cpp
+++ b/src/platform/a2a3sim/host/device_runner.cpp
@@ -276,8 +276,8 @@ int DeviceRunner::run(Runtime& runtime,
     // Poll and collect performance data during execution (if enabled)
     std::thread collector_thread;
     if (runtime.enable_profiling) {
-        collector_thread = std::thread([this, &runtime, num_aicore]() {
-            poll_and_collect_performance_data(num_aicore, runtime.get_task_count());
+        collector_thread = std::thread([this, &runtime]() {
+            poll_and_collect_performance_data(runtime.get_task_count());
         });
     }
 
@@ -489,8 +489,8 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
                                        alloc_cb, nullptr, nullptr);
 }
 
-void DeviceRunner::poll_and_collect_performance_data(int num_aicore, int expected_tasks) {
-    perf_collector_.poll_and_collect(num_aicore, expected_tasks);
+void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
+    perf_collector_.poll_and_collect(expected_tasks);
 }
 
 int DeviceRunner::export_swimlane_json(const std::string& output_path) {

--- a/src/platform/a2a3sim/host/device_runner.h
+++ b/src/platform/a2a3sim/host/device_runner.h
@@ -140,10 +140,9 @@ public:
      * This is a synchronous polling function that should be called after
      * launching kernels but before thread synchronization.
      *
-     * @param num_cores Number of cores
      * @param expected_tasks Expected total number of tasks (used for exit condition)
      */
-    void poll_and_collect_performance_data(int num_cores, int expected_tasks);
+    void poll_and_collect_performance_data(int expected_tasks);
 
     /**
      * Export performance data to merged_swimlane.json

--- a/src/platform/include/aicore/performance_collector_aicore.h
+++ b/src/platform/include/aicore/performance_collector_aicore.h
@@ -33,7 +33,6 @@
  * @param start_time Start timestamp
  * @param end_time End timestamp
  * @param kernel_ready_time Kernel ready timestamp
- * @param core_id Core ID
  * @param core_type Core type (AIC/AIV)
  */
 __aicore__ __attribute__((always_inline))
@@ -44,7 +43,6 @@ static inline void perf_aicore_record_task(
     uint64_t start_time,
     uint64_t end_time,
     uint64_t kernel_ready_time,
-    int core_id,
     CoreType core_type) {
 
     // Read current buffer count
@@ -63,7 +61,6 @@ static inline void perf_aicore_record_task(
     record->kernel_ready_time = kernel_ready_time;
     record->task_id = task_id;
     record->func_id = func_id;
-    record->core_id = core_id;
     record->core_type = core_type;
 
     perf_buf->count = idx + 1;

--- a/src/platform/include/common/perf_profiling.h
+++ b/src/platform/include/common/perf_profiling.h
@@ -83,7 +83,6 @@ struct PerfRecord {
     // Task identification
     uint32_t task_id;         // Task unique identifier
     uint32_t func_id;         // Kernel function identifier
-    uint32_t core_id;         // Physical core ID (0-71)
     CoreType core_type;       // Core type (AIC/AIV)
 
     // Dependency relationship (fanout only)

--- a/src/platform/include/host/performance_collector.h
+++ b/src/platform/include/host/performance_collector.h
@@ -106,10 +106,9 @@ public:
     /**
      * Poll and collect performance data from shared memory
      *
-     * @param num_aicore Number of cores
      * @param expected_tasks Expected total number of tasks (0 = auto-detect from header)
      */
-    void poll_and_collect(int num_aicore, int expected_tasks = 0);
+    void poll_and_collect(int expected_tasks = 0);
 
     /**
      * Export performance data to Chrome Trace Event Format
@@ -139,7 +138,7 @@ public:
     /**
      * Get collected records (for testing)
      */
-    const std::vector<PerfRecord>& get_records() const { return collected_perf_records_; }
+    const std::vector<std::vector<PerfRecord>>& get_records() const { return collected_perf_records_; }
 
 private:
     // Shared memory pointers
@@ -148,8 +147,11 @@ private:
     bool was_registered_{false};           // True if register_cb was called successfully
     int device_id_{-1};
 
-    // Collected data
-    std::vector<PerfRecord> collected_perf_records_;
+    // Configuration
+    int num_aicore_{0};
+
+    // Collected data (per-core vectors, indexed by core_index)
+    std::vector<std::vector<PerfRecord>> collected_perf_records_;
 };
 
 #endif  // PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_

--- a/src/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -65,7 +65,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
                 perf_aicore_record_task(perf_buf, task_ptr->task_id, task_ptr->func_id,
                                       start_time, end_time, kernel_ready_time,
-                                      block_idx, core_type);
+                                      core_type);
             }
 
             last_task_id = task_id;

--- a/src/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -116,7 +116,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
                 perf_aicore_record_task(perf_buf, payload->task_id, payload->kernel_id,
                                        start_time, end_time, kernel_ready_time,
-                                       block_idx, core_type);
+                                       core_type);
             }
 
             last_task_id = task_id;

--- a/tools/README.md
+++ b/tools/README.md
@@ -83,7 +83,7 @@ log root 解析顺序：
 - **Head/Tail OH**：调度头部/尾部开销
 - **Exec_%**：Exec / Latency 百分比（kernel 利用率）
 
-解析到 device log 时，还会输出 Sched CPU（AICPU scheduler 线程实际 CPU 时间 per task）。
+解析到 device log 时，还会输出 Sched CPU（AICPU scheduler 线程实际 CPU 时间 per task）和 Exec/Sched_CPU 比率。
 
 #### 3. Scheduler overhead deep-dive（自动）
 


### PR DESCRIPTION
## Summary
- Remove `core_id` from `PerfRecord`, store records in per-core vectors indexed by core_id directly (host performance_collector). Struct raw size drops from 2116→2112 bytes (exact 64-byte alignment)
- Snapshot device log directory before `runner.run()`, diff after to find the exact new log created by this run — handles CANN async dlog writes deterministically
- Pass precise `--device-log` path to swimlane converter instead of guessing by timestamp

## Testing
- [x] Hardware profiling test verified (`tests/device_tests/tensormap_and_ringbuffer/paged_attention`)
- [x] Device log correctly resolved via snapshot diff (`Selection: explicit --device-log file`)
- [x] Scheduler overhead deep dive completes with Exec/Sched ratios