### PR TITLE
CI: use per-runner env vars for device range and CANN path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,4 @@ jobs:
       - name: Run on-device examples
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          source /home/github-ci/Ascend/ascend-toolkit/latest/bin/setenv.bash && ./ci.sh -p a2a3 -d 4-7 --parallel -c 1b22fea -t 600
+          source ${ASCEND_HOME_PATH}/bin/setenv.bash && ./ci.sh -p a2a3 -d ${DEVICE_RANGE} --parallel -c 1b22fea -t 600


### PR DESCRIPTION
## Summary
- Replace hardcoded `-d 4-7` and CANN toolkit path with env vars
- `DEVICE_RANGE` — device range passed to `ci.sh -d`
- `ASCEND_HOME_PATH` — path to CANN installation (`setenv.bash` location)
- Allows multiple self-hosted runners with different hardware configs to share the same job

## Setup required
Add a `.env` file in each self-hosted runner directory:
```
DEVICE_RANGE=4-7
ASCEND_HOME_PATH=/home/github-ci/Ascend/ascend-toolkit/latest
```
or
```
DEVICE_RANGE=8-11
ASCEND_HOME_PATH=/usr/local/Ascend/cann-8.5.0
```

## Testing
- [ ] Verify runners pick up env vars from `.env`
- [ ] Hardware CI passes on at least one runner