### PR TITLE
Update: optimize Tensor layout and orchestrator profiling

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -223,8 +223,6 @@ void pto2_submit_task(
     // === STEP 1: Allocate task slot from Task Ring (blocks until available) ===
     int32_t task_id = orch->task_ring.pto2_task_ring_alloc();
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, task_id);
-
     PTO2TaskDescriptor* task = pto2_task_ring_get(&orch->task_ring, task_id);
 
     // Initialize task descriptor
@@ -243,6 +241,8 @@ void pto2_submit_task(
 
     // Register this task in its owning scope
     scope_tasks_push(orch, task_id);
+
+    CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, task_id);
 
     // Temporary storage for fanin
     int32_t fanin_temp[PTO2_MAX_INPUTS];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -76,7 +76,7 @@
 
 // Scope management
 #define PTO2_MAX_SCOPE_DEPTH      64      // Maximum nesting depth
-#define PTO2_SCOPE_TASKS_INIT_CAP 256     // Initial capacity for scope task buffer
+#define PTO2_SCOPE_TASKS_INIT_CAP 65536     // Initial capacity for scope task buffer
 
 // Ready queue
 #define PTO2_READY_QUEUE_SIZE     65536   // Per-worker-type queue size (16x larger to avoid queue full)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -53,15 +53,15 @@ struct Segment {
  *   - Outer dim: 3 rows with stride 6 elements (derived from raw_shapes[1])
  */
 struct Tensor {
-    // === Data fields (same layout as former Tensor) ===
-    int32_t version;                               // Tensor version for overlap detection
+    // === Data fields (same layout as former TensorData) ===
     PTOBufferHandle buffer;                        // Underlying memory buffer (addr in bytes, size in bytes)
-    uint64_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
-    uint64_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
-    uint64_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
+    int32_t version;                               // Tensor version for overlap detection
     uint64_t start_offset;                         // Cached 1D element offset (precomputed from raw_shapes + offsets)
     uint64_t ndims;                                // Number of dimensions used
     DataType dtype;                                // Data type of tensor elements
+    uint64_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
+    uint64_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
+    uint64_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
 
     Tensor() = default;
     Tensor(const Tensor&) = default;
@@ -103,9 +103,9 @@ struct Tensor {
 
     void init(const Tensor& other) {
         buffer = other.buffer;
+        version = other.version;
         ndims = other.ndims;
         dtype = other.dtype;
-        version = other.version;
         for (uint64_t i = 0; i < ndims; i++) {
             raw_shapes[i] = other.raw_shapes[i];
             shapes[i] = other.shapes[i];

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -64,14 +64,15 @@ __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestrati
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
     uint64_t prof_param_extract = 0;
-    uint64_t prof_ext_tensor    = 0;
-    uint64_t prof_make_tensor   = 0;
-    uint64_t prof_tensor_view   = 0;
-    uint64_t prof_param_setup   = 0;
-    uint64_t prof_submit_task   = 0;
-    int      prof_submit_count  = 0;
-    int      prof_make_count    = 0;
-    int      prof_view_count    = 0;
+    uint64_t prof_ext_tensor = 0;
+    uint64_t prof_scope = 0;
+    uint64_t prof_make_tensor = 0;
+    uint64_t prof_tensor_view = 0;
+    uint64_t prof_param_setup = 0;
+    uint64_t prof_submit_task = 0;
+    int prof_submit_count = 0;
+    int prof_make_count = 0;
+    int prof_view_count = 0;
 
     CYCLE_COUNT_START();
 
@@ -126,10 +127,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     // Tensor context_lens = make_tensor_external(host_context_lens, context_lens_size);
     Tensor out = make_tensor_external(host_out, out_shapes, 2, DataType::FLOAT32);
     CYCLE_COUNT_LAP(prof_ext_tensor);
-    LOG_DEBUG(rt, "query=%s", query.dump().c_str());
-    LOG_DEBUG(rt, "key_cache=%s", key_cache.dump().c_str());
-    LOG_DEBUG(rt, "value_cache=%s", value_cache.dump().c_str());
-    LOG_DEBUG(rt, "out=%s", out.dump().c_str());
+    // LOG_DEBUG(rt, "query=%s", query.dump().c_str());
+    // LOG_DEBUG(rt, "key_cache=%s", key_cache.dump().c_str());
+    // LOG_DEBUG(rt, "value_cache=%s", value_cache.dump().c_str());
+    // LOG_DEBUG(rt, "out=%s", out.dump().c_str());
 
     int total_tasks = 0;
 
@@ -138,8 +139,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             PTO2_SCOPE(rt) {
+                CYCLE_COUNT_LAP(prof_scope);
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
-                CYCLE_COUNT_START();
 
                 uint64_t oi_shapes[2] = {q_tile, head_dim};
                 uint64_t li_shapes[1] = {q_tile};
@@ -255,11 +256,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     CYCLE_COUNT_LAP(prof_submit_task);
                 }
             }
+            CYCLE_COUNT_LAP(prof_scope);
         }
     }
 
     uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor +
-                     prof_tensor_view + prof_param_setup + prof_submit_task;
+                     prof_tensor_view + prof_param_setup + prof_submit_task + prof_scope;
     LOG_ALWAYS(rt, "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
         prof_submit_count, prof_make_count, prof_view_count, cycles_to_us(total));
     if (total > 0) {
@@ -273,8 +275,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
         LOG_ALWAYS(rt, "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
             prof_view_count, cycles_to_us(prof_tensor_view), prof_tensor_view * 100.0 / total,
             prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
-        LOG_ALWAYS(rt, "  param_setup      : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  param_setup      : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_param_setup),
+            prof_param_setup * 100.0 / total);
+        LOG_ALWAYS(rt, "  scope            : %7.3fus (%5.1f%%)", cycles_to_us(prof_scope), prof_scope * 100.0 / total);
         LOG_ALWAYS(rt, "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
             prof_submit_count, cycles_to_us(prof_submit_task), prof_submit_task * 100.0 / total,
             prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);


### PR DESCRIPTION
- Reorder Tensor struct fields: move buffer to first position for cache-friendly access in hot-path lookups (hash, overlap check)
- Increase PTO2_SCOPE_TASKS_INIT_CAP from 256 to 65536 to avoid reallocation in large task graphs
- Move ORCH_ALLOC profiling marker after task initialization for more accurate measurement
- Add scope profiling to paged_attention test orchestration and disable verbose tensor debug logging