### PR TITLE
Fix: harden AICPU init with physical_core_id validation and emergency shutdown

### DIFF
--- a/python/kernel_compiler.py
+++ b/python/kernel_compiler.py
@@ -78,7 +78,6 @@ class KernelCompiler:
             List of include directory paths (e.g., for device_runner.h, core_type.h)
         """
         return [
-            str(self.platform_dir / "host"),
             str(self.platform_dir.parent / "include"),  # For common headers like core_type.h
         ]
 

--- a/src/platform/a2a3/host/host_regs.cpp
+++ b/src/platform/a2a3/host/host_regs.cpp
@@ -116,7 +116,7 @@ void get_aicore_regs(std::vector<int64_t>& regs, uint64_t device_id) {
     if (rt != 0) {
         LOG_ERROR("get_aicore_reg_info failed, using placeholder addresses");
         // Fallback: generate placeholder addresses
-        for (int i = 0; i < 25; i++) {
+        for (int i = 0; i < DAV_2201::PLATFORM_MAX_PHYSICAL_CORES; i++) {
             aic.push_back(0xDEADBEEF00000000ULL + (i * 0x800000));  // 8M stride
             aiv.push_back(0xDEADBEEF00000000ULL + (i * 0x800000) + 0x100000);
             aiv.push_back(0xDEADBEEF00000000ULL + (i * 0x800000) + 0x200000);

--- a/src/platform/include/aicpu/platform_regs.h
+++ b/src/platform/include/aicpu/platform_regs.h
@@ -61,5 +61,34 @@ uint64_t read_reg(uint64_t reg_base_addr, RegId reg);
  */
 void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value);
 
+/**
+ * Initialize AICore registers after core discovery
+ *
+ * This function performs platform-agnostic register initialization that works
+ * for both a2a3 and a2a3sim, including enabling fast path control and clearing
+ * dispatch registers.
+ *
+ * @param reg_addr  Register base address of the AICore
+ */
+void platform_init_aicore_regs(uint64_t reg_addr);
+
+/**
+ * Deinitialize AICore registers before termination
+ *
+ * This function sends exit signal and closes fast path control.
+ *
+ * @param reg_addr  Register base address of the AICore
+ */
+void platform_deinit_aicore_regs(uint64_t reg_addr);
+
+/**
+ * Get physical core count for current platform
+ *
+ * This function returns the maximum valid physical_core_id value (exclusive upper bound).
+ * Used for validating physical_core_id from AICore handshake before using as array index.
+ *
+ * @return Physical core count (exclusive upper bound)
+ */
+uint32_t platform_get_physical_cores_count();
 
 #endif  // PLATFORM_AICPU_PLATFORM_REGS_H_

--- a/src/platform/src/aicpu/platform_regs.cpp
+++ b/src/platform/src/aicpu/platform_regs.cpp
@@ -5,6 +5,7 @@
  * Provides unified interface for:
  * 1. Platform register base address management (set/get_platform_regs)
  * 2. Register read/write operations with optimized memory barriers
+ * 3. Platform-agnostic AICore register initialization/deinitialization
  *
  * Memory Barrier Strategy:
  * - read_reg: Full barriers (__sync_synchronize) to ensure store-load ordering
@@ -17,6 +18,7 @@
 
 #include <cstdint>
 #include "aicpu/platform_regs.h"
+#include "common/platform_config.h"
 
 static uint64_t g_platform_regs = 0;
 
@@ -52,4 +54,24 @@ void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {
     *ptr = static_cast<uint32_t>(value);
 
     __sync_synchronize();
+}
+
+void platform_init_aicore_regs(uint64_t reg_addr) {
+    // Both a2a3 and a2a3sim require fast path control to be enabled before use
+    write_reg(reg_addr, RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_OPEN);
+
+    // Initialize task dispatch register to idle state
+    write_reg(reg_addr, RegId::DATA_MAIN_BASE, 0);
+}
+
+void platform_deinit_aicore_regs(uint64_t reg_addr) {
+    // Send exit signal to AICore
+    write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
+
+    // Close fast path control
+    write_reg(reg_addr, RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_CLOSE);
+}
+
+uint32_t platform_get_physical_cores_count() {
+    return DAV_2201::PLATFORM_MAX_PHYSICAL_CORES * PLATFORM_CORES_PER_BLOCKDIM;
 }

--- a/src/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -97,6 +97,7 @@ struct AicpuExecutor {
     int shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores);
     int run(Runtime* runtime);
     void deinit();
+    void emergency_shutdown();
     void diagnose_stuck_state(
         Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num, Handshake* hank);
 
@@ -237,6 +238,11 @@ int AicpuExecutor::init(Runtime* runtime) {
         return -1;
     }
 
+    // Initialize core_id_to_reg_addr_ array to 0 before handshake
+    for (int i = 0; i < MAX_CORES_PER_THREAD; i++) {
+        core_id_to_reg_addr_[i] = 0;
+    }
+
     // Perform core discovery: handshake with all cores and collect core type information
     int rc = handshake_all_cores(runtime);
     if (rc != 0) {
@@ -296,14 +302,9 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     Handshake* all_hanks = (Handshake*)runtime->workers;
     cores_total_num_ = runtime->worker_count;
 
-    if (cores_total_num_ == 0) {
-        LOG_ERROR("worker_count is 0, no cores to handshake");
-        return -1;
-    }
-
-    // Simplified defensive check
-    if (cores_total_num_ > MAX_CORES_PER_THREAD) {
-        LOG_ERROR("Total cores %d exceeds maximum %d", cores_total_num_, MAX_CORES_PER_THREAD);
+    // Validate cores_total_num_ before using as array index
+    if (cores_total_num_ == 0 || cores_total_num_ > MAX_CORES_PER_THREAD) {
+        LOG_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, MAX_CORES_PER_THREAD);
         return -1;
     }
 
@@ -317,7 +318,11 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         all_hanks[i].aicpu_ready = 1;
     }
 
+    // Get platform physical cores count for validation
+    uint32_t max_physical_cores_count = platform_get_physical_cores_count();
+
     // Step 2: Wait for all cores to respond and collect core type information
+    bool handshake_failed = false;
     for (int i = 0; i < cores_total_num_; i++) {
         Handshake* hank = &all_hanks[i];
 
@@ -328,6 +333,14 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
 
         CoreType type = hank->core_type;
         uint32_t physical_core_id = hank->physical_core_id;
+
+        // Validate physical_core_id before using as array index
+        if (physical_core_id >= max_physical_cores_count) {
+            LOG_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
+                      i, physical_core_id, max_physical_cores_count);
+            handshake_failed = true;
+            continue;
+        }
 
         // Get register address using physical_core_id
         uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
@@ -347,7 +360,7 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
             aiv_count_++;
         } else {
             LOG_ERROR("Unknown core type from core %d", i);
-            return -1;
+            handshake_failed = true;
         }
 
         core_id_to_reg_addr_[i] = reg_addr;
@@ -359,9 +372,13 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
             reg_addr);
 
         if (reg_addr != 0) {
-            write_reg(reg_addr, RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_OPEN);
-            write_reg(reg_addr, RegId::DATA_MAIN_BASE, 0);
+            platform_init_aicore_regs(reg_addr);
         }
+    }
+
+    if (handshake_failed) {
+        emergency_shutdown();
+        return -1;
     }
 
     LOG_INFO("Discovery complete: AIC=%d, AIV=%d, Total=%d", aic_count_, aiv_count_, cores_total_num_);
@@ -542,8 +559,7 @@ int AicpuExecutor::shutdown_aicore(Runtime* runtime, int thread_idx, const int* 
 
         uint64_t reg_addr = core_id_to_reg_addr_[core_id];
         if (reg_addr != 0) {
-            write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
-            write_reg(reg_addr, RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_CLOSE);
+            platform_deinit_aicore_regs(reg_addr);
         } else {
             LOG_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
         }
@@ -1034,6 +1050,18 @@ void AicpuExecutor::deinit() {
     finished_.store(false, std::memory_order_release);
 
     LOG_INFO("DeInit: AicpuExecutor reset complete");
+}
+
+void AicpuExecutor::emergency_shutdown() {
+    LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
+
+    for (int i = 0; i < cores_total_num_; i++) {
+        if (core_id_to_reg_addr_[i] != 0) {
+            platform_deinit_aicore_regs(core_id_to_reg_addr_[i]);
+        }
+    }
+
+    LOG_WARN("Emergency shutdown complete");
 }
 
 void AicpuExecutor::diagnose_stuck_state(

--- a/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -132,6 +132,7 @@ struct AicpuExecutor {
     int shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num);
     int run(Runtime* runtime);
     void deinit();
+    void emergency_shutdown();
     void diagnose_stuck_state(Runtime* runtime, int thread_idx, const int* cur_thread_cores,
                               int core_num, Handshake* hank);
 };
@@ -151,6 +152,12 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     Handshake* all_hanks = (Handshake*)runtime->workers;
     cores_total_num_ = runtime->worker_count;
 
+    // Validate cores_total_num_ before using as array index
+    if (cores_total_num_ == 0 || cores_total_num_ > MAX_CORES_PER_THREAD) {
+        DEV_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, MAX_CORES_PER_THREAD);
+        return -1;
+    }
+
     aic_count_ = 0;
     aiv_count_ = 0;
 
@@ -163,7 +170,11 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         all_hanks[i].aicpu_ready = 1;
     }
 
+    // Get platform physical cores count for validation
+    uint32_t max_physical_cores_count = platform_get_physical_cores_count();
+
     // Step 2: Wait for all cores to respond, collect core type and register addresses
+    bool handshake_failed = false;
     for (int i = 0; i < cores_total_num_; i++) {
         Handshake* hank = &all_hanks[i];
         while (hank->aicore_done == 0) {
@@ -172,6 +183,14 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
 
         CoreType type = hank->core_type;
         uint32_t physical_core_id = hank->physical_core_id;
+
+        // Validate physical_core_id before using as array index
+        if (physical_core_id >= max_physical_cores_count) {
+            DEV_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
+                      i, physical_core_id, max_physical_cores_count);
+            handshake_failed = true;
+            continue;
+        }
 
         // Get register address using physical_core_id
         uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
@@ -195,11 +214,15 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
 
         core_id_to_reg_addr_[i] = reg_addr;
 
-        // Initialize fast path registers
+        // Initialize AICore registers (platform-specific)
         if (reg_addr != 0) {
-            write_reg(reg_addr, RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_OPEN);
-            write_reg(reg_addr, RegId::DATA_MAIN_BASE, 0);
+            platform_init_aicore_regs(reg_addr);
         }
+    }
+
+    if (handshake_failed) {
+        emergency_shutdown();
+        return -1;
     }
 
     DEV_INFO("Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
@@ -277,6 +300,11 @@ int AicpuExecutor::init(Runtime* runtime) {
         return -1;
     }
 
+    // Initialize core_id_to_reg_addr_ array to 0 before handshake
+    for (int i = 0; i < MAX_CORES_PER_THREAD; i++) {
+        core_id_to_reg_addr_[i] = 0;
+    }
+
     // Use handshake mechanism to discover cores (aligned with host_build_graph)
     int rc = handshake_all_cores(runtime);
     if (rc != 0) {
@@ -287,12 +315,6 @@ int AicpuExecutor::init(Runtime* runtime) {
 
     // Dynamically assign cores to threads
     assign_cores_to_threads();
-
-    if (cores_total_num_ > MAX_CORES_PER_THREAD * MAX_AICPU_THREADS) {
-        DEV_ERROR("Total cores %d exceeds maximum", cores_total_num_);
-        init_failed_.store(true, std::memory_order_release);
-        return -1;
-    }
 
     // Initialize executing_task_ids_ to AICPU_TASK_INVALID (idle)
     for (int i = 0; i < MAX_CORES_PER_THREAD; i++) {
@@ -345,8 +367,7 @@ int AicpuExecutor::shutdown_aicore(Runtime* runtime, int thread_idx, const int* 
         int core_id = cur_thread_cores[i];
         uint64_t reg_addr = core_id_to_reg_addr_[core_id];
         if (reg_addr != 0) {
-            write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
-            write_reg(reg_addr, RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_CLOSE);
+            platform_deinit_aicore_regs(reg_addr);
         } else {
             DEV_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
         }
@@ -1034,6 +1055,18 @@ void AicpuExecutor::deinit() {
     finished_.store(false, std::memory_order_release);
 
     DEV_INFO("DeInit: AicpuExecutor reset complete");
+}
+
+void AicpuExecutor::emergency_shutdown() {
+    DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
+
+    for (int i = 0; i < cores_total_num_; i++) {
+        if (core_id_to_reg_addr_[i] != 0) {
+            platform_deinit_aicore_regs(core_id_to_reg_addr_[i]);
+        }
+    }
+
+    DEV_WARN("Emergency shutdown complete");
 }
 
 void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int thread_idx,


### PR DESCRIPTION

- Validate physical_core_id against platform max before register array access in both runtimes, preventing out-of-bounds memory access
- Consolidate cores_total_num_ into single range check (0 or overflow) instead of two separate guards
- Zero-initialize core_id_to_reg_addr_ before handshake so emergency shutdown can safely iterate partially-initialized state
- Add emergency_shutdown() to both runtimes: sends exit signal to all already-launched cores when init fails mid-handshake
- Add platform_get_physical_cores_count() to supply the validation bound
- Extract platform_init/deinit_aicore_regs to avoid duplicated write_reg pairs (incidental cleanup)