### PR TITLE
Fix: add AICore cache flush at kernel exit for multi-round correctness

### DIFF
--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -53,8 +53,6 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
-    // Invalidate cache before first read to avoid stale aicpu_ready from previous round
-    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     }
@@ -80,4 +78,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             my_hank->task_status = 0;
         }
     }
+
+    // Flush all dirty cache lines to HBM before kernel exit.
+    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
 }

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -21,8 +21,6 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
-    // Invalidate cache before first read to avoid stale aicpu_ready from previous round
-    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     }
@@ -78,4 +76,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             write_reg(RegId::COND, MAKE_FIN_VALUE(actual_task_id));
         }
     }
+
+    // Flush all dirty cache lines to HBM before kernel exit.
+    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -53,8 +53,6 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
-    // Invalidate cache before first read to avoid stale aicpu_ready from previous round
-    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, SINGLE_CACHE_LINE);
     }
@@ -128,4 +126,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             write_reg(RegId::COND, MAKE_FIN_VALUE(payload->task_id));
         }
     }
+
+    // Flush all dirty cache lines to HBM before kernel exit.
+    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -174,7 +174,6 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     for (int i = 0; i < cores_total_num_; i++) {
         Handshake* hank = &all_handshakes[i];
         while (hank->aicore_done == 0) {
-            // Spin wait for core to respond
         }
 
         CoreType type = hank->core_type;
@@ -1084,7 +1083,7 @@ int AicpuExecutor::run(Runtime* runtime) {
                 SPIN_WAIT_HINT();
             }
 
-            // Call orchestration function wrapped in an outer scope
+            // Call orchestration wrapped in outer scope (matches old PTO2_ORCHESTRATION behavior)
             DEV_INFO("Thread %d: Calling aicpu_orchestration_entry from SO", thread_idx);
 #if PTO2_PROFILING
             DEV_ALWAYS("BENCHMARK: thread=%d orch_start=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
@@ -1256,14 +1255,11 @@ int AicpuExecutor::run(Runtime* runtime) {
 }
 
 void AicpuExecutor::deinit(Runtime* runtime) {
-    // === Exit cleanup: reset all inter-round state ===
-
     // 1. Invalidate AICPU cache for Runtime address range.
     //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
     //    bypasses this cache. Invalidating now ensures next round reads from HBM.
     cache_invalidate_range(runtime, sizeof(Runtime));
 
-    // === Existing reset logic ===
     // Reset per-core dispatch timestamps and task counters
     for (int i = 0; i < RUNTIME_MAX_WORKER; i++) {
         dispatch_timestamps_[i] = 0;


### PR DESCRIPTION
## Summary
- Remove redundant pre-loop cache invalidate in AICore spin-wait (all 3 runtime variants)
- Add `dcci` flush after the task dispatch loop so dirty handshake state is written back to HBM before AICore exits
- Clean up planning-style section comments in AICPU deinit

## Testing
- [ ] Simulation tests pass
- [ ] Hardware tests pass