### PR TITLE
Refactor: unify runtime atomics in tensormap_and_ringbuffer

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -78,8 +78,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     }
 
     // Phase 3: Main execution loop - poll register for tasks until exit signal
-    volatile uint32_t task_id = 0;
-    volatile uint32_t last_task_id = 0;
+    uint32_t task_id = 0;
+    uint32_t last_task_id = 0;
 
     while (true) {
         task_id = static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE));

--- a/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -326,7 +326,8 @@ int AicpuExecutor::init(Runtime* runtime) {
     // Initialize runtime execution state
     // Task count comes from PTO2 shared memory
     if (runtime->get_pto2_gm_sm_ptr()) {
-        int32_t pto2_count = *static_cast<const volatile int32_t*>(runtime->get_pto2_gm_sm_ptr());
+        auto* header = static_cast<PTO2SharedMemoryHeader*>(runtime->get_pto2_gm_sm_ptr());
+        int32_t pto2_count = header->current_task_index.load(std::memory_order_acquire);
         total_tasks_.store(pto2_count > 0 ? pto2_count : 0, std::memory_order_release);
     } else {
         total_tasks_.store(0, std::memory_order_release);
@@ -604,7 +605,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
 
         // Update perf header total_tasks if visible tasks have changed
         {
-            int32_t visible = __atomic_load_n(&header->current_task_index, __ATOMIC_ACQUIRE);
+            int32_t visible = header->current_task_index.load(std::memory_order_acquire);
             if (profiling_enabled && visible > 0 && visible != last_reported_task_count) {
                 perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(visible));
 
@@ -627,9 +628,9 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                 int cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
                 for (int si = 0; si < task_count; si++) {
                     int32_t slot = si & window_mask;
-                    PTO2TaskState st = (PTO2TaskState)__atomic_load_n(&sched->task_state[slot], __ATOMIC_RELAXED);
-                    int32_t rc  = __atomic_load_n(&sched->fanin_refcount[slot], __ATOMIC_RELAXED);
-                    int32_t fi  = __atomic_load_n(&task_descriptors[slot].fanin_count, __ATOMIC_RELAXED);
+                    PTO2TaskState st = sched->task_state[slot].load(std::memory_order_relaxed);
+                    int32_t rc = sched->fanin_refcount[slot].load(std::memory_order_relaxed);
+                    int32_t fi = task_descriptors[slot].fanin_count;
                     int32_t kid = task_descriptors[slot].kernel_id;
                     if (st >= PTO2_TASK_COMPLETED) continue; // Already done
                     if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) { cnt_inflight++; continue; }
@@ -970,7 +971,8 @@ int AicpuExecutor::run(Runtime* runtime) {
             // Device mode: task count lives in PTO2 shared memory
             void* sm = runtime->get_pto2_gm_sm_ptr();
             PTO2SharedMemoryHeader* sm_header = static_cast<PTO2SharedMemoryHeader*>(sm);
-            int32_t pto2_task_count = sm_header ? sm_header->current_task_index : 0;
+            int32_t pto2_task_count =
+                sm_header ? sm_header->current_task_index.load(std::memory_order_acquire) : 0;
             DEV_ALWAYS("PTO2 total submitted tasks = %d", pto2_task_count);
             total_tasks_.store(pto2_task_count, std::memory_order_release);
             orchestrator_done_.store(true, std::memory_order_release);

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -134,9 +134,9 @@ void pto2_orchestrator_reset(PTO2OrchestratorState* orch) {
     orch->bytes_allocated = 0;
 
     // Reset shared memory header
-    orch->sm_handle->header->current_task_index = 0;
-    orch->sm_handle->header->heap_top = 0;
-    orch->sm_handle->header->orchestrator_done = 0;
+    orch->sm_handle->header->current_task_index.store(0, std::memory_order_relaxed);
+    orch->sm_handle->header->heap_top.store(0, std::memory_order_relaxed);
+    orch->sm_handle->header->orchestrator_done.store(0, std::memory_order_relaxed);
 }
 
 void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler) {
@@ -206,34 +206,22 @@ void pto2_add_consumer_to_producer(
     // This synchronizes with scheduler's on_task_complete_threadsafe
     pto2_fanout_lock(producer);
 
-    // AICPU parallel mode: check if producer already completed before adding to fanout.
-    // Read completed FIRST (ACQUIRE) to establish happens-before with the scheduler's
-    // RELEASE stores (completed_by_task is stored before completed in program order).
-    // Then check completed_by_task to guard against stale state from recycled slots.
-    if (orch->aicpu_task_completed) {
-        int32_t prod_slot = producer_id & orch->aicpu_window_mask;
-        if (__atomic_load_n(&orch->aicpu_task_completed[prod_slot], __ATOMIC_ACQUIRE) >= 2 &&
-            __atomic_load_n(&orch->aicpu_completed_by_task[prod_slot], __ATOMIC_RELAXED) == producer_id) {
-            int32_t cons_slot = consumer_id & orch->aicpu_window_mask;
-            __atomic_fetch_add(&orch->aicpu_fanin_refcount[cons_slot], 1, __ATOMIC_ACQ_REL);
-            pto2_fanout_unlock(producer);
-            return;
-        }
-    }
-
     // Normal path: prepend consumer to producer's fanout list
-    producer->fanout_head = pto2_dep_list_prepend(&orch->dep_pool, producer->fanout_head, consumer_id);
-    producer->fanout_count++;
+    int32_t fanout_head = producer->fanout_head.load(std::memory_order_relaxed);
+    producer->fanout_head.store(
+        pto2_dep_list_prepend(&orch->dep_pool, fanout_head, consumer_id),
+        std::memory_order_relaxed);
+    producer->fanout_count.fetch_add(1, std::memory_order_relaxed);
 
     // Check if producer has already completed (scheduler mode)
     if (orch->scheduler) {
         PTO2SchedulerState* sched = orch->scheduler;
         int32_t prod_slot = sched->pto2_task_slot(producer_id);
-        int32_t prod_state = __atomic_load_n(&sched->task_state[prod_slot], __ATOMIC_ACQUIRE);
+        int32_t prod_state = sched->task_state[prod_slot].load(std::memory_order_acquire);
 
         if (prod_state >= PTO2_TASK_COMPLETED) {
             int32_t cons_slot = sched->pto2_task_slot(consumer_id);
-            __atomic_fetch_add(&sched->fanin_refcount[cons_slot], 1, __ATOMIC_SEQ_CST);
+            sched->fanin_refcount[cons_slot].fetch_add(1, std::memory_order_acq_rel);
         }
     }
 
@@ -263,25 +251,16 @@ void pto2_submit_task(PTO2OrchestratorState* orch,
 
     PTO2TaskDescriptor* task = pto2_task_ring_get(&orch->task_ring, task_id);
 
-    // Reset scheduler-side slot state for reuse.  The old task's fanout/lock
-    // protocol is fully complete by the time last_task_alive advances past it,
-    // so resetting here (after allocation) is safe.
-    if (orch->aicpu_task_completed) {
-        int32_t slot = task_id & orch->aicpu_window_mask;
-        __atomic_store_n(&orch->aicpu_task_completed[slot], 0, __ATOMIC_RELEASE);
-        __atomic_store_n(&orch->aicpu_completed_by_task[slot], -1, __ATOMIC_RELEASE);
-    }
-
     // Initialize task descriptor
     task->task_id = task_id;
     task->kernel_id = kernel_id;
     task->worker_type = worker_type;
     task->fanin_head = 0;
     task->fanin_count = 0;
-    task->fanout_head = 0;
-    task->fanout_lock = 0;
+    task->fanout_head.store(0, std::memory_order_relaxed);
+    task->fanout_lock.store(0, std::memory_order_relaxed);
     // Initial fanout_count = 1 (the owning scope holds one reference)
-    task->fanout_count = 1;
+    task->fanout_count.store(1, std::memory_order_relaxed);
     task->packed_buffer_base = NULL;
     task->packed_buffer_end = NULL;
     task->is_active = true;
@@ -414,20 +393,23 @@ void pto2_submit_task(PTO2OrchestratorState* orch,
             // Add this task to producer's fanout list (with spinlock)
             PTO2TaskDescriptor* producer = pto2_task_ring_get(&orch->task_ring, producer_task_id);
             pto2_fanout_lock(producer);
-            producer->fanout_head = pto2_dep_list_prepend(&orch->dep_pool, producer->fanout_head, task_id);
-            producer->fanout_count++;
+            int32_t producer_fanout_head = producer->fanout_head.load(std::memory_order_relaxed);
+            producer->fanout_head.store(
+                pto2_dep_list_prepend(&orch->dep_pool, producer_fanout_head, task_id),
+                std::memory_order_relaxed);
+            producer->fanout_count.fetch_add(1, std::memory_order_relaxed);
             // Normal path: prepend consumer to producer's fanout list
             task->fanin_head = pto2_dep_list_prepend(&orch->dep_pool, task->fanin_head, producer_task_id);
 
             int32_t prod_slot = sched->pto2_task_slot(producer_task_id);
-            int32_t prod_state = __atomic_load_n(&sched->task_state[prod_slot], __ATOMIC_ACQUIRE);
+            int32_t prod_state = sched->task_state[prod_slot].load(std::memory_order_acquire);
             if (prod_state >= PTO2_TASK_COMPLETED) {
                 early_finished++;
             }
             pto2_fanout_unlock(producer);
         }
         if (early_finished > 0) {
-            __atomic_fetch_add(&sched->fanin_refcount[slot], early_finished, __ATOMIC_SEQ_CST);
+            sched->fanin_refcount[slot].fetch_add(early_finished, std::memory_order_acq_rel);
         }
     } else {
         // No scheduler: just build fanin list + add to producers using pto2_add_consumer_to_producer
@@ -436,7 +418,7 @@ void pto2_submit_task(PTO2OrchestratorState* orch,
             PTO2TaskDescriptor* producer = pto2_task_ring_get(&orch->task_ring, fanin_temp[i]);
             pto2_add_consumer_to_producer(orch, producer, fanin_temp[i], task_id);
         }
-        __atomic_store_n(&task->fanin_count, fanin_count, __ATOMIC_SEQ_CST);
+        task->fanin_count = fanin_count;
     }
 
     CYCLE_COUNT_LAP_RECORD(g_orch_fanin_cycle, AicpuPhaseId::ORCH_FANIN);
@@ -449,7 +431,7 @@ void pto2_submit_task(PTO2OrchestratorState* orch,
     }
 
     // === STEP 7: Update shared memory with current task index ===
-    PTO2_STORE_RELEASE(&orch->sm_handle->header->current_task_index, orch->task_ring.current_index);
+    orch->sm_handle->header->current_task_index.store(orch->task_ring.current_index, std::memory_order_release);
 
     CYCLE_COUNT_LAP_RECORD(g_orch_finalize_cycle, AicpuPhaseId::ORCH_FINALIZE);
 
@@ -467,7 +449,7 @@ void pto2_submit_task(PTO2OrchestratorState* orch,
 void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
     int32_t total_tasks = orch->task_ring.current_index;
     LOG_INFO("=== [Orchestrator] total_tasks=%d ===", total_tasks);
-    PTO2_STORE_RELEASE(&orch->sm_handle->header->orchestrator_done, 1);
+    orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
 }
 
 void pto2_orchestrator_wait_all(PTO2OrchestratorState* orch) {

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -76,12 +76,6 @@ struct PTO2OrchestratorState {
     int64_t buffers_allocated;
     int64_t bytes_allocated;
 
-    // === AICPU PARALLEL MODE (set by aicpu_executor, NULL when unused) ===
-    int32_t* aicpu_fanin_refcount;
-    volatile int32_t* aicpu_task_completed;
-    int32_t* aicpu_completed_by_task;  // task_id that set the completed state (for slot-reuse validation)
-    int32_t aicpu_window_mask;
-
     /**
      * Allocate packed output buffer for a task
      */
@@ -96,7 +90,7 @@ struct PTO2OrchestratorState {
         bytes_allocated += total_size;
 
         // Update shared memory with new heap top
-        PTO2_STORE_RELEASE(&sm_handle->header->heap_top, heap_ring.top);
+        sm_handle->header->heap_top.store(heap_ring.top, std::memory_order_release);
 
         return buffer;
     }

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -18,7 +18,7 @@
 // =============================================================================
 
 void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
-                          volatile uint64_t* tail_ptr) {
+                          std::atomic<uint64_t>* tail_ptr) {
     ring->base = base;
     ring->size = size;
     ring->top = 0;
@@ -34,7 +34,7 @@ void pto2_heap_ring_reset(PTO2HeapRing* ring) {
 // =============================================================================
 
 void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
-                          int32_t window_size, volatile int32_t* last_alive_ptr) {
+                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr) {
     ring->descriptors = descriptors;
     ring->window_size = window_size;
     ring->current_index = 0;
@@ -42,7 +42,7 @@ void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
 }
 
 int32_t pto2_task_ring_active_count(PTO2TaskRing* ring) {
-    int32_t last_alive = PTO2_LOAD_ACQUIRE(ring->last_alive_ptr);
+    int32_t last_alive = ring->last_alive_ptr->load(std::memory_order_acquire);
     return ring->current_index - last_alive;
 }
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -62,7 +62,7 @@ struct PTO2HeapRing {
     uint64_t top;         // Allocation pointer (local copy)
 
     // Reference to shared memory tail (for back-pressure)
-    volatile uint64_t* tail_ptr;  // Points to header->heap_tail
+    std::atomic<uint64_t>* tail_ptr;  // Points to header->heap_tail
 
     /**
      * Allocate memory from heap ring
@@ -101,7 +101,7 @@ struct PTO2HeapRing {
 #if PTO2_SPIN_VERBOSE_LOGGING
             // Periodic block notification
             if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count < PTO2_HEAP_SPIN_LIMIT) {
-                uint64_t tail = PTO2_LOAD_ACQUIRE(tail_ptr);
+                uint64_t tail = tail_ptr->load(std::memory_order_acquire);
                 uint64_t available = pto2_heap_ring_available();
                 LOG_WARN("[HeapRing] BLOCKED: requesting %" PRIu64 " bytes, available=%" PRIu64
                      ", top=%" PRIu64 ", tail=%" PRIu64 ", spins=%d",
@@ -111,7 +111,7 @@ struct PTO2HeapRing {
 #endif
 
             if (spin_count >= PTO2_HEAP_SPIN_LIMIT) {
-                uint64_t tail = PTO2_LOAD_ACQUIRE(tail_ptr);
+                uint64_t tail = tail_ptr->load(std::memory_order_acquire);
                 uint64_t available = pto2_heap_ring_available();
                 LOG_ERROR("========================================");
                 LOG_ERROR("FATAL: Heap Ring Deadlock Detected!");
@@ -142,7 +142,7 @@ struct PTO2HeapRing {
         alloc_size = PTO2_ALIGN_UP(alloc_size, PTO2_ALIGN_SIZE);
 
         // Read latest tail from shared memory (Scheduler updates this)
-        uint64_t tail = PTO2_LOAD_ACQUIRE(tail_ptr);
+        uint64_t tail = tail_ptr->load(std::memory_order_acquire);
 
         if (top >= tail) {
             // Case 1: top is at or ahead of tail (normal case)
@@ -190,7 +190,7 @@ struct PTO2HeapRing {
      * Get available space in heap ring
      */
     uint64_t pto2_heap_ring_available() {
-        uint64_t tail = PTO2_LOAD_ACQUIRE(tail_ptr);
+        uint64_t tail = tail_ptr->load(std::memory_order_acquire);
 
         if (top >= tail) {
             // Space at end + space at beginning (if any)
@@ -213,7 +213,7 @@ struct PTO2HeapRing {
  * @param tail_ptr  Pointer to shared memory heap_tail
  */
 void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
-                          volatile uint64_t* tail_ptr);
+                          std::atomic<uint64_t>* tail_ptr);
 
 /**
  * Reset heap ring to initial state
@@ -236,7 +236,7 @@ struct PTO2TaskRing {
     int32_t current_index;            // Next task to allocate (absolute ID)
     
     // Reference to shared memory last_task_alive (for back-pressure)
-    volatile int32_t* last_alive_ptr;  // Points to header->last_task_alive
+    std::atomic<int32_t>* last_alive_ptr;  // Points to header->last_task_alive
 
     /**
      * Allocate a task slot from task ring
@@ -270,7 +270,7 @@ struct PTO2TaskRing {
 #if PTO2_SPIN_VERBOSE_LOGGING
             // Periodic block notification
             if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count < PTO2_FLOW_CONTROL_SPIN_LIMIT) {
-                int32_t last_alive = PTO2_LOAD_ACQUIRE(last_alive_ptr);
+                int32_t last_alive = last_alive_ptr->load(std::memory_order_acquire);
                 int32_t active_count = current_index - last_alive;
                 LOG_WARN("[TaskRing] BLOCKED (Flow Control): current=%d, last_alive=%d, "
                      "active=%d/%d (%.1f%%), spins=%d",
@@ -282,7 +282,7 @@ struct PTO2TaskRing {
 
             // Check for potential deadlock
             if (spin_count >= PTO2_FLOW_CONTROL_SPIN_LIMIT) {
-                int32_t last_alive = PTO2_LOAD_ACQUIRE(last_alive_ptr);
+                int32_t last_alive = last_alive_ptr->load(std::memory_order_acquire);
                 int32_t active_count = current_index - last_alive;
 
                 LOG_ERROR("========================================");
@@ -325,7 +325,7 @@ struct PTO2TaskRing {
      */
     int32_t pto2_task_ring_try_alloc() {
         // Read latest last_task_alive from shared memory
-        int32_t last_alive = PTO2_LOAD_ACQUIRE(last_alive_ptr);
+        int32_t last_alive = last_alive_ptr->load(std::memory_order_acquire);
         int32_t current = current_index;
 
         // Calculate number of active tasks (handles wrap-around)
@@ -363,7 +363,7 @@ struct PTO2TaskRing {
  * @param last_alive_ptr  Pointer to shared memory last_task_alive
  */
 void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
-                          int32_t window_size, volatile int32_t* last_alive_ptr);
+                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr);
 
 /**
  * Get number of active tasks in window

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -14,6 +14,7 @@
 #ifndef PTO_RUNTIME2_TYPES_H
 #define PTO_RUNTIME2_TYPES_H
 
+#include <atomic>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -259,9 +260,9 @@ struct PTO2TaskDescriptor {
     
     // Fanout: consumers that depend on this task (grows as consumers submit)
     // PROTECTED BY fanout_lock
-    volatile int32_t fanout_lock; // Per-task spinlock (0=unlocked, 1=locked)
-    volatile int32_t fanout_head; // Offset to first fanout entry (0 = empty)
-    volatile int32_t fanout_count;// 1 (owning scope) + number of consumers
+    std::atomic<int32_t> fanout_lock; // Per-task spinlock (0=unlocked, 1=locked)
+    std::atomic<int32_t> fanout_head; // Offset to first fanout entry (0 = empty)
+    std::atomic<int32_t> fanout_count;// 1 (owning scope) + number of consumers
     
     // Packed output buffer (all outputs packed into single contiguous buffer)
     void*    packed_buffer_base;  // Start of packed buffer in GM Heap
@@ -304,16 +305,10 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
  */
 #if defined(__aarch64__)
     #define PTO2_MEMORY_BARRIER()     __asm__ __volatile__("dmb sy" ::: "memory")
-    #define PTO2_LOAD_ACQUIRE(ptr)    __atomic_load_n(ptr, __ATOMIC_ACQUIRE)
-    #define PTO2_STORE_RELEASE(ptr, val) __atomic_store_n(ptr, val, __ATOMIC_RELEASE)
 #elif defined(__x86_64__)
     #define PTO2_MEMORY_BARRIER()     __asm__ __volatile__("mfence" ::: "memory")
-    #define PTO2_LOAD_ACQUIRE(ptr)    __atomic_load_n(ptr, __ATOMIC_ACQUIRE)
-    #define PTO2_STORE_RELEASE(ptr, val) __atomic_store_n(ptr, val, __ATOMIC_RELEASE)
 #else
     #define PTO2_MEMORY_BARRIER()     __sync_synchronize()
-    #define PTO2_LOAD_ACQUIRE(ptr)    __atomic_load_n(ptr, __ATOMIC_ACQUIRE)
-    #define PTO2_STORE_RELEASE(ptr, val) __atomic_store_n(ptr, val, __ATOMIC_RELEASE)
 #endif
 
 /**
@@ -332,25 +327,6 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
     #define PTO2_SPIN_PAUSE_LIGHT()   ((void)0)
 #endif
 
-/**
- * Atomic compare-and-swap
- */
-#define PTO2_CAS(ptr, expected, desired) \
-    __atomic_compare_exchange_n(ptr, expected, desired, false, \
-                                __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)
-
-/**
- * Atomic fetch-and-add
- */
-#define PTO2_FETCH_ADD(ptr, val) \
-    __atomic_fetch_add(ptr, val, __ATOMIC_ACQ_REL)
-
-/**
- * Atomic exchange
- */
-#define PTO2_EXCHANGE(ptr, val) \
-    __atomic_exchange_n(ptr, val, __ATOMIC_ACQ_REL)
-
 // =============================================================================
 // Per-task fanout spinlock helpers
 //
@@ -364,13 +340,13 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 // =============================================================================
 
 static inline void pto2_fanout_lock(PTO2TaskDescriptor* task) {
-    while (PTO2_EXCHANGE(&task->fanout_lock, 1) != 0) {
+    while (task->fanout_lock.exchange(1, std::memory_order_acq_rel) != 0) {
         PTO2_SPIN_PAUSE_LIGHT();
     }
 }
 
 static inline void pto2_fanout_unlock(PTO2TaskDescriptor* task) {
-    PTO2_STORE_RELEASE(&task->fanout_lock, 0);
+    task->fanout_lock.store(0, std::memory_order_release);
 }
 
 #endif // PTO_RUNTIME2_TYPES_H

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -8,8 +8,8 @@
 
 #include "pto_scheduler.h"
 #include <inttypes.h>
+#include <new>
 #include <stdlib.h>
-#include <string.h>
 #include "common/unified_log.h"
 
 // =============================================================================
@@ -41,7 +41,7 @@ bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity) {
     queue->tail = 0;
     queue->capacity = capacity;
     queue->count = 0;
-    queue->spinlock = 0;
+    queue->spinlock.store(0, std::memory_order_relaxed);
 
     return true;
 }
@@ -60,7 +60,7 @@ void pto2_ready_queue_reset(PTO2ReadyQueue* queue) {
 }
 
 bool pto2_ready_queue_push(PTO2ReadyQueue* queue, int32_t task_id) {
-    while (__atomic_exchange_n(&queue->spinlock, 1, __ATOMIC_ACQUIRE)) {
+    while (queue->spinlock.exchange(1, std::memory_order_acquire)) {
         PTO2_SPIN_PAUSE_LIGHT();
     }
 
@@ -72,12 +72,12 @@ bool pto2_ready_queue_push(PTO2ReadyQueue* queue, int32_t task_id) {
         result = true;
     }
 
-    __atomic_store_n(&queue->spinlock, 0, __ATOMIC_RELEASE);
+    queue->spinlock.store(0, std::memory_order_release);
     return result;
 }
 
 int32_t pto2_ready_queue_pop(PTO2ReadyQueue* queue) {
-    while (__atomic_exchange_n(&queue->spinlock, 1, __ATOMIC_ACQUIRE)) {
+    while (queue->spinlock.exchange(1, std::memory_order_acquire)) {
         PTO2_SPIN_PAUSE_LIGHT();
     }
 
@@ -88,7 +88,7 @@ int32_t pto2_ready_queue_pop(PTO2ReadyQueue* queue) {
         queue->count--;
     }
 
-    __atomic_store_n(&queue->spinlock, 0, __ATOMIC_RELEASE);
+    queue->spinlock.store(0, std::memory_order_release);
     return task_id;
 }
 
@@ -100,11 +100,15 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
                           PTO2SharedMemoryHandle* sm_handle,
                           PTO2DepListPool* dep_pool,
                           void* heap_base) {
-    memset(sched, 0, sizeof(PTO2SchedulerState));
-
     sched->sm_handle = sm_handle;
     sched->dep_pool = dep_pool;
     sched->heap_base = heap_base;
+    sched->task_state = nullptr;
+    sched->fanin_refcount = nullptr;
+    sched->fanout_refcount = nullptr;
+    sched->tasks_completed.store(0, std::memory_order_relaxed);
+    sched->tasks_consumed.store(0, std::memory_order_relaxed);
+    sched->total_dispatch_cycles = 0;
 
     // Get runtime task_window_size from shared memory header
     uint64_t window_size = sm_handle->header->task_window_size;
@@ -117,21 +121,24 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
     sched->heap_tail = 0;
 
     // Allocate per-task state arrays (dynamically sized based on runtime window_size)
-    sched->task_state = (PTO2TaskState*)calloc(window_size, sizeof(PTO2TaskState));
+    sched->task_state = new (std::nothrow) std::atomic<PTO2TaskState>[window_size];
     if (!sched->task_state) {
         return false;
     }
 
-    sched->fanin_refcount = (int32_t*)calloc(window_size, sizeof(int32_t));
+    sched->fanin_refcount = new (std::nothrow) std::atomic<int32_t>[window_size];
     if (!sched->fanin_refcount) {
-        free(sched->task_state);
+        delete[] sched->task_state;
+        sched->task_state = nullptr;
         return false;
     }
 
-    sched->fanout_refcount = (int32_t*)calloc(window_size, sizeof(int32_t));
+    sched->fanout_refcount = new (std::nothrow) std::atomic<int32_t>[window_size];
     if (!sched->fanout_refcount) {
-        free(sched->fanin_refcount);
-        free(sched->task_state);
+        delete[] sched->fanin_refcount;
+        delete[] sched->task_state;
+        sched->fanin_refcount = nullptr;
+        sched->task_state = nullptr;
         return false;
     }
 
@@ -142,9 +149,12 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
             for (int j = 0; j < i; j++) {
                 pto2_ready_queue_destroy(&sched->ready_queues[j]);
             }
-            free(sched->fanout_refcount);
-            free(sched->fanin_refcount);
-            free(sched->task_state);
+            delete[] sched->fanout_refcount;
+            delete[] sched->fanin_refcount;
+            delete[] sched->task_state;
+            sched->fanout_refcount = nullptr;
+            sched->fanin_refcount = nullptr;
+            sched->task_state = nullptr;
             return false;
         }
     }
@@ -154,18 +164,18 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
 
 void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
     if (sched->task_state) {
-        free(sched->task_state);
-        sched->task_state = NULL;
+        delete[] sched->task_state;
+        sched->task_state = nullptr;
     }
 
     if (sched->fanin_refcount) {
-        free(sched->fanin_refcount);
-        sched->fanin_refcount = NULL;
+        delete[] sched->fanin_refcount;
+        sched->fanin_refcount = nullptr;
     }
 
     if (sched->fanout_refcount) {
-        free(sched->fanout_refcount);
-        sched->fanout_refcount = NULL;
+        delete[] sched->fanout_refcount;
+        sched->fanout_refcount = nullptr;
     }
 
     for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {
@@ -177,21 +187,23 @@ void pto2_scheduler_reset(PTO2SchedulerState* sched) {
     sched->last_task_alive = 0;
     sched->last_heap_consumed = 0;
     sched->heap_tail = 0;
-    memset(sched->task_state, 0, sched->task_window_size * sizeof(PTO2TaskState));
-    memset(sched->fanin_refcount, 0, sched->task_window_size * sizeof(int32_t));
-    memset(sched->fanout_refcount, 0, sched->task_window_size * sizeof(int32_t));
+    for (uint64_t i = 0; i < sched->task_window_size; i++) {
+        sched->task_state[i].store(PTO2_TASK_PENDING, std::memory_order_relaxed);
+        sched->fanin_refcount[i].store(0, std::memory_order_relaxed);
+        sched->fanout_refcount[i].store(0, std::memory_order_relaxed);
+    }
 
     for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {
         pto2_ready_queue_reset(&sched->ready_queues[i]);
     }
 
-    sched->tasks_completed = 0;
-    sched->tasks_consumed = 0;
+    sched->tasks_completed.store(0, std::memory_order_relaxed);
+    sched->tasks_consumed.store(0, std::memory_order_relaxed);
 }
 
 void pto2_scheduler_mark_running(PTO2SchedulerState* sched, int32_t task_id) {
     int32_t slot = sched->pto2_task_slot(task_id);
-    sched->task_state[slot] = PTO2_TASK_RUNNING;
+    sched->task_state[slot].store(PTO2_TASK_RUNNING, std::memory_order_relaxed);
 }
 
 int32_t pto2_scheduler_get_ready_task(PTO2SchedulerState* sched,
@@ -213,9 +225,9 @@ void pto2_scheduler_on_task_complete(PTO2SchedulerState* sched, int32_t task_id)
     // skip this producer (prod_state >= COMPLETED), so no new entries can be
     // appended to the fanout list. Traversal outside the lock is safe.
     pto2_fanout_lock(task);
-    __atomic_store_n(&sched->task_state[slot], PTO2_TASK_COMPLETED, __ATOMIC_RELEASE);
-    __atomic_fetch_add(&sched->tasks_completed, 1, __ATOMIC_RELAXED);
-    int32_t fanout_head = PTO2_LOAD_ACQUIRE(&task->fanout_head);
+    sched->task_state[slot].store(PTO2_TASK_COMPLETED, std::memory_order_release);
+    sched->tasks_completed.fetch_add(1, std::memory_order_relaxed);
+    int32_t fanout_head = task->fanout_head.load(std::memory_order_acquire);
     pto2_fanout_unlock(task);
 
     // Traverse fanout chain OUTSIDE the lock to notify consumers
@@ -236,37 +248,37 @@ void pto2_scheduler_on_task_complete(PTO2SchedulerState* sched, int32_t task_id)
     // === STEP 2: Mark CONSUMED and CAS-advance ring pointers ===
     // Mark this task as fully processed. Once CONSUMED is visible, the CAS loop
     // below (or another thread's) can advance last_task_alive past this slot.
-    __atomic_store_n(&sched->task_state[slot], PTO2_TASK_CONSUMED, __ATOMIC_RELEASE);
-    __atomic_fetch_add(&sched->tasks_consumed, 1, __ATOMIC_RELAXED);
+    sched->task_state[slot].store(PTO2_TASK_CONSUMED, std::memory_order_release);
+    sched->tasks_consumed.fetch_add(1, std::memory_order_relaxed);
 
     // CAS-based lock-free advancement of last_task_alive (matches pre-migration logic).
     // Multiple threads race to advance; CAS serializes winners.
     PTO2SharedMemoryHeader* header = sched->sm_handle->header;
-    int32_t la = PTO2_LOAD_ACQUIRE(&header->last_task_alive);
-    int32_t cti = PTO2_LOAD_ACQUIRE(&header->current_task_index);
+    int32_t la = header->last_task_alive.load(std::memory_order_acquire);
+    int32_t cti = header->current_task_index.load(std::memory_order_acquire);
 
     while (la < cti) {
         int32_t la_slot = la & sched->task_window_mask;
-        if (__atomic_load_n(&sched->task_state[la_slot], __ATOMIC_ACQUIRE) != PTO2_TASK_CONSUMED)
+        if (sched->task_state[la_slot].load(std::memory_order_acquire) != PTO2_TASK_CONSUMED)
             break;
 
         // Reset fanin_refcount before exposing slot for reuse
-        __atomic_store_n(&sched->fanin_refcount[la_slot], 0, __ATOMIC_RELEASE);
+        sched->fanin_refcount[la_slot].store(0, std::memory_order_release);
 
         // Atomically advance last_task_alive by 1
         int32_t expected = la;
-        if (__atomic_compare_exchange_n(&header->last_task_alive, &expected, la + 1,
-                false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+        if (header->last_task_alive.compare_exchange_strong(
+                expected, la + 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
             // Ticket-based heap_tail serialization: wait for our turn, then write
-            while (__atomic_load_n(&header->heap_tail_gen, __ATOMIC_ACQUIRE) != la) {
+            while (header->heap_tail_gen.load(std::memory_order_acquire) != la) {
                 PTO2_SPIN_PAUSE_LIGHT();
             }
             PTO2TaskDescriptor* consumed_t = pto2_sm_get_task(sched->sm_handle, la);
             if (consumed_t->packed_buffer_end != NULL) {
                 uint64_t new_tail = (uint64_t)((char*)consumed_t->packed_buffer_end - (char*)sched->heap_base);
-                PTO2_STORE_RELEASE(&header->heap_tail, new_tail);
+                header->heap_tail.store(new_tail, std::memory_order_release);
             }
-            PTO2_STORE_RELEASE(&header->heap_tail_gen, la + 1);
+            header->heap_tail_gen.store(la + 1, std::memory_order_release);
             la = la + 1;
         } else {
             break;
@@ -306,14 +318,14 @@ bool pto2_scheduler_is_done(PTO2SchedulerState* sched) {
     PTO2SharedMemoryHeader* header = sched->sm_handle->header;
 
     // Check if orchestrator has finished
-    int32_t orch_done = PTO2_LOAD_ACQUIRE(&header->orchestrator_done);
+    int32_t orch_done = header->orchestrator_done.load(std::memory_order_acquire);
     if (!orch_done) {
         return false;
     }
 
     // Check if all tasks have been consumed (read directly from shared memory)
-    int32_t current_task_index = PTO2_LOAD_ACQUIRE(&header->current_task_index);
-    int32_t last_alive = PTO2_LOAD_ACQUIRE(&header->last_task_alive);
+    int32_t current_task_index = header->current_task_index.load(std::memory_order_acquire);
+    int32_t last_alive = header->last_task_alive.load(std::memory_order_acquire);
     return last_alive >= current_task_index;
 }
 
@@ -325,8 +337,8 @@ void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
     LOG_INFO("=== Scheduler Statistics ===");
     LOG_INFO("last_task_alive:   %d", sched->last_task_alive);
     LOG_INFO("heap_tail:         %" PRIu64, sched->heap_tail);
-    LOG_INFO("tasks_completed:   %lld", (long long)sched->tasks_completed);
-    LOG_INFO("tasks_consumed:    %lld", (long long)sched->tasks_consumed);
+    LOG_INFO("tasks_completed:   %lld", (long long)sched->tasks_completed.load(std::memory_order_relaxed));
+    LOG_INFO("tasks_consumed:    %lld", (long long)sched->tasks_consumed.load(std::memory_order_relaxed));
     LOG_INFO("============================");
 }
 

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -18,6 +18,8 @@
 #ifndef PTO_SCHEDULER_H
 #define PTO_SCHEDULER_H
 
+#include <atomic>
+
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
 #include "pto_ring_buffer.h"
@@ -30,14 +32,14 @@
  * Per-worker-type ready queue
  * Circular buffer of task IDs
  */
-typedef struct {
+struct PTO2ReadyQueue {
     int32_t* task_ids;    // Circular buffer of task IDs
     uint64_t head;        // Dequeue position
     uint64_t tail;        // Enqueue position
     uint64_t capacity;    // Queue capacity
     uint64_t count;       // Current number of tasks in queue
-    int32_t spinlock;     // Spinlock for thread-safe push/pop
-} PTO2ReadyQueue;
+    std::atomic<int32_t> spinlock; // Spinlock for thread-safe push/pop
+};
 
 /**
  * Push task to ready queue
@@ -74,9 +76,9 @@ struct PTO2SchedulerState {
     // === PRIVATE DATA (not in shared memory) ===
 
     // Per-task state arrays (dynamically allocated, indexed by task_id & task_window_mask)
-    PTO2TaskState* task_state;        // PENDING/READY/RUNNING/COMPLETED/CONSUMED
-    int32_t* fanin_refcount;          // Dynamic: counts completed producers
-    int32_t* fanout_refcount;         // Dynamic: counts released references
+    std::atomic<PTO2TaskState>* task_state; // PENDING/READY/RUNNING/COMPLETED/CONSUMED
+    std::atomic<int32_t>* fanin_refcount;   // Dynamic: counts completed producers
+    std::atomic<int32_t>* fanout_refcount;  // Dynamic: counts released references
 
     // Ready queues (one per worker type)
     PTO2ReadyQueue ready_queues[PTO2_NUM_WORKER_TYPES];
@@ -85,8 +87,8 @@ struct PTO2SchedulerState {
     PTO2DepListPool* dep_pool;
 
     // Statistics
-    int64_t tasks_completed;
-    int64_t tasks_consumed;
+    std::atomic<int64_t> tasks_completed;
+    std::atomic<int64_t> tasks_consumed;
     int64_t total_dispatch_cycles;
 
 
@@ -118,14 +120,14 @@ struct PTO2SchedulerState {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
         // release in init_task, making fanin_count visible — plain load suffices.
-        int32_t new_refcount = __atomic_fetch_add(&fanin_refcount[slot], 1, __ATOMIC_ACQ_REL) + 1;
+        int32_t new_refcount = fanin_refcount[slot].fetch_add(1, std::memory_order_acq_rel) + 1;
 
         // Check if all producers have completed
         if (new_refcount == task->fanin_count) {
             // CAS PENDING -> READY to prevent double-enqueue from concurrent threads
             PTO2TaskState expected = PTO2_TASK_PENDING;
-            if (__atomic_compare_exchange_n(&task_state[slot], &expected, PTO2_TASK_READY,
-                                             false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+            if (task_state[slot].compare_exchange_strong(
+                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
                 pto2_ready_queue_push(&ready_queues[task->worker_type], task_id);
             }
         }
@@ -134,12 +136,12 @@ struct PTO2SchedulerState {
     void init_task(int32_t task_id, PTO2TaskDescriptor* task) {
         int32_t slot = pto2_task_slot(task_id);
 
-        task_state[slot] = PTO2_TASK_PENDING; // Orchestrator is the unique owner
+        task_state[slot].store(PTO2_TASK_PENDING, std::memory_order_relaxed); // Orchestrator is the unique owner
 
         // Reset fanout_refcount for new task lifecycle.
         // Do NOT reset fanin_refcount — it may have been incremented by
         // concurrent on_task_complete between Step 5 and Step 6.
-        fanout_refcount[slot] = 0;
+        fanout_refcount[slot].store(0, std::memory_order_relaxed);
 
         release_fanin_and_check_ready(task_id, task);
     }

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -143,12 +143,12 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
     PTO2SharedMemoryHeader* header = handle->header;
     
     // Flow control pointers (start at 0)
-    header->current_task_index = 0;
-    header->heap_top = 0;
-    header->orchestrator_done = 0;
-    header->last_task_alive = 0;
-    header->heap_tail = 0;
-    header->heap_tail_gen = 0;
+    header->current_task_index.store(0, std::memory_order_relaxed);
+    header->heap_top.store(0, std::memory_order_relaxed);
+    header->orchestrator_done.store(0, std::memory_order_relaxed);
+    header->last_task_alive.store(0, std::memory_order_relaxed);
+    header->heap_tail.store(0, std::memory_order_relaxed);
+    header->heap_tail_gen.store(0, std::memory_order_relaxed);
 
     // Layout info
     header->task_window_size = task_window_size;
@@ -163,8 +163,8 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
     header->dep_list_pool_offset = offset;
     
     header->total_size = handle->sm_size;
-    header->graph_output_ptr = 0;
-    header->graph_output_size = 0;
+    header->graph_output_ptr.store(0, std::memory_order_relaxed);
+    header->graph_output_size.store(0, std::memory_order_relaxed);
     
     // Initialize dep_list_pool entry 0 as NULL marker
     handle->dep_list_pool[0].task_id = -1;
@@ -177,15 +177,15 @@ void pto2_sm_reset(PTO2SharedMemoryHandle* handle) {
     PTO2SharedMemoryHeader* header = handle->header;
 
     // Reset flow control pointers
-    header->current_task_index = 0;
-    header->heap_top = 0;
-    header->orchestrator_done = 0;
-    header->last_task_alive = 0;
-    header->heap_tail = 0;
-    header->heap_tail_gen = 0;
+    header->current_task_index.store(0, std::memory_order_relaxed);
+    header->heap_top.store(0, std::memory_order_relaxed);
+    header->orchestrator_done.store(0, std::memory_order_relaxed);
+    header->last_task_alive.store(0, std::memory_order_relaxed);
+    header->heap_tail.store(0, std::memory_order_relaxed);
+    header->heap_tail_gen.store(0, std::memory_order_relaxed);
 
-    header->graph_output_ptr = 0;
-    header->graph_output_size = 0;
+    header->graph_output_ptr.store(0, std::memory_order_relaxed);
+    header->graph_output_size.store(0, std::memory_order_relaxed);
     // Clear task descriptors
     memset(handle->task_descriptors, 0, 
            header->task_window_size * sizeof(PTO2TaskDescriptor));
@@ -214,11 +214,11 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
     LOG_INFO("  TaskDescriptors:  %" PRIu64 " (0x%" PRIx64 ")", h->task_descriptors_offset, h->task_descriptors_offset);
     LOG_INFO("  DepListPool:      %" PRIu64 " (0x%" PRIx64 ")", h->dep_list_pool_offset, h->dep_list_pool_offset);
     LOG_INFO("Flow control:");
-    LOG_INFO("  heap_top:           %" PRIu64, h->heap_top);
-    LOG_INFO("  heap_tail:          %" PRIu64, h->heap_tail);
-    LOG_INFO("  current_task_index: %d", h->current_task_index);
-    LOG_INFO("  orchestrator_done:  %d", h->orchestrator_done);
-    LOG_INFO("  last_task_alive:    %d", h->last_task_alive);
+    LOG_INFO("  heap_top:           %" PRIu64, h->heap_top.load(std::memory_order_acquire));
+    LOG_INFO("  heap_tail:          %" PRIu64, h->heap_tail.load(std::memory_order_acquire));
+    LOG_INFO("  current_task_index: %d", h->current_task_index.load(std::memory_order_acquire));
+    LOG_INFO("  orchestrator_done:  %d", h->orchestrator_done.load(std::memory_order_acquire));
+    LOG_INFO("  last_task_alive:    %d", h->last_task_alive.load(std::memory_order_acquire));
     LOG_INFO("================================");
 }
 
@@ -238,10 +238,14 @@ bool pto2_sm_validate(PTO2SharedMemoryHandle* handle) {
     if ((uintptr_t)handle->dep_list_pool % PTO2_ALIGN_SIZE != 0) return false;
     
     // Check flow control pointer sanity
-    if (h->current_task_index < 0) return false;
-    if (h->last_task_alive < 0) return false;
-    if (h->heap_top > h->heap_size) return false;
-    if (h->heap_tail > h->heap_size) return false;
+    int32_t current_task_index = h->current_task_index.load(std::memory_order_acquire);
+    int32_t last_task_alive = h->last_task_alive.load(std::memory_order_acquire);
+    uint64_t heap_top = h->heap_top.load(std::memory_order_acquire);
+    uint64_t heap_tail = h->heap_tail.load(std::memory_order_acquire);
+    if (current_task_index < 0) return false;
+    if (last_task_alive < 0) return false;
+    if (heap_top > h->heap_size) return false;
+    if (heap_tail > h->heap_size) return false;
     
     return true;
 }

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -15,7 +15,7 @@
  * Design principles:
  * - Only data needed for Orchestrator<->Scheduler communication is here
  * - TensorMap, scope_stack, ready_queues are in private memory
- * - Flow control via volatile pointers (no locks needed for single-word R/W)
+ * - Flow control via atomic counters/flags (no locks needed for single-word R/W)
  * 
  * Based on: docs/runtime_buffer_manager_methods.md
  */
@@ -43,15 +43,15 @@ typedef struct {
     // === FLOW CONTROL POINTERS ===
 
     // Written by Orchestrator, Read by Scheduler
-    volatile uint64_t heap_top;           // Heap ring allocation pointer
-    volatile int32_t current_task_index;  // Task ring head (next to allocate)
-    volatile int32_t orchestrator_done;   // Flag: orchestration complete
+    std::atomic<uint64_t> heap_top;           // Heap ring allocation pointer
+    std::atomic<int32_t> current_task_index;  // Task ring head (next to allocate)
+    std::atomic<int32_t> orchestrator_done;   // Flag: orchestration complete
     
     // Written by Scheduler, Read by Orchestrator (for back-pressure)
-    volatile uint64_t heap_tail;          // Heap ring free pointer (on-device, matches pto2_heap_ring_init)
-    volatile int32_t last_task_alive;     // Task ring tail (oldest active task)
-    volatile int32_t heap_tail_gen;       // Ticket counter for serialized heap_tail writes
-                                          // (ensures concurrent threads write in task order)
+    std::atomic<uint64_t> heap_tail;          // Heap ring free pointer (on-device, matches pto2_heap_ring_init)
+    std::atomic<int32_t> last_task_alive;     // Task ring tail (oldest active task)
+    std::atomic<int32_t> heap_tail_gen;       // Ticket counter for serialized heap_tail writes
+                                              // (ensures concurrent threads write in task order)
 
     // === LAYOUT INFO (set once at init) ===
     uint64_t task_window_size;            // PTO2_TASK_WINDOW_SIZE
@@ -67,8 +67,8 @@ typedef struct {
 
     // Graph output for copy-back (set by orchestrator when using packed buffer)
     // Host finalize copies from this address instead of dev_ptr when non-zero
-    volatile uint64_t graph_output_ptr;   // Address where final output was written (packed buffer)
-    volatile uint64_t graph_output_size;  // Size in bytes
+    std::atomic<uint64_t> graph_output_ptr;   // Address where final output was written (packed buffer)
+    std::atomic<uint64_t> graph_output_size;  // Size in bytes
 
     // Padding to 128-byte cache line
     uint64_t _padding[4];

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -238,7 +238,8 @@ void PTO2TensorMap::sync_tensormap() {
     always_assert(orch != nullptr);
     while(true) {
         // Read current last_task_alive from shared memory
-        int32_t new_last_task_alive = PTO2_LOAD_ACQUIRE(&orch->sm_handle->header->last_task_alive);
+        int32_t new_last_task_alive =
+            orch->sm_handle->header->last_task_alive.load(std::memory_order_acquire);
         sync_validity(new_last_task_alive);
         if ((pool_size - next_entry_idx + free_num < MIN_FREE_NUM) || new_last_task_alive - orch->tensormap_last_cleanup >= PTO2_TENSORMAP_CLEANUP_INTERVAL) {
             cleanup_retired(orch->tensormap_last_cleanup, new_last_task_alive);

--- a/src/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -165,7 +165,7 @@ void Runtime::complete_perf_records(PerfBuffer* perf_buf) {
 
         // Fill fanout information by traversing the linked list
         record->fanout_count = 0;
-        int32_t fanout_offset = task->fanout_head;
+        int32_t fanout_offset = task->fanout_head.load(std::memory_order_acquire);
 
         while (fanout_offset != 0 && record->fanout_count < RUNTIME_MAX_FANOUT) {
             PTO2DepListEntry* entry = &dep_list_pool[fanout_offset];


### PR DESCRIPTION
This pr fixes issue #126.

- Convert PTO2SharedMemoryHeader flow-control and graph-output fields to std::atomic and migrate orchestrator/scheduler/executor/ring-buffer accesses to explicit atomic operations.
- Convert PTO2TaskDescriptor fanout_lock/fanout_head/fanout_count to std::atomic and update fanout lock/list update paths.
- Remove PTO2 atomic helper macros and replace remaining call sites with direct std::atomic load/store/CAS usage.
- Remove redundant volatile locals from AICore task polling loop.
- Keep Handshake volatile fields as the only AICore boundary synchronization surface.

This unifies the in-runtime concurrency model on std::atomic while keeping the AICore handshake boundary semantics explicit.