### PR TITLE
Support: add pre-loop cache invalidation in AICore handshake

### DIFF
--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -53,6 +53,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
+    // Invalidate cache before first read to avoid stale aicpu_ready from previous round
+    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     }

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -21,6 +21,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
+    // Invalidate cache before first read to avoid stale aicpu_ready from previous round
+    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -53,6 +53,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
+    // Invalidate cache before first read to avoid stale aicpu_ready from previous round
+    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, SINGLE_CACHE_LINE);
     }


### PR DESCRIPTION
## Summary
- Add `dcci` before the `aicpu_ready` spin-wait loop in all three AICore executors
- On multi-round execution, the cache may hold stale `aicpu_ready=0` from a previous round, causing AICore to miss the AICPU ready signal until the next periodic invalidation
- The pre-loop `dcci` ensures the first read sees fresh data
- Use `ENTIRE_DATA_CACHE` for the initial invalidation (broad flush), while keeping `SINGLE_CACHE_LINE` in the tensormap_and_ringbuffer spin-wait loop for performance

## Testing
- [ ] Simulation tests pass
- [ ] Hardware tests pass