### PR TITLE
Refactor: parameterize toolchain and runtime compiler for A5 platform support

### DIFF
--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -727,6 +727,17 @@ class CodeRunner:
         # (they are independent — all only need kernel_compiler which is ready)
         logger.info(f"=== Building Runtime: {self.runtime_name} (platform: {self.platform}) ===")
         builder = RuntimeBuilder(platform=self.platform)
+
+        # Validate runtime exists before starting any compilation
+        available_runtimes = builder.list_runtimes()
+        if self.runtime_name not in available_runtimes:
+            available_str = ", ".join(available_runtimes) or "(none)"
+            raise ValueError(
+                f"Runtime '{self.runtime_name}' is not available for platform '{self.platform}'.\n"
+                f"Available runtimes for {self.platform}: {available_str}\n"
+                f"Note: Different platforms may support different runtimes."
+            )
+
         kernel_compiler = builder.get_kernel_compiler()
 
         from concurrent.futures import ThreadPoolExecutor, Future

--- a/python/kernel_compiler.py
+++ b/python/kernel_compiler.py
@@ -62,7 +62,7 @@ class KernelCompiler:
         # Create toolchain objects based on platform
         if platform in ("a2a3", "a5"):
             env_manager.ensure("ASCEND_HOME_PATH")
-            self.ccec = CCECToolchain()
+            self.ccec = CCECToolchain(platform)
             self.aarch64 = Aarch64GxxToolchain()
             self.host_gxx = GxxToolchain()
         else:

--- a/python/runtime_builder.py
+++ b/python/runtime_builder.py
@@ -80,7 +80,10 @@ class RuntimeBuilder:
         if name not in self._runtimes:
             available = ", ".join(self._runtimes.keys()) or "(none)"
             raise ValueError(
-                f"Runtime '{name}' not found. Available runtimes: {available}"
+                f"Runtime '{name}' is not available for platform '{self.platform}'.\n"
+                f"Available runtimes for {self.platform}: {available}\n"
+                f"Note: Different platforms may support different runtimes. "
+                f"Check {self.runtime_dir} for available implementations."
             )
 
         config_path = self._runtimes[name]

--- a/python/runtime_compiler.py
+++ b/python/runtime_compiler.py
@@ -86,10 +86,14 @@ class RuntimeCompiler:
                 f"Platform '{platform}' not found at {self.platform_dir}"
             )
 
-        if platform in ("a2a3", "a5"):
-            self._init_a2a3()  # Phase 1: A5 uses A2A3 toolchain
-        elif platform in ("a2a3sim", "a5sim"):
-            self._init_a2a3sim()  # Phase 1: A5sim uses A2A3sim toolchain
+        if platform == "a2a3":
+            self._init_a2a3()
+        elif platform == "a2a3sim":
+            self._init_a2a3sim()
+        elif platform == "a5":
+            self._init_a5()
+        elif platform == "a5sim":
+            self._init_a5sim()
         else:
             raise ValueError(f"Unknown platform: {platform}. Supported: a2a3, a2a3sim, a5, a5sim")
 
@@ -98,7 +102,7 @@ class RuntimeCompiler:
         env_manager.ensure("ASCEND_HOME_PATH")
 
         # AICore: Bisheng CCE compiler
-        ccec = CCECToolchain()
+        ccec = CCECToolchain(platform="a2a3")
         self.aicore_target = BuildTarget(
             ccec, str(self.platform_dir / "aicore"), "aicore_kernel.o"
         )
@@ -118,6 +122,47 @@ class RuntimeCompiler:
 
     def _init_a2a3sim(self):
         """Initialize toolchains for simulation platform.
+        All targets use host gcc/g++ with platform-specific CMake dirs.
+        No Ascend SDK required.
+        """
+        self._ensure_host_compilers()
+        gxx = GxxToolchain()
+
+        self.aicore_target = BuildTarget(
+            gxx, str(self.platform_dir / "aicore"), "libaicore_kernel.so"
+        )
+        self.aicpu_target = BuildTarget(
+            gxx, str(self.platform_dir / "aicpu"), "libaicpu_kernel.so"
+        )
+        self.host_target = BuildTarget(
+            gxx, str(self.platform_dir / "host"), "libhost_runtime.so"
+        )
+
+    def _init_a5(self):
+        """Initialize toolchains for real a5 hardware."""
+        env_manager.ensure("ASCEND_HOME_PATH")
+
+        # AICore: Bisheng CCE compiler with A5 platform
+        ccec = CCECToolchain(platform="a5")
+        self.aicore_target = BuildTarget(
+            ccec, str(self.platform_dir / "aicore"), "aicore_kernel.o"
+        )
+
+        # AICPU: aarch64 cross-compiler
+        aarch64 = Aarch64GxxToolchain()
+        self.aicpu_target = BuildTarget(
+            aarch64, str(self.platform_dir / "aicpu"), "libaicpu_kernel.so"
+        )
+
+        # Host: standard gcc/g++
+        self._ensure_host_compilers()
+        host_gxx = GxxToolchain()
+        self.host_target = BuildTarget(
+            host_gxx, str(self.platform_dir / "host"), "libhost_runtime.so"
+        )
+
+    def _init_a5sim(self):
+        """Initialize toolchains for A5 simulation platform.
         All targets use host gcc/g++ with platform-specific CMake dirs.
         No Ascend SDK required.
         """

--- a/python/toolchain.py
+++ b/python/toolchain.py
@@ -45,10 +45,23 @@ class Toolchain:
 class CCECToolchain(Toolchain):
     """Ascend ccec compiler for AICore kernels."""
 
-    def __init__(self):
+    def __init__(self, platform: str = "a2a3"):
         super().__init__()
-        self.cxx_path = os.path.join(self.ascend_home_path, "bin", "ccec")
-        self.linker_path = os.path.join(self.ascend_home_path, "bin", "ld.lld")
+        self.platform = platform
+
+        if platform in ("a5", "a5sim"):
+            self.cxx_path = os.path.join(
+                self.ascend_home_path, "tools", "bisheng_compiler", "bin", "ccec"
+            )
+            self.linker_path = os.path.join(
+                self.ascend_home_path, "tools", "bisheng_compiler", "bin", "ld.lld"
+            )
+        elif platform in ("a2a3", "a2a3sim"):
+            self.cxx_path = os.path.join(self.ascend_home_path, "bin", "ccec")
+            self.linker_path = os.path.join(self.ascend_home_path, "bin", "ld.lld")
+        else:
+            raise ValueError(f"Unknown platform: {platform}. Supported: a2a3, a2a3sim, a5, a5sim")
+
         if not os.path.isfile(self.cxx_path):
             raise FileNotFoundError(
                 f"ccec compiler not found: {self.cxx_path}"
@@ -59,7 +72,14 @@ class CCECToolchain(Toolchain):
             )
 
     def get_compile_flags(self, core_type: str = "aiv", **kwargs) -> List[str]:
-        arch = "dav-c220-vec" if core_type == "aiv" else "dav-c220-cube"
+        # A5 uses dav-c310 architecture, A2A3 uses dav-c220
+        if self.platform in ("a5", "a5sim"):
+            arch = "dav-c310-vec" if core_type == "aiv" else "dav-c310-cube"
+        elif self.platform in ("a2a3", "a2a3sim"):
+            arch = "dav-c220-vec" if core_type == "aiv" else "dav-c220-cube"
+        else:
+            raise ValueError(f"Unknown platform: {self.platform}. Supported: a2a3, a2a3sim, a5, a5sim")
+
         core_define = "__AIV__" if core_type == "aiv" else "__AIC__"
         return [
             "-c", "-O3", "-g", "-x", "cce",

--- a/tests/test_runtime_builder.py
+++ b/tests/test_runtime_builder.py
@@ -136,7 +136,7 @@ class TestRuntimeBuilderBuildErrors:
         from runtime_builder import RuntimeBuilder
 
         builder = RuntimeBuilder(platform=default_test_platform)
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(ValueError, match="is not available for platform"):
             builder.build("nonexistent_runtime")
 
     def test_build_unknown_runtime_lists_available(self, default_test_platform):


### PR DESCRIPTION

Separate platform-specific initialization logic to prepare for A5 integration:
- Add platform parameter to CCECToolchain for architecture selection (dav-c220 vs dav-c310)
- Split RuntimeCompiler init: add dedicated _init_a5() and _init_a5sim() methods
- Update compiler paths: A5 uses tools/bisheng_compiler/bin/ instead of bin/
- Add early runtime validation in CodeRunner with clearer error messages
- Improve error reporting to clarify platform-specific runtime availability