### PR TITLE
Refactor: extract common pto_runtime_c_api into shared source

### DIFF
--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/host_log.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/unified_log_host.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/performance_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/pto_runtime_c_api_common.cpp"
 )
 if(DEFINED CUSTOM_SOURCE_DIRS)
     foreach(SRC_DIR ${CUSTOM_SOURCE_DIRS})

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -1,172 +1,18 @@
 /**
- * PTO Runtime C API - Implementation
+ * PTO Runtime C API - Onboard (Hardware) Platform-Specific Functions
  *
- * Wraps C++ classes as opaque pointers, providing C interface for ctypes
- * bindings. Simplified single-concept model: Runtime only.
+ * Only launch_runtime() and set_device() differ between onboard and simulation.
+ * All other C API functions are in src/host/pto_runtime_c_api_common.cpp.
  */
 
 #include "host/pto_runtime_c_api.h"
 
+#include <vector>
+
 #include "device_runner.h"
-#include "common/unified_log.h"
 #include "runtime.h"
 
 extern "C" {
-
-/* ===========================================================================
- */
-/* Runtime Implementation Functions (defined in runtimemaker.cpp) */
-/* ===========================================================================
- */
-int init_runtime_impl(Runtime* runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    uint64_t* func_args,
-                    int func_args_count,
-                    int* arg_types,
-                    uint64_t* arg_sizes,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count);
-int validate_runtime_impl(Runtime* runtime);
-
-/* Forward declarations for device memory functions used in init_runtime */
-void* device_malloc(size_t size);
-void device_free(void* dev_ptr);
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
-void remove_kernel_binary_wrapper(int func_id);
-
-/* ===========================================================================
- */
-/* Runtime API Implementation */
-/* ===========================================================================
- */
-
-size_t get_runtime_size(void) { return sizeof(Runtime); }
-
-int init_runtime(RuntimeHandle runtime,
-                const uint8_t* orch_so_binary,
-                size_t orch_so_size,
-                const char* orch_func_name,
-                uint64_t* func_args,
-                int func_args_count,
-                int* arg_types,
-                uint64_t* arg_sizes,
-                const int* kernel_func_ids,
-                const uint8_t* const* kernel_binaries,
-                const size_t* kernel_sizes,
-                int kernel_count) {
-    if (runtime == NULL) {
-        return -1;
-    }
-    // Note: orchestration parameters may be empty for device-side orchestration (rt2)
-    // Validation is done in init_runtime_impl which knows the runtime type
-
-    try {
-        // Placement new to construct Runtime in user-allocated memory
-        Runtime* r = new (runtime) Runtime();
-
-        // Initialize host API function pointers (host-only, not available on device)
-        r->host_api.device_malloc = device_malloc;
-        r->host_api.device_free = device_free;
-        r->host_api.copy_to_device = copy_to_device;
-        r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
-
-        LOG_DEBUG("About to call init_runtime_impl, r=%p", (void*)r);
-
-        // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
-        int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
-                               orch_func_name, func_args, func_args_count,
-                               arg_types, arg_sizes,
-                               kernel_func_ids, kernel_binaries,
-                               kernel_sizes, kernel_count);
-
-        LOG_DEBUG("init_runtime_impl returned: %d", result);
-
-        if (result != 0) {
-            r->~Runtime();
-        }
-
-        return result;
-    } catch (...) {
-        return -1;
-    }
-}
-
-/* ===========================================================================
- */
-/* Device Memory API Implementation */
-/* ===========================================================================
- */
-
-void* device_malloc(size_t size) {
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.allocate_tensor(size);
-    } catch (...) {
-        return NULL;
-    }
-}
-
-void device_free(void* dev_ptr) {
-    if (dev_ptr == NULL) {
-        return;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        runner.free_tensor(dev_ptr);
-    } catch (...) {
-        // Ignore errors during free
-    }
-}
-
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size) {
-    if (dev_ptr == NULL || host_ptr == NULL) {
-        return -1;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.copy_to_device(dev_ptr, host_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size) {
-    if (host_ptr == NULL || dev_ptr == NULL) {
-        return -1;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.copy_from_device(host_ptr, dev_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size) {
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.upload_kernel_binary(func_id, bin_data, bin_size);
-    } catch (...) {
-        return 0;
-    }
-}
-
-void remove_kernel_binary_wrapper(int func_id) {
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        runner.remove_kernel_binary(func_id);
-    } catch (...) {
-        // Ignore errors during cleanup
-    }
-}
 
 int launch_runtime(RuntimeHandle runtime,
     int aicpu_thread_num,
@@ -199,55 +45,10 @@ int launch_runtime(RuntimeHandle runtime,
     }
 }
 
-int finalize_runtime(RuntimeHandle runtime) {
-    if (runtime == NULL) {
-        return -1;
-    }
-    try {
-        Runtime* r = static_cast<Runtime*>(runtime);
-        int rc = validate_runtime_impl(r);
-
-        // Call destructor (user will call free())
-        r->~Runtime();
-        return rc;
-    } catch (...) {
-        return -1;
-    }
-}
-
 int set_device(int device_id) {
     try {
         DeviceRunner& runner = DeviceRunner::get();
         return runner.ensure_device_set(device_id);
-    } catch (...) {
-        return -1;
-    }
-}
-
-/* Note: register_kernel() has been internalized into init_runtime().
- * Kernel binaries are now passed directly to init_runtime() which handles
- * registration and stores addresses in Runtime's func_id_to_addr_[] array.
- */
-
-void record_tensor_pair(RuntimeHandle runtime,
-                       void* host_ptr,
-                       void* dev_ptr,
-                       size_t size) {
-    if (runtime == NULL) {
-        return;
-    }
-    Runtime* r = static_cast<Runtime*>(runtime);
-    r->record_tensor_pair(host_ptr, dev_ptr, size);
-}
-
-int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
-    if (runtime == NULL) {
-        return -1;
-    }
-    try {
-        Runtime* r = static_cast<Runtime*>(runtime);
-        r->enable_profiling = (enabled != 0);
-        return 0;
     } catch (...) {
         return -1;
     }

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -32,6 +32,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/host_log.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/unified_log_host.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/performance_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/pto_runtime_c_api_common.cpp"
 )
 
 if(DEFINED CUSTOM_SOURCE_DIRS)

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -1,171 +1,18 @@
 /**
- * PTO Runtime C API - Implementation (Simulation)
+ * PTO Runtime C API - Simulation Platform-Specific Functions
  *
- * Wraps C++ classes as opaque pointers, providing C interface for ctypes.
- * This implementation uses thread-based simulation instead of actual device
- * execution.
+ * Only launch_runtime() and set_device() differ between onboard and simulation.
+ * All other C API functions are in src/host/pto_runtime_c_api_common.cpp.
  */
 
 #include "host/pto_runtime_c_api.h"
 
-#include <new>
 #include <vector>
 
 #include "device_runner.h"
-#include "common/unified_log.h"
 #include "runtime.h"
 
 extern "C" {
-
-/* ===========================================================================
- * Runtime Implementation Functions (defined in runtimemaker.cpp)
- * ===========================================================================
- */
-int init_runtime_impl(Runtime* runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    uint64_t* func_args,
-                    int func_args_count,
-                    int* arg_types,
-                    uint64_t* arg_sizes,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count);
-int validate_runtime_impl(Runtime* runtime);
-
-/* Forward declarations */
-void* device_malloc(size_t size);
-void device_free(void* dev_ptr);
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
-void remove_kernel_binary_wrapper(int func_id);
-
-/* ===========================================================================
- * Runtime API Implementation
- * ===========================================================================
- */
-
-size_t get_runtime_size(void) {
-    return sizeof(Runtime);
-}
-
-int init_runtime(RuntimeHandle runtime,
-                const uint8_t* orch_so_binary,
-                size_t orch_so_size,
-                const char* orch_func_name,
-                uint64_t* func_args,
-                int func_args_count,
-                int* arg_types,
-                uint64_t* arg_sizes,
-                const int* kernel_func_ids,
-                const uint8_t* const* kernel_binaries,
-                const size_t* kernel_sizes,
-                int kernel_count) {
-    if (runtime == NULL) {
-        return -1;
-    }
-    // Note: orchestration parameters may be empty for device-side orchestration (rt2)
-    // Validation is done in init_runtime_impl which knows the runtime type
-
-    try {
-        // Placement new to construct Runtime in user-allocated memory
-        Runtime* r = new (runtime) Runtime();
-
-        // Initialize host API function pointers
-        r->host_api.device_malloc = device_malloc;
-        r->host_api.device_free = device_free;
-        r->host_api.copy_to_device = copy_to_device;
-        r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
-
-        // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
-        int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
-                               orch_func_name, func_args, func_args_count,
-                               arg_types, arg_sizes,
-                               kernel_func_ids, kernel_binaries,
-                               kernel_sizes, kernel_count);
-
-        if (result != 0) {
-            r->~Runtime();
-        }
-
-        return result;
-    } catch (...) {
-        return -1;
-    }
-}
-
-/* ===========================================================================
- * Device Memory API Implementation (Simulation)
- * ===========================================================================
- */
-
-void* device_malloc(size_t size) {
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.allocate_tensor(size);
-    } catch (...) {
-        return NULL;
-    }
-}
-
-void device_free(void* dev_ptr) {
-    if (dev_ptr == NULL) {
-        return;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        runner.free_tensor(dev_ptr);
-    } catch (...) {
-        // Ignore errors during free
-    }
-}
-
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size) {
-    if (dev_ptr == NULL || host_ptr == NULL) {
-        return -1;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.copy_to_device(dev_ptr, host_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size) {
-    if (host_ptr == NULL || dev_ptr == NULL) {
-        return -1;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.copy_from_device(host_ptr, dev_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size) {
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.upload_kernel_binary(func_id, bin_data, bin_size);
-    } catch (...) {
-        return 0;
-    }
-}
-
-void remove_kernel_binary_wrapper(int func_id) {
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        runner.remove_kernel_binary(func_id);
-    } catch (...) {
-        // Ignore errors during cleanup
-    }
-}
 
 int launch_runtime(RuntimeHandle runtime,
                    int aicpu_thread_num,
@@ -202,54 +49,9 @@ int launch_runtime(RuntimeHandle runtime,
     }
 }
 
-int finalize_runtime(RuntimeHandle runtime) {
-    if (runtime == NULL) {
-        return -1;
-    }
-    try {
-        Runtime* r = static_cast<Runtime*>(runtime);
-        int rc = validate_runtime_impl(r);
-
-        // Call destructor (user will call free())
-        r->~Runtime();
-        return rc;
-    } catch (...) {
-        return -1;
-    }
-}
-
 int set_device(int device_id) {
     (void)device_id;  // Unused in simulation
     return 0;
 }
 
-int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
-    if (runtime == NULL) {
-        return -1;
-    }
-    try {
-        Runtime* r = static_cast<Runtime*>(runtime);
-        r->enable_profiling = (enabled != 0);
-        return 0;
-    } catch (...) {
-        return -1;
-    }
-}
-
-/* Note: register_kernel() has been internalized into init_runtime().
- * Kernel binaries are now passed directly to init_runtime() which handles
- * registration and stores addresses in Runtime's func_id_to_addr_[] array.
- */
-
-void record_tensor_pair(RuntimeHandle runtime,
-                       void* host_ptr,
-                       void* dev_ptr,
-                       size_t size) {
-    if (runtime == NULL) {
-        return;
-    }
-    Runtime* r = static_cast<Runtime*>(runtime);
-    r->record_tensor_pair(host_ptr, dev_ptr, size);
-}
-
-}  // extern "C"
+} /* extern "C" */

--- a/src/a2a3/platform/src/host/pto_runtime_c_api_common.cpp
+++ b/src/a2a3/platform/src/host/pto_runtime_c_api_common.cpp
@@ -1,0 +1,216 @@
+/**
+ * PTO Runtime C API - Common Implementation
+ *
+ * Platform-independent functions shared between onboard and simulation.
+ * Platform-specific functions (launch_runtime, set_device) are implemented
+ * in onboard/host/pto_runtime_c_api.cpp and sim/host/pto_runtime_c_api.cpp.
+ */
+
+#include "host/pto_runtime_c_api.h"
+
+#include <new>
+
+#include "device_runner.h"
+#include "common/unified_log.h"
+#include "runtime.h"
+
+extern "C" {
+
+/* ===========================================================================
+ * Runtime Implementation Functions (defined in runtimemaker.cpp)
+ * ===========================================================================
+ */
+int init_runtime_impl(Runtime* runtime,
+                    const uint8_t* orch_so_binary,
+                    size_t orch_so_size,
+                    const char* orch_func_name,
+                    uint64_t* func_args,
+                    int func_args_count,
+                    int* arg_types,
+                    uint64_t* arg_sizes,
+                    const int* kernel_func_ids,
+                    const uint8_t* const* kernel_binaries,
+                    const size_t* kernel_sizes,
+                    int kernel_count);
+int validate_runtime_impl(Runtime* runtime);
+
+/* Forward declarations for device memory functions used in init_runtime */
+void* device_malloc(size_t size);
+void device_free(void* dev_ptr);
+int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
+int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
+void remove_kernel_binary_wrapper(int func_id);
+
+/* ===========================================================================
+ * Runtime API Implementation
+ * ===========================================================================
+ */
+
+size_t get_runtime_size(void) { return sizeof(Runtime); }
+
+int init_runtime(RuntimeHandle runtime,
+                const uint8_t* orch_so_binary,
+                size_t orch_so_size,
+                const char* orch_func_name,
+                uint64_t* func_args,
+                int func_args_count,
+                int* arg_types,
+                uint64_t* arg_sizes,
+                const int* kernel_func_ids,
+                const uint8_t* const* kernel_binaries,
+                const size_t* kernel_sizes,
+                int kernel_count) {
+    if (runtime == NULL) {
+        return -1;
+    }
+    // Note: orchestration parameters may be empty for device-side orchestration (rt2)
+    // Validation is done in init_runtime_impl which knows the runtime type
+
+    try {
+        // Placement new to construct Runtime in user-allocated memory
+        Runtime* r = new (runtime) Runtime();
+
+        // Initialize host API function pointers
+        r->host_api.device_malloc = device_malloc;
+        r->host_api.device_free = device_free;
+        r->host_api.copy_to_device = copy_to_device;
+        r->host_api.copy_from_device = copy_from_device;
+        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
+        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
+
+        LOG_DEBUG("About to call init_runtime_impl, r=%p", (void*)r);
+
+        // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
+        int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
+                               orch_func_name, func_args, func_args_count,
+                               arg_types, arg_sizes,
+                               kernel_func_ids, kernel_binaries,
+                               kernel_sizes, kernel_count);
+
+        LOG_DEBUG("init_runtime_impl returned: %d", result);
+
+        if (result != 0) {
+            r->~Runtime();
+        }
+
+        return result;
+    } catch (...) {
+        return -1;
+    }
+}
+
+/* ===========================================================================
+ * Device Memory API Implementation
+ * ===========================================================================
+ */
+
+void* device_malloc(size_t size) {
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        return runner.allocate_tensor(size);
+    } catch (...) {
+        return NULL;
+    }
+}
+
+void device_free(void* dev_ptr) {
+    if (dev_ptr == NULL) {
+        return;
+    }
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        runner.free_tensor(dev_ptr);
+    } catch (...) {
+        // Ignore errors during free
+    }
+}
+
+int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size) {
+    if (dev_ptr == NULL || host_ptr == NULL) {
+        return -1;
+    }
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        return runner.copy_to_device(dev_ptr, host_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size) {
+    if (host_ptr == NULL || dev_ptr == NULL) {
+        return -1;
+    }
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        return runner.copy_from_device(host_ptr, dev_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size) {
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        return runner.upload_kernel_binary(func_id, bin_data, bin_size);
+    } catch (...) {
+        return 0;
+    }
+}
+
+void remove_kernel_binary_wrapper(int func_id) {
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        runner.remove_kernel_binary(func_id);
+    } catch (...) {
+        // Ignore errors during cleanup
+    }
+}
+
+int finalize_runtime(RuntimeHandle runtime) {
+    if (runtime == NULL) {
+        return -1;
+    }
+    try {
+        Runtime* r = static_cast<Runtime*>(runtime);
+        int rc = validate_runtime_impl(r);
+
+        // Call destructor (user will call free())
+        r->~Runtime();
+        return rc;
+    } catch (...) {
+        return -1;
+    }
+}
+
+int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
+    if (runtime == NULL) {
+        return -1;
+    }
+    try {
+        Runtime* r = static_cast<Runtime*>(runtime);
+        r->enable_profiling = (enabled != 0);
+        return 0;
+    } catch (...) {
+        return -1;
+    }
+}
+
+/* Note: register_kernel() has been internalized into init_runtime().
+ * Kernel binaries are now passed directly to init_runtime() which handles
+ * registration and stores addresses in Runtime's func_id_to_addr_[] array.
+ */
+
+void record_tensor_pair(RuntimeHandle runtime,
+                       void* host_ptr,
+                       void* dev_ptr,
+                       size_t size) {
+    if (runtime == NULL) {
+        return;
+    }
+    Runtime* r = static_cast<Runtime*>(runtime);
+    r->record_tensor_pair(host_ptr, dev_ptr, size);
+}
+
+} /* extern "C" */

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/host_log.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/unified_log_host.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/performance_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/pto_runtime_c_api_common.cpp"
 )
 if(DEFINED CUSTOM_SOURCE_DIRS)
     foreach(SRC_DIR ${CUSTOM_SOURCE_DIRS})

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -1,161 +1,21 @@
 /**
- * PTO Runtime C API - Implementation
+ * PTO Runtime C API - Onboard (Hardware) Platform-Specific Functions (A5)
  *
- * Wraps C++ classes as opaque pointers, providing C interface for ctypes
- * bindings. Simplified single-concept model: Runtime only.
+ * Only launch_runtime(), finalize_runtime(), and set_device() differ between
+ * onboard and simulation. All other C API functions are in
+ * src/host/pto_runtime_c_api_common.cpp.
  */
 
 #include "host/pto_runtime_c_api.h"
 
+#include <vector>
+
 #include "device_runner.h"
-#include "common/unified_log.h"
 #include "runtime.h"
 
 extern "C" {
 
-/* ===========================================================================
- */
-/* Runtime Implementation Functions (defined in runtimemaker.cpp) */
-/* ===========================================================================
- */
-int init_runtime_impl(Runtime* runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    uint64_t* func_args,
-                    int func_args_count,
-                    int* arg_types,
-                    uint64_t* arg_sizes,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count);
 int validate_runtime_impl(Runtime* runtime);
-
-/* Forward declarations for device memory functions used in init_runtime */
-void* device_malloc(size_t size);
-void device_free(void* dev_ptr);
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
-
-/* ===========================================================================
- */
-/* Runtime API Implementation */
-/* ===========================================================================
- */
-
-size_t get_runtime_size(void) { return sizeof(Runtime); }
-
-int init_runtime(RuntimeHandle runtime,
-                const uint8_t* orch_so_binary,
-                size_t orch_so_size,
-                const char* orch_func_name,
-                uint64_t* func_args,
-                int func_args_count,
-                int* arg_types,
-                uint64_t* arg_sizes,
-                const int* kernel_func_ids,
-                const uint8_t* const* kernel_binaries,
-                const size_t* kernel_sizes,
-                int kernel_count) {
-    if (runtime == NULL) {
-        return -1;
-    }
-    // Note: orchestration parameters may be empty for device-side orchestration (rt2)
-    // Validation is done in init_runtime_impl which knows the runtime type
-
-    try {
-        // Placement new to construct Runtime in user-allocated memory
-        Runtime* r = new (runtime) Runtime();
-
-        // Initialize host API function pointers (host-only, not available on device)
-        r->host_api.device_malloc = device_malloc;
-        r->host_api.device_free = device_free;
-        r->host_api.copy_to_device = copy_to_device;
-        r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-
-        LOG_DEBUG("About to call init_runtime_impl, r=%p", (void*)r);
-
-        // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
-        int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
-                               orch_func_name, func_args, func_args_count,
-                               arg_types, arg_sizes,
-                               kernel_func_ids, kernel_binaries,
-                               kernel_sizes, kernel_count);
-
-        LOG_DEBUG("init_runtime_impl returned: %d", result);
-
-        if (result != 0) {
-            r->~Runtime();
-        }
-
-        return result;
-    } catch (...) {
-        return -1;
-    }
-}
-
-/* ===========================================================================
- */
-/* Device Memory API Implementation */
-/* ===========================================================================
- */
-
-void* device_malloc(size_t size) {
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.allocate_tensor(size);
-    } catch (...) {
-        return NULL;
-    }
-}
-
-void device_free(void* dev_ptr) {
-    if (dev_ptr == NULL) {
-        return;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        runner.free_tensor(dev_ptr);
-    } catch (...) {
-        // Ignore errors during free
-    }
-}
-
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size) {
-    if (dev_ptr == NULL || host_ptr == NULL) {
-        return -1;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.copy_to_device(dev_ptr, host_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size) {
-    if (host_ptr == NULL || dev_ptr == NULL) {
-        return -1;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.copy_from_device(host_ptr, dev_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size) {
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.upload_kernel_binary(func_id, bin_data, bin_size);
-    } catch (...) {
-        return 0;
-    }
-}
 
 int launch_runtime(RuntimeHandle runtime,
     int aicpu_thread_num,
@@ -197,7 +57,7 @@ int finalize_runtime(RuntimeHandle runtime) {
         // Clean cached resources to prepare for next test
         DeviceRunner& runner = DeviceRunner::get();
         runner.clean_cache();
-        
+
         // Call destructor (user will call free())
         r->~Runtime();
         return rc;
@@ -210,35 +70,6 @@ int set_device(int device_id) {
     try {
         DeviceRunner& runner = DeviceRunner::get();
         return runner.ensure_device_set(device_id);
-    } catch (...) {
-        return -1;
-    }
-}
-
-/* Note: register_kernel() has been internalized into init_runtime().
- * Kernel binaries are now passed directly to init_runtime() which handles
- * registration and stores addresses in Runtime's func_id_to_addr_[] array.
- */
-
-void record_tensor_pair(RuntimeHandle runtime,
-                       void* host_ptr,
-                       void* dev_ptr,
-                       size_t size) {
-    if (runtime == NULL) {
-        return;
-    }
-    Runtime* r = static_cast<Runtime*>(runtime);
-    r->record_tensor_pair(host_ptr, dev_ptr, size);
-}
-
-int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
-    if (runtime == NULL) {
-        return -1;
-    }
-    try {
-        Runtime* r = static_cast<Runtime*>(runtime);
-        r->enable_profiling = (enabled != 0);
-        return 0;
     } catch (...) {
         return -1;
     }

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -32,6 +32,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/host_log.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/unified_log_host.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/performance_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/pto_runtime_c_api_common.cpp"
 )
 
 if(DEFINED CUSTOM_SOURCE_DIRS)

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -1,160 +1,21 @@
 /**
- * PTO Runtime C API - Implementation (Simulation)
+ * PTO Runtime C API - Simulation Platform-Specific Functions (A5)
  *
- * Wraps C++ classes as opaque pointers, providing C interface for ctypes.
- * This implementation uses thread-based simulation instead of actual device
- * execution.
+ * Only launch_runtime(), finalize_runtime(), and set_device() differ between
+ * onboard and simulation. All other C API functions are in
+ * src/host/pto_runtime_c_api_common.cpp.
  */
 
 #include "host/pto_runtime_c_api.h"
 
-#include <new>
 #include <vector>
 
 #include "device_runner.h"
-#include "common/unified_log.h"
 #include "runtime.h"
 
 extern "C" {
 
-/* ===========================================================================
- * Runtime Implementation Functions (defined in runtimemaker.cpp)
- * ===========================================================================
- */
-int init_runtime_impl(Runtime* runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    uint64_t* func_args,
-                    int func_args_count,
-                    int* arg_types,
-                    uint64_t* arg_sizes,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count);
 int validate_runtime_impl(Runtime* runtime);
-
-/* Forward declarations */
-void* device_malloc(size_t size);
-void device_free(void* dev_ptr);
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
-
-/* ===========================================================================
- * Runtime API Implementation
- * ===========================================================================
- */
-
-size_t get_runtime_size(void) {
-    return sizeof(Runtime);
-}
-
-int init_runtime(RuntimeHandle runtime,
-                const uint8_t* orch_so_binary,
-                size_t orch_so_size,
-                const char* orch_func_name,
-                uint64_t* func_args,
-                int func_args_count,
-                int* arg_types,
-                uint64_t* arg_sizes,
-                const int* kernel_func_ids,
-                const uint8_t* const* kernel_binaries,
-                const size_t* kernel_sizes,
-                int kernel_count) {
-    if (runtime == NULL) {
-        return -1;
-    }
-    // Note: orchestration parameters may be empty for device-side orchestration (rt2)
-    // Validation is done in init_runtime_impl which knows the runtime type
-
-    try {
-        // Placement new to construct Runtime in user-allocated memory
-        Runtime* r = new (runtime) Runtime();
-
-        // Initialize host API function pointers
-        r->host_api.device_malloc = device_malloc;
-        r->host_api.device_free = device_free;
-        r->host_api.copy_to_device = copy_to_device;
-        r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-
-        // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
-        int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
-                               orch_func_name, func_args, func_args_count,
-                               arg_types, arg_sizes,
-                               kernel_func_ids, kernel_binaries,
-                               kernel_sizes, kernel_count);
-
-        if (result != 0) {
-            r->~Runtime();
-        }
-
-        return result;
-    } catch (...) {
-        return -1;
-    }
-}
-
-/* ===========================================================================
- * Device Memory API Implementation (Simulation)
- * ===========================================================================
- */
-
-void* device_malloc(size_t size) {
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.allocate_tensor(size);
-    } catch (...) {
-        return NULL;
-    }
-}
-
-void device_free(void* dev_ptr) {
-    if (dev_ptr == NULL) {
-        return;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        runner.free_tensor(dev_ptr);
-    } catch (...) {
-        // Ignore errors during free
-    }
-}
-
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size) {
-    if (dev_ptr == NULL || host_ptr == NULL) {
-        return -1;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.copy_to_device(dev_ptr, host_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size) {
-    if (host_ptr == NULL || dev_ptr == NULL) {
-        return -1;
-    }
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.copy_from_device(host_ptr, dev_ptr, size);
-    } catch (...) {
-        return -1;
-    }
-}
-
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size) {
-    try {
-        DeviceRunner& runner = DeviceRunner::get();
-        return runner.upload_kernel_binary(func_id, bin_data, bin_size);
-    } catch (...) {
-        return 0;
-    }
-}
 
 int launch_runtime(RuntimeHandle runtime,
                    int aicpu_thread_num,
@@ -217,33 +78,4 @@ int set_device(int device_id) {
     return 0;
 }
 
-int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
-    if (runtime == NULL) {
-        return -1;
-    }
-    try {
-        Runtime* r = static_cast<Runtime*>(runtime);
-        r->enable_profiling = (enabled != 0);
-        return 0;
-    } catch (...) {
-        return -1;
-    }
-}
-
-/* Note: register_kernel() has been internalized into init_runtime().
- * Kernel binaries are now passed directly to init_runtime() which handles
- * registration and stores addresses in Runtime's func_id_to_addr_[] array.
- */
-
-void record_tensor_pair(RuntimeHandle runtime,
-                       void* host_ptr,
-                       void* dev_ptr,
-                       size_t size) {
-    if (runtime == NULL) {
-        return;
-    }
-    Runtime* r = static_cast<Runtime*>(runtime);
-    r->record_tensor_pair(host_ptr, dev_ptr, size);
-}
-
-}  // extern "C"
+} /* extern "C" */

--- a/src/a5/platform/src/host/pto_runtime_c_api_common.cpp
+++ b/src/a5/platform/src/host/pto_runtime_c_api_common.cpp
@@ -1,0 +1,190 @@
+/**
+ * PTO Runtime C API - Common Implementation (A5)
+ *
+ * Platform-independent functions shared between onboard and simulation.
+ * Platform-specific functions (launch_runtime, finalize_runtime, set_device)
+ * are implemented in onboard/host/pto_runtime_c_api.cpp and
+ * sim/host/pto_runtime_c_api.cpp.
+ */
+
+#include "host/pto_runtime_c_api.h"
+
+#include <new>
+
+#include "device_runner.h"
+#include "common/unified_log.h"
+#include "runtime.h"
+
+extern "C" {
+
+/* ===========================================================================
+ * Runtime Implementation Functions (defined in runtimemaker.cpp)
+ * ===========================================================================
+ */
+int init_runtime_impl(Runtime* runtime,
+                    const uint8_t* orch_so_binary,
+                    size_t orch_so_size,
+                    const char* orch_func_name,
+                    uint64_t* func_args,
+                    int func_args_count,
+                    int* arg_types,
+                    uint64_t* arg_sizes,
+                    const int* kernel_func_ids,
+                    const uint8_t* const* kernel_binaries,
+                    const size_t* kernel_sizes,
+                    int kernel_count);
+int validate_runtime_impl(Runtime* runtime);
+
+/* Forward declarations for device memory functions used in init_runtime */
+void* device_malloc(size_t size);
+void device_free(void* dev_ptr);
+int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
+int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
+
+/* ===========================================================================
+ * Runtime API Implementation
+ * ===========================================================================
+ */
+
+size_t get_runtime_size(void) { return sizeof(Runtime); }
+
+int init_runtime(RuntimeHandle runtime,
+                const uint8_t* orch_so_binary,
+                size_t orch_so_size,
+                const char* orch_func_name,
+                uint64_t* func_args,
+                int func_args_count,
+                int* arg_types,
+                uint64_t* arg_sizes,
+                const int* kernel_func_ids,
+                const uint8_t* const* kernel_binaries,
+                const size_t* kernel_sizes,
+                int kernel_count) {
+    if (runtime == NULL) {
+        return -1;
+    }
+    // Note: orchestration parameters may be empty for device-side orchestration (rt2)
+    // Validation is done in init_runtime_impl which knows the runtime type
+
+    try {
+        // Placement new to construct Runtime in user-allocated memory
+        Runtime* r = new (runtime) Runtime();
+
+        // Initialize host API function pointers
+        r->host_api.device_malloc = device_malloc;
+        r->host_api.device_free = device_free;
+        r->host_api.copy_to_device = copy_to_device;
+        r->host_api.copy_from_device = copy_from_device;
+        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
+
+        LOG_DEBUG("About to call init_runtime_impl, r=%p", (void*)r);
+
+        // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
+        int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
+                               orch_func_name, func_args, func_args_count,
+                               arg_types, arg_sizes,
+                               kernel_func_ids, kernel_binaries,
+                               kernel_sizes, kernel_count);
+
+        LOG_DEBUG("init_runtime_impl returned: %d", result);
+
+        if (result != 0) {
+            r->~Runtime();
+        }
+
+        return result;
+    } catch (...) {
+        return -1;
+    }
+}
+
+/* ===========================================================================
+ * Device Memory API Implementation
+ * ===========================================================================
+ */
+
+void* device_malloc(size_t size) {
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        return runner.allocate_tensor(size);
+    } catch (...) {
+        return NULL;
+    }
+}
+
+void device_free(void* dev_ptr) {
+    if (dev_ptr == NULL) {
+        return;
+    }
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        runner.free_tensor(dev_ptr);
+    } catch (...) {
+        // Ignore errors during free
+    }
+}
+
+int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size) {
+    if (dev_ptr == NULL || host_ptr == NULL) {
+        return -1;
+    }
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        return runner.copy_to_device(dev_ptr, host_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size) {
+    if (host_ptr == NULL || dev_ptr == NULL) {
+        return -1;
+    }
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        return runner.copy_from_device(host_ptr, dev_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size) {
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        return runner.upload_kernel_binary(func_id, bin_data, bin_size);
+    } catch (...) {
+        return 0;
+    }
+}
+
+int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
+    if (runtime == NULL) {
+        return -1;
+    }
+    try {
+        Runtime* r = static_cast<Runtime*>(runtime);
+        r->enable_profiling = (enabled != 0);
+        return 0;
+    } catch (...) {
+        return -1;
+    }
+}
+
+/* Note: register_kernel() has been internalized into init_runtime().
+ * Kernel binaries are now passed directly to init_runtime() which handles
+ * registration and stores addresses in Runtime's func_id_to_addr_[] array.
+ */
+
+void record_tensor_pair(RuntimeHandle runtime,
+                       void* host_ptr,
+                       void* dev_ptr,
+                       size_t size) {
+    if (runtime == NULL) {
+        return;
+    }
+    Runtime* r = static_cast<Runtime*>(runtime);
+    r->record_tensor_pair(host_ptr, dev_ptr, size);
+}
+
+} /* extern "C" */


### PR DESCRIPTION
## Summary

- Extract common pto_runtime_c_api functions into shared source files for both a2a3 and a5 platforms
- a2a3: 11 of 13 functions extracted, platform-specific files retain only `launch_runtime()` and `set_device()`
- a5: 9 of 12 functions extracted, platform-specific files retain `launch_runtime()`, `finalize_runtime()`, and `set_device()`
- Eliminates ~400 lines of duplicated code across 4 files (2 per chip generation)

## Changes

| File | Action |
|------|--------|
| `a2a3/platform/src/host/pto_runtime_c_api_common.cpp` | New shared file (11 common functions) |
| `a2a3/platform/onboard/host/pto_runtime_c_api.cpp` | Trimmed to 2 platform-specific functions |
| `a2a3/platform/sim/host/pto_runtime_c_api.cpp` | Trimmed to 2 platform-specific functions |
| `a2a3/platform/{onboard,sim}/host/CMakeLists.txt` | Added shared source to build |
| `a5/platform/src/host/pto_runtime_c_api_common.cpp` | New shared file (9 common functions) |
| `a5/platform/onboard/host/pto_runtime_c_api.cpp` | Trimmed to 3 platform-specific functions |
| `a5/platform/sim/host/pto_runtime_c_api.cpp` | Trimmed to 3 platform-specific functions |
| `a5/platform/{onboard,sim}/host/CMakeLists.txt` | Added shared source to build |

## Test plan

- [x] `./ci.sh -p a2a3sim` — all 12 simulation tests pass
- [x] `./ci.sh -p a5sim` — all 4 simulation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)