### PR TITLE
Add benchmark script and improve code_runner INOUT tensor handling

### DIFF
--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -41,7 +41,7 @@ Golden.py interface:
     DEFAULT_CASE = "Case1"  # Default case to run
     RTOL = 1e-5  # Relative tolerance
     ATOL = 1e-5  # Absolute tolerance
-    __outputs__ = ["out_f"]  # Explicit output names (or use 'out_' prefix)
+    __outputs__ = ["out_f"]  # Output tensor names
 """
 
 import importlib.util
@@ -517,27 +517,24 @@ class CodeRunner:
 
     def _identify_outputs(self, tensors: Dict[str, torch.Tensor]) -> Tuple[Dict, Dict]:
         """
-        Separate inputs and outputs from tensor dict.
-
-        Uses either explicit __outputs__ list or 'out_' prefix convention.
+        Separate inputs and outputs from tensor dict using __outputs__.
 
         Returns:
             Tuple of (inputs_dict, outputs_dict)
         """
-        if self.output_names:
-            # Use explicit output names
-            outputs = {k: v for k, v in tensors.items() if k in self.output_names}
-            inputs = {k: v for k, v in tensors.items() if k not in self.output_names}
-        else:
-            # Use 'out_' prefix convention
-            outputs = {k: v for k, v in tensors.items() if k.startswith('out_')}
-            inputs = {k: v for k, v in tensors.items() if not k.startswith('out_')}
+        if not self.output_names:
+            raise ValueError(
+                "No output tensors identified. "
+                "Define __outputs__ = ['tensor_name'] in golden.py"
+            )
+
+        output_set = set(self.output_names)
+        outputs = {k: v for k, v in tensors.items() if k in output_set}
+        inputs = {k: v for k, v in tensors.items() if k not in output_set}
 
         if not outputs:
             raise ValueError(
-                "No output tensors identified. Either:\n"
-                "1. Define __outputs__ = ['tensor_name'] in golden.py, or\n"
-                "2. Use 'out_' prefix for output tensor names (e.g., 'out_result')"
+                f"None of __outputs__ = {self.output_names} found in tensors: {list(tensors.keys())}"
             )
 
         return inputs, outputs
@@ -561,20 +558,27 @@ class CodeRunner:
         """
         import ctypes
         import numpy as np
-        from bindings import ARG_SCALAR, ARG_INPUT_PTR, ARG_OUTPUT_PTR
+        from bindings import ARG_SCALAR, ARG_INPUT_PTR, ARG_OUTPUT_PTR, ARG_INOUT_PTR
 
-        # Identify outputs
-        if self.output_names:
-            output_set = set(self.output_names)
-        else:
-            output_set = set()
+        if not self.output_names:
+            raise ValueError(
+                "No output tensors identified. "
+                "Define __outputs__ = ['tensor_name'] in golden.py"
+            )
+        output_set = set(self.output_names)
+
+        # First pass: collect all tensor names from generate_inputs
+        all_tensor_names = {name for name, value in args_list
+                           if isinstance(value, (torch.Tensor, np.ndarray))}
+        # Tensors in both generate_inputs and __outputs__ are INOUT
+        inout_set = output_set & all_tensor_names
 
         func_args = []
         arg_types = []
         arg_sizes = []
         args = {}    # all named items: tensors + scalars → passed to compute_golden
         inputs = {}  # tensor inputs only → for logging
-        outputs = {} # tensor outputs only → for comparison
+        outputs = {} # tensor outputs (and inouts) → for comparison
 
         for item in args_list:
             if not (isinstance(item, tuple) and len(item) == 2):
@@ -595,7 +599,10 @@ class CodeRunner:
                 nbytes = tensor.element_size() * tensor.numel()
                 arg_sizes.append(nbytes)
 
-                if name in output_set or (not output_set and name.startswith('out_')):
+                if name in inout_set:
+                    arg_types.append(ARG_INOUT_PTR)
+                    outputs[name] = tensor
+                elif name in output_set:
                     arg_types.append(ARG_OUTPUT_PTR)
                     outputs[name] = tensor
                 else:
@@ -621,9 +628,7 @@ class CodeRunner:
 
         if not outputs:
             raise ValueError(
-                "No output tensors identified. Either:\n"
-                "1. Define __outputs__ = ['tensor_name'] in golden.py, or\n"
-                "2. Use 'out_' prefix for output tensor names (e.g., 'out_result')"
+                f"None of __outputs__ = {self.output_names} found in generate_inputs args"
             )
 
         return func_args, arg_types, arg_sizes, args, inputs, outputs
@@ -644,7 +649,7 @@ class CodeRunner:
         Returns:
             Tuple of (func_args, arg_types, arg_sizes)
         """
-        from bindings import ARG_SCALAR, ARG_INPUT_PTR, ARG_OUTPUT_PTR
+        from bindings import ARG_SCALAR, ARG_INPUT_PTR, ARG_OUTPUT_PTR, ARG_INOUT_PTR
 
         # Determine tensor order
         if self.tensor_order:
@@ -652,11 +657,14 @@ class CodeRunner:
         else:
             order = list(tensors.keys())
 
-        # Identify outputs
-        if self.output_names:
-            output_set = set(self.output_names)
-        else:
-            output_set = {k for k in tensors.keys() if k.startswith('out_')}
+        # Identify outputs; tensors in both generate_inputs and __outputs__ are INOUT
+        if not self.output_names:
+            raise ValueError(
+                "No output tensors identified. "
+                "Define __outputs__ = ['tensor_name'] in golden.py"
+            )
+        output_set = set(self.output_names)
+        inout_set = output_set & set(tensors.keys())
 
         # First pass: ensure all tensors are CPU and contiguous (update dict in place)
         for name in order:
@@ -676,8 +684,9 @@ class CodeRunner:
             tensor = tensors[name]
             func_args.append(tensor.data_ptr())
 
-            # Determine arg type based on whether it's an output
-            if name in output_set:
+            if name in inout_set:
+                arg_types.append(ARG_INOUT_PTR)
+            elif name in output_set:
                 arg_types.append(ARG_OUTPUT_PTR)
             else:
                 arg_types.append(ARG_INPUT_PTR)
@@ -855,9 +864,14 @@ class CodeRunner:
             _t_golden_end = time.perf_counter()
             logger.info(f">>> compute_golden() took {_t_golden_end - _t_golden_start:.3f}s")
 
+            initial_outputs = {k: v.clone() for k, v in outputs.items()}
+
             for round_idx in range(self.repeat_rounds):
                 if self.repeat_rounds > 1:
                     logger.info(f"--- Round {round_idx + 1}/{self.repeat_rounds} ---")
+
+                for k, v in initial_outputs.items():
+                    outputs[k].copy_(v)
 
                 runtime = Runtime()
 

--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Benchmark wrapper: run examples on a2a3 hardware,
+# then parse device-log timing lines to report per-round latency.
+#
+# Usage:
+#   ./tools/benchmark_rounds.sh [-d <device>] [-n <rounds>]
+#
+# Runs all examples listed in EXAMPLES array and prints timing for each.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUN_EXAMPLE="$PROJECT_ROOT/examples/scripts/run_example.py"
+EXAMPLES_DIR="$PROJECT_ROOT/tests/device_tests/tensormap_and_ringbuffer"
+
+# ---------------------------------------------------------------------------
+# Examples to benchmark (paths relative to examples/tensormap_and_ringbuffer/)
+# Each entry is just the directory name; kernels/ and golden.py are implied.
+# ---------------------------------------------------------------------------
+EXAMPLES=(
+    benchmark_bgemm
+    batch_paged_attention
+    paged_attention
+)
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+DEVICE_ID=0
+ROUNDS=10
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -d|--device)
+            DEVICE_ID="$2"
+            shift 2
+            ;;
+        -n|--rounds)
+            ROUNDS="$2"
+            shift 2
+            ;;
+        --help|-h)
+            cat <<'USAGE'
+benchmark_rounds.sh — run all examples and report per-round timing from device logs
+
+Usage:
+  ./tools/benchmark_rounds.sh [-d <device>] [-n <rounds>]
+
+Options:
+  -d, --device   Device ID (default: 0)
+  -n, --rounds   Override number of rounds for each example (default: 10)
+  -h, --help     Show this help
+
+All other options are passed through to run_example.py (e.g. --case).
+
+Output:
+  Average elapsed time in microseconds for each example.
+USAGE
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve device log directory (mirrors run_example.py / device_log_resolver.py)
+# ---------------------------------------------------------------------------
+if [[ -n "${ASCEND_WORK_PATH:-}" ]]; then
+    LOG_ROOT="$ASCEND_WORK_PATH/log/debug"
+    if [[ ! -d "$LOG_ROOT" ]]; then
+        LOG_ROOT="$HOME/ascend/log/debug"
+    fi
+else
+    LOG_ROOT="$HOME/ascend/log/debug"
+fi
+DEVICE_LOG_DIR="$LOG_ROOT/device-${DEVICE_ID}"
+
+# ---------------------------------------------------------------------------
+# parse_timing <log_file>
+#   Grep for orch_start / end lines, compute per-round elapsed, print summary.
+# ---------------------------------------------------------------------------
+parse_timing() {
+    local log_file="$1"
+
+    local timing
+    timing=$(grep -E 'Thread=[0-9]+ (orch_start|end)=' "$log_file" || true)
+
+    if [[ -z "$timing" ]]; then
+        echo "  (no benchmark timing data — was PTO2_PROFILING enabled?)"
+        return 1
+    fi
+
+    echo "$timing" | awk '
+    /orch_start=/ {
+        if (round > 0 && max_end > 0) {
+            elapsed = max_end - orch_start
+            results[round - 1] = elapsed / 50.0
+            count++
+        }
+        round++
+        match($0, /orch_start=([0-9]+)/, m)
+        orch_start = m[1] + 0
+        max_end = 0
+    }
+    /end=/ {
+        match($0, /end=([0-9]+)/, m)
+        val = m[1] + 0
+        if (val > max_end) max_end = val
+    }
+    END {
+        if (round > 0 && max_end > 0) {
+            results[round - 1] = (max_end - orch_start) / 50.0
+            count++
+        }
+        if (count == 0) { print "  (no rounds parsed)"; exit 1 }
+
+        printf "  %-8s  %12s\n", "Round", "Elapsed (us)"
+        printf "  %-8s  %12s\n", "-----", "------------"
+        sum_v = 0
+        for (i = 0; i < count; i++) {
+            printf "  %-8d  %12.1f\n", i, results[i]
+            sum_v += results[i]
+        }
+        printf "\n  Avg: %.1f us  (%d rounds)\n", sum_v / count, count
+    }'
+}
+
+# ---------------------------------------------------------------------------
+# wait_for_new_log <pre_run_logs_file>
+#   Wait up to 15s for a new .log file in DEVICE_LOG_DIR. Prints the path.
+# ---------------------------------------------------------------------------
+wait_for_new_log() {
+    local pre_file="$1"
+    local new_log=""
+    local deadline=$((SECONDS + 15))
+
+    while [[ $SECONDS -lt $deadline ]]; do
+        if [[ -d "$DEVICE_LOG_DIR" ]]; then
+            new_log=$(comm -13 "$pre_file" <(ls -1 "$DEVICE_LOG_DIR"/*.log 2>/dev/null | sort) 2>/dev/null | tail -1 || true)
+            if [[ -n "$new_log" ]]; then
+                echo "$new_log"
+                return 0
+            fi
+        fi
+        sleep 0.5
+    done
+
+    # Fallback: newest log
+    if [[ -d "$DEVICE_LOG_DIR" ]]; then
+        new_log=$(ls -t "$DEVICE_LOG_DIR"/*.log 2>/dev/null | head -1 || true)
+        if [[ -n "$new_log" ]]; then
+            echo "$new_log"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+
+for example in "${EXAMPLES[@]}"; do
+    EXAMPLE_DIR="$EXAMPLES_DIR/$example"
+    KERNELS_DIR="$EXAMPLE_DIR/kernels"
+    GOLDEN="$EXAMPLE_DIR/golden.py"
+
+    echo ""
+    echo "================================================================"
+    echo "  $example"
+    echo "================================================================"
+
+    if [[ ! -f "$GOLDEN" || ! -d "$KERNELS_DIR" ]]; then
+        echo "  SKIP: missing kernels/ or golden.py"
+        ((FAIL++)) || true
+        continue
+    fi
+
+    # Snapshot existing logs
+    PRE_LOG_FILE=$(mktemp)
+    ls -1 "$DEVICE_LOG_DIR"/*.log 2>/dev/null | sort > "$PRE_LOG_FILE" || true
+
+    # Run example
+    if ! python3 "$RUN_EXAMPLE" \
+            -k "$KERNELS_DIR" -g "$GOLDEN" \
+            -p a2a3 -d "$DEVICE_ID" \
+            -n "$ROUNDS" \
+            "${EXTRA_ARGS[@]}" > /dev/null 2>&1; then
+        echo "  FAILED: run_example.py returned non-zero"
+        rm -f "$PRE_LOG_FILE"
+        ((FAIL++)) || true
+        continue
+    fi
+
+    # Find new device log
+    NEW_LOG=$(wait_for_new_log "$PRE_LOG_FILE")
+    rm -f "$PRE_LOG_FILE"
+
+    if [[ -z "$NEW_LOG" ]]; then
+        echo "  FAILED: no device log found in $DEVICE_LOG_DIR"
+        ((FAIL++)) || true
+        continue
+    fi
+
+    echo "  Log: $NEW_LOG"
+    if parse_timing "$NEW_LOG"; then
+        ((PASS++)) || true
+    else
+        ((FAIL++)) || true
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "================================================================"
+echo "  Benchmark complete: $PASS passed, $FAIL failed (${#EXAMPLES[@]} total)"
+echo "================================================================"
+
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- Add `tools/benchmark_rounds.sh` for automated multi-example benchmarking with per-round timing extraction from device logs
- Require explicit `__outputs__` in `golden.py` (remove `out_` prefix fallback convention)
- Support `ARG_INOUT_PTR` for tensors that appear in both `generate_inputs` and `__outputs__`
- Reset output tensors between rounds for multi-round correctness

## Testing
- [x] Simulation tests pass
- [x] Hardware tests pass
- [x] Benchmark script tested on device