### PR TITLE
Refactor: extract shared GitHub skill procedures into modular library

### DIFF
--- a/.claude/lib/github/README.md
+++ b/.claude/lib/github/README.md
@@ -1,0 +1,35 @@
+# GitHub Shared Procedures
+
+Reusable procedures for GitHub PR workflows.
+
+## Available Procedures
+
+| Procedure | Description | Used By |
+| --------- | ----------- | ------- |
+| [setup](setup.md) | Authenticate and detect repository context | All |
+| [lookup-pr](lookup-pr.md) | Find PR by number, branch, or list all | All |
+| [detect-permission](detect-permission.md) | Check push access to PR | address-pr-comments |
+| [commit-and-push](commit-and-push.md) | Squash commits, rebase, and push | github-pr, address-pr-comments |
+| [fetch-comments](fetch-comments.md) | Get unresolved PR review comments | address-pr-comments |
+| [reply-and-resolve](reply-and-resolve.md) | Reply to and resolve review threads | address-pr-comments |
+| [branch-naming](branch-naming.md) | Generate branch name from commit | github-pr |
+| [common-issues](common-issues.md) | Troubleshooting reference | All |
+
+## Standard Variables
+
+After running `detect-context`, these variables are available:
+
+| Variable | Description | Example (owner) | Example (fork) |
+| -------- | ----------- | --------------- | -------------- |
+| `REPO_OWNER` | Origin repo owner | `ChaoWao` | `contributor` |
+| `REPO_NAME` | Origin repo name | `simpler` | `simpler` |
+| `PR_REPO_OWNER` | PR target owner | `ChaoWao` | `ChaoWao` |
+| `PR_REPO_NAME` | PR target name | `simpler` | `simpler` |
+| `DEFAULT_BRANCH` | Base branch name | `main` | `main` |
+| `BASE_REF` | Full base ref | `origin/main` | `upstream/main` |
+| `PUSH_REMOTE` | Where to push | `origin` | `origin` |
+| `PR_HEAD_PREFIX` | PR head prefix | *(empty)* | `contributor:` |
+| `ROLE` | Repository role | `owner` | `fork` |
+| `BRANCH_NAME` | Current branch | `feat/new` | `feat/new` |
+| `COMMITS_AHEAD` | Commits ahead of base | `1` | `1` |
+| `UNCOMMITTED` | Uncommitted changes | *(empty or files)* | *(empty or files)* |

--- a/.claude/lib/github/branch-naming.md
+++ b/.claude/lib/github/branch-naming.md
@@ -1,0 +1,29 @@
+# Branch Naming
+
+Generate branch name from commit message.
+
+## Rules
+
+1. Determine the commit type prefix:
+
+| Commit type | Branch prefix |
+| ----------- | ------------- |
+| Add | `feat/` |
+| Fix | `fix/` |
+| Update | `feat/` |
+| Refactor | `refactor/` |
+| Support | `support/` |
+| Sim | `sim/` |
+| CI | `support/` |
+
+2. Take the commit subject description (after `Type: `), lowercase it, replace spaces and special characters with hyphens, strip trailing hyphens.
+
+3. Truncate to 50 characters.
+
+## Examples
+
+**Short commit (no truncation):**
+`Refactor: inline ring buffer hot paths` → `refactor/inline-ring-buffer-hot-paths` (37 chars)
+
+**Long commit (with truncation):**
+`Support: add complete-phase poll hit-rate logging with detailed statistics` → `support/add-complete-phase-poll-hit-rate-logging-w` (50 chars)

--- a/.claude/lib/github/commit-and-push.md
+++ b/.claude/lib/github/commit-and-push.md
@@ -1,0 +1,72 @@
+# Commit and Push
+
+Prepares changes for PR: rebases, squashes commits, and pushes.
+
+## 1. Rebase
+
+First, rebase onto the latest base branch to incorporate upstream changes.
+
+```bash
+# Save commit SHA before rebase
+BEFORE_REBASE=$(git rev-parse HEAD)
+
+# Perform rebase
+git rebase "$BASE_REF"
+
+# Check if commit history changed
+if [ "$BEFORE_REBASE" != "$(git rev-parse HEAD)" ]; then
+  echo "Warning: Rebase changed commit history"
+  REBASE_CHANGED=true
+else
+  REBASE_CHANGED=false
+fi
+```
+
+On conflicts: resolve files, `git add <file>`, `git rebase --continue`. If stuck: `git rebase --abort`.
+
+If `REBASE_CHANGED == true`, validate the commit message and content.
+
+## 2. Ensure Single Valid Commit
+
+After rebasing, squash multiple commits into one if needed.
+
+```bash
+COMMITS_AHEAD=$(git rev-list HEAD --not "$BASE_REF" --count 2>/dev/null || echo "0")
+```
+
+| `COMMITS_AHEAD` | Action |
+| --------------- | ------ |
+| `0` | **Error.** Nothing to push. |
+| `1` | **OK.** Proceed to step 3. |
+| `> 1` | **Must squash.** See below, then re-verify. |
+
+### Squash procedure (when `COMMITS_AHEAD > 1`)
+
+1. Soft-reset to base:
+   ```bash
+   git reset --soft "$BASE_REF"
+   ```
+2. All changes are now staged. Delegate to `/git-commit` to create a single commit with a proper message based on the combined diff.
+3. **Re-verify** the count:
+   ```bash
+   COMMITS_AHEAD=$(git rev-list HEAD --not "$BASE_REF" --count)
+   # Must be exactly 1. If not, something went wrong — do NOT push.
+   ```
+
+**Important:** When squashing, the commit message must be regenerated based on the final combined diff, not copied from any single commit.
+
+## 3. Push
+
+**First push (new branch)**:
+
+```bash
+git push --set-upstream "$PUSH_REMOTE" "$BRANCH_NAME"
+```
+
+**Update push (existing branch)**:
+
+```bash
+git push --force-with-lease "$PUSH_REMOTE" "$BRANCH_NAME"
+```
+
+Always use the determined `PUSH_REMOTE`. Never push to `upstream` or other unrelated remotes.

--- a/.claude/lib/github/common-issues.md
+++ b/.claude/lib/github/common-issues.md
@@ -1,0 +1,16 @@
+# Common Issues
+
+Troubleshooting reference for GitHub workflows.
+
+| Issue | Solution |
+| ----- | -------- |
+| `gh auth` fails | Tell user to run `gh auth login` |
+| Merge conflicts during rebase | Resolve files, `git add <file>`, `git rebase --continue` |
+| Rebase stuck | `git rebase --abort`, investigate manually |
+| Push rejected (non-fast-forward) | Use `git push --force-with-lease` after confirming rebase |
+| More than 1 commit ahead | Run [commit-and-push](commit-and-push.md) |
+| No origin remote | Repository not properly initialized |
+| PR not found | Verify PR number; use [lookup-pr](lookup-pr.md) |
+| PR is merged | Exit — cannot modify merged PR |
+| No unresolved comments | Inform user all comments resolved; exit |
+| No push access | Ask PR author to enable "Allow edits from maintainers" |

--- a/.claude/lib/github/detect-permission.md
+++ b/.claude/lib/github/detect-permission.md
@@ -1,0 +1,63 @@
+# Detect Permission
+
+Used by `address-pr-comments` when working on someone else's PR. Determines push access and overrides `PUSH_REMOTE` if needed.
+
+## Fetch PR Metadata
+
+```bash
+PR_DATA=$(gh pr view $PR_NUMBER --repo "$PR_REPO_OWNER/$PR_REPO_NAME" --json \
+  number,title,headRefName,headRepository,headRepositoryOwner,\
+  baseRefName,state,maintainerCanModify,author)
+
+HEAD_BRANCH=$(echo "$PR_DATA" | jq -r '.headRefName')
+HEAD_REPO_OWNER=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login')
+HEAD_REPO_NAME=$(echo "$PR_DATA" | jq -r '.headRepository.name')
+PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
+MAINTAINER_CAN_MODIFY=$(echo "$PR_DATA" | jq -r '.maintainerCanModify')
+CURRENT_USER=$(gh api user -q '.login')
+```
+
+## Determine Permission
+
+```bash
+if [ "$PR_AUTHOR" = "$CURRENT_USER" ]; then
+  PERMISSION="owner"
+elif [ "$HEAD_REPO_OWNER" = "$PR_REPO_OWNER" ]; then
+  PERMISSION="write"
+elif [ "$MAINTAINER_CAN_MODIFY" = "true" ]; then
+  PERMISSION="maintainer"
+else
+  echo "Error: No push access to PR #$PR_NUMBER"
+  echo "Ask PR author to enable 'Allow edits from maintainers'"
+  exit 1
+fi
+```
+
+## Set Push Target
+
+```bash
+case "$PERMISSION" in
+  owner|write)
+    PUSH_REMOTE="origin"
+    WORK_BRANCH="$HEAD_BRANCH"
+    ;;
+  maintainer)
+    FORK_REMOTE="pr-$PR_NUMBER"
+    if ! git remote | grep -q "^${FORK_REMOTE}$"; then
+      git remote add "$FORK_REMOTE" \
+        "https://github.com/$HEAD_REPO_OWNER/$HEAD_REPO_NAME.git"
+    fi
+    git fetch "$FORK_REMOTE" "$HEAD_BRANCH"
+    PUSH_REMOTE="$FORK_REMOTE"
+    WORK_BRANCH="$HEAD_BRANCH"
+    ;;
+esac
+```
+
+## Cleanup After Push
+
+```bash
+if [ "$PERMISSION" = "maintainer" ]; then
+  git remote remove "$FORK_REMOTE" 2>/dev/null || true
+fi
+```

--- a/.claude/lib/github/fetch-comments.md
+++ b/.claude/lib/github/fetch-comments.md
@@ -1,0 +1,46 @@
+# Fetch Unresolved PR Comments
+
+Fetches all unresolved review threads for a given PR.
+
+```bash
+COMMENTS_JSON=$(gh api graphql -f owner="$PR_REPO_OWNER" -f repo="$PR_REPO_NAME" -F number=$PR_NUMBER \
+  -f query='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 50) {
+            nodes {
+              id
+              databaseId
+              body
+              path
+              line
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}')
+
+# Filter to unresolved threads only
+UNRESOLVED=$(echo "$COMMENTS_JSON" | jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)')
+
+# Check if we hit the pagination limit
+THREAD_COUNT=$(echo "$COMMENTS_JSON" | jq '.data.repository.pullRequest.reviewThreads.nodes | length')
+if [ "$THREAD_COUNT" -eq 100 ]; then
+  echo "Warning: PR has 100+ review threads. Some threads may not be fetched."
+  echo "Consider manually checking the PR for additional unresolved comments."
+fi
+```
+
+**Limits:**
+- `reviewThreads(first: 100)`: Fetches up to 100 threads. PRs with more threads will show a warning.
+- `comments(first: 50)`: Fetches up to 50 comments per thread. Sufficient for most review discussions.
+
+Output: JSON array of unresolved threads with their comments.

--- a/.claude/lib/github/lookup-pr.md
+++ b/.claude/lib/github/lookup-pr.md
@@ -1,0 +1,26 @@
+# Lookup PR
+
+Find PR by number, branch name, or list all open PRs.
+
+## By PR Number
+
+```bash
+gh pr view $PR_NUMBER --repo "$PR_REPO_OWNER/$PR_REPO_NAME" \
+  --json number,title,headRefName,state
+```
+
+## By Branch Name
+
+```bash
+gh pr list --repo "$PR_REPO_OWNER/$PR_REPO_NAME" --head "$BRANCH_NAME" \
+  --json number,title,state
+```
+
+## List Open PRs
+
+For user selection:
+
+```bash
+gh pr list --repo "$PR_REPO_OWNER/$PR_REPO_NAME" --state open \
+  --json number,title,headRefName,author
+```

--- a/.claude/lib/github/reply-and-resolve.md
+++ b/.claude/lib/github/reply-and-resolve.md
@@ -1,0 +1,15 @@
+# Reply and Resolve
+
+Reply using:
+
+```bash
+gh api repos/${PR_REPO_OWNER}/${REPO_NAME}$/pulls/<number>/comments/<comment_id>/replies -f body="..."
+```
+
+Then resolve thread with GraphQL `resolveReviewThread` mutation.
+
+**Response templates:**
+
+- Fixed: "Fixed in `<commit>` — description"
+- Skip: "Current code follows `.claude/rules/<file>`"
+- Acknowledged: "Acknowledged, thank you!"

--- a/.claude/lib/github/setup.md
+++ b/.claude/lib/github/setup.md
@@ -1,0 +1,87 @@
+# Setup
+
+Initialize GitHub workflow: authenticate and detect repository context.
+
+## 1. Authenticate
+
+```bash
+gh auth status
+```
+
+If not authenticated, tell user to run `gh auth login` and stop.
+
+## 2. Detect Context
+
+Detects repository role, remotes, and current state. Sets standard variables used by all skills.
+
+### Parse Remotes
+
+```bash
+# Get remote URLs
+ORIGIN_URL=$(git remote get-url origin 2>/dev/null || echo "")
+UPSTREAM_URL=$(git remote get-url upstream 2>/dev/null || echo "")
+
+# Validate origin exists
+if [ -z "$ORIGIN_URL" ]; then
+  echo "Error: No 'origin' remote found"
+  exit 1
+fi
+
+# Get default branch
+DEFAULT_BRANCH=$(git remote show origin | sed -n 's/.*HEAD branch: \(.*\)/\1/p')
+
+# Parse origin → REPO_OWNER / REPO_NAME
+REPO_OWNER=$(echo "$ORIGIN_URL" | sed -n 's#.*[:/]\([^/]*\)/\([^/]*\)\.git.*#\1#p')
+REPO_NAME=$(echo "$ORIGIN_URL" | sed -n 's#.*[:/]\([^/]*\)/\([^/]*\)\.git.*#\2#p')
+
+# Parse upstream (if exists)
+if [ -n "$UPSTREAM_URL" ]; then
+  UPSTREAM_OWNER=$(echo "$UPSTREAM_URL" | sed -n 's#.*[:/]\([^/]*\)/\([^/]*\)\.git.*#\1#p')
+  UPSTREAM_NAME=$(echo "$UPSTREAM_URL" | sed -n 's#.*[:/]\([^/]*\)/\([^/]*\)\.git.*#\2#p')
+fi
+```
+
+### Determine Role
+
+```bash
+if [ -n "$UPSTREAM_URL" ]; then
+  # Fork contributor
+  ROLE="fork"
+  BASE_REF="upstream/$DEFAULT_BRANCH"
+  PUSH_REMOTE="origin"
+  PR_REPO_OWNER="$UPSTREAM_OWNER"
+  PR_REPO_NAME="$UPSTREAM_NAME"
+  PR_HEAD_PREFIX="$REPO_OWNER:"
+else
+  # Repo owner
+  ROLE="owner"
+  BASE_REF="origin/$DEFAULT_BRANCH"
+  PUSH_REMOTE="origin"
+  PR_REPO_OWNER="$REPO_OWNER"
+  PR_REPO_NAME="$REPO_NAME"
+  PR_HEAD_PREFIX=""
+fi
+```
+
+### Fetch Remotes
+
+```bash
+git fetch origin
+if [ "$ROLE" = "fork" ]; then
+  git fetch upstream
+fi
+```
+
+### Gather State
+
+```bash
+BRANCH_NAME=$(git branch --show-current 2>/dev/null || echo "")
+UNCOMMITTED=$(git status --porcelain)
+if [ -n "$BRANCH_NAME" ]; then
+  COMMITS_AHEAD=$(git rev-list HEAD --not "$BASE_REF" --count 2>/dev/null || echo "0")
+else
+  COMMITS_AHEAD="0"
+fi
+```
+
+See [README.md](README.md) for the full list of variables set by this procedure.

--- a/.claude/skills/address-pr-comments/SKILL.md
+++ b/.claude/skills/address-pr-comments/SKILL.md
@@ -9,53 +9,32 @@ Intelligently triage PR review comments, address actionable feedback, and resolv
 
 ## Input
 
-Accept PR number (`123`, `#123`) or branch name (`feature-branch`).
+Accept PR number (`123`, `#123`), branch name (`feature-branch`), or no input (auto-detect).
 
-## Workflow
+## Setup
 
-1. Match input to PR
-2. Fetch unresolved comments
-3. Classify comments
-4. Get user confirmation on ALL comments
-5. Address user-selected comments with code changes
-6. Reply and resolve threads
+1. [Setup](../../lib/github/setup.md) — authenticate and detect context (role, remotes, state)
 
 ## Step 1: Match Input to PR
 
-```bash
-# PR number
-gh pr view <number> --json number,title,headRefName,state
+Use [lookup-pr](../../lib/github/lookup-pr.md) to find the PR.
 
-# Branch name
-git branch --show-current
-gh pr list --head <branch> --json number,title,state
-```
+- If PR number or branch name provided: use "By PR number" or "By branch name" lookup
+- If no input: auto-detect from current branch, or list open PRs for user selection
 
-## Step 2: Fetch Unresolved Comments
+Validate PR state: OPEN (continue), CLOSED (warn), MERGED (exit).
 
-```bash
-gh api graphql -f query='
-query {
-  repository(owner: "ChaoWao", name: "simpler") {
-    pullRequest(number: <number>) {
-      reviewThreads(first: 50) {
-        nodes {
-          id isResolved
-          comments(first: 1) {
-            nodes { id databaseId body path line }
-          }
-        }
-      }
-    }
-  }
-}'
-```
+## Step 2: Detect Permission
 
-Filter to `isResolved: false` only.
+Run [detect-permission](../../lib/github/detect-permission.md) to determine push access.
 
-**If no unresolved comments exist:** Inform the user that all PR comments have been resolved and exit the workflow. Do not proceed to subsequent steps.
+## Step 3: Fetch Unresolved Comments
 
-## Step 3: Classify Comments
+Run [fetch-comments](../../lib/github/fetch-comments.md).
+
+If no unresolved comments exist, inform user and exit.
+
+## Step 4: Classify Comments
 
 | Category | Description | Examples |
 | -------- | ----------- | -------- |
@@ -65,7 +44,7 @@ Filter to `isResolved: false` only.
 
 Present summary showing category, file:line, and issue for each comment. For Category B, explain why code may already comply with `.claude/rules/`.
 
-## Step 4: Get User Confirmation
+## Step 5: Get User Confirmation
 
 **Always let the user decide which comments to address and which to skip.** Present ALL unresolved comments (A, B, and C) in a numbered list with their classification and brief summary.
 
@@ -79,55 +58,43 @@ Ask the user to specify which comments to address, skip, or discuss:
 
 Only proceed with the comments the user explicitly selects. Do NOT auto-resolve any comment without user consent.
 
-## Step 5: Address Comments
+## Step 6: Work Location Setup
 
-For user-selected comments only:
+Work directly on the PR branch. If not already on `$HEAD_BRANCH`, checkout and pull:
+
+```bash
+git checkout $HEAD_BRANCH
+git pull "$PUSH_REMOTE" "$HEAD_BRANCH"
+```
+
+If in a worktree on different branch, offer to create new worktree or switch to main repo.
+
+## Step 7: Address Comments
+
+For each "Address" comment:
 
 1. Read files with Read tool
 2. Make changes with Edit tool
-3. Commit using `/git-commit` skill
+3. After all changes, commit using `/git-commit` skill
 
-## Step 6: Resolve Comments
+Then run [commit-and-push](../../lib/github/commit-and-push.md):
+1. Rebase onto `$BASE_REF`
+2. Ensure single valid commit (squash with original PR commit)
+3. Push (update push with `--force-with-lease` to `$PUSH_REMOTE`)
 
-Reply using:
+## Step 8: Reply and Resolve
 
-```bash
-gh api repos/ChaoWao/simpler/pulls/<number>/comments/<comment_id>/replies -f body="..."
-```
-
-Then resolve thread with GraphQL `resolveReviewThread` mutation.
-
-**Response templates:**
-
-- Fixed: "Fixed in `<commit>` — description"
-- Skip: "Current code follows `.claude/rules/<file>`"
-- Acknowledged: "Acknowledged, thank you!"
-
-## Best Practices
-
-| Area | Guidelines |
-| ---- | ---------- |
-| **Analysis** | Reference `.claude/rules/`; when unsure → Category B |
-| **Changes** | Read full context; minimal edits; follow project conventions |
-| **Communication** | Be respectful; explain reasoning; reference rules |
-
-## Error Handling
-
-| Error | Action |
-| ----- | ------ |
-| PR not found | `gh pr list`; ask user to confirm |
-| Not authenticated | "Run: `gh auth login`" |
-| No unresolved comments | Inform user all comments resolved; exit workflow |
-| Unclear comment | Mark Category B for discussion |
+Use [reply-and-resolve](../../lib/github/reply-and-resolve.md) for each comment.
 
 ## Checklist
 
-- [ ] PR matched and validated
+- [ ] PR matched, permission determined, comments fetched and classified
 - [ ] Unresolved comments fetched and classified
 - [ ] ALL comments presented to user for selection
 - [ ] Code changes made and committed (use `/git-commit`)
-- [ ] Changes pushed to `origin`
-- [ ] All comments replied to and resolved
+- [ ] Changes pushed (single valid commit, squashed with original PR commit)
+- [ ] All selected comments replied to and resolved
+- [ ] Summary presented
 
 ## Remember
 

--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -5,71 +5,19 @@ description: Create or update a GitHub pull request after committing, rebasing, 
 
 # GitHub Pull Request Workflow
 
-## Setup: Detect Context
+## Setup
 
-### 1. Authenticate
+1. [Setup](../../lib/github/setup.md) — authenticate and detect context (role, remotes, state)
+2. [Lookup PR](../../lib/github/lookup-pr.md) by branch name to check for existing PR
 
-```bash
-gh auth status
-```
+## Route
 
-If not authenticated, tell user to run `gh auth login` and **stop**.
-
-### 2. Detect Role
-
-```bash
-ORIGIN_URL=$(git remote get-url origin)
-UPSTREAM_URL=$(git remote get-url upstream 2>/dev/null || echo "")
-DEFAULT_BRANCH=$(git remote show origin | sed -n 's/.*HEAD branch: \(.*\)/\1/p')
-```
-
-Two developer roles use this repo differently:
-
-| Role | `upstream` exists? | Push target | PR target |
-| ---- | ------------------ | ----------- | --------- |
-| **Repo owner** | No | `origin` | `origin/$DEFAULT_BRANCH` |
-| **Fork contributor** | Yes | `origin` (fork) | `upstream/$DEFAULT_BRANCH` |
-
-Compute these variables once — all later steps use them without role conditionals:
-
-| Variable | Repo owner | Fork contributor |
-| -------- | ---------- | ---------------- |
-| `BASE_REF` | `origin/$DEFAULT_BRANCH` | `upstream/$DEFAULT_BRANCH` |
-| `PUSH_REMOTE` | `origin` | `origin` |
-| `PR_REPO` | *(omit — same repo)* | `OWNER/REPO` from `upstream` URL |
-| `PR_HEAD` | `$BRANCH_NAME` | `FORK_OWNER:$BRANCH_NAME` (`FORK_OWNER` from `origin` URL) |
-
-### 3. Fetch and Gather State
-
-Single fetch for all remotes:
-
-```bash
-git fetch origin
-if [ -n "$UPSTREAM_URL" ]; then git fetch upstream; fi
-```
-
-Gather current state:
-
-```bash
-BRANCH_NAME=$(git branch --show-current)
-UNCOMMITTED=$(git status --porcelain)
-COMMITS_AHEAD=$(git rev-list HEAD --not "$BASE_REF" --count)
-```
-
-### 4. Check for Existing PR
-
-```bash
-gh pr list --head "$BRANCH_NAME" --state open
-```
-
-### 5. Route
-
-| Existing PR? | On default branch? | Commits ahead? | Uncommitted? | Route |
-| ------------ | ------------------- | -------------- | ------------ | ----- |
-| No | * | * | * | **Path A** (create new PR) |
-| Yes | No | Ahead > 0 | * | **Path B** (update existing PR) |
-| Yes | No | 0 | Yes | **Path B** (commit + update) |
-| Yes | No | 0 | No | Already up to date — exit |
+| Existing PR? | Commits ahead? | Uncommitted? | Route |
+| ------------ | -------------- | ------------ | ----- |
+| No | * | * | **Path A** (create new PR) |
+| Yes | > 0 | * | **Path B** (update existing PR) |
+| Yes | 0 | Yes | **Path B** (commit + update) |
+| Yes | 0 | No | Already up to date — exit |
 
 **Validation**: If no existing PR, `COMMITS_AHEAD == 0`, and no uncommitted changes — error. Nothing to PR.
 
@@ -79,81 +27,42 @@ gh pr list --head "$BRANCH_NAME" --state open
 
 ### A1. Prepare Branch
 
-Check the current branch and its relationship to the changes being PR'd:
-
-| Current branch | Commits ahead of `$BASE_REF`? | Commits related to current changes? | Action |
-| -------------- | ----------------------------- | ----------------------------------- | ------ |
-| `$DEFAULT_BRANCH` | — | — | Create new branch from HEAD |
-| Feature branch | Yes, all related | Yes | Continue on it |
-| Feature branch | Yes, unrelated commits exist | No | Stash → new branch from `$BASE_REF` → pop |
-| Feature branch | No (0 ahead) | Branch name fits | Continue on it (uncommitted changes only) |
-| Feature branch | No (0 ahead) | Branch name unrelated | Stash → new branch from `$BASE_REF` → pop |
-
-**Case 1 — On `$DEFAULT_BRANCH`**: Create and switch to a new branch:
+If on `$DEFAULT_BRANCH`, create new branch. If on unrelated feature branch, stash and create new branch from `$BASE_REF`.
 
 ```bash
+# On default branch
 git checkout -b <branch-name>
-```
 
-**Case 2 — Feature branch, all commits related**: Continue on it. No action needed.
-
-**Case 3 — Feature branch, unrelated commits exist**: The branch has commits that are not part of the changes you want to PR. Stash uncommitted work, create a new branch from `$BASE_REF`, and restore:
-
-```bash
+# On unrelated branch
 git stash
 git checkout -b <branch-name> "$BASE_REF"
 git stash pop
 ```
 
-To detect this: inspect `git log $BASE_REF..HEAD --oneline` and compare those commits against the staged/unstaged changes. If any existing commits touch unrelated files or features, treat the branch as unrelated.
-
-**Case 4 — Feature branch, 0 commits ahead, branch name fits**: Continue on it — only uncommitted changes will be committed.
-
-**Case 5 — Feature branch, 0 commits ahead, branch name unrelated**: The branch name doesn't match the intent of the uncommitted changes. Stash, create a new branch, and restore:
-
-```bash
-git stash
-git checkout -b <branch-name> "$BASE_REF"
-git stash pop
-```
-
-See **[Branch Naming](#branch-naming)** for how to generate the name. Do NOT ask the user.
+Generate branch name using [branch-naming](../../lib/github/branch-naming.md). Do NOT ask the user.
 
 ### A2. Commit Changes
 
-If there are uncommitted changes, delegate to `/git-commit` (runs review and testing).
+If there are uncommitted changes, delegate to `/git-commit`.
 
 If already committed, skip.
 
-### A3. Ensure Single Valid Commit
+### A3. Commit and Push
 
-Follow the **[shared procedure](#shared-ensure-single-valid-commit)** below.
+Run [commit-and-push](../../lib/github/commit-and-push.md):
+1. Rebase onto `$BASE_REF`
+2. Ensure single valid commit (squash if needed)
+3. Push (first push with `--set-upstream`)
 
-### A4. Rebase
+If rebase introduces changes, re-validate the commit.
 
-```bash
-git rebase "$BASE_REF"
-```
-
-On conflicts: resolve files, `git add`, `git rebase --continue`. If stuck: `git rebase --abort`.
-
-After rebase, re-run the **[shared procedure](#shared-ensure-single-valid-commit)** if the rebase introduced changes.
-
-### A5. Push
-
-Always push to `origin`. Never push to `upstream` or other remotes. Use `git` commands (not `gh`).
-
-```bash
-git push --set-upstream origin "$BRANCH_NAME"
-```
-
-### A6. Create PR
+### A4. Create PR
 
 ```bash
 gh pr create \
-  --repo "$PR_REPO" \
+  --repo "$PR_REPO_OWNER/$PR_REPO_NAME" \
   --base "$DEFAULT_BRANCH" \
-  --head "$PR_HEAD" \
+  --head "${PR_HEAD_PREFIX}${BRANCH_NAME}" \
   --title "Brief description" \
   --body "$(cat <<'EOF'
 ## Summary
@@ -193,29 +102,16 @@ If there are uncommitted changes, delegate to `/git-commit`.
 
 If already committed, skip.
 
-### B2. Ensure Single Valid Commit
+### B2. Commit and Push
 
-Follow the **[shared procedure](#shared-ensure-single-valid-commit)** below.
+Run [commit-and-push](../../lib/github/commit-and-push.md):
+1. Rebase onto `$BASE_REF`
+2. Ensure single valid commit (squash if needed)
+3. Push (update push with `--force-with-lease`)
 
-### B3. Rebase
+If rebase introduces changes, re-validate the commit.
 
-```bash
-git rebase "$BASE_REF"
-```
-
-On conflicts: resolve files, `git add`, `git rebase --continue`. If stuck: `git rebase --abort`.
-
-After rebase, re-run the **[shared procedure](#shared-ensure-single-valid-commit)** if the rebase introduced changes.
-
-### B4. Push
-
-```bash
-git push --force-with-lease origin "$BRANCH_NAME"
-```
-
-Always push to `origin`. Never push to `upstream` or other remotes.
-
-### B5. Update PR Title/Body
+### B3. Update PR Title/Body
 
 If the commit message changed, update the PR to match:
 
@@ -234,56 +130,6 @@ gh pr edit --title "Updated title" --body "Updated body"
 
 ---
 
-## Shared: Ensure Single Valid Commit
-
-### Squash if Needed
-
-```bash
-COMMITS_AHEAD=$(git rev-list HEAD --not "$BASE_REF" --count)
-```
-
-If more than 1 commit ahead, squash:
-
-```bash
-git reset --soft "$BASE_REF"
-git commit  # Re-commit with proper message via /git-commit conventions
-```
-
-### Validate Commit Message
-
-```bash
-git log -1 --format='%s'   # Subject line
-git log -1 --format='%b'   # Body
-```
-
-| Rule | Check |
-| ---- | ----- |
-| Subject format | `Type: concise description` |
-| Valid types | Add, Fix, Update, Refactor, Support, Sim, CI |
-| Length | Under 72 characters |
-| Style | Imperative mood, no trailing period |
-| Body | Required if commit touches 3+ files |
-| Co-author | No AI co-author lines |
-
-If the message does not comply, amend:
-
-```bash
-git commit --amend -m "Type: corrected description"
-```
-
-For multi-line messages:
-
-```bash
-git commit --amend -m "$(cat <<'EOF'
-Type: corrected description
-
-- What changed and why
-EOF
-)"
-```
-
----
-
 ## Post-Merge Cleanup (Repo Owner Only)
 
 After the PR is merged:
@@ -296,39 +142,3 @@ git push origin --delete "$BRANCH_NAME"
 ```
 
 Fork contributors do not need remote cleanup.
-
----
-
-## Reference
-
-### Branch Naming
-
-1. Determine the commit type prefix:
-
-| Commit type | Branch prefix |
-| ----------- | ------------- |
-| Add | `feat/` |
-| Fix | `fix/` |
-| Update | `feat/` |
-| Refactor | `refactor/` |
-| Support | `support/` |
-| Sim | `sim/` |
-| CI | `support/` |
-
-2. Take the commit subject description (after `Type: `), lowercase it, replace spaces and special characters with hyphens, strip trailing hyphens.
-
-3. Truncate to 50 characters.
-
-Example: `Refactor: inline ring buffer hot paths` → `refactor/inline-ring-buffer-hot-paths`
-
-### Common Issues
-
-| Issue | Solution |
-| ----- | -------- |
-| `gh auth` fails | Tell user to run `gh auth login` |
-| PR already exists | Route to Path B |
-| Merge conflicts during rebase | Resolve, `git add`, `git rebase --continue` |
-| Push rejected (non-fast-forward) | `git push --force-with-lease` after rebase |
-| More than 1 commit ahead | Squash via `git reset --soft` + re-commit |
-| Can't detect role | Check `git remote -v` output |
-| Nothing to PR | Error — tell user to make changes first |


### PR DESCRIPTION
## Summary
- Create `.claude/lib/github/` with 8 reusable procedure files:
  setup, lookup-pr, detect-permission, commit-and-push,
  fetch-comments, reply-and-resolve, branch-naming, common-issues
- Update `github-pr` and `address-pr-comments` skills to reference
  shared procedures instead of duplicating logic
- Standardize variable naming (`REPO_OWNER`, `PUSH_REMOTE`, etc.)
- Fix squash step control flow: replace exit-0 with decision table
  and re-verification gate to prevent multi-commit PRs

## Benefits
- Eliminates ~290 lines of duplication across skills
- Modular design: each procedure is independently maintainable
- Consistent variable naming across all workflows

## Testing
- [x] Documentation-only changes (no tests required)