### PR TITLE
Add: paged_attention_unroll with consolidated 4-task-per-group pipeline

### DIFF
--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
@@ -1,0 +1,331 @@
+"""
+Paged Attention Golden Implementation - Production Scale
+
+Implements the online softmax algorithm for paged attention with:
+- bfloat16 Q/K/V inputs
+- Non-transposed K storage: (total_blocks, block_size, kv_head_num, head_dim)
+- GQA support (kv_head_num=1)
+- Head tiling: q_tile = min(q_head_num, 128)
+- Random block table mapping
+
+Args layout: [ptr_query, ..., ptr_config, size_query, size_key_cache, size_value_cache]
+"""
+
+import ctypes
+import struct
+import torch
+
+__outputs__ = ["out"]
+
+RTOL = 1e-3
+ATOL = 1e-3
+
+
+# All test cases - production scale + N_UNROLL test cases
+ALL_CASES = {
+    "Case1": {
+        "batch": 64,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 8193,
+        "max_model_len": 32768,
+    },
+    "Case2": {
+        "batch": 64,
+        "num_heads": 64,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 64,
+        "context_len": 8192,
+        "max_model_len": 32768,
+    },
+    # N_UNROLL=8 test cases
+    "Batch2": {
+        "batch": 2,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 8193,
+        "max_model_len": 32768,
+    },
+    "Batch8": {
+        "batch": 8,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 8193,
+        "max_model_len": 32768,
+    },
+    "Blocks65": {
+        "batch": 1,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 8193,
+        "max_model_len": 32768,
+    },
+    "Blocks17": {
+        "batch": 1,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 2049,
+        "max_model_len": 4096,
+    },
+    "Blocks33": {
+        "batch": 1,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 4097,
+        "max_model_len": 8192,
+    },
+    "Blocks25": {
+        "batch": 1,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 3073,
+        "max_model_len": 8192,
+    },
+    "Blocks24": {
+        "batch": 1,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 3072,
+        "max_model_len": 8192,
+    },
+}
+
+DEFAULT_CASE = "Blocks17"
+
+
+def generate_inputs(params: dict) -> list:
+    """Generate input tensors and zeroed output tensor."""
+    batch = params["batch"]
+    num_heads = params["num_heads"]
+    kv_head_num = params["kv_head_num"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    context_len = params["context_len"]
+    max_model_len = params["max_model_len"]
+
+    max_num_blocks_per_req = max_model_len // block_size
+    cur_valid_blocks = (context_len + block_size - 1) // block_size
+    total_blocks = batch * cur_valid_blocks
+    scale_value = 1.0
+    scale_bits = struct.unpack('I', struct.pack('f', scale_value))[0]
+
+    block_table = torch.randint(
+        0,
+        max(total_blocks, 1),
+        size=(batch, max_num_blocks_per_req),
+        dtype=torch.int32,
+    )
+
+    context_lens = torch.full((batch,), context_len, dtype=torch.int32)
+
+    config = torch.tensor(
+        [batch, num_heads, kv_head_num, head_dim, block_size,
+         max_num_blocks_per_req, scale_bits],
+        dtype=torch.int64,
+    )
+
+    query_bf16 = torch.empty(batch, 1, num_heads * head_dim).uniform_(-0.5, 0.5).to(torch.bfloat16)
+    query_bf16 = query_bf16.reshape(batch, num_heads, head_dim)
+
+    key_bf16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-0.5, 0.5).to(torch.bfloat16)
+    value_bf16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-1, 1).to(torch.bfloat16)
+
+    query = query_bf16.flatten()
+    key_cache = key_bf16.flatten()
+    value_cache = value_bf16.flatten()
+    block_table_flat = block_table.flatten()
+    out = torch.zeros(batch * num_heads * head_dim, dtype=torch.float32)
+
+    return [
+        ("query", query),
+        ("key_cache", key_cache),
+        ("value_cache", value_cache),
+        ("block_table", block_table_flat),
+        ("context_lens", context_lens),
+        ("out", out),
+        ("config", config),
+        ("size_query", ctypes.c_int64(query.nbytes)),
+        ("size_key_cache", ctypes.c_int64(key_cache.nbytes)),
+        ("size_value_cache", ctypes.c_int64(value_cache.nbytes)),
+    ]
+
+
+def paged_attention(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    num_kv_heads: int,
+    num_heads: int,
+    scale_value: float,
+    block_table: torch.Tensor,
+    context_lens: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Compute paged attention using online softmax with head tiling and GQA.
+
+    Vectorized across the batch dimension for performance.
+    Supports different context_lens per batch via masking.
+
+    Args:
+        query: (batch, num_heads, head_dim) bfloat16
+        key_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
+        value_cache: (total_blocks, block_size, num_kv_heads, head_dim) bfloat16
+        num_kv_heads: int
+        num_heads: int
+        scale_value: float
+        block_table: (batch, block_num) int32
+        context_lens: (batch,) int32
+
+    Returns:
+        out: (batch * num_heads, head_dim) float32
+    """
+    assert num_kv_heads == 1
+    batch, num_heads_dim, head_dim = query.shape
+    _, block_size, _, _ = key_cache.shape
+
+    # Reshape for batched computation
+    key_cache_flat = key_cache.reshape(-1, block_size, head_dim)
+    value_cache_flat = value_cache.reshape(-1, block_size, head_dim)
+
+    out = torch.zeros((batch, num_heads_dim, head_dim), dtype=torch.float32)
+
+    q_tile = min(num_heads_dim, 128)
+
+    # Max blocks across all batches (each batch may have different context_len)
+    max_bn = int(((context_lens.max().item()) + block_size - 1) // block_size)
+
+    for q_offset in range(0, num_heads_dim, q_tile):
+        q_tile_size = min(q_tile, num_heads_dim - q_offset)
+        # qi: (batch, q_tile_size, head_dim)
+        qi = query[:, q_offset:q_offset + q_tile_size, :].to(torch.float32)
+
+        oi = None  # (batch, q_tile_size, head_dim)
+        li = None  # (batch, q_tile_size, 1)
+        mi = None  # (batch, q_tile_size, 1)
+
+        for bn in range(max_bn):
+            # valid_len per batch for this block position
+            valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+            active_mask = valid_lens > 0  # (batch,)
+
+            if not active_mask.any():
+                break
+
+            # Gather block indices for all batches
+            block_indices = block_table[:, bn]  # (batch,)
+
+            # Gather K and V: (batch, block_size, head_dim)
+            kj_all = key_cache_flat[block_indices].to(torch.float32)
+            vj_all = value_cache_flat[block_indices].to(torch.float32)
+
+            # QK matmul: (batch, q_tile_size, block_size)
+            sij = torch.bmm(qi, kj_all.transpose(1, 2)) * scale_value
+
+            # Mask out invalid positions (beyond valid_len per batch)
+            pos = torch.arange(block_size, device=sij.device).unsqueeze(0)  # (1, block_size)
+            valid_mask = pos < valid_lens.unsqueeze(1)  # (batch, block_size)
+            valid_mask = valid_mask.unsqueeze(1)  # (batch, 1, block_size)
+            sij = sij.masked_fill(~valid_mask, float('-inf'))
+
+            # Also mask inactive batches (no blocks at this position)
+            batch_mask = active_mask.view(-1, 1, 1)  # (batch, 1, 1)
+            sij = sij.masked_fill(~batch_mask, float('-inf'))
+
+            mij = sij.max(dim=-1, keepdim=True)[0]  # (batch, q_tile_size, 1)
+            mij = mij.clamp(min=-1e30)
+            pij = torch.exp(sij - mij)
+            pij = pij.masked_fill(~valid_mask, 0.0)
+            pij = pij.masked_fill(~batch_mask, 0.0)
+            pij = pij.to(torch.bfloat16).to(torch.float32)
+            lij = pij.sum(dim=-1, keepdim=True)  # (batch, q_tile_size, 1)
+
+            # PV matmul: (batch, q_tile_size, head_dim)
+            oi_new = torch.bmm(pij, vj_all)
+
+            if bn == 0:
+                oi = oi_new
+                li = lij
+                mi = mij
+            else:
+                mi_new = torch.maximum(mi, mij)
+                alpha = torch.exp(mi - mi_new)
+                beta = torch.exp(mij - mi_new)
+                li = alpha * li + beta * lij
+                oi = alpha * oi + beta * oi_new
+                mi = mi_new
+
+        # Final normalization
+        out[:, q_offset:q_offset + q_tile_size, :] = oi / li
+
+    return out.reshape(-1, head_dim)
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute expected output in-place using online softmax paged attention."""
+    batch = params["batch"]
+    num_heads = params["num_heads"]
+    kv_head_num = params["kv_head_num"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    max_model_len = params["max_model_len"]
+
+    max_num_blocks_per_req = max_model_len // block_size
+
+    # Reconstruct shaped tensors from flat tensors
+    query = tensors["query"].reshape(batch, num_heads, head_dim)
+    key_cache = tensors["key_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    value_cache = tensors["value_cache"].reshape(-1, block_size, kv_head_num, head_dim)
+    block_table = tensors["block_table"].reshape(batch, max_num_blocks_per_req)
+    context_lens = tensors["context_lens"]
+
+    out = paged_attention(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        num_kv_heads=kv_head_num,
+        num_heads=num_heads,
+        scale_value=1.0,
+        block_table=block_table,
+        context_lens=context_lens,
+    )
+
+    tensors["out"][:] = out.flatten()
+
+
+if __name__ == "__main__":
+    params = {"name": DEFAULT_CASE, **ALL_CASES[DEFAULT_CASE]}
+    result = generate_inputs(params)
+    tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
+    compute_golden(tensors, params)
+
+    print(f"=== Paged Attention Golden Test ({params['name']}) ===")
+    print(f"batch={params['batch']}, num_heads={params['num_heads']}, head_dim={params['head_dim']}")
+    print(f"kv_head_num={params['kv_head_num']}, block_size={params['block_size']}")
+    print(f"context_len={params['context_len']}")
+
+    max_num_blocks = params['max_model_len'] // params['block_size']
+    q_tile = min(params['num_heads'], 128)
+    print(f"max_num_blocks_per_req={max_num_blocks}, q_tile_size={q_tile}")
+
+    out = tensors["out"].reshape(params["batch"] * params["num_heads"], params["head_dim"])
+    print(f"Output shape: {out.shape}")
+    print(f"Output range: [{out.min():.4f}, {out.max():.4f}]")
+    print(f"Output mean: {out.mean():.4f}")
+    print("Golden test passed!")

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_hub.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_hub.cpp
@@ -1,0 +1,18 @@
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+constexpr int M = 16;
+constexpr int K = 16;
+constexpr int N = 16;
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -1,0 +1,121 @@
+// SplitK PV Matmul Kernel: Accumulated P @ V across n_blocks
+//
+// Processes n_blocks blocks using SplitK accumulation pattern:
+//   Block 0: TMATMUL(C, A, B)       — initialize accumulator
+//   Block i: TMATMUL_ACC(C, C, A, B) — accumulate into same C
+//
+// Per-block pij addresses: contiguous slices of pij_buf (n_blocks * M * K)
+// Per-block vj addresses: value_cache base + block_indices lookup
+// Single output: oi_new (M, N) fp32 = sum of P_i @ V_i across all blocks
+//
+// Supports two tile configurations via runtime dispatch:
+//   Case1: (16, 128) @ (128, 128) -> (16, 128)
+//   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//
+// pij is bfloat16 (from softmax_prepare TCVT).
+// vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int K, int N>
+static __aicore__ void pv_matmul_n_impl(
+    __gm__ bfloat16_t* pij_base,
+    __gm__ bfloat16_t* val_base,
+    __gm__ float* oi_base,
+    uint64_t n_blocks,
+    uint64_t* block_indices) {
+
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
+
+    using TileMatA = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
+
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile = TileRight<bfloat16_t, K, N, K, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    GlobalOut oiGlobal(oi_base);
+
+    for (uint64_t i = 0; i < n_blocks; i++) {
+        GlobalA pijGlobal(pij_base + i * M * K);
+        GlobalB vjGlobal(val_base + block_indices[i] * K * N);
+
+        TLOAD(aMatTile, pijGlobal);
+        TLOAD(bMatTile, vjGlobal);
+
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+        TMOV(aTile, aMatTile);
+        TMOV(bTile, bMatTile);
+
+        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+        if (i == 0) {
+            TMATMUL(cTile, aTile, bTile);
+        } else {
+            TMATMUL_ACC(cTile, cTile, aTile, bTile);
+        }
+
+        set_flag(PIPE_M, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_M, PIPE_MTE2, EVENT_ID0);
+    }
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    TSTORE(oiGlobal, cTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* pij_buf = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* value_cache = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* oi_new = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    uint64_t n_blocks = static_cast<uint64_t>(args[3]);
+    uint64_t block_indices[8];
+    for (int j = 0; j < 8; j++) {
+        block_indices[j] = static_cast<uint64_t>(args[4 + j]);
+    }
+
+    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_buf->buffer.addr) + pij_buf->start_offset;
+    __gm__ bfloat16_t* val_base = reinterpret_cast<__gm__ bfloat16_t*>(value_cache->buffer.addr);
+    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr) + oi_new->start_offset;
+
+    uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
+    if (n_blocks > 1) {
+        q_tile_size /= n_blocks;
+    }
+
+    if (q_tile_size == 16) {
+        pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, block_indices);
+    } else {
+        pv_matmul_n_impl<64, 64, 128>(pij_base, val_base, oi_base, n_blocks, block_indices);
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -1,0 +1,113 @@
+// Multi-block QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N) for each block
+//
+// Processes n_blocks blocks in a single kernel invocation.
+// Per-block kj addresses computed from key_cache base + block_indices lookup.
+// qi is shared across all blocks (same query head against different key blocks).
+//
+// Output layout: n_blocks contiguous (M, N) tiles stacked vertically.
+// Block i occupies sij[i*M : (i+1)*M, 0:N].
+//
+// Supports two tile configurations via runtime dispatch:
+//   Case1: (16, 128) @ (128, 128).T -> (16, 128)
+//   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//
+// Template: M=q_tile, K=head_dim, N=block_size
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int K, int N>
+static __aicore__ void qk_matmul_n_impl(
+    __gm__ bfloat16_t* qi_base,
+    __gm__ bfloat16_t* key_base,
+    __gm__ float* sij_base,
+    uint64_t n_blocks,
+    uint64_t* block_indices) {
+
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
+
+    using TileMatA = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
+
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile = TileRight<bfloat16_t, K, N, K, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    for (uint64_t i = 0; i < n_blocks; i++) {
+        GlobalA qiGlobal(qi_base);
+        GlobalB kjGlobal(key_base + block_indices[i] * N * K);
+        GlobalOut sijGlobal(sij_base + i * M * N);
+
+        TLOAD(aMatTile, qiGlobal);
+        TLOAD(bMatTile, kjGlobal);
+
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+        TMOV(aTile, aMatTile);
+        TMOV(bTile, bMatTile);
+
+        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+        TMATMUL(cTile, aTile, bTile);
+
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+        TSTORE(sijGlobal, cTile);
+
+        if (i + 1 < n_blocks) {
+            pipe_barrier(PIPE_ALL);
+        }
+    }
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* qi = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* key_cache = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* sij_buf = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    uint64_t n_blocks = static_cast<uint64_t>(args[3]);
+    uint64_t block_indices[8];
+    for (int j = 0; j < 8; j++) {
+        block_indices[j] = static_cast<uint64_t>(args[4 + j]);
+    }
+
+    __gm__ bfloat16_t* qi_base = reinterpret_cast<__gm__ bfloat16_t*>(qi->buffer.addr) + qi->start_offset;
+    __gm__ bfloat16_t* key_base = reinterpret_cast<__gm__ bfloat16_t*>(key_cache->buffer.addr);
+    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_buf->buffer.addr) + sij_buf->start_offset;
+
+    uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
+
+    if (q_tile_size == 16) {
+        qk_matmul_n_impl<16, 128, 128>(qi_base, key_base, sij_base, n_blocks, block_indices);
+    } else {
+        qk_matmul_n_impl<64, 128, 64>(qi_base, key_base, sij_base, n_blocks, block_indices);
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_hub.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_hub.cpp
@@ -1,0 +1,18 @@
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+constexpr int M = 16;
+constexpr int K = 16;
+constexpr int N = 16;
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -1,0 +1,242 @@
+// Online Softmax Update + Normalize Kernel (AIV)
+//
+// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+//   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
+//   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//
+// Scalar layout strategy:
+//   M scalar floats stored contiguously in GM can be loaded as either:
+//   - ND (kScalarRows, kScalarCols) RowMajor for element-wise ops (TMAX, TSUB, TEXP, TMUL, TADD)
+//   - DN (kAlignedRows, 1) ColMajor for row-broadcast ops (TROWEXPANDMUL, TROWEXPANDDIV)
+//   Conversion between layouts uses GM round-trip: ND TSTORE → DN TLOAD.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int N>
+static __aicore__ void online_update_impl(__gm__ TensorData* mij,
+    __gm__ TensorData* lij,
+    __gm__ TensorData* oi_new,
+    __gm__ TensorData* mi,
+    __gm__ TensorData* li,
+    __gm__ TensorData* oi,
+    uint64_t is_first,
+    uint64_t is_last,
+    __gm__ TensorData* dst) {
+    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
+    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
+    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
+    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
+    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
+    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
+    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+
+    // Scalar tile dimensions for RowMajor layout:
+    // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
+    // kScalarRows = M / 8 (M=16 → 2 rows, M=64 → 8 rows)
+    constexpr int kScalarCols = 32 / sizeof(float);
+    constexpr int kScalarRows = M / kScalarCols;
+    // Aligned rows for ColMajor DN tiles (32-byte alignment)
+    constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+
+    // --- GlobalTensor types ---
+
+    // Data (M, N) RowMajor
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+
+    // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
+
+    // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+
+    // --- GlobalTensor instances ---
+
+    GlobalDataMxN oiNewGlobal(oi_new_ptr + oi_new->start_offset);
+    GlobalDataMxN oiGlobal(oi_ptr + oi->start_offset);
+    GlobalDataMxN dstGlobal(dst_ptr + dst->start_offset);
+
+    // ND globals for scalar element-wise operations
+    GlobalScalarND mijGlobalND(mij_ptr + mij->start_offset);
+    GlobalScalarND lijGlobalND(lij_ptr + lij->start_offset);
+    GlobalScalarND miGlobalND(mi_ptr + mi->start_offset);
+    GlobalScalarND liGlobalND(li_ptr + li->start_offset);
+
+    // DN globals aliased to same GM for ColMajor reload (used after ND TSTORE)
+    GlobalScalarDN mijGlobalDN(mij_ptr + mij->start_offset);
+    GlobalScalarDN lijGlobalDN(lij_ptr + lij->start_offset);
+    GlobalScalarDN liGlobalDN(li_ptr + li->start_offset);
+
+    // --- Tile types ---
+
+    using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+
+    // --- UB memory layout ---
+
+    constexpr int kDataBytes = M * N * sizeof(float);
+    constexpr int kScalarNDBytes = kScalarRows * kScalarCols * sizeof(float);
+    constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
+
+    // Data tiles
+    TileDataMxN oiNewTile;
+    TileDataMxN oiTile;
+
+    // Scalar ND tiles for element-wise arithmetic
+    TileScalarND mijND, lijND, miND, liND;
+    TileScalarND miNewND, alphaND, betaND, tmpND;
+
+    // Scalar DN tiles for TROWEXPAND operations
+    TileScalarDN alphaDN, betaDN, liDN;
+
+    TASSIGN(oiNewTile, 0);
+    TASSIGN(oiTile, kDataBytes);
+    TASSIGN(mijND, 2 * kDataBytes);
+    TASSIGN(lijND, 2 * kDataBytes + kScalarNDBytes);
+    TASSIGN(miND, 2 * kDataBytes + 2 * kScalarNDBytes);
+    TASSIGN(liND, 2 * kDataBytes + 3 * kScalarNDBytes);
+    TASSIGN(miNewND, 2 * kDataBytes + 4 * kScalarNDBytes);
+    TASSIGN(alphaND, 2 * kDataBytes + 5 * kScalarNDBytes);
+    TASSIGN(betaND, 2 * kDataBytes + 6 * kScalarNDBytes);
+    TASSIGN(tmpND, 2 * kDataBytes + 7 * kScalarNDBytes);
+    TASSIGN(alphaDN, 2 * kDataBytes + 8 * kScalarNDBytes);
+    TASSIGN(betaDN, 2 * kDataBytes + 8 * kScalarNDBytes + kScalarDNBytes);
+    TASSIGN(liDN, 2 * kDataBytes + 8 * kScalarNDBytes + 2 * kScalarDNBytes);
+
+    if (is_first) {
+        // --- First block: copy inputs to accumulators ---
+        TLOAD(oiNewTile, oiNewGlobal);
+        TLOAD(mijND, mijGlobalND);
+        TLOAD(lijND, lijGlobalND);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // Passthrough to MTE3 (no V compute needed)
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
+
+        if (is_last) {
+            // Single block: normalize dst = oi_new / lij
+            // lij stored to li buffer in ND format; reload as DN for TROWEXPANDDIV
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            TLOAD(liDN, liGlobalDN);
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+            TROWEXPANDDIV(oiNewTile, oiNewTile, liDN);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TSTORE(dstGlobal, oiNewTile);
+        }
+    } else {
+        // --- Subsequent blocks: accumulate ---
+
+        // Phase 1: Load all inputs
+        TLOAD(oiNewTile, oiNewGlobal);
+        TLOAD(oiTile, oiGlobal);
+        TLOAD(mijND, mijGlobalND);
+        TLOAD(lijND, lijGlobalND);
+        TLOAD(miND, miGlobalND);
+        TLOAD(liND, liGlobalND);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
+        // pipe_barrier(PIPE_V) required between each dependent vector operation
+        // to resolve RAW hazards on shared UB tiles.
+        TMAX(miNewND, miND, mijND);  // mi_new = max(mi, mij)
+        pipe_barrier(PIPE_V);
+        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
+        pipe_barrier(PIPE_V);
+        TEXP(alphaND, alphaND);  // alpha = exp(mi - mi_new)
+        pipe_barrier(PIPE_V);
+        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
+        pipe_barrier(PIPE_V);
+        TEXP(betaND, betaND);  // beta = exp(mij - mi_new)
+        pipe_barrier(PIPE_V);
+        TMUL(liND, alphaND, liND);  // li = alpha * li
+        pipe_barrier(PIPE_V);
+        TMUL(tmpND, betaND, lijND);  // tmp = beta * lij
+        pipe_barrier(PIPE_V);
+        TADD(liND, liND, tmpND);  // li = alpha * li + beta * lij (= li_new)
+
+        // Phase 3: Store scalar results to GM (ND format)
+        // mi_new → mi accumulator, li_new → li accumulator
+        // alpha → mij buffer (reuse), beta → lij buffer (reuse)
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(miGlobalND, miNewND);   // persist mi_new
+        TSTORE(liGlobalND, liND);      // persist li_new
+        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
+
+        // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
+        if (is_last) {
+            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
+        }
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+
+        // Phase 5: Scale data tiles using row-broadcast multiply
+        TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
+        pipe_barrier(PIPE_V);
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
+
+        if (is_last) {
+            // Phase 6: Normalize and output
+            pipe_barrier(PIPE_V);
+            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TSTORE(dstGlobal, oiTile);
+        } else {
+            // Phase 6: Store updated accumulators
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TSTORE(oiGlobal, oiTile);
+        }
+    }
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* mij = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* lij = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* oi_new = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    __gm__ TensorData* mi = reinterpret_cast<__gm__ TensorData*>(args[3]);
+    __gm__ TensorData* li = reinterpret_cast<__gm__ TensorData*>(args[4]);
+    __gm__ TensorData* oi = reinterpret_cast<__gm__ TensorData*>(args[5]);
+    __gm__ TensorData* dst = reinterpret_cast<__gm__ TensorData*>(args[6]);
+    uint64_t is_first = static_cast<uint64_t>(args[7]);
+    uint64_t is_last = static_cast<uint64_t>(args[8]);
+    uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);
+    // args[10] = head_dim (128)
+
+    if (q_tile_size == 16) {
+        online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else {
+        online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,0 +1,227 @@
+// Two-Pass Softmax Kernel (AIV) for n_blocks tiles
+//
+// Input:  sij_buf (n_blocks * M, N) fp32 — QK results stacked vertically
+// Output: pij_buf (n_blocks * M, N) bf16 — attention weights per block
+//         mij (M,) fp32 — global row max across all blocks
+//         lij (M,) fp32 — total row sum across all blocks
+//
+// Pass 1: Iterate over n_blocks tiles, apply scale, mask last block,
+//         find global m = max over all blocks of rowmax(S_i * scale)
+// Pass 2: Iterate again, compute P_i = exp(S_i * scale - m) -> bf16,
+//         accumulate l = sum over all blocks of rowsum(P_i)
+//
+// Two-pass ensures all P_i tiles share the same scale (global max),
+// enabling direct TMATMUL_ACC accumulation in the PV kernel.
+//
+// Supports two tile configurations via runtime dispatch:
+//   Case1: M=16, N=128 (q_tile=16, block_size=128)
+//   Case2: M=64, N=64  (q_tile=64, block_size=64)
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int N>
+static __aicore__ void softmax_prepare_n_impl(
+    __gm__ float* sij_base,
+    float scale_value,
+    __gm__ bfloat16_t* pij_base,
+    __gm__ float* mij_addr,
+    __gm__ float* lij_addr,
+    uint64_t n_blocks,
+    uint64_t valid_len_last) {
+
+    constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+    constexpr int kScalarCols = 32 / sizeof(float);
+    constexpr int kScalarRows = M / kScalarCols;
+
+    // --- GlobalTensor types ---
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalDataMxN_bf16 = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
+
+    // --- Tile types ---
+    using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N, SLayout::NoneBox, 512, PadValue::Min>;
+    using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
+
+    // --- UB memory layout ---
+    constexpr int kDataBytes = M * N * sizeof(float);
+    constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
+    constexpr int kScalarNDBytes = kScalarRows * kScalarCols * sizeof(float);
+
+    TileVecMxN sijTile;
+    TileSijPad sijPadTile;
+    TileVecMxN pijTile;
+    TileVecMxN tmpTile;
+    TileVecMxN sumAccTile;
+    TileScalarDN localMaxDN;
+    TileScalarDN globalMaxDN;
+    TileScalarND maxND_a;
+    TileScalarND maxND_b;
+    TileScalarDN sumDN;
+    TileVecMxN_bf16 pijBf16Tile;
+
+    TASSIGN(sijTile, 0x0);
+    TASSIGN(sijPadTile, 0x0);
+    TASSIGN(pijTile, kDataBytes);
+    TASSIGN(tmpTile, 2 * kDataBytes);
+    TASSIGN(sumAccTile, 3 * kDataBytes);
+    int scalarBase = 4 * kDataBytes;
+    TASSIGN(localMaxDN, scalarBase);
+    TASSIGN(globalMaxDN, scalarBase + kScalarDNBytes);
+    TASSIGN(maxND_a, scalarBase + 2 * kScalarDNBytes);
+    TASSIGN(maxND_b, scalarBase + 2 * kScalarDNBytes + kScalarNDBytes);
+    TASSIGN(sumDN, scalarBase + 2 * kScalarDNBytes + 2 * kScalarNDBytes);
+    TASSIGN(pijBf16Tile, scalarBase + 2 * kScalarDNBytes + 2 * kScalarNDBytes + kScalarDNBytes);
+
+    // GM scratch aliases (mij/lij output buffers double as scratch)
+    GlobalScalarND mijGlobalND(mij_addr);
+    GlobalScalarDN mijGlobalDN(mij_addr);
+    GlobalScalarND lijGlobalND(lij_addr);
+    GlobalScalarDN lijGlobalDN(lij_addr);
+
+    // ======== Pass 1: Find global row max ========
+    for (uint64_t i = 0; i < n_blocks; i++) {
+        GlobalDataMxN sijGlobal(sij_base + i * M * N);
+        TLOAD(sijTile, sijGlobal);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        if (i == n_blocks - 1 && valid_len_last < static_cast<uint64_t>(N)) {
+            TileSijDyn sijDynTile(static_cast<size_t>(valid_len_last));
+            TASSIGN(sijDynTile, 0x0);
+            TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+        }
+
+        TMULS(sijTile, sijTile, scale_value);
+        pipe_barrier(PIPE_V);
+        TROWMAX(localMaxDN, sijTile, tmpTile);
+
+        if (i == 0) {
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(mijGlobalDN, localMaxDN);
+        } else {
+            // Store local max to lij buffer (scratch) as DN, reload as ND for TMAX
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(lijGlobalDN, localMaxDN);
+
+            // Reload both as ND for TMAX
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            TLOAD(maxND_a, mijGlobalND);
+            TLOAD(maxND_b, lijGlobalND);
+
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            TMAX(maxND_a, maxND_a, maxND_b);
+
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(mijGlobalND, maxND_a);
+        }
+    }
+
+    // ======== Pass 2: Compute softmax with global max ========
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    TLOAD(globalMaxDN, mijGlobalDN);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    for (uint64_t i = 0; i < n_blocks; i++) {
+        GlobalDataMxN sijGlobal(sij_base + i * M * N);
+        GlobalDataMxN_bf16 pijGlobal(pij_base + i * M * N);
+
+        TLOAD(sijTile, sijGlobal);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        if (i == n_blocks - 1 && valid_len_last < static_cast<uint64_t>(N)) {
+            TileSijDyn sijDynTile(static_cast<size_t>(valid_len_last));
+            TASSIGN(sijDynTile, 0x0);
+            TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+        }
+
+        TMULS(sijTile, sijTile, scale_value);
+        pipe_barrier(PIPE_V);
+        TROWEXPANDSUB(pijTile, sijTile, globalMaxDN);
+        pipe_barrier(PIPE_V);
+        TEXP(pijTile, pijTile);
+        TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
+        TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
+
+        if (i == 0) {
+            TMULS(sumAccTile, pijTile, 1.0f);
+        } else {
+            TADD(sumAccTile, sumAccTile, pijTile);
+        }
+
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(pijGlobal, pijBf16Tile);
+
+        if (i + 1 < n_blocks) {
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        }
+    }
+
+    // Compute final row sum from accumulated pij values
+    pipe_barrier(PIPE_V);
+    TROWSUM(sumDN, sumAccTile, tmpTile);
+
+    // Store mij (global max) and lij (total sum)
+    // mij already contains the correct global max from Pass 1.
+    // Reload and store as DN to ensure consistent format for online_update.
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(lijGlobalDN, sumDN);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* sij_buf = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
+    scale_conv.u = static_cast<uint64_t>(args[1]);
+    float scale_value = scale_conv.f;
+    __gm__ TensorData* pij_buf = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    __gm__ TensorData* mij = reinterpret_cast<__gm__ TensorData*>(args[3]);
+    __gm__ TensorData* lij = reinterpret_cast<__gm__ TensorData*>(args[4]);
+    uint64_t n_blocks = static_cast<uint64_t>(args[5]);
+    uint64_t valid_len_last = static_cast<uint64_t>(args[6]);
+
+    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_buf->buffer.addr) + sij_buf->start_offset;
+    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_buf->buffer.addr) + pij_buf->start_offset;
+    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr) + mij->start_offset;
+    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr) + lij->start_offset;
+
+    uint64_t q_tile_size = static_cast<uint64_t>(sij_buf->shapes[0]) / n_blocks;
+
+    if (q_tile_size == 16) {
+        softmax_prepare_n_impl<16, 128>(sij_base, scale_value, pij_base, mij_addr, lij_addr, n_blocks, valid_len_last);
+    } else {
+        softmax_prepare_n_impl<64, 64>(sij_base, scale_value, pij_base, mij_addr, lij_addr, n_blocks, valid_len_last);
+    }
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
@@ -1,0 +1,45 @@
+"""
+Paged Attention Kernel and Orchestration Configuration
+
+Defines the kernels and orchestration function for paged attention
+with AIC/AIV subgraph splitting:
+
+AIC Kernels (Matrix Multiplication):
+  - aic_qk_matmul: Q @ K^T computation
+  - aic_pv_matmul: P @ V computation
+
+AIV Kernels (Vector Operations):
+  - aiv_softmax_prepare: scale, rowmax, exp, rowsum
+  - aiv_online_update: online softmax accumulation + fused normalization
+
+Note: aiv_normalize has been merged into aiv_online_update for efficiency.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+# Orchestration config
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "paged_attention_orch.cpp"),
+    "function_name": "build_paged_attention_graph",
+}
+
+# Kernel configs (aiv_normalize removed - merged into aiv_online_update)
+KERNELS = [
+    # AIC kernels (matrix multiplication using Cube unit)
+    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),       "core_type": "aic"},
+    # AIV kernels (vector operations)
+    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
+    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
+    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),       "core_type": "aiv"},
+]
+
+# Runtime configuration
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 24,
+}

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -1,0 +1,303 @@
+/**
+ * Paged Attention Orchestration Function V2 - N_UNROLL=8, 4 Tasks Per Group
+ *
+ * Batches up to N_UNROLL blocks per group. Each group submits exactly 4 tasks:
+ *   1. QK matmul:  qi @ K^T for n_blocks → sij_buf (n_blocks * q_tile, block_size)
+ *   2. Softmax:    two-pass over sij_buf → pij_buf, mi, li
+ *   3. PV matmul:  SplitK accumulated P @ V → oi_new (q_tile, head_dim)
+ *   4. Update:     online softmax accumulation with group-level mi, li, oi_new
+ *
+ * Memory Layout:
+ *   Query: (batch * num_heads, head_dim) bf16
+ *   Key:   (total_blocks, block_size, head_dim) bf16 (stored as K^T for QK)
+ *   Value: (total_blocks, block_size, head_dim) bf16
+ */
+
+#include <cstdint>
+#include <cstring>
+
+#include "pto_orchestration_api.h"
+
+#define N_UNROLL 8
+
+#define FUNC_QK_MATMUL 0
+#define FUNC_SOFTMAX_PREPARE 1
+#define FUNC_PV_MATMUL 2
+#define FUNC_ONLINE_UPDATE 3
+#define FUNC_AIC_HUB 4
+#define FUNC_AIV_HUB 5
+
+constexpr uint64_t PLATFORM_PROF_SYS_CNT_FREQ = 50000000;  // 50 MHz
+
+inline double cycles_to_us(uint64_t cycles) {
+    return (static_cast<double>(cycles) / PLATFORM_PROF_SYS_CNT_FREQ) * 1000000.0;
+};
+
+inline uint64_t get_sys_cnt_aicpu() {
+    uint64_t ticks;
+    asm volatile("mrs %0, cntvct_el0" : "=r"(ticks));
+    return ticks;
+}
+
+#define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
+#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+
+// Helper to encode float as uint64_t for scalar params
+static uint64_t float_to_u64(float f) {
+    union {
+        float f32;
+        uint64_t u64;
+    } conv;
+    conv.u64 = 0;  // Clear upper bits
+    conv.f32 = f;
+    return conv.u64;
+}
+
+extern "C" {
+/**
+ * Orchestration config — the executor reads these values to set up
+ * shared memory and runtime before calling aicpu_orchestration_entry.
+ */
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
+    uint64_t* args, int arg_count) {
+    (void)args;
+    (void)arg_count;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 10,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, int orch_thread_num, int orch_thread_index) {
+    (void)orch_thread_num;
+    (void)orch_thread_index;
+    uint64_t prof_param_extract = 0;
+    uint64_t prof_ext_tensor    = 0;
+    uint64_t prof_make_tensor   = 0;
+    uint64_t prof_tensor_view   = 0;
+    uint64_t prof_param_setup   = 0;
+    uint64_t prof_submit_task   = 0;
+    int      prof_submit_count  = 0;
+    int      prof_make_count    = 0;
+    int      prof_view_count    = 0;
+
+    CYCLE_COUNT_START();
+
+    // Extract device pointers (first 7)
+    void* host_query = reinterpret_cast<void*>(args[0]);
+    void* host_key_cache = reinterpret_cast<void*>(args[1]);
+    void* host_value_cache = reinterpret_cast<void*>(args[2]);
+    int* host_block_table = reinterpret_cast<int*>(args[3]);
+    int* host_context_lens = reinterpret_cast<int*>(args[4]);
+    void* host_out = reinterpret_cast<void*>(args[5]);
+    int64_t* host_config = reinterpret_cast<int64_t*>(args[6]);
+
+    // Extract sizes (next 3)
+    size_t query_size = static_cast<size_t>(args[7]);
+    size_t key_cache_size = static_cast<size_t>(args[8]);
+    size_t value_cache_size = static_cast<size_t>(args[9]);
+
+    // Extract config parameters
+    uint64_t batch = static_cast<uint64_t>(static_cast<int>(host_config[0]));
+    uint64_t num_heads = static_cast<uint64_t>(static_cast<int>(host_config[1]));
+    int kv_head_num = static_cast<int>(host_config[2]);
+    uint64_t head_dim = static_cast<uint64_t>(static_cast<int>(host_config[3]));
+    uint64_t block_size = static_cast<uint64_t>(static_cast<int>(host_config[4]));
+    uint64_t block_num = static_cast<uint64_t>(static_cast<int>(host_config[5]));
+    union {
+        uint32_t u;
+        float f;
+    } scale_conv;
+    scale_conv.u = static_cast<uint32_t>(host_config[6]);
+    float scale_value = scale_conv.f;
+    uint64_t q_head_num = num_heads;
+    uint64_t q_tile = std::min(num_heads, 128UL);
+    uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;
+    DataType data_type = DataType::BFLOAT16;
+    CYCLE_COUNT_LAP(prof_param_extract);
+
+    LOG_ALWAYS(rt, ">>>>>> batch = %lu", (unsigned long)batch);
+
+    uint64_t query_shapes[2] = {batch * num_heads, head_dim};
+    uint64_t key_cache_shapes[2] = {batch * block_num * block_size, head_dim};
+    uint64_t value_cache_shapes[2] = {batch * block_num * block_size, head_dim};
+    uint64_t out_shapes[2] = {batch * num_heads, head_dim};
+    Tensor query = make_tensor_external(host_query, query_shapes, 2, data_type);
+    Tensor key_cache = make_tensor_external(host_key_cache, key_cache_shapes, 2, data_type);
+    Tensor value_cache = make_tensor_external(host_value_cache, value_cache_shapes, 2, data_type);
+    Tensor out = make_tensor_external(host_out, out_shapes, 2, DataType::FLOAT32);
+    CYCLE_COUNT_LAP(prof_ext_tensor);
+
+    for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
+        uint64_t cur_seq = host_context_lens[b_idx];
+        uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
+        for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
+            PTO2_SCOPE(rt) {
+                uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
+                CYCLE_COUNT_START();
+
+                uint64_t oi_shapes[2] = {q_tile, head_dim};
+                uint64_t li_shapes[1] = {q_tile};
+                uint64_t mi_shapes[1] = {q_tile};
+                Tensor oi = make_tensor(oi_shapes, 2, DataType::FLOAT32);
+                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32);
+                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32);
+                prof_make_count += 3;
+                CYCLE_COUNT_LAP(prof_make_tensor);
+
+                uint64_t qi_shapes[2] = {q_tile, head_dim};
+                uint64_t qi_offsets[2] = {cur_offset, 0};
+                Tensor qi = query.view(qi_shapes, qi_offsets);
+                uint64_t out_view_shapes[2] = {q_tile, head_dim};
+                uint64_t out_view_offsets[2] = {cur_offset, 0};
+                Tensor out_view = out.view(out_view_shapes, out_view_offsets);
+                prof_view_count += 2;
+                CYCLE_COUNT_LAP(prof_tensor_view);
+
+                PTOParam params_inplace[] = {
+                    make_output_param(oi),
+                    make_output_param(li_update),
+                    make_output_param(mi_update),
+                };
+                CYCLE_COUNT_LAP(prof_param_setup);
+                pto2_rt_submit_task(rt, FUNC_AIV_HUB, PTO2_WORKER_VECTOR, params_inplace, 3);
+                prof_submit_count++;
+                CYCLE_COUNT_LAP(prof_submit_task);
+
+                for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
+                    uint64_t n_blocks = std::min((uint64_t)N_UNROLL, bn_this_batch - bn);
+
+                    // Prepare block indices for this group
+                    uint64_t block_indices[8] = {};
+                    for (uint64_t i = 0; i < n_blocks; i++) {
+                        block_indices[i] = host_block_table[b_idx * block_num + bn + i];
+                    }
+                    CYCLE_COUNT_LAP(prof_param_extract);
+
+                    // Valid length for last block in this group
+                    uint64_t last_block_seq_start = (bn + n_blocks - 1) * block_size;
+                    uint64_t valid_len_last = std::min(block_size, cur_seq - last_block_seq_start);
+
+                    // === Task 1: Batched QK matmul ===
+                    uint64_t sij_buf_shapes[2] = {n_blocks * q_tile, block_size};
+                    Tensor sij_buf = make_tensor(sij_buf_shapes, 2, DataType::FLOAT32);
+                    prof_make_count += 1;
+                    CYCLE_COUNT_LAP(prof_make_tensor);
+
+                    PTOParam params_qk[] = {
+                        make_input_param(qi),
+                        make_input_param(key_cache),
+                        make_output_param(sij_buf),
+                        make_scalar_param(n_blocks),
+                        make_scalar_param(block_indices[0]),
+                        make_scalar_param(block_indices[1]),
+                        make_scalar_param(block_indices[2]),
+                        make_scalar_param(block_indices[3]),
+                        make_scalar_param(block_indices[4]),
+                        make_scalar_param(block_indices[5]),
+                        make_scalar_param(block_indices[6]),
+                        make_scalar_param(block_indices[7]),
+                    };
+                    CYCLE_COUNT_LAP(prof_param_setup);
+                    pto2_rt_submit_task(rt, FUNC_QK_MATMUL, PTO2_WORKER_CUBE, params_qk, 12);
+                    prof_submit_count++;
+                    CYCLE_COUNT_LAP(prof_submit_task);
+
+                    // === Task 2: Two-pass softmax over all blocks in group ===
+                    uint64_t pij_buf_shapes[2] = {n_blocks * q_tile, block_size};
+                    Tensor pij_buf = make_tensor(pij_buf_shapes, 2, data_type);
+                    Tensor mi = make_tensor(mi_shapes, 1, DataType::FLOAT32);
+                    Tensor li = make_tensor(li_shapes, 1, DataType::FLOAT32);
+                    prof_make_count += 3;
+                    CYCLE_COUNT_LAP(prof_make_tensor);
+
+                    PTOParam params_sf[] = {
+                        make_input_param(sij_buf),
+                        make_scalar_param(float_to_u64(scale_value)),
+                        make_output_param(pij_buf),
+                        make_output_param(mi),
+                        make_output_param(li),
+                        make_scalar_param(n_blocks),
+                        make_scalar_param(valid_len_last),
+                    };
+                    CYCLE_COUNT_LAP(prof_param_setup);
+                    pto2_rt_submit_task(rt, FUNC_SOFTMAX_PREPARE, PTO2_WORKER_VECTOR, params_sf, 7);
+                    prof_submit_count++;
+                    CYCLE_COUNT_LAP(prof_submit_task);
+
+                    // === Task 3: SplitK PV matmul (accumulated P @ V) ===
+                    uint64_t oi_new_shapes[2] = {q_tile, head_dim};
+                    Tensor oi_new = make_tensor(oi_new_shapes, 2, DataType::FLOAT32);
+                    prof_make_count += 1;
+                    CYCLE_COUNT_LAP(prof_make_tensor);
+
+                    PTOParam params_pv[] = {
+                        make_input_param(pij_buf),
+                        make_input_param(value_cache),
+                        make_output_param(oi_new),
+                        make_scalar_param(n_blocks),
+                        make_scalar_param(block_indices[0]),
+                        make_scalar_param(block_indices[1]),
+                        make_scalar_param(block_indices[2]),
+                        make_scalar_param(block_indices[3]),
+                        make_scalar_param(block_indices[4]),
+                        make_scalar_param(block_indices[5]),
+                        make_scalar_param(block_indices[6]),
+                        make_scalar_param(block_indices[7]),
+                    };
+                    CYCLE_COUNT_LAP(prof_param_setup);
+                    pto2_rt_submit_task(rt, FUNC_PV_MATMUL, PTO2_WORKER_CUBE, params_pv, 12);
+                    prof_submit_count++;
+                    CYCLE_COUNT_LAP(prof_submit_task);
+
+                    // === Task 4: Online update (per-group) ===
+                    uint64_t is_first = (bn == 0) ? 1 : 0;
+                    uint64_t is_last = (bn + n_blocks >= bn_this_batch) ? 1 : 0;
+                    CYCLE_COUNT_LAP(prof_param_extract);
+
+                    PTOParam params_up[] = {
+                        make_input_param(mi),
+                        make_input_param(li),
+                        make_input_param(oi_new),
+                        make_inout_param(mi_update),
+                        make_inout_param(li_update),
+                        make_inout_param(oi),
+                        make_output_param(out_view),
+                        make_scalar_param(is_first),
+                        make_scalar_param(is_last),
+                    };
+                    CYCLE_COUNT_LAP(prof_param_setup);
+                    pto2_rt_submit_task(rt, FUNC_ONLINE_UPDATE, PTO2_WORKER_VECTOR, params_up, 9);
+                    prof_submit_count++;
+                    CYCLE_COUNT_LAP(prof_submit_task);
+                }
+            }
+        }
+    }
+
+    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor +
+                     prof_tensor_view + prof_param_setup + prof_submit_task;
+    LOG_ALWAYS(rt, "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
+        prof_submit_count, prof_make_count, prof_view_count, cycles_to_us(total));
+    if (total > 0) {
+        LOG_ALWAYS(rt, "  param_extract    : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_param_extract), prof_param_extract * 100.0 / total);
+        LOG_ALWAYS(rt, "  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
+        LOG_ALWAYS(rt, "  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_make_count, cycles_to_us(prof_make_tensor), prof_make_tensor * 100.0 / total,
+            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
+        LOG_ALWAYS(rt, "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_view_count, cycles_to_us(prof_tensor_view), prof_tensor_view * 100.0 / total,
+            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
+        LOG_ALWAYS(rt, "  param_setup      : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
+        LOG_ALWAYS(rt, "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_submit_count, cycles_to_us(prof_submit_task), prof_submit_task * 100.0 / total,
+            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
+    }
+
+#undef CYCLE_COUNT_START
+#undef CYCLE_COUNT_LAP
+}
+
+}  // extern "C"


### PR DESCRIPTION
## Summary
- Add `paged_attention_unroll` device test under `tensormap_and_ringbuffer` runtime with N_UNROLL=8
- QK matmul batches up to 8 key blocks per CUBE invocation
- Two-pass softmax over all blocks in group: Pass 1 finds global row max via GM round-trip TMAX, Pass 2 computes exp with uniform scale and accumulates row sum in UB
- PV matmul uses SplitK accumulation (TMATMUL + TMATMUL_ACC) for single accumulated output per group
- Orchestration submits exactly 4 tasks per group (QK, Softmax, PV, Update) instead of 3*n_blocks+1
- Golden test covers batch=2, num_heads=2, variable sequence lengths

## Testing
- [ ] Hardware tests pass (`-p a2a3`)
- [ ] Simulation not supported (bf16 TMATMUL + orchestration API)