### PR TITLE
Fix broken bash commands in address-pr-comments skill libs

### DIFF
--- a/.claude/lib/github/fetch-comments.md
+++ b/.claude/lib/github/fetch-comments.md
@@ -19,7 +19,10 @@ query($owner: String!, $repo: String!, $number: Int!) {
               body
               path
               line
+              originalLine
+              diffHunk
               author { login }
+              createdAt
             }
           }
         }

--- a/.claude/lib/github/reply-and-resolve.md
+++ b/.claude/lib/github/reply-and-resolve.md
@@ -1,15 +1,36 @@
 # Reply and Resolve
 
-Reply using:
+For each comment, reply then resolve the thread. Both steps are required.
+
+## Step 1: Reply to the comment
 
 ```bash
-gh api repos/${PR_REPO_OWNER}/${REPO_NAME}$/pulls/<number>/comments/<comment_id>/replies -f body="..."
+gh api "repos/${PR_REPO_OWNER}/${PR_REPO_NAME}/pulls/${PR_NUMBER}/comments/${COMMENT_DATABASE_ID}/replies" \
+  -f body='Fixed in <commit-hash> — description'
 ```
 
-Then resolve thread with GraphQL `resolveReviewThread` mutation.
+**Important:** Always use single quotes for `-f body='...'` to avoid bash history expansion issues with `!` and other special characters.
 
 **Response templates:**
 
-- Fixed: "Fixed in `<commit>` — description"
-- Skip: "Current code follows `.claude/rules/<file>`"
-- Acknowledged: "Acknowledged, thank you!"
+- Fixed: `'Fixed in <commit-hash> — description'`
+- Skip: `'Current code follows .claude/rules/<file>'`
+- Acknowledged: `'Acknowledged, thank you!'`
+
+## Step 2: Resolve the thread
+
+Use the thread `id` (the GraphQL node ID from [fetch-comments](./fetch-comments.md), NOT the `databaseId`):
+
+```bash
+gh api graphql -f query='
+mutation ResolveThread($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { isResolved }
+  }
+}' \
+-f threadId="$THREAD_ID"
+```
+
+`$THREAD_ID` is the `id` field from the `reviewThreads.nodes[]` returned by [fetch-comments](./fetch-comments.md).
+
+**Both steps are mandatory.** Do not skip the resolve step.


### PR DESCRIPTION
## Summary
- **fetch-comments.md**: Add `originalLine`, `diffHunk`, `createdAt` fields to GraphQL query so all data needed for comment classification is available without falling back to REST API calls with broken jq
- **reply-and-resolve.md**: Fix stray `$` in API path, add actual `resolveReviewThread` GraphQL mutation code (was missing entirely), use single quotes for `-f body` to avoid bash `!` history expansion

## Context
Two recurring failures when using the `address-pr-comments` skill:
1. Falling back to REST API with `--jq` filters containing `!=`, which breaks due to bash history expansion (`!` → `\!`)
2. Forgetting to resolve threads after replying — because the lib file had no mutation code

Both root causes were in incomplete lib files that forced improvisation.

## Testing
- [ ] Run `/address-pr-comments` on a PR with review comments and verify threads are resolved