### PR TITLE
Support: add hierarchical profiling macros with two-tier scheduler output

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -435,6 +435,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
     if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
         DEV_INFO("Thread %d: doing one-time init", thread_idx);
 
+#if PTO2_PROFILING
         // Assign perf buffers to cores early so profiling captures all tasks
         // (total_tasks written to header later when orchestrator completes)
         if (runtime->enable_profiling) {
@@ -444,6 +445,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
             perf_aicpu_init_phase_profiling(runtime, sched_threads);
             perf_aicpu_set_orch_thread_idx(sched_threads);
         }
+#endif
 
         DEV_INFO("Thread %d: one-time init done", thread_idx);
         pto2_init_complete_.store(true, std::memory_order_release);
@@ -464,8 +466,10 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
     const int STALL_DUMP_CORE_MAX = 8;
     const int PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
     const int PROGRESS_LOG_INTERVAL = 25;       // log every N completions after threshold
+#if PTO2_PROFILING
     bool profiling_enabled = runtime->enable_profiling;
     int32_t last_reported_task_count = 0;
+#endif
 
     // Scheduler profiling counters
 #if PTO2_PROFILING
@@ -544,10 +548,9 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
             }
 #endif
             if (completed_match) {
-
-                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
                 int32_t task_id = executing_task_ids_[core_id];
 #if PTO2_PROFILING
+                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
                 PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id);
                 notify_edges_total += cstats.fanout_edges;
                 if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
@@ -560,6 +563,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
 #endif
                 executing_task_ids_[core_id] = AICPU_TASK_INVALID;
 
+#if PTO2_PROFILING
                 // Write AICPU dispatch/finish timestamps into the PerfRecord
                 if (profiling_enabled) {
                     Handshake* h = &hank[core_id];
@@ -576,6 +580,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                         }
                     }
                 }
+#endif
 
                 DEV_DEBUG("Thread %d: Core %d completed PTO2 task %d", thread_idx, core_id, task_id);
 
@@ -622,6 +627,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                         PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
                         PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
                         build_pto2_payload(payload, runtime, task, task_descriptors, dep_list_pool, window_size);
+#if PTO2_PROFILING
                         // Performance profiling: check if buffer needs switching
                         if (profiling_enabled) {
                             dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
@@ -631,6 +637,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                             }
                             core_dispatch_counts_[core_id]++;
                         }
+#endif
                         write_reg(reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id + 1));
                         executing_task_ids_[core_id] = task_id;
                         cur_thread_tasks_in_flight++;
@@ -654,6 +661,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
         }
 #endif
 
+#if PTO2_PROFILING
         // Update perf header total_tasks if visible tasks have changed
         {
             int32_t visible = header->current_task_index.load(std::memory_order_acquire);
@@ -666,6 +674,7 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                 last_reported_task_count = visible;
             }
         }
+#endif
         CYCLE_COUNT_LAP(sched_scan_cycle);
 #if PTO2_PROFILING
         if (profiling_enabled) {
@@ -751,11 +760,15 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
     }
 
 #if PTO2_PROFILING
-    if (profiling_enabled) {
+    // Scheduler summary logging (always print when PTO2_PROFILING=1)
     uint64_t sched_total =
         sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
+
+#if PTO2_SCHED_PROFILING
     double tasks_per_loop = sched_loop_count > 0 ? (double)cur_thread_completed / sched_loop_count : 0.0;
+
+    // Detailed output with full phase breakdown
     DEV_ALWAYS("Thread %d: completed=%d tasks in %.3fus (%llu loops, %.1f tasks/loop)",
         thread_idx,
         cur_thread_completed,
@@ -803,13 +816,21 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
         thread_idx,
         cycles_to_us(sched_idle_cycle),
         sched_idle_cycle * 100.0 / sched_total);
-    }
+#endif
+    // Summary line (always print when PTO2_PROFILING=1)
+    DEV_ALWAYS("Thread %d: Scheduler summary: total_time=%.3fus, loops=%llu, tasks_scheduled=%d",
+        thread_idx,
+        cycles_to_us(sched_total),
+        (unsigned long long)sched_loop_count,
+        cur_thread_completed);
 #endif
 
+#if PTO2_PROFILING
     // Flush performance buffers for cores managed by this thread
     if (profiling_enabled) {
         perf_aicpu_flush_buffers(runtime, thread_idx, cur_thread_cores, core_num);
     }
+#endif
 
     return cur_thread_completed;
 }
@@ -1002,57 +1023,58 @@ int AicpuExecutor::run(Runtime* runtime) {
 
             // Print orchestrator profiling data
 #if PTO2_ORCH_PROFILING
-            if (runtime->enable_profiling) {
-                PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
-                uint64_t total = p.sync_cycle + p.alloc_cycle + p.params_cycle +
-                                 p.lookup_cycle + p.heap_cycle + p.insert_cycle +
-                                 p.fanin_cycle + p.finalize_cycle;
-                if (total == 0) total = 1;  // avoid div-by-zero
-                DEV_ALWAYS("Thread %d: === Orchestrator Profiling: %lld tasks, total=%.3fus ===", thread_idx,
-                         (long long)p.submit_count, cycles_to_us(total));
-                DEV_ALWAYS("Thread %d:   sync_tensormap : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.sync_cycle), p.sync_cycle * 100.0 / total);
-                DEV_ALWAYS("Thread %d:   task_ring_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
-                    cycles_to_us(p.alloc_cycle), p.alloc_cycle * 100.0 / total,
-                    cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle), cycles_to_us(p.alloc_wait_cycle),
-                    (unsigned long long)p.alloc_atomic_count);
-                DEV_ALWAYS("Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%llu", thread_idx,
-                    cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total,
-                    (unsigned long long)p.params_atomic_count);
-                DEV_ALWAYS("Thread %d:   lookup+dep     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.lookup_cycle), p.lookup_cycle * 100.0 / total);
-                DEV_ALWAYS("Thread %d:   heap_alloc     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
-                    cycles_to_us(p.heap_cycle), p.heap_cycle * 100.0 / total,
-                    cycles_to_us(p.heap_cycle - p.heap_wait_cycle), cycles_to_us(p.heap_wait_cycle),
-                    (unsigned long long)p.heap_atomic_count);
-                DEV_ALWAYS("Thread %d:   tensormap_ins  : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.insert_cycle), p.insert_cycle * 100.0 / total);
-                DEV_ALWAYS("Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
-                    cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
-                    cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
-                    (unsigned long long)p.fanin_atomic_count);
-                DEV_ALWAYS("Thread %d:   finalize+SM    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
-                    cycles_to_us(p.finalize_cycle), p.finalize_cycle * 100.0 / total,
-                    cycles_to_us(p.finalize_cycle - p.finalize_wait_cycle), cycles_to_us(p.finalize_wait_cycle),
-                    (unsigned long long)p.finalize_atomic_count);
-                DEV_ALWAYS("Thread %d:   scope_end      : %.3fus  atomics=%llu", thread_idx,
-                    cycles_to_us(p.scope_end_cycle),
-                    (unsigned long long)p.scope_end_atomic_count);
-                DEV_ALWAYS("Thread %d:   avg/task       : %.3fus", thread_idx,
-                    p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0);
+            PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
+            uint64_t total = p.sync_cycle + p.alloc_cycle + p.params_cycle +
+                             p.lookup_cycle + p.heap_cycle + p.insert_cycle +
+                             p.fanin_cycle + p.finalize_cycle;
+            if (total == 0) total = 1;  // avoid div-by-zero
+            DEV_ALWAYS("Thread %d: === Orchestrator Profiling: %lld tasks, total=%.3fus ===", thread_idx,
+                     (long long)p.submit_count, cycles_to_us(total));
+            DEV_ALWAYS("Thread %d:   sync_tensormap : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.sync_cycle), p.sync_cycle * 100.0 / total);
+            DEV_ALWAYS("Thread %d:   task_ring_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                cycles_to_us(p.alloc_cycle), p.alloc_cycle * 100.0 / total,
+                cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle), cycles_to_us(p.alloc_wait_cycle),
+                (unsigned long long)p.alloc_atomic_count);
+            DEV_ALWAYS("Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%llu", thread_idx,
+                cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total,
+                (unsigned long long)p.params_atomic_count);
+            DEV_ALWAYS("Thread %d:   lookup+dep     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.lookup_cycle), p.lookup_cycle * 100.0 / total);
+            DEV_ALWAYS("Thread %d:   heap_alloc     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                cycles_to_us(p.heap_cycle), p.heap_cycle * 100.0 / total,
+                cycles_to_us(p.heap_cycle - p.heap_wait_cycle), cycles_to_us(p.heap_wait_cycle),
+                (unsigned long long)p.heap_atomic_count);
+            DEV_ALWAYS("Thread %d:   tensormap_ins  : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.insert_cycle), p.insert_cycle * 100.0 / total);
+            DEV_ALWAYS("Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
+                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
+                (unsigned long long)p.fanin_atomic_count);
+            DEV_ALWAYS("Thread %d:   finalize+SM    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                cycles_to_us(p.finalize_cycle), p.finalize_cycle * 100.0 / total,
+                cycles_to_us(p.finalize_cycle - p.finalize_wait_cycle), cycles_to_us(p.finalize_wait_cycle),
+                (unsigned long long)p.finalize_atomic_count);
+            DEV_ALWAYS("Thread %d:   scope_end      : %.3fus  atomics=%llu", thread_idx,
+                cycles_to_us(p.scope_end_cycle),
+                (unsigned long long)p.scope_end_atomic_count);
+            DEV_ALWAYS("Thread %d:   avg/task       : %.3fus", thread_idx,
+                p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0);
 
 #if PTO2_TENSORMAP_PROFILING
-                PTO2TensorMapProfilingData tp = pto2_tensormap_get_profiling();
-                DEV_ALWAYS("Thread %d: === TensorMap Lookup Stats ===", thread_idx);
-                DEV_ALWAYS("Thread %d:   lookups        : %llu, inserts: %llu", thread_idx,
-                    (unsigned long long)tp.lookup_count, (unsigned long long)tp.insert_count);
-                DEV_ALWAYS("Thread %d:   chain walked   : total=%llu, avg=%.1f, max=%d", thread_idx,
-                    (unsigned long long)tp.lookup_chain_total,
-                    tp.lookup_count > 0 ? (double)tp.lookup_chain_total / tp.lookup_count : 0.0,
-                    tp.lookup_chain_max);
-                DEV_ALWAYS("Thread %d:   overlap checks : %llu, hits=%llu (%.1f%%)", thread_idx,
-                    (unsigned long long)tp.overlap_checks, (unsigned long long)tp.overlap_hits,
-                    tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0);
+            PTO2TensorMapProfilingData tp = pto2_tensormap_get_profiling();
+            DEV_ALWAYS("Thread %d: === TensorMap Lookup Stats ===", thread_idx);
+            DEV_ALWAYS("Thread %d:   lookups        : %llu, inserts: %llu", thread_idx,
+                (unsigned long long)tp.lookup_count, (unsigned long long)tp.insert_count);
+            DEV_ALWAYS("Thread %d:   chain walked   : total=%llu, avg=%.1f, max=%d", thread_idx,
+                (unsigned long long)tp.lookup_chain_total,
+                tp.lookup_count > 0 ? (double)tp.lookup_chain_total / tp.lookup_count : 0.0,
+                tp.lookup_chain_max);
+            DEV_ALWAYS("Thread %d:   overlap checks : %llu, hits=%llu (%.1f%%)", thread_idx,
+                (unsigned long long)tp.overlap_checks, (unsigned long long)tp.overlap_hits,
+                tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0);
 #endif
 
-                // Write orchestrator summary to shared memory for host-side export
+#if PTO2_PROFILING
+            // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
+            if (runtime->enable_profiling) {
                 AicpuOrchSummary orch_summary = {};
                 orch_summary.start_time = orch_cycle_start;
                 orch_summary.end_time = orch_cycle_end;
@@ -1068,6 +1090,7 @@ int AicpuExecutor::run(Runtime* runtime) {
                 orch_summary.submit_count = p.submit_count;
                 perf_aicpu_write_orch_summary(&orch_summary);
             }
+#endif
 #endif
 
             // Signal orchestration complete in SM header (needs runtime alive)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -1,0 +1,303 @@
+# PTO Runtime2 Profiling Levels
+
+This document describes the profiling macro hierarchy and logging control in the PTO Runtime2 system.
+
+## Overview
+
+PTO Runtime2 uses a hierarchical profiling system with compile-time macros to control profiling code compilation and log output. The `enable_profiling` runtime flag controls data collection (performance buffers, shared memory writes) but does NOT control log output.
+
+## Profiling Macro Hierarchy
+
+```
+PTO2_PROFILING (base level, default=0)
+├── PTO2_ORCH_PROFILING (orchestrator, default=0, requires PTO2_PROFILING=1)
+├── PTO2_SCHED_PROFILING (scheduler, default=0, requires PTO2_PROFILING=1)
+└── PTO2_TENSORMAP_PROFILING (tensormap, default=0, requires PTO2_PROFILING=1)
+```
+
+### Compile-Time Validation
+
+Each sub-level macro requires `PTO2_PROFILING=1`:
+
+```cpp
+#if PTO2_ORCH_PROFILING && !PTO2_PROFILING
+#error "PTO2_ORCH_PROFILING requires PTO2_PROFILING=1"
+#endif
+
+#if PTO2_SCHED_PROFILING && !PTO2_PROFILING
+#error "PTO2_SCHED_PROFILING requires PTO2_PROFILING=1"
+#endif
+
+#if PTO2_TENSORMAP_PROFILING && !PTO2_PROFILING
+#error "PTO2_TENSORMAP_PROFILING requires PTO2_PROFILING=1"
+#endif
+```
+
+## Profiling Levels
+
+### Level 0: No Profiling (PTO2_PROFILING=0)
+
+**What's compiled:**
+- Debug/diagnostic logs (always present)
+- Progress tracking
+- Stall detection
+- Deadlock/livelock detection
+
+**What's NOT compiled:**
+- All profiling counters
+- All profiling logs
+- Performance data collection
+
+**Log output:** 11 DEV_ALWAYS logs (debug/diagnostic only)
+
+---
+
+### Level 1: Basic Profiling (PTO2_PROFILING=1)
+
+**What's compiled:**
+- All profiling counters (cycles, task counts, loop counts)
+- Basic profiling summaries
+- Scheduler summary output
+- Orchestration completion time
+
+**What's NOT compiled:**
+- Detailed phase breakdowns
+- TensorMap statistics
+
+**Log output:** 13 DEV_ALWAYS logs
+- 11 debug/diagnostic logs (always present)
+- 2 basic profiling summaries:
+  - Orchestration completion time
+  - Total submitted tasks
+
+**Scheduler output:**
+```
+Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
+```
+
+**Note:** Scheduler summary always prints when `PTO2_PROFILING=1`, regardless of `enable_profiling` flag.
+
+---
+
+### Level 2: Scheduler Detailed Profiling (PTO2_SCHED_PROFILING=1)
+
+**Requires:** `PTO2_PROFILING=1`
+
+**What's compiled:**
+- All Level 1 features
+- Detailed scheduler phase counters
+- Phase-specific statistics (complete, scan, dispatch, idle)
+- Hit rate tracking (complete poll, ready queue pop)
+
+**Log output:** 18 DEV_ALWAYS logs (11 debug + 2 basic + 7 scheduler detailed - 2 replaced)
+- Replaces scheduler summary with detailed breakdown
+
+**Scheduler output:**
+```
+Thread X: completed=XXX tasks in XXXus (XXX loops, X.X tasks/loop)
+Thread X: --- Phase Breakdown ---
+Thread X:   complete:    XXXus (XX.X%)  [fanout: edges=XXX, max_degree=X, avg=X.X]  [fanin: edges=XXX, max_degree=X, avg=X.X]
+Thread X:     complete_poll: hit=XXX, miss=XXX, hit_rate=XX.X%
+Thread X:   scan:        XXXus (XX.X%)
+Thread X:   dispatch:    XXXus (XX.X%)  [pop: hit=XXX, miss=XXX, hit_rate=XX.X%]
+Thread X:   idle:        XXXus (XX.X%)
+```
+
+---
+
+### Level 3: Orchestrator Detailed Profiling (PTO2_ORCH_PROFILING=1)
+
+**Requires:** `PTO2_PROFILING=1`
+
+**What's compiled:**
+- All Level 1 features
+- Detailed orchestrator phase counters
+- Per-phase cycle tracking
+- Atomic operation counters
+- Wait time tracking
+
+**Log output:** 30 DEV_ALWAYS logs (11 debug + 2 basic + 1 scheduler summary + 17 orchestrator detailed - 1 replaced)
+- Replaces basic orchestration completion with detailed breakdown
+
+**Orchestrator output:**
+```
+Thread X: === Orchestrator Profiling: XXX tasks, total=XXXus ===
+Thread X:   sync_tensormap : XXXus (XX.X%)
+Thread X:   task_ring_alloc: XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:   param_copy     : XXXus (XX.X%)  atomics=XXX
+Thread X:   lookup+dep     : XXXus (XX.X%)
+Thread X:   heap_alloc     : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:   tensormap_ins  : XXXus (XX.X%)
+Thread X:   fanin+ready    : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:   finalize+SM    : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:   scope_end      : XXXus  atomics=XXX
+Thread X:   avg/task       : XXXus
+```
+
+**Note:** Orchestrator logs always print when `PTO2_ORCH_PROFILING=1`, regardless of `enable_profiling` flag.
+
+---
+
+### Level 4: TensorMap Profiling (PTO2_TENSORMAP_PROFILING=1)
+
+**Requires:** `PTO2_PROFILING=1` AND `PTO2_ORCH_PROFILING=1`
+
+**What's compiled:**
+- All Level 3 features
+- TensorMap lookup statistics
+- Hash chain walk tracking
+- Overlap check counters
+
+**Log output:** 34 DEV_ALWAYS logs (30 from Level 3 + 4 tensormap)
+
+**TensorMap output:**
+```
+Thread X: === TensorMap Lookup Stats ===
+Thread X:   lookups        : XXX, inserts: XXX
+Thread X:   chain walked   : total=XXX, avg=X.X, max=X
+Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
+```
+
+---
+
+## Runtime Flag: enable_profiling
+
+The `runtime->enable_profiling` flag controls **data collection**, NOT log output.
+
+### When enable_profiling=true:
+- Performance buffers are allocated and written
+- Per-task timing data is collected
+- Phase profiling data is recorded
+- Orchestrator summary is written to shared memory
+
+### When enable_profiling=false:
+- No performance data collection
+- No shared memory writes
+- Logs still print (controlled by macros only)
+
+### Usage:
+```cpp
+// Initialize runtime with profiling enabled
+runtime->enable_profiling = true;
+```
+
+---
+
+## Common Profiling Configurations
+
+### Development (default)
+```bash
+# No profiling overhead
+PTO2_PROFILING=0
+```
+
+### Basic Performance Monitoring
+```bash
+# Minimal overhead, summary logs only
+PTO2_PROFILING=1
+PTO2_ORCH_PROFILING=0
+PTO2_SCHED_PROFILING=0
+```
+
+### Scheduler Performance Analysis
+```bash
+# Detailed scheduler breakdown
+PTO2_PROFILING=1
+PTO2_ORCH_PROFILING=0
+PTO2_SCHED_PROFILING=1
+```
+
+### Orchestrator Performance Analysis
+```bash
+# Detailed orchestrator breakdown
+PTO2_PROFILING=1
+PTO2_ORCH_PROFILING=1
+PTO2_SCHED_PROFILING=0
+```
+
+### Full Profiling (maximum overhead)
+```bash
+# All profiling features enabled
+PTO2_PROFILING=1
+PTO2_ORCH_PROFILING=1
+PTO2_SCHED_PROFILING=1
+PTO2_TENSORMAP_PROFILING=1
+```
+
+---
+
+## Setting Profiling Macros
+
+### At compile time:
+```bash
+# In CMakeLists.txt or build command
+add_definitions(-DPTO2_PROFILING=1)
+add_definitions(-DPTO2_ORCH_PROFILING=1)
+```
+
+### In source code (before including headers):
+```cpp
+#define PTO2_PROFILING 1
+#define PTO2_ORCH_PROFILING 1
+#include "pto_runtime2_types.h"
+```
+
+---
+
+## Log Output Summary
+
+| Level | Macro Settings | DEV_ALWAYS Count | Description |
+|-------|---------------|------------------|-------------|
+| 0 | `PTO2_PROFILING=0` | 11 | Debug/diagnostic only |
+| 1 | `PTO2_PROFILING=1` | 13 | Basic summaries |
+| 2 | `+PTO2_SCHED_PROFILING=1` | 18 | Scheduler detailed |
+| 3 | `+PTO2_ORCH_PROFILING=1` | 30 | Orchestrator detailed |
+| 4 | `+PTO2_TENSORMAP_PROFILING=1` | 34 | TensorMap stats |
+
+---
+
+## Implementation Notes
+
+### Key Principles
+
+1. **Macros control compilation and logging**
+   - `#if PTO2_PROFILING` controls whether profiling code is compiled
+   - Logs print when macro is enabled, regardless of runtime flag
+
+2. **Runtime flag controls data collection**
+   - `enable_profiling` controls performance buffer allocation
+   - Controls shared memory writes for host-side export
+   - Does NOT control log output
+
+3. **Consistent behavior across components**
+   - Scheduler logs: macro-controlled only
+   - Orchestrator logs: macro-controlled only
+   - Data collection: runtime flag controlled
+
+### Code Locations
+
+- Macro definitions: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h`
+- Scheduler profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp` (lines 770-835)
+- Orchestrator profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp` (lines 1035-1105)
+- TensorMap profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h`
+
+---
+
+## Performance Impact
+
+### Compilation overhead:
+- Level 0: No overhead
+- Level 1: Minimal (counter increments, basic arithmetic)
+- Level 2-4: Low to moderate (additional counters, cycle measurements)
+
+### Runtime overhead:
+- Logging: Negligible (device logs are asynchronous)
+- Data collection (`enable_profiling=true`): Low to moderate
+  - Performance buffer writes
+  - Shared memory updates
+  - Per-task timing measurements
+
+### Recommendation:
+- Use Level 0 for production
+- Use Level 1-2 for performance monitoring
+- Use Level 3-4 for detailed performance analysis only

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -26,15 +26,31 @@
 // =============================================================================
 
 #ifndef PTO2_PROFILING
-#define PTO2_PROFILING 1
+#define PTO2_PROFILING 0
 #endif
 
 #ifndef PTO2_ORCH_PROFILING
-#define PTO2_ORCH_PROFILING 1
+#define PTO2_ORCH_PROFILING 0
 #endif
 
-#if PTO2_ORCH_PROFILING
-#include "aicpu/device_time.h"
+#ifndef PTO2_SCHED_PROFILING
+#define PTO2_SCHED_PROFILING 0
+#endif
+
+#ifndef PTO2_TENSORMAP_PROFILING
+#define PTO2_TENSORMAP_PROFILING 0
+#endif
+
+#if PTO2_ORCH_PROFILING && !PTO2_PROFILING
+#error "PTO2_ORCH_PROFILING requires PTO2_PROFILING=1"
+#endif
+
+#if PTO2_SCHED_PROFILING && !PTO2_PROFILING
+#error "PTO2_SCHED_PROFILING requires PTO2_PROFILING=1"
+#endif
+
+#if PTO2_TENSORMAP_PROFILING && !PTO2_ORCH_PROFILING
+#error "PTO2_TENSORMAP_PROFILING requires PTO2_ORCH_PROFILING=1"
 #endif
 
 // =============================================================================
@@ -354,6 +370,10 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 // fanout_count, because the orchestrator adds consumers concurrently with the
 // scheduler traversing the list after task completion.
 // =============================================================================
+
+#if PTO2_ORCH_PROFILING
+#include "aicpu/device_time.h"
+#endif
 
 static inline void pto2_fanout_lock(PTO2TaskDescriptor* task) {
 #if PTO2_ORCH_PROFILING

--- a/tools/sched_overhead_analysis.py
+++ b/tools/sched_overhead_analysis.py
@@ -35,18 +35,22 @@ def auto_select_perf_json():
 def parse_scheduler_threads(log_path):
     """Parse device log for PTO2 scheduler stats per thread.
 
-    Expected log format (per thread):
+    Supports two formats:
+    1. Detailed (PTO2_SCHED_PROFILING=1):
         Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
         Thread N: --- Phase Breakdown ---
         Thread N:   complete:    Xus (Y%)  [fanout: edges=A, max_degree=B, avg=C]  [fanin: edges=D, max_degree=E, avg=F]
         Thread N:   scan:        Xus (Y%)
         Thread N:   dispatch:    Xus (Y%)  [pop: hit=A, miss=B, hit_rate=C%]
         Thread N:   idle:        Xus (Y%)
+
+    2. Summary (PTO2_SCHED_PROFILING=0):
+        Thread N: Scheduler summary: total_time=Xus, loops=Y, tasks_scheduled=Z
     """
     threads = {}
     with open(log_path, 'r', errors='ignore') as f:
         for line in f:
-            # Summary: Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
+            # Detailed format: Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
             m = re.search(r'Thread (\d+): completed=(\d+) tasks in ([\d.]+)us \((\d+) loops, ([\d.]+) tasks/loop\)', line)
             if m:
                 tid = int(m.group(1))
@@ -55,6 +59,22 @@ def parse_scheduler_threads(log_path):
                     'total_us': float(m.group(3)),
                     'loops': int(m.group(4)),
                     'tasks_per_loop': float(m.group(5)),
+                }
+
+            # Summary format: Thread N: Scheduler summary: total_time=Xus, loops=Y, tasks_scheduled=Z
+            m = re.search(r'Thread (\d+): Scheduler summary: total_time=([\d.]+)us, loops=(\d+), tasks_scheduled=(\d+)', line)
+            if m:
+                tid = int(m.group(1))
+                total_us = float(m.group(2))
+                loops = int(m.group(3))
+                completed = int(m.group(4))
+                tasks_per_loop = completed / loops if loops > 0 else 0.0
+                threads[tid] = {
+                    'completed': completed,
+                    'total_us': total_us,
+                    'loops': loops,
+                    'tasks_per_loop': tasks_per_loop,
+                    'format': 'summary',  # Mark as summary format
                 }
 
             # Phase: complete [fanout: edges=X, max_degree=Y, avg=Z]  [fanin: edges=D, max_degree=E, avg=F]


### PR DESCRIPTION
## Summary

Implements a hierarchical profiling macro system with compile-time validation and two-tier scheduler output formats.

### Key Changes

- Add `PTO2_SCHED_PROFILING` and `PTO2_TENSORMAP_PROFILING` macros with hierarchical validation
- Implement two-tier scheduler output:
  - Detailed breakdown when `PTO2_SCHED_PROFILING=1` (phase stats, fanout/fanin, pop hit rate)
  - Compact summary when `PTO2_SCHED_PROFILING=0` (total_time, loops, tasks_scheduled)
- Separate concerns: macros control compilation/logging, `enable_profiling` flag controls data collection
- Wrap all `enable_profiling` runtime checks in `#if PTO2_PROFILING` guards
- Remove `enable_profiling` check from orchestrator/scheduler logs (macro-controlled only)
- Update `sched_overhead_analysis.py` to support both output formats
- Add comprehensive `profiling_levels.md` documentation

### Profiling Hierarchy

```
PTO2_PROFILING (base)
├── PTO2_ORCH_PROFILING
│   └── PTO2_TENSORMAP_PROFILING
└── PTO2_SCHED_PROFILING
```

### Testing

- [x] Compilation passes with all macro combinations
- [x] Hardware test passes with default settings
- [x] Analysis scripts work with both detailed and summary formats