### PR TITLE
[WIP] Fix: add PTOStride alias and remove pipe_barrier for A5

### DIFF
--- a/examples/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -11,6 +11,9 @@
 #include <pto/common/pto_tile.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -40,11 +43,11 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
     using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+        PTOStride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
     using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+        PTOStride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
     using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+        PTOStride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);

--- a/examples/host_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/host_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -10,6 +10,9 @@
 #include <pto/common/constants.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -27,7 +30,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     constexpr int TILE = 64;
 
     using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
-    using DynStridDim5 = Stride<1, 1, 1, TILE, 1>;
+    using DynStridDim5 = PTOStride<1, 1, 1, TILE, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
     using TileData = Tile<TileType::Vec, float, TILE, TILE, BLayout::RowMajor, -1, -1>;
 

--- a/examples/host_build_graph/matmul/kernels/aic/kernel_matmul.cpp
+++ b/examples/host_build_graph/matmul/kernels/aic/kernel_matmul.cpp
@@ -12,6 +12,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -50,11 +53,11 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     // Global tensor types
     using GlobalDataSrc0 = GlobalTensor<half, Shape<1, 1, 1, validM, validK>,
-        Stride<validM * validK, validM * validK, validM * validK, validK, 1>>;
+        PTOStride<validM * validK, validM * validK, validM * validK, validK, 1>>;
     using GlobalDataSrc1 = GlobalTensor<half, Shape<1, 1, 1, validK, validN>,
-        Stride<validK * validN, validK * validN, validK * validN, validN, 1>>;
+        PTOStride<validK * validN, validK * validN, validK * validN, validN, 1>>;
     using GlobalDataOut = GlobalTensor<float, Shape<1, 1, 1, validM, validN>,
-        Stride<validM * validN, validM * validN, validM * validN, validN, 1>>;
+        PTOStride<validM * validN, validM * validN, validM * validN, validN, 1>>;
 
     GlobalDataSrc0 src0Global(src0);
     GlobalDataSrc1 src1Global(src1);

--- a/examples/host_build_graph/matmul/kernels/aiv/kernel_add_exp.cpp
+++ b/examples/host_build_graph/matmul/kernels/aiv/kernel_add_exp.cpp
@@ -11,6 +11,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -44,7 +47,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     constexpr int vCols = 128;
 
     using DynShapeDim5 = Shape<1, 1, 1, vRows, vCols>;
-    using DynStridDim5 = Stride<1, 1, 1, kTCols_, 1>;
+    using DynStridDim5 = PTOStride<1, 1, 1, kTCols_, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
     using TileData = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
 

--- a/examples/host_build_graph/matmul/kernels/aiv/kernel_log_sqrt.cpp
+++ b/examples/host_build_graph/matmul/kernels/aiv/kernel_log_sqrt.cpp
@@ -11,6 +11,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -43,7 +46,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     // Half types for input and output
     using DynShapeDim5Half = Shape<1, 1, 1, vRows, vCols>;
-    using DynStridDim5Half = Stride<1, 1, 1, kTCols_, 1>;
+    using DynStridDim5Half = PTOStride<1, 1, 1, kTCols_, 1>;
     using GlobalDataHalf = GlobalTensor<half, DynShapeDim5Half, DynStridDim5Half>;
     using TileDataHalf = Tile<TileType::Vec, half, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
 

--- a/examples/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -10,6 +10,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -28,9 +31,9 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
 
     // pij (M, K) fp16, vj (K, N) fp16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
-    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, N, 1>>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, PTOStride<M*K, M*K, M*K, K, 1>>;
+    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, PTOStride<K*N, K*N, K*N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, PTOStride<M*N, M*N, M*N, N, 1>>;
 
     GlobalA   pijGlobal(pij);
     GlobalB   vjGlobal(vj);

--- a/examples/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -10,6 +10,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -28,10 +31,10 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
 
     // qi (M, K) fp16 in ND (row-major) layout
-    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, PTOStride<M*K, M*K, M*K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, PTOStride<K*N, K*N, K*N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, PTOStride<M*N, M*N, M*N, N, 1>>;
 
     GlobalA   qiGlobal(qi);
     GlobalB   kjGlobal(kj);

--- a/examples/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -12,6 +12,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -47,15 +50,15 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     // --- GlobalTensor types ---
 
     // Data (M, N) RowMajor
-    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, PTOStride<1, 1, 1, N, 1>>;
 
     // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
     using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
-                                        Stride<1, 1, 1, kScalarCols, 1>>;
+                                        PTOStride<1, 1, 1, kScalarCols, 1>>;
 
     // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
     using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
-                                        Stride<1, 1, 1, 1, 1>, Layout::DN>;
+                                        PTOStride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -154,22 +157,13 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
-        // pipe_barrier(PIPE_V) required between each dependent vector operation
-        // to resolve RAW hazards on shared UB tiles.
         TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
-        pipe_barrier(PIPE_V);
         TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
-        pipe_barrier(PIPE_V);
         TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
-        pipe_barrier(PIPE_V);
         TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
-        pipe_barrier(PIPE_V);
         TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
-        pipe_barrier(PIPE_V);
         TMUL(liND, alphaND, liND);           // li = alpha * li
-        pipe_barrier(PIPE_V);
         TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
-        pipe_barrier(PIPE_V);
         TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
@@ -196,12 +190,10 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
         TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
-        pipe_barrier(PIPE_V);
         TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
-            pipe_barrier(PIPE_V);
             TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);

--- a/examples/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -12,6 +12,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -34,9 +37,9 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
-    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
-    using GlobalDataMxN_f16 = GlobalTensor<half, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, PTOStride<1, 1, 1, N, 1>>;
+    using GlobalDataMxN_f16 = GlobalTensor<half, Shape<1, 1, 1, M, N>, PTOStride<1, 1, 1, N, 1>>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, PTOStride<1, 1, 1, 1, 1>, Layout::DN>;
 
     GlobalDataMxN sijGlobal(sij);
     GlobalDataMxN_f16 pijGlobal(pij);

--- a/examples/host_build_graph/vector_example/kernels/aiv/kernel_add.cpp
+++ b/examples/host_build_graph/vector_example/kernels/aiv/kernel_add.cpp
@@ -13,6 +13,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -46,7 +49,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     constexpr int vCols = 128;
 
     using DynShapeDim5 = Shape<1, 1, 1, vRows, vCols>;
-    using DynStridDim5 = Stride<1, 1, 1, kTCols_, 1>;
+    using DynStridDim5 = PTOStride<1, 1, 1, kTCols_, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
     using TileData = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
 

--- a/examples/host_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/examples/host_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -13,6 +13,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -54,7 +57,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     constexpr int vCols = 128;
 
     using DynShapeDim5 = Shape<1, 1, 1, vRows, vCols>;
-    using DynStridDim5 = Stride<1, 1, 1, kTCols_, 1>;
+    using DynStridDim5 = PTOStride<1, 1, 1, kTCols_, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
     using TileData = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
 

--- a/examples/host_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/host_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
@@ -13,6 +13,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -46,7 +49,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     constexpr int vCols = 128;
 
     using DynShapeDim5 = Shape<1, 1, 1, vRows, vCols>;
-    using DynStridDim5 = Stride<1, 1, 1, kTCols_, 1>;
+    using DynStridDim5 = PTOStride<1, 1, 1, kTCols_, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
     using TileData = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
 

--- a/tests/device_tests/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -12,6 +12,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -29,9 +32,9 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
 
     // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
-    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, N, 1>>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, PTOStride<M*K, M*K, M*K, K, 1>>;
+    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, PTOStride<K*N, K*N, K*N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, PTOStride<M*N, M*N, M*N, N, 1>>;
 
     GlobalA   pijGlobal(pij);
     GlobalB   vjGlobal(vj);

--- a/tests/device_tests/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/device_tests/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -12,6 +12,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -29,10 +32,10 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
 
     // qi (M, K) bf16 in ND (row-major) layout
-    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, PTOStride<M*K, M*K, M*K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, PTOStride<K*N, K*N, K*N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, PTOStride<M*N, M*N, M*N, N, 1>>;
 
     GlobalA   qiGlobal(qi);
     GlobalB   kjGlobal(kj);

--- a/tests/device_tests/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -14,6 +14,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -48,15 +51,15 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     // --- GlobalTensor types ---
 
     // Data (M, N) RowMajor
-    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, PTOStride<1, 1, 1, N, 1>>;
 
     // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
     using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
-                                        Stride<1, 1, 1, kScalarCols, 1>>;
+                                        PTOStride<1, 1, 1, kScalarCols, 1>>;
 
     // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
     using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
-                                        Stride<1, 1, 1, 1, 1>, Layout::DN>;
+                                        PTOStride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -155,22 +158,13 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
-        // pipe_barrier(PIPE_V) required between each dependent vector operation
-        // to resolve RAW hazards on shared UB tiles.
         TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
-        pipe_barrier(PIPE_V);
         TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
-        pipe_barrier(PIPE_V);
         TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
-        pipe_barrier(PIPE_V);
         TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
-        pipe_barrier(PIPE_V);
         TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
-        pipe_barrier(PIPE_V);
         TMUL(liND, alphaND, liND);           // li = alpha * li
-        pipe_barrier(PIPE_V);
         TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
-        pipe_barrier(PIPE_V);
         TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
@@ -197,12 +191,10 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
         TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
-        pipe_barrier(PIPE_V);
         TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
-            pipe_barrier(PIPE_V);
             TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);

--- a/tests/device_tests/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -19,6 +19,9 @@
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
+template <int64_t SN1 = DYNAMIC, int64_t SN2 = DYNAMIC, int64_t SN3 = DYNAMIC,
+          int64_t SN4 = DYNAMIC, int64_t SN5 = DYNAMIC>
+using PTOStride = pto::Stride<SN1, SN2, SN3, SN4, SN5>;
 
 #ifndef __gm__
 #define __gm__
@@ -40,9 +43,9 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
-    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
-    using GlobalDataMxN_bf16 = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, PTOStride<1, 1, 1, N, 1>>;
+    using GlobalDataMxN_bf16 = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, N>, PTOStride<1, 1, 1, N, 1>>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, PTOStride<1, 1, 1, 1, 1>, Layout::DN>;
 
     GlobalDataMxN sijGlobal(sij);
     GlobalDataMxN_bf16 pijGlobal(pij);


### PR DESCRIPTION

- Define PTOStride template alias (wrapping pto::Stride) in each kernel
  file to resolve naming conflict with the global enum class Stride
  defined in ccec's __clang_cce_vector_intrinsics.h on A5 platform
- Remove pipe_barrier(PIPE_V) calls in aiv_online_update as A5 hardware
  provides ordering guarantees natively