### PR TITLE
Fix: multi-round state initialization and cleanup for AICPU runtime

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1196,6 +1196,7 @@ int AicpuExecutor::run(Runtime* runtime) {
 
             // Safe to destroy — no scheduler thread accesses runtime data anymore
             pto2_runtime_destroy(rt);
+            rt = nullptr;
         }
         DEV_INFO("Thread %d: Orchestrator completed", thread_idx);
     } else {
@@ -1236,6 +1237,9 @@ void AicpuExecutor::deinit() {
         dispatch_timestamps_[i] = 0;
         core_dispatch_counts_[i] = 0;
     }
+
+    // Clear per-core dispatch payloads to prevent stale data on next round
+    memset(s_pto2_payload_per_core, 0, sizeof(s_pto2_payload_per_core));
 
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_.store(0, std::memory_order_release);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -133,6 +133,7 @@ bool pto2_orchestrator_init(
 }
 
 void pto2_orchestrator_destroy(PTO2OrchestratorState* orch) {
+    TensorPool::set_instance(nullptr);
     orch->tensor_map.destroy();
 
     free(orch->scope_tasks);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -150,6 +150,14 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
         return false;
     }
 
+    // Zero-initialize all per-task state arrays.
+    // new[] default-initializes std::atomic<T> which leaves values indeterminate.
+    // Scheduler logic (e.g. fanin_refcount fetch_add in release_fanin_and_check_ready)
+    // assumes slots start at zero before init_task writes them.
+    memset(sched->task_state, 0, window_size * sizeof(std::atomic<PTO2TaskState>));
+    memset(sched->fanin_refcount, 0, window_size * sizeof(std::atomic<int32_t>));
+    memset(sched->fanout_refcount, 0, window_size * sizeof(std::atomic<int32_t>));
+
     // Initialize ready queues
     for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {
         if (!pto2_ready_queue_init(&sched->ready_queues[i], PTO2_READY_QUEUE_SIZE)) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -119,6 +119,19 @@ PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
     handle->dep_list_pool = (PTO2DepListEntry*)ptr;
 
     pto2_sm_init_header(handle, task_window_size, heap_size, dep_list_pool_size);
+
+    // Zero task descriptors and dep list pool.
+    // On multi-round execution the SM buffer may be reused at the same device
+    // address.  PTO2TaskDescriptor contains Tensor members whose move-assignment
+    // calls TensorPool::deref(old_index).  Stale nonzero indices from a previous
+    // round would corrupt the fresh TensorPool.  Zeroing ensures index==0 (no-op
+    // deref) for every slot before new tasks are written.
+    memset(handle->task_descriptors, 0,
+           task_window_size * sizeof(PTO2TaskDescriptor));
+    // Skip slot 0 (sentinel: task_id=-1, next=nullptr; deref(0) is a no-op)
+    memset(handle->dep_list_pool + 1, 0,
+           dep_list_pool_size * sizeof(PTO2DepListEntry));
+
     return handle;
 }
 


### PR DESCRIPTION
## Summary
- Zero-initialize shared memory (task descriptors, dep list pool) in `pto2_sm_create_from_buffer` to prevent stale data from corrupting TensorPool on reused device memory
- Zero-initialize scheduler atomic arrays (`task_state`, `fanin_refcount`, `fanout_refcount`) after `new[]` allocation — default initialization leaves `std::atomic` values indeterminate
- Null out static `rt` pointer after `runtime_destroy` to prevent dangling pointer access
- Clear `s_pto2_payload_per_core` in `deinit()` to prevent stale dispatch payloads across rounds
- Clear `TensorPool` singleton pointer in `orchestrator_destroy` to prevent dangling access

## Testing
- [ ] Simulation tests pass
- [ ] Hardware tests pass (multi-round execution)