### PR TITLE
Support: add orchestrator→dispatch dependency arrows and core-to-thread mapping

### DIFF
--- a/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
@@ -137,9 +137,26 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx);
  * @param start_time Phase start timestamp
  * @param end_time Phase end timestamp
  * @param submit_idx Task submission index (acts as loop_iter)
+ * @param task_id Task ID (stored in tasks_processed field for task tracking)
  */
 void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
                                    uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx);
+                                   uint32_t submit_idx, uint32_t task_id);
+
+/**
+ * Write core-to-thread assignment mapping to shared memory
+ *
+ * Records which scheduler thread manages each core_id.
+ * Called once after orchestration completes (not on the scheduler hot path).
+ *
+ * @param core_assignments 2D array [thread_idx][i] = core_id
+ * @param core_counts Per-thread core count array
+ * @param num_threads Number of scheduler threads
+ * @param total_cores Total number of cores
+ */
+void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
+                                        const int* core_counts,
+                                        int num_threads,
+                                        int total_cores);
 
 #endif  // PLATFORM_AICPU_PERFORMANCE_COLLECTOR_AICPU_H_

--- a/src/a2a3/platform/include/common/perf_profiling.h
+++ b/src/a2a3/platform/include/common/perf_profiling.h
@@ -269,8 +269,9 @@ struct AicpuPhaseHeader {
     uint32_t magic;                  // Validation magic (AICPU_PHASE_MAGIC)
     uint32_t num_sched_threads;      // Number of scheduler threads
     uint32_t records_per_thread;     // Max records per thread
-    uint32_t padding;                // Alignment padding
+    uint32_t num_cores;              // Total number of cores with valid assignments
     volatile uint32_t buffer_counts[PLATFORM_MAX_AICPU_THREADS];  // Per-thread record counts
+    int8_t core_to_thread[PLATFORM_MAX_CORES];  // core_id → scheduler thread index (-1 = unassigned)
     AicpuOrchSummary orch_summary;   // Orchestrator cumulative data
 } __attribute__((aligned(64)));
 

--- a/src/a2a3/platform/include/host/performance_collector.h
+++ b/src/a2a3/platform/include/host/performance_collector.h
@@ -166,6 +166,9 @@ private:
     std::vector<AicpuPhaseRecord> collected_orch_phase_records_;
     AicpuOrchSummary collected_orch_summary_{};
     bool has_phase_data_{false};
+
+    // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
+    std::vector<int8_t> core_to_thread_;
 };
 
 #endif  // PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_

--- a/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -310,12 +310,13 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads) {
     s_phase_header->magic = AICPU_PHASE_MAGIC;
     s_phase_header->num_sched_threads = num_sched_threads;
     s_phase_header->records_per_thread = PLATFORM_PHASE_RECORDS_PER_THREAD;
-    s_phase_header->padding = 0;
+    s_phase_header->num_cores = 0;
 
     for (int i = 0; i < PLATFORM_MAX_AICPU_THREADS; i++) {
         s_phase_header->buffer_counts[i] = 0;
     }
 
+    memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
     memset(&s_phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
 
     // Cache per-thread record pointers and clear buffers
@@ -383,7 +384,32 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx) {
 
 void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
                                    uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx) {
+                                   uint32_t submit_idx, uint32_t task_id) {
     if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
-    perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, 0);
+    perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
+}
+
+void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
+                                        const int* core_counts,
+                                        int num_threads,
+                                        int total_cores) {
+    if (s_phase_header == nullptr) {
+        return;
+    }
+
+    memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
+    s_phase_header->num_cores = static_cast<uint32_t>(total_cores);
+
+    for (int t = 0; t < num_threads; t++) {
+        for (int i = 0; i < core_counts[t]; i++) {
+            int core_id = core_assignments[t][i];
+            if (core_id >= 0 && core_id < PLATFORM_MAX_CORES) {
+                s_phase_header->core_to_thread[core_id] = static_cast<int8_t>(t);
+            }
+        }
+    }
+
+    wmb();
+
+    LOG_INFO("Core-to-thread mapping written: %d cores, %d threads", total_cores, num_threads);
 }

--- a/src/a2a3/platform/src/host/performance_collector.cpp
+++ b/src/a2a3/platform/src/host/performance_collector.cpp
@@ -345,6 +345,15 @@ void PerformanceCollector::collect_phase_data() {
     }
 
     has_phase_data_ = (total_phase_records > 0 || orch_valid);
+
+    // Read core-to-thread mapping
+    int num_cores = static_cast<int>(phase_header->num_cores);
+    if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
+        core_to_thread_.assign(phase_header->core_to_thread,
+                                phase_header->core_to_thread + num_cores);
+        LOG_INFO("  Core-to-thread mapping: %d cores", num_cores);
+    }
+
     LOG_INFO("Phase data collection complete: %d records (%zu orch), orch_summary=%s",
              total_phase_records, collected_orch_phase_records_.size(), orch_valid ? "yes" : "no");
 }
@@ -582,12 +591,23 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                         << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                         << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
                         << ", \"submit_idx\": " << pr.loop_iter
+                        << ", \"task_id\": " << static_cast<int32_t>(pr.tasks_processed)
                         << "}";
                 if (r < collected_orch_phase_records_.size() - 1) outfile << ",";
                 outfile << "\n";
             }
             outfile << "  ]";
         }
+    }
+
+    // Core-to-thread mapping
+    if (!core_to_thread_.empty()) {
+        outfile << ",\n  \"core_to_thread\": [";
+        for (size_t i = 0; i < core_to_thread_.size(); i++) {
+            outfile << static_cast<int>(core_to_thread_[i]);
+            if (i < core_to_thread_.size() - 1) outfile << ", ";
+        }
+        outfile << "]";
     }
 
     outfile << "\n}\n";
@@ -634,6 +654,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
     collected_perf_records_.clear();
     collected_phase_records_.clear();
     collected_orch_phase_records_.clear();
+    core_to_thread_.clear();
     has_phase_data_ = false;
     device_id_ = -1;
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1093,6 +1093,15 @@ int AicpuExecutor::run(Runtime* runtime) {
 #endif
 #endif
 
+#if PTO2_PROFILING
+            // Write core-to-thread mapping (one-time, after orchestration)
+            if (runtime->enable_profiling) {
+                int sched_threads = (thread_num_ == 4) ? 3 : thread_num_;
+                perf_aicpu_write_core_assignments(core_assignments_, core_count_per_thread_,
+                                                   sched_threads, cores_total_num_);
+            }
+#endif
+
             // Signal orchestration complete in SM header (needs runtime alive)
             pto2_rt_orchestration_done(rt);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -32,7 +32,7 @@ __attribute__((weak)) uint64_t get_sys_cnt_aicpu() { return 0; }
 // Weak fallback for builds that don't link performance_collector_aicpu.cpp.
 // The strong symbol from the AICPU build wins when profiling is available.
 __attribute__((weak)) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t) {}
+    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
 // Accumulated nanoseconds per sub-step
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // task ring alloc
@@ -59,16 +59,16 @@ uint64_t g_orch_scope_end_atomic_count = 0;
 #endif
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
 #define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
-#define CYCLE_COUNT_LAP_RECORD(acc, phase_id) do { \
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid) do { \
     _t1 = get_sys_cnt_aicpu(); \
     acc += (_t1 - _t0); \
-    perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx); \
+    perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
     _t0 = _t1; \
 } while(0)
 #else
 #define CYCLE_COUNT_START()
 #define CYCLE_COUNT_LAP(acc)
-#define CYCLE_COUNT_LAP_RECORD(acc, phase_id)
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)
 #endif
 
 // =============================================================================
@@ -208,7 +208,7 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
 #if PTO2_PROFILING
     uint64_t _se1 = get_sys_cnt_aicpu();
     g_orch_scope_end_cycle += (_se1 - _se0);
-    perf_aicpu_record_orch_phase(AicpuPhaseId::ORCH_SCOPE_END, _se0, _se1, g_orch_submit_idx);
+    perf_aicpu_record_orch_phase(AicpuPhaseId::ORCH_SCOPE_END, _se0, _se1, g_orch_submit_idx, -1);
 #endif
 }
 
@@ -222,7 +222,7 @@ void pto2_submit_task(
     // === STEP 0: Sync TensorMap validity and optional cleanup ===
     orch->tensor_map.sync_tensormap();
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC);
+    CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, -1);
 
     // Submission without an open scope is illegal
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit task outside a scope");
@@ -230,7 +230,7 @@ void pto2_submit_task(
     // === STEP 1: Allocate task slot from Task Ring (blocks until available) ===
     int32_t task_id = orch->task_ring.pto2_task_ring_alloc();
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC);
+    CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, task_id);
 
     PTO2TaskDescriptor* task = pto2_task_ring_get(&orch->task_ring, task_id);
 
@@ -265,7 +265,7 @@ void pto2_submit_task(
         }
     }
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS);
+    CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS, task_id);
 #if PTO2_ORCH_PROFILING
     g_orch_params_atomic_count += 2;  // fanout_lock.store + fanout_count.store
 #endif
@@ -288,7 +288,7 @@ void pto2_submit_task(
         task->packed_buffer_base = orch->pto2_alloc_packed_buffer(total_output_size);
         task->packed_buffer_end = (char*)task->packed_buffer_base + total_output_size;
     }
-    CYCLE_COUNT_LAP_RECORD(g_orch_heap_cycle, AicpuPhaseId::ORCH_HEAP);
+    CYCLE_COUNT_LAP_RECORD(g_orch_heap_cycle, AicpuPhaseId::ORCH_HEAP, task_id);
 #if PTO2_ORCH_PROFILING
     if (total_output_size > 0) {
         g_orch_heap_atomic_count += 1;  // heap_top.store in pto2_alloc_packed_buffer
@@ -356,7 +356,7 @@ void pto2_submit_task(
         }
     }
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_lookup_cycle, AicpuPhaseId::ORCH_LOOKUP);
+    CYCLE_COUNT_LAP_RECORD(g_orch_lookup_cycle, AicpuPhaseId::ORCH_LOOKUP, task_id);
 
 
     // === STEP 4: Second pass - register outputs in TensorMap ===
@@ -369,7 +369,7 @@ void pto2_submit_task(
         }
     }
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_insert_cycle, AicpuPhaseId::ORCH_INSERT);
+    CYCLE_COUNT_LAP_RECORD(g_orch_insert_cycle, AicpuPhaseId::ORCH_INSERT, task_id);
 
     // === STEP 5: Finalize fanin list ===
     // First build the fanin list
@@ -416,7 +416,7 @@ void pto2_submit_task(
 #endif
     }
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_fanin_cycle, AicpuPhaseId::ORCH_FANIN);
+    CYCLE_COUNT_LAP_RECORD(g_orch_fanin_cycle, AicpuPhaseId::ORCH_FANIN, task_id);
 
 
     // === STEP 6: Initialize task in scheduler ===
@@ -428,7 +428,7 @@ void pto2_submit_task(
     // === STEP 7: Update shared memory with current task index ===
     orch->sm_handle->header->current_task_index.store(orch->task_ring.current_index, std::memory_order_release);
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_finalize_cycle, AicpuPhaseId::ORCH_FINALIZE);
+    CYCLE_COUNT_LAP_RECORD(g_orch_finalize_cycle, AicpuPhaseId::ORCH_FINALIZE, task_id);
 #if PTO2_ORCH_PROFILING
     // task_state.store + fanout_refcount.store + fanin_refcount.fetch_add
     // + current_task_index.store = 4

--- a/tools/swimlane_converter.py
+++ b/tools/swimlane_converter.py
@@ -290,7 +290,7 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
 
 def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose=False,
                                 scheduler_phases=None, orchestrator_data=None,
-                                orchestrator_phases=None):
+                                orchestrator_phases=None, core_to_thread=None):
     """Generate Chrome Trace Event Format JSON from task data.
 
     Args:
@@ -306,6 +306,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
         scheduler_phases: Optional list of per-thread phase record lists (version 2)
         orchestrator_data: Optional dict with orchestrator summary (version 2)
         orchestrator_phases: Optional list of per-task orchestrator phase records (version 2)
+        core_to_thread: Optional list mapping core_id (index) to scheduler thread index (-1 = unassigned)
 
     Generates processes in the trace:
         - pid=1 "AICore View": start_time_us to end_time_us (kernel execution)
@@ -654,18 +655,26 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
             end_us = record["end_time_us"]
             dur = end_us - start_us
             submit_idx = record.get("submit_idx", 0)
+            task_id = record.get("task_id", -1)
 
             # Strip "orch_" prefix for display name
             display_name = phase.replace("orch_", "") if phase.startswith("orch_") else phase
 
+            # Show task_id in name for task-specific phases
+            if task_id >= 0:
+                label = f"{display_name}(t{task_id})"
+            else:
+                label = f"{display_name}({submit_idx})"
+
             event = {
                 "args": {
                     "phase": phase,
-                    "submit_idx": submit_idx
+                    "submit_idx": submit_idx,
+                    "task_id": task_id
                 },
                 "cat": "orchestrator",
                 "cname": orch_phase_colors.get(phase, "generic_work"),
-                "name": f"{display_name}({submit_idx})",
+                "name": label,
                 "ph": "X",
                 "pid": 4,
                 "tid": 4000,
@@ -748,27 +757,49 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
     # Scheduler DISPATCH → task execution arrows
     if scheduler_phases and has_aicpu_data:
-        # Build index of DISPATCH phase records per thread for fast lookup
-        dispatch_phases_by_thread = {}
-        for thread_idx, thread_records in enumerate(scheduler_phases):
-            dispatch_records = [r for r in thread_records if r.get("phase") == "dispatch"]
-            if dispatch_records:
-                dispatch_phases_by_thread[thread_idx] = dispatch_records
+        # Build core_id → scheduler thread mapping.
+        # Prefer explicit core_to_thread from perf JSON (written by AICPU after orchestration).
+        # Fall back to voting heuristic for older data without the mapping.
+        core_to_sched_thread = {}
+
+        if core_to_thread:
+            for core_id, thread_idx in enumerate(core_to_thread):
+                if thread_idx >= 0:
+                    core_to_sched_thread[core_id] = thread_idx
+            if verbose:
+                print(f"  Core-to-thread mapping: {len(core_to_sched_thread)} cores (from perf JSON)")
+        else:
+            # Fallback: infer via voting (for perf JSON without core_to_thread field)
+            dispatch_phases_by_thread = {}
+            for thread_idx, thread_records in enumerate(scheduler_phases):
+                dispatch_records = [r for r in thread_records if r.get("phase") == "dispatch"]
+                if dispatch_records:
+                    dispatch_phases_by_thread[thread_idx] = dispatch_records
+
+            from collections import defaultdict
+            core_thread_votes = defaultdict(lambda: defaultdict(int))
+            for task in tasks:
+                dispatch_us = task.get('dispatch_time_us', 0)
+                if dispatch_us <= 0:
+                    continue
+                core_id = task['core_id']
+                for thread_idx, dispatch_records in dispatch_phases_by_thread.items():
+                    for dr in dispatch_records:
+                        if dr["start_time_us"] <= dispatch_us <= dr["end_time_us"]:
+                            core_thread_votes[core_id][thread_idx] += 1
+                            break
+
+            for core_id, votes in core_thread_votes.items():
+                core_to_sched_thread[core_id] = max(votes, key=votes.get)
+            if verbose:
+                print(f"  Core-to-thread mapping: {len(core_to_sched_thread)} cores (inferred via voting)")
 
         for task in tasks:
             dispatch_us = task.get('dispatch_time_us', 0)
             if dispatch_us <= 0:
                 continue
 
-            # Find the scheduler DISPATCH phase that contains this dispatch timestamp
-            matched_thread = None
-            for thread_idx, dispatch_records in dispatch_phases_by_thread.items():
-                for dr in dispatch_records:
-                    if dr["start_time_us"] <= dispatch_us <= dr["end_time_us"]:
-                        matched_thread = thread_idx
-                        break
-                if matched_thread is not None:
-                    break
+            matched_thread = core_to_sched_thread.get(task['core_id'])
 
             if matched_thread is not None:
                 sched_tid = 3000 + matched_thread
@@ -817,6 +848,61 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     "bp": "e"
                 })
                 flow_id += 1
+
+    # Orchestrator FINALIZE → Scheduler DISPATCH arrows (per task_id)
+    if orchestrator_phases and scheduler_phases:
+        # Collect orch_finalize records keyed by task_id
+        orch_finalize_by_task = {}
+        for record in orchestrator_phases:
+            if record.get("phase") == "orch_finalize":
+                tid = record.get("task_id", -1)
+                if tid >= 0:
+                    orch_finalize_by_task[tid] = record
+
+        # Use core_to_sched_thread mapping (built above) to find the correct
+        # scheduler thread for each task's core.
+        if orch_finalize_by_task and has_aicpu_data:
+            for task in tasks:
+                tid = task.get('task_id')
+                if tid is None or tid not in orch_finalize_by_task:
+                    continue
+
+                dispatch_us = task.get('dispatch_time_us', 0)
+                if dispatch_us <= 0:
+                    continue
+
+                finalize_rec = orch_finalize_by_task[tid]
+                # Use finalize start_time: init_task() runs at the beginning of FINALIZE,
+                # making the task dispatchable before FINALIZE ends. Using start avoids
+                # reverse arrows when the scheduler dispatches during FINALIZE.
+                finalize_start_us = finalize_rec["start_time_us"]
+
+                matched_thread = core_to_sched_thread.get(task['core_id'])
+
+                if matched_thread is not None:
+                    sched_tid = 3000 + matched_thread
+
+                    # Flow: Orchestrator finalize start → Scheduler DISPATCH
+                    events.append({
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "orch→dispatch",
+                        "ph": "s",
+                        "pid": 4,
+                        "tid": 4000,
+                        "ts": finalize_start_us
+                    })
+                    events.append({
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "orch→dispatch",
+                        "ph": "f",
+                        "pid": 3,
+                        "tid": sched_tid,
+                        "ts": dispatch_us,
+                        "bp": "e"
+                    })
+                    flow_id += 1
 
     if verbose:
         print(f"  Total events: {len(events)}")
@@ -941,6 +1027,7 @@ Examples:
         scheduler_phases = data.get('aicpu_scheduler_phases')
         orchestrator_data = data.get('aicpu_orchestrator')
         orchestrator_phases = data.get('aicpu_orchestrator_phases')
+        core_to_thread = data.get('core_to_thread')
 
         if args.verbose and data['version'] == 2:
             if scheduler_phases:
@@ -951,12 +1038,15 @@ Examples:
                 print(f"  Orchestrator: {orchestrator_data.get('submit_count', 0)} tasks")
             if orchestrator_phases:
                 print(f"  Orchestrator phases: {len(orchestrator_phases)} per-task records")
+            if core_to_thread:
+                print(f"  Core-to-thread mapping: {len(core_to_thread)} cores")
 
         # Generate Perfetto JSON
         generate_chrome_trace_json(data['tasks'], str(output_path), func_names, args.verbose,
                                    scheduler_phases=scheduler_phases,
                                    orchestrator_data=orchestrator_data,
-                                   orchestrator_phases=orchestrator_phases)
+                                   orchestrator_phases=orchestrator_phases,
+                                   core_to_thread=core_to_thread)
 
         print(f"\n✓ Conversion complete")
         print(f"  Input:  {input_path}")


### PR DESCRIPTION
## Summary

- **Core-to-thread mapping**: AICPU writes `core_id → scheduler thread` mapping to shared memory after orchestration (`perf_aicpu_write_core_assignments`); Host reads and exports it as `core_to_thread` in swimlane JSON
- **Per-task tracking**: `perf_aicpu_record_orch_phase()` gains a `task_id` parameter so each orchestrator phase record is associated with a specific task, replacing the previous `submit_idx`-only approach
- **Orchestrator→Dispatch flow arrows**: swimlane converter adds `orch_finalize → scheduler_dispatch` Chrome trace flow events, visualizing the dependency from task orchestration to scheduler dispatch
- **Smart mapping fallback**: converter prefers the explicit `core_to_thread` mapping from perf JSON, falling back to a voting heuristic for older data without the field

## Changed Files

| File | Change |
|------|--------|
| `performance_collector_aicpu.h` | Add `task_id` param and `perf_aicpu_write_core_assignments` declaration |
| `perf_profiling.h` | Replace header `padding` with `num_cores`; add `core_to_thread[]` array |
| `performance_collector.h` | Add `core_to_thread_` member |
| `performance_collector_aicpu.cpp` | Implement core assignment write and task_id in phase recording |
| `performance_collector.cpp` | Host-side mapping read, JSON export, finalize cleanup |
| `aicpu_executor.cpp` | Call `perf_aicpu_write_core_assignments` after orchestration completes |
| `pto_orchestrator.cpp` | Pass `task_id` to all phase recording macros |
| `swimlane_converter.py` | Add orch→dispatch arrows, explicit mapping with voting fallback |