### PR TITLE
Support: add cache_invalidate_range for AICPU inter-round cleanup

### DIFF
--- a/src/a2a3/platform/include/aicpu/platform_regs.h
+++ b/src/a2a3/platform/include/aicpu/platform_regs.h
@@ -17,6 +17,7 @@
 #define PLATFORM_AICPU_PLATFORM_REGS_H_
 
 #include <cstdint>
+#include <cstddef>
 #include "common/platform_config.h"
 
 #ifdef __cplusplus
@@ -90,5 +91,21 @@ void platform_deinit_aicore_regs(uint64_t reg_addr);
  * @return Physical core count (exclusive upper bound)
  */
 uint32_t platform_get_physical_cores_count();
+
+/**
+ * Invalidate data cache for a memory range.
+ *
+ * On ARM64 AICPU, DMA writes from the host (rtMemcpy) go directly to HBM
+ * without invalidating the AICPU's data cache.  When rtMalloc returns the
+ * same device address across rounds, the AICPU may read stale cached data
+ * instead of the fresh values written by the host.
+ *
+ * On real hardware (onboard): performs DC CIVAC per cache line + DSB/ISB.
+ * On simulation (sim): no-op.
+ *
+ * @param addr  Start address of the memory range
+ * @param size  Size of the memory range in bytes
+ */
+void cache_invalidate_range(const void* addr, size_t size);
 
 #endif  // PLATFORM_AICPU_PLATFORM_REGS_H_

--- a/src/a2a3/platform/onboard/aicpu/cache_ops.cpp
+++ b/src/a2a3/platform/onboard/aicpu/cache_ops.cpp
@@ -1,0 +1,18 @@
+#include <cstddef>
+#include <cstdint>
+
+#include "aicpu/platform_regs.h"
+
+void cache_invalidate_range(const void* addr, size_t size) {
+    if (size == 0) {
+        return;
+    }
+    const size_t kCacheLineSize = 64;
+    uintptr_t start = (uintptr_t)addr & ~(kCacheLineSize - 1);
+    uintptr_t end   = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    for (uintptr_t p = start; p < end; p += kCacheLineSize) {
+        __asm__ __volatile__("dc civac, %0" :: "r"(p) : "memory");
+    }
+    __asm__ __volatile__("dsb sy" ::: "memory");
+    __asm__ __volatile__("isb" ::: "memory");
+}

--- a/src/a2a3/platform/sim/aicpu/cache_ops.cpp
+++ b/src/a2a3/platform/sim/aicpu/cache_ops.cpp
@@ -1,0 +1,7 @@
+#include <cstddef>
+
+#include "aicpu/platform_regs.h"
+
+void cache_invalidate_range(const void* /* addr */, size_t /* size */) {
+    // No-op on simulation: no hardware cache to invalidate
+}

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -11,6 +11,8 @@
 
 #include "aicpu/device_log.h"
 #include "aicpu/device_malloc.h"
+#include "aicpu/platform_regs.h"
+#include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "runtime.h"
 
@@ -203,7 +205,7 @@ struct AicpuExecutor {
     int resolve_and_dispatch(Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num);
     int shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num);
     int run(Runtime* runtime);
-    void deinit();
+    void deinit(Runtime* runtime);
     void diagnose_stuck_state(
         Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num, Handshake* hank);
 };
@@ -326,7 +328,7 @@ int AicpuExecutor::init(Runtime* runtime) {
  * @return 0 on success, -1 on failure
  */
 int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
-    Handshake* all_hanks = (Handshake*)runtime->workers;
+    Handshake* all_handshakes = (Handshake*)runtime->workers;
     cores_total_num_ = runtime->worker_count;
 
     if (cores_total_num_ == 0) {
@@ -347,12 +349,12 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
 
     // Step 1: Send handshake signal to all cores
     for (int i = 0; i < cores_total_num_; i++) {
-        all_hanks[i].aicpu_ready = 1;
+        all_handshakes[i].aicpu_ready = 1;
     }
 
     // Step 2: Wait for all cores to respond and collect core type information
     for (int i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_hanks[i];
+        Handshake* hank = &all_handshakes[i];
 
         // Wait for aicore_done signal
         while (hank->aicore_done == 0) {
@@ -467,13 +469,13 @@ void AicpuExecutor::assign_cores_to_threads() {
  * Shutdown AICore - Send quit signal to all AICore kernels
  */
 int AicpuExecutor::shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
-    Handshake* all_hanks = (Handshake*)runtime->workers;
+    Handshake* all_handshakes = (Handshake*)runtime->workers;
 
     DEV_INFO("Thread %d: Shutting down %d cores", thread_idx, core_num);
 
     for (int i = 0; i < core_num; i++) {
         int core_id = cur_thread_cores[i];
-        Handshake* hank = &all_hanks[core_id];
+        Handshake* hank = &all_handshakes[core_id];
         DEV_INFO("Thread %d: AICPU hank addr = 0x%lx", thread_idx, (uint64_t)hank);
         hank->control = 1;
     }
@@ -802,7 +804,15 @@ int AicpuExecutor::run(Runtime* runtime) {
     return final_rc;
 }
 
-void AicpuExecutor::deinit() {
+void AicpuExecutor::deinit(Runtime* runtime) {
+    // === Exit cleanup: reset all inter-round state ===
+
+    // 1. Invalidate AICPU cache for Runtime address range.
+    //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
+    //    bypasses this cache. Invalidating now ensures next round reads from HBM.
+    cache_invalidate_range(runtime, sizeof(Runtime));
+
+    // === Existing reset logic ===
     // Cleanup runtime execution state
     ready_count_aic_.store(0, std::memory_order_release);
     ready_count_aiv_.store(0, std::memory_order_release);
@@ -939,7 +949,7 @@ extern "C" int aicpu_execute(Runtime* runtime) {
     // Last thread cleans up
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
         DEV_INFO("aicpu_execute: Last thread finished, cleaning up");
-        g_aicpu_executor.deinit();
+        g_aicpu_executor.deinit(runtime);
     }
 
     DEV_INFO("%s", "aicpu_execute: Kernel execution completed successfully");

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -27,6 +27,9 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
         dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     }
 
+    // Clear stale EXIT_SIGNAL from previous round before entering main loop
+    write_reg(RegId::DATA_MAIN_BASE, 0);
+
     // Report physical core ID and core type for AICPU
     my_hank->physical_core_id = get_physical_core_id();
     my_hank->core_type = core_type;

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -96,7 +96,7 @@ struct AicpuExecutor {
     int resolve_and_dispatch(Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num);
     int shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores);
     int run(Runtime* runtime);
-    void deinit();
+    void deinit(Runtime* runtime);
     void emergency_shutdown();
     void diagnose_stuck_state(
         Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num, Handshake* hank);
@@ -299,7 +299,7 @@ int AicpuExecutor::init(Runtime* runtime) {
  * @return 0 on success, -1 on failure
  */
 int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
-    Handshake* all_hanks = (Handshake*)runtime->workers;
+    Handshake* all_handshakes = (Handshake*)runtime->workers;
     cores_total_num_ = runtime->worker_count;
 
     // Validate cores_total_num_ before using as array index
@@ -315,7 +315,7 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
 
     // Step 1: Send handshake signal to all cores
     for (int i = 0; i < cores_total_num_; i++) {
-        all_hanks[i].aicpu_ready = 1;
+        all_handshakes[i].aicpu_ready = 1;
     }
 
     // Get platform physical cores count for validation
@@ -324,7 +324,7 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     // Step 2: Wait for all cores to respond and collect core type information
     bool handshake_failed = false;
     for (int i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_hanks[i];
+        Handshake* hank = &all_handshakes[i];
 
         // Wait for aicore_done signal
         while (hank->aicore_done == 0) {
@@ -371,6 +371,7 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
             physical_core_id,
             reg_addr);
 
+        // Initialize AICore registers after discovery (first round)
         if (reg_addr != 0) {
             platform_init_aicore_regs(reg_addr);
         }
@@ -548,13 +549,13 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime* runtime) {
  * Shutdown AICore - Send quit signal to all AICore kernels
  */
 int AicpuExecutor::shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores) {
-    Handshake* all_hanks = (Handshake*)runtime->workers;
+    Handshake* all_handshakes = (Handshake*)runtime->workers;
 
     LOG_INFO("Thread %d: Shutting down %d cores", thread_idx, thread_cores_num_);
 
     for (int i = 0; i < thread_cores_num_; i++) {
         int core_id = cur_thread_cores[i];
-        Handshake* hank = &all_hanks[core_id];
+        Handshake* hank = &all_handshakes[core_id];
         LOG_INFO("Thread %d: AICPU hank addr = 0x%lx", thread_idx, (uint64_t)hank);
 
         uint64_t reg_addr = core_id_to_reg_addr_[core_id];
@@ -1015,7 +1016,15 @@ int AicpuExecutor::run(Runtime* runtime) {
     return 0;
 }
 
-void AicpuExecutor::deinit() {
+void AicpuExecutor::deinit(Runtime* runtime) {
+    // === Exit cleanup: reset all inter-round state ===
+
+    // 1. Invalidate AICPU cache for Runtime address range.
+    //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
+    //    bypasses this cache. Invalidating now ensures next round reads from HBM.
+    cache_invalidate_range(runtime, sizeof(Runtime));
+
+    // === Existing reset logic ===
     ready_count_aic_.store(0, std::memory_order_release);
     ready_count_aiv_.store(0, std::memory_order_release);
 
@@ -1208,7 +1217,7 @@ extern "C" int aicpu_execute(Runtime* runtime) {
     // Last thread cleans up
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
         LOG_INFO("aicpu_execute: Last thread finished, cleaning up");
-        g_aicpu_executor.deinit();
+        g_aicpu_executor.deinit(runtime);
     }
 
     LOG_INFO("%s", "aicpu_execute: Kernel execution completed successfully");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -59,6 +59,9 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
         dcci(my_hank, SINGLE_CACHE_LINE);
     }
 
+    // Clear stale EXIT_SIGNAL from previous round before entering main loop
+    write_reg(RegId::DATA_MAIN_BASE, 0);
+
     // Phase 2: Report physical core ID and core type, signal ready
     my_hank->physical_core_id = get_physical_core_id();
     my_hank->core_type = core_type;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -127,7 +127,7 @@ struct AicpuExecutor {
     int resolve_and_dispatch_pto2(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num);
     int shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num);
     int run(Runtime* runtime);
-    void deinit();
+    void deinit(Runtime* runtime);
     void emergency_shutdown();
     void diagnose_stuck_state(Runtime* runtime, int thread_idx, const int* cur_thread_cores,
                               int core_num, Handshake* hank);
@@ -145,7 +145,7 @@ static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
  * Sets up register addresses for fast dispatch.
  */
 int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
-    Handshake* all_hanks = (Handshake*)runtime->workers;
+    Handshake* all_handshakes = (Handshake*)runtime->workers;
     cores_total_num_ = runtime->worker_count;
 
     // Validate cores_total_num_ before using as array index
@@ -162,8 +162,8 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     // Step 1: Write per-core payload addresses and send handshake signal
     // task must be written BEFORE aicpu_ready so AICore sees it after waking up
     for (int i = 0; i < cores_total_num_; i++) {
-        all_hanks[i].task = reinterpret_cast<uint64_t>(&s_pto2_payload_per_core[i]);
-        all_hanks[i].aicpu_ready = 1;
+        all_handshakes[i].task = reinterpret_cast<uint64_t>(&s_pto2_payload_per_core[i]);
+        all_handshakes[i].aicpu_ready = 1;
     }
 
     // Get platform physical cores count for validation
@@ -172,7 +172,7 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     // Step 2: Wait for all cores to respond, collect core type and register addresses
     bool handshake_failed = false;
     for (int i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_hanks[i];
+        Handshake* hank = &all_handshakes[i];
         while (hank->aicore_done == 0) {
             // Spin wait for core to respond
         }
@@ -210,7 +210,7 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
 
         core_id_to_reg_addr_[i] = reg_addr;
 
-        // Initialize AICore registers (platform-specific)
+        // Initialize AICore registers after discovery (first round)
         if (reg_addr != 0) {
             platform_init_aicore_regs(reg_addr);
         }
@@ -1231,7 +1231,15 @@ int AicpuExecutor::run(Runtime* runtime) {
     return 0;
 }
 
-void AicpuExecutor::deinit() {
+void AicpuExecutor::deinit(Runtime* runtime) {
+    // === Exit cleanup: reset all inter-round state ===
+
+    // 1. Invalidate AICPU cache for Runtime address range.
+    //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
+    //    bypasses this cache. Invalidating now ensures next round reads from HBM.
+    cache_invalidate_range(runtime, sizeof(Runtime));
+
+    // === Existing reset logic ===
     // Reset per-core dispatch timestamps and task counters
     for (int i = 0; i < RUNTIME_MAX_WORKER; i++) {
         dispatch_timestamps_[i] = 0;
@@ -1259,6 +1267,9 @@ void AicpuExecutor::deinit() {
         core_id_to_reg_addr_[i] = 0;
     }
     regs_ = 0;
+
+    // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
+    rt = nullptr;
 
     DEV_INFO("DeInit: Runtime execution state reset");
 
@@ -1394,7 +1405,7 @@ extern "C" int aicpu_execute(Runtime* runtime) {
     // Last thread cleans up
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
         DEV_INFO("aicpu_execute: Last thread finished, cleaning up");
-        g_aicpu_executor.deinit();
+        g_aicpu_executor.deinit(runtime);
     }
 
     DEV_INFO("%s", "aicpu_execute: Kernel execution completed successfully");


### PR DESCRIPTION
## Summary
- Add `cache_invalidate_range()` as platform-split function (DC CIVAC + DSB/ISB on onboard, no-op on sim) for AICPU cache coherency
- Call `cache_invalidate_range` in `AicpuExecutor::deinit(Runtime*)` to ensure next round reads fresh data from HBM
- AICore self-clears stale `EXIT_SIGNAL`: after waking from `aicpu_ready`, writes `DATA_MAIN_BASE=0` before entering dispatch loop (prevents reading leftover exit signal from previous round)

## Testing
- [x] Simulation tests pass (11/11, parallel)
- [ ] Hardware tests pass