### PR TITLE
Fix: remove incorrect profiling fallback and fix parser

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1143,15 +1143,28 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             thread_idx, cycles_to_us(sched_total), cur_thread_completed);
 
         // Level 1: complete
-        DEV_ALWAYS("Thread %d:   complete       : %.3fus (%.1f%%)",
+        double notify_avg = cur_thread_completed > 0
+            ? (double)notify_edges_total / cur_thread_completed : 0.0;
+        double fanin_avg = cur_thread_completed > 0
+            ? (double)fanin_edges_total / cur_thread_completed : 0.0;
+        DEV_ALWAYS("Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%llu, max_degree=%d, avg=%.1f]  [fanin: edges=%llu, max_degree=%d, avg=%.1f]",
             thread_idx, cycles_to_us(sched_complete_cycle),
-            sched_complete_cycle * 100.0 / sched_total);
+            sched_complete_cycle * 100.0 / sched_total,
+            (unsigned long long)notify_edges_total, notify_max_degree, notify_avg,
+            (unsigned long long)fanin_edges_total, fanin_max_degree, fanin_avg);
 
         // Level 2: complete sub-phases (percentage relative to complete)
         uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
-        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)",
+        uint64_t complete_miss_count = (complete_probe_count > complete_hit_count)
+            ? (complete_probe_count - complete_hit_count) : 0;
+        double complete_hit_rate = complete_probe_count > 0
+            ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
+        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)  hit=%llu, miss=%llu, hit_rate=%.1f%%",
             thread_idx, cycles_to_us(complete_poll),
-            complete_poll * 100.0 / c_parent);
+            complete_poll * 100.0 / c_parent,
+            (unsigned long long)complete_hit_count,
+            (unsigned long long)complete_miss_count,
+            complete_hit_rate);
         DEV_ALWAYS("Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
             thread_idx, cycles_to_us(sp.lock_cycle),
             sp.lock_cycle * 100.0 / c_parent,
@@ -1175,9 +1188,14 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             sched_complete_perf_cycle * 100.0 / c_parent);
 
         // Level 1: dispatch
-        DEV_ALWAYS("Thread %d:   dispatch       : %.3fus (%.1f%%)",
+        uint64_t pop_total = pop_hit + pop_miss;
+        double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
+        DEV_ALWAYS("Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%llu, miss=%llu, hit_rate=%.1f%%]",
             thread_idx, cycles_to_us(sched_dispatch_cycle),
-            sched_dispatch_cycle * 100.0 / sched_total);
+            sched_dispatch_cycle * 100.0 / sched_total,
+            (unsigned long long)pop_hit,
+            (unsigned long long)pop_miss,
+            pop_hit_rate);
 
         // Level 2: dispatch sub-phases (percentage relative to dispatch)
         uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -94,13 +94,22 @@ Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
 
 **Scheduler output:**
 ```
-Thread X: completed=XXX tasks in XXXus (XXX loops, X.X tasks/loop)
-Thread X: --- Phase Breakdown ---
-Thread X:   complete:    XXXus (XX.X%)  [fanout: edges=XXX, max_degree=X, avg=X.X]  [fanin: edges=XXX, max_degree=X, avg=X.X]
-Thread X:     complete_poll: hit=XXX, miss=XXX, hit_rate=XX.X%
-Thread X:   scan:        XXXus (XX.X%)
-Thread X:   dispatch:    XXXus (XX.X%)  [pop: hit=XXX, miss=XXX, hit_rate=XX.X%]
-Thread X:   idle:        XXXus (XX.X%)
+Thread X: === Scheduler Phase Breakdown: total=XXXus, XXX tasks ===
+Thread X:   complete       : XXXus (XX.X%)  [fanout: edges=XXX, max_degree=X, avg=X.X]  [fanin: edges=XXX, max_degree=X, avg=X.X]
+Thread X:     poll         : XXXus (XX.X%)  hit=XXX, miss=XXX, hit_rate=XX.X%
+Thread X:     otc_lock     : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:     otc_fanout   : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:     otc_fanin    : XXXus (XX.X%)  atomics=XXX
+Thread X:     otc_self     : XXXus (XX.X%)  atomics=XXX
+Thread X:     perf         : XXXus (XX.X%)
+Thread X:   dispatch       : XXXus (XX.X%)  [pop: hit=XXX, miss=XXX, hit_rate=XX.X%]
+Thread X:     poll         : XXXus (XX.X%)
+Thread X:     pop          : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:     setup        : XXXus (XX.X%)
+Thread X:   scan           : XXXus (XX.X%)
+Thread X:   idle           : XXXus (XX.X%)
+Thread X:   avg/complete   : XXXus
+Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
 ```
 
 ---

--- a/tools/sched_overhead_analysis.py
+++ b/tools/sched_overhead_analysis.py
@@ -38,20 +38,12 @@ def parse_scheduler_threads(log_path):
     Supports three formats:
     1. New two-level tree (PTO2_SCHED_PROFILING=1):
         Thread N: === Scheduler Phase Breakdown: total=Xus, Y tasks ===
-        Thread N:   complete       : Xus (Y%)
-        Thread N:   dispatch       : Xus (Y%)
+        Thread N:   complete       : Xus (Y%)  [fanout: edges=A, max_degree=B, avg=C]  [fanin: edges=D, max_degree=E, avg=F]
+        Thread N:   dispatch       : Xus (Y%)  [pop: hit=A, miss=B, hit_rate=C%]
         Thread N:   scan           : Xus (Y%)
         Thread N:   idle           : Xus (Y%)
 
-    2. Legacy detailed (PTO2_SCHED_PROFILING=1):
-        Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
-        Thread N: --- Phase Breakdown ---
-        Thread N:   complete:    Xus (Y%)  [fanout: edges=A, max_degree=B, avg=C]  [fanin: edges=D, max_degree=E, avg=F]
-        Thread N:   scan:        Xus (Y%)
-        Thread N:   dispatch:    Xus (Y%)  [pop: hit=A, miss=B, hit_rate=C%]
-        Thread N:   idle:        Xus (Y%)
-
-    3. Summary (PTO2_SCHED_PROFILING=0):
+    2. Summary (PTO2_SCHED_PROFILING=0):
         Thread N: Scheduler summary: total_time=Xus, loops=Y, tasks_scheduled=Z
     """
     threads = {}
@@ -67,17 +59,6 @@ def parse_scheduler_threads(log_path):
                     'format': 'two-level',
                 }
 
-            # Legacy detailed format: Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
-            m = re.search(r'Thread (\d+): completed=(\d+) tasks in ([\d.]+)us \((\d+) loops, ([\d.]+) tasks/loop\)', line)
-            if m:
-                tid = int(m.group(1))
-                threads[tid] = {
-                    'completed': int(m.group(2)),
-                    'total_us': float(m.group(3)),
-                    'loops': int(m.group(4)),
-                    'tasks_per_loop': float(m.group(5)),
-                }
-
             # Summary format: Thread N: Scheduler summary: total_time=Xus, loops=Y, tasks_scheduled=Z
             m = re.search(r'Thread (\d+): Scheduler summary: total_time=([\d.]+)us, loops=(\d+), tasks_scheduled=(\d+)', line)
             if m:
@@ -86,26 +67,22 @@ def parse_scheduler_threads(log_path):
                 loops = int(m.group(3))
                 completed = int(m.group(4))
                 tasks_per_loop = completed / loops if loops > 0 else 0.0
-                threads[tid] = {
-                    'completed': completed,
-                    'total_us': total_us,
-                    'loops': loops,
-                    'tasks_per_loop': tasks_per_loop,
-                    'format': 'summary',  # Mark as summary format
-                }
-
-            # New format phase lines: Thread N:   complete       : Xus (Y%)
-            m = re.search(r'Thread (\d+):\s+(complete|dispatch|scan|idle)\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)', line)
-            if m:
-                tid = int(m.group(1))
                 if tid in threads:
-                    phase = m.group(2)
-                    threads[tid][f'{phase}_us'] = float(m.group(3))
-                    threads[tid][f'{phase}_pct'] = float(m.group(4))
+                    # Enrich existing entry (e.g. two-level) with loop stats
+                    threads[tid]['loops'] = loops
+                    threads[tid]['tasks_per_loop'] = tasks_per_loop
+                else:
+                    threads[tid] = {
+                        'completed': completed,
+                        'total_us': total_us,
+                        'loops': loops,
+                        'tasks_per_loop': tasks_per_loop,
+                        'format': 'summary',
+                    }
 
-            # Legacy phase: complete [fanout: edges=X, max_degree=Y, avg=Z]  [fanin: edges=D, max_degree=E, avg=F]
+            # New format: complete with fanout/fanin stats
             m = re.search(
-                r'Thread (\d+):\s+complete:\s+([\d.]+)us \(\s*([\d.]+)%\)'
+                r'Thread (\d+):\s+complete\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)'
                 r'\s+\[fanout: edges=(\d+), max_degree=(\d+), avg=([\d.]+)\]'
                 r'\s+\[fanin: edges=(\d+), max_degree=(\d+), avg=([\d.]+)\]',
                 line)
@@ -120,17 +97,13 @@ def parse_scheduler_threads(log_path):
                     threads[tid]['fanin_edges'] = int(m.group(7))
                     threads[tid]['fanin_max_degree'] = int(m.group(8))
                     threads[tid]['fanin_avg'] = float(m.group(9))
+                continue
 
-            # Legacy phase: scan
-            m = re.search(r'Thread (\d+):\s+scan:\s+([\d.]+)us \(\s*([\d.]+)%\)', line)
-            if m:
-                tid = int(m.group(1))
-                if tid in threads:
-                    threads[tid]['scan_us'] = float(m.group(2))
-                    threads[tid]['scan_pct'] = float(m.group(3))
-
-            # Phase: dispatch [pop: hit=X, miss=Y, hit_rate=Z%]
-            m = re.search(r'Thread (\d+):\s+dispatch:\s+([\d.]+)us \(\s*([\d.]+)%\)\s+\[pop: hit=(\d+), miss=(\d+), hit_rate=([\d.]+)%\]', line)
+            # New format: dispatch with pop stats
+            m = re.search(
+                r'Thread (\d+):\s+dispatch\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)'
+                r'\s+\[pop: hit=(\d+), miss=(\d+), hit_rate=([\d.]+)%\]',
+                line)
             if m:
                 tid = int(m.group(1))
                 if tid in threads:
@@ -139,14 +112,17 @@ def parse_scheduler_threads(log_path):
                     threads[tid]['pop_hit'] = int(m.group(4))
                     threads[tid]['pop_miss'] = int(m.group(5))
                     threads[tid]['pop_hit_rate'] = float(m.group(6))
+                continue
 
-            # Phase: idle
-            m = re.search(r'Thread (\d+):\s+idle:\s+([\d.]+)us \(\s*([\d.]+)%\)', line)
+            # New format: scan and idle (no extra stats)
+            m = re.search(r'Thread (\d+):\s+(scan|idle)\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)', line)
             if m:
                 tid = int(m.group(1))
                 if tid in threads:
-                    threads[tid]['idle_us'] = float(m.group(2))
-                    threads[tid]['idle_pct'] = float(m.group(3))
+                    phase = m.group(2)
+                    threads[tid][f'{phase}_us'] = float(m.group(3))
+                    threads[tid][f'{phase}_pct'] = float(m.group(4))
+                continue
 
     return threads
 


### PR DESCRIPTION
## Summary

- Remove `#else` fallback in `aicpu_executor.cpp` that incorrectly output detailed phase breakdown when `PTO2_SCHED_PROFILING=0`
- Add fanout/fanin/pop stats to Level 1 output (complete and dispatch lines)
- Fix parser: add regexes for `complete` with `[fanout:][fanin:]` and `dispatch` with `[pop:]`
- Fix parser: `Scheduler summary:` line was overwriting all phase data previously collected from `Phase Breakdown` lines
- Remove legacy parser rules for formats no longer produced by C++ code

## Testing

- [x] Verified parser correctly extracts all stats from actual device log (device-12)
- [ ] Hardware tests pass