### PR TITLE
Support: move PTO-ISA fallback retry into ci.sh and add timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,7 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Run simulation examples
-        id: sim
-        run: ./ci.sh -p a2a3sim
-        continue-on-error: true
-
-      - name: Retry sim with pinned PTO-ISA on failure
-        if: steps.sim.outcome == 'failure'
-        run: |
-          rm -rf examples/scripts/_deps/pto-isa
-          ./ci.sh -p a2a3sim --pto-isa-commit 1b22fea
+        run: ./ci.sh -p a2a3sim -c 1b22fea -t 600
 
   run-example-on-device:
     runs-on: self-hosted
@@ -78,4 +70,4 @@ jobs:
       - name: Run on-device examples
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          source /home/github-ci/Ascend/ascend-toolkit/latest/bin/setenv.bash && ./ci.sh -p a2a3 -d 4-7 --parallel
+          source /home/github-ci/Ascend/ascend-toolkit/latest/bin/setenv.bash && ./ci.sh -p a2a3 -d 4-7 --parallel -t 600

--- a/ci.sh
+++ b/ci.sh
@@ -6,6 +6,7 @@ DEVICE_RANGE=""
 PARALLEL=false
 RUNTIME=""
 PTO_ISA_COMMIT=""
+TIMEOUT=600  # 10 minutes default
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -23,6 +24,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -c|--pto-isa-commit)
             PTO_ISA_COMMIT="$2"
+            shift 2
+            ;;
+        -t|--timeout)
+            TIMEOUT="$2"
             shift 2
             ;;
         --parallel)
@@ -85,18 +90,44 @@ RESULTS_FILE="${LOG_DIR}/results.txt"
 touch "$RESULTS_FILE"
 
 cleanup() {
+    kill $WATCHDOG_PID 2>/dev/null
     kill 0 2>/dev/null
     rm -rf "$LOG_DIR"
     exit 130
 }
 trap cleanup INT TERM
-trap 'rm -rf "$LOG_DIR"' EXIT
+trap 'kill $WATCHDOG_PID 2>/dev/null; rm -rf "$LOG_DIR"' EXIT
 
-# Build commit flag for run_example.py
+# Watchdog: abort CI if it exceeds the timeout
+(
+    sleep "$TIMEOUT"
+    echo ""
+    echo "========================================"
+    echo "[CI] TIMEOUT: exceeded ${TIMEOUT}s ($(( TIMEOUT / 60 ))min) limit, aborting"
+    echo "========================================"
+    kill -TERM $$ 2>/dev/null
+) &
+WATCHDOG_PID=$!
+
+# commit_flag starts empty (try latest PTO-ISA first).
+# If -c is given AND a test fails, pin_pto_isa_on_failure sets commit_flag.
 commit_flag=()
-if [[ -n "$PTO_ISA_COMMIT" ]]; then
+
+# Pin PTO-ISA to the specified commit on first failure.
+# On first failure: cleans cached clone, sets commit_flag, returns 0 (caller retries).
+# On subsequent failures (already pinned): returns 1 (real failure).
+pin_pto_isa_on_failure() {
+    if [[ -z "$PTO_ISA_COMMIT" ]]; then
+        return 1  # No fallback commit configured
+    fi
+    if [[ ${#commit_flag[@]} -gt 0 ]]; then
+        return 1  # Already pinned, real failure
+    fi
+    echo "[CI] First failure detected, pinning PTO-ISA to commit $PTO_ISA_COMMIT"
+    rm -rf examples/scripts/_deps/pto-isa
     commit_flag=(-c "$PTO_ISA_COMMIT")
-fi
+    return 0  # Pinned, caller should retry
+}
 
 # ---- Discover all tasks ----
 EXAMPLES_DIR="examples"
@@ -215,7 +246,7 @@ if [[ "$PARALLEL" == "false" ]]; then
             fi
         done
     done
-    # SIM tasks
+    # SIM tasks (with pin-on-first-failure for PTO-ISA)
     for i in "${!SIM_TASK_NAMES[@]}"; do
         name="${SIM_TASK_NAMES[$i]}"
         dir="${SIM_TASK_DIRS[$i]}"
@@ -226,6 +257,15 @@ if [[ "$PARALLEL" == "false" ]]; then
             -k "${dir}/kernels" -g "${dir}/golden.py" \
             -p a2a3sim "${commit_flag[@]}"; then
             echo "${name}:a2a3sim|PASS" >> "$RESULTS_FILE"
+        elif pin_pto_isa_on_failure; then
+            echo "[CI] Retrying: $name with pinned PTO-ISA"
+            if python examples/scripts/run_example.py \
+                -k "${dir}/kernels" -g "${dir}/golden.py" \
+                -p a2a3sim "${commit_flag[@]}"; then
+                echo "${name}:a2a3sim|PASS" >> "$RESULTS_FILE"
+            else
+                echo "${name}:a2a3sim|FAIL" >> "$RESULTS_FILE"
+            fi
         else
             echo "${name}:a2a3sim|FAIL" >> "$RESULTS_FILE"
         fi
@@ -245,7 +285,7 @@ else
             echo "Running: $name (a2a3sim)"
             echo "========================================"
             if python examples/scripts/run_example.py \
-                -k "${dir}/kernels" -g "${dir}/golden.py" -p a2a3sim $COMMIT_FLAG; then
+                -k "${dir}/kernels" -g "${dir}/golden.py" -p a2a3sim "${commit_flag[@]}"; then
                 echo "${name}:a2a3sim|PASS" >> "$RESULTS_FILE"
             else
                 echo "${name}:a2a3sim|FAIL" >> "$RESULTS_FILE"


### PR DESCRIPTION
## Summary
- Add `pin_pto_isa_on_failure()` in `ci.sh`: pins PTO-ISA to fallback commit on first test failure, then retries automatically
- Replace two-step GitHub Actions retry (`continue-on-error` + conditional step) with single `./ci.sh -p a2a3sim -c 1b22fea` call
- Add `-t/--timeout` flag with 10min default watchdog that aborts CI via SIGTERM if execution exceeds the limit
- Fix parallel mode to use proper bash array expansion for `commit_flag`

## Testing
- [x] Simulation tests pass
- [x] Hardware tests pass (if applicable)