### PR TITLE
CI: quarantine device after task failure

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -412,6 +412,8 @@ run_hw_tasks() {
                     else
                         echo "${idx}|FAIL" >> "$hw_marker"
                     fi
+                    echo "[${HW_PLATFORM}:dev${device_id}] Device quarantined after failure"
+                    break
                 fi
             done
         ) &


### PR DESCRIPTION
## Summary
- When a HW task fails on a device, the device worker now exits its loop instead of continuing to pick up new tasks
- Remaining queued work is redistributed to healthy devices
- Failed tasks are still re-enqueued for retry on other devices

## Testing
- [ ] Simulation tests pass
- [ ] Hardware tests pass