### PR TITLE
Refactor: convert TensorMap to C++ member API and inline hot paths

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -266,8 +266,6 @@ struct PTO2TaskDescriptor {
     // Packed output buffer (all outputs packed into single contiguous buffer)
     void*    packed_buffer_base;  // Start of packed buffer in GM Heap
     void*    packed_buffer_end;   // End of packed buffer (for heap reclamation)
-    int32_t  output_index[PTO2_MAX_OUTPUTS]; // Offset of each output in params;
-    int32_t  num_outputs;         // Number of output buffers
 
     // Status flags
     bool     is_active;           // Task slot is in use

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -21,7 +21,6 @@
 #include "common.h"
 #include "common/unified_log.h"
 #include "pto_orchestrator.h"
-#include "tensor.h"
 
 // =============================================================================
 // TensorMap Lookup Chain Length Statistics (compile-time toggle)
@@ -39,380 +38,136 @@ static uint64_t g_insert_count = 0;
 // Initialization and Destruction
 // =============================================================================
 
-bool pto2_tensormap_init(PTO2TensorMap* tm, int32_t num_buckets, int32_t pool_size) {
+bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size) {
     // Validate power of 2 for fast modulo
-    if ((num_buckets & (num_buckets - 1)) != 0) {
+    if ((new_num_buckets & (new_num_buckets - 1)) != 0) {
         return false;  // num_buckets must be power of 2
     }
 
     // Allocate buckets
-    tm->buckets = (int32_t*)malloc(num_buckets * sizeof(int32_t));
-    if (!tm->buckets) {
+    buckets = (PTO2TensorMapEntry**)malloc(new_num_buckets * sizeof(PTO2TensorMapEntry*));
+    if (!buckets) {
         return false;
     }
 
     // Initialize all buckets to empty (-1)
-    for (int32_t i = 0; i < num_buckets; i++) {
-        tm->buckets[i] = -1;
+    for (int32_t i = 0; i < new_num_buckets; i++) {
+        buckets[i] = nullptr;
     }
 
-    tm->num_buckets = num_buckets;
+    num_buckets = new_num_buckets;
 
     // Allocate entry pool
-    tm->entry_pool = (PTO2TensorMapEntry*)calloc(pool_size, sizeof(PTO2TensorMapEntry));
-    if (!tm->entry_pool) {
-        free(tm->buckets);
-        tm->buckets = NULL;
+    entry_pool = (PTO2TensorMapEntry*)calloc(new_pool_size, sizeof(PTO2TensorMapEntry));
+    if (!entry_pool) {
+        free(buckets);
+        buckets = NULL;
         return false;
     }
 
     // Allocate free entry list
-    tm->free_entry_list = (int32_t*)calloc(pool_size, sizeof(int32_t));
-    if (!tm->free_entry_list) {
-        free(tm->buckets);
-        free(tm->entry_pool);
-        tm->buckets = NULL;
-        tm->entry_pool = NULL;
+    free_entry_list = (PTO2TensorMapEntry**)calloc(new_pool_size, sizeof(PTO2TensorMapEntry*));
+    if (!free_entry_list) {
+        free(buckets);
+        free(entry_pool);
+        buckets = NULL;
+        entry_pool = NULL;
         return false;
     }
 
-    tm->pool_size = pool_size;
-    tm->next_entry_idx = 0;
-    tm->free_num = 0;
+    pool_size = new_pool_size;
+    next_entry_idx = 0;
+    free_num = 0;
 
     // Initialize all entries as not in bucket
     for (int32_t i = 0; i < pool_size; i++) {
-        tm->entry_pool[i].in_bucket = false;
-        tm->entry_pool[i].next_in_bucket = -1;
-        tm->entry_pool[i].prev_in_bucket = -1;
-        tm->entry_pool[i].next_in_task = -1;
-        tm->entry_pool[i].prev_in_task = -1;
-        tm->entry_pool[i].producer_task_id = -1;
+        entry_pool[i].bucket_index = -1;
+        entry_pool[i].next_in_bucket = nullptr;
+        entry_pool[i].prev_in_bucket = nullptr;
+        entry_pool[i].next_in_task = nullptr;
+        entry_pool[i].prev_in_task = nullptr;
+        entry_pool[i].producer_task_id = -1;
     }
 
     // Allocate per-task entry tracking
-    tm->task_entry_head = (int32_t*)malloc(PTO2_TASK_WINDOW_SIZE * sizeof(int32_t));
-    if (!tm->task_entry_head) {
-        free(tm->entry_pool);
-        free(tm->buckets);
-        free(tm->free_entry_list);
-        tm->entry_pool = NULL;
-        tm->buckets = NULL;
-        tm->free_entry_list = NULL;
+    task_entry_head = (PTO2TensorMapEntry**)malloc(new_pool_size * sizeof(PTO2TensorMapEntry*));
+    if (!task_entry_head) {
+        free(entry_pool);
+        free(buckets);
+        free(free_entry_list);
+        entry_pool = NULL;
+        buckets = NULL;
+        free_entry_list = NULL;
         return false;
     }
 
     // Initialize all task entry heads to -1 (no entries)
     for (int32_t i = 0; i < PTO2_TASK_WINDOW_SIZE; i++) {
-        tm->task_entry_head[i] = -1;
+        task_entry_head[i] = nullptr;
     }
 
-    tm->last_task_alive = 0;
+    last_task_alive = 0;
 
     return true;
 }
 
-bool pto2_tensormap_init_default(PTO2TensorMap* tm) {
-    return pto2_tensormap_init(tm, PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE);
+bool PTO2TensorMap::init_default() {
+    return init(PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE);
 }
 
-void pto2_tensormap_destroy(PTO2TensorMap* tm) {
-    if (tm->buckets) {
-        free(tm->buckets);
-        tm->buckets = NULL;
+void PTO2TensorMap::destroy() {
+    if (buckets) {
+        free(buckets);
+        buckets = NULL;
     }
 
-    if (tm->entry_pool) {
-        free(tm->entry_pool);
-        tm->entry_pool = NULL;
+    if (entry_pool) {
+        free(entry_pool);
+        entry_pool = NULL;
     }
 
-    if (tm->task_entry_head) {
-        free(tm->task_entry_head);
-        tm->task_entry_head = NULL;
+    if (task_entry_head) {
+        free(task_entry_head);
+        task_entry_head = NULL;
+    }
+
+    if (free_entry_list) {
+        free(free_entry_list);
+        free_entry_list = NULL;
     }
 }
 
-void pto2_tensormap_reset(PTO2TensorMap* tm) {
+void PTO2TensorMap::reset() {
     // Reset all buckets to empty
-    for (int32_t i = 0; i < tm->num_buckets; i++) {
-        tm->buckets[i] = -1;
+    for (int32_t i = 0; i < num_buckets; i++) {
+        buckets[i] = nullptr;
     }
 
     // Reset all entries
-    for (int32_t i = 0; i < tm->pool_size; i++) {
-        tm->entry_pool[i].in_bucket = false;
-        tm->entry_pool[i].next_in_bucket = -1;
-        tm->entry_pool[i].prev_in_bucket = -1;
-        tm->entry_pool[i].next_in_task = -1;
-        tm->entry_pool[i].prev_in_task = -1;
-        tm->entry_pool[i].producer_task_id = -1;
+    for (int32_t i = 0; i < pool_size; i++) {
+        entry_pool[i].bucket_index = -1;
+        entry_pool[i].next_in_bucket = nullptr;
+        entry_pool[i].prev_in_bucket = nullptr;
+        entry_pool[i].next_in_task = nullptr;
+        entry_pool[i].prev_in_task = nullptr;
+        entry_pool[i].producer_task_id = -1;
     }
 
     // Reset per-task entry tracking
-    for (int32_t i = 0; i < PTO2_TASK_WINDOW_SIZE; i++) {
-        tm->task_entry_head[i] = -1;
+    for (int32_t i = 0; i < pool_size; i++) {
+        task_entry_head[i] = nullptr;
     }
 
-    tm->next_entry_idx = 0;
-    tm->free_num = 0;
-    tm->last_task_alive = 0;
-}
-
-// =============================================================================
-// Hash Function
-// =============================================================================
-
-uint32_t pto2_tensormap_hash(PTO2TensorMap* tm, const Tensor& tensor) {
-    // ========================================================================
-    // CRITICAL: Hash ONLY by base_ptr for correct overlap detection!
-    // ========================================================================
-    //
-    // For overlap detection to work, ALL regions accessing the same base
-    // tensor MUST be in the SAME hash bucket. This allows lookup to find
-    // and check all potentially overlapping regions.
-    //
-    // If we included offset in the hash, overlapping regions with different
-    // offsets would end up in different buckets and never be compared:
-    //   Region A: base=X, offset=0   → bucket 5
-    //   Region B: base=X, offset=128 → bucket 12  (WRONG! Can't detect overlap)
-    //
-    // With base_ptr-only hash:
-    //   Region A: base=X, offset=0   → bucket 5
-    //   Region B: base=X, offset=128 → bucket 5   (CORRECT! Same bucket)
-    //
-    uint64_t key = (uint64_t)(uintptr_t)tensor.data().buffer.addr;
-
-    // Improve distribution by mixing bits (pointers often have aligned low bits)
-    key = key ^ (key >> 16);
-    key = key ^ (key >> 32);
-
-    // Use bitwise AND for power-of-2 modulo (faster than %)
-    return (uint32_t)(key & (tm->num_buckets - 1));
-}
-
-// =============================================================================
-// Validity and Cleanup
-// =============================================================================
-
-void pto2_tensormap_sync_validity(PTO2TensorMap* tm, int32_t last_task_alive) { tm->last_task_alive = last_task_alive; }
-
-void pto2_tensormap_remove_entry(PTO2TensorMap& tm, int32_t entry_idx) {
-    pto2_tensormap_remove_from_task(&tm, entry_idx);
-    tm.free_entry(entry_idx);
-}
-
-void pto2_tensormap_remove_from_task(PTO2TensorMap* tm, int32_t entry_idx) {
-    auto entry = &tm->entry_pool[entry_idx];
-    // Update predecessor's next pointer (O(1) via prev_in_task)
-    if (entry->prev_in_task == -1) {
-        // Entry is the head of its task chain, update task_entry_head
-        int32_t task_slot = entry->producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
-        tm->task_entry_head[task_slot] = entry->next_in_task;
-    } else {
-        tm->entry_pool[entry->prev_in_task].next_in_task = entry->next_in_task;
-    }
-
-    // Update successor's prev pointer
-    if (entry->next_in_task >= 0) {
-        tm->entry_pool[entry->next_in_task].prev_in_task = entry->prev_in_task;
-    }
-
-    entry->next_in_task = -1;
-    entry->prev_in_task = -1;
-}
-
-void pto2_tensormap_cleanup_retired(PTO2TensorMap* tm, int32_t old_last_task_alive, int32_t new_last_task_alive) {
-    // Iterate through retired tasks and remove their entries from bucket chains
-    for (int32_t task_id = old_last_task_alive; task_id < new_last_task_alive; task_id++) {
-        int32_t task_slot = task_id & (PTO2_TASK_WINDOW_SIZE - 1);
-        int32_t offset = tm->task_entry_head[task_slot];
-
-        while (offset >= 0) {
-            PTO2TensorMapEntry* entry = &tm->entry_pool[offset];
-            int32_t next = entry->next_in_task;  // Save before clearing
-            // Only remove if this entry belongs to the retiring task
-            // (slot may have been reused by a newer task)
-            if (entry->producer_task_id == task_id) {
-                // Clear task chain pointers (entire chain is being destroyed)
-                tm->free_entry(offset);
-            }
-            offset = next;
-        }
-
-        // Clear task's entry head (slot will be reused by task_id + TASK_WINDOW_SIZE)
-        tm->task_entry_head[task_slot] = -1;
-    }
-}
-
-// =============================================================================
-// Lookup with Chain Truncation
-// =============================================================================
-
-void pto2_tensormap_lookup(PTO2TensorMap* tm, const Tensor &tensor, PTO2LookupResult* result) {
-    uint32_t bucket = pto2_tensormap_hash(tm, tensor);
-    int32_t* prev_ptr = &tm->buckets[bucket];  // For truncation
-    int32_t offset = *prev_ptr;
-
-    result->count = 0;
-#if PTO2_ORCH_PROFILING
-    int32_t chain_len = 0;
-#endif
-
-    while (offset >= 0) {
-        PTO2TensorMapEntry* entry = &tm->entry_pool[offset];
-
-        // Check validity first
-        if (!pto2_tensormap_entry_valid(tm, entry)) {
-            // ========== STALE ENTRY: Truncate chain here ==========
-            // All subsequent entries are guaranteed to be stale too!
-            // Truncate: unlink this and all following entries
-            *prev_ptr = -1;  // Terminate chain at previous entry
-
-            // Mark truncated entries as not in bucket (for correct reuse)
-            while (offset >= 0) {
-                PTO2TensorMapEntry* stale = &tm->entry_pool[offset];
-                int32_t next = stale->next_in_bucket;
-                stale->in_bucket = false;
-                stale->next_in_bucket = -1;
-                stale->prev_in_bucket = -1;
-                offset = next;
-            }
-
-#if PTO2_ORCH_PROFILING
-            g_lookup_chain_total += chain_len;
-            g_lookup_count++;
-            if (chain_len > g_lookup_chain_max) g_lookup_chain_max = chain_len;
-#endif
-            return;
-        }
-
-#if PTO2_ORCH_PROFILING
-        chain_len++;
-        g_lookup_overlap_checks++;
-#endif
-        // Entry is valid - check if regions OVERLAP (not just exact match)
-        // Since we hash only by base_ptr, all entries in this bucket have
-        // potential to overlap. We must check actual byte-range overlap.
-        auto overlap_status = tensor.is_overlap(entry->tensor);
-        if (overlap_status != OverlapStatus::NO_OVERLAP) {
-            result->push(offset, overlap_status);
-#if PTO2_ORCH_PROFILING
-            g_lookup_overlap_hits++;
-#endif
-        }
-
-        // Move to next entry
-        prev_ptr = &entry->next_in_bucket;
-        offset = *prev_ptr;
-    }
-
-#if PTO2_ORCH_PROFILING
-    g_lookup_chain_total += chain_len;
-    g_lookup_count++;
-    if (chain_len > g_lookup_chain_max) g_lookup_chain_max = chain_len;
-#endif
-}
-
-int32_t PTO2TensorMap::new_entry() {
-    if (free_num > 0) {
-        int32_t res = free_entry_list[--free_num];
-        debug_assert(!entry_pool[res].in_bucket);
-        return res;
-    }
-    if (next_entry_idx < pool_size) {
-        int32_t res = next_entry_idx++;
-        debug_assert(!entry_pool[res].in_bucket);
-        return res;
-    }
-
-    size_t wait_count = 0;
-    while (free_num == 0) {
-        pto2_orchestrator_sync_tensormap(this, true);
-        always_assert(wait_count++ <= 1000000000UL);
-    }
-    debug_assert(free_num > 0);
-    int32_t res = free_entry_list[--free_num];
-    debug_assert(!entry_pool[res].in_bucket);
-    return res;
-}
-
-void PTO2TensorMap::free_entry(int32_t entry_idx) {
-    auto entry = &entry_pool[entry_idx];
-    if (!entry->in_bucket) {
-        return;  // Already removed
-    }
-
-    // Update predecessor's next pointer (O(1) via prev_in_bucket)
-    if (entry->prev_in_bucket == -1) {
-        // Entry is the head of its bucket chain, update bucket head
-        // Must compute hash BEFORE clearing tensor (tensor.data() needs valid tensor_pool)
-        uint32_t bucket = pto2_tensormap_hash(this, entry->tensor);
-        buckets[bucket] = entry->next_in_bucket;
-    } else {
-        entry_pool[entry->prev_in_bucket].next_in_bucket = entry->next_in_bucket;
-    }
-
-    // Update successor's prev pointer
-    if (entry->next_in_bucket >= 0) {
-        entry_pool[entry->next_in_bucket].prev_in_bucket = entry->prev_in_bucket;
-    }
-
-    // Clear tensor AFTER bucket chain manipulation (hash computation needs valid tensor)
-    entry->tensor = Tensor();
-
-    free_entry_list[free_num++] = entry_idx;
-    entry->in_bucket = false;
-    entry->next_in_bucket = -1;
-    entry->prev_in_bucket = -1;
-    entry->next_in_task = -1;
-    entry->prev_in_task = -1;
-}
-
-// =============================================================================
-// Insert
-// =============================================================================
-
-void pto2_tensormap_insert(PTO2TensorMap* tm, const Tensor& tensor, int32_t producer_task_id, bool with_alloc) {
-#if PTO2_ORCH_PROFILING
-    g_insert_count++;
-#endif
-    // Allocate entry from ring buffer pool
-    int32_t entry_offset = tm->new_entry();
-    PTO2TensorMapEntry* entry = &tm->entry_pool[entry_offset];
-
-    // Initialize new entry
-    entry->tensor = tensor;
-    entry->producer_task_id = producer_task_id;
-    entry->with_alloc = with_alloc;
-
-    // Insert at head of hash bucket (maintains task_id descending order)
-    uint32_t bucket = pto2_tensormap_hash(tm, tensor);
-    entry->next_in_bucket = tm->buckets[bucket];
-    entry->prev_in_bucket = -1;  // New head has no predecessor
-    // Update old head's prev pointer
-    if (entry->next_in_bucket >= 0) {
-        tm->entry_pool[entry->next_in_bucket].prev_in_bucket = entry_offset;
-    }
-    tm->buckets[bucket] = entry_offset;
-    entry->in_bucket = true;
-
-    // Link to task's entry list (for cleanup)
-    int32_t task_slot = producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
-    entry->next_in_task = tm->task_entry_head[task_slot];
-    entry->prev_in_task = -1;  // New head has no predecessor
-    // Update old head's prev pointer
-    if (entry->next_in_task >= 0) {
-        tm->entry_pool[entry->next_in_task].prev_in_task = entry_offset;
-    }
-    tm->task_entry_head[task_slot] = entry_offset;
+    next_entry_idx = 0;
+    free_num = 0;
+    last_task_alive = 0;
 }
 
 // =============================================================================
 // Debug Utilities
 // =============================================================================
 
-void pto2_tensormap_print_stats(PTO2TensorMap* tm) {
+void PTO2TensorMap::print_stats() {
     int32_t valid = 0;
     int32_t stale = 0;
     int32_t empty_buckets = 0;
@@ -421,9 +176,9 @@ void pto2_tensormap_print_stats(PTO2TensorMap* tm) {
     int32_t non_empty_buckets = 0;
 
     // Count entries
-    for (int32_t i = 0; i < tm->pool_size; i++) {
-        if (tm->entry_pool[i].in_bucket) {
-            if (pto2_tensormap_entry_valid(tm, &tm->entry_pool[i])) {
+    for (int32_t i = 0; i < pool_size; i++) {
+        if (entry_pool[i].bucket_index != -1) {
+            if (entry_valid(entry_pool[i])) {
                 valid++;
             } else {
                 stale++;
@@ -432,13 +187,13 @@ void pto2_tensormap_print_stats(PTO2TensorMap* tm) {
     }
 
     // Count bucket stats
-    for (int32_t b = 0; b < tm->num_buckets; b++) {
+    for (int32_t b = 0; b < num_buckets; b++) {
         int32_t chain_len = 0;
-        int32_t offset = tm->buckets[b];
+        auto cur_entry = buckets[b];
 
-        while (offset >= 0) {
+        while (cur_entry != nullptr) {
             chain_len++;
-            offset = tm->entry_pool[offset].next_in_bucket;
+            cur_entry = cur_entry->next_in_bucket;
         }
 
         if (chain_len == 0) {
@@ -453,24 +208,24 @@ void pto2_tensormap_print_stats(PTO2TensorMap* tm) {
     }
 
     LOG_INFO("=== TensorMap Statistics ===");
-    LOG_INFO("Pool size:           %d", tm->pool_size);
-    LOG_INFO("Pool next entry idx: %d", tm->next_entry_idx);
-    LOG_INFO("Pool free_num:       %d", tm->free_num);
-    LOG_INFO("Num buckets:         %d", tm->num_buckets);
+    LOG_INFO("Pool size:           %d", pool_size);
+    LOG_INFO("Pool next entry idx: %d", next_entry_idx);
+    LOG_INFO("Pool free_num:       %d", free_num);
+    LOG_INFO("Num buckets:         %d", num_buckets);
     LOG_INFO("Valid entries:       %d", valid);
     LOG_INFO("Stale entries:       %d", stale);
     LOG_INFO("Empty buckets:       %d", empty_buckets);
     LOG_INFO("Max chain len:       %d", max_chain);
     LOG_INFO("Avg chain len:       %.2f", non_empty_buckets > 0 ? (float)total_chain / non_empty_buckets : 0);
-    LOG_INFO("Last task alive:     %d", tm->last_task_alive);
+    LOG_INFO("Last task alive:     %d", last_task_alive);
     LOG_INFO("============================");
 }
 
-int32_t pto2_tensormap_valid_count(PTO2TensorMap* tm) {
+int32_t PTO2TensorMap::valid_count() {
     int32_t count = 0;
 
-    for (int32_t i = 0; i < tm->pool_size; i++) {
-        if (tm->entry_pool[i].in_bucket && pto2_tensormap_entry_valid(tm, &tm->entry_pool[i])) {
+    for (int32_t i = 0; i < pool_size; i++) {
+        if (entry_pool[i].bucket_index != -1 && entry_valid(entry_pool[i])) {
             count++;
         }
     }
@@ -478,22 +233,19 @@ int32_t pto2_tensormap_valid_count(PTO2TensorMap* tm) {
     return count;
 }
 
-// =============================================================================
-// TensorMap Synchronization
-// =============================================================================
-
-void pto2_orchestrator_sync_tensormap(PTO2TensorMap* tm, bool force) {
-    always_assert(tm->orch != nullptr);
-    // Read current last_task_alive from shared memory
-    int32_t new_last_task_alive = PTO2_LOAD_ACQUIRE(&tm->orch->sm_handle->header->last_task_alive);
-
-    // Update TensorMap validity threshold
-    pto2_tensormap_sync_validity(tm, new_last_task_alive);
-
-    // Periodically cleanup TensorMap to remove stale entries from bucket chains
-    if (force || (new_last_task_alive - tm->orch->tensormap_last_cleanup >= PTO2_TENSORMAP_CLEANUP_INTERVAL)) {
-        pto2_tensormap_cleanup_retired(tm, tm->orch->tensormap_last_cleanup, new_last_task_alive);
-        tm->orch->tensormap_last_cleanup = new_last_task_alive;
+void PTO2TensorMap::sync_tensormap() {
+    constexpr int MIN_FREE_NUM = 1024;
+    always_assert(orch != nullptr);
+    while(true) {
+        // Read current last_task_alive from shared memory
+        int32_t new_last_task_alive = PTO2_LOAD_ACQUIRE(&orch->sm_handle->header->last_task_alive);
+        sync_validity(new_last_task_alive);
+        if ((pool_size - next_entry_idx + free_num < MIN_FREE_NUM) || new_last_task_alive - orch->tensormap_last_cleanup >= PTO2_TENSORMAP_CLEANUP_INTERVAL) {
+            cleanup_retired(orch->tensormap_last_cleanup, new_last_task_alive);
+            orch->tensormap_last_cleanup = new_last_task_alive;
+        } else {
+            break;
+        }
     }
 }
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -30,9 +30,9 @@
  * Based on: docs/runtime_buffer_manager_methods.md
  */
 
-#ifndef PTO_TENSORMAP_H
-#define PTO_TENSORMAP_H
+#pragma once
 
+#include "common.h"
 #include "pto_runtime2_types.h"
 #include "tensor.h"
 
@@ -56,15 +56,38 @@ struct PTO2OrchestratorState;  // forward declare
  * - When lookup hits stale entry, truncate rest of chain
  */
 struct PTO2TensorMapEntry {
-    Tensor tensor;             // Tensor descriptor key
-    int32_t producer_task_id;  // Task that produces this region
-    int32_t next_in_bucket;    // Offset to next entry in hash bucket (-1 = end)
-    int32_t prev_in_bucket;    // Offset to prev entry in hash bucket (-1 = head is buckets[bucket])
-    int32_t next_in_task;      // Offset to next entry for same task (-1 = end)
-    int32_t prev_in_task;      // Offset to prev entry for same task (-1 = head is task_entry_head[slot])
-    bool in_bucket;            // True if entry is linked in a bucket chain
-                               // CRITICAL: Must be set false before overwriting!
     bool with_alloc{true};     // True if entry is task output, False if entry is task inout
+    int32_t producer_task_id;  // Task that produces this region
+    PTO2TensorMapEntry* next_in_bucket;    // Offset to next entry in hash bucket (-1 = end)
+    PTO2TensorMapEntry* prev_in_bucket;    // Offset to prev entry in hash bucket (-1 = head is buckets[bucket])
+    PTO2TensorMapEntry* next_in_task;      // Offset to next entry for same task (-1 = end)
+    PTO2TensorMapEntry* prev_in_task;      // Offset to prev entry for same task (-1 = head is task_entry_head[slot])
+    int32_t bucket_index;      // != -1 if entry is linked in a bucket chain
+                               // CRITICAL: Must be set -1 before overwriting!
+    uint64_t addr;
+    Tensor tensor;             // Tensor descriptor key
+};
+
+/**
+ * Stack-allocated lookup result (avoids heap allocation per lookup)
+ */
+#define PTO2_LOOKUP_MAX_RESULTS 16
+// =============================================================================
+// TensorMap Lookup Chain Length Statistics (compile-time toggle)
+// =============================================================================
+struct PTO2LookupResult {
+    struct Entry {
+        PTO2TensorMapEntry* entry;
+        OverlapStatus overlap_status;
+    };
+    Entry entries[PTO2_LOOKUP_MAX_RESULTS];
+    int32_t count{0};
+
+    void push(PTO2TensorMapEntry* entry, OverlapStatus s) {
+        if (count < PTO2_LOOKUP_MAX_RESULTS) {
+            entries[count++] = {entry, s};
+        }
+    }
 };
 
 /**
@@ -74,18 +97,18 @@ struct PTO2TensorMapEntry {
  */
 struct PTO2TensorMap {
     // Hash table buckets (fixed size, power of 2)
-    int32_t* buckets;     // Array of offsets into entry_pool (-1 = empty)
+    PTO2TensorMapEntry** buckets;     // Array of offsets into entry_pool (-1 = empty)
     int32_t num_buckets;  // Must be power of 2 for fast modulo
 
     // Entry pool as ring buffer
     PTO2TensorMapEntry* entry_pool;  // Ring buffer of entries
-    int32_t* free_entry_list;        // free entry ids
+    PTO2TensorMapEntry** free_entry_list;        // free entry ids
     int32_t pool_size;               // Total pool capacity
-    int32_t next_entry_idx;               // id when next entry insert
+    int32_t next_entry_idx;          // id when next entry insert
     int32_t free_num;                // free entry number in entry pool
 
     // Per-task entry tracking (for efficient bucket cleanup)
-    int32_t* task_entry_head;  // Per-task head offset (-1 = no entries)
+    PTO2TensorMapEntry** task_entry_head;  // Per-task head offset (-1 = no entries)
                                // Indexed by task_id % TASK_WINDOW_SIZE
 
     // Validity threshold (for lazy invalidation)
@@ -93,155 +116,283 @@ struct PTO2TensorMap {
 
     PTO2OrchestratorState* orch{nullptr};
 
-    int32_t new_entry();
-    void free_entry(int32_t entry_idx);
-};
+    // new_entry目前不负责分配属性，仅分配内存
+    PTO2TensorMapEntry* new_entry() {
+        if (free_num > 0) {
+            PTO2TensorMapEntry* res = free_entry_list[--free_num];
+            debug_assert(res->bucket_index == -1);
+            return res;
+        }
+        always_assert(next_entry_idx < pool_size);
+        PTO2TensorMapEntry* res = &entry_pool[next_entry_idx++];
+        debug_assert(res->bucket_index == -1);
+        return res;
+    }
 
-// =============================================================================
-// TensorMap API
-// =============================================================================
+    void free_entry(PTO2TensorMapEntry& entry) {
+        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
 
-/**
- * Initialize TensorMap
- *
- * @param tm          TensorMap to initialize
- * @param num_buckets Number of hash buckets (must be power of 2)
- * @param pool_size   Size of entry pool
- * @return true on success, false on allocation failure
- */
-bool pto2_tensormap_init(PTO2TensorMap* tm, int32_t num_buckets, int32_t pool_size);
+        // Update predecessor's next pointer (O(1) via prev_in_bucket)
+        if (entry.prev_in_bucket == nullptr) {
+            // Entry is the head of its bucket chain, update bucket head
+            // Must compute hash BEFORE clearing tensor (tensor.data() needs valid tensor_pool)
+            buckets[entry.bucket_index] = entry.next_in_bucket;
+        } else {
+            entry.prev_in_bucket->next_in_bucket = entry.next_in_bucket;
+        }
 
-/**
- * Initialize TensorMap with default sizes
- */
-bool pto2_tensormap_init_default(PTO2TensorMap* tm);
+        // Update successor's prev pointer
+        if (entry.next_in_bucket != nullptr) {
+            entry.next_in_bucket->prev_in_bucket = entry.prev_in_bucket;
+        }
 
-/**
- * Destroy TensorMap and free resources
- */
-void pto2_tensormap_destroy(PTO2TensorMap* tm);
+        // Clear tensor AFTER bucket chain manipulation (hash computation needs valid tensor)
+        entry.tensor = Tensor();
 
-/**
- * Reset TensorMap to empty state
- */
-void pto2_tensormap_reset(PTO2TensorMap* tm);
+        free_entry_list[free_num++] = &entry;
+        entry.bucket_index = -1;
+        entry.next_in_bucket = nullptr;
+        entry.prev_in_bucket = nullptr;
+        entry.next_in_task = nullptr;
+        entry.prev_in_task = nullptr;
+    }
 
-/**
- * Update validity threshold from shared memory
- * Called periodically to refresh the lazy invalidation threshold.
- *
- * @param tm               TensorMap
- * @param last_task_alive  Current value from shared memory
- */
-void pto2_tensormap_sync_validity(PTO2TensorMap* tm, int32_t last_task_alive);
+    // =============================================================================
+    // TensorMap API
+    // =============================================================================
 
-/**
- * Stack-allocated lookup result (avoids heap allocation per lookup)
- */
-#define PTO2_LOOKUP_MAX_RESULTS 16
-struct PTO2LookupResult {
-    struct Entry {
-        int32_t entry_idx;
-        OverlapStatus overlap_status;
-    };
-    Entry entries[PTO2_LOOKUP_MAX_RESULTS];
-    int32_t count{0};
+    /**
+     * Initialize TensorMap
+     *
+     * @param num_buckets Number of hash buckets (must be power of 2)
+     * @param pool_size   Size of entry pool
+     * @return true on success, false on allocation failure
+     */
+    bool init(int32_t num_buckets, int32_t pool_size);
 
-    void push(int32_t entry_idx, OverlapStatus s) {
-        if (count < PTO2_LOOKUP_MAX_RESULTS) {
-            entries[count++] = {entry_idx, s};
+    /**
+     * Initialize TensorMap with default sizes
+     */
+    bool init_default();
+
+    /**
+     * Destroy TensorMap and free resources
+     */
+    void destroy();
+
+    /**
+     * Reset TensorMap to empty state
+     */
+    void reset();
+
+    /**
+     * Update validity threshold from shared memory
+     * Called periodically to refresh the lazy invalidation threshold.
+     *
+     * @param last_task_alive  Current value from shared memory
+     */
+    void sync_validity(int32_t last_task_alive) { this->last_task_alive = last_task_alive; }
+
+    /**
+     * Lookup producer for a tensor region
+     *
+     * Searches the hash table for a matching region.
+     * Returns producer entry if found and valid.
+     *
+     * Chain truncation: When first stale entry is found, truncates
+     * the rest of the chain (all subsequent entries are also stale).
+     *
+     * @param tensor  Tensor to look up
+     * @param result  Output: stack-allocated result buffer
+     */
+    void lookup(const Tensor& tensor, PTO2LookupResult& result) {
+        auto& query_tensor_data = tensor.data();
+        uint32_t bucket_index = hash(query_tensor_data.buffer.addr);
+        PTO2TensorMapEntry** prev_ptr = &buckets[bucket_index];  // For truncation
+        PTO2TensorMapEntry* cur_entry = *prev_ptr;
+
+        result.count = 0;
+
+        while (cur_entry != nullptr) {
+            // Check validity first
+            if (!entry_valid(*cur_entry)) {
+                // ========== STALE ENTRY: Truncate chain here ==========
+                // All subsequent entries are guaranteed to be stale too!
+                // Truncate: unlink this and all following entries
+                *prev_ptr = nullptr;  // Terminate chain at previous entry
+
+                // Mark truncated entries as not in bucket (for correct reuse)
+                while (cur_entry != nullptr) {
+                    PTO2TensorMapEntry* next_entry = cur_entry->next_in_bucket;
+                    remove_entry(*cur_entry);
+                    cur_entry = next_entry;
+                }
+                return;
+            }
+
+            // Entry is valid - check if regions OVERLAP (not just exact match)
+            // Since we hash only by base_ptr, all entries in this bucket have
+            // potential to overlap. We must check actual byte-range overlap.
+            if (query_tensor_data.buffer.addr == cur_entry->addr) {
+                auto overlap_status = query_tensor_data.is_overlap(cur_entry->tensor.data());
+                if (overlap_status != OverlapStatus::NO_OVERLAP) {
+                    result.push(cur_entry, overlap_status);
+                }
+            }
+
+            // Move to next entry
+            prev_ptr = &cur_entry->next_in_bucket;
+            cur_entry = *prev_ptr;
         }
     }
+
+    /**
+     * Insert a new entry (called when task produces output)
+     *
+     * Allocates from ring buffer pool, may overwrite stale entries.
+     * Inserts at head of hash bucket chain (maintains task_id ordering).
+     *
+     * @param tensor            Tensor produced
+     * @param producer_task_id  Task ID of producer
+     */
+    void insert(const Tensor& tensor, int32_t producer_task_id, bool with_alloc) {
+        // Allocate entry from ring buffer pool
+        PTO2TensorMapEntry* entry = new_entry();
+
+        // Initialize new entry
+        entry->tensor = tensor;
+        entry->producer_task_id = producer_task_id;
+        entry->with_alloc = with_alloc;
+
+        // Insert at head of hash bucket (maintains task_id descending order)
+        entry->addr = tensor.data().buffer.addr;
+        entry->bucket_index = hash(entry->addr);
+        entry->next_in_bucket = buckets[entry->bucket_index];
+        // Update old head's prev pointer
+        if (entry->next_in_bucket != nullptr) {
+            entry->next_in_bucket->prev_in_bucket = entry;
+        }
+        buckets[entry->bucket_index] = entry;
+        entry->prev_in_bucket = nullptr;  // New head has no predecessor
+
+        // Link to task's entry list (for cleanup)
+        int32_t task_slot = producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+        entry->next_in_task = task_entry_head[task_slot];
+        entry->prev_in_task = nullptr;  // New head has no predecessor
+        // Update old head's prev pointer
+        if (entry->next_in_task != nullptr) {
+            entry->next_in_task->prev_in_task = entry;
+        }
+        task_entry_head[task_slot] = entry;
+    }
+
+    /**
+     * Cleanup stale entries for retired tasks
+     *
+     * Called periodically by Orchestrator when last_task_alive advances.
+     * Removes entries from bucket chains for tasks in [old, new) range.
+     *
+     * @param old_last_task_alive  Previous threshold
+     * @param new_last_task_alive  New threshold
+     */
+    void cleanup_retired(int32_t old_last_task_alive, int32_t new_last_task_alive) {
+        // Iterate through retired tasks and remove their entries from bucket chains
+        for (int32_t task_id = old_last_task_alive; task_id < new_last_task_alive; task_id++) {
+            int32_t task_slot = task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+            PTO2TensorMapEntry* cur_entry = task_entry_head[task_slot];
+
+            while (cur_entry != nullptr) {
+                PTO2TensorMapEntry* next_entry = cur_entry->next_in_task;  // Save before clearing
+                // Only remove if this entry belongs to the retiring task
+                // (slot may have been reused by a newer task)
+                debug_assert(cur_entry->producer_task_id == task_id);
+                free_entry(*cur_entry);
+                cur_entry = next_entry;
+            }
+
+            // Clear task's entry head (slot will be reused by task_id + TASK_WINDOW_SIZE)
+            task_entry_head[task_slot] = nullptr;
+        }
+    }
+
+    // =============================================================================
+    // Internal Helpers (exposed for testing)
+    // =============================================================================
+
+    /**
+     * Compute hash for tensor addr
+     */
+    uint32_t hash(uint64_t key) {
+        // Improve distribution by mixing bits (pointers often have aligned low bits)
+        key = key ^ (key >> 16);
+        key = key ^ (key >> 32);
+
+        // Use bitwise AND for power-of-2 modulo (faster than %)
+        return (uint32_t)(key & (num_buckets - 1));
+    }
+
+    /**
+     * Check if entry is valid (producer has not retired)
+     */
+    bool entry_valid(const PTO2TensorMapEntry& entry) const {
+        return entry.producer_task_id >= last_task_alive;
+    }
+
+    void remove_entry(PTO2TensorMapEntry& entry) {
+        remove_from_task(entry);
+        free_entry(entry);
+    }
+
+    /**
+     * Remove entry from its task chain (O(1) with prev pointer)
+     * Called during pool wrap-around to unlink reused entries.
+     */
+    void remove_from_task(PTO2TensorMapEntry& entry) {
+        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+        // Update predecessor's next pointer (O(1) via prev_in_task)
+        if (entry.prev_in_task == nullptr) {
+            // Entry is the head of its task chain, update task_entry_head
+            int32_t task_slot = entry.producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+            task_entry_head[task_slot] = entry.next_in_task;
+        } else {
+            entry.prev_in_task->next_in_task = entry.next_in_task;
+        }
+
+        // Update successor's prev pointer
+        if (entry.next_in_task != nullptr) {
+            entry.next_in_task->prev_in_task = entry.prev_in_task;
+        }
+
+        entry.next_in_task = nullptr;
+        entry.prev_in_task = nullptr;
+    }
+
+    // =============================================================================
+    // Debug Utilities
+    // =============================================================================
+
+    /**
+     * Print TensorMap statistics
+     */
+    void print_stats();
+
+    /**
+     * Get count of valid entries
+     */
+    int32_t valid_count();
+
+    // =============================================================================
+    // TensorMap Synchronization
+    // =============================================================================
+
+    /**
+     * Sync TensorMap validity threshold from shared memory
+     *
+     * Called periodically to refresh the lazy invalidation threshold.
+     * Also triggers cleanup if threshold has advanced significantly.
+     */
+    void sync_tensormap();
 };
-
-/**
- * Lookup producer for a tensor region
- *
- * Searches the hash table for a matching region.
- * Returns producer entry if found and valid.
- *
- * Chain truncation: When first stale entry is found, truncates
- * the rest of the chain (all subsequent entries are also stale).
- *
- * @param tm      TensorMap
- * @param tensor  Tensor to look up
- * @param result  Output: stack-allocated result buffer
- */
-void pto2_tensormap_lookup(PTO2TensorMap* tm, const Tensor& tensor, PTO2LookupResult* result);
-
-/**
- * Insert a new entry (called when task produces output)
- *
- * Allocates from ring buffer pool, may overwrite stale entries.
- * Inserts at head of hash bucket chain (maintains task_id ordering).
- *
- * @param tm                TensorMap
- * @param tensor            Tensor produced
- * @param producer_task_id  Task ID of producer
- */
-void pto2_tensormap_insert(PTO2TensorMap* tm, const Tensor& tensor, int32_t producer_task_id, bool with_alloc);
-
-/**
- * Cleanup stale entries for retired tasks
- *
- * Called periodically by Orchestrator when last_task_alive advances.
- * Removes entries from bucket chains for tasks in [old, new) range.
- *
- * @param tm                   TensorMap
- * @param old_last_task_alive  Previous threshold
- * @param new_last_task_alive  New threshold
- */
-void pto2_tensormap_cleanup_retired(PTO2TensorMap* tm, int32_t old_last_task_alive, int32_t new_last_task_alive);
-
-// =============================================================================
-// Internal Helpers (exposed for testing)
-// =============================================================================
-
-/**
- * Compute hash for tensor region
- */
-uint32_t pto2_tensormap_hash(PTO2TensorMap* tm, Tensor* tensor);
-
-/**
- * Check if entry is valid (producer has not retired)
- */
-static inline bool pto2_tensormap_entry_valid(PTO2TensorMap* tm, PTO2TensorMapEntry* entry) {
-    return entry->producer_task_id >= tm->last_task_alive;
-}
-
-void pto2_tensormap_remove_entry(PTO2TensorMap& tm, int32_t entry_idx);
-
-/**
- * Remove entry from its task chain (O(1) with prev pointer)
- * Called during pool wrap-around to unlink reused entries.
- */
-void pto2_tensormap_remove_from_task(PTO2TensorMap* tm, int32_t entry_idx);
-
-// =============================================================================
-// Debug Utilities
-// =============================================================================
-
-/**
- * Print TensorMap statistics
- */
-void pto2_tensormap_print_stats(PTO2TensorMap* tm);
-
-/**
- * Get count of valid entries
- */
-int32_t pto2_tensormap_valid_count(PTO2TensorMap* tm);
-
-// =============================================================================
-// TensorMap Synchronization
-// =============================================================================
-
-/**
- * Sync TensorMap validity threshold from shared memory
- *
- * Called periodically to refresh the lazy invalidation threshold.
- * Also triggers cleanup if threshold has advanced significantly.
- */
-void pto2_orchestrator_sync_tensormap(PTO2TensorMap* tm, bool force = false);
 
 // =============================================================================
 // TensorMap Lookup Profiling
@@ -262,5 +413,3 @@ struct PTO2TensorMapProfilingData {
 
 PTO2TensorMapProfilingData pto2_tensormap_get_profiling();
 #endif
-
-#endif  // PTO_TENSORMAP_H


### PR DESCRIPTION
## Summary
- Convert TensorMap free functions to C++ member methods (`init_default`, `destroy`, `reset`, `lookup`, `insert`, `remove_entry`, `sync_tensormap`, `valid_count`)
- Replace index-based entry access with pointer-based API (`entry_idx` → `PTO2TensorMapEntry*`) for simpler call sites
- Inline hot-path methods (`lookup`, `insert`, `hash`, `new_entry`) into the header for better codegen
- Convert `pto2_alloc_packed_buffer` from free function to `PTO2OrchestratorState` member method
- Remove unused `output_index`/`num_outputs` fields from `PTO2TaskDescriptor`
- Simplify `TensorPool` overlap detection with early-return and set `ref_count=1` in `init()`

## Testing
- [x] Simulation tests pass (`./ci.sh -p a2a3sim` — 10/10)
- [ ] Hardware tests pass (if applicable)