### PR TITLE
Fix: resolve scheduler data race and premature CONSUMED transition

### DIFF
--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -367,7 +367,7 @@ void pto2_submit_task(
             int32_t producer_task_id = fanin_temp[i];
             // Add this task to producer's fanout list (with spinlock)
             PTO2TaskDescriptor* producer = pto2_task_ring_get(&orch->task_ring, producer_task_id);
-            producer->fanout_count.fetch_add(1, std::memory_order_relaxed);
+            producer->fanout_count.fetch_add(1, std::memory_order_release);
             int32_t prod_slot = sched->pto2_task_slot(producer_task_id);
             pto2_fanout_lock(producer);
             // Normal path: prepend consumer to producer's fanout list

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -82,6 +82,7 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
     sched->tasks_completed.store(0, std::memory_order_relaxed);
     sched->tasks_consumed.store(0, std::memory_order_relaxed);
     sched->total_dispatch_cycles = 0;
+    sched->ring_advance_lock.store(0, std::memory_order_relaxed);
 
     // Get runtime task_window_size from shared memory header
     uint64_t window_size = sm_handle->header->task_window_size;
@@ -172,6 +173,7 @@ void pto2_scheduler_reset(PTO2SchedulerState* sched) {
 
     sched->tasks_completed.store(0, std::memory_order_relaxed);
     sched->tasks_consumed.store(0, std::memory_order_relaxed);
+    sched->ring_advance_lock.store(0, std::memory_order_relaxed);
 }
 
 // =============================================================================

--- a/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -166,6 +166,7 @@ struct PTO2SchedulerState {
     std::atomic<int64_t> tasks_completed;
     std::atomic<int64_t> tasks_consumed;
     int64_t total_dispatch_cycles;
+    std::atomic<int32_t> ring_advance_lock{0};  // Try-lock for advance_ring_pointers
 
     // =========================================================================
     // Inline hot-path methods
@@ -223,8 +224,12 @@ struct PTO2SchedulerState {
         fanout_refcount[slot].store(0, std::memory_order_release);
         fanin_refcount[slot].store(0, std::memory_order_release);
 
-        if (task_id == last_task_alive) {
+        // Try-lock — if another thread is advancing, it will scan our CONSUMED task
+        int32_t expected_lock = 0;
+        if (ring_advance_lock.compare_exchange_strong(expected_lock, 1,
+                std::memory_order_acquire, std::memory_order_relaxed)) {
             advance_ring_pointers();
+            ring_advance_lock.store(0, std::memory_order_release);
         }
     }
 


### PR DESCRIPTION
## Summary
- Add CAS try-lock to serialize concurrent `advance_ring_pointers` calls, preventing a data race on non-atomic `last_task_alive` and `heap_tail` when multiple scheduler threads enter `check_and_handle_consumed` simultaneously
- Strengthen `fanout_count.fetch_add` ordering from `relaxed` to `release` in the orchestrator, ensuring the scheduler's `acquire` load sees the up-to-date count before comparing with `fanout_refcount`

## Testing
- [ ] Simulation tests pass (`./ci.sh -p a2a3sim`)
- [ ] Hardware tests pass (`./ci.sh -p a2a3 -d <devices>`)
- [ ] Taskring tests with small window (`PTO2_RING_TASK_WINDOW=16`)