### PR TITLE
Support: add cross-fork PR workflow to GitHub skills

### DIFF
--- a/.claude/lib/github/checkout-fork-branch.md
+++ b/.claude/lib/github/checkout-fork-branch.md
@@ -1,0 +1,23 @@
+# Checkout Fork Branch
+
+Create or switch to a local working branch for a cross-fork PR, and set `BRANCH_NAME` to the correct push refspec.
+
+**Requires:** `PR_NUMBER`, `PUSH_REMOTE`, `HEAD_BRANCH` (set by [detect-permission](detect-permission.md)).
+
+```bash
+LOCAL_BRANCH="pr-$PR_NUMBER-work"
+
+if git show-ref --verify --quiet "refs/heads/$LOCAL_BRANCH"; then
+  git checkout "$LOCAL_BRANCH"
+  git pull "$PUSH_REMOTE" "$HEAD_BRANCH"
+else
+  git fetch "$PUSH_REMOTE" "$HEAD_BRANCH:$LOCAL_BRANCH"
+  git checkout "$LOCAL_BRANCH"
+fi
+
+# Set refspec so commit-and-push pushes local branch to the fork's remote branch
+# e.g. git push --force-with-lease pr-176 pr-176-work:feat/batch-counter
+BRANCH_NAME="$LOCAL_BRANCH:$HEAD_BRANCH"
+```
+
+**Variables set:** `LOCAL_BRANCH`, `BRANCH_NAME`.

--- a/.claude/lib/github/detect-permission.md
+++ b/.claude/lib/github/detect-permission.md
@@ -45,7 +45,7 @@ case "$PERMISSION" in
     FORK_REMOTE="pr-$PR_NUMBER"
     if ! git remote | grep -q "^${FORK_REMOTE}$"; then
       git remote add "$FORK_REMOTE" \
-        "https://github.com/$HEAD_REPO_OWNER/$HEAD_REPO_NAME.git"
+        "git@github.com:$HEAD_REPO_OWNER/$HEAD_REPO_NAME.git"
     fi
     git fetch "$FORK_REMOTE" "$HEAD_BRANCH"
     PUSH_REMOTE="$FORK_REMOTE"

--- a/.claude/skills/address-pr-comments/SKILL.md
+++ b/.claude/skills/address-pr-comments/SKILL.md
@@ -60,12 +60,17 @@ Only proceed with the comments the user explicitly selects. Do NOT auto-resolve 
 
 ## Step 6: Work Location Setup
 
-Work directly on the PR branch. If not already on `$HEAD_BRANCH`, checkout and pull:
+Work directly on the PR branch. Setup depends on permission level:
 
+**For owner/write permission:**
 ```bash
 git checkout $HEAD_BRANCH
 git pull "$PUSH_REMOTE" "$HEAD_BRANCH"
 ```
+
+**For maintainer permission (cross-fork PR):**
+
+Run [checkout-fork-branch](../../lib/github/checkout-fork-branch.md) to create/switch to the local working branch and set the push refspec.
 
 If in a worktree on different branch, offer to create new worktree or switch to main repo.
 

--- a/.claude/skills/checkout-pr/SKILL.md
+++ b/.claude/skills/checkout-pr/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: checkout-pr
+description: Add a remote for a given PR's head repository and checkout a local pr-xxx-work branch. Use when the user wants to work on someone else's PR locally.
+---
+
+# Checkout PR Workflow
+
+Add a remote for a PR's head repository (if not already added) and checkout a local working branch.
+
+## Input
+
+Accept PR number (`123`, `#123`). Required.
+
+## Setup
+
+1. [Setup](../../lib/github/setup.md) — authenticate and detect context (role, remotes, state)
+
+## Step 1: Fetch PR Metadata
+
+```bash
+PR_DATA=$(gh pr view $PR_NUMBER --repo "$PR_REPO_OWNER/$PR_REPO_NAME" --json \
+  number,title,headRefName,headRepository,headRepositoryOwner,\
+  baseRefName,state,maintainerCanModify,author)
+
+HEAD_BRANCH=$(echo "$PR_DATA" | jq -r '.headRefName')
+HEAD_REPO_OWNER=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login')
+HEAD_REPO_NAME=$(echo "$PR_DATA" | jq -r '.headRepository.name')
+PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
+MAINTAINER_CAN_MODIFY=$(echo "$PR_DATA" | jq -r '.maintainerCanModify')
+PR_STATE=$(echo "$PR_DATA" | jq -r '.state')
+```
+
+Validate PR state: OPEN (continue), CLOSED (warn user), MERGED (exit).
+
+## Step 2: Add Remote (if needed)
+
+```bash
+FORK_REMOTE="pr-$PR_NUMBER"
+
+if git remote | grep -q "^${FORK_REMOTE}$"; then
+  echo "Remote '$FORK_REMOTE' already exists, fetching latest..."
+else
+  git remote add "$FORK_REMOTE" \
+    "git@github.com:$HEAD_REPO_OWNER/$HEAD_REPO_NAME.git"
+fi
+
+git fetch "$FORK_REMOTE" "$HEAD_BRANCH"
+```
+
+## Step 3: Checkout Work Branch
+
+Run [checkout-fork-branch](../../lib/github/checkout-fork-branch.md) with `PUSH_REMOTE=$FORK_REMOTE` and `HEAD_BRANCH` from Step 1.
+
+## Step 4: Report
+
+Print summary:
+
+```
+Checked out PR #$PR_NUMBER ($PR_AUTHOR)
+  Remote: $FORK_REMOTE -> git@github.com:$HEAD_REPO_OWNER/$HEAD_REPO_NAME.git
+  Branch: $LOCAL_BRANCH -> $FORK_REMOTE/$HEAD_BRANCH
+  Push:   PUSH_REMOTE=$FORK_REMOTE  BRANCH_NAME=$LOCAL_BRANCH:$HEAD_BRANCH
+```
+
+Remind user that `/github-pr $PR_NUMBER` and `/address-pr-comments $PR_NUMBER` will pick up the correct push target automatically.

--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -5,10 +5,15 @@ description: Create or update a GitHub pull request after committing, rebasing, 
 
 # GitHub Pull Request Workflow
 
+## Input
+
+Accept optional PR number (`123`, `#123`) to update a specific PR, or no input (auto-detect from current branch).
+
 ## Setup
 
 1. [Setup](../../lib/github/setup.md) — authenticate and detect context (role, remotes, state)
-2. [Lookup PR](../../lib/github/lookup-pr.md) by branch name to check for existing PR
+2. [Lookup PR](../../lib/github/lookup-pr.md) by PR number (if provided) or branch name to check for existing PR
+3. **If PR number provided:** Run [detect-permission](../../lib/github/detect-permission.md) to setup cross-fork push target
 
 ## Route
 
@@ -95,6 +100,12 @@ Auto-generate title and body from the commit message. Keep title under 72 charac
 ## Path B: Update Existing PR
 
 Display the existing PR with `gh pr view`.
+
+### B0. Setup Work Branch (if updating cross-fork PR)
+
+If PR number was provided and permission is "maintainer" (cross-fork with maintainerCanModify), run [checkout-fork-branch](../../lib/github/checkout-fork-branch.md) to create/switch to the local working branch and set the push refspec.
+
+For owner/write permission, work directly on the existing branch.
 
 ### B1. Commit Changes
 


### PR DESCRIPTION
## Summary
- Add `checkout-pr` skill to set up remote and local branch for working on someone else's PR
- Add `checkout-fork-branch` shared library for local branch creation and push refspec logic used by all cross-fork workflows
- Update `github-pr` to accept PR number input and handle cross-fork push via `detect-permission` and `checkout-fork-branch`
- Update `address-pr-comments` to checkout cross-fork PR branches with correct push target when permission is "maintainer"
- Default `detect-permission` remote URL to SSH protocol

## Testing
- [ ] Manual test: `/checkout-pr 176` sets up correct remote and branch
- [ ] Manual test: `/github-pr 176` pushes to cross-fork PR correctly
- [ ] Manual test: `/address-pr-comments 176` works on cross-fork PR