### PR TITLE
Add: TensorLayout with DN column-major support for tensor dimension transposition

### DIFF
--- a/src/a2a3/runtime/aicpu_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/aicpu_build_graph/orchestration/pto_orchestration_api.h
@@ -30,8 +30,9 @@
 
 // OrchArg::to_tensor() — deferred definition (needs make_tensor_external from tensor.h)
 static_assert(ORCH_ARG_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "OrchArg and runtime max dims must match");
+template<TensorLayout Layout>
 inline Tensor OrchArg::to_tensor(bool manual_dep, int32_t version) const {
-    return make_tensor_external(
+    return make_tensor_external<Layout>(
         reinterpret_cast<void*>(static_cast<uintptr_t>(tensor.data)),
         tensor.shapes, tensor.ndims, tensor.dtype,
         manual_dep, version);

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/data_type.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/data_type.h
@@ -26,6 +26,18 @@ enum class DataType : uint32_t {
 };
 
 /**
+ * Tensor Layout
+ *
+ * Defines memory layout for the last two dimensions (row-major vs column-major).
+ * - ND: Row-major for all dimensions
+ * - DN: Column-major for LAST TWO dimensions only
+ */
+enum class TensorLayout : uint32_t {
+    ND = 0,  // Normal Dimensions
+    DN = 1   // Last two Dimensions transposed (col-major for last 2D)
+};
+
+/**
  * Get the size in bytes of a single element of the given data type
  *
  * @param dtype Data type

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/orch_arg.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/orch_arg.h
@@ -45,6 +45,7 @@ struct OrchArg {
     // For simple cases where golden shape == kernel shape.
     // When reshape is needed, read fields manually and call make_tensor_external.
     // Defined in pto_orchestration_api.h (needs make_tensor_external).
+    template<TensorLayout Layout = TensorLayout::ND>
     Tensor to_tensor(bool manual_dep = false, int32_t version = 0) const;
 
     // Get raw pointer to tensor data (eliminates verbose double-cast)

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/tensor.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/tensor.h
@@ -45,6 +45,7 @@ struct Segment {
  * - `buffer` contains the underlying memory allocation (addr in bytes, size in bytes)
  * - `raw_shapes[]`, `shapes[]`, `offsets[]` are in ELEMENTS
  * - `dtype` specifies element type for interpreting buffer contents
+ * - `layout` specifies the relationship between logical (shapes) and physical (raw_shapes) dimensions
  *
  * Fast-path flags (both on cache line 1):
  * - is_all_offset_zero: when true, offsets[] are implicitly zero — skip offset read/write
@@ -62,12 +63,12 @@ struct alignas(64) Tensor {
     uint64_t start_offset;                         // Cached 1D element offset (precomputed from raw_shapes + offsets), only calc before incore, useless in orch
     int32_t version;                               // Tensor version for overlap detection
     DataType dtype;                                // Data type of tensor elements
+    TensorLayout layout;                           // Tensor layout (ND or DN) for logical-to-physical dimension mapping
     uint32_t ndims;                                // Number of dimensions used
     bool is_all_offset_zero;                       // True when all offsets[] are zero (skip offset read/write)
     bool is_raw_eq_shapes;                         // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
     bool manual_dep;                               // True when dependency is managed manually (skip tensormap lookup/insert)
     uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
-    uint32_t __padding__;
 
     // === Cache line 2 (64B) — warm path ===
     uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
@@ -94,11 +95,12 @@ struct alignas(64) Tensor {
         uint32_t ndims,
         DataType dtype,
         int32_t version,
+        TensorLayout layout = TensorLayout::ND,
         bool is_all_offset_zero = false,
         bool is_raw_eq_shapes = false,
         bool manual_dep = false) {
         init(addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version,
-             is_all_offset_zero, is_raw_eq_shapes, manual_dep);
+             layout, is_all_offset_zero, is_raw_eq_shapes, manual_dep);
     }
 
     // --- Initialization ---
@@ -110,6 +112,7 @@ struct alignas(64) Tensor {
         uint32_t in_ndims,
         DataType in_dtype,
         int32_t in_version,
+        TensorLayout in_layout = TensorLayout::ND,
         bool in_is_all_offset_zero = false,
         bool in_is_raw_eq_shapes = false,
         bool in_manual_dep = false) {
@@ -117,6 +120,7 @@ struct alignas(64) Tensor {
         ndims = in_ndims;
         dtype = in_dtype;
         version = in_version;
+        layout = in_layout;
         is_all_offset_zero = in_is_all_offset_zero;
         is_raw_eq_shapes = in_is_raw_eq_shapes;
         manual_dep = in_manual_dep;
@@ -205,7 +209,19 @@ struct alignas(64) Tensor {
 
     Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
         Tensor result;
-        result.init_with_view(*this, view_shapes, view_offsets, manual_dep);
+        if (layout == TensorLayout::DN && ndims >= 2) {
+            always_assert(ndims <= RUNTIME_MAX_TENSOR_DIMS);
+            uint32_t adjusted_offsets[RUNTIME_MAX_TENSOR_DIMS];
+            for (uint32_t i = 0; i < ndims - 2; i++) {
+                adjusted_offsets[i] = view_offsets[i];
+            }
+            // Swap only the last two dimensions (DN reverses row/col order)
+            adjusted_offsets[ndims - 2] = view_offsets[ndims - 1];
+            adjusted_offsets[ndims - 1] = view_offsets[ndims - 2];
+            result.init_with_view(*this, view_shapes, adjusted_offsets, manual_dep);
+        } else {
+            result.init_with_view(*this, view_shapes, view_offsets, manual_dep);
+        }
         return result;
     }
 
@@ -285,6 +301,7 @@ struct alignas(64) Tensor {
         ss << indent << "dtype: " << get_dtype_name(dtype) << std::endl;
         ss << indent << "ndims: " << ndims << std::endl;
         ss << indent << "version: " << version << std::endl;
+        ss << indent << "layout: " << (layout == TensorLayout::ND ? "ND" : "DN") << std::endl;
 
         const uint32_t* rs = get_raw_shapes();
         ss << indent << "raw_shapes: [";
@@ -326,7 +343,11 @@ using TensorData = Tensor;
 // =============================================================================
 /**
  * Create a Tensor for pre-allocated external memory.
+ *
+ * For DN layout, raw_shapes (physical layout) will have the last two
+ * dimensions swapped compared to the logical shapes.
  */
+template<TensorLayout Layout = TensorLayout::ND>
 static inline Tensor make_tensor_external(void* addr,
     const uint32_t shapes[],
     uint32_t ndims,
@@ -338,8 +359,22 @@ static inline Tensor make_tensor_external(void* addr,
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(addr, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    uint64_t buf_size = total * get_element_size(dtype);
+
+    if constexpr (Layout == TensorLayout::DN) {
+        always_assert(ndims >= 2 && ndims <= RUNTIME_MAX_TENSOR_DIMS);
+        uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];
+        for (uint32_t i = 0; i < ndims - 2; i++) raw_shapes[i] = shapes[i];
+        raw_shapes[ndims - 2] = shapes[ndims - 1];
+        raw_shapes[ndims - 1] = shapes[ndims - 2];
+        return Tensor(addr, buf_size, raw_shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::DN,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/false, manual_dep);
+    } else {
+        return Tensor(addr, buf_size, shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::ND,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    }
 }
 
 /**
@@ -347,7 +382,11 @@ static inline Tensor make_tensor_external(void* addr,
  * NO memory allocation: only records dtype, shape, and buffer.size in the Tensor struct.
  * The runtime allocates from the heap ring and fills buffer.addr during pto2_submit_task
  * when this tensor is passed as OUTPUT param. No buffer content is ever copied.
+ *
+ * For DN layout, raw_shapes (physical layout) will have the last two
+ * dimensions swapped compared to the logical shapes.
  */
+template<TensorLayout Layout = TensorLayout::ND>
 static inline Tensor make_tensor(const uint32_t shapes[],
     uint32_t ndims,
     DataType dtype = DataType::FLOAT32,
@@ -358,6 +397,77 @@ static inline Tensor make_tensor(const uint32_t shapes[],
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(0, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    uint64_t buf_size = total * get_element_size(dtype);
+
+    if constexpr (Layout == TensorLayout::DN) {
+        always_assert(ndims >= 2 && ndims <= RUNTIME_MAX_TENSOR_DIMS);
+        uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];
+        for (uint32_t i = 0; i < ndims - 2; i++) raw_shapes[i] = shapes[i];
+        raw_shapes[ndims - 2] = shapes[ndims - 1];
+        raw_shapes[ndims - 1] = shapes[ndims - 2];
+        return Tensor(0, buf_size, raw_shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::DN,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/false, manual_dep);
+    } else {
+        return Tensor(0, buf_size, shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::ND,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    }
+}
+
+// =============================================================================
+// Layout Reinterpretation
+// =============================================================================
+
+/**
+ * Zero-cost layout reinterpretation.
+ *
+ * Returns a copy of src with the layout field changed to NewLayout.
+ * raw_shapes (physical layout) are unchanged; shapes[] last two dimensions
+ * are swapped to reflect the new logical interpretation.
+ *
+ * Uses Tensor::copy() for cache-line-aware copying — avoids touching
+ * cache line 2 when is_raw_eq_shapes and is_all_offset_zero are both true.
+ *
+ * Safe for both addr=0 (make_tensor) and addr!=0 (make_tensor_external)
+ * tensors — this is pure metadata reinterpretation, no data is moved.
+ */
+template<TensorLayout NewLayout>
+static inline Tensor reinterpret_layout(const Tensor& src) {
+    if (src.layout == NewLayout) {
+        return src;
+    }
+
+    always_assert(src.ndims >= 2 && src.ndims <= RUNTIME_MAX_TENSOR_DIMS);
+
+    Tensor dst;
+    dst.copy(src);
+    dst.layout = NewLayout;
+
+    if (src.is_raw_eq_shapes) {
+        // src is ND full tensor → dst is DN → materialize raw_shapes, set false
+        for (uint32_t i = 0; i < dst.ndims; i++) {
+            dst.raw_shapes[i] = src.shapes[i];
+        }
+        dst.is_raw_eq_shapes = false;
+    }
+
+    std::swap(dst.shapes[dst.ndims - 2], dst.shapes[dst.ndims - 1]);
+
+    // DN→ND: check if swap restores shapes == raw_shapes (full tensor round-trip)
+    if constexpr (NewLayout == TensorLayout::ND) {
+        if (!src.is_raw_eq_shapes) {
+            bool eq = true;
+            for (uint32_t i = 0; i < dst.ndims; i++) {
+                if (dst.shapes[i] != dst.raw_shapes[i]) { eq = false; break; }
+            }
+            dst.is_raw_eq_shapes = eq;
+        }
+    }
+
+    if (!dst.is_all_offset_zero) {
+        std::swap(dst.offsets[dst.ndims - 2], dst.offsets[dst.ndims - 1]);
+    }
+
+    return dst;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -33,7 +33,11 @@
 
 /**
  * Create a Tensor for pre-allocated external memory.
+ *
+ * For DN layout, raw_shapes (physical layout) will have the last two
+ * dimensions swapped compared to the logical shapes.
  */
+template<TensorLayout Layout = TensorLayout::ND>
 static inline Tensor make_tensor_external(void* addr,
     const uint32_t shapes[],
     uint32_t ndims,
@@ -45,8 +49,22 @@ static inline Tensor make_tensor_external(void* addr,
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(addr, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    uint64_t buf_size = total * get_element_size(dtype);
+
+    if constexpr (Layout == TensorLayout::DN) {
+        always_assert(ndims >= 2 && ndims <= RUNTIME_MAX_TENSOR_DIMS);
+        uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];
+        for (uint32_t i = 0; i < ndims - 2; i++) raw_shapes[i] = shapes[i];
+        raw_shapes[ndims - 2] = shapes[ndims - 1];
+        raw_shapes[ndims - 1] = shapes[ndims - 2];
+        return Tensor(addr, buf_size, raw_shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::DN,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/false, manual_dep);
+    } else {
+        return Tensor(addr, buf_size, shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::ND,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    }
 }
 
 /**
@@ -54,7 +72,11 @@ static inline Tensor make_tensor_external(void* addr,
  * NO memory allocation: only records dtype, shape, and buffer.size in the Tensor struct.
  * The runtime allocates from the heap ring and fills buffer.addr during pto2_submit_task
  * when this tensor is passed as OUTPUT param. No buffer content is ever copied.
+ *
+ * For DN layout, raw_shapes (physical layout) will have the last two
+ * dimensions swapped compared to the logical shapes.
  */
+template<TensorLayout Layout = TensorLayout::ND>
 static inline Tensor make_tensor(const uint32_t shapes[],
     uint32_t ndims,
     DataType dtype = DataType::FLOAT32,
@@ -65,14 +87,29 @@ static inline Tensor make_tensor(const uint32_t shapes[],
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(0, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    uint64_t buf_size = total * get_element_size(dtype);
+
+    if constexpr (Layout == TensorLayout::DN) {
+        always_assert(ndims >= 2 && ndims <= RUNTIME_MAX_TENSOR_DIMS);
+        uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];
+        for (uint32_t i = 0; i < ndims - 2; i++) raw_shapes[i] = shapes[i];
+        raw_shapes[ndims - 2] = shapes[ndims - 1];
+        raw_shapes[ndims - 1] = shapes[ndims - 2];
+        return Tensor(0, buf_size, raw_shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::DN,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/false, manual_dep);
+    } else {
+        return Tensor(0, buf_size, shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::ND,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    }
 }
 
 // OrchArg::to_tensor() — deferred definition (needs make_tensor_external above)
 static_assert(ORCH_ARG_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "OrchArg and runtime max dims must match");
+template<TensorLayout Layout>
 inline Tensor OrchArg::to_tensor(bool manual_dep, int32_t version) const {
-    return make_tensor_external(
+    return make_tensor_external<Layout>(
         reinterpret_cast<void*>(static_cast<uintptr_t>(tensor.data)),
         tensor.shapes, tensor.ndims, tensor.dtype,
         manual_dep, version);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/data_type.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/data_type.h
@@ -26,6 +26,18 @@ enum class DataType : uint32_t {
 };
 
 /**
+ * Tensor Layout
+ *
+ * Defines memory layout for the last two dimensions (row-major vs column-major).
+ * - ND: Row-major for all dimensions
+ * - DN: Column-major for LAST TWO dimensions only
+ */
+enum class TensorLayout : uint32_t {
+    ND = 0,  // Normal Dimensions
+    DN = 1   // Last two Dimensions transposed (col-major for last 2D)
+};
+
+/**
  * Get the size in bytes of a single element of the given data type
  *
  * @param dtype Data type

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orch_arg.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orch_arg.h
@@ -45,6 +45,7 @@ struct OrchArg {
     // For simple cases where golden shape == kernel shape.
     // When reshape is needed, read fields manually and call make_tensor_external.
     // Defined in pto_orchestration_api.h (needs make_tensor_external).
+    template<TensorLayout Layout = TensorLayout::ND>
     Tensor to_tensor(bool manual_dep = false, int32_t version = 0) const;
 
     // Get raw pointer to tensor data (eliminates verbose double-cast)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -45,6 +45,7 @@ struct Segment {
  * - `buffer` contains the underlying memory allocation (addr in bytes, size in bytes)
  * - `raw_shapes[]`, `shapes[]`, `offsets[]` are in ELEMENTS
  * - `dtype` specifies element type for interpreting buffer contents
+ * - `layout` specifies the relationship between logical (shapes) and physical (raw_shapes) dimensions
  *
  * Fast-path flags (both on cache line 1):
  * - is_all_offset_zero: when true, offsets[] are implicitly zero — skip offset read/write
@@ -62,12 +63,12 @@ struct alignas(64) Tensor {
     uint64_t start_offset;                         // Cached 1D element offset (precomputed from raw_shapes + offsets), only calc before incore, useless in orch
     int32_t version;                               // Tensor version for overlap detection
     DataType dtype;                                // Data type of tensor elements
+    TensorLayout layout;                           // Tensor layout (ND or DN) for logical-to-physical dimension mapping
     uint32_t ndims;                                // Number of dimensions used
     bool is_all_offset_zero;                       // True when all offsets[] are zero (skip offset read/write)
     bool is_raw_eq_shapes;                         // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
     bool manual_dep;                               // True when dependency is managed manually (skip tensormap lookup/insert)
     uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
-    uint32_t __padding__;
 
     // === Cache line 2 (64B) — warm path ===
     uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
@@ -94,11 +95,12 @@ struct alignas(64) Tensor {
         uint32_t ndims,
         DataType dtype,
         int32_t version,
+        TensorLayout layout = TensorLayout::ND,
         bool is_all_offset_zero = false,
         bool is_raw_eq_shapes = false,
         bool manual_dep = false) {
         init(addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version,
-             is_all_offset_zero, is_raw_eq_shapes, manual_dep);
+             layout, is_all_offset_zero, is_raw_eq_shapes, manual_dep);
     }
 
     // --- Initialization ---
@@ -110,6 +112,7 @@ struct alignas(64) Tensor {
         uint32_t in_ndims,
         DataType in_dtype,
         int32_t in_version,
+        TensorLayout in_layout = TensorLayout::ND,
         bool in_is_all_offset_zero = false,
         bool in_is_raw_eq_shapes = false,
         bool in_manual_dep = false) {
@@ -117,6 +120,7 @@ struct alignas(64) Tensor {
         ndims = in_ndims;
         dtype = in_dtype;
         version = in_version;
+        layout = in_layout;
         is_all_offset_zero = in_is_all_offset_zero;
         is_raw_eq_shapes = in_is_raw_eq_shapes;
         manual_dep = in_manual_dep;
@@ -205,7 +209,19 @@ struct alignas(64) Tensor {
 
     Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
         Tensor result;
-        result.init_with_view(*this, view_shapes, view_offsets, manual_dep);
+        if (layout == TensorLayout::DN && ndims >= 2) {
+            always_assert(ndims <= RUNTIME_MAX_TENSOR_DIMS);
+            uint32_t adjusted_offsets[RUNTIME_MAX_TENSOR_DIMS];
+            for (uint32_t i = 0; i < ndims - 2; i++) {
+                adjusted_offsets[i] = view_offsets[i];
+            }
+            // Swap only the last two dimensions (DN reverses row/col order)
+            adjusted_offsets[ndims - 2] = view_offsets[ndims - 1];
+            adjusted_offsets[ndims - 1] = view_offsets[ndims - 2];
+            result.init_with_view(*this, view_shapes, adjusted_offsets, manual_dep);
+        } else {
+            result.init_with_view(*this, view_shapes, view_offsets, manual_dep);
+        }
         return result;
     }
 
@@ -285,6 +301,7 @@ struct alignas(64) Tensor {
         ss << indent << "dtype: " << get_dtype_name(dtype) << std::endl;
         ss << indent << "ndims: " << ndims << std::endl;
         ss << indent << "version: " << version << std::endl;
+        ss << indent << "layout: " << (layout == TensorLayout::ND ? "ND" : "DN") << std::endl;
 
         const uint32_t* rs = get_raw_shapes();
         ss << indent << "raw_shapes: [";
@@ -320,3 +337,60 @@ static_assert(sizeof(Tensor) == 128, "Tensor must be exactly 2 cache lines (128 
 static_assert(offsetof(Tensor, raw_shapes) == 64);
 
 using TensorData = Tensor;
+
+// =============================================================================
+// Layout Reinterpretation
+// =============================================================================
+
+/**
+ * Zero-cost layout reinterpretation.
+ *
+ * Returns a copy of src with the layout field changed to NewLayout.
+ * raw_shapes (physical layout) are unchanged; shapes[] last two dimensions
+ * are swapped to reflect the new logical interpretation.
+ *
+ * Uses Tensor::copy() for cache-line-aware copying — avoids touching
+ * cache line 2 when is_raw_eq_shapes and is_all_offset_zero are both true.
+ *
+ * Safe for both addr=0 (make_tensor) and addr!=0 (make_tensor_external)
+ * tensors — this is pure metadata reinterpretation, no data is moved.
+ */
+template<TensorLayout NewLayout>
+static inline Tensor reinterpret_layout(const Tensor& src) {
+    if (src.layout == NewLayout) {
+        return src;
+    }
+
+    always_assert(src.ndims >= 2 && src.ndims <= RUNTIME_MAX_TENSOR_DIMS);
+
+    Tensor dst;
+    dst.copy(src);
+    dst.layout = NewLayout;
+
+    if (src.is_raw_eq_shapes) {
+        // src is ND full tensor → dst is DN → materialize raw_shapes, set false
+        for (uint32_t i = 0; i < dst.ndims; i++) {
+            dst.raw_shapes[i] = src.shapes[i];
+        }
+        dst.is_raw_eq_shapes = false;
+    }
+
+    std::swap(dst.shapes[dst.ndims - 2], dst.shapes[dst.ndims - 1]);
+
+    // DN→ND: check if swap restores shapes == raw_shapes (full tensor round-trip)
+    if constexpr (NewLayout == TensorLayout::ND) {
+        if (!src.is_raw_eq_shapes) {
+            bool eq = true;
+            for (uint32_t i = 0; i < dst.ndims; i++) {
+                if (dst.shapes[i] != dst.raw_shapes[i]) { eq = false; break; }
+            }
+            dst.is_raw_eq_shapes = eq;
+        }
+    }
+
+    if (!dst.is_all_offset_zero) {
+        std::swap(dst.offsets[dst.ndims - 2], dst.offsets[dst.ndims - 1]);
+    }
+
+    return dst;
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -29,8 +29,9 @@
 
 // OrchArg::to_tensor() — deferred definition (needs make_tensor_external from tensor.h)
 static_assert(ORCH_ARG_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "OrchArg and runtime max dims must match");
+template<TensorLayout Layout>
 inline Tensor OrchArg::to_tensor(bool manual_dep, int32_t version) const {
-    return make_tensor_external(
+    return make_tensor_external<Layout>(
         reinterpret_cast<void*>(static_cast<uintptr_t>(tensor.data)),
         tensor.shapes, tensor.ndims, tensor.dtype,
         manual_dep, version);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/data_type.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/data_type.h
@@ -26,6 +26,18 @@ enum class DataType : uint32_t {
 };
 
 /**
+ * Tensor Layout
+ *
+ * Defines memory layout for the last two dimensions (row-major vs column-major).
+ * - ND: Row-major for all dimensions
+ * - DN: Column-major for LAST TWO dimensions only
+ */
+enum class TensorLayout : uint32_t {
+    ND = 0,  // Normal Dimensions
+    DN = 1   // Last two Dimensions transposed (col-major for last 2D)
+};
+
+/**
  * Get the size in bytes of a single element of the given data type
  *
  * @param dtype Data type

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orch_arg.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orch_arg.h
@@ -45,6 +45,7 @@ struct OrchArg {
     // For simple cases where golden shape == kernel shape.
     // When reshape is needed, read fields manually and call make_tensor_external.
     // Defined in pto_orchestration_api.h (needs make_tensor_external).
+    template<TensorLayout Layout = TensorLayout::ND>
     Tensor to_tensor(bool manual_dep = false, int32_t version = 0) const;
 
     // Get raw pointer to tensor data (eliminates verbose double-cast)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -45,6 +45,7 @@ struct Segment {
  * - `buffer` contains the underlying memory allocation (addr in bytes, size in bytes)
  * - `raw_shapes[]`, `shapes[]`, `offsets[]` are in ELEMENTS
  * - `dtype` specifies element type for interpreting buffer contents
+ * - `layout` specifies the relationship between logical (shapes) and physical (raw_shapes) dimensions
  *
  * Fast-path flags (both on cache line 1):
  * - is_all_offset_zero: when true, offsets[] are implicitly zero — skip offset read/write
@@ -62,12 +63,12 @@ struct alignas(64) Tensor {
     uint64_t start_offset;                         // Cached 1D element offset (precomputed from raw_shapes + offsets), only calc before incore, useless in orch
     int32_t version;                               // Tensor version for overlap detection
     DataType dtype;                                // Data type of tensor elements
+    TensorLayout layout;                           // Tensor layout (ND or DN) for logical-to-physical dimension mapping
     uint32_t ndims;                                // Number of dimensions used
     bool is_all_offset_zero;                       // True when all offsets[] are zero (skip offset read/write)
     bool is_raw_eq_shapes;                         // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
     bool manual_dep;                               // True when dependency is managed manually (skip tensormap lookup/insert)
     uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
-    uint32_t __padding__;
 
     // === Cache line 2 (64B) — warm path ===
     uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
@@ -94,11 +95,12 @@ struct alignas(64) Tensor {
         uint32_t ndims,
         DataType dtype,
         int32_t version,
+        TensorLayout layout = TensorLayout::ND,
         bool is_all_offset_zero = false,
         bool is_raw_eq_shapes = false,
         bool manual_dep = false) {
         init(addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version,
-             is_all_offset_zero, is_raw_eq_shapes, manual_dep);
+             layout, is_all_offset_zero, is_raw_eq_shapes, manual_dep);
     }
 
     // --- Initialization ---
@@ -110,6 +112,7 @@ struct alignas(64) Tensor {
         uint32_t in_ndims,
         DataType in_dtype,
         int32_t in_version,
+        TensorLayout in_layout = TensorLayout::ND,
         bool in_is_all_offset_zero = false,
         bool in_is_raw_eq_shapes = false,
         bool in_manual_dep = false) {
@@ -117,6 +120,7 @@ struct alignas(64) Tensor {
         ndims = in_ndims;
         dtype = in_dtype;
         version = in_version;
+        layout = in_layout;
         is_all_offset_zero = in_is_all_offset_zero;
         is_raw_eq_shapes = in_is_raw_eq_shapes;
         manual_dep = in_manual_dep;
@@ -205,7 +209,19 @@ struct alignas(64) Tensor {
 
     Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
         Tensor result;
-        result.init_with_view(*this, view_shapes, view_offsets, manual_dep);
+        if (layout == TensorLayout::DN && ndims >= 2) {
+            always_assert(ndims <= RUNTIME_MAX_TENSOR_DIMS);
+            uint32_t adjusted_offsets[RUNTIME_MAX_TENSOR_DIMS];
+            for (uint32_t i = 0; i < ndims - 2; i++) {
+                adjusted_offsets[i] = view_offsets[i];
+            }
+            // Swap only the last two dimensions (DN reverses row/col order)
+            adjusted_offsets[ndims - 2] = view_offsets[ndims - 1];
+            adjusted_offsets[ndims - 1] = view_offsets[ndims - 2];
+            result.init_with_view(*this, view_shapes, adjusted_offsets, manual_dep);
+        } else {
+            result.init_with_view(*this, view_shapes, view_offsets, manual_dep);
+        }
         return result;
     }
 
@@ -285,6 +301,7 @@ struct alignas(64) Tensor {
         ss << indent << "dtype: " << get_dtype_name(dtype) << std::endl;
         ss << indent << "ndims: " << ndims << std::endl;
         ss << indent << "version: " << version << std::endl;
+        ss << indent << "layout: " << (layout == TensorLayout::ND ? "ND" : "DN") << std::endl;
 
         const uint32_t* rs = get_raw_shapes();
         ss << indent << "raw_shapes: [";
@@ -326,7 +343,11 @@ using TensorData = Tensor;
 // =============================================================================
 /**
  * Create a Tensor for pre-allocated external memory.
+ *
+ * For DN layout, raw_shapes (physical layout) will have the last two
+ * dimensions swapped compared to the logical shapes.
  */
+template<TensorLayout Layout = TensorLayout::ND>
 static inline Tensor make_tensor_external(void* addr,
     const uint32_t shapes[],
     uint32_t ndims,
@@ -338,8 +359,22 @@ static inline Tensor make_tensor_external(void* addr,
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(addr, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    uint64_t buf_size = total * get_element_size(dtype);
+
+    if constexpr (Layout == TensorLayout::DN) {
+        always_assert(ndims >= 2 && ndims <= RUNTIME_MAX_TENSOR_DIMS);
+        uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];
+        for (uint32_t i = 0; i < ndims - 2; i++) raw_shapes[i] = shapes[i];
+        raw_shapes[ndims - 2] = shapes[ndims - 1];
+        raw_shapes[ndims - 1] = shapes[ndims - 2];
+        return Tensor(addr, buf_size, raw_shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::DN,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/false, manual_dep);
+    } else {
+        return Tensor(addr, buf_size, shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::ND,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    }
 }
 
 /**
@@ -347,7 +382,11 @@ static inline Tensor make_tensor_external(void* addr,
  * NO memory allocation: only records dtype, shape, and buffer.size in the Tensor struct.
  * The runtime allocates from the heap ring and fills buffer.addr during pto2_submit_task
  * when this tensor is passed as OUTPUT param. No buffer content is ever copied.
+ *
+ * For DN layout, raw_shapes (physical layout) will have the last two
+ * dimensions swapped compared to the logical shapes.
  */
+template<TensorLayout Layout = TensorLayout::ND>
 static inline Tensor make_tensor(const uint32_t shapes[],
     uint32_t ndims,
     DataType dtype = DataType::FLOAT32,
@@ -358,6 +397,77 @@ static inline Tensor make_tensor(const uint32_t shapes[],
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(0, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    uint64_t buf_size = total * get_element_size(dtype);
+
+    if constexpr (Layout == TensorLayout::DN) {
+        always_assert(ndims >= 2 && ndims <= RUNTIME_MAX_TENSOR_DIMS);
+        uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];
+        for (uint32_t i = 0; i < ndims - 2; i++) raw_shapes[i] = shapes[i];
+        raw_shapes[ndims - 2] = shapes[ndims - 1];
+        raw_shapes[ndims - 1] = shapes[ndims - 2];
+        return Tensor(0, buf_size, raw_shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::DN,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/false, manual_dep);
+    } else {
+        return Tensor(0, buf_size, shapes, shapes, zero_offsets,
+                      ndims, dtype, version, TensorLayout::ND,
+                      /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    }
+}
+
+// =============================================================================
+// Layout Reinterpretation
+// =============================================================================
+
+/**
+ * Zero-cost layout reinterpretation.
+ *
+ * Returns a copy of src with the layout field changed to NewLayout.
+ * raw_shapes (physical layout) are unchanged; shapes[] last two dimensions
+ * are swapped to reflect the new logical interpretation.
+ *
+ * Uses Tensor::copy() for cache-line-aware copying — avoids touching
+ * cache line 2 when is_raw_eq_shapes and is_all_offset_zero are both true.
+ *
+ * Safe for both addr=0 (make_tensor) and addr!=0 (make_tensor_external)
+ * tensors — this is pure metadata reinterpretation, no data is moved.
+ */
+template<TensorLayout NewLayout>
+static inline Tensor reinterpret_layout(const Tensor& src) {
+    if (src.layout == NewLayout) {
+        return src;
+    }
+
+    always_assert(src.ndims >= 2 && src.ndims <= RUNTIME_MAX_TENSOR_DIMS);
+
+    Tensor dst;
+    dst.copy(src);
+    dst.layout = NewLayout;
+
+    if (src.is_raw_eq_shapes) {
+        // src is ND full tensor → dst is DN → materialize raw_shapes, set false
+        for (uint32_t i = 0; i < dst.ndims; i++) {
+            dst.raw_shapes[i] = src.shapes[i];
+        }
+        dst.is_raw_eq_shapes = false;
+    }
+
+    std::swap(dst.shapes[dst.ndims - 2], dst.shapes[dst.ndims - 1]);
+
+    // DN→ND: check if swap restores shapes == raw_shapes (full tensor round-trip)
+    if constexpr (NewLayout == TensorLayout::ND) {
+        if (!src.is_raw_eq_shapes) {
+            bool eq = true;
+            for (uint32_t i = 0; i < dst.ndims; i++) {
+                if (dst.shapes[i] != dst.raw_shapes[i]) { eq = false; break; }
+            }
+            dst.is_raw_eq_shapes = eq;
+        }
+    }
+
+    if (!dst.is_all_offset_zero) {
+        std::swap(dst.offsets[dst.ndims - 2], dst.offsets[dst.ndims - 1]);
+    }
+
+    return dst;
 }

--- a/tests/device_tests/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -73,9 +73,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     uint32_t key_cache_shapes[2] = {(uint32_t)(total_blocks_count * block_size), (uint32_t)head_dim};
     uint32_t value_cache_shapes[2] = {(uint32_t)(total_blocks_count * block_size), (uint32_t)head_dim};
     uint32_t out_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
-    Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type, false);
-    Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type, false);
-    Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
+    Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type);
+    Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type);
+    Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
     int* host_block_table  = orch_args[3].data<int>();
@@ -93,8 +93,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                 uint32_t li_shapes[1] = {(uint32_t)q_tile};
                 uint32_t mi_shapes[1] = {(uint32_t)q_tile};
                 Tensor oi = make_tensor(oi_shapes, 2, DataType::FLOAT32);
-                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32, false);
-                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32, false);
+                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32);
+                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32);
 
                 uint32_t qi_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
                 uint32_t qi_offsets[2] = {(uint32_t)cur_offset, 0};

--- a/tests/device_tests/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -118,9 +118,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     uint32_t key_cache_shapes[2] = {(uint32_t)(total_blocks_count * block_size), (uint32_t)head_dim};
     uint32_t value_cache_shapes[2] = {(uint32_t)(total_blocks_count * block_size), (uint32_t)head_dim};
     uint32_t out_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
-    Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type, false);
-    Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type, false);
-    Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
+    Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type);
+    Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type);
+    Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
     int* host_block_table  = orch_args[3].data<int>();
@@ -159,8 +159,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                 uint32_t li_shapes[1] = {(uint32_t)q_tile};
                 uint32_t mi_shapes[1] = {(uint32_t)q_tile};
                 Tensor oi = make_tensor(oi_shapes, 2, DataType::FLOAT32);
-                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32, false);
-                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32, false);
+                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32);
+                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32);
 #ifdef ENABLE_PROFILING
                 prof_make_count += 3;
                 CYCLE_COUNT_LAP(prof_make_tensor);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -115,9 +115,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(OrchArg* o
     uint32_t key_cache_shapes[2] = {(uint32_t)(total_blocks_count * block_size), (uint32_t)head_dim};
     uint32_t value_cache_shapes[2] = {(uint32_t)(total_blocks_count * block_size), (uint32_t)head_dim};
     uint32_t out_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
-    Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type, false);
-    Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type, false);
-    Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
+    Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type);
+    Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type);
+    Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
     int* host_block_table  = orch_args[3].data<int>();
@@ -156,8 +156,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(OrchArg* o
                 uint32_t li_shapes[1] = {(uint32_t)q_tile};
                 uint32_t mi_shapes[1] = {(uint32_t)q_tile};
                 Tensor oi = make_tensor(oi_shapes, 2, DataType::FLOAT32);
-                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32, false);
-                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32, false);
+                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32);
+                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32);
 #ifdef ENABLE_PROFILING
                 prof_make_count += 3;
                 CYCLE_COUNT_LAP(prof_make_tensor);

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -115,9 +115,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     uint32_t key_cache_shapes[2] = {(uint32_t)(total_blocks_count * block_size), (uint32_t)head_dim};
     uint32_t value_cache_shapes[2] = {(uint32_t)(total_blocks_count * block_size), (uint32_t)head_dim};
     uint32_t out_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
-    Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type, false);
-    Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type, false);
-    Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
+    Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type);
+    Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type);
+    Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
     int* host_block_table  = orch_args[3].data<int>();
@@ -156,8 +156,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                 uint32_t li_shapes[1] = {(uint32_t)q_tile};
                 uint32_t mi_shapes[1] = {(uint32_t)q_tile};
                 Tensor oi = make_tensor(oi_shapes, 2, DataType::FLOAT32);
-                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32, false);
-                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32, false);
+                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32);
+                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32);
 #ifdef ENABLE_PROFILING
                 prof_make_count += 3;
                 CYCLE_COUNT_LAP(prof_make_tensor);


### PR DESCRIPTION

- Introduce TensorLayout enum (ND/DN) to specify logical-to-physical dimension mapping
- Add layout field to Tensor struct, replacing __padding__
- Promote layout to compile-time template parameter in make_tensor, make_tensor_external,
  and OrchArg::to_tensor for if-constexpr optimization
- ND path avoids raw_shapes allocation (is_raw_eq_shapes=true, shares shapes pointer)
- Add reinterpret_layout<NewLayout>() for zero-cost metadata-only layout conversion
- Adjust view offsets for DN layout in Tensor::view
- Sync changes across a2a3 aicpu_build_graph, tensormap_and_ringbuffer, and a5 runtimes
