### PR TITLE
Refactor: add local-first dispatch to skip MPMC queue for same-thread ready tasks

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -222,7 +222,8 @@ struct AicpuExecutor {
         int32_t& cur_thread_completed,
         bool& made_progress,
         int32_t deferred_release_ids[],
-        int32_t& deferred_release_count
+        int32_t& deferred_release_count,
+        PTO2LocalReadyBuffer& local_buf
 #if PTO2_PROFILING
         ,
         bool profiling_enabled,
@@ -262,20 +263,20 @@ struct AicpuExecutor {
                 executing_task_ids[core_id] = AICPU_TASK_INVALID;
 #if PTO2_SCHED_PROFILING
                 PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
-                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, thread_idx);
+                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, thread_idx, &local_buf);
                 notify_edges_total += cstats.fanout_edges;
                 if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
                 notify_tasks_enqueued += cstats.tasks_enqueued;
                 phase_complete_count++;
 #elif PTO2_PROFILING
                 PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
-                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id);
+                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, &local_buf);
                 notify_edges_total += cstats.fanout_edges;
                 if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
                 notify_tasks_enqueued += cstats.tasks_enqueued;
                 phase_complete_count++;
 #else
-                rt->scheduler.on_task_complete(task_id);
+                rt->scheduler.on_task_complete(task_id, &local_buf);
 #endif
                 if (deferred_release_count < 64) {
                     deferred_release_ids[deferred_release_count++] = task_id;
@@ -846,12 +847,21 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     uint64_t pop_miss = 0;
     uint32_t phase_complete_count = 0;
     uint32_t phase_dispatch_count = 0;
+    uint64_t local_dispatch_count = 0;
+    uint64_t local_overflow_count = 0;
 #if PTO2_SCHED_PROFILING
     uint64_t sched_complete_perf_cycle = 0;
     uint64_t sched_dispatch_pop_cycle = 0;
     uint64_t sched_dispatch_setup_cycle = 0;
 #endif
 #endif
+
+    // Local-first dispatch buffer (stack-allocated, one per scheduling thread).
+    // Initialized once; must be empty at the start of each iteration.
+    constexpr int LOCAL_READY_CAP = 64;
+    int32_t local_task_ids[LOCAL_READY_CAP];
+    PTO2LocalReadyBuffer local_buf;
+    local_buf.reset(local_task_ids, LOCAL_READY_CAP);
     int32_t deferred_release_ids[128];
     int32_t deferred_release_count = 0;
 
@@ -907,12 +917,14 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
         // Check AIC running cores
         bool try_completed = false;
+        always_assert(local_buf.count == 0);  // Invariant: previous iteration fully consumed
         if (tracker.aic().running_count > 0) {
             try_completed = true;
             check_running_cores_for_completion<CoreType::AIC>(
                 thread_idx, tracker.aic(), hank, executing_task_ids,
                 completed_this_turn, cur_thread_completed, made_progress,
-                deferred_release_ids, deferred_release_count
+                deferred_release_ids, deferred_release_count,
+                local_buf
 #if PTO2_PROFILING
                 , profiling_enabled, complete_probe_count, complete_hit_count, phase_complete_count,
                 notify_edges_total, notify_max_degree, notify_tasks_enqueued,
@@ -930,7 +942,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             check_running_cores_for_completion<CoreType::AIV>(
                 thread_idx, tracker.aiv(), hank, executing_task_ids,
                 completed_this_turn, cur_thread_completed, made_progress,
-                deferred_release_ids, deferred_release_count
+                deferred_release_ids, deferred_release_count,
+                local_buf
 #if PTO2_PROFILING
                 , profiling_enabled, complete_probe_count, complete_hit_count, phase_complete_count,
                 notify_edges_total, notify_max_degree, notify_tasks_enqueued,
@@ -969,8 +982,65 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         }
 #endif
 
-        // Phase 2: Dispatch ready tasks to idle cores (register-based dispatch)
+        // Phase 2: Local dispatch — match local_buf tasks to idle cores (zero MPMC operations)
+        // Phase 3: Global queue — push overflow to readyQ + fill remaining idle cores from readyQ
         bool try_pushed = false;
+
+        // Local dispatch: drain local_buf, match to idle cores by type
+        int32_t overflow_ids[LOCAL_READY_CAP];
+        int overflow_count = 0;
+        while (local_buf.count > 0) {
+            int32_t task_id = local_buf.pop();
+            PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
+            CoreType ct_type = static_cast<CoreType>(task->worker_type);
+            CoreTypeTracker& ct = (ct_type == CoreType::AIC) ? tracker.aic() : tracker.aiv();
+
+            if (ct.idle_count > 0) {
+                try_pushed = true;
+                int32_t idle_idx = ct.idle_count - 1;
+                int32_t core_id = ct.idle[idle_idx];
+                PTO2TaskPayload* task_pl = &task_payloads[task_id & window_mask];
+                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
+                if (ct_type == CoreType::AIC) {
+                    build_pto2_payload<CoreType::AIC>(payload, runtime, task, task_pl);
+                } else {
+                    build_pto2_payload<CoreType::AIV>(payload, runtime, task, task_pl);
+                }
+#if PTO2_PROFILING
+                if (profiling_enabled) {
+                    dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    if (core_dispatch_counts_[core_id] >= PLATFORM_PROF_BUFFER_SIZE) {
+                        perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
+                        core_dispatch_counts_[core_id] = 0;
+                    }
+                    core_dispatch_counts_[core_id]++;
+                }
+                pop_hit++;
+                phase_dispatch_count++;
+                local_dispatch_count++;
+#endif
+                write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE,
+                          static_cast<uint64_t>(task_id + 1));
+                ct.move_idle_to_running(idle_idx);
+                executing_task_ids[core_id] = task_id;
+                made_progress = true;
+                DEV_DEBUG("Thread %d: Dispatching PTO2 task %d to core %d (local)",
+                          thread_idx, task_id, core_id);
+            } else {
+                overflow_ids[overflow_count++] = task_id;
+#if PTO2_PROFILING
+                local_overflow_count++;
+#endif
+            }
+        }
+
+        // Push overflow to global readyQ
+        for (int i = 0; i < overflow_count; i++) {
+            PTO2TaskDescriptor* task = &task_descriptors[overflow_ids[i] & window_mask];
+            rt->scheduler.ready_queues[task->worker_type].push(overflow_ids[i]);
+        }
+
+        // Global dispatch: fill remaining idle cores from global readyQ
         // Process AIC cores if CUBE queue has tasks
         if (tracker.aic().idle_count > 0 && rt->scheduler.ready_queues[PTO2_WORKER_CUBE].size() > 0) {
             try_pushed = true;
@@ -1195,6 +1265,16 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             (unsigned long long)pop_hit,
             (unsigned long long)pop_miss,
             pop_hit_rate);
+        uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
+        uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
+        double local_hit_rate = total_dispatched > 0
+            ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
+        DEV_ALWAYS("Thread %d:     local_disp   : local=%llu, global=%llu, overflow=%llu, local_rate=%.1f%%",
+            thread_idx,
+            (unsigned long long)local_dispatch_count,
+            (unsigned long long)global_dispatch_count,
+            (unsigned long long)local_overflow_count,
+            local_hit_rate);
 
         // Level 2: dispatch sub-phases (percentage relative to dispatch)
         uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -46,6 +46,43 @@ struct PTO2ReadyQueueSlot {
 };
 
 /**
+ * Thread-local ready buffer for local-first dispatch optimization.
+ *
+ * One buffer per scheduling thread (mixed worker types).
+ * Initialized once before the scheduling loop; must be empty at
+ * the start of each iteration (verified by always_assert).
+ *
+ * Phase 1 fills this buffer via on_task_complete().
+ * Phase 2 drains it: matched tasks dispatch to idle cores,
+ * unmatched tasks are stored in an overflow array for Phase 3.
+ * Phase 3 pushes overflow to global readyQ and fills remaining
+ * idle cores from global readyQ.
+ */
+struct PTO2LocalReadyBuffer {
+    int32_t* task_ids = nullptr;  // Points to caller's stack array
+    int count = 0;
+    int capacity = 0;
+
+    void reset(int32_t* buf, int cap) {
+        task_ids = buf;
+        count = 0;
+        capacity = cap;
+    }
+
+    bool try_push(int32_t task_id) {
+        if (task_ids && count < capacity) {
+            task_ids[count++] = task_id;
+            return true;
+        }
+        return false;
+    }
+
+    int32_t pop() {
+        return (count > 0) ? task_ids[--count] : -1;  // LIFO: better cache locality
+    }
+};
+
+/**
  * Lock-free bounded MPMC queue (Dmitry Vyukov design)
  *
  * Key properties:
@@ -392,7 +429,8 @@ struct PTO2SchedulerState {
 #endif
 
     bool release_fanin_and_check_ready(int32_t task_id,
-                                        PTO2TaskDescriptor* task) {
+                                        PTO2TaskDescriptor* task,
+                                        PTO2LocalReadyBuffer* local_buf = nullptr) {
         int32_t slot = pto2_task_slot(task_id);
 
         // Atomically increment fanin_refcount and check if all producers are done
@@ -401,7 +439,14 @@ struct PTO2SchedulerState {
         int32_t new_refcount = fanin_refcount[slot].fetch_add(1, std::memory_order_acq_rel) + 1;
 
         if (new_refcount == task->fanin_count) {
-            ready_queues[task->worker_type].push(task_id);
+            // Local-first: try thread-local buffer before global queue
+            bool pushed_local = false;
+            if (local_buf) {
+                pushed_local = local_buf->try_push(task_id);
+            }
+            if (!pushed_local) {
+                ready_queues[task->worker_type].push(task_id);
+            }
             return true;
         }
         return false;
@@ -409,7 +454,8 @@ struct PTO2SchedulerState {
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
     bool release_fanin_and_check_ready(int32_t task_id, PTO2TaskDescriptor* task,
-                                        uint64_t& atomic_count, uint64_t& push_wait) {
+                                        uint64_t& atomic_count, uint64_t& push_wait,
+                                        PTO2LocalReadyBuffer* local_buf = nullptr) {
         int32_t slot = pto2_task_slot(task_id);
 
         int32_t new_refcount = fanin_refcount[slot].fetch_add(1, std::memory_order_acq_rel) + 1;
@@ -420,7 +466,14 @@ struct PTO2SchedulerState {
             if (task_state[slot].compare_exchange_strong(
                     expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
                 atomic_count += 1;  // CAS(task_state PENDING→READY)
-                ready_queues[task->worker_type].push(task_id, atomic_count, push_wait);
+                // Local-first: try thread-local buffer before global queue
+                bool pushed_local = false;
+                if (local_buf) {
+                    pushed_local = local_buf->try_push(task_id);
+                }
+                if (!pushed_local) {
+                    ready_queues[task->worker_type].push(task_id, atomic_count, push_wait);
+                }
                 return true;
             }
         }
@@ -474,13 +527,16 @@ struct PTO2SchedulerState {
     }
 
 #if PTO2_SCHED_PROFILING
-    PTO2CompletionStats on_task_complete(int32_t task_id, int thread_idx) {
+    PTO2CompletionStats on_task_complete(int32_t task_id, int thread_idx,
+                                          PTO2LocalReadyBuffer* local_buf = nullptr) {
         PTO2CompletionStats stats = {0, 0, 0};
 #elif PTO2_PROFILING
-    PTO2CompletionStats on_task_complete(int32_t task_id) {
+    PTO2CompletionStats on_task_complete(int32_t task_id,
+                                          PTO2LocalReadyBuffer* local_buf = nullptr) {
         PTO2CompletionStats stats = {0, 0, 0};
 #else
-    void on_task_complete(int32_t task_id) {
+    void on_task_complete(int32_t task_id,
+                           PTO2LocalReadyBuffer* local_buf = nullptr) {
 #endif
         int32_t slot = pto2_task_slot(task_id);
         PTO2TaskDescriptor& task = pto2_sm_get_task_by_slot(sm_handle, task_id);
@@ -528,17 +584,17 @@ struct PTO2SchedulerState {
 #endif
 #if PTO2_SCHED_PROFILING
             if (release_fanin_and_check_ready(consumer_id, consumer,
-                                               fanout_atomics, push_wait)) {
+                                               fanout_atomics, push_wait, local_buf)) {
 #if PTO2_PROFILING
                 stats.tasks_enqueued++;
 #endif
             }
 #elif PTO2_PROFILING
-            if (release_fanin_and_check_ready(consumer_id, consumer)) {
+            if (release_fanin_and_check_ready(consumer_id, consumer, local_buf)) {
                 stats.tasks_enqueued++;
             }
 #else
-            release_fanin_and_check_ready(consumer_id, consumer);
+            release_fanin_and_check_ready(consumer_id, consumer, local_buf);
 #endif
             current = current->next;
         }


### PR DESCRIPTION
## Summary

- Introduce thread-local `PTO2LocalReadyBuffer` so that newly-ready tasks discovered during Phase 1 (task completion / fanout traversal) are stored in a stack-allocated buffer instead of being pushed to the global MPMC queue
- Phase 2 consumes from the local buffer first (LIFO for cache locality), falling back to the global queue only when the buffer is empty
- Remaining tasks are unconditionally drained back to the global queue after dispatch to prevent task loss

## Motivation

The current scheduler's `release_fanin_and_check_ready()` unconditionally pushes ready tasks to the global lock-free MPMC queue, then Phase 2 pops from the same queue. For tasks that the same thread just made ready, this introduces two unnecessary CAS operations (push + pop) and contends with other scheduler threads, causing cache line bouncing.

## Design

```
Phase 1:  on_task_complete → fanout traversal → release_fanin_and_check_ready
          → push to local buffer or global queue (when buffer full)

Phase 2:  idle core detected → pop from local buffer (LIFO) if available
          → type mismatch → overflow array

Phase 3:  push overflow back to global queue
          → fill remaining idle cores from global MPMC queue
```

Key properties:
- Zero new synchronization primitives — local buffer is stack-allocated, single-thread access
- Backward compatible — `local_buf = nullptr` default preserves existing `init_task` path
- Integrated with PTO2_PROFILING and PTO2_SCHED_PROFILING systems

## Benchmark Results (Ascend 910, 10 rounds)

| Example | Baseline | PR #172 | Delta |
|---------|----------|---------|-------|
| paged_attention | 21049.6 us | 18966.4 us | **-9.9%** |
| benchmark_bgemm | 1228.4 us | 1192.8 us | -2.9% |
| batch_paged_attention | 2112.6 us | 2107.5 us | -0.2% |
| alternating_matmul_add | 1126.8 us | 1130.9 us | +0.4% |

## Changed Files

| File | Change |
|------|--------|
| `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h` | Add `PTO2LocalReadyBuffer` struct; add `local_buf` parameter to `release_fanin_and_check_ready()` and `on_task_complete()` (all profiling variants) |
| `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp` | Declare local buffers; integrate with Phase 1/2; add drain step; extend profiling output with local dispatch stats |

## Testing
- [x] Simulation tests pass (6/6 tensormap_and_ringbuffer examples)
- [x] Hardware benchmark pass (4/4 device tests)