### PR TITLE
Support: add kernel binary tracking API to Runtime

### DIFF
--- a/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
@@ -305,6 +305,25 @@ int validate_runtime_impl(Runtime* runtime) {
     std::cout << "Freed " << freed_allocs << " recorded device allocation(s) and " << freed_pairs
               << " tensor-pair device pointer(s)\n";
 
+    // Cleanup kernel binaries allocated in init_runtime_impl
+    int kernel_freed = 0;
+    int kernel_count = runtime->get_registered_kernel_count();
+    for (int i = 0; i < kernel_count; i++) {
+        int func_id = runtime->get_registered_kernel_func_id(i);
+        uint64_t addr = runtime->get_function_bin_addr(func_id);
+        if (addr != 0) {
+            // Kernel binary is stored at (addr - sizeof(uint64_t))
+            void* gm_addr = reinterpret_cast<void*>(addr - sizeof(uint64_t));
+            runtime->host_api.device_free(gm_addr);
+            runtime->set_function_bin_addr(func_id, 0);
+            kernel_freed++;
+        }
+    }
+    if (kernel_freed > 0) {
+        std::cout << "Freed " << kernel_freed << " kernel binaries\n";
+    }
+    runtime->clear_registered_kernels();
+
     // Note: AICPU orchestration plugin bytes are embedded in `Runtime` and do not
     // require device_free(). (They may be overwritten next run.)
 

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
@@ -38,6 +38,9 @@ Runtime::Runtime() {
     tensor_pair_count = 0;
     device_alloc_count = 0;
 
+    // Initialize kernel binary tracking
+    registered_kernel_count_ = 0;
+
     orch_argc = 0;
     memset(orch_args, 0, sizeof(orch_args));
     memset(kernel_addrs, 0, sizeof(kernel_addrs));

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
@@ -336,6 +336,10 @@ private:
     DeviceAlloc device_allocs[RUNTIME_MAX_TENSOR_PAIRS];
     int device_alloc_count;
 
+    // Kernel binary tracking for cleanup
+    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
+    int registered_kernel_count_;
+
 public:
     /**
      * Constructor - zero-initialize all arrays
@@ -430,7 +434,19 @@ public:
             return;
         }
         kernel_addrs[func_id] = addr;
+        if (addr != 0 && registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
+            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
+        }
     }
+
+    int get_registered_kernel_count() const { return registered_kernel_count_; }
+
+    int get_registered_kernel_func_id(int index) const {
+        if (index < 0 || index >= registered_kernel_count_) return -1;
+        return registered_kernel_func_ids_[index];
+    }
+
+    void clear_registered_kernels() { registered_kernel_count_ = 0; }
 
     /**
      * Get initially ready tasks (fanin == 0) as entry point for execution

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -208,6 +208,22 @@ int validate_runtime_impl(Runtime *runtime) {
     }
     LOG_INFO("Freed %d device tensors", tensor_pair_count);
 
+    // Cleanup kernel binaries
+    int kernel_count = runtime->get_registered_kernel_count();
+    for (int i = 0; i < kernel_count; i++) {
+        int func_id = runtime->get_registered_kernel_func_id(i);
+        uint64_t addr = runtime->get_function_bin_addr(func_id);
+        if (addr != 0) {
+            void* gm_addr = reinterpret_cast<void*>(addr - sizeof(uint64_t));
+            runtime->host_api.device_free(gm_addr);
+            runtime->set_function_bin_addr(func_id, 0);
+        }
+    }
+    if (kernel_count > 0) {
+        LOG_INFO("Freed %d kernel binaries", kernel_count);
+    }
+    runtime->clear_registered_kernels();
+
     // Clear tensor pairs
     runtime->clear_tensor_pairs();
 

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -35,6 +35,9 @@ Runtime::Runtime() {
     sche_cpu_num = 1;
     tensor_pair_count = 0;
 
+    // Initialize kernel binary tracking
+    registered_kernel_count_ = 0;
+
     // Initialize function address mapping
     for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
         func_id_to_addr_[i] = 0;

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -208,6 +208,10 @@ private:
     // Function address mapping (for API compatibility with rt2)
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
+    // Kernel binary tracking for cleanup
+    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
+    int registered_kernel_count_;
+
 public:
     /**
      * Constructor - zero-initialize all arrays
@@ -355,8 +359,20 @@ public:
     void set_function_bin_addr(int func_id, uint64_t addr) {
         if (func_id >= 0 && func_id < RUNTIME_MAX_FUNC_ID) {
             func_id_to_addr_[func_id] = addr;
+            if (addr != 0 && registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
+                registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
+            }
         }
     }
+
+    int get_registered_kernel_count() const { return registered_kernel_count_; }
+
+    int get_registered_kernel_func_id(int index) const {
+        if (index < 0 || index >= registered_kernel_count_) return -1;
+        return registered_kernel_func_ids_[index];
+    }
+
+    void clear_registered_kernels() { registered_kernel_count_ = 0; }
 
     // =========================================================================
     // Host API (host-only, not copied to device)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -410,6 +410,22 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     }
     LOG_INFO("Freed %d device allocations", tensor_pair_count);
 
+    // Cleanup kernel binaries
+    int kernel_count = runtime->get_registered_kernel_count();
+    for (int i = 0; i < kernel_count; i++) {
+        int func_id = runtime->get_registered_kernel_func_id(i);
+        uint64_t addr = runtime->get_function_bin_addr(func_id);
+        if (addr != 0) {
+            void* gm_addr = reinterpret_cast<void*>(addr - sizeof(uint64_t));
+            runtime->host_api.device_free(gm_addr);
+            runtime->set_function_bin_addr(func_id, 0);
+        }
+    }
+    if (kernel_count > 0) {
+        LOG_INFO("Freed %d kernel binaries", kernel_count);
+    }
+    runtime->clear_registered_kernels();
+
     // Clear tensor pairs
     runtime->clear_tensor_pairs();
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -40,6 +40,9 @@ Runtime::Runtime() {
     // Initialize device orchestration SO binary
     device_orch_so_size_ = 0;
 
+    // Initialize kernel binary tracking
+    registered_kernel_count_ = 0;
+
     // Initialize function address mapping
     for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
         func_id_to_addr_[i] = 0;
@@ -131,7 +134,23 @@ uint64_t Runtime::get_function_bin_addr(int func_id) const {
 void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
     if (func_id >= 0 && func_id < RUNTIME_MAX_FUNC_ID) {
         func_id_to_addr_[func_id] = addr;
+        if (addr != 0 && registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
+            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
+        }
     }
+}
+
+int Runtime::get_registered_kernel_count() const {
+    return registered_kernel_count_;
+}
+
+int Runtime::get_registered_kernel_func_id(int index) const {
+    if (index < 0 || index >= registered_kernel_count_) return -1;
+    return registered_kernel_func_ids_[index];
+}
+
+void Runtime::clear_registered_kernels() {
+    registered_kernel_count_ = 0;
 }
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -161,6 +161,10 @@ private:
     TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
     int tensor_pair_count;
 
+    // Kernel binary tracking for cleanup
+    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
+    int registered_kernel_count_;
+
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
     void* pto2_gm_sm_ptr_;  // GM pointer to PTO2 shared memory (device)
@@ -239,6 +243,10 @@ public:
 
     uint64_t get_function_bin_addr(int func_id) const;
     void set_function_bin_addr(int func_id, uint64_t addr);
+
+    int get_registered_kernel_count() const;
+    int get_registered_kernel_func_id(int index) const;
+    void clear_registered_kernels();
 
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)


### PR DESCRIPTION
## Summary
- Add `registered_kernel_func_ids_[]` + `registered_kernel_count_` to all 3 Runtime variants for tracking which kernels were registered
- Tracking is done automatically inside `set_function_bin_addr()` when `addr != 0`, eliminating the need for separate record calls
- Update `validate_runtime_impl` to use this tracking to free kernel binaries symmetrically with init

Previously kernel binaries were tracked via `tensor_pairs` (wrong — those are for user arguments needing copy-back) or by scanning all `RUNTIME_MAX_FUNC_ID` slots (inefficient).

## Testing
- [ ] Simulation tests pass (`./ci.sh -p a2a3sim`)
- [ ] Hardware tests pass (`./ci.sh -p a2a3 -d 4-7 --parallel`)