### PR TITLE
Support: add per-phase atomic operation and wait-time tracking

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1001,7 +1001,7 @@ int AicpuExecutor::run(Runtime* runtime) {
 #endif
 
             // Print orchestrator profiling data
-#if PTO2_PROFILING
+#if PTO2_ORCH_PROFILING
             if (runtime->enable_profiling) {
                 PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
                 uint64_t total = p.sync_cycle + p.alloc_cycle + p.params_cycle +
@@ -1011,14 +1011,30 @@ int AicpuExecutor::run(Runtime* runtime) {
                 DEV_ALWAYS("Thread %d: === Orchestrator Profiling: %lld tasks, total=%.3fus ===", thread_idx,
                          (long long)p.submit_count, cycles_to_us(total));
                 DEV_ALWAYS("Thread %d:   sync_tensormap : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.sync_cycle), p.sync_cycle * 100.0 / total);
-                DEV_ALWAYS("Thread %d:   task_ring_alloc: %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.alloc_cycle), p.alloc_cycle * 100.0 / total);
-                DEV_ALWAYS("Thread %d:   param_copy     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total);
+                DEV_ALWAYS("Thread %d:   task_ring_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                    cycles_to_us(p.alloc_cycle), p.alloc_cycle * 100.0 / total,
+                    cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle), cycles_to_us(p.alloc_wait_cycle),
+                    (unsigned long long)p.alloc_atomic_count);
+                DEV_ALWAYS("Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%llu", thread_idx,
+                    cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total,
+                    (unsigned long long)p.params_atomic_count);
                 DEV_ALWAYS("Thread %d:   lookup+dep     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.lookup_cycle), p.lookup_cycle * 100.0 / total);
-                DEV_ALWAYS("Thread %d:   heap_alloc     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.heap_cycle), p.heap_cycle * 100.0 / total);
+                DEV_ALWAYS("Thread %d:   heap_alloc     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                    cycles_to_us(p.heap_cycle), p.heap_cycle * 100.0 / total,
+                    cycles_to_us(p.heap_cycle - p.heap_wait_cycle), cycles_to_us(p.heap_wait_cycle),
+                    (unsigned long long)p.heap_atomic_count);
                 DEV_ALWAYS("Thread %d:   tensormap_ins  : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.insert_cycle), p.insert_cycle * 100.0 / total);
-                DEV_ALWAYS("Thread %d:   fanin+ready    : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total);
-                DEV_ALWAYS("Thread %d:   finalize+SM    : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.finalize_cycle), p.finalize_cycle * 100.0 / total);
-                DEV_ALWAYS("Thread %d:   scope_end      : %.3fus", thread_idx, cycles_to_us(p.scope_end_cycle));
+                DEV_ALWAYS("Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                    cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
+                    cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
+                    (unsigned long long)p.fanin_atomic_count);
+                DEV_ALWAYS("Thread %d:   finalize+SM    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                    cycles_to_us(p.finalize_cycle), p.finalize_cycle * 100.0 / total,
+                    cycles_to_us(p.finalize_cycle - p.finalize_wait_cycle), cycles_to_us(p.finalize_wait_cycle),
+                    (unsigned long long)p.finalize_atomic_count);
+                DEV_ALWAYS("Thread %d:   scope_end      : %.3fus  atomics=%llu", thread_idx,
+                    cycles_to_us(p.scope_end_cycle),
+                    (unsigned long long)p.scope_end_atomic_count);
                 DEV_ALWAYS("Thread %d:   avg/task       : %.3fus", thread_idx,
                     p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -45,6 +45,18 @@ static uint64_t g_orch_finalize_cycle = 0;   // scheduler init + SM update
 static uint64_t g_orch_scope_end_cycle = 0;  // scope_end overhead
 static int64_t  g_orch_submit_count = 0;
 static uint32_t g_orch_submit_idx = 0;
+#if PTO2_ORCH_PROFILING
+uint64_t g_orch_alloc_wait_cycle = 0;
+uint64_t g_orch_heap_wait_cycle = 0;
+uint64_t g_orch_fanin_wait_cycle = 0;
+uint64_t g_orch_finalize_wait_cycle = 0;
+uint64_t g_orch_alloc_atomic_count = 0;
+uint64_t g_orch_params_atomic_count = 0;
+uint64_t g_orch_heap_atomic_count = 0;
+uint64_t g_orch_fanin_atomic_count = 0;
+uint64_t g_orch_finalize_atomic_count = 0;
+uint64_t g_orch_scope_end_atomic_count = 0;
+#endif
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
 #define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
 #define CYCLE_COUNT_LAP_RECORD(acc, phase_id) do { \
@@ -254,6 +266,9 @@ void pto2_submit_task(
     }
 
     CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS);
+#if PTO2_ORCH_PROFILING
+    g_orch_params_atomic_count += 2;  // fanout_lock.store + fanout_count.store
+#endif
 
     // Temporary storage for collecting output sizes
     int32_t total_output_size = 0;
@@ -274,6 +289,11 @@ void pto2_submit_task(
         task->packed_buffer_end = (char*)task->packed_buffer_base + total_output_size;
     }
     CYCLE_COUNT_LAP_RECORD(g_orch_heap_cycle, AicpuPhaseId::ORCH_HEAP);
+#if PTO2_ORCH_PROFILING
+    if (total_output_size > 0) {
+        g_orch_heap_atomic_count += 1;  // heap_top.store in pto2_alloc_packed_buffer
+    }
+#endif
 
     // === STEP 2: First pass - set output addr and process tensor ===
     int32_t offset = 0;
@@ -386,6 +406,14 @@ void pto2_submit_task(
         if (early_finished > 0) {
             sched->fanin_refcount[slot].fetch_add(early_finished, std::memory_order_acq_rel);
         }
+#if PTO2_ORCH_PROFILING
+        // Per producer: fetch_add(fanout_count) + load(task_state) + store(unlock) = 3 atomics
+        // Lock atomics (loads + CAS) are counted inside pto2_fanout_lock
+        g_orch_fanin_atomic_count += fanin_count * 3;
+        if (early_finished > 0) {
+            g_orch_fanin_atomic_count += 1;  // fanin_refcount.fetch_add
+        }
+#endif
     }
 
     CYCLE_COUNT_LAP_RECORD(g_orch_fanin_cycle, AicpuPhaseId::ORCH_FANIN);
@@ -401,6 +429,12 @@ void pto2_submit_task(
     orch->sm_handle->header->current_task_index.store(orch->task_ring.current_index, std::memory_order_release);
 
     CYCLE_COUNT_LAP_RECORD(g_orch_finalize_cycle, AicpuPhaseId::ORCH_FINALIZE);
+#if PTO2_ORCH_PROFILING
+    // task_state.store + fanout_refcount.store + fanin_refcount.fetch_add
+    // + current_task_index.store = 4
+    // Conditional CAS(task_state PENDING→READY) and push() atomics counted inside push()
+    g_orch_finalize_atomic_count += 4;
+#endif
 
 #if PTO2_PROFILING
     orch->tasks_submitted++;
@@ -464,7 +498,7 @@ void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch) {
     LOG_INFO("==================");
 }
 
-#if PTO2_PROFILING
+#if PTO2_ORCH_PROFILING
 PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     PTO2OrchProfilingData d;
     d.sync_cycle = g_orch_sync_cycle;
@@ -477,6 +511,16 @@ PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     d.finalize_cycle = g_orch_finalize_cycle;
     d.scope_end_cycle = g_orch_scope_end_cycle;
     d.submit_count = g_orch_submit_count;
+    d.alloc_wait_cycle = g_orch_alloc_wait_cycle;
+    d.heap_wait_cycle = g_orch_heap_wait_cycle;
+    d.fanin_wait_cycle = g_orch_fanin_wait_cycle;
+    d.finalize_wait_cycle = g_orch_finalize_wait_cycle;
+    d.alloc_atomic_count = g_orch_alloc_atomic_count;
+    d.params_atomic_count = g_orch_params_atomic_count;
+    d.heap_atomic_count = g_orch_heap_atomic_count;
+    d.fanin_atomic_count = g_orch_fanin_atomic_count;
+    d.finalize_atomic_count = g_orch_finalize_atomic_count;
+    d.scope_end_atomic_count = g_orch_scope_end_atomic_count;
 
     // Reset
     g_orch_sync_cycle = g_orch_alloc_cycle = g_orch_params_cycle = 0;
@@ -484,6 +528,16 @@ PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     g_orch_fanin_cycle = g_orch_finalize_cycle = g_orch_scope_end_cycle = 0;
     g_orch_submit_count = 0;
     g_orch_submit_idx = 0;
+    g_orch_alloc_wait_cycle = 0;
+    g_orch_heap_wait_cycle = 0;
+    g_orch_fanin_wait_cycle = 0;
+    g_orch_finalize_wait_cycle = 0;
+    g_orch_alloc_atomic_count = 0;
+    g_orch_params_atomic_count = 0;
+    g_orch_heap_atomic_count = 0;
+    g_orch_fanin_atomic_count = 0;
+    g_orch_finalize_atomic_count = 0;
+    g_orch_scope_end_atomic_count = 0;
     return d;
 }
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -233,7 +233,7 @@ void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch);
 // Orchestrator Profiling Data
 // =============================================================================
 
-#if PTO2_PROFILING
+#if PTO2_ORCH_PROFILING
 struct PTO2OrchProfilingData {
     uint64_t sync_cycle;
     uint64_t alloc_cycle;
@@ -245,6 +245,18 @@ struct PTO2OrchProfilingData {
     uint64_t finalize_cycle;
     uint64_t scope_end_cycle;
     int64_t  submit_count;
+    // Wait time tracking for blocking phases
+    uint64_t alloc_wait_cycle;      // Cycles spent waiting in task_ring_alloc
+    uint64_t heap_wait_cycle;       // Cycles spent waiting in heap_ring_alloc
+    uint64_t fanin_wait_cycle;      // Cycles spent waiting in fanout_lock
+    uint64_t finalize_wait_cycle;   // Cycles spent in ready queue push CAS retries
+    // Atomic operation counts per phase
+    uint64_t alloc_atomic_count;
+    uint64_t params_atomic_count;
+    uint64_t heap_atomic_count;
+    uint64_t fanin_atomic_count;
+    uint64_t finalize_atomic_count;
+    uint64_t scope_end_atomic_count;
 };
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -83,6 +83,10 @@ struct PTO2HeapRing {
 #if PTO2_SPIN_VERBOSE_LOGGING
         bool notified = false;
 #endif
+#if PTO2_ORCH_PROFILING
+        uint64_t wait_start = 0;
+        bool waiting = false;
+#endif
 
         while (1) {
             void* ptr = pto2_heap_ring_try_alloc(size);
@@ -92,11 +96,24 @@ struct PTO2HeapRing {
                     LOG_INFO("[HeapRing] Unblocked after %d spins", spin_count);
                 }
 #endif
+#if PTO2_ORCH_PROFILING
+                if (waiting) {
+                    extern uint64_t g_orch_heap_wait_cycle;
+                    g_orch_heap_wait_cycle += (get_sys_cnt_aicpu() - wait_start);
+                }
+                {
+                    extern uint64_t g_orch_heap_atomic_count;
+                    g_orch_heap_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
+                }
+#endif
                 return ptr;
             }
 
             // No space available, spin-wait
             spin_count++;
+#if PTO2_ORCH_PROFILING
+            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+#endif
 
 #if PTO2_SPIN_VERBOSE_LOGGING
             // Periodic block notification
@@ -252,6 +269,10 @@ struct PTO2TaskRing {
 #if PTO2_SPIN_VERBOSE_LOGGING
         bool notified = false;
 #endif
+#if PTO2_ORCH_PROFILING
+        uint64_t wait_start = 0;
+        bool waiting = false;
+#endif
 
         while (1) {
             int32_t task_id = pto2_task_ring_try_alloc();
@@ -261,11 +282,24 @@ struct PTO2TaskRing {
                     LOG_INFO("[TaskRing] Unblocked after %d spins, task_id=%d", spin_count, task_id);
                 }
 #endif
+#if PTO2_ORCH_PROFILING
+                if (waiting) {
+                    extern uint64_t g_orch_alloc_wait_cycle;
+                    g_orch_alloc_wait_cycle += (get_sys_cnt_aicpu() - wait_start);
+                }
+                {
+                    extern uint64_t g_orch_alloc_atomic_count;
+                    g_orch_alloc_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
+                }
+#endif
                 return task_id;
             }
 
             // Window is full, spin-wait (with yield to prevent CPU starvation)
             spin_count++;
+#if PTO2_ORCH_PROFILING
+            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+#endif
 
 #if PTO2_SPIN_VERBOSE_LOGGING
             // Periodic block notification

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -1,13 +1,13 @@
 /**
  * PTO Runtime2 - Core Type Definitions
- * 
+ *
  * This header defines all fundamental types used by the PTO Runtime2 system:
  * - Configuration constants
  * - Worker types and task states
  * - Tensor regions and task parameters
  * - Task descriptors with fanin/fanout tracking
  * - Dependency list entries
- * 
+ *
  * Based on: docs/runtime_buffer_manager_methods.md
  */
 
@@ -27,6 +27,14 @@
 
 #ifndef PTO2_PROFILING
 #define PTO2_PROFILING 1
+#endif
+
+#ifndef PTO2_ORCH_PROFILING
+#define PTO2_ORCH_PROFILING 1
+#endif
+
+#if PTO2_ORCH_PROFILING
+#include "aicpu/device_time.h"
 #endif
 
 // =============================================================================
@@ -87,10 +95,10 @@ typedef enum {
 
 /**
  * Task state enumeration
- * 
+ *
  * State transitions:
  *   PENDING -> READY -> RUNNING -> COMPLETED -> CONSUMED
- * 
+ *
  * Conditions:
  *   PENDING->READY:     fanin_refcount == fanin_count
  *   COMPLETED->CONSUMED: fanout_refcount == fanout_count && state == COMPLETED
@@ -164,7 +172,7 @@ typedef enum {
 
 /**
  * Raw tensor (storage provider)
- * 
+ *
  * The raw tensor owns the actual memory allocation.
  * Multiple logical tensors can share the same raw tensor (aliasing).
  */
@@ -177,18 +185,18 @@ typedef struct {
 
 /**
  * Logical tensor structure
- * 
+ *
  * A "view" into raw tensor storage with specific layout.
  * Supports multi-dimensional tensors with strides (for view/reshape/transpose).
- * 
+ *
  * Memory footprint is determined by:
  *   - storage_offset: byte offset from raw_base to first element
  *   - shape[d]: number of elements in dimension d
  *   - strides[d]: byte offset between consecutive elements in dimension d
- * 
+ *
  * For element at indices [i0, i1, ..., i_{n-1}]:
  *   byte_offset = storage_offset + sum(i_d * strides[d])
- * 
+ *
  * Examples:
  *   - Contiguous row-major (3,4): shape=[3,4], strides=[4*elem_size, elem_size]
  *   - Transposed (4,3): shape=[4,3], strides=[elem_size, 4*elem_size]
@@ -198,32 +206,32 @@ typedef struct {
     // === Raw tensor reference (shared storage) ===
     void*    raw_base;            // Pointer to raw tensor's base (for aliasing check)
     int64_t  raw_total_size;      // Total size of raw tensor in bytes
-    
+
     // === Storage offset ===
     int64_t  storage_offset;      // Byte offset from raw_base to first element
-    
+
     // === Shape and strides ===
     int64_t  shape[PTO2_MAX_TENSOR_DIM];    // Size in each dimension
     int64_t  strides[PTO2_MAX_TENSOR_DIM];  // Byte stride in each dimension
     int32_t  ndim;                          // Number of dimensions (0 = scalar)
-    
+
     // === Precomputed bounding box (for fast overlap detection) ===
     int64_t  min_byte_offset;     // First byte accessed (relative to raw_base)
     int64_t  max_byte_offset;     // Last byte accessed (relative to raw_base)
-    
+
     // === Element info ===
     int64_t  elem_size;           // Size of each element in bytes
     int64_t  numel;               // Total number of elements
-    
+
     // === Extraction tracking ===
     PTO2TensorExtractionType extraction_type;  // How this tensor was created
     bool     is_contiguous;       // True if memory is contiguous (no gaps)
                                   // Equivalent to layout_depth == 1
-    
+
     // === Layout history for HBB overlap detection ===
     int32_t  layout_depth;                           // Number of layout ops (1=simple)
     PTO2LayoutOp layout_ops[PTO2_MAX_LAYOUT_DEPTH];  // Derivation history
-    
+
 } PTO2LogicalTensor;
 
 // =============================================================================
@@ -233,7 +241,7 @@ typedef struct {
 /**
  * Dependency list entry (singly-linked list node)
  * Stored in DepListPool ring buffer
- * 
+ *
  * Used for both fanin_list and fanout_list
  */
 struct PTO2DepListEntry {
@@ -247,10 +255,10 @@ struct PTO2DepListEntry {
 
 /**
  * Task descriptor structure
- * 
+ *
  * Stored in the TaskDescriptor ring buffer in shared memory.
  * Contains both static info (set at submission) and dynamic state.
- * 
+ *
  * Concurrency notes:
  * - fanout_head, fanout_count protected by fanout_lock (per-task spinlock)
  * - fanin_head, fanin_count set once at submission, read-only after
@@ -265,13 +273,13 @@ struct PTO2TaskDescriptor {
     // Fanin: producers this task depends on (set once at submission)
     PTO2DepListEntry* fanin_head;           // Offset to first fanin entry (0 = empty)
     int32_t fanin_count;          // Number of producer dependencies
-    
+
     // Fanout: consumers that depend on this task (grows as consumers submit)
     // PROTECTED BY fanout_lock
     std::atomic<int32_t> fanout_lock; // Per-task spinlock (0=unlocked, 1=locked)
     PTO2DepListEntry* fanout_head;    // Pointer to first fanout entry (nullptr = empty), PROTECTED BY fanout_lock
     std::atomic<int32_t> fanout_count;// 1 (owning scope) + number of consumers
-    
+
     // Packed output buffer (all outputs packed into single contiguous buffer)
     void*    packed_buffer_base;  // Start of packed buffer in GM Heap
     void*    packed_buffer_end;   // End of packed buffer (for heap reclamation)
@@ -348,15 +356,38 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 // =============================================================================
 
 static inline void pto2_fanout_lock(PTO2TaskDescriptor* task) {
+#if PTO2_ORCH_PROFILING
+    uint64_t t0 = get_sys_cnt_aicpu();
+    bool contended = false;
+    uint32_t atomic_ops = 0;
+#endif
+
     for (;;) {
         while (task->fanout_lock.load(std::memory_order_acquire) != 0) {
+#if PTO2_ORCH_PROFILING
+            contended = true;
+            atomic_ops++;  // each load = 1 atomic
+#endif
             PTO2_SPIN_PAUSE_LIGHT();
         }
         int32_t expected = 0;
         if (task->fanout_lock.compare_exchange_weak(expected, 1,
                                         std::memory_order_acquire, std::memory_order_relaxed)) {
+#if PTO2_ORCH_PROFILING
+            atomic_ops++;  // successful CAS = 1 atomic
+            extern uint64_t g_orch_fanin_atomic_count;
+            g_orch_fanin_atomic_count += atomic_ops;
+            if (contended) {
+                extern uint64_t g_orch_fanin_wait_cycle;
+                g_orch_fanin_wait_cycle += (get_sys_cnt_aicpu() - t0);
+            }
+#endif
             return;
         }
+#if PTO2_ORCH_PROFILING
+        contended = true;
+        atomic_ops++;  // failed CAS = 1 atomic
+#endif
     }
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -68,19 +68,51 @@ struct alignas(64) PTO2ReadyQueue {
     bool push(int32_t task_id) {
         uint64_t pos;
         PTO2ReadyQueueSlot* slot;
+#if PTO2_ORCH_PROFILING
+        uint64_t t0 = get_sys_cnt_aicpu();
+        bool contended = false;
+        uint32_t atomic_ops = 0;
+#endif
         while (true) {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)pos;
+#if PTO2_ORCH_PROFILING
+            atomic_ops += 2;  // enqueue_pos.load + sequence.load
+#endif
             if (diff == 0) {
                 if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed))
+                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+#if PTO2_ORCH_PROFILING
+                    atomic_ops++;  // successful CAS
+#endif
                     break;
+                }
+#if PTO2_ORCH_PROFILING
+                contended = true;
+                atomic_ops++;  // failed CAS
+#endif
             } else if (diff < 0) {
                 return false;  // Queue full
             }
+#if PTO2_ORCH_PROFILING
+            else {
+                contended = true;  // diff > 0: slot not yet released, spin
+            }
+#endif
         }
+#if PTO2_ORCH_PROFILING
+        atomic_ops++;  // final sequence.store
+        {
+            extern uint64_t g_orch_finalize_atomic_count;
+            g_orch_finalize_atomic_count += atomic_ops;
+        }
+        if (contended) {
+            extern uint64_t g_orch_finalize_wait_cycle;
+            g_orch_finalize_wait_cycle += (get_sys_cnt_aicpu() - t0);
+        }
+#endif
 
         slot->task_id = task_id;
         slot->sequence.store((int64_t)(pos + 1), std::memory_order_release);
@@ -222,13 +254,33 @@ struct PTO2SchedulerState {
         int32_t fc = task->fanout_count.load(std::memory_order_acquire);
         int32_t rc = fanout_refcount[slot].load(std::memory_order_acquire);
 
+#if PTO2_ORCH_PROFILING
+        {
+            extern uint64_t g_orch_scope_end_atomic_count;
+            g_orch_scope_end_atomic_count += 2;  // fanout_count.load + fanout_refcount.load
+        }
+#endif
+
         if (rc != fc) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
         if (!task_state[slot].compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
                                           std::memory_order_acq_rel, std::memory_order_acquire)) {
+#if PTO2_ORCH_PROFILING
+            {
+                extern uint64_t g_orch_scope_end_atomic_count;
+                g_orch_scope_end_atomic_count += 1;  // failed CAS
+            }
+#endif
             return;
         }
+
+#if PTO2_ORCH_PROFILING
+        {
+            extern uint64_t g_orch_scope_end_atomic_count;
+            g_orch_scope_end_atomic_count += 1;  // successful CAS
+        }
+#endif
 
 #if PTO2_PROFILING
         tasks_consumed.fetch_add(1, std::memory_order_relaxed);
@@ -236,19 +288,44 @@ struct PTO2SchedulerState {
         fanout_refcount[slot].store(0, std::memory_order_release);
         fanin_refcount[slot].store(0, std::memory_order_release);
 
+#if PTO2_ORCH_PROFILING
+        {
+            extern uint64_t g_orch_scope_end_atomic_count;
+            g_orch_scope_end_atomic_count += 2;  // fanout_refcount.store + fanin_refcount.store
+        }
+#endif
+
         // Try-lock — if another thread is advancing, it will scan our CONSUMED task
         int32_t expected_lock = 0;
         if (ring_advance_lock.compare_exchange_strong(expected_lock, 1,
                 std::memory_order_acquire, std::memory_order_relaxed)) {
             advance_ring_pointers();
             ring_advance_lock.store(0, std::memory_order_release);
+#if PTO2_ORCH_PROFILING
+            {
+                extern uint64_t g_orch_scope_end_atomic_count;
+                g_orch_scope_end_atomic_count += 2;  // try-lock CAS + unlock store
+            }
+#endif
         }
+#if PTO2_ORCH_PROFILING
+        else {
+            extern uint64_t g_orch_scope_end_atomic_count;
+            g_orch_scope_end_atomic_count += 1;  // failed try-lock CAS
+        }
+#endif
     }
 
     void release_producer(int32_t producer_id) {
         int32_t slot = pto2_task_slot(producer_id);
         PTO2TaskDescriptor* producer = pto2_sm_get_task(sm_handle, producer_id);
         fanout_refcount[slot].fetch_add(1, std::memory_order_acq_rel);
+#if PTO2_ORCH_PROFILING
+        {
+            extern uint64_t g_orch_scope_end_atomic_count;
+            g_orch_scope_end_atomic_count += 1;  // fanout_refcount.fetch_add
+        }
+#endif
         check_and_handle_consumed(producer_id, producer);
     }
 
@@ -265,6 +342,12 @@ struct PTO2SchedulerState {
             PTO2TaskState expected = PTO2_TASK_PENDING;
             if (task_state[slot].compare_exchange_strong(
                     expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
+#if PTO2_ORCH_PROFILING
+                {
+                    extern uint64_t g_orch_finalize_atomic_count;
+                    g_orch_finalize_atomic_count += 1;  // CAS(task_state PENDING→READY)
+                }
+#endif
                 ready_queues[task->worker_type].push(task_id);
                 return true;
             }


### PR DESCRIPTION
## Summary
- Add per-phase atomic operation counting to orchestrator profiling, tracking how many atomic ops (loads, CAS, fetch_add, stores) each orchestration phase executes
- Add wait-time tracking for all blocking phases: task_ring_alloc, heap_ring_alloc, fanout_lock contention, and ready queue push CAS retries
- Instrument 6 files across the runtime: fanout_lock, ring buffer allocs, ready queue push, release_producer, and check_and_handle_consumed
- Display `atomics=N` and `work/wait` time split in device log profiling output

## Testing
- [x] Simulation tests pass (`a2a3sim`)
- [ ] Hardware tests pass with `--enable-profiling` (verify `atomics=N` output)