### PR TITLE
Refactor: move per-run cleanup into run() and remove clean_cache()

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -383,6 +383,10 @@ int DeviceRunner::run(Runtime& runtime,
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServerInit", 1);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (init) failed: %d", rc);
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
         kernel_args_.finalize_runtime_args();
         return rc;
     }
@@ -392,6 +396,10 @@ int DeviceRunner::run(Runtime& runtime,
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", launch_aicpu_num);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
         kernel_args_.finalize_runtime_args();
         return rc;
     }
@@ -401,6 +409,10 @@ int DeviceRunner::run(Runtime& runtime,
     rc = launch_aicore_kernel(stream_aicore_, kernel_args_.args.runtime_args);
     if (rc != 0) {
         LOG_ERROR("launch_aicore_kernel failed: %d", rc);
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
         kernel_args_.finalize_runtime_args();
         return rc;
     }
@@ -415,6 +427,10 @@ int DeviceRunner::run(Runtime& runtime,
     rc = rtStreamSynchronize(stream_aicpu_);
     if (rc != 0) {
         LOG_ERROR("rtStreamSynchronize (AICPU) failed: %d", rc);
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
         kernel_args_.finalize_runtime_args();
         return rc;
     }
@@ -423,6 +439,10 @@ int DeviceRunner::run(Runtime& runtime,
     rc = rtStreamSynchronize(stream_aicore_);
     if (rc != 0) {
         LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
         kernel_args_.finalize_runtime_args();
         return rc;
     }
@@ -433,7 +453,15 @@ int DeviceRunner::run(Runtime& runtime,
         export_swimlane_json();
     }
 
-    // Note: FinalizeRuntimeArgs is deferred to Finalize() so PrintHandshakeResults can access device data
+    // Print handshake results (reads from device memory, must be before free)
+    print_handshake_results();
+
+    // Free per-run resources
+    if (kernel_args_.args.regs != 0) {
+        mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+        kernel_args_.args.regs = 0;
+    }
+    kernel_args_.finalize_runtime_args();
 
     return 0;
 }
@@ -456,30 +484,10 @@ void DeviceRunner::print_handshake_results() {
     }
 }
 
-int DeviceRunner::clean_cache() {
-    if (stream_aicpu_ == nullptr) {
-        return 0;  // Nothing to cleanup if device not initialized
-    }
-    for (const auto& [func_id, addr] : func_id_to_addr_) {
-        void* gm_addr = reinterpret_cast<void*>(addr - sizeof(uint64_t));
-        mem_alloc_.free(gm_addr);
-    }
-    func_id_to_addr_.clear();
-
-    LOG_INFO("DeviceRunner: cache cleaned (test-specific resources only)");
-    return 0;
-}
-
 int DeviceRunner::finalize() {
     if (stream_aicpu_ == nullptr) {
         return 0;
     }
-
-    // Print handshake results before cleanup (reads from device memory)
-    print_handshake_results();
-
-    // Cleanup runtime args (deferred from Run)
-    kernel_args_.finalize_runtime_args();
 
     // Cleanup kernel args (deviceArgs)
     kernel_args_.finalize_device_args();

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -249,17 +249,6 @@ public:
     int export_swimlane_json(const std::string& output_path = "outputs");
 
     /**
-     * Clean cached resources - lightweight cleanup between tests
-     *
-     * Cleans up test-specific resources while preserving device resources for reuse:
-     * - Frees kernel memory from global memory allocator
-     * - Clears kernel address cache
-     *
-     * @return 0 on success, error code on failure
-     */
-    int clean_cache();
-
-    /**
      * Cleanup all resources
      *
      * Frees all device memory, destroys streams, and resets state.

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -194,10 +194,6 @@ int finalize_runtime(RuntimeHandle runtime) {
         Runtime* r = static_cast<Runtime*>(runtime);
         int rc = validate_runtime_impl(r);
 
-        // Clean cached resources to prepare for next test
-        DeviceRunner& runner = DeviceRunner::get();
-        runner.clean_cache();
-        
         // Call destructor (user will call free())
         r->~Runtime();
         return rc;

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -303,6 +303,9 @@ int DeviceRunner::run(Runtime& runtime,
         export_swimlane_json();
     }
 
+    // Print handshake results at end of run
+    print_handshake_results();
+
     return 0;
 }
 
@@ -322,38 +325,11 @@ void DeviceRunner::print_handshake_results() {
     }
 }
 
-int DeviceRunner::clean_cache() {
-    // Skip if not initialized
-    if (device_id_ == -1) {
-        return 0;
-    }
-
-    // Only cleanup test-specific resources:
-
-    // 1. Close dlopen'd kernel libraries (different tests may have different kernels)
-    for (auto& pair : func_id_to_addr_) {
-        MappedKernel& kernel = pair.second;
-        if (kernel.dl_handle != nullptr) {
-            dlclose(kernel.dl_handle);
-            LOG_DEBUG("Closed dlopen kernel: func_id=%d", pair.first);
-            kernel.dl_handle = nullptr;
-            kernel.func_addr = 0;
-        }
-    }
-    func_id_to_addr_.clear();
-
-    LOG_INFO("DeviceRunner(sim): cache cleaned (test-specific resources only)");
-    return 0;
-}
-
 int DeviceRunner::finalize() {
     // Skip if already finalized
     if (device_id_ == -1 && aicpu_so_handle_ == nullptr && aicore_so_handle_ == nullptr) {
         return 0;
     }
-
-    // Print handshake results before cleanup
-    print_handshake_results();
 
     // Cleanup performance profiling
     if (perf_collector_.is_initialized()) {

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -157,17 +157,6 @@ public:
     int export_swimlane_json(const std::string& output_path = "outputs");
 
     /**
-     * Clean cached resources - lightweight cleanup between tests
-     *
-     * Cleans up test-specific resources while preserving device resources for reuse:
-     * - Closes dlopen'd kernel libraries (different tests may have different kernels)
-     * - Clears kernel address cache
-     *
-     * @return 0 on success, error code on failure
-     */
-    int clean_cache();
-
-    /**
      * Cleanup all resources
      *
      * Use this for final cleanup when no more tests will run.

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -197,13 +197,6 @@ int finalize_runtime(RuntimeHandle runtime) {
         Runtime* r = static_cast<Runtime*>(runtime);
         int rc = validate_runtime_impl(r);
 
-        // Clean cached resources before finalization
-        DeviceRunner& runner = DeviceRunner::get();
-        runner.clean_cache();
-
-        // Finalize DeviceRunner (clears last_runtime_ to avoid dangling pointer)
-        runner.finalize();
-
         // Call destructor (user will call free())
         r->~Runtime();
         return rc;


### PR DESCRIPTION
## Summary
- Move `print_handshake_results` + `finalize_runtime_args` + regs cleanup from `finalize()` to end of `run()`, so per-run resources are freed immediately after each run
- Add regs cleanup on all error paths in `run()` (onboard)
- Remove `DeviceRunner::clean_cache()` method and its call sites — kernel tracking is moving to the Runtime layer

## Test plan
- [ ] Run simulation tests (`./ci.sh -p a2a3sim`)
- [ ] Run hardware tests (`./ci.sh -p a2a3 -d 4-7 --parallel`)