### PR TITLE
Refactor: remove dead runtime_reset code chain

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -141,28 +141,6 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState* orch) {
     orch->scope_begins = NULL;
 }
 
-void pto2_orchestrator_reset(PTO2OrchestratorState* orch) {
-    pto2_heap_ring_reset(&orch->heap_ring);
-    pto2_task_ring_reset(&orch->task_ring);
-    pto2_dep_pool_reset(&orch->dep_pool);
-    orch->tensor_map.reset();
-
-    orch->tensormap_last_cleanup = 0;
-    orch->scope_stack_top = -1;
-    orch->scope_tasks_size = 0;
-
-#if PTO2_PROFILING
-    orch->tasks_submitted = 0;
-    orch->buffers_allocated = 0;
-    orch->bytes_allocated = 0;
-#endif
-
-    // Reset shared memory header
-    orch->sm_handle->header->current_task_index.store(0, std::memory_order_relaxed);
-    orch->sm_handle->header->heap_top.store(0, std::memory_order_relaxed);
-    orch->sm_handle->header->orchestrator_done.store(0, std::memory_order_relaxed);
-}
-
 void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler) {
     orch->scheduler = scheduler;
     orch->init_task_on_submit = true;  // Default: initialize task on submit

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -122,11 +122,6 @@ bool pto2_orchestrator_init(
 void pto2_orchestrator_destroy(PTO2OrchestratorState* orch);
 
 /**
- * Reset orchestrator state for reuse
- */
-void pto2_orchestrator_reset(PTO2OrchestratorState* orch);
-
-/**
  * Set scheduler reference (for simulated mode)
  */
 void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -25,10 +25,6 @@ void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
     ring->tail_ptr = tail_ptr;
 }
 
-void pto2_heap_ring_reset(PTO2HeapRing* ring) {
-    ring->top = 0;
-}
-
 // =============================================================================
 // Task Ring Buffer Implementation
 // =============================================================================
@@ -41,14 +37,6 @@ void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
     ring->last_alive_ptr = last_alive_ptr;
 }
 
-
-void pto2_task_ring_reset(PTO2TaskRing* ring) {
-    ring->current_index = 0;
-    
-    // Clear all task descriptors
-    memset(ring->descriptors, 0, ring->window_size * sizeof(PTO2TaskDescriptor));
-}
-
 // =============================================================================
 // Dependency List Pool Implementation
 // =============================================================================
@@ -59,17 +47,6 @@ void pto2_dep_pool_init(PTO2DepListPool* pool, PTO2DepListEntry* base, int32_t c
     pool->top = 1;  // Start from 1, 0 means NULL/empty
     
     // Initialize entry 0 as NULL marker
-    pool->base[0].task_id = -1;
-    pool->base[0].next = nullptr;
-}
-
-void pto2_dep_pool_reset(PTO2DepListPool* pool) {
-    pool->top = 1;
-    
-    // Clear pool (optional, for debugging)
-    memset(pool->base + 1, 0, (pool->capacity - 1) * sizeof(PTO2DepListEntry));
-    
-    // Re-initialize entry 0 as NULL marker
     pool->base[0].task_id = -1;
     pool->base[0].next = nullptr;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -232,11 +232,6 @@ struct PTO2HeapRing {
 void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
                           std::atomic<uint64_t>* tail_ptr);
 
-/**
- * Reset heap ring to initial state
- */
-void pto2_heap_ring_reset(PTO2HeapRing* ring);
-
 // =============================================================================
 // Task Ring Buffer
 // =============================================================================
@@ -422,11 +417,6 @@ static inline PTO2TaskDescriptor* pto2_task_ring_get(PTO2TaskRing* ring, int32_t
     return &ring->descriptors[task_id & (ring->window_size - 1)];
 }
 
-/**
- * Reset task ring to initial state
- */
-void pto2_task_ring_reset(PTO2TaskRing* ring);
-
 // =============================================================================
 // Dependency List Pool
 // =============================================================================
@@ -488,11 +478,6 @@ struct PTO2DepListPool {
  * @param capacity  Total number of entries
  */
 void pto2_dep_pool_init(PTO2DepListPool* pool, PTO2DepListEntry* base, int32_t capacity);
-
-/**
- * Reset dependency list pool
- */
-void pto2_dep_pool_reset(PTO2DepListPool* pool);
 
 /**
  * Get pool usage statistics

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -174,16 +174,6 @@ void pto2_runtime_destroy(PTO2Runtime* rt) {
     free(rt);
 }
 
-void pto2_runtime_reset(PTO2Runtime* rt) {
-    if (!rt) return;
-
-    pto2_orchestrator_reset(&rt->orchestrator);
-    pto2_scheduler_reset(&rt->scheduler);
-    pto2_sm_reset(rt->sm_handle);
-
-    rt->total_cycles = 0;
-}
-
 void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -146,11 +146,6 @@ PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
 void pto2_runtime_destroy(PTO2Runtime* rt);
 
 /**
- * Reset runtime for reuse (keeps allocations, clears state)
- */
-void pto2_runtime_reset(PTO2Runtime* rt);
-
-/**
  * Set execution mode
  */
 void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -98,14 +98,6 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
     }
 }
 
-void pto2_ready_queue_reset(PTO2ReadyQueue* queue) {
-    queue->enqueue_pos.store(0, std::memory_order_relaxed);
-    queue->dequeue_pos.store(0, std::memory_order_relaxed);
-    for (uint64_t i = 0; i < queue->capacity; i++) {
-        queue->slots[i].sequence.store((int64_t)i, std::memory_order_relaxed);
-    }
-}
-
 // =============================================================================
 // Scheduler Initialization
 // =============================================================================
@@ -197,27 +189,6 @@ void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
     for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {
         pto2_ready_queue_destroy(&sched->ready_queues[i]);
     }
-}
-
-void pto2_scheduler_reset(PTO2SchedulerState* sched) {
-    sched->last_task_alive = 0;
-    sched->last_heap_consumed = 0;
-    sched->heap_tail = 0;
-    for (uint64_t i = 0; i < sched->task_window_size; i++) {
-        sched->task_state[i].store(PTO2_TASK_PENDING, std::memory_order_relaxed);
-        sched->fanin_refcount[i].store(0, std::memory_order_relaxed);
-        sched->fanout_refcount[i].store(0, std::memory_order_relaxed);
-    }
-
-    for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {
-        pto2_ready_queue_reset(&sched->ready_queues[i]);
-    }
-
-#if PTO2_PROFILING
-    sched->tasks_completed.store(0, std::memory_order_relaxed);
-    sched->tasks_consumed.store(0, std::memory_order_relaxed);
-#endif
-    sched->ring_advance_lock.store(0, std::memory_order_relaxed);
 }
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -214,7 +214,6 @@ struct alignas(64) PTO2ReadyQueue {
 // Cold-path ready queue operations (defined in pto_scheduler.cpp)
 bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity);
 void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
-void pto2_ready_queue_reset(PTO2ReadyQueue* queue);
 
 // =============================================================================
 // Scheduler State
@@ -616,7 +615,6 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
                           PTO2DepListPool* dep_pool,
                           void* heap_base);
 void pto2_scheduler_destroy(PTO2SchedulerState* sched);
-void pto2_scheduler_reset(PTO2SchedulerState* sched);
 
 // =============================================================================
 // Debug Utilities (cold path, defined in pto_scheduler.cpp)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -171,30 +171,6 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
     handle->dep_list_pool[0].next = nullptr;
 }
 
-void pto2_sm_reset(PTO2SharedMemoryHandle* handle) {
-    if (!handle) return;
-    
-    PTO2SharedMemoryHeader* header = handle->header;
-
-    // Reset flow control pointers
-    header->current_task_index.store(0, std::memory_order_relaxed);
-    header->heap_top.store(0, std::memory_order_relaxed);
-    header->orchestrator_done.store(0, std::memory_order_relaxed);
-    header->last_task_alive.store(0, std::memory_order_relaxed);
-    header->heap_tail.store(0, std::memory_order_relaxed);
-    header->heap_tail_gen.store(0, std::memory_order_relaxed);
-
-    header->graph_output_ptr.store(0, std::memory_order_relaxed);
-    header->graph_output_size.store(0, std::memory_order_relaxed);
-    // Clear task descriptors
-    memset(handle->task_descriptors, 0, 
-           header->task_window_size * sizeof(PTO2TaskDescriptor));
-    
-    // Clear dependency list pool (keep entry 0 as NULL marker)
-    memset(handle->dep_list_pool + 1, 0,
-           header->dep_list_pool_size * sizeof(PTO2DepListEntry));
-}
-
 // =============================================================================
 // Debug Utilities
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -162,12 +162,6 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
                           uint64_t dep_list_pool_size);
 
 /**
- * Reset shared memory to initial state (for reuse)
- * Clears all task descriptors and resets pointers
- */
-void pto2_sm_reset(PTO2SharedMemoryHandle* handle);
-
-/**
  * Get task descriptor by task ID
  * Uses runtime window_size for ring buffer indexing (not compile-time constant)
  */

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -137,32 +137,6 @@ void PTO2TensorMap::destroy() {
     }
 }
 
-void PTO2TensorMap::reset() {
-    // Reset all buckets to empty
-    for (int32_t i = 0; i < num_buckets; i++) {
-        buckets[i] = nullptr;
-    }
-
-    // Reset all entries
-    for (int32_t i = 0; i < pool_size; i++) {
-        entry_pool[i].bucket_index = -1;
-        entry_pool[i].next_in_bucket = nullptr;
-        entry_pool[i].prev_in_bucket = nullptr;
-        entry_pool[i].next_in_task = nullptr;
-        entry_pool[i].prev_in_task = nullptr;
-        entry_pool[i].producer_task_id = -1;
-    }
-
-    // Reset per-task entry tracking
-    for (int32_t i = 0; i < pool_size; i++) {
-        task_entry_head[i] = nullptr;
-    }
-
-    next_entry_idx = 0;
-    free_num = 0;
-    last_task_alive = 0;
-}
-
 // =============================================================================
 // Debug Utilities
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -197,11 +197,6 @@ struct PTO2TensorMap {
     void destroy();
 
     /**
-     * Reset TensorMap to empty state
-     */
-    void reset();
-
-    /**
      * Update validity threshold from shared memory
      * Called periodically to refresh the lazy invalidation threshold.
      *


### PR DESCRIPTION
## Summary
- Remove 9 never-called `_reset` functions and their declarations across 12 files (172 lines deleted)
- Removed: `pto2_runtime_reset`, `pto2_orchestrator_reset`, `pto2_scheduler_reset`, `pto2_sm_reset`, `pto2_ready_queue_reset`, `pto2_heap_ring_reset`, `pto2_task_ring_reset`, `pto2_dep_pool_reset`, `PTO2TensorMap::reset()`
- We use the destroy+create model; the entire reset chain was dead code

## Testing
- [ ] Simulation tests pass (`./ci.sh -p a2a3sim`)
- [ ] Hardware tests pass (if applicable)