### PR TITLE
Fix: x86 host compile error

### DIFF
--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -71,7 +71,7 @@ target_include_directories(host_runtime
         ${ASCEND_HOME_PATH}/pkg_inc
         ${ASCEND_HOME_PATH}/pkg_inc/runtime
         ${ASCEND_HOME_PATH}/pkg_inc/profiling
-        ${ASCEND_HOME_PATH}/aarch64-linux/include/driver
+        ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/include/driver
 )
 
 target_link_directories(host_runtime

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/build_config.py
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/build_config.py
@@ -13,7 +13,7 @@
 BUILD_CONFIG = {
     "aicore": {
         "include_dirs": ["runtime"],
-        "source_dirs": ["aicore", "runtime", "orchestration"]
+        "source_dirs": ["aicore", "orchestration"]
     },
     "aicpu": {
         "include_dirs": ["runtime"],


### PR DESCRIPTION
- Remove unnecessary runtime for compiling aicore
- Remove use x86 cann for header file