### PR TITLE
Add: fine-grained BGEMM benchmark with configurable incore task granularity

### DIFF
--- a/tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/golden.py
@@ -1,0 +1,162 @@
+"""
+Golden test specification for BGEMM (tensormap_and_ringbuffer Runtime).
+
+Computation: C = A @ B (tiled matrix multiplication)
+Configuration controlled by ALL_CASES parameters:
+  - matmul_add_task_num: number of matmul/add tasks (each matmul has a corresponding add)
+  - incore_task_granularity: dict with incore_data_size (tile size) and incore_loop
+  - grid_k: number of K-dimension partitions
+  - num_groups = matmul_add_task_num / grid_k
+
+Args layout: [ptr_A, ptr_B, ptr_C, ptr_config, size_A, size_B, size_C]
+"""
+
+import ctypes
+import torch
+
+__outputs__ = ["C"]
+RTOL = 1e-3
+ATOL = 1e-3
+
+# Supported tile sizes must match the switch-case in kernel_gemm_tile.cpp (AIC)
+# and kernel_tile_add.cpp (AIV), which only instantiate templates for these values.
+SUPPORTED_INCORE_DATA_SIZES = {16, 32, 64, 128}
+
+ALL_CASES = {
+    "Case1": {
+        "matmul_add_task_num": 64,
+        "incore_task_granularity": {
+            "incore_data_size": 128,
+            "incore_loop": 4,
+        },
+        "grid_k": 2,
+    },
+    "Case2": {
+        "matmul_add_task_num": 256,
+        "incore_task_granularity": {
+            "incore_data_size": 128,
+            "incore_loop": 4,
+        },
+        "grid_k": 2,
+    },
+    "Case3": {
+        "matmul_add_task_num": 64,
+        "incore_task_granularity": {
+            "incore_data_size": 128,
+            "incore_loop": 16,
+        },
+        "grid_k": 2,
+    },
+    "Case4": {
+        "matmul_add_task_num": 64,
+        "incore_task_granularity": {
+            "incore_data_size": 128,
+            "incore_loop": 4,
+        },
+        "grid_k": 4,
+    },
+}
+
+DEFAULT_CASE = "Case1"
+
+
+def generate_inputs(params: dict) -> list:
+    """Generate input tensors with tile-first memory layout."""
+    granularity = params["incore_task_granularity"]
+    tile_size = granularity["incore_data_size"]
+    incore_loop = granularity["incore_loop"]
+    matmul_add_task_num = params["matmul_add_task_num"]
+    grid_k = params["grid_k"]
+
+    # --- constraint checks ---
+    if tile_size not in SUPPORTED_INCORE_DATA_SIZES:
+        raise ValueError(
+            f"incore_data_size={tile_size} is not supported. "
+            f"Must be one of {sorted(SUPPORTED_INCORE_DATA_SIZES)}."
+        )
+    if incore_loop <= 0:
+        raise ValueError(f"incore_loop must be positive, got {incore_loop}")
+    if grid_k <= 0:
+        raise ValueError(f"grid_k must be positive, got {grid_k}")
+    if matmul_add_task_num % grid_k != 0:
+        raise ValueError(
+            f"matmul_add_task_num ({matmul_add_task_num}) must be "
+            f"divisible by grid_k ({grid_k})."
+        )
+
+    num_groups = matmul_add_task_num // grid_k
+
+    A = torch.randn(incore_loop * num_groups, grid_k, tile_size, tile_size, dtype=torch.float32) * 0.01
+    B = torch.randn(incore_loop * num_groups, grid_k, tile_size, tile_size, dtype=torch.float32) * 0.01
+    C = torch.zeros(incore_loop * num_groups, tile_size, tile_size, dtype=torch.float32)
+
+    # Reshape A/B to [num_groups, grid_k, incore_loop, tile_size, tile_size]
+    # so that incore_loop tiles are contiguous for each (group, k_idx)
+    A = A.reshape(num_groups, incore_loop, grid_k, tile_size, tile_size)
+    A = A.permute(0, 2, 1, 3, 4).contiguous()  # [num_groups, grid_k, incore_loop, tile_size, tile_size]
+    B = B.reshape(num_groups, incore_loop, grid_k, tile_size, tile_size)
+    B = B.permute(0, 2, 1, 3, 4).contiguous()
+
+    config = torch.tensor([tile_size, grid_k, num_groups, incore_loop], dtype=torch.int64)
+
+    A_flat = A.flatten()
+    B_flat = B.flatten()
+    C_flat = C.flatten()
+
+    return [
+        ("A", A_flat),
+        ("B", B_flat),
+        ("C", C_flat),
+        ("config", config),
+        ("size_A", ctypes.c_int64(A_flat.nbytes)),
+        ("size_B", ctypes.c_int64(B_flat.nbytes)),
+        ("size_C", ctypes.c_int64(C_flat.nbytes)),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute golden result: C[i] = sum(k) A[i,k] @ B[i,k]."""
+    granularity = params["incore_task_granularity"]
+    tile_size = granularity["incore_data_size"]
+    incore_loop = granularity["incore_loop"]
+    grid_k = params["grid_k"]
+    num_groups = params["matmul_add_task_num"] // grid_k
+
+    # A/B layout: [num_groups, grid_k, incore_loop, tile_size, tile_size]
+    A = torch.as_tensor(tensors["A"]).reshape(num_groups, grid_k, incore_loop, tile_size, tile_size)
+    B = torch.as_tensor(tensors["B"]).reshape(num_groups, grid_k, incore_loop, tile_size, tile_size)
+    C = torch.as_tensor(tensors["C"]).reshape(incore_loop * num_groups, tile_size, tile_size)
+
+    C[:] = 0.0
+
+    for group in range(num_groups):
+        for k_idx in range(grid_k):
+            for i in range(incore_loop):
+                batch = group * incore_loop + i
+                C[batch] += torch.matmul(A[group, k_idx, i], B[group, k_idx, i])
+
+    tensors["C"][:] = C.flatten()
+
+
+if __name__ == "__main__":
+    params = {"name": DEFAULT_CASE, **ALL_CASES[DEFAULT_CASE]}
+    result = generate_inputs(params)
+    tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
+    compute_golden(tensors, params)
+
+    granularity = params["incore_task_granularity"]
+    tile_size = granularity["incore_data_size"]
+    incore_loop = granularity["incore_loop"]
+    grid_k = params["grid_k"]
+    num_groups = params["matmul_add_task_num"] // grid_k
+
+    print(f"=== BGEMM Golden Test ({params['name']}) ===")
+    print(f"matmul_add_task_num={params['matmul_add_task_num']}")
+    print(f"incore_task_granularity={granularity}")
+    print(f"grid_k={grid_k}, num_groups={num_groups}")
+
+    C = tensors["C"].reshape(incore_loop * num_groups, tile_size, tile_size)
+    print(f"Output shape: {C.shape}")
+    print(f"Output range: [{C.min():.4f}, {C.max():.4f}]")
+    print(f"Output mean: {C.mean():.4f}")
+    print("Golden test passed!")

--- a/tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -1,0 +1,134 @@
+/**
+ * Tile-based Matrix Multiplication Kernel (Cube Core)
+ *
+ * Computes: output = input_a @ input_b (tile_size x tile_size tile matmul)
+ * Uses TMATMUL instruction
+ *
+ * Tile size is determined by golden.py configuration and passed through
+ * tensor shapes from orchestration.
+ *
+ * Args (TensorData*):
+ *   args[0] = input_a (INPUT)
+ *   args[1] = input_b (INPUT)
+ *   args[2] = output  (OUTPUT)
+ *   args[3] = config  (INPUT) - int64_t[4]: [tile_size, grid_k, num_groups, incore_loop]
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <typename T>
+AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
+    if (num_2 == 0) {
+        return 0;
+    }
+    return (num_1 + num_2 - 1) / num_2 * num_2;
+}
+
+template <int TILE>
+static __aicore__ void gemm_tile_impl(
+    __gm__ float* input_a,
+    __gm__ float* input_b,
+    __gm__ float* output) {
+
+    constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
+    constexpr int M = CeilAlign<int>(TILE, 16);
+    constexpr int K = CeilAlign<int>(TILE, blockAlign);
+    constexpr int N = CeilAlign<int>(TILE, blockAlign);
+
+    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+
+    GlobalDataA src0Global(input_a);
+    GlobalDataB src1Global(input_b);
+    GlobalDataC dstGlobal(output);
+
+    using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+
+    using LeftTile = TileLeft<float, M, K, TILE, TILE>;
+    using RightTile = TileRight<float, K, N, TILE, TILE>;
+    using AccTile = TileAcc<float, M, N, TILE, TILE>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    TLOAD(aMatTile, src0Global);
+    TLOAD(bMatTile, src1Global);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(dstGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* input_a = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* input_b = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* output  = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    __gm__ TensorData* config  = reinterpret_cast<__gm__ TensorData*>(args[3]);
+
+    __gm__ int64_t* cfg = reinterpret_cast<__gm__ int64_t*>(config->buffer.addr);
+    uint64_t tile_size = static_cast<uint64_t>(cfg[0]);
+    uint64_t tile_elems = tile_size * tile_size;
+    int num_tiles = static_cast<uint64_t>(cfg[3]);
+
+    __gm__ float* base_a = reinterpret_cast<__gm__ float*>(input_a->buffer.addr) + input_a->start_offset;
+    __gm__ float* base_b = reinterpret_cast<__gm__ float*>(input_b->buffer.addr) + input_b->start_offset;
+    __gm__ float* base_c = reinterpret_cast<__gm__ float*>(output->buffer.addr) + output->start_offset;
+
+    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        __gm__ float* a_ptr = base_a + (tile_idx * tile_elems);
+        __gm__ float* b_ptr = base_b + (tile_idx * tile_elems);
+        __gm__ float* c_ptr = base_c + (tile_idx * tile_elems);
+
+        switch (tile_size) {
+            case 16:  gemm_tile_impl<16>(a_ptr, b_ptr, c_ptr);  break;
+            case 32:  gemm_tile_impl<32>(a_ptr, b_ptr, c_ptr);  break;
+            case 64:  gemm_tile_impl<64>(a_ptr, b_ptr, c_ptr);  break;
+            case 128: gemm_tile_impl<128>(a_ptr, b_ptr, c_ptr); break;
+            default: break;
+        }
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -1,0 +1,90 @@
+/**
+ * Tile-based Element-wise Addition Kernel (Vector Core) - INOUT Pattern
+ *
+ * Computes: C_tile = C_tile + P (tile_size x tile_size tile accumulation)
+ * Uses TADD instruction
+ *
+ * Tile size is determined by golden.py configuration and passed through
+ * tensor shapes from orchestration.
+ *
+ * Args (TensorData*):
+ *   args[0] = C_tile (INOUT: read + write accumulator)
+ *   args[1] = P      (INPUT: matmul result to accumulate)
+ *   args[2] = config (INPUT) - int64_t[4]: [tile_size, grid_k, num_groups, incore_loop]
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int TILE>
+static __aicore__ void tile_add_impl(
+    __gm__ float* c_ptr,
+    __gm__ float* p_ptr) {
+
+    using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
+    using DynStridDim5 = Stride<1, 1, 1, TILE, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, TILE, TILE, BLayout::RowMajor, -1, -1>;
+
+    TileData cTile(TILE, TILE);
+    TileData pTile(TILE, TILE);
+    TileData outTile(TILE, TILE);
+    TASSIGN(cTile, 0x0);
+    TASSIGN(pTile, 0x10000);
+    TASSIGN(outTile, 0x20000);
+
+    GlobalData cGlobal(c_ptr);
+    GlobalData pGlobal(p_ptr);
+    GlobalData outGlobal(c_ptr);  // write back to same C location
+
+    TLOAD(cTile, cGlobal);
+    TLOAD(pTile, pGlobal);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(outTile, cTile, pTile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(outGlobal, outTile);
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* c_tensor = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* p_tensor = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* config   = reinterpret_cast<__gm__ TensorData*>(args[2]);
+
+    __gm__ int64_t* cfg = reinterpret_cast<__gm__ int64_t*>(config->buffer.addr);
+    uint64_t tile_size = static_cast<uint64_t>(cfg[0]);
+    uint64_t tile_elems = tile_size * tile_size;
+    int num_tiles = static_cast<int>(cfg[3]);
+
+    __gm__ float* base_c = reinterpret_cast<__gm__ float*>(c_tensor->buffer.addr) + c_tensor->start_offset;
+    __gm__ float* base_p = reinterpret_cast<__gm__ float*>(p_tensor->buffer.addr) + p_tensor->start_offset;
+
+    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        __gm__ float* c_ptr = base_c + (tile_idx * tile_elems);
+        __gm__ float* p_ptr = base_p + (tile_idx * tile_elems);
+
+        switch (tile_size) {
+            case 16:  tile_add_impl<16>(c_ptr, p_ptr);  break;
+            case 32:  tile_add_impl<32>(c_ptr, p_ptr);  break;
+            case 64:  tile_add_impl<64>(c_ptr, p_ptr);  break;
+            case 128: tile_add_impl<128>(c_ptr, p_ptr); break;
+            default: break;
+        }
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/kernels/kernel_config.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/kernels/kernel_config.py
@@ -1,0 +1,35 @@
+"""
+Kernel configuration for BGEMM (tensormap_and_ringbuffer Runtime).
+
+Cube core (AIC) for matrix multiplication, Vector core (AIV) for element-wise addition.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "bgemm_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "GEMM",
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_gemm_tile.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "ADD",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_tile_add.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 24,
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -1,0 +1,148 @@
+/**
+ * BGEMM Orchestration Function (tensormap_and_ringbuffer Runtime)
+ *
+ * Builds the task graph for tiled matrix multiplication: C = A @ B
+ *
+ * Configuration read from config tensor (set in golden.py):
+ *   - tile_size: tile dimension (tile_size x tile_size per tile)
+ *   - grid_k: number of K-dimension partitions
+ *   - num_groups: number of independent groups (= matmul_add_task_num / grid_k)
+ *   - incore_loop: number of tiles per group
+ *
+ * Memory layout (tile-first, flattened):
+ *   A: [num_groups, grid_k, incore_loop, tile_size, tile_size]
+ *   B: [num_groups, grid_k, incore_loop, tile_size, tile_size]
+ *   C: [incore_loop * num_groups, tile_size, tile_size]
+ *
+ * Task graph per group:
+ *   for k in [0, grid_k):
+ *     P[0..incore_loop-1] = A[group,k,0..incore_loop-1] @ B[group,k,0..incore_loop-1]
+ *     C[group*incore_loop..] += P[0..incore_loop-1]
+ *
+ * Dependencies are automatic via TensorMap overlap detection.
+ *
+ * This file compiles as a standalone .so with zero runtime link dependencies.
+ * All runtime calls go through the PTO2RuntimeOps function-pointer table.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_GEMM_TILE 0
+#define FUNC_TILE_ADD  1
+
+// Args layout: [ptr_A, ptr_B, ptr_C, ptr_config, size_A, size_B, size_C]
+#define ARG_PTR_A      0
+#define ARG_PTR_B      1
+#define ARG_PTR_C      2
+#define ARG_PTR_CONFIG 3
+#define ARG_SIZE_A     4
+#define ARG_SIZE_B     5
+#define ARG_SIZE_C     6
+
+extern "C" {
+
+__attribute__((visibility("default")))
+PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count) {
+    (void)args;
+    (void)arg_count;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 7,
+    };
+}
+
+__attribute__((visibility("default")))
+void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
+    (void)arg_count;
+    pto2_rt_init_tensor_pool(rt);
+
+    void* dev_A = (void*)(uintptr_t)args[ARG_PTR_A];
+    void* dev_B = (void*)(uintptr_t)args[ARG_PTR_B];
+    void* dev_C = (void*)(uintptr_t)args[ARG_PTR_C];
+    void* dev_config = (void*)(uintptr_t)args[ARG_PTR_CONFIG];
+    size_t size_A = (size_t)args[ARG_SIZE_A];
+    size_t size_B = (size_t)args[ARG_SIZE_B];
+    size_t size_C = (size_t)args[ARG_SIZE_C];
+
+    // Read config from golden.py
+    int64_t* host_config = (int64_t*)(uintptr_t)args[ARG_PTR_CONFIG];
+    int tile_size = (int)host_config[0];
+    int grid_k = (int)host_config[1];
+    int num_groups = (int)host_config[2];
+    int incore_loop = (int)host_config[3];
+    uint64_t tile_elems = (uint64_t)tile_size * tile_size;
+
+    int grid_m = 1;
+    int grid_n = 1;
+
+    LOG_INFO(rt, "[bgemm_orch] tile_size: %d, grid_m: %d, grid_n: %d, grid_k: %d, num_groups: %d, incore_loop: %d",
+             tile_size, grid_m, grid_n, grid_k, num_groups, incore_loop);
+
+    // Create 1D external tensors for the full A, B, C arrays
+    uint64_t ext_A_shapes[1] = {size_A / sizeof(float)};
+    Tensor ext_A = make_tensor_external(dev_A, ext_A_shapes, 1, DataType::FLOAT32);
+    uint64_t ext_B_shapes[1] = {size_B / sizeof(float)};
+    Tensor ext_B = make_tensor_external(dev_B, ext_B_shapes, 1, DataType::FLOAT32);
+    uint64_t ext_C_shapes[1] = {size_C / sizeof(float)};
+    Tensor ext_C = make_tensor_external(dev_C, ext_C_shapes, 1, DataType::FLOAT32);
+
+    // Wrap config as a device tensor so AICore kernels can read tile_size directly
+    uint64_t config_shapes[1] = {4};  // [tile_size, grid_k, num_groups, incore_loop]
+    Tensor ext_config = make_tensor_external(dev_config, config_shapes, 1, DataType::INT64);
+
+    uint64_t tile_shapes[1] = {tile_elems};
+    uint64_t group_tile_elems = (uint64_t)incore_loop * tile_elems;
+    uint64_t group_shapes[1] = {group_tile_elems};
+
+    int total_gemm = 0;
+    int total_add = 0;
+
+    // A/B layout: [num_groups, grid_k, incore_loop, tile_size, tile_size]
+    // C layout:   [incore_loop * num_groups, tile_size, tile_size]
+    for (int group_idx = 0; group_idx < num_groups; group_idx++) {
+        PTO2_SCOPE(rt) {
+            uint64_t c_elem_offset = (uint64_t)group_idx * group_tile_elems;
+            uint64_t c_view_offsets[1] = {c_elem_offset};
+            Tensor C_view = ext_C.view(group_shapes, c_view_offsets);
+
+            for (int k_idx = 0; k_idx < grid_k; k_idx++) {
+                // In layout [num_groups, grid_k, incore_loop, tile_size, tile_size],
+                // offset = (group_idx * grid_k + k_idx) * incore_loop * tile_elems
+                uint64_t ab_offset =
+                    ((uint64_t)group_idx * grid_k + (uint64_t)k_idx) * group_tile_elems;
+
+                uint64_t a_view_offsets[1] = {ab_offset};
+                Tensor A_view = ext_A.view(group_shapes, a_view_offsets);
+                uint64_t b_view_offsets[1] = {ab_offset};
+                Tensor B_view = ext_B.view(group_shapes, b_view_offsets);
+                Tensor P = make_tensor(group_shapes, 1, DataType::FLOAT32);
+
+                PTOParam params_gemm[] = {
+                    make_input_param(A_view),
+                    make_input_param(B_view),
+                    make_output_param(P),
+                    make_input_param(ext_config),
+                };
+                pto2_rt_submit_task(rt, FUNC_GEMM_TILE, PTO2_WORKER_CUBE,
+                                   params_gemm, 4);
+                total_gemm++;
+
+                PTOParam params_add[] = {
+                    make_inout_param(C_view),
+                    make_input_param(P),
+                    make_input_param(ext_config),
+                };
+                pto2_rt_submit_task(rt, FUNC_TILE_ADD, PTO2_WORKER_VECTOR,
+                                   params_add, 3);
+                total_add++;
+            }
+        }
+    }
+
+    LOG_INFO(rt, "[bgemm_orch] Submitted %d gemm tasks and %d add tasks (%d total)",
+             total_gemm, total_add, total_gemm + total_add);
+}
+
+}  // extern "C"


### PR DESCRIPTION
## Summary

- Add a single-dependency BGEMM (batched GEMM) benchmark under
  `tests/device_tests/tensormap_and_ringbuffer/benchmark_bgemm/` that supports
  fine-grained control over incore task count and data size
- The task graph uses automatic dependency detection via TensorMap overlap:
  each output tile C[batch] is computed through a reduction chain
  GEMM → ADD → GEMM → ADD → ... (one chain per K-partition), making it suitable
  for benchmarking scheduler overhead and dependency resolution at varying
  granularities

## Parameter Configuration (`golden.py`)

All test cases are defined in the `ALL_CASES` dictionary. Each case has three
parameters that jointly control the incore task granularity:

| Parameter | Type | Description |
|---|---|---|
| `matmul_add_task_num` | int | Total number of matmul/add task pairs. The orchestration generates `matmul_add_task_num` GEMM tasks and `matmul_add_task_num` ADD tasks. Must be divisible by `grid_k`. |
| `incore_task_granularity.incore_data_size` | int | Tile dimension for each task. Each GEMM/ADD task operates on `incore_loop` tiles of size `(incore_data_size × incore_data_size)`. Must be one of `{16, 32, 64, 128}` (matching the compile-time template instantiations in the AIC/AIV kernels). |
| `incore_task_granularity.incore_loop` | int | Number of tiles processed per task. Each GEMM/ADD task processes `incore_loop` consecutive tiles in a loop. Must be positive. |
| `grid_k` | int | Number of K-dimension partitions per output group. Controls how many GEMM+ADD pairs contribute to each output group via reduction. |

### Derived values

- `tile_size = incore_data_size` — the square tile edge length
- `num_groups = matmul_add_task_num / grid_k` — number of independent output groups
- Total GEMM tasks = `matmul_add_task_num`
- Total ADD tasks = `matmul_add_task_num`
- Total incore tasks = `2 × matmul_add_task_num`
- Data per task = `incore_loop × incore_data_size²` elements

### Constraints

1. `matmul_add_task_num` must be evenly divisible by `grid_k`
2. `incore_data_size` must be in `{16, 32, 64, 128}` (validated at runtime)
3. `incore_loop` must be positive
4. Increasing `incore_data_size` increases per-tile data volume quadratically
   (tile elements = `incore_data_size²`)
5. Increasing `incore_loop` increases per-task data volume linearly
   (task elements = `incore_loop × incore_data_size²`)
6. Increasing `matmul_add_task_num` (with fixed `grid_k`) increases the number
   of independent output groups, adding more parallel task chains
7. Increasing `grid_k` (with fixed `matmul_add_task_num`) makes each group's
   reduction chain longer (more GEMM→ADD steps per group) while reducing
   group-level parallelism

### Example

```python
"Case1": {
    "matmul_add_task_num": 64,
    "incore_task_granularity": {
        "incore_data_size": 128,  # each tile is 128×128 floats (64 KB)
        "incore_loop": 4,         # 4 tiles per task (256 KB per task)
    },
    "grid_k": 2,                  # 2 K-partitions per output group
}
# → num_groups = 64/2 = 32 independent output groups
# → each group: 2 GEMM→ADD chains (grid_k=2), each processing 4 tiles (incore_loop=4)
# → dependency per group: GEMM(4 tiles)→ADD(4 tiles)→GEMM(4 tiles)→ADD(4 tiles)
```

### Tuning guide

| Goal | Adjust |
|---|---|
| More total tasks (stress scheduler) | Increase `matmul_add_task_num` |
| Larger per-tile data (stress memory bandwidth) | Increase `incore_data_size` |
| Larger per-task data (stress task granularity) | Increase `incore_loop` |
| Longer dependency chains (stress serial latency) | Increase `grid_k` with fixed `matmul_add_task_num` |
| More parallelism (stress concurrent dispatch) | Decrease `grid_k` with fixed `matmul_add_task_num` |

### Test Cases

Four cases demonstrate different granularity configurations:

| Case | matmul_add_task_num | incore_data_size | incore_loop | grid_k | Effect |
|------|---------------------|------------------|-------------|--------|--------|
| Case1 | 64 | 128 | 4 | 2 | Baseline: 32 groups, 2 chains/group, 4 tiles/task |
| Case2 | 256 | 128 | 4 | 2 | 4× task count: 128 groups, same chain depth |
| Case3 | 64 | 128 | 16 | 2 | 4× tiles per task: same groups, larger tasks |
| Case4 | 64 | 128 | 4 | 4 | 2× chain depth: 16 groups, longer chains |

## Implementation

### Memory Layout

```
A: [num_groups, grid_k, incore_loop, tile_size, tile_size]
B: [num_groups, grid_k, incore_loop, tile_size, tile_size]
C: [incore_loop * num_groups, tile_size, tile_size]
```

Layout ensures contiguous access for each task's `incore_loop` tiles.