### PR TITLE
Support: add orch_pending SPMC buffer to eliminate cross-thread CAS contention

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -847,6 +847,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     uint64_t pop_miss = 0;
     uint32_t phase_complete_count = 0;
     uint32_t phase_dispatch_count = 0;
+    uint32_t phase_scan_enqueue = 0;
+    uint64_t scan_enqueue_total = 0;
     uint64_t local_dispatch_count = 0;
     uint64_t local_overflow_count = 0;
 #if PTO2_SCHED_PROFILING
@@ -980,6 +982,33 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             }
             CYCLE_COUNT_LAP(sched_complete_cycle);
         }
+#endif
+
+        // Scan phase: drain orch_pending into ready_queues
+        {
+            int32_t pending_task_id;
+            while ((pending_task_id = rt->scheduler.orch_pending_try_pop()) >= 0) {
+                PTO2TaskDescriptor* ptask = &task_descriptors[pending_task_id & window_mask];
+                if (ptask->worker_type >= 0 && ptask->worker_type < PTO2_NUM_WORKER_TYPES) {
+                    rt->scheduler.ready_queues[ptask->worker_type].push(pending_task_id);
+                    made_progress = true;
+#if PTO2_PROFILING
+                    phase_scan_enqueue++;
+#endif
+                } else {
+                    DEV_ERROR("Invalid worker_type %d for task %d", ptask->worker_type, pending_task_id);
+                }
+            }
+        }
+        CYCLE_COUNT_LAP(sched_scan_cycle);
+#if PTO2_PROFILING
+        scan_enqueue_total += phase_scan_enqueue;
+        if (profiling_enabled && phase_scan_enqueue > 0) {
+            perf_aicpu_record_phase(
+                thread_idx, AicpuPhaseId::SCHED_SCAN, _t0_phase, _t1, sched_loop_count, phase_scan_enqueue);
+            _t0_phase = _t1;
+        }
+        phase_scan_enqueue = 0;
 #endif
 
         // Phase 2: Local dispatch — match local_buf tasks to idle cores (zero MPMC operations)
@@ -1291,9 +1320,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             sched_dispatch_setup_cycle * 100.0 / d_parent);
 
         // Level 1: scan
-        DEV_ALWAYS("Thread %d:   scan           : %.3fus (%.1f%%)",
+        DEV_ALWAYS("Thread %d:   scan           : %.3fus (%.1f%%)  [enqueue: %llu]",
             thread_idx, cycles_to_us(sched_scan_cycle),
-            sched_scan_cycle * 100.0 / sched_total);
+            sched_scan_cycle * 100.0 / sched_total,
+            (unsigned long long)scan_enqueue_total);
 
         // Level 1: idle
         DEV_ALWAYS("Thread %d:   idle           : %.3fus (%.1f%%)",

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -86,7 +86,7 @@ Each of the 3 scheduler threads (Thread 0, 1, 2) prints its own summary after co
 Thread 0: completed=352 tasks in 3477.420us (147 loops, 2.4 tasks/loop)
 Thread 0: --- Phase Breakdown ---
 Thread 0:   complete:    1485.020us (42.7%)  [fanout: edges=432, max_degree=2, avg=1.2]  [fanin: edges=320, max_degree=3, avg=0.9]
-Thread 0:   scan:        14.400us (0.4%)
+Thread 0:   scan:        14.400us (0.4%)  [enqueue: 120]
 Thread 0:   dispatch:    1973.060us (56.7%)  [pop: hit=352, miss=3043, hit_rate=10.4%]
 Thread 0:   idle:        4.940us (0.1%)
 ```
@@ -111,7 +111,7 @@ The scheduler loop runs four phases each iteration. Each phase's time is accumul
 | Phase | What it does | Inline stats |
 |-------|-------------|-------------|
 | **complete** | Polls handshake on each managed core; when a core completes, traverses fanout list (notify consumers) and fanin list (release producers) via `on_task_complete` | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
-| **scan** | Updates the perf profiling header with latest scheduler state | — |
+| **scan** | Drains the `orch_pending` SPMC buffer (orchestrator→ready queue transfer) and updates the perf profiling header with latest scheduler state | `enqueue`: number of tasks drained from `orch_pending` into ready queues |
 | **dispatch** | For each idle core, pops a task from the ready queue via `pto2_scheduler_get_ready_task`, builds the dispatch payload, and writes the task to the core's handshake register | `pop`: `hit` = successful pops (task dispatched), `miss` = empty queue pops, `hit_rate` = hit/(hit+miss) |
 | **idle** | Scheduler loop iteration where no progress was made (no completions, no dispatches) | — |
 
@@ -119,7 +119,7 @@ The scheduler loop runs four phases each iteration. Each phase's time is accumul
 
 - **dispatch** is typically the largest (~55-60%) because it includes ready-queue pops (with spinlock), payload construction, and cache flush (`dc cvac` + `dsb sy`).
 - **complete** is the second largest (~40-45%) because it traverses both fanout (CAS-based fanin decrement, conditional ready-queue push) and fanin (release_producer, check_consumed, ring pointer advancement).
-- **scan** is small (<1%) — only updates the perf header.
+- **scan** is typically small (<1%) — drains `orch_pending` (tasks made ready by the orchestrator) into ready queues and updates the perf header.
 - **idle** is negligible when tasks are flowing; high idle% indicates the scheduler is starved.
 
 **Interpreting pop hit_rate:**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -175,6 +175,37 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
         }
     }
 
+    // Initialize orch_pending buffer (SPMC: orchestrator pushes, scheduler threads pop)
+    if (window_size == 0 || window_size > PTO2_TASK_WINDOW_SIZE) {
+        for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {
+            pto2_ready_queue_destroy(&sched->ready_queues[i]);
+        }
+        delete[] sched->fanout_refcount;
+        delete[] sched->fanin_refcount;
+        delete[] sched->task_state;
+        sched->fanout_refcount = nullptr;
+        sched->fanin_refcount = nullptr;
+        sched->task_state = nullptr;
+        return false;
+    }
+    sched->orch_pending_capacity = window_size;
+    sched->orch_pending_mask = window_size - 1;
+    sched->orch_pending_buf = new (std::nothrow) int32_t[window_size];
+    if (!sched->orch_pending_buf) {
+        for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {
+            pto2_ready_queue_destroy(&sched->ready_queues[i]);
+        }
+        delete[] sched->fanout_refcount;
+        delete[] sched->fanin_refcount;
+        delete[] sched->task_state;
+        sched->fanout_refcount = nullptr;
+        sched->fanin_refcount = nullptr;
+        sched->task_state = nullptr;
+        return false;
+    }
+    sched->orch_pending_head.store(0, std::memory_order_relaxed);
+    sched->orch_pending_tail.store(0, std::memory_order_relaxed);
+
     return true;
 }
 
@@ -192,6 +223,11 @@ void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
     if (sched->fanout_refcount) {
         delete[] sched->fanout_refcount;
         sched->fanout_refcount = nullptr;
+    }
+
+    if (sched->orch_pending_buf) {
+        delete[] sched->orch_pending_buf;
+        sched->orch_pending_buf = nullptr;
     }
 
     for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -23,6 +23,7 @@
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
 #include "pto_ring_buffer.h"
+#include "spin_hint.h"
 
 #include "common/core_type.h"
 
@@ -300,6 +301,13 @@ struct PTO2SchedulerState {
     // Ready queues (one per worker type)
     PTO2ReadyQueue ready_queues[PTO2_NUM_WORKER_TYPES];
 
+    // Orchestrator pending buffer (SPMC: orch pushes, scheduler threads pop)
+    int32_t* orch_pending_buf;
+    std::atomic<int64_t> orch_pending_head;  // Written by orchestrator only (SP)
+    std::atomic<int64_t> orch_pending_tail;  // CAS'd by scheduler threads (MC)
+    uint64_t orch_pending_capacity;
+    uint64_t orch_pending_mask;
+
     // Statistics
 #if PTO2_PROFILING
     std::atomic<int64_t> tasks_completed;
@@ -481,6 +489,56 @@ struct PTO2SchedulerState {
     }
 #endif
 
+    bool release_fanin_and_mark_ready(int32_t task_id,
+                                       PTO2TaskDescriptor* task) {
+        int32_t slot = pto2_task_slot(task_id);
+        int32_t new_refcount = fanin_refcount[slot].fetch_add(1, std::memory_order_acq_rel) + 1;
+        if (new_refcount == task->fanin_count) {
+            PTO2TaskState expected = PTO2_TASK_PENDING;
+            return task_state[slot].compare_exchange_strong(
+                expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire);
+        }
+        return false;
+    }
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    bool release_fanin_and_mark_ready(int32_t task_id, PTO2TaskDescriptor* task,
+                                       uint64_t& atomic_count) {
+        int32_t slot = pto2_task_slot(task_id);
+        int32_t new_refcount = fanin_refcount[slot].fetch_add(1, std::memory_order_acq_rel) + 1;
+        atomic_count += 1;  // fanin_refcount.fetch_add
+        if (new_refcount == task->fanin_count) {
+            PTO2TaskState expected = PTO2_TASK_PENDING;
+            if (task_state[slot].compare_exchange_strong(
+                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
+                atomic_count += 1;  // CAS(task_state PENDING->READY)
+                return true;
+            }
+        }
+        return false;
+    }
+#endif
+
+    void orch_pending_push(int32_t task_id) {
+        int64_t h = orch_pending_head.load(std::memory_order_relaxed);
+        while (h - orch_pending_tail.load(std::memory_order_acquire) >= (int64_t)orch_pending_capacity) {
+            SPIN_WAIT_HINT();
+        }
+        orch_pending_buf[h & orch_pending_mask] = task_id;
+        orch_pending_head.store(h + 1, std::memory_order_release);
+    }
+
+    int32_t orch_pending_try_pop() {
+        int64_t t = orch_pending_tail.load(std::memory_order_relaxed);
+        int64_t h = orch_pending_head.load(std::memory_order_acquire);
+        if (t >= h) return -1;
+        if (orch_pending_tail.compare_exchange_weak(t, t + 1,
+                std::memory_order_release, std::memory_order_relaxed)) {
+            return orch_pending_buf[t & orch_pending_mask];
+        }
+        return -1;
+    }
+
     void init_task(int32_t task_id, PTO2TaskDescriptor* task) {
         int32_t slot = pto2_task_slot(task_id);
 
@@ -493,11 +551,13 @@ struct PTO2SchedulerState {
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
         extern uint64_t g_orch_finalize_atomic_count;
-        extern uint64_t g_orch_finalize_wait_cycle;
-        release_fanin_and_check_ready(task_id, task,
-                                       g_orch_finalize_atomic_count, g_orch_finalize_wait_cycle);
+        if (release_fanin_and_mark_ready(task_id, task, g_orch_finalize_atomic_count)) {
+            orch_pending_push(task_id);
+        }
 #else
-        release_fanin_and_check_ready(task_id, task);
+        if (release_fanin_and_mark_ready(task_id, task)) {
+            orch_pending_push(task_id);
+        }
 #endif
     }
 

--- a/tools/sched_overhead_analysis.py
+++ b/tools/sched_overhead_analysis.py
@@ -114,14 +114,16 @@ def parse_scheduler_threads(log_path):
                     threads[tid]['pop_hit_rate'] = float(m.group(6))
                 continue
 
-            # New format: scan and idle (no extra stats)
-            m = re.search(r'Thread (\d+):\s+(scan|idle)\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)', line)
+            # New format: scan with optional enqueue count, and idle (no extra stats)
+            m = re.search(r'Thread (\d+):\s+(scan|idle)\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)(?:\s+\[enqueue: (\d+)\])?', line)
             if m:
                 tid = int(m.group(1))
                 if tid in threads:
                     phase = m.group(2)
                     threads[tid][f'{phase}_us'] = float(m.group(3))
                     threads[tid][f'{phase}_pct'] = float(m.group(4))
+                    if m.group(5) is not None:
+                        threads[tid]['scan_enqueue'] = int(m.group(5))
                 continue
 
     return threads
@@ -309,6 +311,11 @@ def run_analysis(perf_path, log_path, print_sources=True, selection_strategy=Non
     pop_total = pop_hit + pop_miss
     pop_hit_rate = pop_hit / pop_total * 100 if pop_total > 0 else 0
     print(f'  Pop: hit={pop_hit}, miss={pop_miss}, hit_rate={pop_hit_rate:.1f}%')
+
+    # Scan enqueue stats (from scan phase, orch_pending drain)
+    scan_enqueue = sum(t.get('scan_enqueue', 0) for t in threads.values())
+    if scan_enqueue > 0:
+        print(f'  Scan enqueue (orch_pending drain): total={scan_enqueue}')
 
     print()
     print('=' * 90)


### PR DESCRIPTION
## Summary
- Add `orch_pending` bounded SPMC ring buffer to `PTO2SchedulerState`
- Replace direct `ready_queue.push()` in `init_task()` with two-stage pipeline: orchestrator pushes to `orch_pending`, scheduler threads drain in scan phase
- Add `release_fanin_and_mark_ready()` that marks task state without queue push
- Insert scan phase in dispatch loop with `worker_type` bounds check and `DEV_ERROR` logging
- Add `scan_enqueue` profiling counter and summary output
- Update `sched_overhead_analysis.py` to parse enqueue stats

## Benchmark Results (3-round A/B, 10 iterations each)

| Workload | Baseline (μs) | PR (μs) | Delta |
|---|---|---|---|
| alternating_matmul_add | 1146.6 | 1226.7 | +7.0% |
| benchmark_bgemm | 1216.3 | 1186.7 | -2.4% |
| batch_paged_attention | 2066.9 | 2118.5 | +2.5% |
| paged_attention | 19703.9 | 21153.9 | +7.4% |

**Note**: Baseline includes PR #172 (local-first dispatch). The orch_pending buffer adds an extra indirection layer which currently outweighs the CAS contention reduction on these workloads. The paged_attention regression (~1450μs) is most significant due to its longer task graph.

## Testing
- [x] Simulation tests pass (`ci.sh -p a2a3sim`)
- [x] Hardware benchmarks (3 rounds A/B on Ascend device)