### PR TITLE
CI: cat fail log on failure and fix pto-isa clone race

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -319,6 +319,9 @@ run_task() {
     else
         status="FAIL"
         echo "[${platform}${device_id:+:dev${device_id}}] FAIL: $name (${elapsed}s)"
+        echo "--- LOG: $name (attempt $attempt) ---"
+        cat "$task_log"
+        echo "--- END ---"
     fi
     echo "${name}|${platform}|${status}|device:${device_id:-sim}|attempt:${attempt}|${elapsed}s" \
         >> "$RESULTS_FILE"

--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -45,6 +45,7 @@ Golden.py interface:
 """
 
 import importlib.util
+import fcntl
 import logging
 import os
 import sys
@@ -289,6 +290,8 @@ def _ensure_pto_isa_root(verbose: bool = False, commit: Optional[str] = None) ->
     2. If not, tries to clone pto-isa repository
     3. Returns the resolved path
 
+    Uses a file lock to prevent parallel processes from racing on the clone.
+
     Args:
         verbose: Print detailed progress information
         commit: If provided, checkout this specific commit
@@ -305,6 +308,19 @@ def _ensure_pto_isa_root(verbose: bool = False, commit: Optional[str] = None) ->
 
     # Try to use cloned repository
     clone_path = _get_pto_isa_clone_path()
+
+    # Use a file lock so only one process clones at a time
+    lock_path = clone_path.parent / ".pto-isa.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "w") as lock_fd:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        return _ensure_pto_isa_root_locked(clone_path, verbose=verbose, commit=commit)
+
+
+def _ensure_pto_isa_root_locked(
+    clone_path: Path, verbose: bool = False, commit: Optional[str] = None
+) -> Optional[str]:
+    """Inner logic for _ensure_pto_isa_root, called while holding the file lock."""
 
     # Clone if needed
     if not _is_pto_isa_cloned():


### PR DESCRIPTION
## Summary
- Print full task log inline when a task fails in `ci.sh` for easier debugging
- Fix race condition where parallel workers all try to `git clone` pto-isa simultaneously
  - 3 of 4 workers were failing with `PTO_ISA_ROOT could not be resolved` because the clone was in progress
  - Added `fcntl.flock` around the clone logic so only one process clones while others wait

## Testing
- [ ] Hardware CI uses all 4 devices without quarantine failures