### PR TITLE
Support: add two-level scheduler profiling with complete/dispatch sub-phase breakdown

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -489,6 +489,11 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
     uint64_t pop_miss = 0;
     uint32_t phase_complete_count = 0;
     uint32_t phase_dispatch_count = 0;
+#if PTO2_SCHED_PROFILING
+    uint64_t sched_complete_perf_cycle = 0;
+    uint64_t sched_dispatch_pop_cycle = 0;
+    uint64_t sched_dispatch_setup_cycle = 0;
+#endif
 #endif
 
     while (true) {
@@ -549,7 +554,16 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
 #endif
             if (completed_match) {
                 int32_t task_id = executing_task_ids_[core_id];
-#if PTO2_PROFILING
+#if PTO2_SCHED_PROFILING
+                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
+                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, thread_idx);
+                notify_edges_total += cstats.fanout_edges;
+                if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
+                notify_tasks_enqueued += cstats.tasks_enqueued;
+                fanin_edges_total += cstats.fanin_edges;
+                if (cstats.fanin_edges > fanin_max_degree) fanin_max_degree = cstats.fanin_edges;
+                phase_complete_count++;
+#elif PTO2_PROFILING
                 PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
                 PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id);
                 notify_edges_total += cstats.fanout_edges;
@@ -566,6 +580,9 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
 #if PTO2_PROFILING
                 // Write AICPU dispatch/finish timestamps into the PerfRecord
                 if (profiling_enabled) {
+#if PTO2_SCHED_PROFILING
+                    uint64_t t_perf_start = get_sys_cnt_aicpu();
+#endif
                     Handshake* h = &hank[core_id];
                     uint64_t finish_ts = get_sys_cnt_aicpu();
                     PerfBuffer* perf_buf = (PerfBuffer*)h->perf_records_addr;
@@ -579,6 +596,9 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                                                                         finish_ts);
                         }
                     }
+#if PTO2_SCHED_PROFILING
+                    sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
+#endif
                 }
 #endif
 
@@ -618,11 +638,23 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                 if (reg_state == TASK_FIN_STATE && executing_task_ids_[core_id] == AICPU_TASK_INVALID) {
                     Handshake* h = &hank[core_id];
                     PTO2WorkerType wt = (h->core_type == CoreType::AIC) ? PTO2_WORKER_CUBE : PTO2_WORKER_VECTOR;
+#if PTO2_SCHED_PROFILING
+                    extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
+                    uint64_t t_pop_start = get_sys_cnt_aicpu();
+                    int32_t task_id = rt->scheduler.get_ready_task(wt,
+                                         g_sched_pop_atomic_count[thread_idx],
+                                         g_sched_pop_wait_cycle[thread_idx]);
+                    sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
+#else
                     int32_t task_id = rt->scheduler.get_ready_task(wt);
+#endif
                     if (task_id >= 0) {
 #if PTO2_PROFILING
                         pop_hit++;
                         phase_dispatch_count++;
+#endif
+#if PTO2_SCHED_PROFILING
+                        uint64_t t_setup_start = get_sys_cnt_aicpu();
 #endif
                         PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
                         PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
@@ -642,6 +674,9 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
                         executing_task_ids_[core_id] = task_id;
                         cur_thread_tasks_in_flight++;
                         made_progress = true;
+#if PTO2_SCHED_PROFILING
+                        sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
+#endif
                         DEV_DEBUG("Thread %d: Dispatching PTO2 task %d to core %d", thread_idx, task_id, core_id);
                     } else {
 #if PTO2_PROFILING
@@ -766,56 +801,85 @@ int AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx,
     if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
 
 #if PTO2_SCHED_PROFILING
-    double tasks_per_loop = sched_loop_count > 0 ? (double)cur_thread_completed / sched_loop_count : 0.0;
+    // Two-level tree display: sub-phase breakdown within complete and dispatch
+    {
+        PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
+        uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
+        uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle)
+            ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle) : 0;
+        uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle)
+            ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) : 0;
 
-    // Detailed output with full phase breakdown
-    DEV_ALWAYS("Thread %d: completed=%d tasks in %.3fus (%llu loops, %.1f tasks/loop)",
-        thread_idx,
-        cur_thread_completed,
-        cycles_to_us(sched_total),
-        (unsigned long long)sched_loop_count,
-        tasks_per_loop);
-    DEV_ALWAYS("Thread %d: --- Phase Breakdown ---", thread_idx);
-    double notify_avg = cur_thread_completed > 0
-        ? (double)notify_edges_total / cur_thread_completed : 0.0;
-    double fanin_avg = cur_thread_completed > 0
-        ? (double)fanin_edges_total / cur_thread_completed : 0.0;
-    DEV_ALWAYS("Thread %d:   complete:    %.3fus (%.1f%%)  [fanout: edges=%llu, max_degree=%d, avg=%.1f]  [fanin: edges=%llu, max_degree=%d, avg=%.1f]",
-        thread_idx,
-        cycles_to_us(sched_complete_cycle),
-        sched_complete_cycle * 100.0 / sched_total,
-        (unsigned long long)notify_edges_total,
-        notify_max_degree,
-        notify_avg,
-        (unsigned long long)fanin_edges_total,
-        fanin_max_degree,
-        fanin_avg);
-    uint64_t complete_miss_count = (complete_probe_count > complete_hit_count)
-        ? (complete_probe_count - complete_hit_count) : 0;
-    double complete_hit_rate = complete_probe_count > 0
-        ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
-    DEV_ALWAYS("Thread %d:     complete_poll: hit=%llu, miss=%llu, hit_rate=%.1f%%",
-        thread_idx,
-        (unsigned long long)complete_hit_count,
-        (unsigned long long)complete_miss_count,
-        complete_hit_rate);
-    DEV_ALWAYS("Thread %d:   scan:        %.3fus (%.1f%%)",
-        thread_idx,
-        cycles_to_us(sched_scan_cycle),
-        sched_scan_cycle * 100.0 / sched_total);
-    uint64_t pop_total = pop_hit + pop_miss;
-    double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
-    DEV_ALWAYS("Thread %d:   dispatch:    %.3fus (%.1f%%)  [pop: hit=%llu, miss=%llu, hit_rate=%.1f%%]",
-        thread_idx,
-        cycles_to_us(sched_dispatch_cycle),
-        sched_dispatch_cycle * 100.0 / sched_total,
-        (unsigned long long)pop_hit,
-        (unsigned long long)pop_miss,
-        pop_hit_rate);
-    DEV_ALWAYS("Thread %d:   idle:        %.3fus (%.1f%%)",
-        thread_idx,
-        cycles_to_us(sched_idle_cycle),
-        sched_idle_cycle * 100.0 / sched_total);
+        DEV_ALWAYS("Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===",
+            thread_idx, cycles_to_us(sched_total), cur_thread_completed);
+
+        // Level 1: complete
+        DEV_ALWAYS("Thread %d:   complete       : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(sched_complete_cycle),
+            sched_complete_cycle * 100.0 / sched_total);
+
+        // Level 2: complete sub-phases (percentage relative to complete)
+        uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
+        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(complete_poll),
+            complete_poll * 100.0 / c_parent);
+        DEV_ALWAYS("Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
+            thread_idx, cycles_to_us(sp.lock_cycle),
+            sp.lock_cycle * 100.0 / c_parent,
+            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
+            (unsigned long long)sp.lock_atomic_count);
+        DEV_ALWAYS("Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
+            thread_idx, cycles_to_us(sp.fanout_cycle),
+            sp.fanout_cycle * 100.0 / c_parent,
+            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
+            (unsigned long long)sp.fanout_atomic_count);
+        DEV_ALWAYS("Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%llu",
+            thread_idx, cycles_to_us(sp.fanin_cycle),
+            sp.fanin_cycle * 100.0 / c_parent,
+            (unsigned long long)sp.fanin_atomic_count);
+        DEV_ALWAYS("Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%llu",
+            thread_idx, cycles_to_us(sp.self_consumed_cycle),
+            sp.self_consumed_cycle * 100.0 / c_parent,
+            (unsigned long long)sp.self_atomic_count);
+        DEV_ALWAYS("Thread %d:     perf         : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(sched_complete_perf_cycle),
+            sched_complete_perf_cycle * 100.0 / c_parent);
+
+        // Level 1: dispatch
+        DEV_ALWAYS("Thread %d:   dispatch       : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(sched_dispatch_cycle),
+            sched_dispatch_cycle * 100.0 / sched_total);
+
+        // Level 2: dispatch sub-phases (percentage relative to dispatch)
+        uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
+        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(dispatch_poll),
+            dispatch_poll * 100.0 / d_parent);
+        DEV_ALWAYS("Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
+            thread_idx, cycles_to_us(sched_dispatch_pop_cycle),
+            sched_dispatch_pop_cycle * 100.0 / d_parent,
+            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+            (unsigned long long)sp.pop_atomic_count);
+        DEV_ALWAYS("Thread %d:     setup        : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
+            sched_dispatch_setup_cycle * 100.0 / d_parent);
+
+        // Level 1: scan
+        DEV_ALWAYS("Thread %d:   scan           : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(sched_scan_cycle),
+            sched_scan_cycle * 100.0 / sched_total);
+
+        // Level 1: idle
+        DEV_ALWAYS("Thread %d:   idle           : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(sched_idle_cycle),
+            sched_idle_cycle * 100.0 / sched_total);
+
+        // Average per completion
+        if (cur_thread_completed > 0) {
+            DEV_ALWAYS("Thread %d:   avg/complete   : %.3fus",
+                thread_idx, cycles_to_us(sched_complete_cycle) / cur_thread_completed);
+        }
+    }
 #endif
     // Summary line (always print when PTO2_PROFILING=1)
     DEV_ALWAYS("Thread %d: Scheduler summary: total_time=%.3fus, loops=%llu, tasks_scheduled=%d",

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -56,6 +56,14 @@ uint64_t g_orch_heap_atomic_count = 0;
 uint64_t g_orch_fanin_atomic_count = 0;
 uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
+#elif PTO2_SCHED_PROFILING
+// When only PTO2_SCHED_PROFILING is enabled, shared methods still need
+// orch counters as targets for orchestrator-context calls.
+uint64_t g_orch_fanin_atomic_count = 0;
+uint64_t g_orch_fanin_wait_cycle = 0;
+uint64_t g_orch_finalize_atomic_count = 0;
+uint64_t g_orch_finalize_wait_cycle = 0;
+uint64_t g_orch_scope_end_atomic_count = 0;
 #endif
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
 #define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
@@ -391,7 +399,11 @@ void pto2_submit_task(
             PTO2TaskDescriptor* producer = pto2_task_ring_get(&orch->task_ring, producer_task_id);
             producer->fanout_count.fetch_add(1, std::memory_order_release);
             int32_t prod_slot = sched->pto2_task_slot(producer_task_id);
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+            pto2_fanout_lock(producer, g_orch_fanin_atomic_count, g_orch_fanin_wait_cycle);
+#else
             pto2_fanout_lock(producer);
+#endif
             // Normal path: prepend consumer to producer's fanout list
             int32_t prod_state = sched->task_state[prod_slot].load(std::memory_order_acquire);
             if (prod_state >= PTO2_TASK_COMPLETED) {
@@ -406,7 +418,7 @@ void pto2_submit_task(
         if (early_finished > 0) {
             sched->fanin_refcount[slot].fetch_add(early_finished, std::memory_order_acq_rel);
         }
-#if PTO2_ORCH_PROFILING
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
         // Per producer: fetch_add(fanout_count) + load(task_state) + store(unlock) = 3 atomics
         // Lock atomics (loads + CAS) are counted inside pto2_fanout_lock
         g_orch_fanin_atomic_count += fanin_count * 3;
@@ -429,7 +441,7 @@ void pto2_submit_task(
     orch->sm_handle->header->current_task_index.store(orch->task_ring.current_index, std::memory_order_release);
 
     CYCLE_COUNT_LAP_RECORD(g_orch_finalize_cycle, AicpuPhaseId::ORCH_FINALIZE, task_id);
-#if PTO2_ORCH_PROFILING
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
     // task_state.store + fanout_refcount.store + fanin_refcount.fetch_add
     // + current_task_index.store = 4
     // Conditional CAS(task_state PENDING→READY) and push() atomics counted inside push()

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -26,7 +26,7 @@
 // =============================================================================
 
 #ifndef PTO2_PROFILING
-#define PTO2_PROFILING 0
+#define PTO2_PROFILING 1
 #endif
 
 #ifndef PTO2_ORCH_PROFILING
@@ -371,43 +371,49 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 // scheduler traversing the list after task completion.
 // =============================================================================
 
-#if PTO2_ORCH_PROFILING
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
 #include "aicpu/device_time.h"
 #endif
 
-static inline void pto2_fanout_lock(PTO2TaskDescriptor* task) {
-#if PTO2_ORCH_PROFILING
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+static inline void pto2_fanout_lock(PTO2TaskDescriptor* task,
+                                     uint64_t& atomic_count, uint64_t& wait_cycle) {
     uint64_t t0 = get_sys_cnt_aicpu();
     bool contended = false;
     uint32_t atomic_ops = 0;
-#endif
 
     for (;;) {
         while (task->fanout_lock.load(std::memory_order_acquire) != 0) {
-#if PTO2_ORCH_PROFILING
             contended = true;
             atomic_ops++;  // each load = 1 atomic
-#endif
             PTO2_SPIN_PAUSE_LIGHT();
         }
         int32_t expected = 0;
         if (task->fanout_lock.compare_exchange_weak(expected, 1,
                                         std::memory_order_acquire, std::memory_order_relaxed)) {
-#if PTO2_ORCH_PROFILING
             atomic_ops++;  // successful CAS = 1 atomic
-            extern uint64_t g_orch_fanin_atomic_count;
-            g_orch_fanin_atomic_count += atomic_ops;
+            atomic_count += atomic_ops;
             if (contended) {
-                extern uint64_t g_orch_fanin_wait_cycle;
-                g_orch_fanin_wait_cycle += (get_sys_cnt_aicpu() - t0);
+                wait_cycle += (get_sys_cnt_aicpu() - t0);
             }
-#endif
             return;
         }
-#if PTO2_ORCH_PROFILING
         contended = true;
         atomic_ops++;  // failed CAS = 1 atomic
+    }
+}
 #endif
+
+static inline void pto2_fanout_lock(PTO2TaskDescriptor* task) {
+    for (;;) {
+        while (task->fanout_lock.load(std::memory_order_acquire) != 0) {
+            PTO2_SPIN_PAUSE_LIGHT();
+        }
+        int32_t expected = 0;
+        if (task->fanout_lock.compare_exchange_weak(expected, 1,
+                                        std::memory_order_acquire, std::memory_order_relaxed)) {
+            return;
+        }
     }
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -10,7 +10,48 @@
 #include <inttypes.h>
 #include <new>
 #include <stdlib.h>
+#include <utility>
 #include "common/unified_log.h"
+
+// =============================================================================
+// Scheduler Profiling Counters
+// =============================================================================
+
+#if PTO2_SCHED_PROFILING
+#include "common/platform_config.h"
+
+uint64_t g_sched_lock_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_fanout_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_fanin_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_self_consumed_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_lock_wait_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_push_wait_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_pop_wait_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_lock_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_fanout_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_fanin_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_self_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_pop_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_complete_count[PLATFORM_MAX_AICPU_THREADS] = {};
+
+PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
+    PTO2SchedProfilingData d;
+    d.lock_cycle = std::exchange(g_sched_lock_cycle[thread_idx], 0);
+    d.fanout_cycle = std::exchange(g_sched_fanout_cycle[thread_idx], 0);
+    d.fanin_cycle = std::exchange(g_sched_fanin_cycle[thread_idx], 0);
+    d.self_consumed_cycle = std::exchange(g_sched_self_consumed_cycle[thread_idx], 0);
+    d.lock_wait_cycle = std::exchange(g_sched_lock_wait_cycle[thread_idx], 0);
+    d.push_wait_cycle = std::exchange(g_sched_push_wait_cycle[thread_idx], 0);
+    d.pop_wait_cycle = std::exchange(g_sched_pop_wait_cycle[thread_idx], 0);
+    d.lock_atomic_count = std::exchange(g_sched_lock_atomic_count[thread_idx], 0);
+    d.fanout_atomic_count = std::exchange(g_sched_fanout_atomic_count[thread_idx], 0);
+    d.fanin_atomic_count = std::exchange(g_sched_fanin_atomic_count[thread_idx], 0);
+    d.self_atomic_count = std::exchange(g_sched_self_atomic_count[thread_idx], 0);
+    d.pop_atomic_count = std::exchange(g_sched_pop_atomic_count[thread_idx], 0);
+    d.complete_count = std::exchange(g_sched_complete_count[thread_idx], 0);
+    return d;
+}
+#endif
 
 // =============================================================================
 // Task State Names

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -24,6 +24,12 @@
 #include "pto_shared_memory.h"
 #include "pto_ring_buffer.h"
 
+#if PTO2_SCHED_PROFILING
+#include "aicpu/device_time.h"
+#define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
+#define PTO2_SCHED_CYCLE_LAP(acc) do { _st1 = get_sys_cnt_aicpu(); acc += (_st1 - _st0); _st0 = _st1; } while(0)
+#endif
+
 // =============================================================================
 // Ready Queue (Lock-free bounded MPMC — Vyukov design)
 // =============================================================================
@@ -68,56 +74,64 @@ struct alignas(64) PTO2ReadyQueue {
     bool push(int32_t task_id) {
         uint64_t pos;
         PTO2ReadyQueueSlot* slot;
-#if PTO2_ORCH_PROFILING
-        uint64_t t0 = get_sys_cnt_aicpu();
-        bool contended = false;
-        uint32_t atomic_ops = 0;
-#endif
         while (true) {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)pos;
-#if PTO2_ORCH_PROFILING
-            atomic_ops += 2;  // enqueue_pos.load + sequence.load
-#endif
             if (diff == 0) {
                 if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
                         std::memory_order_relaxed, std::memory_order_relaxed)) {
-#if PTO2_ORCH_PROFILING
-                    atomic_ops++;  // successful CAS
-#endif
                     break;
                 }
-#if PTO2_ORCH_PROFILING
-                contended = true;
-                atomic_ops++;  // failed CAS
-#endif
             } else if (diff < 0) {
                 return false;  // Queue full
             }
-#if PTO2_ORCH_PROFILING
-            else {
-                contended = true;  // diff > 0: slot not yet released, spin
-            }
-#endif
         }
-#if PTO2_ORCH_PROFILING
-        atomic_ops++;  // final sequence.store
-        {
-            extern uint64_t g_orch_finalize_atomic_count;
-            g_orch_finalize_atomic_count += atomic_ops;
-        }
-        if (contended) {
-            extern uint64_t g_orch_finalize_wait_cycle;
-            g_orch_finalize_wait_cycle += (get_sys_cnt_aicpu() - t0);
-        }
-#endif
 
         slot->task_id = task_id;
         slot->sequence.store((int64_t)(pos + 1), std::memory_order_release);
         return true;
     }
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    bool push(int32_t task_id, uint64_t& atomic_count, uint64_t& wait_cycle) {
+        uint64_t pos;
+        PTO2ReadyQueueSlot* slot;
+        uint64_t t0 = get_sys_cnt_aicpu();
+        bool contended = false;
+        uint32_t atomic_ops = 0;
+        while (true) {
+            pos = enqueue_pos.load(std::memory_order_relaxed);
+            slot = &slots[pos & mask];
+            int64_t seq = slot->sequence.load(std::memory_order_acquire);
+            int64_t diff = seq - (int64_t)pos;
+            atomic_ops += 2;  // enqueue_pos.load + sequence.load
+            if (diff == 0) {
+                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
+                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                    atomic_ops++;  // successful CAS
+                    break;
+                }
+                contended = true;
+                atomic_ops++;  // failed CAS
+            } else if (diff < 0) {
+                return false;  // Queue full
+            } else {
+                contended = true;  // diff > 0: slot not yet released, spin
+            }
+        }
+        atomic_ops++;  // final sequence.store
+        atomic_count += atomic_ops;
+        if (contended) {
+            wait_cycle += (get_sys_cnt_aicpu() - t0);
+        }
+
+        slot->task_id = task_id;
+        slot->sequence.store((int64_t)(pos + 1), std::memory_order_release);
+        return true;
+    }
+#endif
 
     int32_t pop() {
         // Fast-path: skip slot load when queue is clearly empty
@@ -147,6 +161,54 @@ struct alignas(64) PTO2ReadyQueue {
         slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
         return task_id;
     }
+
+#if PTO2_SCHED_PROFILING
+    int32_t pop(uint64_t& atomic_count, uint64_t& wait_cycle) {
+        // Fast-path: skip slot load when queue is clearly empty
+        uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
+        uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
+        atomic_count += 2;  // dequeue_pos.load + enqueue_pos.load
+        if (d >= e) {
+            return -1;
+        }
+
+        uint64_t pos;
+        PTO2ReadyQueueSlot* slot;
+        uint64_t t0 = get_sys_cnt_aicpu();
+        bool contended = false;
+        uint32_t atomic_ops = 0;
+        while (true) {
+            pos = dequeue_pos.load(std::memory_order_relaxed);
+            slot = &slots[pos & mask];
+            int64_t seq = slot->sequence.load(std::memory_order_acquire);
+            int64_t diff = seq - (int64_t)(pos + 1);
+            atomic_ops += 2;  // dequeue_pos.load + sequence.load
+            if (diff == 0) {
+                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
+                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                    atomic_ops++;  // successful CAS
+                    break;
+                }
+                contended = true;
+                atomic_ops++;  // failed CAS
+            } else if (diff < 0) {
+                atomic_count += atomic_ops;
+                return -1;  // Queue empty
+            } else {
+                contended = true;
+            }
+        }
+        atomic_ops++;  // final sequence.store
+        atomic_count += atomic_ops;
+        if (contended) {
+            wait_cycle += (get_sys_cnt_aicpu() - t0);
+        }
+
+        int32_t task_id = slot->task_id;
+        slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
+        return task_id;
+    }
+#endif
 };
 
 // Cold-path ready queue operations (defined in pto_scheduler.cpp)
@@ -254,33 +316,13 @@ struct PTO2SchedulerState {
         int32_t fc = task->fanout_count.load(std::memory_order_acquire);
         int32_t rc = fanout_refcount[slot].load(std::memory_order_acquire);
 
-#if PTO2_ORCH_PROFILING
-        {
-            extern uint64_t g_orch_scope_end_atomic_count;
-            g_orch_scope_end_atomic_count += 2;  // fanout_count.load + fanout_refcount.load
-        }
-#endif
-
         if (rc != fc) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
         if (!task_state[slot].compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
                                           std::memory_order_acq_rel, std::memory_order_acquire)) {
-#if PTO2_ORCH_PROFILING
-            {
-                extern uint64_t g_orch_scope_end_atomic_count;
-                g_orch_scope_end_atomic_count += 1;  // failed CAS
-            }
-#endif
             return;
         }
-
-#if PTO2_ORCH_PROFILING
-        {
-            extern uint64_t g_orch_scope_end_atomic_count;
-            g_orch_scope_end_atomic_count += 1;  // successful CAS
-        }
-#endif
 
 #if PTO2_PROFILING
         tasks_consumed.fetch_add(1, std::memory_order_relaxed);
@@ -288,12 +330,43 @@ struct PTO2SchedulerState {
         fanout_refcount[slot].store(0, std::memory_order_release);
         fanin_refcount[slot].store(0, std::memory_order_release);
 
-#if PTO2_ORCH_PROFILING
-        {
-            extern uint64_t g_orch_scope_end_atomic_count;
-            g_orch_scope_end_atomic_count += 2;  // fanout_refcount.store + fanin_refcount.store
+        // Try-lock — if another thread is advancing, it will scan our CONSUMED task
+        int32_t expected_lock = 0;
+        if (ring_advance_lock.compare_exchange_strong(expected_lock, 1,
+                std::memory_order_acquire, std::memory_order_relaxed)) {
+            advance_ring_pointers();
+            ring_advance_lock.store(0, std::memory_order_release);
         }
+    }
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    void check_and_handle_consumed(int32_t task_id, PTO2TaskDescriptor* task,
+                                    uint64_t& atomic_count) {
+        int32_t slot = pto2_task_slot(task_id);
+
+        int32_t fc = task->fanout_count.load(std::memory_order_acquire);
+        int32_t rc = fanout_refcount[slot].load(std::memory_order_acquire);
+
+        atomic_count += 2;  // fanout_count.load + fanout_refcount.load
+
+        if (rc != fc) return;
+
+        PTO2TaskState expected = PTO2_TASK_COMPLETED;
+        if (!task_state[slot].compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
+                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+            atomic_count += 1;  // failed CAS
+            return;
+        }
+
+        atomic_count += 1;  // successful CAS
+
+#if PTO2_PROFILING
+        tasks_consumed.fetch_add(1, std::memory_order_relaxed);
 #endif
+        fanout_refcount[slot].store(0, std::memory_order_release);
+        fanin_refcount[slot].store(0, std::memory_order_release);
+
+        atomic_count += 2;  // fanout_refcount.store + fanin_refcount.store
 
         // Try-lock — if another thread is advancing, it will scan our CONSUMED task
         int32_t expected_lock = 0;
@@ -301,33 +374,29 @@ struct PTO2SchedulerState {
                 std::memory_order_acquire, std::memory_order_relaxed)) {
             advance_ring_pointers();
             ring_advance_lock.store(0, std::memory_order_release);
-#if PTO2_ORCH_PROFILING
-            {
-                extern uint64_t g_orch_scope_end_atomic_count;
-                g_orch_scope_end_atomic_count += 2;  // try-lock CAS + unlock store
-            }
-#endif
+            atomic_count += 2;  // try-lock CAS + unlock store
+        } else {
+            atomic_count += 1;  // failed try-lock CAS
         }
-#if PTO2_ORCH_PROFILING
-        else {
-            extern uint64_t g_orch_scope_end_atomic_count;
-            g_orch_scope_end_atomic_count += 1;  // failed try-lock CAS
-        }
-#endif
     }
+#endif
 
     void release_producer(int32_t producer_id) {
         int32_t slot = pto2_task_slot(producer_id);
         PTO2TaskDescriptor* producer = pto2_sm_get_task(sm_handle, producer_id);
         fanout_refcount[slot].fetch_add(1, std::memory_order_acq_rel);
-#if PTO2_ORCH_PROFILING
-        {
-            extern uint64_t g_orch_scope_end_atomic_count;
-            g_orch_scope_end_atomic_count += 1;  // fanout_refcount.fetch_add
-        }
-#endif
         check_and_handle_consumed(producer_id, producer);
     }
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    void release_producer(int32_t producer_id, uint64_t& atomic_count) {
+        int32_t slot = pto2_task_slot(producer_id);
+        PTO2TaskDescriptor* producer = pto2_sm_get_task(sm_handle, producer_id);
+        fanout_refcount[slot].fetch_add(1, std::memory_order_acq_rel);
+        atomic_count += 1;  // fanout_refcount.fetch_add
+        check_and_handle_consumed(producer_id, producer, atomic_count);
+    }
+#endif
 
     bool release_fanin_and_check_ready(int32_t task_id,
                                         PTO2TaskDescriptor* task) {
@@ -342,18 +411,33 @@ struct PTO2SchedulerState {
             PTO2TaskState expected = PTO2_TASK_PENDING;
             if (task_state[slot].compare_exchange_strong(
                     expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
-#if PTO2_ORCH_PROFILING
-                {
-                    extern uint64_t g_orch_finalize_atomic_count;
-                    g_orch_finalize_atomic_count += 1;  // CAS(task_state PENDING→READY)
-                }
-#endif
                 ready_queues[task->worker_type].push(task_id);
                 return true;
             }
         }
         return false;
     }
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    bool release_fanin_and_check_ready(int32_t task_id, PTO2TaskDescriptor* task,
+                                        uint64_t& atomic_count, uint64_t& push_wait) {
+        int32_t slot = pto2_task_slot(task_id);
+
+        int32_t new_refcount = fanin_refcount[slot].fetch_add(1, std::memory_order_acq_rel) + 1;
+        atomic_count += 1;  // fanin_refcount.fetch_add
+
+        if (new_refcount == task->fanin_count) {
+            PTO2TaskState expected = PTO2_TASK_PENDING;
+            if (task_state[slot].compare_exchange_strong(
+                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
+                atomic_count += 1;  // CAS(task_state PENDING→READY)
+                ready_queues[task->worker_type].push(task_id, atomic_count, push_wait);
+                return true;
+            }
+        }
+        return false;
+    }
+#endif
 
     void init_task(int32_t task_id, PTO2TaskDescriptor* task) {
         int32_t slot = pto2_task_slot(task_id);
@@ -365,7 +449,14 @@ struct PTO2SchedulerState {
         // concurrent on_task_complete between Step 5 and Step 6.
         fanout_refcount[slot].store(0, std::memory_order_relaxed);
 
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+        extern uint64_t g_orch_finalize_atomic_count;
+        extern uint64_t g_orch_finalize_wait_cycle;
+        release_fanin_and_check_ready(task_id, task,
+                                       g_orch_finalize_atomic_count, g_orch_finalize_wait_cycle);
+#else
         release_fanin_and_check_ready(task_id, task);
+#endif
     }
 
     void mark_running(int32_t task_id) {
@@ -377,6 +468,13 @@ struct PTO2SchedulerState {
         return ready_queues[worker_type].pop();
     }
 
+#if PTO2_SCHED_PROFILING
+    int32_t get_ready_task(PTO2WorkerType worker_type,
+                           uint64_t& atomic_count, uint64_t& wait_cycle) {
+        return ready_queues[worker_type].pop(atomic_count, wait_cycle);
+    }
+#endif
+
     bool is_done() {
         PTO2SharedMemoryHeader* header = sm_handle->header;
         int32_t orch_done = header->orchestrator_done.load(std::memory_order_acquire);
@@ -386,12 +484,23 @@ struct PTO2SchedulerState {
     }
 
     void on_scope_end(const int32_t* task_ids, int32_t count) {
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+        extern uint64_t g_orch_scope_end_atomic_count;
+        for (int32_t i = 0; i < count; i++) {
+            release_producer(task_ids[i], g_orch_scope_end_atomic_count);
+        }
+#else
         for (int32_t i = 0; i < count; i++) {
             release_producer(task_ids[i]);
         }
+#endif
     }
 
+#if PTO2_SCHED_PROFILING
+    PTO2CompletionStats on_task_complete(int32_t task_id, int thread_idx) {
+#else
     PTO2CompletionStats on_task_complete(int32_t task_id) {
+#endif
         PTO2CompletionStats stats = {0, 0, 0};
         int32_t slot = pto2_task_slot(task_id);
         PTO2TaskDescriptor* task = pto2_sm_get_task(sm_handle, task_id);
@@ -399,16 +508,52 @@ struct PTO2SchedulerState {
 #if PTO2_PROFILING
         tasks_completed.fetch_add(1, std::memory_order_relaxed);
 #endif
+
+#if PTO2_SCHED_PROFILING
+        extern uint64_t g_sched_lock_cycle[], g_sched_fanout_cycle[];
+        extern uint64_t g_sched_fanin_cycle[], g_sched_self_consumed_cycle[];
+        extern uint64_t g_sched_lock_atomic_count[], g_sched_lock_wait_cycle[];
+        extern uint64_t g_sched_fanout_atomic_count[], g_sched_push_wait_cycle[];
+        extern uint64_t g_sched_fanin_atomic_count[], g_sched_self_atomic_count[];
+        extern uint64_t g_sched_complete_count[];
+        uint64_t lock_atomics = 0, lock_wait = 0;
+        PTO2_SCHED_CYCLE_START();
+#endif
+
+#if PTO2_SCHED_PROFILING
+        pto2_fanout_lock(task, lock_atomics, lock_wait);
+#else
         pto2_fanout_lock(task);
+#endif
         task_state[slot].store(PTO2_TASK_COMPLETED, std::memory_order_release);
         PTO2DepListEntry* current = task->fanout_head;  // Protected by fanout_lock
         pto2_fanout_unlock(task);
 
+#if PTO2_SCHED_PROFILING
+        lock_atomics += 2;  // state.store + unlock.store
+        g_sched_lock_atomic_count[thread_idx] += lock_atomics;
+        g_sched_lock_wait_cycle[thread_idx] += lock_wait;
+        PTO2_SCHED_CYCLE_LAP(g_sched_lock_cycle[thread_idx]);
+#endif
+
+        // Fanout: notify consumers
+#if PTO2_SCHED_PROFILING
+        uint64_t fanout_atomics = 0, push_wait = 0;
+#endif
         while (current != nullptr) {
             int32_t consumer_id = current->task_id;
             PTO2TaskDescriptor* consumer = pto2_sm_get_task(sm_handle, consumer_id);
 #if PTO2_PROFILING
             stats.fanout_edges++;
+#endif
+#if PTO2_SCHED_PROFILING
+            if (release_fanin_and_check_ready(consumer_id, consumer,
+                                               fanout_atomics, push_wait)) {
+#if PTO2_PROFILING
+                stats.tasks_enqueued++;
+#endif
+            }
+#elif PTO2_PROFILING
             if (release_fanin_and_check_ready(consumer_id, consumer)) {
                 stats.tasks_enqueued++;
             }
@@ -418,17 +563,46 @@ struct PTO2SchedulerState {
             current = current->next;
         }
 
+#if PTO2_SCHED_PROFILING
+        g_sched_fanout_atomic_count[thread_idx] += fanout_atomics;
+        g_sched_push_wait_cycle[thread_idx] += push_wait;
+        PTO2_SCHED_CYCLE_LAP(g_sched_fanout_cycle[thread_idx]);
+#endif
+
+        // Fanin: release producers
+#if PTO2_SCHED_PROFILING
+        uint64_t fanin_atomics = 0;
+#endif
         current = task->fanin_head;
         while (current != nullptr) {
             int32_t producer_id = current->task_id;
+#if PTO2_SCHED_PROFILING
+            release_producer(producer_id, fanin_atomics);
+#else
             release_producer(producer_id);
+#endif
 #if PTO2_PROFILING
             stats.fanin_edges++;
 #endif
             current = current->next;
         }
 
+#if PTO2_SCHED_PROFILING
+        g_sched_fanin_atomic_count[thread_idx] += fanin_atomics;
+        PTO2_SCHED_CYCLE_LAP(g_sched_fanin_cycle[thread_idx]);
+#endif
+
+        // Self consumed check
+#if PTO2_SCHED_PROFILING
+        uint64_t self_atomics = 0;
+        check_and_handle_consumed(task_id, task, self_atomics);
+        g_sched_self_atomic_count[thread_idx] += self_atomics;
+        PTO2_SCHED_CYCLE_LAP(g_sched_self_consumed_cycle[thread_idx]);
+        g_sched_complete_count[thread_idx]++;
+#else
         check_and_handle_consumed(task_id, task);
+#endif
+
         return stats;
     }
 };
@@ -451,5 +625,39 @@ void pto2_scheduler_reset(PTO2SchedulerState* sched);
 void pto2_scheduler_print_stats(PTO2SchedulerState* sched);
 void pto2_scheduler_print_queues(PTO2SchedulerState* sched);
 const char* pto2_task_state_name(PTO2TaskState state);
+
+// =============================================================================
+// Scheduler Profiling Data
+// =============================================================================
+
+#if PTO2_SCHED_PROFILING
+struct PTO2SchedProfilingData {
+    // Sub-phase cycle breakdown within on_task_complete
+    uint64_t lock_cycle;           // pto2_fanout_lock + state store + unlock
+    uint64_t fanout_cycle;         // fanout traversal
+    uint64_t fanin_cycle;          // fanin traversal
+    uint64_t self_consumed_cycle;  // self check_and_handle_consumed
+
+    // Wait times
+    uint64_t lock_wait_cycle;      // spin-wait in fanout_lock
+    uint64_t push_wait_cycle;      // CAS contention in push()
+    uint64_t pop_wait_cycle;       // CAS contention in pop()
+
+    // Atomic counts per sub-phase
+    uint64_t lock_atomic_count;
+    uint64_t fanout_atomic_count;
+    uint64_t fanin_atomic_count;
+    uint64_t self_atomic_count;
+    uint64_t pop_atomic_count;
+
+    int64_t  complete_count;
+};
+
+/**
+ * Get and reset scheduler profiling data for a specific thread.
+ * Returns accumulated profiling data and resets counters.
+ */
+PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
+#endif
 
 #endif // PTO_SCHEDULER_H

--- a/tools/sched_overhead_analysis.py
+++ b/tools/sched_overhead_analysis.py
@@ -35,8 +35,15 @@ def auto_select_perf_json():
 def parse_scheduler_threads(log_path):
     """Parse device log for PTO2 scheduler stats per thread.
 
-    Supports two formats:
-    1. Detailed (PTO2_SCHED_PROFILING=1):
+    Supports three formats:
+    1. New two-level tree (PTO2_SCHED_PROFILING=1):
+        Thread N: === Scheduler Phase Breakdown: total=Xus, Y tasks ===
+        Thread N:   complete       : Xus (Y%)
+        Thread N:   dispatch       : Xus (Y%)
+        Thread N:   scan           : Xus (Y%)
+        Thread N:   idle           : Xus (Y%)
+
+    2. Legacy detailed (PTO2_SCHED_PROFILING=1):
         Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
         Thread N: --- Phase Breakdown ---
         Thread N:   complete:    Xus (Y%)  [fanout: edges=A, max_degree=B, avg=C]  [fanin: edges=D, max_degree=E, avg=F]
@@ -44,13 +51,23 @@ def parse_scheduler_threads(log_path):
         Thread N:   dispatch:    Xus (Y%)  [pop: hit=A, miss=B, hit_rate=C%]
         Thread N:   idle:        Xus (Y%)
 
-    2. Summary (PTO2_SCHED_PROFILING=0):
+    3. Summary (PTO2_SCHED_PROFILING=0):
         Thread N: Scheduler summary: total_time=Xus, loops=Y, tasks_scheduled=Z
     """
     threads = {}
     with open(log_path, 'r', errors='ignore') as f:
         for line in f:
-            # Detailed format: Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
+            # New format: Thread N: === Scheduler Phase Breakdown: total=Xus, Y tasks ===
+            m = re.search(r'Thread (\d+): === Scheduler Phase Breakdown: total=([\d.]+)us, (\d+) tasks ===', line)
+            if m:
+                tid = int(m.group(1))
+                threads[tid] = {
+                    'completed': int(m.group(3)),
+                    'total_us': float(m.group(2)),
+                    'format': 'two-level',
+                }
+
+            # Legacy detailed format: Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
             m = re.search(r'Thread (\d+): completed=(\d+) tasks in ([\d.]+)us \((\d+) loops, ([\d.]+) tasks/loop\)', line)
             if m:
                 tid = int(m.group(1))
@@ -77,7 +94,16 @@ def parse_scheduler_threads(log_path):
                     'format': 'summary',  # Mark as summary format
                 }
 
-            # Phase: complete [fanout: edges=X, max_degree=Y, avg=Z]  [fanin: edges=D, max_degree=E, avg=F]
+            # New format phase lines: Thread N:   complete       : Xus (Y%)
+            m = re.search(r'Thread (\d+):\s+(complete|dispatch|scan|idle)\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)', line)
+            if m:
+                tid = int(m.group(1))
+                if tid in threads:
+                    phase = m.group(2)
+                    threads[tid][f'{phase}_us'] = float(m.group(3))
+                    threads[tid][f'{phase}_pct'] = float(m.group(4))
+
+            # Legacy phase: complete [fanout: edges=X, max_degree=Y, avg=Z]  [fanin: edges=D, max_degree=E, avg=F]
             m = re.search(
                 r'Thread (\d+):\s+complete:\s+([\d.]+)us \(\s*([\d.]+)%\)'
                 r'\s+\[fanout: edges=(\d+), max_degree=(\d+), avg=([\d.]+)\]'
@@ -95,7 +121,7 @@ def parse_scheduler_threads(log_path):
                     threads[tid]['fanin_max_degree'] = int(m.group(8))
                     threads[tid]['fanin_avg'] = float(m.group(9))
 
-            # Phase: scan
+            # Legacy phase: scan
             m = re.search(r'Thread (\d+):\s+scan:\s+([\d.]+)us \(\s*([\d.]+)%\)', line)
             if m:
                 tid = int(m.group(1))


### PR DESCRIPTION
## Summary
- Add `PTO2_SCHED_PROFILING` counters for `on_task_complete` sub-phases: fanout_lock, fanout_notify, fanin_release, self_consumed
- Track atomic operation counts and wait cycles per sub-phase using per-thread counter arrays
- Shared inline methods accept counter-ref parameters to separate orchestrator vs scheduler accounting
- Break down complete and dispatch phases into sub-phases with two-tier tree display (level-1 relative to sched_total, level-2 relative to parent phase)
- Update `sched_overhead_analysis.py` to parse the new two-level format while maintaining backward compatibility

## Testing
- [x] `./ci.sh -p a2a3sim` — all tests pass (profiling off)
- [x] Compile + test with `PTO2_SCHED_PROFILING=1, PTO2_PROFILING=1` (sched only)
- [x] Compile + test with `PTO2_ORCH_PROFILING=1, PTO2_SCHED_PROFILING=1, PTO2_PROFILING=1` (both)