### PR TITLE
Feature: AICPU scheduler phase profiling and orchestrator summary

### DIFF
--- a/src/platform/a2a3/host/device_runner.cpp
+++ b/src/platform/a2a3/host/device_runner.cpp
@@ -427,8 +427,9 @@ int DeviceRunner::run(Runtime& runtime,
         return rc;
     }
 
-    // Print collected performance data (after stream sync)
+    // Collect phase data and print performance data (after stream sync)
     if (runtime.enable_profiling) {
+        perf_collector_.collect_phase_data();
         export_swimlane_json();
     }
 

--- a/src/platform/a2a3sim/aicpu/CMakeLists.txt
+++ b/src/platform/a2a3sim/aicpu/CMakeLists.txt
@@ -50,6 +50,8 @@ target_compile_options(aicpu_kernel
     PRIVATE
         -Wall
         -Wextra
+        -Werror
+        -Wno-error=class-memaccess
         -fPIC
         -O3
         -g

--- a/src/platform/a2a3sim/host/device_runner.cpp
+++ b/src/platform/a2a3sim/host/device_runner.cpp
@@ -297,8 +297,9 @@ int DeviceRunner::run(Runtime& runtime,
 
     LOG_INFO("All threads completed");
 
-    // Print performance data after execution completes
+    // Collect AICPU phase data and print performance data after execution completes
     if (runtime.enable_profiling) {
+        perf_collector_.collect_phase_data();
         export_swimlane_json();
     }
 

--- a/src/platform/include/host/performance_collector.h
+++ b/src/platform/include/host/performance_collector.h
@@ -136,6 +136,14 @@ public:
     bool is_initialized() const { return perf_shared_mem_host_ != nullptr; }
 
     /**
+     * Collect AICPU phase profiling data from shared memory
+     *
+     * Reads scheduler phase records and orchestrator summary from the
+     * phase profiling region. Must be called after AICPU threads have joined.
+     */
+    void collect_phase_data();
+
+    /**
      * Get collected records (for testing)
      */
     const std::vector<std::vector<PerfRecord>>& get_records() const { return collected_perf_records_; }
@@ -152,6 +160,12 @@ private:
 
     // Collected data (per-core vectors, indexed by core_index)
     std::vector<std::vector<PerfRecord>> collected_perf_records_;
+
+    // AICPU phase profiling data
+    std::vector<std::vector<AicpuPhaseRecord>> collected_phase_records_;
+    std::vector<AicpuPhaseRecord> collected_orch_phase_records_;
+    AicpuOrchSummary collected_orch_summary_{};
+    bool has_phase_data_{false};
 };
 
 #endif  // PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_


### PR DESCRIPTION
## Summary
- Add phase profiling data structures (`AicpuPhaseRecord`, `AicpuOrchSummary`, `AicpuPhaseHeader`) appended after DoubleBuffer array in shared memory
- Implement AICPU-side recording API with cached pointers for hot-path efficiency
- Instrument 4 scheduler phases (COMPLETE, DISPATCH, SCAN, EARLY_READY) and orchestrator cumulative summary in `aicpu_executor`
- Host-side collection (`collect_phase_data`) and version 2 JSON export with `phase_us` (microseconds)
- Perfetto visualization: pid=3 scheduler phase bars, pid=4 orchestrator with phase sub-events

## Testing
- [x] Simulation tests pass (10/10)
- [ ] Hardware tests pass (if applicable)