### PR TITLE
Support: add PTO-ISA commit pinning via -c flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,15 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Run simulation examples
+        id: sim
         run: ./ci.sh -p a2a3sim
+        continue-on-error: true
+
+      - name: Retry sim with pinned PTO-ISA on failure
+        if: steps.sim.outcome == 'failure'
+        run: |
+          rm -rf examples/scripts/_deps/pto-isa
+          ./ci.sh -p a2a3sim --pto-isa-commit 1b22fea
 
   run-example-on-device:
     runs-on: self-hosted

--- a/ci.sh
+++ b/ci.sh
@@ -5,6 +5,7 @@ PLATFORM=""
 DEVICE_RANGE=""
 PARALLEL=false
 RUNTIME=""
+PTO_ISA_COMMIT=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -18,6 +19,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -r|--runtime)
             RUNTIME="$2"
+            shift 2
+            ;;
+        -c|--pto-isa-commit)
+            PTO_ISA_COMMIT="$2"
             shift 2
             ;;
         --parallel)
@@ -86,6 +91,12 @@ cleanup() {
 }
 trap cleanup INT TERM
 trap 'rm -rf "$LOG_DIR"' EXIT
+
+# Build commit flag for run_example.py
+commit_flag=()
+if [[ -n "$PTO_ISA_COMMIT" ]]; then
+    commit_flag=(-c "$PTO_ISA_COMMIT")
+fi
 
 # ---- Discover all tasks ----
 EXAMPLES_DIR="examples"
@@ -175,7 +186,7 @@ run_hw_task() {
         echo "========================================"
         python examples/scripts/run_example.py \
             -k "${dir}/kernels" -g "${dir}/golden.py" \
-            -p a2a3 -d "$device_id"
+            -p a2a3 -d "$device_id" "${commit_flag[@]}"
     } > "$task_log" 2>&1
     local rc=$?
     local elapsed=$(( SECONDS - start_time ))
@@ -213,7 +224,7 @@ if [[ "$PARALLEL" == "false" ]]; then
         echo "========================================"
         if python examples/scripts/run_example.py \
             -k "${dir}/kernels" -g "${dir}/golden.py" \
-            -p a2a3sim; then
+            -p a2a3sim "${commit_flag[@]}"; then
             echo "${name}:a2a3sim|PASS" >> "$RESULTS_FILE"
         else
             echo "${name}:a2a3sim|FAIL" >> "$RESULTS_FILE"
@@ -234,7 +245,7 @@ else
             echo "Running: $name (a2a3sim)"
             echo "========================================"
             if python examples/scripts/run_example.py \
-                -k "${dir}/kernels" -g "${dir}/golden.py" -p a2a3sim; then
+                -k "${dir}/kernels" -g "${dir}/golden.py" -p a2a3sim $COMMIT_FLAG; then
                 echo "${name}:a2a3sim|PASS" >> "$RESULTS_FILE"
             else
                 echo "${name}:a2a3sim|FAIL" >> "$RESULTS_FILE"

--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -153,12 +153,13 @@ def _is_git_available() -> bool:
 _PTO_ISA_REPO = "https://gitcode.com/cann/pto-isa.git"
 
 
-def _clone_pto_isa(verbose: bool = False) -> bool:
+def _clone_pto_isa(verbose: bool = False, commit: Optional[str] = None) -> bool:
     """
-    Clone pto-isa repository.
+    Clone pto-isa repository, optionally at a specific commit.
 
     Args:
         verbose: Print detailed progress information
+        commit: If provided, checkout this commit after cloning
 
     Returns:
         True if successful, False otherwise
@@ -202,8 +203,21 @@ def _clone_pto_isa(verbose: bool = False) -> bool:
                 logger.warning(f"Failed to clone pto-isa:\n{result.stderr}")
             return False
 
+        # Checkout specific commit if requested
+        if commit:
+            result = subprocess.run(
+                ["git", "checkout", commit],
+                capture_output=True, text=True,
+                cwd=str(clone_path), timeout=30
+            )
+            if result.returncode != 0:
+                if verbose:
+                    logger.warning(f"Failed to checkout pto-isa commit {commit}:\n{result.stderr}")
+                return False
+
         if verbose:
-            logger.info(f"pto-isa cloned successfully to: {clone_path}")
+            suffix = f" at commit {commit}" if commit else ""
+            logger.info(f"pto-isa cloned successfully{suffix}: {clone_path}")
 
         return True
 
@@ -217,7 +231,56 @@ def _clone_pto_isa(verbose: bool = False) -> bool:
         return False
 
 
-def _ensure_pto_isa_root(verbose: bool = False) -> Optional[str]:
+def _checkout_pto_isa_commit(clone_path: Path, commit: str, verbose: bool = False) -> None:
+    """Checkout the specified commit if the existing clone is at a different revision."""
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, cwd=str(clone_path), timeout=5
+        )
+        current = result.stdout.strip() if result.returncode == 0 else ""
+        if current and not commit.startswith(current) and not current.startswith(commit):
+            if verbose:
+                logger.info(f"pto-isa at {current}, checking out {commit}...")
+            subprocess.run(
+                ["git", "fetch", "origin"], capture_output=True, text=True,
+                cwd=str(clone_path), timeout=120, check=True
+            )
+            subprocess.run(
+                ["git", "checkout", commit], capture_output=True, text=True,
+                cwd=str(clone_path), timeout=30, check=True
+            )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        logger.warning(f"Failed to checkout pto-isa commit {commit}: "
+                       f"{e.stderr if hasattr(e, 'stderr') else e}")
+    except Exception as e:
+        logger.warning(f"Unexpected error checking out pto-isa commit {commit}: {e}")
+
+
+def _update_pto_isa_to_latest(clone_path: Path, verbose: bool = False) -> None:
+    """Fetch and reset existing clone to the remote default branch."""
+    import subprocess
+    try:
+        if verbose:
+            logger.info("Updating pto-isa to latest...")
+        subprocess.run(
+            ["git", "fetch", "origin"], capture_output=True, text=True,
+            cwd=str(clone_path), timeout=120, check=True
+        )
+        # Use origin/HEAD which tracks the remote's default branch
+        subprocess.run(
+            ["git", "reset", "--hard", "origin/HEAD"], capture_output=True, text=True,
+            cwd=str(clone_path), timeout=30, check=True
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        logger.warning(f"Failed to update pto-isa to latest: "
+                       f"{e.stderr if hasattr(e, 'stderr') else e}")
+    except Exception as e:
+        logger.warning(f"Unexpected error updating pto-isa: {e}")
+
+
+def _ensure_pto_isa_root(verbose: bool = False, commit: Optional[str] = None) -> Optional[str]:
     """
     Ensure PTO_ISA_ROOT is available, either from environment or cloned repo.
 
@@ -228,6 +291,7 @@ def _ensure_pto_isa_root(verbose: bool = False) -> Optional[str]:
 
     Args:
         verbose: Print detailed progress information
+        commit: If provided, checkout this specific commit
 
     Returns:
         PTO_ISA_ROOT path if successful, None otherwise
@@ -246,7 +310,7 @@ def _ensure_pto_isa_root(verbose: bool = False) -> Optional[str]:
     if not _is_pto_isa_cloned():
         if verbose:
             logger.info("PTO_ISA_ROOT not set, cloning pto-isa repository...")
-        if not _clone_pto_isa(verbose=verbose):
+        if not _clone_pto_isa(verbose=verbose, commit=commit):
             if verbose:
                 logger.warning("Failed to automatically clone pto-isa.")
                 logger.warning("You can manually clone it with:")
@@ -255,6 +319,10 @@ def _ensure_pto_isa_root(verbose: bool = False) -> Optional[str]:
                 logger.warning("Or set PTO_ISA_ROOT to an existing pto-isa installation:")
                 logger.warning("  export PTO_ISA_ROOT=/path/to/pto-isa")
             return None
+    elif commit:
+        _checkout_pto_isa_commit(clone_path, commit, verbose=verbose)
+    else:
+        _update_pto_isa_to_latest(clone_path, verbose=verbose)
 
     # Verify clone has expected content
     include_dir = clone_path / "include"
@@ -338,6 +406,7 @@ class CodeRunner:
         enable_profiling: bool = False,
         run_all_cases: bool = False,
         case_name: Optional[str] = None,
+        pto_isa_commit: Optional[str] = None,
     ):
         # Setup logging if not already configured (e.g., when used directly, not via run_example.py)
         _setup_logging_if_needed()
@@ -350,6 +419,7 @@ class CodeRunner:
 
         # Resolve device ID
         self.device_id = device_id if device_id is not None else 0
+        self.pto_isa_commit = pto_isa_commit
 
         # Load configurations
         self._kernel_config = self._load_kernel_config()
@@ -618,7 +688,7 @@ class CodeRunner:
         from elf_parser import extract_text_section
 
         # Auto-setup PTO_ISA_ROOT if needed (for all platforms, since kernels may use PTO ISA headers)
-        pto_isa_root = _ensure_pto_isa_root(verbose=True)
+        pto_isa_root = _ensure_pto_isa_root(verbose=True, commit=self.pto_isa_commit)
         if pto_isa_root is None:
             raise EnvironmentError(
                 "PTO_ISA_ROOT could not be resolved.\n"
@@ -829,9 +899,11 @@ class CodeRunner:
 
 
 def create_code_runner(kernels_dir, golden_path, device_id=None, platform="a2a3",
-                       enable_profiling=False, run_all_cases=False, case_name=None):
+                       enable_profiling=False, run_all_cases=False, case_name=None,
+                       pto_isa_commit=None):
     """Factory: creates a CodeRunner based on kernel_config."""
     return CodeRunner(kernels_dir=kernels_dir, golden_path=golden_path,
                       device_id=device_id, platform=platform,
                       enable_profiling=enable_profiling,
-                      run_all_cases=run_all_cases, case_name=case_name)
+                      run_all_cases=run_all_cases, case_name=case_name,
+                      pto_isa_commit=pto_isa_commit)

--- a/examples/scripts/run_example.py
+++ b/examples/scripts/run_example.py
@@ -159,6 +159,13 @@ Golden.py interface:
         help="Run a specific test case by name (e.g., --case Case2)"
     )
 
+    parser.add_argument(
+        "-c", "--pto-isa-commit",
+        type=str,
+        default=None,
+        help="Checkout PTO-ISA at this commit (e.g., -c 1b22fea)"
+    )
+
     args = parser.parse_args()
 
     if args.all and args.case:
@@ -226,6 +233,7 @@ Golden.py interface:
             enable_profiling=args.enable_profiling,
             run_all_cases=args.all,
             case_name=args.case,
+            pto_isa_commit=args.pto_isa_commit,
         )
 
         # Snapshot existing device logs before the run so we can identify the


### PR DESCRIPTION
## Summary
- Add `-c`/`--pto-isa-commit` argument to `run_example.py` and `ci.sh` to checkout PTO-ISA at a specific commit
- Without `-c`, existing clones always fetch and reset to latest `origin/HEAD`
- With `-c`, checkout the specified commit (fetching if needed)
- CI workflow retries sim tests with `-c 1b22fea` on failure (upstream `bc92b59` broke CPU_SIM include ordering in `pto-inst.hpp`)

## Testing
- [x] Simulation tests pass (with `-c 1b22fea`)
- [x] Hardware tests pass