### PR TITLE
Add: single-dependency BGEMM task with configurable incore granularity

### DIFF
--- a/tests/device_tests/tensormap_and_ringbuffer/bgemm/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/bgemm/golden.py
@@ -1,0 +1,104 @@
+"""
+Golden test specification for BGEMM (tensormap_and_ringbuffer Runtime).
+
+Computation: C = A @ B (tiled matrix multiplication)
+Configuration controlled by ALL_CASES parameters:
+  - incore_task_num: total number of incore tasks
+  - incore_data_size: tile size (tile_size = incore_data_size)
+  - grid_k: number of K-dimension partitions (batch_size = incore_task_num / grid_k)
+
+Args layout: [ptr_A, ptr_B, ptr_C, ptr_config, size_A, size_B, size_C]
+"""
+
+import ctypes
+import torch
+
+__outputs__ = ["C"]
+RTOL = 1e-3
+ATOL = 1e-3
+
+# Supported tile sizes must match the switch-case in kernel_gemm_tile.cpp (AIC)
+# and kernel_tile_add.cpp (AIV), which only instantiate templates for these values.
+SUPPORTED_TILE_SIZES = {16, 32, 64, 128}
+
+ALL_CASES = {
+    "Case1": {
+        "incore_task_num": 64,
+        "incore_data_size": 128,
+        "grid_k": 2,
+    },
+}
+
+DEFAULT_CASE = "Case1"
+
+
+def generate_inputs(params: dict) -> list:
+    """Generate input tensors with tile-first memory layout."""
+    tile_size = params["incore_data_size"]
+    if tile_size not in SUPPORTED_TILE_SIZES:
+        raise ValueError(
+            f"incore_data_size={tile_size} is not supported. "
+            f"Must be one of {sorted(SUPPORTED_TILE_SIZES)}."
+        )
+    grid_k = params["grid_k"]
+    batch_size = params["incore_task_num"] // grid_k
+
+    A = torch.randn(batch_size, grid_k, tile_size, tile_size, dtype=torch.float32) * 0.01
+    B = torch.randn(batch_size, grid_k, tile_size, tile_size, dtype=torch.float32) * 0.01
+    C = torch.zeros(batch_size, tile_size, tile_size, dtype=torch.float32)
+
+    config = torch.tensor([tile_size, grid_k, batch_size], dtype=torch.int64)
+
+    A_flat = A.flatten()
+    B_flat = B.flatten()
+    C_flat = C.flatten()
+
+    return [
+        ("A", A_flat),
+        ("B", B_flat),
+        ("C", C_flat),
+        ("config", config),
+        ("size_A", ctypes.c_int64(A_flat.nbytes)),
+        ("size_B", ctypes.c_int64(B_flat.nbytes)),
+        ("size_C", ctypes.c_int64(C_flat.nbytes)),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute golden result: C[batch] = sum(k) A[batch,k] @ B[batch,k]."""
+    tile_size = params["incore_data_size"]
+    grid_k = params["grid_k"]
+    batch_size = params["incore_task_num"] // grid_k
+
+    A = torch.as_tensor(tensors["A"]).reshape(batch_size, grid_k, tile_size, tile_size)
+    B = torch.as_tensor(tensors["B"]).reshape(batch_size, grid_k, tile_size, tile_size)
+    C = torch.as_tensor(tensors["C"]).reshape(batch_size, tile_size, tile_size)
+
+    C[:] = 0.0
+
+    for batch in range(batch_size):
+        for k_idx in range(grid_k):
+            C[batch] += torch.matmul(A[batch, k_idx], B[batch, k_idx])
+
+    tensors["C"][:] = C.flatten()
+
+
+if __name__ == "__main__":
+    params = {"name": DEFAULT_CASE, **ALL_CASES[DEFAULT_CASE]}
+    result = generate_inputs(params)
+    tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
+    compute_golden(tensors, params)
+
+    tile_size = params["incore_data_size"]
+    grid_k = params["grid_k"]
+    batch_size = params["incore_task_num"] // grid_k
+
+    print(f"=== BGEMM Golden Test ({params['name']}) ===")
+    print(f"incore_task_num={params['incore_task_num']}, incore_data_size={tile_size}, grid_k={grid_k}")
+    print(f"Derived: tile_size={tile_size}, batch_size={batch_size}")
+
+    C = tensors["C"].reshape(batch_size, tile_size, tile_size)
+    print(f"Output shape: {C.shape}")
+    print(f"Output range: [{C.min():.4f}, {C.max():.4f}]")
+    print(f"Output mean: {C.mean():.4f}")
+    print("Golden test passed!")

--- a/tests/device_tests/tensormap_and_ringbuffer/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -1,0 +1,122 @@
+/**
+ * Tile-based Matrix Multiplication Kernel (Cube Core)
+ *
+ * Computes: output = input_a @ input_b (tile_size x tile_size tile matmul)
+ * Uses TMATMUL instruction
+ *
+ * Tile size is determined by golden.py configuration and passed through
+ * tensor shapes from orchestration.
+ *
+ * Args (TensorData*):
+ *   args[0] = input_a (INPUT)
+ *   args[1] = input_b (INPUT)
+ *   args[2] = output  (OUTPUT)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <typename T>
+AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
+    if (num_2 == 0) {
+        return 0;
+    }
+    return (num_1 + num_2 - 1) / num_2 * num_2;
+}
+
+template <int TILE>
+static __aicore__ void gemm_tile_impl(
+    __gm__ TensorData* input_a_tensor,
+    __gm__ TensorData* input_b_tensor,
+    __gm__ TensorData* output_tensor) {
+
+    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
+    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
+    __gm__ float* output  = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr)  + output_tensor->start_offset;
+
+    constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
+    constexpr int M = CeilAlign<int>(TILE, 16);
+    constexpr int K = CeilAlign<int>(TILE, blockAlign);
+    constexpr int N = CeilAlign<int>(TILE, blockAlign);
+
+    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+
+    GlobalDataA src0Global(input_a);
+    GlobalDataB src1Global(input_b);
+    GlobalDataC dstGlobal(output);
+
+    using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+
+    using LeftTile = TileLeft<float, M, K, TILE, TILE>;
+    using RightTile = TileRight<float, K, N, TILE, TILE>;
+    using AccTile = TileAcc<float, M, N, TILE, TILE>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    TLOAD(aMatTile, src0Global);
+    TLOAD(bMatTile, src1Global);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(dstGlobal, cTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* input_a = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* input_b = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* output  = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    uint64_t total_elems = static_cast<uint64_t>(input_a->shapes[0]);
+    uint64_t tile_size = 1;
+    while (tile_size * tile_size < total_elems) {
+        tile_size <<= 1;
+    }
+    switch (tile_size) {
+        case 16:  gemm_tile_impl<16>(input_a, input_b, output);  break;
+        case 32:  gemm_tile_impl<32>(input_a, input_b, output);  break;
+        case 64:  gemm_tile_impl<64>(input_a, input_b, output);  break;
+        case 128: gemm_tile_impl<128>(input_a, input_b, output); break;
+        default: break;
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -1,0 +1,80 @@
+/**
+ * Tile-based Element-wise Addition Kernel (Vector Core) - INOUT Pattern
+ *
+ * Computes: C_tile = C_tile + P (tile_size x tile_size tile accumulation)
+ * Uses TADD instruction
+ *
+ * Tile size is determined by golden.py configuration and passed through
+ * tensor shapes from orchestration.
+ *
+ * Args (TensorData*):
+ *   args[0] = C_tile (INOUT: read + write accumulator)
+ *   args[1] = P      (INPUT: matmul result to accumulate)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int TILE>
+static __aicore__ void tile_add_impl(
+    __gm__ TensorData* c_tensor,
+    __gm__ TensorData* p_tensor) {
+
+    __gm__ float* c_ptr = reinterpret_cast<__gm__ float*>(c_tensor->buffer.addr) + c_tensor->start_offset;
+    __gm__ float* p_ptr = reinterpret_cast<__gm__ float*>(p_tensor->buffer.addr) + p_tensor->start_offset;
+
+    using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
+    using DynStridDim5 = Stride<1, 1, 1, TILE, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, TILE, TILE, BLayout::RowMajor, -1, -1>;
+
+    TileData cTile(TILE, TILE);
+    TileData pTile(TILE, TILE);
+    TileData outTile(TILE, TILE);
+    TASSIGN(cTile, 0x0);
+    TASSIGN(pTile, 0x10000);
+    TASSIGN(outTile, 0x20000);
+
+    GlobalData cGlobal(c_ptr);
+    GlobalData pGlobal(p_ptr);
+    GlobalData outGlobal(c_ptr);  // write back to same C location
+
+    TLOAD(cTile, cGlobal);
+    TLOAD(pTile, pGlobal);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(outTile, cTile, pTile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(outGlobal, outTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* c_tensor = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* p_tensor = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    uint64_t total_elems = static_cast<uint64_t>(p_tensor->shapes[0]);
+    uint64_t tile_size = 1;
+    while (tile_size * tile_size < total_elems) {
+        tile_size <<= 1;
+    }
+    switch (tile_size) {
+        case 16:  tile_add_impl<16>(c_tensor, p_tensor);  break;
+        case 32:  tile_add_impl<32>(c_tensor, p_tensor);  break;
+        case 64:  tile_add_impl<64>(c_tensor, p_tensor);  break;
+        case 128: tile_add_impl<128>(c_tensor, p_tensor); break;
+        default: break;
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/bgemm/kernels/kernel_config.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/bgemm/kernels/kernel_config.py
@@ -1,0 +1,35 @@
+"""
+Kernel configuration for BGEMM (tensormap_and_ringbuffer Runtime).
+
+Cube core (AIC) for matrix multiplication, Vector core (AIV) for element-wise addition.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "bgemm_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "GEMM",
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_gemm_tile.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "ADD",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_tile_add.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 3,
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -1,0 +1,137 @@
+/**
+ * BGEMM Orchestration Function (tensormap_and_ringbuffer Runtime)
+ *
+ * Builds the task graph for tiled matrix multiplication: C = A @ B
+ *
+ * Configuration read from config tensor (set in golden.py):
+ *   - tile_size: tile dimension (tile_size x tile_size per tile)
+ *   - grid_k: number of K-dimension partitions
+ *   - batch_size: number of independent batch elements
+ *
+ * Memory layout (tile-first, flattened):
+ *   A: [batch_size, grid_k, tile_size, tile_size]
+ *   B: [batch_size, grid_k, tile_size, tile_size]
+ *   C: [batch_size, tile_size, tile_size]
+ *
+ * Task graph per output tile C[batch]:
+ *   for k in [0, grid_k):
+ *     P = A[batch,k] @ B[batch,k]  (gemm_tile on Cube core, func_id=0)
+ *     C[batch] = C[batch] + P      (tile_add on Vector core, func_id=1)
+ *
+ * Dependencies are automatic via TensorMap overlap detection.
+ *
+ * This file compiles as a standalone .so with zero runtime link dependencies.
+ * All runtime calls go through the PTO2RuntimeOps function-pointer table.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_GEMM_TILE 0
+#define FUNC_TILE_ADD  1
+
+// Args layout: [ptr_A, ptr_B, ptr_C, ptr_config, size_A, size_B, size_C]
+#define ARG_PTR_A      0
+#define ARG_PTR_B      1
+#define ARG_PTR_C      2
+#define ARG_PTR_CONFIG 3
+#define ARG_SIZE_A     4
+#define ARG_SIZE_B     5
+#define ARG_SIZE_C     6
+
+extern "C" {
+
+__attribute__((visibility("default")))
+PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count) {
+    (void)args;
+    (void)arg_count;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 7,
+    };
+}
+
+__attribute__((visibility("default")))
+void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
+    (void)arg_count;
+    pto2_rt_init_tensor_pool(rt);
+
+    void* dev_A = (void*)(uintptr_t)args[ARG_PTR_A];
+    void* dev_B = (void*)(uintptr_t)args[ARG_PTR_B];
+    void* dev_C = (void*)(uintptr_t)args[ARG_PTR_C];
+    size_t size_A = (size_t)args[ARG_SIZE_A];
+    size_t size_B = (size_t)args[ARG_SIZE_B];
+    size_t size_C = (size_t)args[ARG_SIZE_C];
+
+    // Read config from golden.py
+    int64_t* host_config = (int64_t*)(uintptr_t)args[ARG_PTR_CONFIG];
+    int tile_size = (int)host_config[0];
+    int grid_k = (int)host_config[1];
+    int batch_size = (int)host_config[2];
+    uint64_t tile_elems = (uint64_t)tile_size * tile_size;
+
+    int grid_m = 1;
+    int grid_n = 1;
+
+    LOG_INFO(rt, "[bgemm_orch] tile_size: %d, grid_m: %d, grid_n: %d, grid_k: %d, batch_size: %d",
+             tile_size, grid_m, grid_n, grid_k, batch_size);
+
+    // Create 1D external tensors for the full A, B, C arrays
+    uint64_t ext_A_shapes[1] = {size_A / sizeof(float)};
+    Tensor ext_A = make_tensor_external(dev_A, ext_A_shapes, 1, DataType::FLOAT32);
+    uint64_t ext_B_shapes[1] = {size_B / sizeof(float)};
+    Tensor ext_B = make_tensor_external(dev_B, ext_B_shapes, 1, DataType::FLOAT32);
+    uint64_t ext_C_shapes[1] = {size_C / sizeof(float)};
+    Tensor ext_C = make_tensor_external(dev_C, ext_C_shapes, 1, DataType::FLOAT32);
+
+    uint64_t tile_shapes[1] = {tile_elems};
+
+    int total_gemm = 0;
+    int total_add = 0;
+
+    for (int batch = 0; batch < batch_size; batch++) {
+        PTO2_SCOPE(rt) {
+            uint64_t c_elem_offset = (uint64_t)batch * tile_elems;
+            uint64_t c_view_offsets[1] = {c_elem_offset};
+            Tensor C_view = ext_C.view(tile_shapes, c_view_offsets);
+
+            for (int k_idx = 0; k_idx < grid_k; k_idx++) {
+                uint64_t a_elem_offset =
+                    ((uint64_t)batch * grid_k + (uint64_t)k_idx) * tile_elems;
+                uint64_t b_elem_offset =
+                    ((uint64_t)batch * grid_k + (uint64_t)k_idx) * tile_elems;
+
+                uint64_t a_view_offsets[1] = {a_elem_offset};
+                Tensor A_view = ext_A.view(tile_shapes, a_view_offsets);
+                uint64_t b_view_offsets[1] = {b_elem_offset};
+                Tensor B_view = ext_B.view(tile_shapes, b_view_offsets);
+                Tensor P = make_tensor(tile_shapes, 1, DataType::FLOAT32);
+
+                // P = A[batch,k] @ B[batch,k]
+                PTOParam params_gemm[] = {
+                    make_input_param(A_view),
+                    make_input_param(B_view),
+                    make_output_param(P),
+                };
+                pto2_rt_submit_task(rt, FUNC_GEMM_TILE, PTO2_WORKER_CUBE,
+                                   params_gemm, 3); // gemm
+                total_gemm++;
+
+                // C[batch] += P
+                PTOParam params_add[] = {
+                    make_inout_param(C_view),
+                    make_input_param(P),
+                };
+                pto2_rt_submit_task(rt, FUNC_TILE_ADD, PTO2_WORKER_VECTOR,
+                                   params_add, 2); // add
+                total_add++;
+            }
+        }
+    }
+
+    LOG_INFO(rt, "[bgemm_orch] Submitted %d gemm tasks and %d add tasks (%d total)",
+             total_gemm, total_add, total_gemm + total_add);
+}
+
+}  // extern "C"


### PR DESCRIPTION
## Summary

- Add a single-dependency BGEMM (batched GEMM) benchmark under
  `tests/device_tests/tensormap_and_ringbuffer/bgemm/` that supports
  fine-grained control over incore task count and data size
- The task graph uses a simple linear dependency chain per batch element:
  GEMM → ADD → GEMM → ADD → ... (single dependency per task via TensorMap
  overlap detection), making it suitable for benchmarking scheduler overhead
  at varying granularities

## Parameter Configuration (`golden.py`)

All test cases are defined in the `ALL_CASES` dictionary. Each case has three
parameters that jointly control the incore task granularity:

| Parameter | Type | Description |
|---|---|---|
| `incore_task_num` | int | Total number of incore tasks (GEMM + ADD). The orchestration generates `incore_task_num` tasks in total, split equally between GEMM and ADD. Must be divisible by `grid_k`. |
| `incore_data_size` | int | Tile dimension for each task. Each GEMM/ADD task operates on a `(incore_data_size × incore_data_size)` tile. Must be one of `{16, 32, 64, 128}` (matching the compile-time template instantiations in the AIC/AIV kernels). |
| `grid_k` | int | Number of K-dimension partitions per output tile. Controls how many GEMM+ADD pairs contribute to each output C[batch]. |

### Derived values

- `tile_size = incore_data_size` — the square tile edge length
- `batch_size = incore_task_num / grid_k` — number of independent output tiles
- Total GEMM tasks = `batch_size × grid_k` = `incore_task_num`
- Total ADD tasks = `batch_size × grid_k` = `incore_task_num`
- Total incore tasks = `2 × incore_task_num`

### Constraints

1. `incore_task_num` must be evenly divisible by `grid_k`
2. `incore_data_size` must be in `{16, 32, 64, 128}` (validated at runtime)
3. Increasing `incore_data_size` increases per-task data volume quadratically
   (tile elements = `incore_data_size²`)
4. Increasing `incore_task_num` (with fixed `grid_k`) increases the number of
   independent batch elements, adding more parallel task chains
5. Increasing `grid_k` (with fixed `incore_task_num`) makes each batch chain
   longer (more GEMM→ADD steps per output tile) while reducing batch parallelism

### Example

```python
"Case1": {
    "incore_task_num": 64,    # 64 GEMM + 64 ADD = 128 total tasks
    "incore_data_size": 128,  # each tile is 128×128 floats (64 KB)
    "grid_k": 2,              # 2 K-partitions per output tile
}
# → batch_size = 64/2 = 32 independent output tiles
# → each output tile: 2 GEMM→ADD chains, dependency: GEMM→ADD→GEMM→ADD
```

### Tuning guide

| Goal | Adjust |
|---|---|
| More total tasks (stress scheduler) | Increase `incore_task_num` |
| Larger per-task data (stress memory bandwidth) | Increase `incore_data_size` |
| Longer dependency chains (stress serial latency) | Increase `grid_k` with fixed `incore_task_num` |
| More parallelism (stress concurrent dispatch) | Decrease `grid_k` with fixed `incore_task_num` |