### PR TITLE
Support: add matmul_batch and add_batch to control task execution granularity

### DIFF
--- a/examples/tensormap_and_ringbuffer/alternating_matmul_add/golden.py
+++ b/examples/tensormap_and_ringbuffer/alternating_matmul_add/golden.py
@@ -19,20 +19,24 @@ ATOL = 1e-3
 
 ALL_CASES = {
     "case1": {
-        "batch": 32,
-        "M": 1,  # Number of matmul tasks per batch
-        "N": 1,  # Number of add tasks per batch
-        "random_seed": False,  # False = use fixed seed (42), True = random seed
+        "batch": 512,
+        "M": 2,  # Number of matmul tasks per batch
+        "N": 5,  # Number of add tasks per batch
+        "random_seed": True,  # False = use fixed seed (42), True = random seed
+        "matmul_batch": 2,  # Number of matmul tiles per task
+        "add_batch": 5,  # Number of add tiles per task
     },
     "case2": {
-        "batch": 64,
+        "batch": 1024,
         "M": 1,
         "N": 1,
-        "random_seed": True,
+        "random_seed": False,
+        "matmul_batch": 1,
+        "add_batch": 1,
     },
 }
 
-DEFAULT_CASE = "case1"
+DEFAULT_CASE = "case2"
 
 
 def generate_inputs(params: dict) -> list:
@@ -41,6 +45,8 @@ def generate_inputs(params: dict) -> list:
     M = params["M"]
     N = params["N"]
     random_seed = params.get("random_seed", False)
+    matmul_batch = params.get("matmul_batch", 1)
+    add_batch = params.get("add_batch", 1)
 
     # Validate parameters
     if batch <= 0:
@@ -49,13 +55,32 @@ def generate_inputs(params: dict) -> list:
         raise ValueError(f"M must be positive, got {M}")
     if N <= 0:
         raise ValueError(f"N must be positive, got {N}")
+    if matmul_batch <= 0:
+        raise ValueError(f"matmul_batch must be positive, got {matmul_batch}")
+    if add_batch <= 0:
+        raise ValueError(f"add_batch must be positive, got {add_batch}")
+
+    # Validate divisibility for task grouping
+    total_matmul_tasks = batch * M
+    total_add_tasks = batch * N
+
+    if total_matmul_tasks % matmul_batch != 0:
+        raise ValueError(
+            f"total_matmul_tasks ({total_matmul_tasks}) must be "
+            f"divisible by matmul_batch ({matmul_batch})"
+        )
+    if total_add_tasks % add_batch != 0:
+        raise ValueError(
+            f"total_add_tasks ({total_add_tasks}) must be "
+            f"divisible by add_batch ({add_batch})"
+        )
 
     # Prevent integer overflow in orchestration (task_idx = b * M + m or b * N + n)
     INT32_MAX = 2**31 - 1
-    if batch * M > INT32_MAX:
-        raise ValueError(f"batch * M = {batch * M} exceeds INT32_MAX ({INT32_MAX}), risk of overflow")
-    if batch * N > INT32_MAX:
-        raise ValueError(f"batch * N = {batch * N} exceeds INT32_MAX ({INT32_MAX}), risk of overflow")
+    if total_matmul_tasks > INT32_MAX:
+        raise ValueError(f"total_matmul_tasks ({total_matmul_tasks}) exceeds INT32_MAX ({INT32_MAX}), risk of overflow")
+    if total_add_tasks > INT32_MAX:
+        raise ValueError(f"total_add_tasks ({total_add_tasks}) exceeds INT32_MAX ({INT32_MAX}), risk of overflow")
 
     # Fixed sizes: matmul 128x128x128, add 64x128
     matmul_size = 128
@@ -102,7 +127,7 @@ def generate_inputs(params: dict) -> list:
     Y_flat = Y.flatten()
     Z_flat = Z.flatten()
 
-    config = torch.tensor([batch, M, N], dtype=torch.int64)
+    config = torch.tensor([batch, M, N, matmul_batch, add_batch], dtype=torch.int64)
 
     return [
         ("A", A_flat),

--- a/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp
+++ b/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp
@@ -35,15 +35,16 @@ AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
     return (num_1 + num_2 - 1) / num_2 * num_2;
 }
 
+static __aicore__ inline int get_num_tiles(__gm__ TensorData* tensor, uint64_t tile_elems) {
+    uint64_t total_elems = tensor->shapes[0];
+    return static_cast<int>(total_elems / tile_elems);
+}
+
 template <int TILE>
 static __aicore__ void matmul_impl(
-    __gm__ TensorData* input_a_tensor,
-    __gm__ TensorData* input_b_tensor,
-    __gm__ TensorData* output_tensor) {
-
-    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
-    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
-    __gm__ float* output  = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr)  + output_tensor->start_offset;
+    __gm__ float* input_a,
+    __gm__ float* input_b,
+    __gm__ float* output) {
 
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
     constexpr int M = CeilAlign<int>(TILE, 16);
@@ -98,6 +99,9 @@ static __aicore__ void matmul_impl(
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(dstGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
@@ -105,5 +109,18 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ TensorData* input_b = reinterpret_cast<__gm__ TensorData*>(args[1]);
     __gm__ TensorData* output  = reinterpret_cast<__gm__ TensorData*>(args[2]);
 
-    matmul_impl<128>(input_a, input_b, output);
+    constexpr uint64_t TILE_ELEMS = 128 * 128;
+    int num_tiles = get_num_tiles(input_a, TILE_ELEMS);
+
+    __gm__ float* base_a = reinterpret_cast<__gm__ float*>(input_a->buffer.addr) + input_a->start_offset;
+    __gm__ float* base_b = reinterpret_cast<__gm__ float*>(input_b->buffer.addr) + input_b->start_offset;
+    __gm__ float* base_c = reinterpret_cast<__gm__ float*>(output->buffer.addr) + output->start_offset;
+
+    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        __gm__ float* a_ptr = base_a + (tile_idx * TILE_ELEMS);
+        __gm__ float* b_ptr = base_b + (tile_idx * TILE_ELEMS);
+        __gm__ float* c_ptr = base_c + (tile_idx * TILE_ELEMS);
+
+        matmul_impl<128>(a_ptr, b_ptr, c_ptr);
+    }
 }

--- a/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp
+++ b/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp
@@ -25,15 +25,16 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
+static __aicore__ inline int get_num_tiles(__gm__ TensorData* tensor, uint64_t tile_elems) {
+    uint64_t total_elems = tensor->shapes[0];
+    return static_cast<int>(total_elems / tile_elems);
+}
+
 template <int ROWS, int COLS>
 static __aicore__ void add_impl(
-    __gm__ TensorData* src0_tensor,
-    __gm__ TensorData* src1_tensor,
-    __gm__ TensorData* out_tensor) {
-
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    __gm__ float* src0,
+    __gm__ float* src1,
+    __gm__ float* out) {
 
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
@@ -59,12 +60,27 @@ static __aicore__ void add_impl(
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
 }
 
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ TensorData* src0_tensor = reinterpret_cast<__gm__ TensorData*>(args[0]);
     __gm__ TensorData* src1_tensor = reinterpret_cast<__gm__ TensorData*>(args[1]);
     __gm__ TensorData* out_tensor = reinterpret_cast<__gm__ TensorData*>(args[2]);
 
-    add_impl<64, 128>(src0_tensor, src1_tensor, out_tensor);
+    constexpr uint64_t TILE_ELEMS = 64 * 128;
+    int num_tiles = get_num_tiles(src0_tensor, TILE_ELEMS);
+
+    __gm__ float* base_src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float* base_src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float* base_out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        __gm__ float* src0_ptr = base_src0 + (tile_idx * TILE_ELEMS);
+        __gm__ float* src1_ptr = base_src1 + (tile_idx * TILE_ELEMS);
+        __gm__ float* out_ptr = base_out + (tile_idx * TILE_ELEMS);
+
+        add_impl<64, 128>(src0_ptr, src1_ptr, out_ptr);
+    }
 }

--- a/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/kernel_config.py
+++ b/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/kernel_config.py
@@ -31,5 +31,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "block_dim": 3,
+    "block_dim": 24,
 }

--- a/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/examples/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -73,8 +73,16 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
     int batch = (int)config[0];
     int M = (int)config[1];
     int N = (int)config[2];
+    int matmul_batch = (int)config[3];
+    int add_batch = (int)config[4];
 
-    LOG_INFO(rt, "[alternating_orch] Batch: %d, M: %d, N: %d", batch, M, N);
+    LOG_INFO(rt, "[alternating_orch] Batch: %d, M: %d, N: %d, matmul_batch: %d, add_batch: %d",
+             batch, M, N, matmul_batch, add_batch);
+
+    int total_matmul_tasks = batch * M;
+    int total_add_tasks = batch * N;
+    int num_matmul_groups = total_matmul_tasks / matmul_batch;
+    int num_add_groups = total_add_tasks / add_batch;
 
     uint64_t ext_A_shapes[1] = {size_A / sizeof(float)};
     Tensor ext_A = make_tensor_external(dev_A, ext_A_shapes, 1, DataType::FLOAT32);
@@ -90,57 +98,55 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
     uint64_t ext_Z_shapes[1] = {size_Z / sizeof(float)};
     Tensor ext_Z = make_tensor_external(dev_Z, ext_Z_shapes, 1, DataType::FLOAT32);
 
-    uint64_t matmul_tile_shapes[1] = {MATMUL_ELEMS};
-    uint64_t add_tile_shapes[1] = {ADD_ELEMS};
-
     int total_matmul = 0;
     int total_add = 0;
 
-    // Iterate over batches: for each batch, submit all M matmul tasks, then all N add tasks
-    for (int b = 0; b < batch; b++) {
-        // First, submit all M matmul tasks for this batch
-        for (int m = 0; m < M; m++) {
-            int task_idx = b * M + m;
-            uint64_t offset = (uint64_t)task_idx * MATMUL_ELEMS;
-            uint64_t view_offsets[1] = {offset};
+    // Submit matmul groups
+    for (int group_idx = 0; group_idx < num_matmul_groups; group_idx++) {
+        int start_task_idx = group_idx * matmul_batch;
+        uint64_t offset = (uint64_t)start_task_idx * MATMUL_ELEMS;
+        uint64_t group_size = (uint64_t)matmul_batch * MATMUL_ELEMS;
 
-            Tensor A_view = ext_A.view(matmul_tile_shapes, view_offsets);
-            Tensor B_view = ext_B.view(matmul_tile_shapes, view_offsets);
-            Tensor C_view = ext_C.view(matmul_tile_shapes, view_offsets);
+        uint64_t matmul_group_shapes[1] = {group_size};
+        uint64_t view_offsets[1] = {offset};
 
-            PTOParam params_matmul[] = {
-                make_input_param(A_view),
-                make_input_param(B_view),
-                make_output_param(C_view),
-            };
-            pto2_rt_submit_task(rt, FUNC_MATMUL, PTO2_WORKER_CUBE,
-                               params_matmul, 3);
-            total_matmul++;
-        }
+        Tensor A_view = ext_A.view(matmul_group_shapes, view_offsets);
+        Tensor B_view = ext_B.view(matmul_group_shapes, view_offsets);
+        Tensor C_view = ext_C.view(matmul_group_shapes, view_offsets);
 
-        // Then, submit all N add tasks for this batch
-        for (int n = 0; n < N; n++) {
-            int task_idx = b * N + n;
-            uint64_t offset = (uint64_t)task_idx * ADD_ELEMS;
-            uint64_t view_offsets[1] = {offset};
-
-            Tensor X_view = ext_X.view(add_tile_shapes, view_offsets);
-            Tensor Y_view = ext_Y.view(add_tile_shapes, view_offsets);
-            Tensor Z_view = ext_Z.view(add_tile_shapes, view_offsets);
-
-            PTOParam params_add[] = {
-                make_input_param(X_view),
-                make_input_param(Y_view),
-                make_output_param(Z_view),
-            };
-            pto2_rt_submit_task(rt, FUNC_ADD, PTO2_WORKER_VECTOR,
-                               params_add, 3);
-            total_add++;
-        }
+        PTOParam params_matmul[] = {
+            make_input_param(A_view),
+            make_input_param(B_view),
+            make_output_param(C_view),
+        };
+        pto2_rt_submit_task(rt, FUNC_MATMUL, PTO2_WORKER_CUBE, params_matmul, 3);
+        total_matmul++;
     }
 
-    LOG_INFO(rt, "[alternating_orch] Submitted %d matmul tasks and %d add tasks",
-                  total_matmul, total_add);
+    // Submit add groups
+    for (int group_idx = 0; group_idx < num_add_groups; group_idx++) {
+        int start_task_idx = group_idx * add_batch;
+        uint64_t offset = (uint64_t)start_task_idx * ADD_ELEMS;
+        uint64_t group_size = (uint64_t)add_batch * ADD_ELEMS;
+
+        uint64_t add_group_shapes[1] = {group_size};
+        uint64_t view_offsets[1] = {offset};
+
+        Tensor X_view = ext_X.view(add_group_shapes, view_offsets);
+        Tensor Y_view = ext_Y.view(add_group_shapes, view_offsets);
+        Tensor Z_view = ext_Z.view(add_group_shapes, view_offsets);
+
+        PTOParam params_add[] = {
+            make_input_param(X_view),
+            make_input_param(Y_view),
+            make_output_param(Z_view),
+        };
+        pto2_rt_submit_task(rt, FUNC_ADD, PTO2_WORKER_VECTOR, params_add, 3);
+        total_add++;
+    }
+
+    LOG_INFO(rt, "[alternating_orch] Submitted %d matmul groups and %d add groups",
+             total_matmul, total_add);
 }
 
 }  // extern "C"


### PR DESCRIPTION

Enable batching multiple tiles per kernel task to tune execution time. Extend config to 5 elements, add kernel loops, and synchronization barriers to prevent data races in multi-tile processing.

New features:
- Configurable task granularity: control tiles per task via matmul_batch/add_batch
- Reduced scheduling overhead: fewer tasks with larger workloads
- Parameter validation: divisibility checks and overflow protection
- Synchronization barriers: prevent data races in multi-tile loops
- Backward compatibility: default batch=1 preserves original behavior
- Flexible configurations: support symmetric and asymmetric batching