### PR TITLE
Update: fix paged_attention_unroll shapes and add to benchmark

### DIFF
--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
@@ -21,7 +21,7 @@ RTOL = 1e-3
 ATOL = 1e-3
 
 
-# All test cases - production scale + N_UNROLL test cases
+# All test cases - production scale
 ALL_CASES = {
     "Case1": {
         "batch": 64,
@@ -41,73 +41,9 @@ ALL_CASES = {
         "context_len": 8192,
         "max_model_len": 32768,
     },
-    # N_UNROLL=8 test cases
-    "Batch2": {
-        "batch": 2,
-        "num_heads": 16,
-        "kv_head_num": 1,
-        "head_dim": 128,
-        "block_size": 128,
-        "context_len": 8193,
-        "max_model_len": 32768,
-    },
-    "Batch8": {
-        "batch": 8,
-        "num_heads": 16,
-        "kv_head_num": 1,
-        "head_dim": 128,
-        "block_size": 128,
-        "context_len": 8193,
-        "max_model_len": 32768,
-    },
-    "Blocks65": {
-        "batch": 1,
-        "num_heads": 16,
-        "kv_head_num": 1,
-        "head_dim": 128,
-        "block_size": 128,
-        "context_len": 8193,
-        "max_model_len": 32768,
-    },
-    "Blocks17": {
-        "batch": 1,
-        "num_heads": 16,
-        "kv_head_num": 1,
-        "head_dim": 128,
-        "block_size": 128,
-        "context_len": 2049,
-        "max_model_len": 4096,
-    },
-    "Blocks33": {
-        "batch": 1,
-        "num_heads": 16,
-        "kv_head_num": 1,
-        "head_dim": 128,
-        "block_size": 128,
-        "context_len": 4097,
-        "max_model_len": 8192,
-    },
-    "Blocks25": {
-        "batch": 1,
-        "num_heads": 16,
-        "kv_head_num": 1,
-        "head_dim": 128,
-        "block_size": 128,
-        "context_len": 3073,
-        "max_model_len": 8192,
-    },
-    "Blocks24": {
-        "batch": 1,
-        "num_heads": 16,
-        "kv_head_num": 1,
-        "head_dim": 128,
-        "block_size": 128,
-        "context_len": 3072,
-        "max_model_len": 8192,
-    },
 }
 
-DEFAULT_CASE = "Blocks17"
+DEFAULT_CASE = "Case1"
 
 
 def generate_inputs(params: dict) -> list:

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -109,9 +109,6 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr) + oi_new->start_offset;
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
-    if (n_blocks > 1) {
-        q_tile_size /= n_blocks;
-    }
 
     if (q_tile_size == 16) {
         pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, block_indices);

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -217,7 +217,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr) + mij->start_offset;
     __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr) + lij->start_offset;
 
-    uint64_t q_tile_size = static_cast<uint64_t>(sij_buf->shapes[0]) / n_blocks;
+    uint64_t q_tile_size = static_cast<uint64_t>(sij_buf->shapes[0]);
 
     if (q_tile_size == 16) {
         softmax_prepare_n_impl<16, 128>(sij_base, scale_value, pij_base, mij_addr, lij_addr, n_blocks, valid_len_last);

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -2,7 +2,7 @@
  * Paged Attention Orchestration Function V2 - N_UNROLL=8, 4 Tasks Per Group
  *
  * Batches up to N_UNROLL blocks per group. Each group submits exactly 4 tasks:
- *   1. QK matmul:  qi @ K^T for n_blocks → sij_buf (n_blocks * q_tile, block_size)
+ *   1. QK matmul:  qi @ K^T for n_blocks → sij_buf (q_tile, n_blocks * block_size)
  *   2. Softmax:    two-pass over sij_buf → pij_buf, mi, li
  *   3. PV matmul:  SplitK accumulated P @ V → oi_new (q_tile, head_dim)
  *   4. Update:     online softmax accumulation with group-level mi, li, oi_new
@@ -178,7 +178,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     uint64_t valid_len_last = std::min(block_size, cur_seq - last_block_seq_start);
 
                     // === Task 1: Batched QK matmul ===
-                    uint64_t sij_buf_shapes[2] = {n_blocks * q_tile, block_size};
+                    uint64_t sij_buf_shapes[2] = {q_tile, n_blocks * block_size};
                     Tensor sij_buf = make_tensor(sij_buf_shapes, 2, DataType::FLOAT32);
                     prof_make_count += 1;
                     CYCLE_COUNT_LAP(prof_make_tensor);
@@ -203,7 +203,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     CYCLE_COUNT_LAP(prof_submit_task);
 
                     // === Task 2: Two-pass softmax over all blocks in group ===
-                    uint64_t pij_buf_shapes[2] = {n_blocks * q_tile, block_size};
+                    uint64_t pij_buf_shapes[2] = {q_tile, n_blocks * block_size};
                     Tensor pij_buf = make_tensor(pij_buf_shapes, 2, data_type);
                     Tensor mi = make_tensor(mi_shapes, 1, DataType::FLOAT32);
                     Tensor li = make_tensor(li_shapes, 1, DataType::FLOAT32);

--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -21,6 +21,7 @@ EXAMPLES_DIR="$PROJECT_ROOT/tests/device_tests/tensormap_and_ringbuffer"
 EXAMPLES=(
     alternating_matmul_add
     benchmark_bgemm
+    paged_attention_unroll
     batch_paged_attention
     paged_attention
 )


### PR DESCRIPTION
## Summary
- Fix sij_buf/pij_buf tensor shapes from `(n_blocks*q_tile, block_size)` to `(q_tile, n_blocks*block_size)` for correct semantic representation (memory layout unchanged)
- Simplify kernel q_tile_size extraction — `shapes[0]` is now directly q_tile, no division needed
- Align test cases with `paged_attention` (Case1 + Case2, default Case1)
- Add `paged_attention_unroll` to `benchmark_rounds.sh` before `batch_paged_attention`

## Testing
- [ ] Hardware CI passes (Case1)
- [ ] Benchmark script runs paged_attention_unroll successfully