### PR TITLE
Fix: enforce aarch64-first guard order in cross-platform macros

### DIFF
--- a/.claude/rules/codestyle.md
+++ b/.claude/rules/codestyle.md
@@ -17,3 +17,13 @@
 3. Prefer `volatile` decorator on struct members rather than volatile pointer casts unless necessary.
 4. Avoid using pointer arithmetic with hardcoded offsets when `offsetof` is available.
 5. **Never use `std::this_thread::yield()` or `sched_yield()` in AICPU spin-wait loops.** On the Ascend AICPU, yielding to the OS scheduler introduces unacceptable latency for tight spin-waits (ticket locks, CAS retries, etc.). Use an empty loop body or a bare architecture hint (`__asm__ volatile("yield")`) instead.
+6. **For cross-platform/platform-isolation preprocessor blocks, place the `__aarch64__` branch first.** Use this ordering pattern:
+    ```cpp
+    #if defined(__aarch64__)
+    // aarch64 path (must be first)
+    #elif defined(__x86_64__)
+    // x86_64 path
+    #else
+    // other platforms
+    #endif
+    ```

--- a/README.md
+++ b/README.md
@@ -322,6 +322,21 @@ host_binary = compiler.compile("host", include_dirs, source_dirs)        # → .
 
 Each component is compiled independently with its own toolchain, allowing modular development.
 
+### Cross-platform Platform-Isolation Requirement
+
+When preprocessor guards are used to isolate platform code paths, the `__aarch64__`
+block must be placed at the very beginning of the conditional chain.
+
+```cpp
+#if defined(__aarch64__)
+// aarch64 path (must be first)
+#elif defined(__x86_64__)
+// x86_64 host simulation path
+#else
+// other platforms
+#endif
+```
+
 ## Usage
 
 ### Quick Start - Python Example

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -41,10 +41,11 @@
 // scheduler give time slices to threads doing real work (e.g., kernel execution),
 // preventing starvation-induced timeouts on resource-constrained CI runners.
 #include <sched.h>
-#if defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
-#elif defined(__aarch64__)
+
+#if defined(__aarch64__)
 #define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#elif defined(__x86_64__)
+#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif

--- a/src/a2a3/platform/sim/aicpu/spin_hint.h
+++ b/src/a2a3/platform/sim/aicpu/spin_hint.h
@@ -18,10 +18,10 @@
 
 #include <sched.h>
 
-#if defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
-#elif defined(__aarch64__)
+#if defined(__aarch64__)
 #define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#elif defined(__x86_64__)
+#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif


### PR DESCRIPTION
- Reorder SPIN_WAIT_HINT preprocessor guards in simulation headers so __aarch64__ is checked before __x86_64__ in order to avoid the misdefinition of host platform macros during cross-platform compilation in Bisheng CCEC.
- Document the same ordering rule in README and codestyle rules.