### PR TITLE
perf(platform): Replace double-buffer with SPSC free queue and dynamic memory manager

### DIFF
--- a/src/a2a3/platform/include/common/perf_profiling.h
+++ b/src/a2a3/platform/include/common/perf_profiling.h
@@ -2,40 +2,42 @@
  * @file perf_profiling.h
  * @brief Performance profiling data structures
  *
- * Architecture: Fixed header + dynamic tail + optional phase profiling region
+ * Architecture: Fixed header + per-core/thread buffer states + optional phase profiling region
  *
- * Memory layout:
+ * Memory layout (shared memory between Host and Device):
  * ┌─────────────────────────────────────────────────────────────┐
  * │ PerfDataHeader (fixed header)                               │
  * │  - ReadyQueue (FIFO, capacity=PLATFORM_PROF_READYQUEUE_SIZE)│
- * │  - Metadata (num_cores, buffer_capacity, flags)             │
+ * │  - Metadata (num_cores, flags)                              │
  * ├─────────────────────────────────────────────────────────────┤
- * │ DoubleBuffer[0] (Core 0)                                    │
- * │  - buffer1, buffer2 (PerfBuffer)                            │
- * │  - buffer1_status, buffer2_status (IDLE/WRITING/READY)      │
+ * │ PerfBufferState[0] (Core 0)                                 │
+ * │  - free_queue: SPSC queue of available buffer pointers      │
+ * │  - current_buf_ptr, current_buf_seq                         │
  * ├─────────────────────────────────────────────────────────────┤
- * │ DoubleBuffer[1] (Core 1)                                    │
+ * │ PerfBufferState[1] (Core 1)                                 │
  * ├─────────────────────────────────────────────────────────────┤
  * │ ...                                                         │
  * ├─────────────────────────────────────────────────────────────┤
- * │ DoubleBuffer[num_cores-1]                                   │
+ * │ PerfBufferState[num_cores-1]                                │
  * ├─────────────────────────────────────────────────────────────┤
  * │ AicpuPhaseHeader (optional, present when phase profiling)   │
  * │  - magic, num_sched_threads, records_per_thread             │
- * │  - current_buffer_idx[PLATFORM_MAX_AICPU_THREADS]           │
  * │  - orch_summary                                             │
  * ├─────────────────────────────────────────────────────────────┤
- * │ PhaseRingBuffer[thread0]                                    │
- * │  - buffers[0..N-1] (PhaseBuffer ring, N=PHASE_RING_DEPTH)  │
- * │  - buffer_status[0..N-1]                                    │
+ * │ PhaseBufferState[thread0]                                   │
+ * │  - free_queue: SPSC queue of available buffer pointers      │
+ * │  - current_buf_ptr, current_buf_seq                         │
  * ├─────────────────────────────────────────────────────────────┤
- * │ PhaseRingBuffer[thread1]                                    │
+ * │ PhaseBufferState[thread1]                                   │
  * ├─────────────────────────────────────────────────────────────┤
  * │ ...                                                         │
  * └─────────────────────────────────────────────────────────────┘
  *
- * Base size = sizeof(PerfDataHeader) + num_cores * sizeof(DoubleBuffer)
- * With phases = Base + sizeof(AicpuPhaseHeader) + num_threads * sizeof(PhaseRingBuffer)
+ * Actual PerfBuffer / PhaseBuffer are allocated dynamically by Host
+ * and pushed into the per-core/thread free_queue.
+ *
+ * Base size = sizeof(PerfDataHeader) + num_cores * sizeof(PerfBufferState)
+ * With phases = Base + sizeof(AicpuPhaseHeader) + num_threads * sizeof(PhaseBufferState)
  */
 
 #ifndef PLATFORM_COMMON_PERF_PROFILING_H_
@@ -51,28 +53,6 @@
 #ifndef RUNTIME_MAX_FANOUT
 #define RUNTIME_MAX_FANOUT 512
 #endif
-
-// =============================================================================
-// Buffer Status Enumeration
-// =============================================================================
-
-/**
- * Buffer status enumeration (3-state design)
- *
- * State transition flow:
- * IDLE (0) → WRITING (1) → READY (2) → IDLE (0)
- *
- * - AICPU: IDLE→WRITING (on allocation), WRITING→READY (when buffer full)
- * - AICore: Only writes data, does not modify status
- * - Host:   READY→IDLE (after reading)
- *
- * Note: Using uint32_t for binary compatibility with volatile fields.
- */
-enum class BufferStatus : uint32_t {
-    IDLE    = 0,  // Idle: can be allocated by AICPU
-    WRITING = 1,  // Writing: in use by AICore
-    READY   = 2   // Ready: full, waiting for Host
-};
 
 // =============================================================================
 // PerfRecord - Single Task Execution Record
@@ -115,6 +95,7 @@ static_assert(sizeof(PerfRecord) % 64 == 0,
  * Fixed-size performance record buffer
  *
  * Capacity: PLATFORM_PROF_BUFFER_SIZE (defined in platform_config.h)
+ * Allocated dynamically by Host, pushed into per-core free_queue.
  */
 struct PerfBuffer {
     PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Record array
@@ -122,28 +103,68 @@ struct PerfBuffer {
 } __attribute__((aligned(64)));
 
 // =============================================================================
-// DoubleBuffer - Per-Core Ping-Pong Buffers
+// PerfFreeQueue - SPSC Lock-Free Queue for Free Buffers
 // =============================================================================
 
 /**
- * Per-core double buffer with status management
+ * Single Producer Single Consumer (SPSC) lock-free queue for free buffer management
  *
- * Two independent PerfBuffers with independent status fields.
- * AICPU manages buffer allocation and status transitions (0→1→2).
- * AICore only writes records and increments count.
- * Host reads ready buffers and resets status to idle (2→0).
+ * Producer: Host (ProfMemoryManager thread) pushes newly allocated buffers
+ * Consumer: Device (AICPU thread) pops buffers when switching
  *
- * When both buffers are idle, AICPU prioritizes buffer1.
+ * Queue semantics:
+ * - Empty: head == tail
+ * - Full: (tail - head) >= PLATFORM_PROF_SLOT_COUNT
+ * - Capacity: PLATFORM_PROF_SLOT_COUNT buffers
+ *
+ * Memory ordering:
+ * - Device pop: rmb() → read tail → read buffer_ptrs[head % COUNT] → rmb() → write head → wmb()
+ * - Host push: write buffer_ptrs[tail % COUNT] → wmb() → write tail → wmb()
  */
-struct DoubleBuffer {
-    // Buffer 1 (Ping)
-    PerfBuffer buffer1;                              // First buffer
-    volatile BufferStatus buffer1_status;            // Buffer1 status (IDLE/WRITING/READY)
-
-    // Buffer 2 (Pong)
-    PerfBuffer buffer2;                              // Second buffer
-    volatile BufferStatus buffer2_status;            // Buffer2 status (IDLE/WRITING/READY)
+struct PerfFreeQueue {
+    volatile uint64_t buffer_ptrs[PLATFORM_PROF_SLOT_COUNT];  // Free buffer addresses
+    volatile uint32_t head;  // Consumer read position (Device increments)
+    volatile uint32_t tail;  // Producer write position (Host increments)
+    uint32_t pad[13];        // Pad to 128 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
+
+static_assert(sizeof(PerfFreeQueue) == 128,
+              "PerfFreeQueue must be 128 bytes for cache alignment");
+
+// =============================================================================
+// PerfBufferState - Per-Core/Thread Buffer State (Unified for PerfRecord and Phase)
+// =============================================================================
+
+/**
+ * Per-core or per-thread buffer state for dynamic profiling
+ *
+ * Contains:
+ * - free_queue: SPSC queue of available buffer addresses
+ * - current_buf_ptr: Currently active buffer being written (0 = no active buffer)
+ * - current_buf_seq: Monotonic sequence number for ordering
+ *
+ * Used in two contexts:
+ * - Per-core PerfRecord profiling (current_buf_ptr → PerfBuffer)
+ * - Per-thread Phase profiling (current_buf_ptr → PhaseBuffer)
+ *
+ * Writers:
+ * - free_queue.tail: Host writes (pushes new buffers)
+ * - free_queue.head: Device writes (pops buffers)
+ * - current_buf_ptr: Device writes (after pop), Host reads (for flush/collect)
+ * - current_buf_seq: Device writes (monotonic counter)
+ */
+struct PerfBufferState {
+    PerfFreeQueue free_queue;            // SPSC queue of free buffer addresses
+    volatile uint64_t current_buf_ptr;   // Current active buffer (0 = none)
+    volatile uint32_t current_buf_seq;   // Sequence number for ordering
+    uint32_t pad[13];                    // Pad to 192 bytes (aligned to cache line)
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(PerfBufferState) == 192,
+              "PerfBufferState must be 192 bytes for cache alignment");
+
+// Type alias for semantic clarity in Phase profiling context
+using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
 
 // =============================================================================
 // ReadyQueueEntry - Queue Entry for Ready Buffers
@@ -152,17 +173,20 @@ struct DoubleBuffer {
 /**
  * Ready queue entry
  *
- * When a buffer on a core is full, AICPU adds this entry to the queue.
- * Host retrieves entries from the queue to locate (core_index, buffer_id) for reading.
+ * When a buffer on a core/thread is full, AICPU adds this entry to the queue.
+ * Host memory manager retrieves entries from the queue.
  *
- * Entry types (distinguished by PHASE_BUFFER_FLAG in buffer_id):
- * - PerfRecord entry: core_index = core ID, buffer_id = 1 or 2
- * - Phase entry:      core_index = thread_idx, buffer_id = (ring_idx+1) | PHASE_BUFFER_FLAG
+ * Entry types (distinguished by is_phase flag):
+ * - PerfRecord entry: core_index = core ID, is_phase = 0
+ * - Phase entry:      core_index = thread_idx, is_phase = 1
  */
 struct ReadyQueueEntry {
     uint32_t core_index;      // Core index (0 ~ num_cores-1), or thread_idx for phase entries
-    uint32_t buffer_id;       // PerfRecord: 1 or 2; Phase: (ring_idx+1) | PHASE_BUFFER_FLAG
-} __attribute__((aligned(16)));
+    uint32_t is_phase;        // 0 = PerfRecord, 1 = Phase
+    uint64_t buffer_ptr;      // Device pointer to the full buffer
+    uint32_t buffer_seq;      // Sequence number for ordering
+    uint32_t pad;             // Alignment padding
+} __attribute__((aligned(32)));
 
 // =============================================================================
 // PerfDataHeader - Fixed Header
@@ -180,7 +204,7 @@ struct ReadyQueueEntry {
  * - Capacity per queue: PLATFORM_PROF_READYQUEUE_SIZE (full capacity for each thread)
  * - Implementation: Circular Buffer
  * - Producer: AICPU thread (adds full buffers to its own queue)
- * - Consumer: Host (reads from all queues)
+ * - Consumer: Host memory manager thread (reads from all queues)
  * - Queue empty: head == tail
  * - Queue full: (tail + 1) % capacity == head
  */
@@ -265,15 +289,10 @@ constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per thread
 
 /**
- * Flag bit in ReadyQueueEntry.buffer_id to distinguish phase entries from core entries.
- * Phase entry: buffer_id = (ring_idx+1) | PHASE_BUFFER_FLAG
- */
-constexpr uint32_t PHASE_BUFFER_FLAG = 0x80000000;
-
-/**
  * Fixed-size phase record buffer (analogous to PerfBuffer)
  *
  * Capacity: PLATFORM_PHASE_RECORDS_PER_THREAD
+ * Allocated dynamically by Host, pushed into per-thread free_queue.
  */
 struct PhaseBuffer {
     AicpuPhaseRecord records[PLATFORM_PHASE_RECORDS_PER_THREAD];
@@ -281,30 +300,16 @@ struct PhaseBuffer {
 } __attribute__((aligned(64)));
 
 /**
- * Per-thread phase ring buffer with status management
- *
- * N independent PhaseBuffers with independent status fields, forming a ring.
- * AICPU manages buffer allocation and status transitions (IDLE→WRITING→READY).
- * Host reads ready buffers and resets status to idle (READY→IDLE).
- * Ring depth is PLATFORM_PHASE_RING_DEPTH (default 16).
- */
-struct PhaseRingBuffer {
-    PhaseBuffer buffers[PLATFORM_PHASE_RING_DEPTH];
-    volatile BufferStatus buffer_status[PLATFORM_PHASE_RING_DEPTH];
-} __attribute__((aligned(64)));
-
-/**
  * AICPU phase profiling header
  *
- * Located after the DoubleBuffer array in shared memory.
- * Contains metadata and per-thread buffer tracking.
+ * Located after the PerfBufferState array in shared memory.
+ * Contains metadata and per-thread tracking.
  */
 struct AicpuPhaseHeader {
     uint32_t magic;                  // Validation magic (AICPU_PHASE_MAGIC)
     uint32_t num_sched_threads;      // Number of scheduler threads
     uint32_t records_per_thread;     // Max records per PhaseBuffer
     uint32_t num_cores;              // Total number of cores with valid assignments
-    uint32_t current_buffer_idx[PLATFORM_MAX_AICPU_THREADS];  // Per-thread active ring index (0..N-1)
     int8_t core_to_thread[PLATFORM_MAX_CORES];  // core_id → scheduler thread index (-1 = unassigned)
     AicpuOrchSummary orch_summary;   // Orchestrator cumulative data
 } __attribute__((aligned(64)));
@@ -318,16 +323,16 @@ extern "C" {
 #endif
 
 /**
- * Calculate total memory size for performance data
+ * Calculate total memory size for performance data (buffer states only, no buffers)
  *
  * Formula: Total size = Fixed header + Dynamic tail
- *                     = sizeof(PerfDataHeader) + num_cores × sizeof(DoubleBuffer)
+ *                     = sizeof(PerfDataHeader) + num_cores × sizeof(PerfBufferState)
  *
  * @param num_cores Number of cores (block_dim × PLATFORM_CORES_PER_BLOCKDIM)
- * @return Total bytes
+ * @return Total bytes for header + buffer states
  */
 inline size_t calc_perf_data_size(int num_cores) {
-    return sizeof(PerfDataHeader) + num_cores * sizeof(DoubleBuffer);
+    return sizeof(PerfDataHeader) + num_cores * sizeof(PerfBufferState);
 }
 
 /**
@@ -341,61 +346,41 @@ inline PerfDataHeader* get_perf_header(void* base_ptr) {
 }
 
 /**
- * Get DoubleBuffer array start address
+ * Get PerfBufferState array start address
  *
  * @param base_ptr Shared memory base address
- * @return DoubleBuffer array pointer
+ * @return PerfBufferState array pointer
  */
-inline DoubleBuffer* get_double_buffers(void* base_ptr) {
-    return (DoubleBuffer*)((char*)base_ptr + sizeof(PerfDataHeader));
+inline PerfBufferState* get_perf_buffer_states(void* base_ptr) {
+    return (PerfBufferState*)((char*)base_ptr + sizeof(PerfDataHeader));
 }
 
 /**
- * Get DoubleBuffer for specified core
+ * Get PerfBufferState for specified core
  *
  * @param base_ptr Shared memory base address
  * @param core_index Core index (0 ~ num_cores-1)
- * @return DoubleBuffer pointer
+ * @return PerfBufferState pointer
  */
-inline DoubleBuffer* get_core_double_buffer(void* base_ptr, int core_index) {
-    DoubleBuffer* buffers = get_double_buffers(base_ptr);
-    return &buffers[core_index];
+inline PerfBufferState* get_perf_buffer_state(void* base_ptr, int core_index) {
+    return &get_perf_buffer_states(base_ptr)[core_index];
 }
 
 /**
- * Get buffer pointer and status pointer for specified buffer
- *
- * @param db DoubleBuffer pointer
- * @param buffer_id Buffer ID (1=buffer1, 2=buffer2)
- * @param[out] buf PerfBuffer pointer
- * @param[out] status Status pointer
- */
-inline void get_buffer_and_status(DoubleBuffer* db, uint32_t buffer_id,
-                                  PerfBuffer** buf, volatile BufferStatus** status) {
-    if (buffer_id == 1) {
-        *buf = &db->buffer1;
-        *status = &db->buffer1_status;
-    } else {
-        *buf = &db->buffer2;
-        *status = &db->buffer2_status;
-    }
-}
-
-/**
- * Calculate total memory size including phase profiling region
+ * Calculate total memory size including phase profiling region (buffer states only)
  *
  * @param num_cores Number of AICore instances
  * @param num_sched_threads Number of phase profiling threads (scheduler + orchestrator)
- * @return Total bytes needed
+ * @return Total bytes needed for header + all buffer states
  */
 inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threads) {
     return calc_perf_data_size(num_cores)
          + sizeof(AicpuPhaseHeader)
-         + num_sched_threads * sizeof(PhaseRingBuffer);
+         + num_sched_threads * sizeof(PhaseBufferState);
 }
 
 /**
- * Get AicpuPhaseHeader pointer (located after DoubleBuffer array)
+ * Get AicpuPhaseHeader pointer (located after PerfBufferState array)
  *
  * @param base_ptr Shared memory base address
  * @param num_cores Number of AICore instances
@@ -406,40 +391,26 @@ inline AicpuPhaseHeader* get_phase_header(void* base_ptr, int num_cores) {
 }
 
 /**
- * Get PhaseRingBuffer array start address (located after AicpuPhaseHeader)
+ * Get PhaseBufferState array start address (located after AicpuPhaseHeader)
  *
  * @param base_ptr Shared memory base address
  * @param num_cores Number of AICore instances
- * @return PhaseRingBuffer array pointer
+ * @return PhaseBufferState array pointer
  */
-inline PhaseRingBuffer* get_phase_ring_buffers(void* base_ptr, int num_cores) {
-    return (PhaseRingBuffer*)((char*)get_phase_header(base_ptr, num_cores) + sizeof(AicpuPhaseHeader));
+inline PhaseBufferState* get_phase_buffer_states(void* base_ptr, int num_cores) {
+    return (PhaseBufferState*)((char*)get_phase_header(base_ptr, num_cores) + sizeof(AicpuPhaseHeader));
 }
 
 /**
- * Get PhaseRingBuffer for specified thread
+ * Get PhaseBufferState for specified thread
  *
  * @param base_ptr Shared memory base address
  * @param num_cores Number of AICore instances
  * @param thread_idx Thread index
- * @return PhaseRingBuffer pointer
+ * @return PhaseBufferState pointer
  */
-inline PhaseRingBuffer* get_phase_ring_buffer(void* base_ptr, int num_cores, int thread_idx) {
-    return &get_phase_ring_buffers(base_ptr, num_cores)[thread_idx];
-}
-
-/**
- * Get phase buffer pointer and status pointer by ring index
- *
- * @param ring PhaseRingBuffer pointer
- * @param idx Ring buffer index (0..PLATFORM_PHASE_RING_DEPTH-1)
- * @param[out] buf PhaseBuffer pointer
- * @param[out] status Status pointer
- */
-inline void get_phase_buffer_by_idx(PhaseRingBuffer* ring, uint32_t idx,
-                                     PhaseBuffer** buf, volatile BufferStatus** status) {
-    *buf = &ring->buffers[idx];
-    *status = &ring->buffer_status[idx];
+inline PhaseBufferState* get_phase_buffer_state(void* base_ptr, int num_cores, int thread_idx) {
+    return &get_phase_buffer_states(base_ptr, num_cores)[thread_idx];
 }
 
 #ifdef __cplusplus

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -73,27 +73,30 @@ constexpr int PLATFORM_MAX_CORES =
     PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 72
 
 /**
- * Performance buffer capacity for each double buffer
- * Number of PerfRecord entries per buffer (ping or pong)
+ * Performance buffer capacity per buffer
+ * Number of PerfRecord entries per dynamically allocated PerfBuffer
  */
 constexpr int PLATFORM_PROF_BUFFER_SIZE = 1000;
 
 /**
- * Phase profiling ring buffer depth per thread
- * More buffers = less chance of data loss when Host is slow to drain.
- * Memory cost per thread: PHASE_RING_DEPTH * ~512KB = ~8MB (4 threads = ~32MB total).
+ * Number of buffer slots per core/thread for dynamic profiling
+ * Host dynamically allocates buffers and writes addresses into these slots.
+ * Device reads slot addresses when switching buffers.
+ * Using 8 slots (ring buffer) instead of 2 (double-buffer) to tolerate
+ * Host-side latency in replacing full buffers.
  */
-constexpr int PLATFORM_PHASE_RING_DEPTH = 16;
+constexpr int PLATFORM_PROF_SLOT_COUNT = 8;
 
 /**
  * Ready queue capacity for performance data collection
- * Queue holds (core_index, buffer_id) entries for buffers ready to be read by Host.
+ * Queue holds ReadyQueueEntry structs for buffers ready to be read by Host.
  * Includes both PerfRecord and PhaseRecord entries:
- *   PerfRecord: PLATFORM_MAX_CORES * 2 (each core has 2 buffers)
- *   Phase:      PLATFORM_MAX_AICPU_THREADS * PLATFORM_PHASE_RING_DEPTH
+ *   PerfRecord: PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT
+ *   Phase:      PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT
  */
 constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
-    PLATFORM_MAX_CORES * 2 + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PHASE_RING_DEPTH;  // 208
+    PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT
+    + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT;  // 608
 
 /**
  * System counter frequency (get_sys_cnt)

--- a/src/a2a3/platform/include/host/performance_collector.h
+++ b/src/a2a3/platform/include/host/performance_collector.h
@@ -1,22 +1,26 @@
 /**
  * @file performance_collector.h
- * @brief Platform-agnostic performance data collector
+ * @brief Platform-agnostic performance data collector with dynamic memory management
  *
- * This module provides a unified interface for collecting performance profiling
- * data across different platforms (a2a3, a2a3sim). Platform-specific memory
- * management is delegated to callback functions, enabling code reuse while
- * maintaining platform separation.
+ * Architecture:
+ * - ProfMemoryManager: Dedicated thread that polls ReadyQueue, allocates new
+ *   device buffers, and replaces full buffers in slot arrays.
+ * - PerformanceCollector: Main thread collects data from ProfMemoryManager's
+ *   internal queue, copies records to host vectors, and exports results.
  *
- * Design Pattern: Dependency Injection via Callbacks
- * - Memory allocation: PerfAllocCallback
- * - Host-Device mapping: PerfRegisterCallback (optional for simulation)
- * - Memory cleanup: PerfUnregisterCallback + PerfFreeCallback
+ * Design Pattern: Dependency Injection via Callbacks for memory operations.
  */
 
 #ifndef PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_
 #define PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
 #include <string>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "common/perf_profiling.h"
@@ -64,13 +68,167 @@ using PerfUnregisterCallback = int (*)(void* dev_ptr, int device_id, void* user_
  */
 using PerfFreeCallback = int (*)(void* dev_ptr, void* user_data);
 
+// =============================================================================
+// ProfMemoryManager - Dynamic Buffer Memory Management Thread
+// =============================================================================
+
+/**
+ * Buffer type identifier for ReadyBufferInfo
+ */
+enum class ProfBufferType { PERF_RECORD, PHASE };
+
+/**
+ * Information about a ready (full) buffer, passed from mgmt thread to main thread
+ */
+struct ReadyBufferInfo {
+    ProfBufferType type;
+    uint32_t index;           // core_index (PERF_RECORD) or thread_idx (PHASE)
+    uint32_t slot_idx;        // Reserved (unused in free queue design)
+    void* dev_buffer_ptr;     // Device address of the full buffer
+    void* host_buffer_ptr;    // Host-mapped address (sim: same as dev)
+    uint32_t buffer_seq;      // Sequence number for ordering
+};
+
+/**
+ * Notification that a buffer has been copied and can be freed
+ */
+struct CopyDoneInfo {
+    void* dev_buffer_ptr;     // Device buffer to free
+};
+
+/**
+ * Dynamic profiling buffer memory manager
+ *
+ * Runs a dedicated thread that:
+ * 1. Polls ReadyQueue in shared memory for full buffer entries
+ * 2. Allocates new device buffers via callback
+ * 3. Writes new buffer addresses into slots (for device to pick up)
+ * 4. Pushes old (full) buffer info to internal queue for main thread to copy
+ * 5. Frees device buffers after main thread confirms copy is done
+ */
+class ProfMemoryManager {
+public:
+    ProfMemoryManager() = default;
+    ~ProfMemoryManager();
+
+    // Disable copy
+    ProfMemoryManager(const ProfMemoryManager&) = delete;
+    ProfMemoryManager& operator=(const ProfMemoryManager&) = delete;
+
+    // Allow PerformanceCollector to register initial buffer mappings
+    friend class PerformanceCollector;
+
+    /**
+     * Start the memory management thread
+     *
+     * @param shared_mem_host Host-mapped shared memory base address
+     * @param num_cores Number of AICore instances (PerfBufferState count)
+     * @param num_phase_threads Number of phase profiling threads (PhaseBufferState count)
+     * @param alloc_cb Device memory allocation callback
+     * @param register_cb Host-device mapping callback (nullptr for simulation)
+     * @param free_cb Device memory free callback
+     * @param user_data User context for callbacks
+     * @param device_id Device ID for registration
+     */
+    void start(void* shared_mem_host, int num_cores, int num_phase_threads,
+               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
+               PerfFreeCallback free_cb, void* user_data, int device_id);
+
+    /**
+     * Stop the memory management thread
+     * Blocks until the thread exits.
+     */
+    void stop();
+
+    /**
+     * Try to pop a ready buffer info (non-blocking)
+     *
+     * @param[out] info Ready buffer info
+     * @return true if an item was available, false otherwise
+     */
+    bool try_pop_ready(ReadyBufferInfo& info);
+
+    /**
+     * Wait for a ready buffer info with timeout
+     *
+     * @param[out] info Ready buffer info
+     * @param timeout Maximum wait time
+     * @return true if an item was available, false on timeout
+     */
+    bool wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout);
+
+    /**
+     * Notify that a buffer has been copied and can be freed
+     *
+     * @param info Copy done notification
+     */
+    void notify_copy_done(const CopyDoneInfo& info);
+
+    /**
+     * Check if the manager thread is running
+     */
+    bool is_running() const { return running_.load(); }
+
+private:
+    std::thread mgmt_thread_;
+    std::atomic<bool> running_{false};
+
+    // Shared memory references
+    void* shared_mem_host_{nullptr};
+    int num_cores_{0};
+    int num_phase_threads_{0};
+
+    // Callbacks
+    PerfAllocCallback alloc_cb_{nullptr};
+    PerfRegisterCallback register_cb_{nullptr};
+    PerfFreeCallback free_cb_{nullptr};
+    void* user_data_{nullptr};
+    int device_id_{-1};
+
+    // Management thread → main thread (ready buffers)
+    std::mutex ready_mutex_;
+    std::condition_variable ready_cv_;
+    std::queue<ReadyBufferInfo> ready_queue_;
+
+    // Main thread → management thread (buffers to free)
+    std::mutex done_mutex_;
+    std::queue<CopyDoneInfo> done_queue_;
+
+    // Device-to-host pointer mapping (populated during alloc_and_register)
+    std::unordered_map<void*, void*> dev_to_host_;
+
+    // Management thread main loop
+    void mgmt_loop();
+
+    // Allocate a new buffer and optionally register for host access
+    void* alloc_and_register(size_t size, void** host_ptr_out);
+
+    // Free a previously allocated buffer
+    void free_buffer(void* dev_ptr);
+
+    // Resolve device pointer to host pointer
+    void* resolve_host_ptr(void* dev_ptr);
+
+    // Register an external dev→host mapping (for initial buffers)
+    void register_mapping(void* dev_ptr, void* host_ptr);
+
+    // Process one ReadyQueue entry
+    void process_ready_entry(PerfDataHeader* header, int thread_idx,
+                              const ReadyQueueEntry& entry);
+};
+
+// =============================================================================
+// PerformanceCollector - Main Collector
+// =============================================================================
+
 /**
  * Performance data collector
  *
  * Manages performance profiling lifecycle:
- * 1. Initialize shared memory (Header + DoubleBuffers)
- * 2. Poll ready queue and collect records from full buffers
- * 3. Print statistics and export swimlane visualization
+ * 1. Initialize shared memory (Header + SlotArrays) and allocate initial buffers
+ * 2. Start ProfMemoryManager thread
+ * 3. Collect records from ProfMemoryManager's queue (main thread)
+ * 4. Export swimlane visualization
  *
  * Platform-agnostic: Memory management delegated to callbacks
  */
@@ -86,13 +244,15 @@ public:
     /**
      * Initialize performance profiling
      *
-     * Allocates and initializes shared memory for performance data collection.
+     * Allocates shared memory for slot arrays, allocates initial buffers,
+     * and writes buffer addresses into slots.
      *
      * @param runtime Runtime instance to configure
      * @param num_aicore Number of AICore instances
      * @param device_id Device ID
      * @param alloc_cb Memory allocation callback
      * @param register_cb Memory registration callback (can be nullptr for simulation)
+     * @param free_cb Memory free callback
      * @param user_data User-provided context pointer passed to callbacks
      * @return 0 on success, error code on failure
      */
@@ -101,12 +261,24 @@ public:
                    int device_id,
                    PerfAllocCallback alloc_cb,
                    PerfRegisterCallback register_cb,
+                   PerfFreeCallback free_cb,
                    void* user_data);
 
     /**
-     * Poll and collect performance data from shared memory
+     * Start the memory management thread
      *
-     * @param expected_tasks Expected total number of tasks (0 = auto-detect from header)
+     * Must be called after initialize() and before device execution starts.
+     */
+    void start_memory_manager();
+
+    /**
+     * Poll and collect performance data from the memory manager's queue
+     *
+     * Runs on the main thread (or a dedicated collector thread in sim mode).
+     * Pulls ready buffers from ProfMemoryManager, copies records to host vectors,
+     * and notifies the manager to free old device buffers.
+     *
+     * @param expected_tasks Expected total number of tasks (0 = auto-detect)
      */
     void poll_and_collect(int expected_tasks = 0);
 
@@ -117,6 +289,13 @@ public:
      * @return 0 on success, error code on failure
      */
     int export_swimlane_json(const std::string& output_path = "outputs");
+
+    /**
+     * Stop the memory management thread and clean up remaining data
+     *
+     * Must be called after device execution completes.
+     */
+    void stop_memory_manager();
 
     /**
      * Cleanup all resources
@@ -136,6 +315,17 @@ public:
     bool is_initialized() const { return perf_shared_mem_host_ != nullptr; }
 
     /**
+     * Drain remaining buffers from the memory manager's ready queue
+     *
+     * After poll_and_collect() exits (all PERF records collected) and
+     * the memory manager is stopped, Phase buffers may still be in the
+     * ready queue. This method drains them into the collected vectors.
+     *
+     * Must be called after stop_memory_manager() and before collect_phase_data().
+     */
+    void drain_remaining_buffers();
+
+    /**
      * Collect AICPU phase profiling data from shared memory
      *
      * Reads scheduler phase records and orchestrator summary from the
@@ -150,13 +340,22 @@ public:
 
 private:
     // Shared memory pointers
-    void* perf_shared_mem_dev_{nullptr};   // Device memory pointer
-    void* perf_shared_mem_host_{nullptr};  // Host-mapped pointer
+    void* perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
+    void* perf_shared_mem_host_{nullptr};  // Host-mapped pointer (slot arrays)
     bool was_registered_{false};           // True if register_cb was called successfully
     int device_id_{-1};
 
     // Configuration
     int num_aicore_{0};
+
+    // Callbacks (stored for memory manager)
+    PerfAllocCallback alloc_cb_{nullptr};
+    PerfRegisterCallback register_cb_{nullptr};
+    PerfFreeCallback free_cb_{nullptr};
+    void* user_data_{nullptr};
+
+    // Memory manager
+    ProfMemoryManager memory_manager_;
 
     // Collected data (per-core vectors, indexed by core_index)
     std::vector<std::vector<PerfRecord>> collected_perf_records_;
@@ -169,6 +368,9 @@ private:
 
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
     std::vector<int8_t> core_to_thread_;
+
+    // Allocate a single buffer (PerfBuffer or PhaseBuffer) and register it
+    void* alloc_single_buffer(size_t size, void** host_ptr_out);
 };
 
 #endif  // PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -387,6 +387,8 @@ int DeviceRunner::run(Runtime& runtime,
             LOG_ERROR("init_performance_profiling failed: %d", rc);
             return rc;
         }
+        // Start memory management thread
+        perf_collector_.start_memory_manager();
     }
 
     std::cout << "\n=== Initialize runtime args ===" << '\n';
@@ -436,9 +438,12 @@ int DeviceRunner::run(Runtime& runtime,
         return rc;
     }
 
-    // Poll and collect performance data (must be before stream sync)
+    // Poll and collect performance data in a separate collector thread
+    std::thread collector_thread;
     if (runtime.enable_profiling) {
-        poll_and_collect_performance_data(runtime.get_task_count());
+        collector_thread = std::thread([this, &runtime]() {
+            poll_and_collect_performance_data(runtime.get_task_count());
+        });
     }
 
     std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
@@ -446,6 +451,9 @@ int DeviceRunner::run(Runtime& runtime,
     rc = rtStreamSynchronize(stream_aicpu_);
     if (rc != 0) {
         LOG_ERROR("rtStreamSynchronize (AICPU) failed: %d", rc);
+        if (runtime.enable_profiling && collector_thread.joinable()) {
+            collector_thread.join();
+        }
         if (kernel_args_.args.regs != 0) {
             mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
             kernel_args_.args.regs = 0;
@@ -458,6 +466,9 @@ int DeviceRunner::run(Runtime& runtime,
     rc = rtStreamSynchronize(stream_aicore_);
     if (rc != 0) {
         LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
+        if (runtime.enable_profiling && collector_thread.joinable()) {
+            collector_thread.join();
+        }
         if (kernel_args_.args.regs != 0) {
             mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
             kernel_args_.args.regs = 0;
@@ -466,8 +477,15 @@ int DeviceRunner::run(Runtime& runtime,
         return rc;
     }
 
-    // Collect phase data and print performance data (after stream sync)
+    // Wait for collector thread to finish
+    if (runtime.enable_profiling && collector_thread.joinable()) {
+        collector_thread.join();
+    }
+
+    // Stop memory management, drain remaining buffers, collect phase data, export
     if (runtime.enable_profiling) {
+        perf_collector_.stop_memory_manager();
+        perf_collector_.drain_remaining_buffers();
         perf_collector_.collect_phase_data();
         export_swimlane_json();
     }
@@ -722,8 +740,13 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
 
+    auto free_cb = [](void* dev_ptr, void* user_data) -> int {
+        auto* allocator = static_cast<MemoryAllocator*>(user_data);
+        return allocator->free(dev_ptr);
+    };
+
     return perf_collector_.initialize(runtime, num_aicore, device_id,
-                                       alloc_cb, register_cb, &mem_alloc_);
+                                       alloc_cb, register_cb, free_cb, &mem_alloc_);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -237,6 +237,8 @@ int DeviceRunner::run(Runtime& runtime,
             LOG_ERROR("init_performance_profiling failed: %d", rc);
             return rc;
         }
+        // Start memory management thread
+        perf_collector_.start_memory_manager();
     }
 
     // Allocate simulated register blocks for all AICore cores
@@ -316,8 +318,10 @@ int DeviceRunner::run(Runtime& runtime,
 
     LOG_INFO("All threads completed");
 
-    // Collect AICPU phase data and print performance data after execution completes
+    // Stop memory management, drain remaining buffers, collect phase data, export
     if (runtime.enable_profiling) {
+        perf_collector_.stop_memory_manager();
+        perf_collector_.drain_remaining_buffers();
         perf_collector_.collect_phase_data();
         export_swimlane_json();
     }
@@ -498,9 +502,16 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
         return malloc(size);
     };
 
+    // Define free callback (a2a3sim: use free)
+    auto free_cb = [](void* dev_ptr, void* user_data) -> int {
+        (void)user_data;  // Not needed for free
+        free(dev_ptr);
+        return 0;
+    };
+
     // Simulation: no registration needed (pass nullptr)
     return perf_collector_.initialize(runtime, num_aicore, device_id,
-                                       alloc_cb, nullptr, nullptr);
+                                       alloc_cb, nullptr, free_cb, nullptr);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {

--- a/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -1,6 +1,10 @@
 /**
  * @file performance_collector_aicpu.cpp
- * @brief AICPU performance data collection implementation
+ * @brief AICPU performance data collection implementation (SPSC free queue)
+ *
+ * Uses per-core PerfBufferState with SPSC free queues for O(1) buffer switching.
+ * Host memory manager dynamically allocates replacement buffers and pushes
+ * them into the free_queue. Device pops from free_queue when switching.
  */
 
 #include "aicpu/performance_collector_aicpu.h"
@@ -10,12 +14,17 @@
 
 #include <cstring>
 
-// Cached phase profiling pointers (set during init, used on hot path)
+// Cached pointers for hot-path access (set during init)
 static AicpuPhaseHeader* s_phase_header = nullptr;
-static PhaseRingBuffer* s_phase_rings[PLATFORM_MAX_AICPU_THREADS] = {};
-static PhaseBuffer* s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
-static uint32_t s_phase_write_idx[PLATFORM_MAX_AICPU_THREADS] = {};
 static PerfDataHeader* s_perf_header = nullptr;
+
+// Per-core PerfBufferState cache
+static PerfBufferState* s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
+
+// Per-thread PhaseBufferState cache
+static PhaseBufferState* s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
+static PhaseBuffer* s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
+
 static int s_orch_thread_idx = -1;
 
 /**
@@ -23,14 +32,18 @@ static int s_orch_thread_idx = -1;
  *
  * @param header PerfDataHeader pointer
  * @param thread_idx Thread index
- * @param core_index Core index
- * @param buffer_id Buffer ID (1 or 2)
+ * @param core_index Core index (or thread_idx for phase entries)
+ * @param buffer_ptr Device pointer to the full buffer
+ * @param buffer_seq Sequence number for ordering
+ * @param is_phase 0 = PerfRecord, 1 = Phase
  * @return 0 on success, -1 if queue full
  */
 static int enqueue_ready_buffer(PerfDataHeader* header,
                                  int thread_idx,
                                  uint32_t core_index,
-                                 uint32_t buffer_id) {
+                                 uint64_t buffer_ptr,
+                                 uint32_t buffer_seq,
+                                 uint32_t is_phase) {
     uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
     uint32_t current_tail = header->queue_tails[thread_idx];
     uint32_t current_head = header->queue_heads[thread_idx];
@@ -42,7 +55,9 @@ static int enqueue_ready_buffer(PerfDataHeader* header,
     }
 
     header->queues[thread_idx][current_tail].core_index = core_index;
-    header->queues[thread_idx][current_tail].buffer_id = buffer_id;
+    header->queues[thread_idx][current_tail].is_phase = is_phase;
+    header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
+    header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
     header->queue_tails[thread_idx] = next_tail;
 
     return 0;
@@ -55,23 +70,43 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
         return;
     }
 
-    PerfDataHeader* header = get_perf_header(perf_base);
-    DoubleBuffer* buffers = get_double_buffers(perf_base);
+    s_perf_header = get_perf_header(perf_base);
 
     int32_t task_count = runtime->get_task_count();
-    header->total_tasks = static_cast<uint32_t>(task_count);
+    s_perf_header->total_tasks = static_cast<uint32_t>(task_count);
 
-    LOG_INFO("Initializing performance profiling for %d cores", runtime->worker_count);
+    LOG_INFO("Initializing performance profiling for %d cores (free queue)", runtime->worker_count);
 
-    // Assign buffer1 to each core for initial writing
+    // Pop first buffer from free_queue for each core
     for (int i = 0; i < runtime->worker_count; i++) {
         Handshake* h = &runtime->workers[i];
-        DoubleBuffer* db = &buffers[i];
+        PerfBufferState* state = get_perf_buffer_state(perf_base, i);
 
-        h->perf_records_addr = (uint64_t)&db->buffer1;
-        db->buffer1_status = BufferStatus::WRITING;
+        s_perf_buffer_states[i] = state;
 
-        LOG_DEBUG("Core %d: assigned buffer1 (addr=0x%lx)", i, h->perf_records_addr);
+        // Pop first buffer from free_queue
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+
+            PerfBuffer* buf = (PerfBuffer*)buf_ptr;
+            buf->count = 0;
+            h->perf_records_addr = buf_ptr;
+
+            LOG_DEBUG("Core %d: popped initial buffer (addr=0x%lx)", i, buf_ptr);
+        } else {
+            LOG_ERROR("Core %d: free_queue is empty during init!", i);
+            state->current_buf_ptr = 0;
+            h->perf_records_addr = 0;
+        }
     }
 
     wmb();
@@ -90,126 +125,72 @@ void perf_aicpu_record_dispatch_and_finish_time(PerfRecord* record,
     wmb();
 }
 
-
 void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
     void* perf_base = (void*)runtime->perf_data_base;
     if (perf_base == nullptr) {
         return;
     }
 
-    rmb();
-
-    Handshake* h = &runtime->workers[core_id];
-    PerfDataHeader* header = get_perf_header(perf_base);
-    DoubleBuffer* db = get_core_double_buffer(perf_base, core_id);
-
-    uint64_t current_addr = h->perf_records_addr;
-    uint64_t buffer1_addr = (uint64_t)&db->buffer1;
-    uint64_t buffer2_addr = (uint64_t)&db->buffer2;
-
-    uint32_t full_buffer_id = 0;
-    PerfBuffer* full_buf = nullptr;
-    volatile BufferStatus* full_status_ptr = nullptr;
-    PerfBuffer* alternate_buf = nullptr;
-    volatile BufferStatus* alternate_status_ptr = nullptr;
-    uint32_t alternate_buffer_id = 0;
-
-    if (current_addr == buffer1_addr) {
-        full_buffer_id = 1;
-        full_buf = &db->buffer1;
-        full_status_ptr = &db->buffer1_status;
-        alternate_buf = &db->buffer2;
-        alternate_status_ptr = &db->buffer2_status;
-        alternate_buffer_id = 2;
-    } else if (current_addr == buffer2_addr) {
-        full_buffer_id = 2;
-        full_buf = &db->buffer2;
-        full_status_ptr = &db->buffer2_status;
-        alternate_buf = &db->buffer1;
-        alternate_status_ptr = &db->buffer1_status;
-        alternate_buffer_id = 1;
-    } else {
-        LOG_ERROR("Thread %d: Core %d has invalid perf_records_addr=0x%lx",
-                  thread_idx, core_id, current_addr);
+    PerfBufferState* state = s_perf_buffer_states[core_id];
+    if (state == nullptr) {
         return;
     }
 
-    LOG_INFO("Thread %d: Core %d buffer%u is full (count=%u)",
-             thread_idx, core_id, full_buffer_id, full_buf->count);
-
-    // Complete performance records by filling fanout information
-    // Use Runtime's method - each runtime provides its own implementation
+    // Complete performance records (fill fanout info)
+    PerfBuffer* full_buf = (PerfBuffer*)state->current_buf_ptr;
+    if (full_buf == nullptr) {
+        return;
+    }
     runtime->complete_perf_records(full_buf);
 
-    BufferStatus alternate_status = *alternate_status_ptr;
+    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)",
+             thread_idx, core_id, full_buf->count);
 
-    // Wait if alternate buffer is not ready
-    if (alternate_status != BufferStatus::IDLE) {
-        LOG_WARN("Thread %d: Core %d cannot switch, buffer%u status=%u, spinning until Host reads it",
-                 thread_idx, core_id, alternate_buffer_id, static_cast<uint32_t>(alternate_status));
-
-        constexpr uint64_t TIMEOUT_SECONDS = 2;
-
-        uint64_t start_time = get_sys_cnt_aicpu();
-        bool timeout = false;
-
-        while (true) {
-            rmb();
-            alternate_status = *alternate_status_ptr;
-            uint64_t current_time = get_sys_cnt_aicpu();
-            uint64_t elapsed = current_time - start_time;
-
-            if (alternate_status == BufferStatus::IDLE) {
-                LOG_INFO("Thread %d: Core %d buffer%u now idle, proceeding with switch",
-                         thread_idx, core_id, alternate_buffer_id);
-                break;
-            } 
-
-            if (elapsed >= TIMEOUT_SECONDS * PLATFORM_PROF_SYS_CNT_FREQ) {
-                LOG_ERROR("Thread %d: Core %d buffer%u timeout after %lu seconds (status=%u)",
-                         thread_idx, core_id, alternate_buffer_id, TIMEOUT_SECONDS,
-                         static_cast<uint32_t>(alternate_status));
-                LOG_ERROR("Forcing buffer%u to IDLE and discarding performance data to prevent deadlock",
-                         alternate_buffer_id);
-                timeout = true;
-                break;
-            }
-        }
-
-        // Discard full buffer data on timeout to avoid deadlock
-        if (timeout) {
-            full_buf->count = 0;
-            *full_status_ptr = BufferStatus::WRITING;
-
-            wmb();
-
-            LOG_ERROR("Thread %d: Core %d timeout - discarded buffer%u data, reusing it for writing",
-                     thread_idx, core_id, full_buffer_id);
-
-            return;
-        }
-    }
-
-    *full_status_ptr = BufferStatus::READY;
-    *alternate_status_ptr = BufferStatus::WRITING;
-
-    // Enqueue full buffer 
-    int enqueue_result = enqueue_ready_buffer(header, thread_idx, core_id, full_buffer_id);
-    if (enqueue_result != 0) {
-        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer%u (queue full), data lost!",
-                 thread_idx, core_id, full_buffer_id);
-        // Revert status changes since we failed to enqueue
-        *full_status_ptr = BufferStatus::WRITING;
-        *alternate_status_ptr = BufferStatus::IDLE;
+    // Enqueue to ReadyQueue
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
+                                   state->current_buf_ptr, seq, 0);
+    if (rc != 0) {
+        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
+                 thread_idx, core_id);
+        // Revert: discard data and keep writing
+        full_buf->count = 0;
+        wmb();
         return;
     }
 
-    LOG_INFO("Thread %d: Core %d enqueued buffer%u", thread_idx, core_id, full_buffer_id);
+    // Pop next buffer from free_queue
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
 
-    h->perf_records_addr = (uint64_t)alternate_buf;
+    if (head != tail) {
+        uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+        rmb();
+        state->free_queue.head = head + 1;
+        state->current_buf_ptr = new_buf_ptr;
+        state->current_buf_seq = seq + 1;
+        wmb();
 
-    LOG_INFO("Thread %d: Core %d switched to buffer%u",
-             thread_idx, core_id, alternate_buffer_id);
+        PerfBuffer* new_buf = (PerfBuffer*)new_buf_ptr;
+        new_buf->count = 0;
+
+        // Update handshake for AICore
+        Handshake* h = &runtime->workers[core_id];
+        h->perf_records_addr = new_buf_ptr;
+        wmb();
+
+        LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)",
+                 thread_idx, core_id, new_buf_ptr);
+    } else {
+        // No free buffer available, stop profiling
+        LOG_WARN("Thread %d: Core %d no free buffer available, stopping profiling",
+                 thread_idx, core_id);
+        state->current_buf_ptr = 0;
+        Handshake* h = &runtime->workers[core_id];
+        h->perf_records_addr = 0;
+        wmb();
+    }
 }
 
 void perf_aicpu_flush_buffers(Runtime* runtime,
@@ -227,64 +208,45 @@ void perf_aicpu_flush_buffers(Runtime* runtime,
 
     rmb();
 
-    PerfDataHeader* header = get_perf_header(perf_base);
-    DoubleBuffer* buffers = get_double_buffers(perf_base);
-
     LOG_INFO("Thread %d: Flushing performance buffers for %d cores", thread_idx, core_num);
 
     int flushed_count = 0;
 
     for (int i = 0; i < core_num; i++) {
         int core_id = cur_thread_cores[i];
-        Handshake* h = &runtime->workers[core_id];
-        DoubleBuffer* db = &buffers[core_id];
+        PerfBufferState* state = s_perf_buffer_states[core_id];
+        if (state == nullptr) continue;
 
-        uint64_t current_addr = h->perf_records_addr;
-        if (current_addr == 0) {
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) {
+            // No active buffer
             continue;
         }
 
-        uint64_t buf1_addr = (uint64_t)&db->buffer1;
-        uint64_t buf2_addr = (uint64_t)&db->buffer2;
+        PerfBuffer* buf = (PerfBuffer*)buf_ptr;
+        if (buf->count == 0) {
+            continue;
+        }
 
-        PerfBuffer* current_buf = nullptr;
-        volatile BufferStatus* current_status = nullptr;
-        uint32_t buffer_id = 0;
+        runtime->complete_perf_records(buf);
 
-        if (current_addr == buf1_addr) {
-            current_buf = &db->buffer1;
-            current_status = &db->buffer1_status;
-            buffer_id = 1;
-        } else if (current_addr == buf2_addr) {
-            current_buf = &db->buffer2;
-            current_status = &db->buffer2_status;
-            buffer_id = 2;
+        uint32_t seq = state->current_buf_seq;
+        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
+                                       buf_ptr, seq, 0);
+        if (rc == 0) {
+            LOG_INFO("Thread %d: Core %d flushed buffer with %u records",
+                     thread_idx, core_id, buf->count);
+            flushed_count++;
+            state->current_buf_ptr = 0;
+            wmb();
         } else {
-            LOG_WARN("Thread %d: Core %d perf_records_addr=0x%lx doesn't match buffer1=0x%lx or buffer2=0x%lx",
-                     thread_idx, core_id, current_addr, buf1_addr, buf2_addr);
-            continue;
-        }
-
-        uint32_t count = current_buf->count;
-
-        if (count > 0) {
-            runtime->complete_perf_records(current_buf);
-
-            *current_status = BufferStatus::READY;
-
-            int rc = enqueue_ready_buffer(header, thread_idx, core_id, buffer_id);
-            if (rc == 0) {
-                LOG_INFO("Thread %d: Core %d flushed buffer%d with %u records",
-                         thread_idx, core_id, buffer_id, count);
-                flushed_count++;
-            } else {
-                LOG_ERROR("Thread %d: Core %d failed to enqueue buffer%d (queue full), data lost!",
-                         thread_idx, core_id, buffer_id);
-                // Revert status since we failed to enqueue
-                *current_status = BufferStatus::WRITING;
-            }
+            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
+                     thread_idx, core_id);
         }
     }
+
+    wmb();
 
     LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed",
              thread_idx, flushed_count);
@@ -326,86 +288,102 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
         total_threads = PLATFORM_MAX_AICPU_THREADS;
     }
     for (int t = 0; t < total_threads; t++) {
-        PhaseRingBuffer* ring = get_phase_ring_buffer(perf_base, runtime->worker_count, t);
-        memset(ring, 0, sizeof(PhaseRingBuffer));
+        PhaseBufferState* state = get_phase_buffer_state(perf_base, runtime->worker_count, t);
 
-        // First buffer starts as WRITING, rest as IDLE
-        ring->buffer_status[0] = BufferStatus::WRITING;
-        for (int i = 1; i < PLATFORM_PHASE_RING_DEPTH; i++) {
-            ring->buffer_status[i] = BufferStatus::IDLE;
+        s_phase_buffer_states[t] = state;
+
+        // Pop first buffer from free_queue
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+
+            PhaseBuffer* buf = (PhaseBuffer*)buf_ptr;
+            buf->count = 0;
+            s_current_phase_buf[t] = buf;
+
+            LOG_DEBUG("Thread %d: popped initial phase buffer (addr=0x%lx)", t, buf_ptr);
+        } else {
+            LOG_ERROR("Thread %d: phase free_queue is empty during init!", t);
+            state->current_buf_ptr = 0;
+            s_current_phase_buf[t] = nullptr;
         }
-
-        s_phase_rings[t] = ring;
-        s_current_phase_buf[t] = &ring->buffers[0];
-        s_phase_write_idx[t] = 0;
-        s_phase_header->current_buffer_idx[t] = 0;
     }
 
     // Clear remaining slots
     for (int t = total_threads; t < PLATFORM_MAX_AICPU_THREADS; t++) {
-        s_phase_rings[t] = nullptr;
+        s_phase_buffer_states[t] = nullptr;
         s_current_phase_buf[t] = nullptr;
-        s_phase_write_idx[t] = 0;
-        s_phase_header->current_buffer_idx[t] = 0;
     }
 
     wmb();
 
-    LOG_INFO("Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread, ring depth %d",
-             num_sched_threads, num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD, PLATFORM_PHASE_RING_DEPTH);
+    LOG_INFO("Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread",
+             num_sched_threads, num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD);
 }
 
 /**
- * Switch phase buffer when current buffer is full (non-blocking ring buffer version)
+ * Switch phase buffer when current buffer is full (free queue version)
  *
- * Marks the full buffer as READY, enqueues it to the per-thread ready queue,
- * and advances to the next buffer in the ring. Never spins or blocks.
- * If the next buffer is not IDLE, it is forcibly reclaimed (data discarded).
+ * Enqueues the full buffer to ReadyQueue and pops the next buffer from free_queue.
+ * If no free buffer is available, sets s_current_phase_buf to nullptr so subsequent
+ * records are dropped (preserving already-enqueued data).
  */
 static void switch_phase_buffer(int thread_idx) {
-    PhaseRingBuffer* ring = s_phase_rings[thread_idx];
-    if (ring == nullptr) return;
+    PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+    if (state == nullptr) return;
 
-    uint32_t cur_idx = s_phase_write_idx[thread_idx];
+    PhaseBuffer* full_buf = s_current_phase_buf[thread_idx];
+    if (full_buf == nullptr) return;
 
-    LOG_INFO("Thread %d: phase ring[%u] is full (count=%u)",
-             thread_idx, cur_idx, ring->buffers[cur_idx].count);
+    LOG_INFO("Thread %d: phase buffer is full (count=%u)",
+             thread_idx, full_buf->count);
 
-    // Mark current buffer as READY
-    ring->buffer_status[cur_idx] = BufferStatus::READY;
-
-    // Enqueue full buffer with PHASE_BUFFER_FLAG (buffer_id is 1-based: idx+1)
+    // Enqueue to ReadyQueue
+    uint32_t seq = state->current_buf_seq;
     int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-                                  (cur_idx + 1) | PHASE_BUFFER_FLAG);
+                                   state->current_buf_ptr, seq, 1);
     if (rc != 0) {
-        LOG_ERROR("Thread %d: failed to enqueue phase ring[%u] (queue full), discarding data",
-                 thread_idx, cur_idx);
-        // Revert: discard data and keep writing to current buffer
-        ring->buffer_status[cur_idx] = BufferStatus::WRITING;
-        ring->buffers[cur_idx].count = 0;
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data",
+                 thread_idx);
+        full_buf->count = 0;
         wmb();
         return;
     }
 
-    // Advance to next buffer in ring (non-blocking)
-    uint32_t next_idx = (cur_idx + 1) % PLATFORM_PHASE_RING_DEPTH;
-
+    // Pop next buffer from free_queue
     rmb();
-    if (ring->buffer_status[next_idx] != BufferStatus::IDLE) {
-        LOG_WARN("Thread %d: phase ring[%u] not idle (status=%u), discarding and reusing",
-                 thread_idx, next_idx, static_cast<uint32_t>(ring->buffer_status[next_idx]));
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head != tail) {
+        uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+        rmb();
+        state->free_queue.head = head + 1;
+        state->current_buf_ptr = new_buf_ptr;
+        state->current_buf_seq = seq + 1;
+        wmb();
+
+        PhaseBuffer* new_buf = (PhaseBuffer*)new_buf_ptr;
+        new_buf->count = 0;
+        s_current_phase_buf[thread_idx] = new_buf;
+
+        LOG_INFO("Thread %d: switched to new phase buffer", thread_idx);
+    } else {
+        // No free buffer available, drop subsequent records
+        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up",
+                 thread_idx);
+        s_current_phase_buf[thread_idx] = nullptr;
+        state->current_buf_ptr = 0;
+        wmb();
     }
-
-    ring->buffers[next_idx].count = 0;
-    ring->buffer_status[next_idx] = BufferStatus::WRITING;
-
-    s_phase_write_idx[thread_idx] = next_idx;
-    s_current_phase_buf[thread_idx] = &ring->buffers[next_idx];
-    s_phase_header->current_buffer_idx[thread_idx] = next_idx;
-
-    wmb();
-
-    LOG_INFO("Thread %d: switched to phase ring[%u]", thread_idx, next_idx);
 }
 
 void perf_aicpu_record_phase(int thread_idx,
@@ -417,17 +395,43 @@ void perf_aicpu_record_phase(int thread_idx,
     }
 
     PhaseBuffer* buf = s_current_phase_buf[thread_idx];
-    if (buf == nullptr) return;
+
+    // Try to recover from nullptr (no buffer was available on previous switch)
+    if (buf == nullptr) {
+        PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+        if (state == nullptr) return;
+
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = state->current_buf_seq + 1;
+            wmb();
+
+            buf = (PhaseBuffer*)buf_ptr;
+            buf->count = 0;
+            s_current_phase_buf[thread_idx] = buf;
+
+            LOG_INFO("Thread %d: recovered phase buffer", thread_idx);
+        }
+        if (buf == nullptr) return;  // Still no buffer available
+    }
 
     uint32_t idx = buf->count;
 
     if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
-        // Buffer full, switch to alternate
+        // Buffer full, switch to next buffer
         switch_phase_buffer(thread_idx);
         buf = s_current_phase_buf[thread_idx];
+        if (buf == nullptr) return;  // No buffer available
         idx = buf->count;
         if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
-            return;  // Ring buffer not available or switch failed; drop this record
+            return;  // Switch failed; drop this record
         }
     }
 
@@ -476,25 +480,33 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
         return;
     }
 
-    PhaseBuffer* buf = s_current_phase_buf[thread_idx];
-    if (buf == nullptr || buf->count == 0) {
+    PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+    if (state == nullptr) return;
+
+    rmb();
+    uint64_t buf_ptr = state->current_buf_ptr;
+    if (buf_ptr == 0) {
+        // No active buffer
         return;
     }
 
-    PhaseRingBuffer* ring = s_phase_rings[thread_idx];
-    uint32_t cur_idx = s_phase_write_idx[thread_idx];
+    PhaseBuffer* buf = (PhaseBuffer*)buf_ptr;
+    if (buf->count == 0) {
+        return;
+    }
 
-    ring->buffer_status[cur_idx] = BufferStatus::READY;
-
+    uint32_t seq = state->current_buf_seq;
     int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-                                  (cur_idx + 1) | PHASE_BUFFER_FLAG);
+                                   buf_ptr, seq, 1);
     if (rc == 0) {
-        LOG_INFO("Thread %d: flushed phase ring[%u] with %u records",
-                 thread_idx, cur_idx, buf->count);
+        LOG_INFO("Thread %d: flushed phase buffer with %u records",
+                 thread_idx, buf->count);
+        state->current_buf_ptr = 0;
+        s_current_phase_buf[thread_idx] = nullptr;
+        wmb();
     } else {
-        LOG_ERROR("Thread %d: failed to enqueue phase ring[%u] (queue full), data lost!",
-                 thread_idx, cur_idx);
-        ring->buffer_status[cur_idx] = BufferStatus::WRITING;
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!",
+                 thread_idx);
     }
 
     wmb();

--- a/src/a2a3/platform/src/host/performance_collector.cpp
+++ b/src/a2a3/platform/src/host/performance_collector.cpp
@@ -1,6 +1,9 @@
 /**
  * @file performance_collector.cpp
  * @brief Platform-agnostic performance data collector implementation
+ *
+ * Implements ProfMemoryManager (dynamic buffer management thread) and
+ * PerformanceCollector (data collection and export).
  */
 
 #include "host/performance_collector.h"
@@ -17,10 +20,361 @@
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
 
+// =============================================================================
+// ProfMemoryManager Implementation
+// =============================================================================
+
+ProfMemoryManager::~ProfMemoryManager() {
+    if (running_.load()) {
+        stop();
+    }
+}
+
+void ProfMemoryManager::start(void* shared_mem_host, int num_cores, int num_phase_threads,
+                               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
+                               PerfFreeCallback free_cb, void* user_data, int device_id) {
+    shared_mem_host_ = shared_mem_host;
+    num_cores_ = num_cores;
+    num_phase_threads_ = num_phase_threads;
+    alloc_cb_ = alloc_cb;
+    register_cb_ = register_cb;
+    free_cb_ = free_cb;
+    user_data_ = user_data;
+    device_id_ = device_id;
+
+    running_.store(true);
+    mgmt_thread_ = std::thread(&ProfMemoryManager::mgmt_loop, this);
+
+    LOG_INFO("ProfMemoryManager started: %d cores, %d phase threads", num_cores, num_phase_threads);
+}
+
+void ProfMemoryManager::stop() {
+    running_.store(false);
+    if (mgmt_thread_.joinable()) {
+        mgmt_thread_.join();
+    }
+
+    // Drain remaining done_queue and free buffers
+    {
+        std::lock_guard<std::mutex> lock(done_mutex_);
+        while (!done_queue_.empty()) {
+            CopyDoneInfo info = done_queue_.front();
+            done_queue_.pop();
+            free_buffer(info.dev_buffer_ptr);
+        }
+    }
+
+    LOG_INFO("ProfMemoryManager stopped");
+}
+
+bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo& info) {
+    std::lock_guard<std::mutex> lock(ready_mutex_);
+    if (ready_queue_.empty()) {
+        return false;
+    }
+    info = ready_queue_.front();
+    ready_queue_.pop();
+    return true;
+}
+
+bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(ready_mutex_);
+    if (ready_cv_.wait_for(lock, timeout, [this]{ return !ready_queue_.empty(); })) {
+        info = ready_queue_.front();
+        ready_queue_.pop();
+        return true;
+    }
+    return false;
+}
+
+void ProfMemoryManager::notify_copy_done(const CopyDoneInfo& info) {
+    std::lock_guard<std::mutex> lock(done_mutex_);
+    done_queue_.push(info);
+}
+
+void* ProfMemoryManager::alloc_and_register(size_t size, void** host_ptr_out) {
+    void* dev_ptr = alloc_cb_(size, user_data_);
+    if (dev_ptr == nullptr) {
+        LOG_ERROR("ProfMemoryManager: alloc failed for %zu bytes", size);
+        *host_ptr_out = nullptr;
+        return nullptr;
+    }
+
+    if (register_cb_ != nullptr) {
+        void* host_ptr = nullptr;
+        int rc = register_cb_(dev_ptr, size, device_id_, user_data_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("ProfMemoryManager: register failed: %d", rc);
+            free_buffer(dev_ptr);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        *host_ptr_out = host_ptr;
+    } else {
+        // Simulation mode: dev_ptr == host_ptr
+        *host_ptr_out = dev_ptr;
+    }
+
+    dev_to_host_[dev_ptr] = *host_ptr_out;
+    return dev_ptr;
+}
+
+void ProfMemoryManager::free_buffer(void* dev_ptr) {
+    if (dev_ptr != nullptr && free_cb_ != nullptr) {
+        dev_to_host_.erase(dev_ptr);
+        free_cb_(dev_ptr, user_data_);
+    }
+}
+
+void* ProfMemoryManager::resolve_host_ptr(void* dev_ptr) {
+    if (register_cb_ == nullptr) {
+        return dev_ptr;  // Simulation mode: dev_ptr == host_ptr
+    }
+    auto it = dev_to_host_.find(dev_ptr);
+    if (it != dev_to_host_.end()) {
+        return it->second;
+    }
+    LOG_ERROR("ProfMemoryManager: no host mapping for dev_ptr=%p", dev_ptr);
+    return nullptr;
+}
+
+void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) {
+    dev_to_host_[dev_ptr] = host_ptr;
+}
+
+void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*thread_idx*/,
+                                              const ReadyQueueEntry& entry) {
+    bool is_phase = (entry.is_phase != 0);
+    uint64_t old_dev_ptr = entry.buffer_ptr;
+    uint32_t seq = entry.buffer_seq;
+
+    if (is_phase) {
+        uint32_t tidx = entry.core_index;
+        if (tidx >= static_cast<uint32_t>(PLATFORM_MAX_AICPU_THREADS)) {
+            LOG_ERROR("ProfMemoryManager: invalid phase entry: thread=%u", tidx);
+            return;
+        }
+
+        PhaseBufferState* state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
+
+        // Allocate new PhaseBuffer
+        void* host_ptr = nullptr;
+        void* new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
+        if (new_dev_ptr != nullptr) {
+            // Initialize new buffer
+            PhaseBuffer* new_buf = (PhaseBuffer*)host_ptr;
+            new_buf->count = 0;
+
+            // Push to free_queue (with overflow guard)
+            rmb();
+            uint32_t head_val = state->free_queue.head;
+            uint32_t tail = state->free_queue.tail;
+            if ((tail - head_val) >= PLATFORM_PROF_SLOT_COUNT) {
+                LOG_ERROR("ProfMemoryManager: phase free_queue overflow for thread %u", tidx);
+                free_buffer(new_dev_ptr);
+            } else {
+                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] = (uint64_t)new_dev_ptr;
+                wmb();
+                state->free_queue.tail = tail + 1;
+                wmb();
+            }
+        } else {
+            LOG_ERROR("ProfMemoryManager: phase buffer alloc failed, device may lose data");
+        }
+
+        // Resolve host pointer of old buffer
+        void* old_host_ptr = resolve_host_ptr((void*)old_dev_ptr);
+        if (old_host_ptr == nullptr) {
+            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p", (void*)old_dev_ptr);
+            return;
+        }
+
+        // Push old buffer to ready queue for main thread to copy
+        ReadyBufferInfo info;
+        info.type = ProfBufferType::PHASE;
+        info.index = tidx;
+        info.slot_idx = 0;  // Not used in free queue design
+        info.dev_buffer_ptr = (void*)old_dev_ptr;
+        info.host_buffer_ptr = old_host_ptr;
+        info.buffer_seq = seq;
+
+        {
+            std::lock_guard<std::mutex> lock(ready_mutex_);
+            ready_queue_.push(info);
+        }
+        ready_cv_.notify_one();
+
+    } else {
+        uint32_t core_index = entry.core_index;
+        if (core_index >= static_cast<uint32_t>(num_cores_)) {
+            LOG_ERROR("ProfMemoryManager: invalid perf entry: core=%u", core_index);
+            return;
+        }
+
+        PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, core_index);
+
+        // Allocate new PerfBuffer
+        void* host_ptr = nullptr;
+        void* new_dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
+        if (new_dev_ptr != nullptr) {
+            PerfBuffer* new_buf = (PerfBuffer*)host_ptr;
+            new_buf->count = 0;
+
+            // Push to free_queue (with overflow guard)
+            rmb();
+            uint32_t head_val = state->free_queue.head;
+            uint32_t tail = state->free_queue.tail;
+            if ((tail - head_val) >= PLATFORM_PROF_SLOT_COUNT) {
+                LOG_ERROR("ProfMemoryManager: perf free_queue overflow for core %u", core_index);
+                free_buffer(new_dev_ptr);
+            } else {
+                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] = (uint64_t)new_dev_ptr;
+                wmb();
+                state->free_queue.tail = tail + 1;
+                wmb();
+            }
+        } else {
+            LOG_ERROR("ProfMemoryManager: perf buffer alloc failed, device may lose data");
+        }
+
+        void* old_host_ptr = resolve_host_ptr((void*)old_dev_ptr);
+        if (old_host_ptr == nullptr) {
+            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p", (void*)old_dev_ptr);
+            return;
+        }
+
+        ReadyBufferInfo info;
+        info.type = ProfBufferType::PERF_RECORD;
+        info.index = core_index;
+        info.slot_idx = 0;  // Not used in free queue design
+        info.dev_buffer_ptr = (void*)old_dev_ptr;
+        info.host_buffer_ptr = old_host_ptr;
+        info.buffer_seq = seq;
+
+        {
+            std::lock_guard<std::mutex> lock(ready_mutex_);
+            ready_queue_.push(info);
+        }
+        ready_cv_.notify_one();
+    }
+}
+
+void ProfMemoryManager::mgmt_loop() {
+    PerfDataHeader* header = get_perf_header(shared_mem_host_);
+
+    while (running_.load()) {
+        // 1. Process done queue: free buffers that main thread has finished copying
+        {
+            std::lock_guard<std::mutex> lock(done_mutex_);
+            while (!done_queue_.empty()) {
+                CopyDoneInfo info = done_queue_.front();
+                done_queue_.pop();
+                free_buffer(info.dev_buffer_ptr);
+            }
+        }
+
+        // 2. Poll ReadyQueues from all AICPU threads
+        bool found_any = false;
+        for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+            rmb();
+            uint32_t head = header->queue_heads[t];
+            uint32_t tail = header->queue_tails[t];
+
+            // Validate indices to prevent OOB access from corrupted shared memory
+            if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                LOG_ERROR("mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)",
+                          t, head, tail, PLATFORM_PROF_READYQUEUE_SIZE);
+                continue;
+            }
+
+            while (head != tail) {
+                ReadyQueueEntry entry = header->queues[t][head];
+
+                process_ready_entry(header, t, entry);
+
+                head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
+                header->queue_heads[t] = head;
+                wmb();
+
+                found_any = true;
+
+                // Re-read tail in case more entries arrived
+                rmb();
+                tail = header->queue_tails[t];
+                if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                    LOG_ERROR("mgmt_loop: invalid tail for thread %d: %u", t, tail);
+                    break;
+                }
+            }
+        }
+
+        // 3. If nothing found, yield briefly to avoid busy-spinning
+        if (!found_any) {
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
+        }
+    }
+
+    // Final drain: process any remaining entries
+    PerfDataHeader* hdr = get_perf_header(shared_mem_host_);
+    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        rmb();
+        uint32_t head = hdr->queue_heads[t];
+        uint32_t tail = hdr->queue_tails[t];
+        if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u",
+                      t, head, tail);
+            continue;
+        }
+        while (head != tail) {
+            ReadyQueueEntry entry = hdr->queues[t][head];
+            process_ready_entry(hdr, t, entry);
+            head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
+            hdr->queue_heads[t] = head;
+            wmb();
+            rmb();
+            tail = hdr->queue_tails[t];
+            if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                LOG_ERROR("mgmt_loop drain: invalid tail for thread %d: %u", t, tail);
+                break;
+            }
+        }
+    }
+}
+
+// =============================================================================
+// PerformanceCollector Implementation
+// =============================================================================
+
 PerformanceCollector::~PerformanceCollector() {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_WARN("PerformanceCollector destroyed without finalize()");
     }
+}
+
+void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out) {
+    void* dev_ptr = alloc_cb_(size, user_data_);
+    if (dev_ptr == nullptr) {
+        LOG_ERROR("Failed to allocate buffer (%zu bytes)", size);
+        *host_ptr_out = nullptr;
+        return nullptr;
+    }
+
+    if (register_cb_ != nullptr) {
+        void* host_ptr = nullptr;
+        int rc = register_cb_(dev_ptr, size, device_id_, user_data_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("Buffer registration failed: %d", rc);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        *host_ptr_out = host_ptr;
+    } else {
+        *host_ptr_out = dev_ptr;
+    }
+
+    // Register mapping so ProfMemoryManager can resolve dev→host
+    memory_manager_.register_mapping(dev_ptr, *host_ptr_out);
+    return dev_ptr;
 }
 
 int PerformanceCollector::initialize(Runtime& runtime,
@@ -28,6 +382,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
                                       int device_id,
                                       PerfAllocCallback alloc_cb,
                                       PerfRegisterCallback register_cb,
+                                      PerfFreeCallback free_cb,
                                       void* user_data) {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
@@ -43,33 +398,32 @@ int PerformanceCollector::initialize(Runtime& runtime,
 
     device_id_ = device_id;
     num_aicore_ = num_aicore;
+    alloc_cb_ = alloc_cb;
+    register_cb_ = register_cb;
+    free_cb_ = free_cb;
+    user_data_ = user_data;
 
-    // Step 1: Calculate total memory size (with phase profiling region)
-    // All PLATFORM_MAX_AICPU_THREADS slots: scheduler threads + orchestrator thread
+    // Step 1: Calculate shared memory size (slot arrays only, no actual buffers)
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
     size_t total_size = calc_perf_data_size_with_phases(num_aicore, num_phase_threads);
-    size_t header_size = sizeof(PerfDataHeader);
-    size_t single_db_size = sizeof(DoubleBuffer);
-    size_t buffers_size = num_aicore * single_db_size;
 
-    LOG_DEBUG("Memory allocation plan:");
+    LOG_DEBUG("Shared memory allocation plan:");
     LOG_DEBUG("  Number of cores:      %d", num_aicore);
-    LOG_DEBUG("  Header size:          %zu bytes", header_size);
-    LOG_DEBUG("  Ready queue entries:  %d", PLATFORM_PROF_READYQUEUE_SIZE);
-    LOG_DEBUG("  Single DoubleBuffer:  %zu bytes", single_db_size);
-    LOG_DEBUG("  All DoubleBuffers:    %zu bytes", buffers_size);
-    LOG_DEBUG("  Total size:           %zu bytes (%zu KB, %zu MB)",
-              total_size, total_size / 1024, total_size / (1024 * 1024));
+    LOG_DEBUG("  Header size:          %zu bytes", sizeof(PerfDataHeader));
+    LOG_DEBUG("  PerfBufferState size: %zu bytes each", sizeof(PerfBufferState));
+    LOG_DEBUG("  PhaseBufferState size:%zu bytes each", sizeof(PhaseBufferState));
+    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)",
+              total_size, total_size / 1024);
 
-    // Step 2: Allocate device memory via callback
+    // Step 2: Allocate shared memory for slot arrays
     void* perf_dev_ptr = alloc_cb(total_size, user_data);
     if (perf_dev_ptr == nullptr) {
-        LOG_ERROR("Failed to allocate device memory for profiling (%zu bytes)", total_size);
+        LOG_ERROR("Failed to allocate shared memory (%zu bytes)", total_size);
         return -1;
     }
-    LOG_DEBUG("Allocated device memory: %p", perf_dev_ptr);
+    LOG_DEBUG("Allocated shared memory: %p", perf_dev_ptr);
 
-    // Step 3: Register to host mapping (optional, can be nullptr for simulation)
+    // Step 3: Register to host mapping (optional)
     void* perf_host_ptr = nullptr;
     if (register_cb != nullptr) {
         int rc = register_cb(perf_dev_ptr, total_size, device_id, user_data, &perf_host_ptr);
@@ -84,7 +438,6 @@ int PerformanceCollector::initialize(Runtime& runtime,
         }
         LOG_DEBUG("Mapped to host memory: %p", perf_host_ptr);
     } else {
-        // Simulation mode: both pointers point to same memory
         perf_host_ptr = perf_dev_ptr;
         LOG_DEBUG("Simulation mode: host_ptr = dev_ptr = %p", perf_host_ptr);
     }
@@ -105,32 +458,100 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("  num_cores:        %d", header->num_cores);
     LOG_DEBUG("  buffer_capacity:  %d", PLATFORM_PROF_BUFFER_SIZE);
     LOG_DEBUG("  queue capacity:   %d", PLATFORM_PROF_READYQUEUE_SIZE);
-    LOG_DEBUG("  num threads:      %d", PLATFORM_MAX_AICPU_THREADS);
 
-    // Step 5: Initialize all DoubleBuffers
-    DoubleBuffer* buffers = get_double_buffers(perf_host_ptr);
+    // Step 5: Initialize PerfBufferStates and pre-fill free_queues
     for (int i = 0; i < num_aicore; i++) {
-        DoubleBuffer* db = &buffers[i];
-        memset(&db->buffer1, 0, sizeof(PerfBuffer));
-        db->buffer1.count = 0;
-        db->buffer1_status = BufferStatus::IDLE;
-        memset(&db->buffer2, 0, sizeof(PerfBuffer));
-        db->buffer2.count = 0;
-        db->buffer2_status = BufferStatus::IDLE;
+        PerfBufferState* state = get_perf_buffer_state(perf_host_ptr, i);
+        memset(state, 0, sizeof(PerfBufferState));
+
+        state->free_queue.head = 0;
+        state->free_queue.tail = 0;
+        state->current_buf_ptr = 0;
+        state->current_buf_seq = 0;
+
+        // Pre-fill free_queue with PLATFORM_PROF_SLOT_COUNT buffers
+        for (int s = 0; s < PLATFORM_PROF_SLOT_COUNT; s++) {
+            void* host_buf_ptr = nullptr;
+            void* dev_buf_ptr = alloc_single_buffer(sizeof(PerfBuffer), &host_buf_ptr);
+            if (dev_buf_ptr == nullptr) {
+                LOG_ERROR("Failed to allocate PerfBuffer for core %d, buffer %d", i, s);
+                return -1;
+            }
+            // Initialize buffer
+            PerfBuffer* buf = (PerfBuffer*)host_buf_ptr;
+            memset(buf, 0, sizeof(PerfBuffer));
+            buf->count = 0;
+
+            // Push to free_queue
+            state->free_queue.buffer_ptrs[s] = (uint64_t)dev_buf_ptr;
+        }
+        wmb();
+        state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
+        wmb();
     }
-    LOG_DEBUG("Initialized %d DoubleBuffers (all status=0, idle)", num_aicore);
+    LOG_DEBUG("Initialized %d PerfBufferStates with %d buffers each",
+              num_aicore, PLATFORM_PROF_SLOT_COUNT);
+
+    // Step 6: Initialize PhaseBufferStates and pre-fill free_queues
+    for (int t = 0; t < num_phase_threads; t++) {
+        PhaseBufferState* state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
+        memset(state, 0, sizeof(PhaseBufferState));
+
+        state->free_queue.head = 0;
+        state->free_queue.tail = 0;
+        state->current_buf_ptr = 0;
+        state->current_buf_seq = 0;
+
+        // Pre-fill free_queue with PLATFORM_PROF_SLOT_COUNT buffers
+        for (int s = 0; s < PLATFORM_PROF_SLOT_COUNT; s++) {
+            void* host_buf_ptr = nullptr;
+            void* dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
+            if (dev_buf_ptr == nullptr) {
+                LOG_ERROR("Failed to allocate PhaseBuffer for thread %d, buffer %d", t, s);
+                return -1;
+            }
+            PhaseBuffer* buf = (PhaseBuffer*)host_buf_ptr;
+            memset(buf, 0, sizeof(PhaseBuffer));
+            buf->count = 0;
+
+            // Push to free_queue
+            state->free_queue.buffer_ptrs[s] = (uint64_t)dev_buf_ptr;
+        }
+        wmb();
+        state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
+        wmb();
+    }
+    LOG_DEBUG("Initialized %d PhaseBufferStates with %d buffers each",
+              num_phase_threads, PLATFORM_PROF_SLOT_COUNT);
 
     wmb();
 
-    // Step 6: Pass to Runtime
+    // Step 7: Pass base address to Runtime
     runtime.perf_data_base = (uint64_t)perf_dev_ptr;
     LOG_DEBUG("Set runtime.perf_data_base = 0x%lx", runtime.perf_data_base);
 
     perf_shared_mem_dev_ = perf_dev_ptr;
     perf_shared_mem_host_ = perf_host_ptr;
 
-    LOG_INFO("Performance profiling initialized");
+    LOG_INFO("Performance profiling initialized (dynamic buffer mode)");
     return 0;
+}
+
+void PerformanceCollector::start_memory_manager() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    memory_manager_.start(perf_shared_mem_host_, num_aicore_,
+                           PLATFORM_MAX_AICPU_THREADS,
+                           alloc_cb_, register_cb_, free_cb_,
+                           user_data_, device_id_);
+}
+
+void PerformanceCollector::stop_memory_manager() {
+    if (memory_manager_.is_running()) {
+        memory_manager_.stop();
+    }
 }
 
 void PerformanceCollector::poll_and_collect(int expected_tasks) {
@@ -141,8 +562,6 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     LOG_INFO("Collecting performance data");
 
     PerfDataHeader* header = get_perf_header(perf_shared_mem_host_);
-    DoubleBuffer* buffers = get_double_buffers(perf_shared_mem_host_);
-    int num_aicore = num_aicore_;
 
     const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);
     std::optional<std::chrono::steady_clock::time_point> idle_start;
@@ -165,8 +584,14 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             if (elapsed >= timeout_duration) {
                 LOG_ERROR("Timeout waiting for AICPU task count after %ld seconds",
                          std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
-                LOG_INFO("AICPU finally reported task count: %d", raw_total_tasks);
                 return;
+            }
+
+            // Check for ready buffers while waiting
+            ReadyBufferInfo info;
+            if (memory_manager_.try_pop_ready(info)) {
+                // Process it (even before we know expected_tasks)
+                // Will be counted below
             }
         }
     }
@@ -177,17 +602,14 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     int buffers_processed = 0;
 
     collected_perf_records_.clear();
-    collected_perf_records_.resize(num_aicore);
-    idle_start.reset();
-    int empty_poll_count = 0;
+    collected_perf_records_.resize(num_aicore_);
 
-    // Pre-allocate phase record storage for double-buffer collection during polling
+    // Pre-allocate phase record storage
     AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
     int num_sched_for_poll = 0;
     if (phase_header->magic == AICPU_PHASE_MAGIC) {
         num_sched_for_poll = phase_header->num_sched_threads;
         if (num_sched_for_poll > PLATFORM_MAX_AICPU_THREADS) {
-            LOG_WARN("num_sched_threads %d capped to %d", num_sched_for_poll, PLATFORM_MAX_AICPU_THREADS);
             num_sched_for_poll = PLATFORM_MAX_AICPU_THREADS;
         }
         collected_phase_records_.clear();
@@ -195,128 +617,84 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
         collected_orch_phase_records_.clear();
     }
 
-    int current_thread = 0;
+    idle_start.reset();
+    int last_logged_expected = -1;
 
     while (total_records_collected < expected_tasks) {
+        // Check for updated expected_tasks
         rmb();
+        int current_expected = static_cast<int>(header->total_tasks);
+        if (current_expected > expected_tasks) {
+            expected_tasks = current_expected;
+            if (last_logged_expected < 0) {
+                LOG_INFO("Updated expected_tasks to %d (orchestrator progress)", expected_tasks);
+                last_logged_expected = expected_tasks;
+            }
+        }
 
-        uint32_t head = header->queue_heads[current_thread];
-        uint32_t tail = header->queue_tails[current_thread];
+        ReadyBufferInfo info;
+        if (memory_manager_.wait_pop_ready(info, std::chrono::milliseconds(100))) {
+            idle_start.reset();
 
-        if (head == tail) {
-            current_thread = (current_thread + 1) % PLATFORM_MAX_AICPU_THREADS;
-
-            if (current_thread == 0) {
-                if (!idle_start.has_value()) {
-                    idle_start = std::chrono::steady_clock::now();
+            if (info.type == ProfBufferType::PERF_RECORD) {
+                PerfBuffer* buf = (PerfBuffer*)info.host_buffer_ptr;
+                rmb();
+                uint32_t count = buf->count;
+                if (count > PLATFORM_PROF_BUFFER_SIZE) {
+                    count = PLATFORM_PROF_BUFFER_SIZE;
                 }
 
-                empty_poll_count++;
-                if (empty_poll_count >= PLATFORM_PROF_EMPTY_POLLS_CHECK_NUM) {
-                    empty_poll_count = 0;
-                    auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
-                    if (elapsed >= timeout_duration) {
-                        LOG_ERROR("Performance data collection idle timeout after %ld seconds",
-                                 std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
-                        LOG_ERROR("Collected %d / %d records before timeout",
-                                 total_records_collected, expected_tasks);
-                        break;
+                uint32_t core_index = info.index;
+                if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_perf_records_[core_index].push_back(buf->records[i]);
+                    }
+                    total_records_collected += count;
+                }
+
+                LOG_DEBUG("Collected %u perf records from core %u (total: %d/%d)",
+                         count, core_index, total_records_collected, expected_tasks);
+
+            } else {
+                PhaseBuffer* buf = (PhaseBuffer*)info.host_buffer_ptr;
+                rmb();
+                uint32_t count = buf->count;
+                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                }
+
+                uint32_t tidx = info.index;
+                if (tidx < static_cast<uint32_t>(num_sched_for_poll)) {
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_phase_records_[tidx].push_back(buf->records[i]);
+                    }
+                } else {
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_orch_phase_records_.push_back(buf->records[i]);
                     }
                 }
-            }
-            continue;
-        }
 
-        idle_start.reset();
-        empty_poll_count = 0;
-
-        ReadyQueueEntry entry = header->queues[current_thread][head];
-        uint32_t raw_buffer_id = entry.buffer_id;
-        bool is_phase = (raw_buffer_id & PHASE_BUFFER_FLAG) != 0;
-        uint32_t buffer_id = raw_buffer_id & ~PHASE_BUFFER_FLAG;
-
-        if (is_phase) {
-            // Phase buffer entry: core_index stores thread_idx, buffer_id is 1-based ring index
-            uint32_t thread_idx = entry.core_index;
-            if (thread_idx >= static_cast<uint32_t>(PLATFORM_MAX_AICPU_THREADS)) {
-                LOG_ERROR("Invalid phase thread_idx %u (max=%d)", thread_idx, PLATFORM_MAX_AICPU_THREADS);
-                header->queue_heads[current_thread] = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
-                wmb();
-                continue;
-            }
-            uint32_t ring_idx = buffer_id - 1;  // Convert 1-based to 0-based
-            if (ring_idx >= static_cast<uint32_t>(PLATFORM_PHASE_RING_DEPTH)) {
-                LOG_ERROR("Invalid phase ring_idx %u for thread %u (buffer_id=%u)",
-                         ring_idx, thread_idx, buffer_id);
-                header->queue_heads[current_thread] = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
-                wmb();
-                continue;
-            }
-            PhaseRingBuffer* ring = get_phase_ring_buffer(perf_shared_mem_host_, num_aicore_, thread_idx);
-            PhaseBuffer* pbuf = nullptr;
-            volatile BufferStatus* pstatus = nullptr;
-            get_phase_buffer_by_idx(ring, ring_idx, &pbuf, &pstatus);
-
-            rmb();
-            uint32_t count = pbuf->count;
-            if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                LOG_DEBUG("Collected %u phase records from thread %u", count, tidx);
             }
 
-            LOG_DEBUG("Processing phase: thread=%u, buffer=%u, count=%u", thread_idx, buffer_id, count);
+            // Notify memory manager to free old buffer
+            memory_manager_.notify_copy_done({info.dev_buffer_ptr});
+            buffers_processed++;
 
-            // Store phase records: scheduler threads → collected_phase_records_,
-            // orchestrator thread → collected_orch_phase_records_
-            if (thread_idx < static_cast<uint32_t>(num_sched_for_poll)) {
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_phase_records_[thread_idx].push_back(pbuf->records[i]);
-                }
-            } else {
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_orch_phase_records_.push_back(pbuf->records[i]);
-                }
-            }
-
-            pbuf->count = 0;
-            *pstatus = BufferStatus::IDLE;
-            // Phase records don't count toward total_records_collected
         } else {
-            // PerfRecord buffer entry (original logic)
-            uint32_t core_index = entry.core_index;
-
-            if (core_index >= static_cast<uint32_t>(num_aicore)) {
-                LOG_ERROR("Invalid core_index %u (max=%d)", core_index, num_aicore);
-                header->queue_heads[current_thread] = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
-                wmb();
-                continue;
+            // Timeout on wait — check for overall timeout
+            if (!idle_start.has_value()) {
+                idle_start = std::chrono::steady_clock::now();
             }
-
-            LOG_DEBUG("Processing: thread=%d, core=%u, buffer=%u", current_thread, core_index, buffer_id);
-
-            DoubleBuffer* db = &buffers[core_index];
-            PerfBuffer* buf = nullptr;
-            volatile BufferStatus* status = nullptr;
-            get_buffer_and_status(db, buffer_id, &buf, &status);
-
-            rmb();
-            uint32_t count = buf->count;
-            LOG_DEBUG("  Records in buffer: %u", count);
-
-            for (uint32_t i = 0; i < count && i < PLATFORM_PROF_BUFFER_SIZE; i++) {
-                collected_perf_records_[core_index].push_back(buf->records[i]);
-                total_records_collected++;
+            auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
+            if (elapsed >= timeout_duration) {
+                LOG_ERROR("Performance data collection idle timeout after %ld seconds",
+                         std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                LOG_ERROR("Collected %d / %d records before timeout",
+                         total_records_collected, expected_tasks);
+                break;
             }
-
-            buf->count = 0;
-            *status = BufferStatus::IDLE;
         }
-
-        header->queue_heads[current_thread] = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
-        wmb();
-
-        buffers_processed++;
-
-        current_thread = (current_thread + 1) % PLATFORM_MAX_AICPU_THREADS;
     }
 
     LOG_INFO("Total buffers processed: %d", buffers_processed);
@@ -328,6 +706,77 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     }
 
     LOG_INFO("Performance data collection complete");
+}
+
+void PerformanceCollector::drain_remaining_buffers() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    // Ensure phase record storage is initialized
+    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    rmb();
+    int num_sched = 0;
+    if (phase_header->magic == AICPU_PHASE_MAGIC) {
+        num_sched = phase_header->num_sched_threads;
+        if (num_sched > PLATFORM_MAX_AICPU_THREADS) {
+            num_sched = PLATFORM_MAX_AICPU_THREADS;
+        }
+        if (collected_phase_records_.size() < static_cast<size_t>(num_sched)) {
+            collected_phase_records_.resize(num_sched);
+        }
+    }
+
+    int drained_perf = 0;
+    int drained_phase = 0;
+
+    ReadyBufferInfo info;
+    while (memory_manager_.try_pop_ready(info)) {
+        if (info.type == ProfBufferType::PERF_RECORD) {
+            PerfBuffer* buf = (PerfBuffer*)info.host_buffer_ptr;
+            rmb();
+            uint32_t count = buf->count;
+            if (count > PLATFORM_PROF_BUFFER_SIZE) {
+                count = PLATFORM_PROF_BUFFER_SIZE;
+            }
+            uint32_t core_index = info.index;
+            if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_perf_records_[core_index].push_back(buf->records[i]);
+                }
+                drained_perf += count;
+            }
+        } else {
+            PhaseBuffer* buf = (PhaseBuffer*)info.host_buffer_ptr;
+            rmb();
+            uint32_t count = buf->count;
+            if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+            }
+            uint32_t tidx = info.index;
+            if (tidx < static_cast<uint32_t>(num_sched)) {
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_phase_records_[tidx].push_back(buf->records[i]);
+                }
+            } else {
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_orch_phase_records_.push_back(buf->records[i]);
+                }
+            }
+            drained_phase += count;
+        }
+
+        memory_manager_.notify_copy_done({info.dev_buffer_ptr});
+    }
+
+    if (drained_perf > 0 || drained_phase > 0) {
+        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records",
+                 drained_perf, drained_phase);
+    }
+
+    if (drained_phase > 0) {
+        has_phase_data_ = true;
+    }
 }
 
 void PerformanceCollector::collect_phase_data() {
@@ -354,32 +803,36 @@ void PerformanceCollector::collect_phase_data() {
     }
     LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
 
-    // Ensure collected_phase_records_ is allocated (may already have data from poll_and_collect)
     int total_slots = (num_sched_threads < PLATFORM_MAX_AICPU_THREADS)
                       ? num_sched_threads + 1 : num_sched_threads;
     if (collected_phase_records_.size() < static_cast<size_t>(num_sched_threads)) {
         collected_phase_records_.resize(num_sched_threads);
     }
 
-    // Scan remaining PhaseRingBuffers (READY or WRITING with data)
+    // Scan remaining PhaseBufferStates for active buffers with partial data.
+    // READY buffers were already enqueued to the ReadyQueue and collected via
+    // poll_and_collect() or drain_remaining_buffers(). Only current_buf_ptr
+    // contains partial data that was never enqueued (the active buffer when execution ended).
     int total_phase_records = 0;
     for (int t = 0; t < total_slots; t++) {
-        PhaseRingBuffer* ring = get_phase_ring_buffer(perf_shared_mem_host_, num_aicore_, t);
+        PhaseBufferState* state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
 
-        for (int idx = 0; idx < PLATFORM_PHASE_RING_DEPTH; idx++) {
-            PhaseBuffer* pbuf = nullptr;
-            volatile BufferStatus* pstatus = nullptr;
-            get_phase_buffer_by_idx(ring, idx, &pbuf, &pstatus);
-
-            rmb();
-            BufferStatus st = *pstatus;
-            if ((st == BufferStatus::READY || st == BufferStatus::WRITING) && pbuf->count > 0) {
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr != 0) {
+            void* host_ptr = memory_manager_.resolve_host_ptr((void*)buf_ptr);
+            if (host_ptr == nullptr) {
+                LOG_ERROR("collect_phase_data: no host mapping for dev_ptr=%p (thread %d)",
+                          (void*)buf_ptr, t);
+                continue;
+            }
+            PhaseBuffer* pbuf = (PhaseBuffer*)host_ptr;
+            if (pbuf->count > 0) {
                 uint32_t count = pbuf->count;
                 if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
                     count = PLATFORM_PHASE_RECORDS_PER_THREAD;
                 }
 
-                // Scheduler threads go to collected_phase_records_, orchestrator to orch
                 if (t < num_sched_threads) {
                     for (uint32_t i = 0; i < count; i++) {
                         collected_phase_records_[t].push_back(pbuf->records[i]);
@@ -414,7 +867,15 @@ void PerformanceCollector::collect_phase_data() {
         LOG_INFO("  Orchestrator: no summary data");
     }
 
-    has_phase_data_ = (total_phase_records > 0 || orch_valid);
+    // Check if drain_remaining_buffers() already accumulated some Phase records
+    bool has_accumulated = has_phase_data_;
+    if (!has_accumulated) {
+        for (const auto& v : collected_phase_records_) {
+            if (!v.empty()) { has_accumulated = true; break; }
+        }
+        if (!collected_orch_phase_records_.empty()) has_accumulated = true;
+    }
+    has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
 
     // Read core-to-thread mapping
     int num_cores = static_cast<int>(phase_header->num_cores);
@@ -635,7 +1096,6 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         if (!collected_orch_phase_records_.empty()) {
             outfile << ",\n  \"aicpu_orchestrator_phases\": [\n";
 
-            // Map orchestrator phase IDs to names
             auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
                 switch (id) {
                     case AicpuPhaseId::ORCH_SYNC:      return "orch_sync";
@@ -699,7 +1159,68 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
         return 0;
     }
 
+    // Stop memory manager if still running
+    stop_memory_manager();
+
     LOG_DEBUG("Cleaning up performance profiling resources");
+
+    // Free initial buffers that are still in the slot arrays
+    // (These were not freed by the memory manager because they were never replaced)
+    // The memory manager frees old buffers after copy; initial buffers in free_queues remain.
+    // Free all buffers in the free_queues and current_buf_ptr.
+    for (int i = 0; i < num_aicore_; i++) {
+        PerfBufferState* state = get_perf_buffer_state(perf_shared_mem_host_, i);
+
+        // Free current buffer if any
+        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
+            free_cb((void*)state->current_buf_ptr, user_data);
+        }
+
+        // Free all buffers in free_queue (limit iterations to max capacity)
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
+        while (head != tail && max_iters-- > 0) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            if (buf_ptr != 0 && free_cb != nullptr) {
+                free_cb((void*)buf_ptr, user_data);
+            }
+            head++;
+        }
+        if (head != tail) {
+            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)",
+                     i, head, tail);
+        }
+    }
+
+    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
+    for (int t = 0; t < num_phase_threads; t++) {
+        PhaseBufferState* state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+
+        // Free current buffer if any
+        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
+            free_cb((void*)state->current_buf_ptr, user_data);
+        }
+
+        // Free all buffers in free_queue (limit iterations to max capacity)
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
+        while (head != tail && max_iters-- > 0) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            if (buf_ptr != 0 && free_cb != nullptr) {
+                free_cb((void*)buf_ptr, user_data);
+            }
+            head++;
+        }
+        if (head != tail) {
+            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)",
+                     t, head, tail);
+        }
+    }
 
     // Unregister host mapping (optional)
     if (unregister_cb != nullptr && was_registered_) {
@@ -711,10 +1232,10 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
         LOG_DEBUG("Host mapping unregistered");
     }
 
-    // Free device memory
+    // Free shared memory (slot arrays)
     if (free_cb != nullptr && perf_shared_mem_dev_ != nullptr) {
         free_cb(perf_shared_mem_dev_, user_data);
-        LOG_DEBUG("Device memory freed");
+        LOG_DEBUG("Shared memory freed");
     }
 
     perf_shared_mem_dev_ = nullptr;
@@ -726,6 +1247,10 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
     core_to_thread_.clear();
     has_phase_data_ = false;
     device_id_ = -1;
+    alloc_cb_ = nullptr;
+    register_cb_ = nullptr;
+    free_cb_ = nullptr;
+    user_data_ = nullptr;
 
     LOG_DEBUG("Performance profiling cleanup complete");
     return 0;

--- a/tools/sched_overhead_analysis.py
+++ b/tools/sched_overhead_analysis.py
@@ -3,7 +3,9 @@
 
 Analyzes scheduling overhead from two sources:
   1. Per-task perf profiling data (perf_swimlane_*.json)
-  2. AICPU scheduler loop breakdown (device log)
+  2. AICPU scheduler loop breakdown:
+     - From perf JSON Phase data (version >= 2, preferred)
+     - From device log (fallback for older data or PTO2_SCHED_PROFILING=1 details)
 
 Usage:
     python sched_overhead_analysis.py                          # auto-select latest files
@@ -30,6 +32,72 @@ def auto_select_perf_json():
     if not files:
         raise FileNotFoundError(f"No perf_swimlane_*.json files found in {outputs_dir}")
     return files[0]
+
+
+def parse_scheduler_from_json_phases(data):
+    """Extract scheduler Phase breakdown from perf_swimlane JSON (version >= 2).
+
+    Computes per-thread loop counts, task counts, and phase totals
+    from aicpu_scheduler_phases records.
+
+    Returns:
+        dict: Thread data keyed by thread index, same schema as parse_scheduler_threads.
+              Returns empty dict if Phase data not available.
+    """
+    if data.get('version', 1) < 2:
+        return {}
+    phases_by_thread = data.get('aicpu_scheduler_phases', [])
+    if not phases_by_thread:
+        return {}
+
+    # Map JSON phase names to internal names
+    phase_map = {
+        'complete': 'complete',
+        'dispatch': 'dispatch',
+        'scan': 'scan',
+        'idle': 'idle',
+    }
+
+    threads = {}
+    for tid, records in enumerate(phases_by_thread):
+        if not records:
+            continue
+
+        phase_us = {p: 0.0 for p in ['complete', 'scan', 'dispatch', 'idle']}
+        total_tasks = 0
+        max_loop_iter = 0
+
+        for rec in records:
+            phase = phase_map.get(rec.get('phase', ''))
+            if phase is None:
+                continue
+            dur = rec.get('end_time_us', 0) - rec.get('start_time_us', 0)
+            if dur > 0:
+                phase_us[phase] += dur
+            if rec.get('tasks_processed', 0) > 0 and phase == 'complete':
+                total_tasks += rec['tasks_processed']
+            loop_iter = rec.get('loop_iter', 0)
+            if loop_iter > max_loop_iter:
+                max_loop_iter = loop_iter
+
+        total_us = sum(phase_us.values())
+        loops = max_loop_iter
+        tasks_per_loop = total_tasks / loops if loops > 0 else 0.0
+
+        t = {
+            'completed': total_tasks,
+            'total_us': total_us,
+            'loops': loops,
+            'tasks_per_loop': tasks_per_loop,
+            'format': 'json_phase',
+        }
+        for p, us in phase_us.items():
+            t[f'{p}_us'] = us
+            t[f'{p}_pct'] = us / total_us * 100 if total_us > 0 else 0
+
+        threads[tid] = t
+
+    return threads
 
 
 def parse_scheduler_threads(log_path):
@@ -245,12 +313,17 @@ def run_analysis(perf_path, log_path, print_sources=True, selection_strategy=Non
     print(fmt.format('Tail OH (finish-end)', f'{all_tail:.1f}', f'{all_tail/n_total:.2f}', f'{all_tail/all_latency*100:.1f}%'))
     print()
 
-    # === Part 2: AICPU scheduler loop breakdown from device log ===
-    threads = parse_scheduler_threads(log_path)
+    # === Part 2: AICPU scheduler loop breakdown ===
+    # Prefer JSON Phase data (version >= 2), fall back to device log
+    threads = parse_scheduler_from_json_phases(data)
+    phase_source = 'perf JSON phase data'
+    if not threads:
+        threads = parse_scheduler_threads(log_path)
+        phase_source = 'device log'
     n_threads = len(threads)
 
     print('=' * 90)
-    print('Part 2: AICPU scheduler loop breakdown (from device log)')
+    print('Part 2: AICPU scheduler loop breakdown (from ' + phase_source + ')')
     print(f'  {n_threads} scheduler threads')
     print('=' * 90)
     print()


### PR DESCRIPTION
## Summary

Replaces the fixed double-buffer (ping-pong) and phase ring buffer design with **SPSC lock-free free queues** and a dedicated **Host memory management thread** (ProfMemoryManager). This removes spin-wait contention between Host and Device, provides O(1) buffer switching, and uses dynamically allocated buffers instead of embedding them in shared memory.

## Motivation

- The previous double-buffer / phase ring design caused spin-wait contention when Host was slow to replace full buffers.
- Buffers were embedded in shared memory; switching required status handshakes and could block the device side.

## Key changes

- **Data structures**
  - Remove `BufferStatus` enum, `DoubleBuffer`, and `PhaseRingBuffer` structs.
  - Add `PerfFreeQueue` (SPSC queue) and `PerfBufferState` (unified for perf and phase).
  - `ReadyQueueEntry` now carries `buffer_ptr` and `buffer_seq` directly.

- **Host**
  - Add **ProfMemoryManager** thread: polls ReadyQueue, allocates replacement buffers, pushes to free_queue, and manages dev-to-host pointer mapping.
  - Add overflow guard when pushing to the Host free_queue.

- **AICPU**
  - Non-blocking buffer switch via free_queue pop (O(1)).

- **Tooling**
  - Update `sched_overhead_analysis.py` to parse Phase data from JSON.