### PR TITLE
fix(sim): fix profiling dispatch/finish timestamps always being zero in a2a3sim

### DIFF
--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -20,11 +20,16 @@
 #define __aicore__
 #endif
 
-// dcci (Data Cache Clean and Invalidate) - acquire fence in simulation
-// Hardware dcci invalidates cache to ensure fresh reads from shared memory.
-// In simulation, an acquire fence provides the equivalent ordering guarantee.
+// dcci (Data Cache Clean and Invalidate) - full fence in simulation
+// Hardware dcci has two roles:
+//   - without CACHELINE_OUT: invalidate (read from memory) -> acquire semantics
+//   - with CACHELINE_OUT: write-back/flush (write to memory) -> release semantics
+// On aarch64, acquire-only fences do NOT prevent store-store reordering across the
+// barrier, so using acquire for the flush direction causes a race: the AICPU can
+// observe the COND register FIN signal before perf_buf->count is visible.
+// Using seq_cst (dmb ish / full barrier) covers both directions safely.
 // Use variadic macro to support both 2-arg and 3-arg calls.
-#define dcci(...) std::atomic_thread_fence(std::memory_order_acquire)
+#define dcci(...) std::atomic_thread_fence(std::memory_order_seq_cst)
 
 // Cache coherency constants (no-op in simulation)
 #define ENTIRE_DATA_CACHE 0

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -28,10 +28,20 @@
 #include "aicpu/performance_collector_aicpu.h"
 // Weak fallback for builds that don't link device_time.cpp (e.g. host).
 // The strong symbol from platform/.../device_time.cpp wins in the AICPU build.
-__attribute__((weak)) uint64_t get_sys_cnt_aicpu() { return 0; }
+//
+// IMPORTANT: visibility("hidden") is required to prevent the HOST .so from
+// exporting this weak fallback into the global dynamic symbol table via
+// RTLD_GLOBAL. Without it, when the AICPU .so is loaded and its PLT entry
+// for get_sys_cnt_aicpu is resolved, the dynamic linker finds the HOST .so's
+// weak definition first (already in global table) and uses it — returning 0.
+// With hidden visibility, the HOST .so does not export this symbol globally,
+// so the AICPU .so's PLT resolves to its own strong definition from
+// device_time.cpp.
+__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
 // Weak fallback for builds that don't link performance_collector_aicpu.cpp.
 // The strong symbol from the AICPU build wins when profiling is available.
-__attribute__((weak)) void perf_aicpu_record_orch_phase(
+// Also hidden to prevent HOST .so from polluting the global symbol table.
+__attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
     AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
 // Accumulated nanoseconds per sub-step
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync


### PR DESCRIPTION
## Problem

In `a2a3sim`, `dispatch_time` and `finish_time` in profiling records were
always `0`, making performance analysis impossible. All other call sites of
`get_sys_cnt_aicpu()` worked correctly; only the profiling timestamps inside
the AICPU executor were affected.

## Root Cause

Two separate issues were identified:

### 1. ELF symbol interposition (primary cause)

`libhost_runtime.so` is loaded first via Python `ctypes.CDLL(..., RTLD_GLOBAL)`,
which places all its exported symbols into the process-wide dynamic symbol table.
`pto_orchestrator.cpp` contains a weak fallback definition of `get_sys_cnt_aicpu()`
that returns `0` — this was exported as a globally visible weak symbol.

When `libaicpu_kernel.so` is subsequently loaded with `RTLD_NOW | RTLD_GLOBAL`,
its PLT entries for `get_sys_cnt_aicpu` are resolved by the dynamic linker, which
finds the HOST `.so`'s weak symbol first (already in the global table) and uses it
instead of the AICPU `.so`'s own strong definition in `device_time.cpp`.

**Fix:** Add `visibility("hidden")` to both weak fallbacks in `pto_orchestrator.cpp`.
This prevents HOST `.so` from exporting these symbols globally. The AICPU `.so`'s
internal calls then bypass the PLT entirely and bind directly to the strong local
definition.

### 2. Insufficient memory fence in `dcci()` simulation macro (secondary cause)

The `dcci()` macro in `sim/aicore/inner_kernel.h` used
`std::atomic_thread_fence(std::memory_order_acquire)`, which lowers to
`dmb ishld` on AArch64 — a load-only barrier that does **not** prevent
store-store reordering.

The flush path in `perf_aicore_record_task` calls `dcci(..., CACHELINE_OUT)`
after writing `perf_buf->count`. Without a full barrier, the AICPU could
observe the FIN register signal before the updated `count` is visible, causing
the AICPU executor to miss the record.

**Fix:** Change to `std::memory_order_seq_cst` (`dmb ish` — full barrier),
which covers both load and store ordering.