### PR TITLE
Support: test commands read pto-isa commit and timeout from ci.yml

### DIFF
--- a/.claude/commands/test-all-device.md
+++ b/.claude/commands/test-all-device.md
@@ -1,10 +1,11 @@
 Run the full hardware CI pipeline with automatic device detection.
 
 1. Check `command -v npu-smi` — if not found, tell the user to use `/test-all-sim` instead and stop
-2. Run `npu-smi info` and parse the output to find devices whose **HBM-Usage is 0** (idle)
-3. From the idle devices, take **at most 4**. If no idle device is found, report the situation and stop
-4. Build the device range flag: from the idle devices, find the **longest consecutive sub-range** (at most 4). Pass as `-d <start>-<end>`. If no consecutive pair exists, use the lowest-ID idle device as `-d <id>`
-5. If **2 or more** idle devices selected, run: `./ci.sh -p a2a3 -d <range> --parallel`
-6. If only **1** idle device, run: `./ci.sh -p a2a3 -d <id>`
-7. Report the results summary (pass/fail counts per task)
-8. If any tests fail, show the relevant error output and which device/round failed
+2. Read `.github/workflows/ci.yml` to extract the current `-c` (pto-isa commit) and `-t` (timeout) flags from the `run-example-on-device` job's `./ci.sh` invocation
+3. Run `npu-smi info` and parse the output to find devices whose **HBM-Usage is 0** (idle)
+4. From the idle devices, take **at most 4**. If no idle device is found, report the situation and stop
+5. Build the device range flag: from the idle devices, find the **longest consecutive sub-range** (at most 4). Pass as `-d <start>-<end>`. If no consecutive pair exists, use the lowest-ID idle device as `-d <id>`
+6. If **2 or more** idle devices selected, run: `./ci.sh -p a2a3 -d <range> -c <commit> -t <timeout> --parallel`
+7. If only **1** idle device, run: `./ci.sh -p a2a3 -d <id> -c <commit> -t <timeout>`
+8. Report the results summary (pass/fail counts per task)
+9. If any tests fail, show the relevant error output and which device/round failed

--- a/.claude/commands/test-all-sim.md
+++ b/.claude/commands/test-all-sim.md
@@ -1,7 +1,8 @@
 Run the full simulation CI pipeline.
 
-1. Detect CPU core count: `CORES=$(nproc)`
-2. If `CORES >= 16`, run: `./ci.sh -p a2a3sim --parallel`
-3. Otherwise, run: `./ci.sh -p a2a3sim`
-4. Report the results summary (pass/fail counts)
-5. If any tests fail, show the relevant error output
+1. Read `.github/workflows/ci.yml` to extract the current `-c` (pto-isa commit) and `-t` (timeout) flags from the `run-example-on-sim` job's `./ci.sh` invocation
+2. Detect CPU core count: `CORES=$(nproc)`
+3. Build the command: `./ci.sh -p a2a3sim -c <commit> -t <timeout>` and append `--parallel` if `CORES >= 16`
+4. Run the command
+5. Report the results summary (pass/fail counts)
+6. If any tests fail, show the relevant error output

--- a/.claude/commands/test-example-device.md
+++ b/.claude/commands/test-example-device.md
@@ -1,5 +1,6 @@
 Run the hardware device test for the example at $ARGUMENTS.
 
 1. Verify the directory exists and contains `kernels/kernel_config.py` and `golden.py`
-2. Run: `python examples/scripts/run_example.py -k $ARGUMENTS/kernels -g $ARGUMENTS/golden.py -p a2a3`
-3. Report pass/fail status with any error output
+2. Read `.github/workflows/ci.yml` to extract the current `-c` (pto-isa commit) flag from the `run-example-on-device` job's `./ci.sh` invocation
+3. Run: `python examples/scripts/run_example.py -k $ARGUMENTS/kernels -g $ARGUMENTS/golden.py -p a2a3 -c <commit>`
+4. Report pass/fail status with any error output

--- a/.claude/commands/test-example-sim.md
+++ b/.claude/commands/test-example-sim.md
@@ -1,5 +1,6 @@
 Run the simulation test for the example at $ARGUMENTS.
 
 1. Verify the directory exists and contains `kernels/kernel_config.py` and `golden.py`
-2. Run: `python examples/scripts/run_example.py -k $ARGUMENTS/kernels -g $ARGUMENTS/golden.py -p a2a3sim`
-3. Report pass/fail status with any error output
+2. Read `.github/workflows/ci.yml` to extract the current `-c` (pto-isa commit) flag from the `run-example-on-sim` job's `./ci.sh` invocation
+3. Run: `python examples/scripts/run_example.py -k $ARGUMENTS/kernels -g $ARGUMENTS/golden.py -p a2a3sim -c <commit>`
+4. Report pass/fail status with any error output

--- a/.claude/commands/test-runtime-device.md
+++ b/.claude/commands/test-runtime-device.md
@@ -2,10 +2,11 @@ Run hardware device tests for a single runtime specified by $ARGUMENTS.
 
 1. Validate that `$ARGUMENTS` is one of: `host_build_graph`, `aicpu_build_graph`, `tensormap_and_ringbuffer`. If not, list the valid runtimes and stop
 2. Check `command -v npu-smi` — if not found, tell the user to use `/test-runtime-sim` instead and stop
-3. Run `npu-smi info` and parse the output to find devices whose **HBM-Usage is 0** (idle)
-4. From the idle devices, take **at most 4**. If no idle device is found, report the situation and stop
-5. Build the device range flag: from the idle devices, find the **longest consecutive sub-range** (at most 4). Pass as `-d <start>-<end>`. If no consecutive pair exists, use the lowest-ID idle device as `-d <id>`
-6. If **2 or more** idle devices selected, run: `./ci.sh -p a2a3 -r $ARGUMENTS -d <range> --parallel`
-7. If only **1** idle device, run: `./ci.sh -p a2a3 -r $ARGUMENTS -d <id>`
-8. Report the results summary (pass/fail counts per task)
-9. If any tests fail, show the relevant error output and which device/round failed
+3. Read `.github/workflows/ci.yml` to extract the current `-c` (pto-isa commit) and `-t` (timeout) flags from the `run-example-on-device` job's `./ci.sh` invocation
+4. Run `npu-smi info` and parse the output to find devices whose **HBM-Usage is 0** (idle)
+5. From the idle devices, take **at most 4**. If no idle device is found, report the situation and stop
+6. Build the device range flag: from the idle devices, find the **longest consecutive sub-range** (at most 4). Pass as `-d <start>-<end>`. If no consecutive pair exists, use the lowest-ID idle device as `-d <id>`
+7. If **2 or more** idle devices selected, run: `./ci.sh -p a2a3 -r $ARGUMENTS -d <range> -c <commit> -t <timeout> --parallel`
+8. If only **1** idle device, run: `./ci.sh -p a2a3 -r $ARGUMENTS -d <id> -c <commit> -t <timeout>`
+9. Report the results summary (pass/fail counts per task)
+10. If any tests fail, show the relevant error output and which device/round failed

--- a/.claude/commands/test-runtime-sim.md
+++ b/.claude/commands/test-runtime-sim.md
@@ -1,8 +1,9 @@
 Run simulation tests for a single runtime specified by $ARGUMENTS.
 
 1. Validate that `$ARGUMENTS` is one of: `host_build_graph`, `aicpu_build_graph`, `tensormap_and_ringbuffer`. If not, list the valid runtimes and stop
-2. Detect CPU core count: `CORES=$(nproc)`
-3. If `CORES >= 16`, run: `./ci.sh -p a2a3sim -r $ARGUMENTS --parallel`
-4. Otherwise, run: `./ci.sh -p a2a3sim -r $ARGUMENTS`
-5. Report the results summary (pass/fail counts)
-6. If any tests fail, show the relevant error output
+2. Read `.github/workflows/ci.yml` to extract the current `-c` (pto-isa commit) and `-t` (timeout) flags from the `run-example-on-sim` job's `./ci.sh` invocation
+3. Detect CPU core count: `CORES=$(nproc)`
+4. Build the command: `./ci.sh -p a2a3sim -r $ARGUMENTS -c <commit> -t <timeout>` and append `--parallel` if `CORES >= 16`
+5. Run the command
+6. Report the results summary (pass/fail counts)
+7. If any tests fail, show the relevant error output

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -13,24 +13,26 @@ description: Testing guide and pre-commit testing strategy for PTO Runtime. Use 
 
 ## Running Tests
 
+**Important**: Always read `.github/workflows/ci.yml` first to extract the current `-c` (pto-isa commit) and `-t` (timeout) flags. These ensure reproducible builds by pinning the PTO-ISA dependency to a known-good commit.
+
 ```bash
 # Python unit tests
 pytest tests -v
 
-# All simulation tests
-./ci.sh -p a2a3sim
+# All simulation tests (extract -c and -t from ci.yml)
+./ci.sh -p a2a3sim -c <commit> -t <timeout>
 
-# All hardware tests (auto-detect idle devices — see Pre-Commit Testing Strategy)
-./ci.sh -p a2a3 -d <range>
+# All hardware tests (extract -c and -t from ci.yml, auto-detect idle devices)
+./ci.sh -p a2a3 -d <range> -c <commit> -t <timeout>
 
 # Single runtime
-./ci.sh -p a2a3sim -r host_build_graph
+./ci.sh -p a2a3sim -r host_build_graph -c <commit> -t <timeout>
 
 # Single example
 python examples/scripts/run_example.py \
     -k examples/host_build_graph/vector_example/kernels \
     -g examples/host_build_graph/vector_example/golden.py \
-    -p a2a3sim
+    -p a2a3sim -c <commit>
 ```
 
 ## Pre-Commit Testing Strategy


### PR DESCRIPTION
## Summary

Updates all test command files to extract `-c` (pto-isa commit) and `-t` (timeout) flags from `.github/workflows/ci.yml` before running tests. This ensures local test runs match CI configuration for reproducible builds with pinned PTO-ISA dependency.

## Changes

- `test-all-sim`, `test-all-device`: Read flags from ci.yml before running full CI pipeline
- `test-runtime-sim`, `test-runtime-device`: Read flags for single-runtime tests
- `test-example-sim`, `test-example-device`: Read flags for single-example tests
- `testing/SKILL.md`: Updated documentation with flag usage examples

## Motivation

The CI uses `-c 1b22fea -t 600` to pin PTO-ISA to a known-good commit and set timeout. Local test runs should match this configuration to avoid environment-dependent failures.

## Testing

- [x] Documentation changes only (no code changes)
- [x] Commands follow the same pattern as ci.yml