### PR TITLE
Add: alternating matmul-add example for tensormap_and_ringbuffer

### DIFF
--- a/examples/tensormap_and_ringbuffer/alternating_matmul_add/golden.py
+++ b/examples/tensormap_and_ringbuffer/alternating_matmul_add/golden.py
@@ -1,0 +1,129 @@
+"""
+Golden test specification for alternating matmul-add test.
+
+Computation:
+- M independent matmul tasks per batch: C[b,m] = A[b,m] @ B[b,m] (128x128x128)
+- N independent add tasks per batch: Z[b,n] = X[b,n] + Y[b,n] (64x128)
+
+Args layout: [ptr_A, ptr_B, ptr_C, ptr_X, ptr_Y, ptr_Z,
+              size_A, size_B, size_C, size_X, size_Y, size_Z, ptr_config]
+"""
+
+import ctypes
+import torch
+import time
+
+__outputs__ = ["C", "Z"]
+RTOL = 1e-3
+ATOL = 1e-3
+
+ALL_CASES = {
+    "case1": {
+        "batch": 32,
+        "M": 1,  # Number of matmul tasks per batch
+        "N": 1,  # Number of add tasks per batch
+        "random_seed": False,  # False = use fixed seed (42), True = random seed
+    },
+    "case2": {
+        "batch": 64,
+        "M": 1,
+        "N": 1,
+        "random_seed": True,
+    },
+}
+
+DEFAULT_CASE = "case1"
+
+
+def generate_inputs(params: dict) -> list:
+    """Generate input tensors with configurable batch and task counts."""
+    batch = params["batch"]
+    M = params["M"]
+    N = params["N"]
+    random_seed = params.get("random_seed", False)
+
+    # Validate parameters
+    if batch <= 0:
+        raise ValueError(f"batch must be positive, got {batch}")
+    if M <= 0:
+        raise ValueError(f"M must be positive, got {M}")
+    if N <= 0:
+        raise ValueError(f"N must be positive, got {N}")
+
+    # Fixed sizes: matmul 128x128x128, add 64x128
+    matmul_size = 128
+    add_rows = 64
+    add_cols = 128
+
+    # If random_seed is False, use fixed seed (42); if True, use random seed
+    if not random_seed:
+        seed = 42
+    else:
+        seed = int(time.time() * 1000) % (2**31)
+    torch.manual_seed(seed)
+
+    # Matmul tensors: 128x128x128
+    A = torch.randn(batch, M, matmul_size, matmul_size, dtype=torch.float32) * 0.01
+    B = torch.randn(batch, M, matmul_size, matmul_size, dtype=torch.float32) * 0.01
+    C = torch.zeros(batch, M, matmul_size, matmul_size, dtype=torch.float32)
+
+    # Add tensors: 64x128
+    X = torch.randn(batch, N, add_rows, add_cols, dtype=torch.float32) * 0.01
+    Y = torch.randn(batch, N, add_rows, add_cols, dtype=torch.float32) * 0.01
+    Z = torch.zeros(batch, N, add_rows, add_cols, dtype=torch.float32)
+
+    A_flat = A.flatten()
+    B_flat = B.flatten()
+    C_flat = C.flatten()
+    X_flat = X.flatten()
+    Y_flat = Y.flatten()
+    Z_flat = Z.flatten()
+
+    config = torch.tensor([batch, M, N], dtype=torch.int64)
+
+    return [
+        ("A", A_flat),
+        ("B", B_flat),
+        ("C", C_flat),
+        ("X", X_flat),
+        ("Y", Y_flat),
+        ("Z", Z_flat),
+        ("size_A", ctypes.c_int64(A_flat.nbytes)),
+        ("size_B", ctypes.c_int64(B_flat.nbytes)),
+        ("size_C", ctypes.c_int64(C_flat.nbytes)),
+        ("size_X", ctypes.c_int64(X_flat.nbytes)),
+        ("size_Y", ctypes.c_int64(Y_flat.nbytes)),
+        ("size_Z", ctypes.c_int64(Z_flat.nbytes)),
+        ("config", config),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute golden results for matmul and add operations."""
+    batch = params["batch"]
+    M = params["M"]
+    N = params["N"]
+
+    # Fixed sizes: matmul 128x128x128, add 64x128
+    matmul_size = 128
+    add_rows = 64
+    add_cols = 128
+
+    A = torch.as_tensor(tensors["A"]).reshape(batch, M, matmul_size, matmul_size)
+    B = torch.as_tensor(tensors["B"]).reshape(batch, M, matmul_size, matmul_size)
+    C = torch.as_tensor(tensors["C"]).reshape(batch, M, matmul_size, matmul_size)
+
+    X = torch.as_tensor(tensors["X"]).reshape(batch, N, add_rows, add_cols)
+    Y = torch.as_tensor(tensors["Y"]).reshape(batch, N, add_rows, add_cols)
+    Z = torch.as_tensor(tensors["Z"]).reshape(batch, N, add_rows, add_cols)
+
+    for b in range(batch):
+        for m in range(M):
+            C[b, m] = torch.matmul(A[b, m], B[b, m])
+
+    for b in range(batch):
+        for n in range(N):
+            Z[b, n] = X[b, n] + Y[b, n]
+
+    tensors["C"][:] = C.flatten()
+    tensors["Z"][:] = Z.flatten()

--- a/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp
+++ b/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp
@@ -1,0 +1,109 @@
+/**
+ * Matrix Multiplication Kernel (Cube Core)
+ *
+ * Computes: C = A @ B (TILE x TILE x TILE matmul)
+ * Uses TMATMUL instruction
+ *
+ * Args (TensorData*):
+ *   args[0] = A (INPUT)  - TILE x TILE
+ *   args[1] = B (INPUT)  - TILE x TILE
+ *   args[2] = C (OUTPUT) - TILE x TILE
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <typename T>
+AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
+    if (num_2 == 0) {
+        return 0;
+    }
+    return (num_1 + num_2 - 1) / num_2 * num_2;
+}
+
+template <int TILE>
+static __aicore__ void matmul_impl(
+    __gm__ TensorData* input_a_tensor,
+    __gm__ TensorData* input_b_tensor,
+    __gm__ TensorData* output_tensor) {
+
+    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
+    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
+    __gm__ float* output  = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr)  + output_tensor->start_offset;
+
+    constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
+    constexpr int M = CeilAlign<int>(TILE, 16);
+    constexpr int K = CeilAlign<int>(TILE, blockAlign);
+    constexpr int N = CeilAlign<int>(TILE, blockAlign);
+
+    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+
+    GlobalDataA src0Global(input_a);
+    GlobalDataB src1Global(input_b);
+    GlobalDataC dstGlobal(output);
+
+    using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+
+    using LeftTile = TileLeft<float, M, K, TILE, TILE>;
+    using RightTile = TileRight<float, K, N, TILE, TILE>;
+    using AccTile = TileAcc<float, M, N, TILE, TILE>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    TLOAD(aMatTile, src0Global);
+    TLOAD(bMatTile, src1Global);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(dstGlobal, cTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* input_a = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* input_b = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* output  = reinterpret_cast<__gm__ TensorData*>(args[2]);
+
+    matmul_impl<128>(input_a, input_b, output);
+}

--- a/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp
+++ b/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp
@@ -1,0 +1,70 @@
+/**
+ * Element-wise Tensor Addition Kernel
+ *
+ * Implements: out[i] = src0[i] + src1[i]
+ * Tile size: ROWS x COLS
+ *
+ * Args (TensorData*):
+ *   args[0] = src0 (INPUT)  - ROWS x COLS
+ *   args[1] = src1 (INPUT)  - ROWS x COLS
+ *   args[2] = out (OUTPUT)  - ROWS x COLS
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int ROWS, int COLS>
+static __aicore__ void add_impl(
+    __gm__ TensorData* src0_tensor,
+    __gm__ TensorData* src1_tensor,
+    __gm__ TensorData* out_tensor) {
+
+    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
+    using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, ROWS, COLS, BLayout::RowMajor, -1, -1>;
+
+    TileData src0Tile(ROWS, COLS);
+    TileData src1Tile(ROWS, COLS);
+    TileData dstTile(ROWS, COLS);
+    TASSIGN(src0Tile, 0x0);
+    TASSIGN(src1Tile, 0x10000);
+    TASSIGN(dstTile, 0x20000);
+
+    GlobalData src0Global(src0);
+    GlobalData src1Global(src1);
+    GlobalData dstGlobal(out);
+
+    TLOAD(src0Tile, src0Global);
+    TLOAD(src1Tile, src1Global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(dstTile, src0Tile, src1Tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, dstTile);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* src0_tensor = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* src1_tensor = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* out_tensor = reinterpret_cast<__gm__ TensorData*>(args[2]);
+
+    add_impl<64, 128>(src0_tensor, src1_tensor, out_tensor);
+}

--- a/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/kernel_config.py
+++ b/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/kernel_config.py
@@ -1,0 +1,35 @@
+"""
+Kernel configuration for alternating matmul-add test (tensormap_and_ringbuffer Runtime).
+
+Cube core (AIC) for matrix multiplication, Vector core (AIV) for element-wise addition.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "alternating_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "MATMUL",
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "ADD",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_add.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 3,
+}

--- a/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -1,0 +1,144 @@
+/**
+ * Alternating Matmul-Add Orchestration Function (tensormap_and_ringbuffer Runtime)
+ *
+ * Submits independent matmul and add tasks in fixed alternating order.
+ *
+ * Configuration (from config tensor):
+ *   - batch: Number of batches
+ *   - M: Number of matmul tasks per batch
+ *   - N: Number of add tasks per batch
+ *
+ * Task pattern: [matmul_0, add_0, matmul_1, add_1, ...]
+ * All tasks are completely independent (no dependencies).
+ *
+ * Args layout: [ptr_A, ptr_B, ptr_C, ptr_X, ptr_Y, ptr_Z,
+ *               size_A, size_B, size_C, size_X, size_Y, size_Z, ptr_config]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_MATMUL 0
+#define FUNC_ADD    1
+
+#define ARG_PTR_A      0
+#define ARG_PTR_B      1
+#define ARG_PTR_C      2
+#define ARG_PTR_X      3
+#define ARG_PTR_Y      4
+#define ARG_PTR_Z      5
+#define ARG_SIZE_A     6
+#define ARG_SIZE_B     7
+#define ARG_SIZE_C     8
+#define ARG_SIZE_X     9
+#define ARG_SIZE_Y     10
+#define ARG_SIZE_Z     11
+#define ARG_PTR_CONFIG 12
+
+static constexpr uint64_t MATMUL_ELEMS = 128 * 128;
+static constexpr uint64_t ADD_ELEMS = 64 * 128;
+
+extern "C" {
+
+__attribute__((visibility("default")))
+PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count) {
+    (void)args;
+    (void)arg_count;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 13,
+    };
+}
+
+__attribute__((visibility("default")))
+void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
+    (void)arg_count;
+    pto2_rt_init_tensor_pool(rt);
+
+    void* dev_A = (void*)(uintptr_t)args[ARG_PTR_A];
+    void* dev_B = (void*)(uintptr_t)args[ARG_PTR_B];
+    void* dev_C = (void*)(uintptr_t)args[ARG_PTR_C];
+    void* dev_X = (void*)(uintptr_t)args[ARG_PTR_X];
+    void* dev_Y = (void*)(uintptr_t)args[ARG_PTR_Y];
+    void* dev_Z = (void*)(uintptr_t)args[ARG_PTR_Z];
+    size_t size_A = (size_t)args[ARG_SIZE_A];
+    size_t size_B = (size_t)args[ARG_SIZE_B];
+    size_t size_C = (size_t)args[ARG_SIZE_C];
+    size_t size_X = (size_t)args[ARG_SIZE_X];
+    size_t size_Y = (size_t)args[ARG_SIZE_Y];
+    size_t size_Z = (size_t)args[ARG_SIZE_Z];
+    int64_t* config = (int64_t*)(uintptr_t)args[ARG_PTR_CONFIG];
+
+    int batch = (int)config[0];
+    int M = (int)config[1];
+    int N = (int)config[2];
+
+    LOG_INFO(rt, "[alternating_orch] Batch: %d, M: %d, N: %d", batch, M, N);
+
+    uint64_t ext_A_shapes[1] = {size_A / sizeof(float)};
+    Tensor ext_A = make_tensor_external(dev_A, ext_A_shapes, 1, DataType::FLOAT32);
+    uint64_t ext_B_shapes[1] = {size_B / sizeof(float)};
+    Tensor ext_B = make_tensor_external(dev_B, ext_B_shapes, 1, DataType::FLOAT32);
+    uint64_t ext_C_shapes[1] = {size_C / sizeof(float)};
+    Tensor ext_C = make_tensor_external(dev_C, ext_C_shapes, 1, DataType::FLOAT32);
+
+    uint64_t ext_X_shapes[1] = {size_X / sizeof(float)};
+    Tensor ext_X = make_tensor_external(dev_X, ext_X_shapes, 1, DataType::FLOAT32);
+    uint64_t ext_Y_shapes[1] = {size_Y / sizeof(float)};
+    Tensor ext_Y = make_tensor_external(dev_Y, ext_Y_shapes, 1, DataType::FLOAT32);
+    uint64_t ext_Z_shapes[1] = {size_Z / sizeof(float)};
+    Tensor ext_Z = make_tensor_external(dev_Z, ext_Z_shapes, 1, DataType::FLOAT32);
+
+    uint64_t matmul_tile_shapes[1] = {MATMUL_ELEMS};
+    uint64_t add_tile_shapes[1] = {ADD_ELEMS};
+
+    int total_matmul = batch * M;
+    int total_add = batch * N;
+    int max_tasks = (total_matmul > total_add) ? total_matmul : total_add;
+
+    for (int i = 0; i < max_tasks; i++) {
+        if (i < total_matmul) {
+            uint64_t offset = (uint64_t)i * MATMUL_ELEMS;
+
+
+            uint64_t view_offsets[1] = {offset};
+
+            Tensor A_view = ext_A.view(matmul_tile_shapes, view_offsets);
+            Tensor B_view = ext_B.view(matmul_tile_shapes, view_offsets);
+            Tensor C_view = ext_C.view(matmul_tile_shapes, view_offsets);
+
+            PTOParam params_matmul[] = {
+                make_input_param(A_view),
+                make_input_param(B_view),
+                make_output_param(C_view),
+            };
+            pto2_rt_submit_task(rt, FUNC_MATMUL, PTO2_WORKER_CUBE,
+                               params_matmul, 3);
+        }
+
+        if (i < total_add) {
+            uint64_t offset = (uint64_t)i * ADD_ELEMS;
+
+
+            uint64_t view_offsets[1] = {offset};
+
+            Tensor X_view = ext_X.view(add_tile_shapes, view_offsets);
+            Tensor Y_view = ext_Y.view(add_tile_shapes, view_offsets);
+            Tensor Z_view = ext_Z.view(add_tile_shapes, view_offsets);
+
+            PTOParam params_add[] = {
+                make_input_param(X_view),
+                make_input_param(Y_view),
+                make_output_param(Z_view),
+            };
+            pto2_rt_submit_task(rt, FUNC_ADD, PTO2_WORKER_VECTOR,
+                               params_add, 3);
+        }
+    }
+
+    LOG_INFO(rt, "[alternating_orch] Submitted %d matmul tasks and %d add tasks",
+                  total_matmul, total_add);
+}
+
+}  // extern "C"


### PR DESCRIPTION
- Implement dual-core orchestration: AIC for matmul, AIV for add
- Support configurable batch size and task counts (M matmuls, N adds)
- Golden test covers fixed-seed (case1) and random-seed (case2) scenarios
- Demonstrates tensormap_and_ringbuffer runtime with multi-core coordination