### PR TITLE
Sync: backport a2a3 platform improvements to a5

### DIFF
--- a/src/a5/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/performance_collector_aicpu.h
@@ -86,8 +86,9 @@ void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks);
  *
  * @param runtime Runtime instance pointer
  * @param num_sched_threads Number of scheduler threads
+ * @param num_orch_threads Number of orchestrator threads (may become schedulers after transition)
  */
-void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads);
+void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, int num_orch_threads = 1);
 
 /**
  * Record a single scheduler phase
@@ -137,9 +138,36 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx);
  * @param start_time Phase start timestamp
  * @param end_time Phase end timestamp
  * @param submit_idx Task submission index (acts as loop_iter)
+ * @param task_id Task ID (stored in tasks_processed field for task tracking)
  */
 void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
                                    uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx);
+                                   uint32_t submit_idx, uint32_t task_id);
+
+/**
+ * Write core-to-thread assignment mapping to shared memory
+ *
+ * Records which scheduler thread manages each core_id.
+ * Called once after orchestration completes (not on the scheduler hot path).
+ *
+ * @param core_assignments 2D array [thread_idx][i] = core_id
+ * @param core_counts Per-thread core count array
+ * @param num_threads Number of scheduler threads
+ * @param total_cores Total number of cores
+ */
+void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
+                                        const int* core_counts,
+                                        int num_threads,
+                                        int total_cores);
+
+/**
+ * Flush remaining phase records for a thread
+ *
+ * Marks the current WRITING phase buffer as READY and enqueues it
+ * for host collection. Called at thread exit (analogous to perf_aicpu_flush_buffers).
+ *
+ * @param thread_idx Thread index (scheduler thread or orchestrator)
+ */
+void perf_aicpu_flush_phase_buffers(int thread_idx);
 
 #endif  // PLATFORM_AICPU_PERFORMANCE_COLLECTOR_AICPU_H_

--- a/src/a5/platform/include/aicpu/platform_regs.h
+++ b/src/a5/platform/include/aicpu/platform_regs.h
@@ -19,6 +19,7 @@
 #ifndef PLATFORM_AICPU_PLATFORM_REGS_H_
 #define PLATFORM_AICPU_PLATFORM_REGS_H_
 
+#include <cstddef>
 #include <cstdint>
 #include "common/platform_config.h"
 
@@ -93,5 +94,21 @@ void platform_deinit_aicore_regs(uint64_t reg_addr);
  * @return Physical core count (exclusive upper bound)
  */
 uint32_t platform_get_physical_cores_count();
+
+/**
+ * Invalidate data cache for a memory range.
+ *
+ * On ARM64 AICPU, DMA writes from the host (rtMemcpy) go directly to HBM
+ * without invalidating the AICPU's data cache.  When rtMalloc returns the
+ * same device address across rounds, the AICPU may read stale cached data
+ * instead of the fresh values written by the host.
+ *
+ * On real hardware (onboard): performs DC CIVAC per cache line + DSB/ISB.
+ * On simulation (sim): no-op.
+ *
+ * @param addr  Start address of the memory range
+ * @param size  Size of the memory range in bytes
+ */
+void cache_invalidate_range(const void* addr, size_t size);
 
 #endif  // PLATFORM_AICPU_PLATFORM_REGS_H_

--- a/src/a5/platform/include/common/perf_profiling.h
+++ b/src/a5/platform/include/common/perf_profiling.h
@@ -2,38 +2,42 @@
  * @file perf_profiling.h
  * @brief Performance profiling data structures
  *
- * Architecture: Fixed header + dynamic tail + optional phase profiling region
+ * Architecture: Fixed header + per-core/thread buffer states + optional phase profiling region
  *
- * Memory layout:
+ * Memory layout (shared memory between Host and Device):
  * ┌─────────────────────────────────────────────────────────────┐
  * │ PerfDataHeader (fixed header)                               │
  * │  - ReadyQueue (FIFO, capacity=PLATFORM_PROF_READYQUEUE_SIZE)│
- * │  - Metadata (num_cores, buffer_capacity, flags)             │
+ * │  - Metadata (num_cores, flags)                              │
  * ├─────────────────────────────────────────────────────────────┤
- * │ DoubleBuffer[0] (Core 0)                                    │
- * │  - buffer1, buffer2 (PerfBuffer)                            │
- * │  - buffer1_status, buffer2_status (IDLE/WRITING/READY)      │
+ * │ PerfBufferState[0] (Core 0)                                 │
+ * │  - free_queue: SPSC queue of available buffer pointers      │
+ * │  - current_buf_ptr, current_buf_seq                         │
  * ├─────────────────────────────────────────────────────────────┤
- * │ DoubleBuffer[1] (Core 1)                                    │
+ * │ PerfBufferState[1] (Core 1)                                 │
  * ├─────────────────────────────────────────────────────────────┤
  * │ ...                                                         │
  * ├─────────────────────────────────────────────────────────────┤
- * │ DoubleBuffer[num_cores-1]                                   │
+ * │ PerfBufferState[num_cores-1]                                │
  * ├─────────────────────────────────────────────────────────────┤
  * │ AicpuPhaseHeader (optional, present when phase profiling)   │
  * │  - magic, num_sched_threads, records_per_thread             │
- * │  - buffer_counts[PLATFORM_MAX_AICPU_THREADS]                │
  * │  - orch_summary                                             │
  * ├─────────────────────────────────────────────────────────────┤
- * │ AicpuPhaseRecord[thread0][0..records_per_thread-1]          │
+ * │ PhaseBufferState[thread0]                                   │
+ * │  - free_queue: SPSC queue of available buffer pointers      │
+ * │  - current_buf_ptr, current_buf_seq                         │
  * ├─────────────────────────────────────────────────────────────┤
- * │ AicpuPhaseRecord[thread1][0..records_per_thread-1]          │
+ * │ PhaseBufferState[thread1]                                   │
  * ├─────────────────────────────────────────────────────────────┤
  * │ ...                                                         │
  * └─────────────────────────────────────────────────────────────┘
  *
- * Base size = sizeof(PerfDataHeader) + num_cores * sizeof(DoubleBuffer)
- * With phases = Base + sizeof(AicpuPhaseHeader) + num_sched_threads * records_per_thread * sizeof(AicpuPhaseRecord)
+ * Actual PerfBuffer / PhaseBuffer are allocated dynamically by Host
+ * and pushed into the per-core/thread free_queue.
+ *
+ * Base size = sizeof(PerfDataHeader) + num_cores * sizeof(PerfBufferState)
+ * With phases = Base + sizeof(AicpuPhaseHeader) + num_threads * sizeof(PhaseBufferState)
  */
 
 #ifndef PLATFORM_COMMON_PERF_PROFILING_H_
@@ -49,28 +53,6 @@
 #ifndef RUNTIME_MAX_FANOUT
 #define RUNTIME_MAX_FANOUT 512
 #endif
-
-// =============================================================================
-// Buffer Status Enumeration
-// =============================================================================
-
-/**
- * Buffer status enumeration (3-state design)
- *
- * State transition flow:
- * IDLE (0) → WRITING (1) → READY (2) → IDLE (0)
- *
- * - AICPU: IDLE→WRITING (on allocation), WRITING→READY (when buffer full)
- * - AICore: Only writes data, does not modify status
- * - Host:   READY→IDLE (after reading)
- *
- * Note: Using uint32_t for binary compatibility with volatile fields.
- */
-enum class BufferStatus : uint32_t {
-    IDLE    = 0,  // Idle: can be allocated by AICPU
-    WRITING = 1,  // Writing: in use by AICore
-    READY   = 2   // Ready: full, waiting for Host
-};
 
 // =============================================================================
 // PerfRecord - Single Task Execution Record
@@ -113,6 +95,7 @@ static_assert(sizeof(PerfRecord) % 64 == 0,
  * Fixed-size performance record buffer
  *
  * Capacity: PLATFORM_PROF_BUFFER_SIZE (defined in platform_config.h)
+ * Allocated dynamically by Host, pushed into per-core free_queue.
  */
 struct PerfBuffer {
     PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Record array
@@ -120,28 +103,68 @@ struct PerfBuffer {
 } __attribute__((aligned(64)));
 
 // =============================================================================
-// DoubleBuffer - Per-Core Ping-Pong Buffers
+// PerfFreeQueue - SPSC Lock-Free Queue for Free Buffers
 // =============================================================================
 
 /**
- * Per-core double buffer with status management
+ * Single Producer Single Consumer (SPSC) lock-free queue for free buffer management
  *
- * Two independent PerfBuffers with independent status fields.
- * AICPU manages buffer allocation and status transitions (0→1→2).
- * AICore only writes records and increments count.
- * Host reads ready buffers and resets status to idle (2→0).
+ * Producer: Host (ProfMemoryManager thread) pushes newly allocated buffers
+ * Consumer: Device (AICPU thread) pops buffers when switching
  *
- * When both buffers are idle, AICPU prioritizes buffer1.
+ * Queue semantics:
+ * - Empty: head == tail
+ * - Full: (tail - head) >= PLATFORM_PROF_SLOT_COUNT
+ * - Capacity: PLATFORM_PROF_SLOT_COUNT buffers
+ *
+ * Memory ordering:
+ * - Device pop: rmb() → read tail → read buffer_ptrs[head % COUNT] → rmb() → write head → wmb()
+ * - Host push: write buffer_ptrs[tail % COUNT] → wmb() → write tail → wmb()
  */
-struct DoubleBuffer {
-    // Buffer 1 (Ping)
-    PerfBuffer buffer1;                              // First buffer
-    volatile BufferStatus buffer1_status;            // Buffer1 status (IDLE/WRITING/READY)
-
-    // Buffer 2 (Pong)
-    PerfBuffer buffer2;                              // Second buffer
-    volatile BufferStatus buffer2_status;            // Buffer2 status (IDLE/WRITING/READY)
+struct PerfFreeQueue {
+    volatile uint64_t buffer_ptrs[PLATFORM_PROF_SLOT_COUNT];  // Free buffer addresses
+    volatile uint32_t head;  // Consumer read position (Device increments)
+    volatile uint32_t tail;  // Producer write position (Host increments)
+    uint32_t pad[13];        // Pad to 128 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
+
+static_assert(sizeof(PerfFreeQueue) == 128,
+              "PerfFreeQueue must be 128 bytes for cache alignment");
+
+// =============================================================================
+// PerfBufferState - Per-Core/Thread Buffer State (Unified for PerfRecord and Phase)
+// =============================================================================
+
+/**
+ * Per-core or per-thread buffer state for dynamic profiling
+ *
+ * Contains:
+ * - free_queue: SPSC queue of available buffer addresses
+ * - current_buf_ptr: Currently active buffer being written (0 = no active buffer)
+ * - current_buf_seq: Monotonic sequence number for ordering
+ *
+ * Used in two contexts:
+ * - Per-core PerfRecord profiling (current_buf_ptr → PerfBuffer)
+ * - Per-thread Phase profiling (current_buf_ptr → PhaseBuffer)
+ *
+ * Writers:
+ * - free_queue.tail: Host writes (pushes new buffers)
+ * - free_queue.head: Device writes (pops buffers)
+ * - current_buf_ptr: Device writes (after pop), Host reads (for flush/collect)
+ * - current_buf_seq: Device writes (monotonic counter)
+ */
+struct PerfBufferState {
+    PerfFreeQueue free_queue;            // SPSC queue of free buffer addresses
+    volatile uint64_t current_buf_ptr;   // Current active buffer (0 = none)
+    volatile uint32_t current_buf_seq;   // Sequence number for ordering
+    uint32_t pad[13];                    // Pad to 192 bytes (aligned to cache line)
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(PerfBufferState) == 192,
+              "PerfBufferState must be 192 bytes for cache alignment");
+
+// Type alias for semantic clarity in Phase profiling context
+using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
 
 // =============================================================================
 // ReadyQueueEntry - Queue Entry for Ready Buffers
@@ -150,13 +173,20 @@ struct DoubleBuffer {
 /**
  * Ready queue entry
  *
- * When a buffer on a core is full, AICPU adds this entry to the queue.
- * Host retrieves entries from the queue to locate (core_index, buffer_id) for reading.
+ * When a buffer on a core/thread is full, AICPU adds this entry to the queue.
+ * Host memory manager retrieves entries from the queue.
+ *
+ * Entry types (distinguished by is_phase flag):
+ * - PerfRecord entry: core_index = core ID, is_phase = 0
+ * - Phase entry:      core_index = thread_idx, is_phase = 1
  */
 struct ReadyQueueEntry {
-    uint32_t core_index;      // Core index (0 ~ num_cores-1)
-    uint32_t buffer_id;       // Buffer ID (1=buffer1, 2=buffer2)
-} __attribute__((aligned(16)));
+    uint32_t core_index;      // Core index (0 ~ num_cores-1), or thread_idx for phase entries
+    uint32_t is_phase;        // 0 = PerfRecord, 1 = Phase
+    uint64_t buffer_ptr;      // Device pointer to the full buffer
+    uint32_t buffer_seq;      // Sequence number for ordering
+    uint32_t pad;             // Alignment padding
+} __attribute__((aligned(32)));
 
 // =============================================================================
 // PerfDataHeader - Fixed Header
@@ -174,7 +204,7 @@ struct ReadyQueueEntry {
  * - Capacity per queue: PLATFORM_PROF_READYQUEUE_SIZE (full capacity for each thread)
  * - Implementation: Circular Buffer
  * - Producer: AICPU thread (adds full buffers to its own queue)
- * - Consumer: Host (reads from all queues)
+ * - Consumer: Host memory manager thread (reads from all queues)
  * - Queue empty: head == tail
  * - Queue full: (tail + 1) % capacity == head
  */
@@ -205,7 +235,7 @@ enum class AicpuPhaseId : uint32_t {
     SCHED_COMPLETE    = 0,  // Process completed tasks (fanout traversal)
     SCHED_DISPATCH    = 1,  // Dispatch ready tasks to idle cores
     SCHED_SCAN        = 2,  // Incremental scan for root tasks
-    SCHED_EARLY_READY = 3,  // Drain orchestrator's early-ready queue
+    SCHED_IDLE_WAIT   = 3,  // Idle/spinning (no progress)
     // Orchestrator phases (16-24)
     ORCH_SYNC      = 16,  // tensormap sync
     ORCH_ALLOC     = 17,  // task_ring_alloc
@@ -249,7 +279,6 @@ struct AicpuOrchSummary {
     uint64_t heap_cycle;       // heap_alloc phase
     uint64_t insert_cycle;     // tensormap_insert phase
     uint64_t fanin_cycle;      // fanin+ready phase
-    uint64_t finalize_cycle;   // finalize+SM phase
     uint64_t scope_end_cycle;  // scope_end phase
     int64_t  submit_count;     // Total tasks submitted
     uint32_t magic;            // Validation magic (AICPU_PHASE_MAGIC)
@@ -260,17 +289,28 @@ constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per thread
 
 /**
+ * Fixed-size phase record buffer (analogous to PerfBuffer)
+ *
+ * Capacity: PLATFORM_PHASE_RECORDS_PER_THREAD
+ * Allocated dynamically by Host, pushed into per-thread free_queue.
+ */
+struct PhaseBuffer {
+    AicpuPhaseRecord records[PLATFORM_PHASE_RECORDS_PER_THREAD];
+    volatile uint32_t count;
+} __attribute__((aligned(64)));
+
+/**
  * AICPU phase profiling header
  *
- * Located after the DoubleBuffer array in shared memory.
- * Contains metadata and per-thread record counts.
+ * Located after the PerfBufferState array in shared memory.
+ * Contains metadata and per-thread tracking.
  */
 struct AicpuPhaseHeader {
     uint32_t magic;                  // Validation magic (AICPU_PHASE_MAGIC)
     uint32_t num_sched_threads;      // Number of scheduler threads
-    uint32_t records_per_thread;     // Max records per thread
-    uint32_t padding;                // Alignment padding
-    volatile uint32_t buffer_counts[PLATFORM_MAX_AICPU_THREADS];  // Per-thread record counts
+    uint32_t records_per_thread;     // Max records per PhaseBuffer
+    uint32_t num_cores;              // Total number of cores with valid assignments
+    int8_t core_to_thread[PLATFORM_MAX_CORES];  // core_id → scheduler thread index (-1 = unassigned)
     AicpuOrchSummary orch_summary;   // Orchestrator cumulative data
 } __attribute__((aligned(64)));
 
@@ -283,16 +323,16 @@ extern "C" {
 #endif
 
 /**
- * Calculate total memory size for performance data
+ * Calculate total memory size for performance data (buffer states only, no buffers)
  *
  * Formula: Total size = Fixed header + Dynamic tail
- *                     = sizeof(PerfDataHeader) + num_cores × sizeof(DoubleBuffer)
+ *                     = sizeof(PerfDataHeader) + num_cores × sizeof(PerfBufferState)
  *
  * @param num_cores Number of cores (block_dim × PLATFORM_CORES_PER_BLOCKDIM)
- * @return Total bytes
+ * @return Total bytes for header + buffer states
  */
 inline size_t calc_perf_data_size(int num_cores) {
-    return sizeof(PerfDataHeader) + num_cores * sizeof(DoubleBuffer);
+    return sizeof(PerfDataHeader) + num_cores * sizeof(PerfBufferState);
 }
 
 /**
@@ -306,61 +346,41 @@ inline PerfDataHeader* get_perf_header(void* base_ptr) {
 }
 
 /**
- * Get DoubleBuffer array start address
+ * Get PerfBufferState array start address
  *
  * @param base_ptr Shared memory base address
- * @return DoubleBuffer array pointer
+ * @return PerfBufferState array pointer
  */
-inline DoubleBuffer* get_double_buffers(void* base_ptr) {
-    return (DoubleBuffer*)((char*)base_ptr + sizeof(PerfDataHeader));
+inline PerfBufferState* get_perf_buffer_states(void* base_ptr) {
+    return (PerfBufferState*)((char*)base_ptr + sizeof(PerfDataHeader));
 }
 
 /**
- * Get DoubleBuffer for specified core
+ * Get PerfBufferState for specified core
  *
  * @param base_ptr Shared memory base address
  * @param core_index Core index (0 ~ num_cores-1)
- * @return DoubleBuffer pointer
+ * @return PerfBufferState pointer
  */
-inline DoubleBuffer* get_core_double_buffer(void* base_ptr, int core_index) {
-    DoubleBuffer* buffers = get_double_buffers(base_ptr);
-    return &buffers[core_index];
+inline PerfBufferState* get_perf_buffer_state(void* base_ptr, int core_index) {
+    return &get_perf_buffer_states(base_ptr)[core_index];
 }
 
 /**
- * Get buffer pointer and status pointer for specified buffer
- *
- * @param db DoubleBuffer pointer
- * @param buffer_id Buffer ID (1=buffer1, 2=buffer2)
- * @param[out] buf PerfBuffer pointer
- * @param[out] status Status pointer
- */
-inline void get_buffer_and_status(DoubleBuffer* db, uint32_t buffer_id,
-                                  PerfBuffer** buf, volatile BufferStatus** status) {
-    if (buffer_id == 1) {
-        *buf = &db->buffer1;
-        *status = &db->buffer1_status;
-    } else {
-        *buf = &db->buffer2;
-        *status = &db->buffer2_status;
-    }
-}
-
-/**
- * Calculate total memory size including phase profiling region
+ * Calculate total memory size including phase profiling region (buffer states only)
  *
  * @param num_cores Number of AICore instances
- * @param num_sched_threads Number of scheduler threads (typically 3)
- * @return Total bytes needed
+ * @param num_sched_threads Number of phase profiling threads (scheduler + orchestrator)
+ * @return Total bytes needed for header + all buffer states
  */
 inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threads) {
     return calc_perf_data_size(num_cores)
          + sizeof(AicpuPhaseHeader)
-         + num_sched_threads * PLATFORM_PHASE_RECORDS_PER_THREAD * sizeof(AicpuPhaseRecord);
+         + num_sched_threads * sizeof(PhaseBufferState);
 }
 
 /**
- * Get AicpuPhaseHeader pointer (located after DoubleBuffer array)
+ * Get AicpuPhaseHeader pointer (located after PerfBufferState array)
  *
  * @param base_ptr Shared memory base address
  * @param num_cores Number of AICore instances
@@ -371,16 +391,26 @@ inline AicpuPhaseHeader* get_phase_header(void* base_ptr, int num_cores) {
 }
 
 /**
- * Get AicpuPhaseRecord array for specified thread
+ * Get PhaseBufferState array start address (located after AicpuPhaseHeader)
  *
  * @param base_ptr Shared memory base address
  * @param num_cores Number of AICore instances
- * @param thread_idx Scheduler thread index
- * @return AicpuPhaseRecord array pointer
+ * @return PhaseBufferState array pointer
  */
-inline AicpuPhaseRecord* get_phase_records(void* base_ptr, int num_cores, int thread_idx) {
-    char* phase_start = (char*)get_phase_header(base_ptr, num_cores) + sizeof(AicpuPhaseHeader);
-    return (AicpuPhaseRecord*)(phase_start + thread_idx * PLATFORM_PHASE_RECORDS_PER_THREAD * sizeof(AicpuPhaseRecord));
+inline PhaseBufferState* get_phase_buffer_states(void* base_ptr, int num_cores) {
+    return (PhaseBufferState*)((char*)get_phase_header(base_ptr, num_cores) + sizeof(AicpuPhaseHeader));
+}
+
+/**
+ * Get PhaseBufferState for specified thread
+ *
+ * @param base_ptr Shared memory base address
+ * @param num_cores Number of AICore instances
+ * @param thread_idx Thread index
+ * @return PhaseBufferState pointer
+ */
+inline PhaseBufferState* get_phase_buffer_state(void* base_ptr, int num_cores, int thread_idx) {
+    return &get_phase_buffer_states(base_ptr, num_cores)[thread_idx];
 }
 
 #ifdef __cplusplus

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -73,17 +73,30 @@ constexpr int PLATFORM_MAX_CORES =
     PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 108
 
 /**
- * Performance buffer capacity for each double buffer
- * Number of PerfRecord entries per buffer (ping or pong)
+ * Performance buffer capacity per buffer
+ * Number of PerfRecord entries per dynamically allocated PerfBuffer
  */
 constexpr int PLATFORM_PROF_BUFFER_SIZE = 1000;
 
 /**
- * Ready queue capacity for performance data collection
- * Queue holds (core_index, buffer_id) entries for buffers ready to be read by Host.
- * Capacity = PLATFORM_MAX_CORES * 2 (each core has 2 buffers: ping and pong)
+ * Number of buffer slots per core/thread for dynamic profiling
+ * Host dynamically allocates buffers and writes addresses into these slots.
+ * Device reads slot addresses when switching buffers.
+ * Using 8 slots (ring buffer) instead of 2 (double-buffer) to tolerate
+ * Host-side latency in replacing full buffers.
  */
-constexpr int PLATFORM_PROF_READYQUEUE_SIZE = PLATFORM_MAX_CORES * 2;  // 216
+constexpr int PLATFORM_PROF_SLOT_COUNT = 8;
+
+/**
+ * Ready queue capacity for performance data collection
+ * Queue holds ReadyQueueEntry structs for buffers ready to be read by Host.
+ * Includes both PerfRecord and PhaseRecord entries:
+ *   PerfRecord: PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT
+ *   Phase:      PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT
+ */
+constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
+    PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT
+    + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT;  // 872
 
 /**
  * System counter frequency (get_sys_cnt)

--- a/src/a5/platform/include/host/performance_collector.h
+++ b/src/a5/platform/include/host/performance_collector.h
@@ -1,22 +1,26 @@
 /**
  * @file performance_collector.h
- * @brief Platform-agnostic performance data collector
+ * @brief Platform-agnostic performance data collector with dynamic memory management
  *
- * This module provides a unified interface for collecting performance profiling
- * data across different platforms (a5, a5sim). Platform-specific memory
- * management is delegated to callback functions, enabling code reuse while
- * maintaining platform separation.
+ * Architecture:
+ * - ProfMemoryManager: Dedicated thread that polls ReadyQueue, allocates new
+ *   device buffers, and replaces full buffers in slot arrays.
+ * - PerformanceCollector: Main thread collects data from ProfMemoryManager's
+ *   internal queue, copies records to host vectors, and exports results.
  *
- * Design Pattern: Dependency Injection via Callbacks
- * - Memory allocation: PerfAllocCallback
- * - Host-Device mapping: PerfRegisterCallback (optional for simulation)
- * - Memory cleanup: PerfUnregisterCallback + PerfFreeCallback
+ * Design Pattern: Dependency Injection via Callbacks for memory operations.
  */
 
 #ifndef PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_
 #define PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
 #include <string>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "common/perf_profiling.h"
@@ -64,13 +68,167 @@ using PerfUnregisterCallback = int (*)(void* dev_ptr, int device_id, void* user_
  */
 using PerfFreeCallback = int (*)(void* dev_ptr, void* user_data);
 
+// =============================================================================
+// ProfMemoryManager - Dynamic Buffer Memory Management Thread
+// =============================================================================
+
+/**
+ * Buffer type identifier for ReadyBufferInfo
+ */
+enum class ProfBufferType { PERF_RECORD, PHASE };
+
+/**
+ * Information about a ready (full) buffer, passed from mgmt thread to main thread
+ */
+struct ReadyBufferInfo {
+    ProfBufferType type;
+    uint32_t index;           // core_index (PERF_RECORD) or thread_idx (PHASE)
+    uint32_t slot_idx;        // Reserved (unused in free queue design)
+    void* dev_buffer_ptr;     // Device address of the full buffer
+    void* host_buffer_ptr;    // Host-mapped address (sim: same as dev)
+    uint32_t buffer_seq;      // Sequence number for ordering
+};
+
+/**
+ * Notification that a buffer has been copied and can be freed
+ */
+struct CopyDoneInfo {
+    void* dev_buffer_ptr;     // Device buffer to free
+};
+
+/**
+ * Dynamic profiling buffer memory manager
+ *
+ * Runs a dedicated thread that:
+ * 1. Polls ReadyQueue in shared memory for full buffer entries
+ * 2. Allocates new device buffers via callback
+ * 3. Writes new buffer addresses into slots (for device to pick up)
+ * 4. Pushes old (full) buffer info to internal queue for main thread to copy
+ * 5. Frees device buffers after main thread confirms copy is done
+ */
+class ProfMemoryManager {
+public:
+    ProfMemoryManager() = default;
+    ~ProfMemoryManager();
+
+    // Disable copy
+    ProfMemoryManager(const ProfMemoryManager&) = delete;
+    ProfMemoryManager& operator=(const ProfMemoryManager&) = delete;
+
+    // Allow PerformanceCollector to register initial buffer mappings
+    friend class PerformanceCollector;
+
+    /**
+     * Start the memory management thread
+     *
+     * @param shared_mem_host Host-mapped shared memory base address
+     * @param num_cores Number of AICore instances (PerfBufferState count)
+     * @param num_phase_threads Number of phase profiling threads (PhaseBufferState count)
+     * @param alloc_cb Device memory allocation callback
+     * @param register_cb Host-device mapping callback (nullptr for simulation)
+     * @param free_cb Device memory free callback
+     * @param user_data User context for callbacks
+     * @param device_id Device ID for registration
+     */
+    void start(void* shared_mem_host, int num_cores, int num_phase_threads,
+               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
+               PerfFreeCallback free_cb, void* user_data, int device_id);
+
+    /**
+     * Stop the memory management thread
+     * Blocks until the thread exits.
+     */
+    void stop();
+
+    /**
+     * Try to pop a ready buffer info (non-blocking)
+     *
+     * @param[out] info Ready buffer info
+     * @return true if an item was available, false otherwise
+     */
+    bool try_pop_ready(ReadyBufferInfo& info);
+
+    /**
+     * Wait for a ready buffer info with timeout
+     *
+     * @param[out] info Ready buffer info
+     * @param timeout Maximum wait time
+     * @return true if an item was available, false on timeout
+     */
+    bool wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout);
+
+    /**
+     * Notify that a buffer has been copied and can be freed
+     *
+     * @param info Copy done notification
+     */
+    void notify_copy_done(const CopyDoneInfo& info);
+
+    /**
+     * Check if the manager thread is running
+     */
+    bool is_running() const { return running_.load(); }
+
+private:
+    std::thread mgmt_thread_;
+    std::atomic<bool> running_{false};
+
+    // Shared memory references
+    void* shared_mem_host_{nullptr};
+    int num_cores_{0};
+    int num_phase_threads_{0};
+
+    // Callbacks
+    PerfAllocCallback alloc_cb_{nullptr};
+    PerfRegisterCallback register_cb_{nullptr};
+    PerfFreeCallback free_cb_{nullptr};
+    void* user_data_{nullptr};
+    int device_id_{-1};
+
+    // Management thread → main thread (ready buffers)
+    std::mutex ready_mutex_;
+    std::condition_variable ready_cv_;
+    std::queue<ReadyBufferInfo> ready_queue_;
+
+    // Main thread → management thread (buffers to free)
+    std::mutex done_mutex_;
+    std::queue<CopyDoneInfo> done_queue_;
+
+    // Device-to-host pointer mapping (populated during alloc_and_register)
+    std::unordered_map<void*, void*> dev_to_host_;
+
+    // Management thread main loop
+    void mgmt_loop();
+
+    // Allocate a new buffer and optionally register for host access
+    void* alloc_and_register(size_t size, void** host_ptr_out);
+
+    // Free a previously allocated buffer
+    void free_buffer(void* dev_ptr);
+
+    // Resolve device pointer to host pointer
+    void* resolve_host_ptr(void* dev_ptr);
+
+    // Register an external dev→host mapping (for initial buffers)
+    void register_mapping(void* dev_ptr, void* host_ptr);
+
+    // Process one ReadyQueue entry
+    void process_ready_entry(PerfDataHeader* header, int thread_idx,
+                              const ReadyQueueEntry& entry);
+};
+
+// =============================================================================
+// PerformanceCollector - Main Collector
+// =============================================================================
+
 /**
  * Performance data collector
  *
  * Manages performance profiling lifecycle:
- * 1. Initialize shared memory (Header + DoubleBuffers)
- * 2. Poll ready queue and collect records from full buffers
- * 3. Print statistics and export swimlane visualization
+ * 1. Initialize shared memory (Header + SlotArrays) and allocate initial buffers
+ * 2. Start ProfMemoryManager thread
+ * 3. Collect records from ProfMemoryManager's queue (main thread)
+ * 4. Export swimlane visualization
  *
  * Platform-agnostic: Memory management delegated to callbacks
  */
@@ -86,13 +244,15 @@ public:
     /**
      * Initialize performance profiling
      *
-     * Allocates and initializes shared memory for performance data collection.
+     * Allocates shared memory for slot arrays, allocates initial buffers,
+     * and writes buffer addresses into slots.
      *
      * @param runtime Runtime instance to configure
      * @param num_aicore Number of AICore instances
      * @param device_id Device ID
      * @param alloc_cb Memory allocation callback
      * @param register_cb Memory registration callback (can be nullptr for simulation)
+     * @param free_cb Memory free callback
      * @param user_data User-provided context pointer passed to callbacks
      * @return 0 on success, error code on failure
      */
@@ -101,12 +261,24 @@ public:
                    int device_id,
                    PerfAllocCallback alloc_cb,
                    PerfRegisterCallback register_cb,
+                   PerfFreeCallback free_cb,
                    void* user_data);
 
     /**
-     * Poll and collect performance data from shared memory
+     * Start the memory management thread
      *
-     * @param expected_tasks Expected total number of tasks (0 = auto-detect from header)
+     * Must be called after initialize() and before device execution starts.
+     */
+    void start_memory_manager();
+
+    /**
+     * Poll and collect performance data from the memory manager's queue
+     *
+     * Runs on the main thread (or a dedicated collector thread in sim mode).
+     * Pulls ready buffers from ProfMemoryManager, copies records to host vectors,
+     * and notifies the manager to free old device buffers.
+     *
+     * @param expected_tasks Expected total number of tasks (0 = auto-detect)
      */
     void poll_and_collect(int expected_tasks = 0);
 
@@ -117,6 +289,13 @@ public:
      * @return 0 on success, error code on failure
      */
     int export_swimlane_json(const std::string& output_path = "outputs");
+
+    /**
+     * Stop the memory management thread and clean up remaining data
+     *
+     * Must be called after device execution completes.
+     */
+    void stop_memory_manager();
 
     /**
      * Cleanup all resources
@@ -136,6 +315,17 @@ public:
     bool is_initialized() const { return perf_shared_mem_host_ != nullptr; }
 
     /**
+     * Drain remaining buffers from the memory manager's ready queue
+     *
+     * After poll_and_collect() exits (all PERF records collected) and
+     * the memory manager is stopped, Phase buffers may still be in the
+     * ready queue. This method drains them into the collected vectors.
+     *
+     * Must be called after stop_memory_manager() and before collect_phase_data().
+     */
+    void drain_remaining_buffers();
+
+    /**
      * Collect AICPU phase profiling data from shared memory
      *
      * Reads scheduler phase records and orchestrator summary from the
@@ -150,13 +340,22 @@ public:
 
 private:
     // Shared memory pointers
-    void* perf_shared_mem_dev_{nullptr};   // Device memory pointer
-    void* perf_shared_mem_host_{nullptr};  // Host-mapped pointer
+    void* perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
+    void* perf_shared_mem_host_{nullptr};  // Host-mapped pointer (slot arrays)
     bool was_registered_{false};           // True if register_cb was called successfully
     int device_id_{-1};
 
     // Configuration
     int num_aicore_{0};
+
+    // Callbacks (stored for memory manager)
+    PerfAllocCallback alloc_cb_{nullptr};
+    PerfRegisterCallback register_cb_{nullptr};
+    PerfFreeCallback free_cb_{nullptr};
+    void* user_data_{nullptr};
+
+    // Memory manager
+    ProfMemoryManager memory_manager_;
 
     // Collected data (per-core vectors, indexed by core_index)
     std::vector<std::vector<PerfRecord>> collected_perf_records_;
@@ -166,6 +365,12 @@ private:
     std::vector<AicpuPhaseRecord> collected_orch_phase_records_;
     AicpuOrchSummary collected_orch_summary_{};
     bool has_phase_data_{false};
+
+    // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
+    std::vector<int8_t> core_to_thread_;
+
+    // Allocate a single buffer (PerfBuffer or PhaseBuffer) and register it
+    void* alloc_single_buffer(size_t size, void** host_ptr_out);
 };
 
 #endif  // PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_

--- a/src/a5/platform/include/host/pto_runtime_c_api.h
+++ b/src/a5/platform/include/host/pto_runtime_c_api.h
@@ -160,6 +160,7 @@ int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
  * @param aicpu_size       Size of AICPU binary in bytes
  * @param aicore_binary    AICore kernel binary data
  * @param aicore_size      Size of AICore binary in bytes
+ * @param orch_thread_num  Number of orchestrator threads (default 1)
  * @return 0 on success, error code on failure
  */
 int launch_runtime(RuntimeHandle runtime,
@@ -169,7 +170,8 @@ int launch_runtime(RuntimeHandle runtime,
     const uint8_t* aicpu_binary,
     size_t aicpu_size,
     const uint8_t* aicore_binary,
-    size_t aicore_size);
+    size_t aicore_size,
+    int orch_thread_num);
 
 /**
  * Finalize and cleanup a runtime instance.

--- a/src/a5/platform/onboard/aicore/CMakeLists.txt
+++ b/src/a5/platform/onboard/aicore/CMakeLists.txt
@@ -28,6 +28,7 @@ else()
 endif()
 list(LENGTH ALL_SOURCES NUM_SOURCES)
 message(STATUS "AICore kernel: ${NUM_SOURCES} source files")
+message(VERBOSE "AICore kernel sources: ${ALL_SOURCES}")
 
 # Output files
 set(AICORE_KERNEL_OBJ ${CMAKE_CURRENT_BINARY_DIR}/aicore_kernel.o)

--- a/src/a5/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a5/platform/onboard/aicpu/CMakeLists.txt
@@ -33,6 +33,9 @@ else()
     message(FATAL_ERROR "MUST set CUSTOM_SOURCE_DIRS to build AICPU kernel")
 endif()
 
+list(LENGTH AICPU_KERNEL_SOURCES NUM_AICPU_KERNEL_SOURCES)
+message(STATUS "AICpu kernel: ${NUM_AICPU_KERNEL_SOURCES} source files")
+message(VERBOSE "AICpu kernel sources: ${AICPU_KERNEL_SOURCES}")
 add_library(aicpu_kernel SHARED ${AICPU_KERNEL_SOURCES})
 
 # Compile options (common to both C and C++)

--- a/src/a5/platform/onboard/aicpu/cache_ops.cpp
+++ b/src/a5/platform/onboard/aicpu/cache_ops.cpp
@@ -1,0 +1,18 @@
+#include <cstddef>
+#include <cstdint>
+
+#include "aicpu/platform_regs.h"
+
+void cache_invalidate_range(const void* addr, size_t size) {
+    if (size == 0) {
+        return;
+    }
+    const size_t kCacheLineSize = 64;
+    uintptr_t start = (uintptr_t)addr & ~(kCacheLineSize - 1);
+    uintptr_t end   = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    for (uintptr_t p = start; p < end; p += kCacheLineSize) {
+        __asm__ __volatile__("dc civac, %0" :: "r"(p) : "memory");
+    }
+    __asm__ __volatile__("dsb sy" ::: "memory");
+    __asm__ __volatile__("isb" ::: "memory");
+}

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -39,6 +39,9 @@ else()
 endif()
 
 # Create shared library
+list(LENGTH HOST_RUNTIME_SOURCES NUM_HOST_RUNTIME_SOURCES)
+message(STATUS "Host runtime: ${NUM_HOST_RUNTIME_SOURCES} source files")
+message(VERBOSE "Host runtime sources: ${HOST_RUNTIME_SOURCES}")
 add_library(host_runtime SHARED ${HOST_RUNTIME_SOURCES})
 
 # C++ standard (applied only to C++ files)
@@ -68,7 +71,7 @@ target_include_directories(host_runtime
         ${ASCEND_HOME_PATH}/pkg_inc
         ${ASCEND_HOME_PATH}/pkg_inc/runtime
         ${ASCEND_HOME_PATH}/pkg_inc/profiling
-        ${ASCEND_HOME_PATH}/aarch64-linux/include/driver
+        ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/include/driver
 )
 
 target_link_directories(host_runtime

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -294,13 +294,32 @@ int DeviceRunner::run(Runtime& runtime,
         return -1;
     }
 
-    // Validate even distribution: block_dim must be divisible by scheduler thread count
-    // When launch_aicpu_num == 4: 3 schedulers + 1 orchestrator (thread 3 has 0 cores)
-    int scheduler_thread_num = (launch_aicpu_num == 4) ? 3 : launch_aicpu_num;
-    if (block_dim % scheduler_thread_num != 0) {
-        LOG_ERROR("block_dim (%d) must be evenly divisible by scheduler_thread_num (%d)",
-                      block_dim, scheduler_thread_num);
+    // Validate orchestrator configuration
+    int scheduler_thread_num = launch_aicpu_num - runtime.orch_thread_num;
+
+    if (runtime.orch_thread_num > launch_aicpu_num) {
+        LOG_ERROR("orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)",
+                  runtime.orch_thread_num, launch_aicpu_num);
         return -1;
+    }
+
+    // Validate even core distribution for initial scheduler threads
+    // All-orchestrator mode (scheduler_thread_num == 0): cores assigned post-transition
+    if (scheduler_thread_num > 0) {
+        if (block_dim % scheduler_thread_num != 0) {
+            LOG_ERROR("block_dim (%d) must be evenly divisible by scheduler_thread_num (%d)",
+                      block_dim, scheduler_thread_num);
+            return -1;
+        }
+    } else {
+        LOG_INFO("All %d threads are orchestrators, cores will be assigned after orchestration completes",
+                 launch_aicpu_num);
+        // Post-transition: all threads become schedulers
+        if (block_dim % launch_aicpu_num != 0) {
+            LOG_WARN("block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
+                     "some threads will have different core counts after transition",
+                     block_dim, launch_aicpu_num);
+        }
     }
 
     // Ensure device is initialized (lazy initialization)
@@ -368,6 +387,8 @@ int DeviceRunner::run(Runtime& runtime,
             LOG_ERROR("init_performance_profiling failed: %d", rc);
             return rc;
         }
+        // Start memory management thread
+        perf_collector_.start_memory_manager();
     }
 
     std::cout << "\n=== Initialize runtime args ===" << '\n';
@@ -383,6 +404,10 @@ int DeviceRunner::run(Runtime& runtime,
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServerInit", 1);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (init) failed: %d", rc);
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
         kernel_args_.finalize_runtime_args();
         return rc;
     }
@@ -392,6 +417,10 @@ int DeviceRunner::run(Runtime& runtime,
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", launch_aicpu_num);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
         kernel_args_.finalize_runtime_args();
         return rc;
     }
@@ -401,13 +430,20 @@ int DeviceRunner::run(Runtime& runtime,
     rc = launch_aicore_kernel(stream_aicore_, kernel_args_.args.runtime_args);
     if (rc != 0) {
         LOG_ERROR("launch_aicore_kernel failed: %d", rc);
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
         kernel_args_.finalize_runtime_args();
         return rc;
     }
 
-    // Poll and collect performance data (must be before stream sync)
+    // Poll and collect performance data in a separate collector thread
+    std::thread collector_thread;
     if (runtime.enable_profiling) {
-        poll_and_collect_performance_data(runtime.get_task_count());
+        collector_thread = std::thread([this, &runtime]() {
+            poll_and_collect_performance_data(runtime.get_task_count());
+        });
     }
 
     std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
@@ -415,6 +451,13 @@ int DeviceRunner::run(Runtime& runtime,
     rc = rtStreamSynchronize(stream_aicpu_);
     if (rc != 0) {
         LOG_ERROR("rtStreamSynchronize (AICPU) failed: %d", rc);
+        if (runtime.enable_profiling && collector_thread.joinable()) {
+            collector_thread.join();
+        }
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
         kernel_args_.finalize_runtime_args();
         return rc;
     }
@@ -423,17 +466,39 @@ int DeviceRunner::run(Runtime& runtime,
     rc = rtStreamSynchronize(stream_aicore_);
     if (rc != 0) {
         LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
+        if (runtime.enable_profiling && collector_thread.joinable()) {
+            collector_thread.join();
+        }
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
         kernel_args_.finalize_runtime_args();
         return rc;
     }
 
-    // Collect phase data and print performance data (after stream sync)
+    // Wait for collector thread to finish
+    if (runtime.enable_profiling && collector_thread.joinable()) {
+        collector_thread.join();
+    }
+
+    // Stop memory management, drain remaining buffers, collect phase data, export
     if (runtime.enable_profiling) {
+        perf_collector_.stop_memory_manager();
+        perf_collector_.drain_remaining_buffers();
         perf_collector_.collect_phase_data();
         export_swimlane_json();
     }
 
-    // Note: FinalizeRuntimeArgs is deferred to Finalize() so PrintHandshakeResults can access device data
+    // Print handshake results (reads from device memory, must be before free)
+    print_handshake_results();
+
+    // Free per-run resources
+    if (kernel_args_.args.regs != 0) {
+        mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+        kernel_args_.args.regs = 0;
+    }
+    kernel_args_.finalize_runtime_args();
 
     return 0;
 }
@@ -456,30 +521,10 @@ void DeviceRunner::print_handshake_results() {
     }
 }
 
-int DeviceRunner::clean_cache() {
-    if (stream_aicpu_ == nullptr) {
-        return 0;  // Nothing to cleanup if device not initialized
-    }
-    for (const auto& [func_id, addr] : func_id_to_addr_) {
-        void* gm_addr = reinterpret_cast<void*>(addr - sizeof(uint64_t));
-        mem_alloc_.free(gm_addr);
-    }
-    func_id_to_addr_.clear();
-
-    LOG_INFO("DeviceRunner: cache cleaned (test-specific resources only)");
-    return 0;
-}
-
 int DeviceRunner::finalize() {
     if (stream_aicpu_ == nullptr) {
         return 0;
     }
-
-    // Print handshake results before cleanup (reads from device memory)
-    print_handshake_results();
-
-    // Cleanup runtime args (deferred from Run)
-    kernel_args_.finalize_runtime_args();
 
     // Cleanup kernel args (deviceArgs)
     kernel_args_.finalize_device_args();
@@ -487,7 +532,17 @@ int DeviceRunner::finalize() {
     // Cleanup AICPU SO
     so_info_.finalize();
 
-    // Clear kernel address mapping
+    // Kernel binaries should have been removed by validate_runtime_impl()
+    if (!func_id_to_addr_.empty()) {
+        LOG_ERROR("finalize() called with %zu kernel binaries still cached (memory leak)",
+                  func_id_to_addr_.size());
+        // Cleanup leaked binaries to prevent memory leaks
+        for (const auto& pair : func_id_to_addr_) {
+            void* gm_addr = reinterpret_cast<void*>(pair.second);
+            mem_alloc_.free(gm_addr);
+            LOG_DEBUG("Freed leaked kernel binary: func_id=%d, addr=0x%lx", pair.first, pair.second);
+        }
+    }
     func_id_to_addr_.clear();
     binaries_loaded_ = false;
 
@@ -623,37 +678,43 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
 
     LOG_DEBUG("Uploading kernel binary: func_id=%d, size=%zu bytes", func_id, bin_size);
 
-    // Allocate device GM memory (size field + binary data)
-    uint64_t alloc_size = sizeof(uint64_t) + bin_size;
-    void* gm_addr = mem_alloc_.alloc(alloc_size);
+    // Allocate device GM memory for kernel binary
+    void* gm_addr = mem_alloc_.alloc(bin_size);
     if (gm_addr == nullptr) {
         LOG_ERROR("Failed to allocate device GM memory for kernel func_id=%d", func_id);
         return 0;
     }
 
-    // Build host buffer with CoreFunctionBin structure (size + data)
-    std::vector<uint8_t> host_buf(alloc_size);
-    uint64_t* size_ptr = reinterpret_cast<uint64_t*>(host_buf.data());
-    *size_ptr = bin_size;
-    std::memcpy(host_buf.data() + sizeof(uint64_t), bin_data, bin_size);
-
-    // Copy to device
-    int rc = rtMemcpy(gm_addr, alloc_size, host_buf.data(), alloc_size, RT_MEMCPY_HOST_TO_DEVICE);
+    // Copy kernel binary to device
+    int rc = rtMemcpy(gm_addr, bin_size, bin_data, bin_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
         LOG_ERROR("rtMemcpy to device failed: %d", rc);
         mem_alloc_.free(gm_addr);
         return 0;
     }
 
-    // Calculate function_bin_addr (skip size field to get actual code address)
-    uint64_t function_bin_addr = reinterpret_cast<uint64_t>(gm_addr) + sizeof(uint64_t);
-
-    // Cache for later reuse and cleanup
+    // Cache the kernel address
+    uint64_t function_bin_addr = reinterpret_cast<uint64_t>(gm_addr);
     func_id_to_addr_[func_id] = function_bin_addr;
 
     LOG_DEBUG("  func_id=%d -> function_bin_addr=0x%lx", func_id, function_bin_addr);
 
     return function_bin_addr;
+}
+
+void DeviceRunner::remove_kernel_binary(int func_id) {
+    auto it = func_id_to_addr_.find(func_id);
+    if (it == func_id_to_addr_.end()) {
+        return;
+    }
+
+    uint64_t function_bin_addr = it->second;
+    void* gm_addr = reinterpret_cast<void*>(function_bin_addr);
+
+    mem_alloc_.free(gm_addr);
+    func_id_to_addr_.erase(it);
+
+    LOG_DEBUG("Removed kernel binary: func_id=%d, addr=0x%lx", func_id, function_bin_addr);
 }
 
 int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, int device_id) {
@@ -679,8 +740,14 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
 
+    // Define free callback (a5: use MemoryAllocator)
+    auto free_cb = [](void* dev_ptr, void* user_data) -> int {
+        auto* allocator = static_cast<MemoryAllocator*>(user_data);
+        return allocator->free(dev_ptr);
+    };
+
     return perf_collector_.initialize(runtime, num_aicore, device_id,
-                                       alloc_cb, register_cb, &mem_alloc_);
+                                       alloc_cb, register_cb, free_cb, &mem_alloc_);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -249,15 +249,14 @@ public:
     int export_swimlane_json(const std::string& output_path = "outputs");
 
     /**
-     * Clean cached resources - lightweight cleanup between tests
+     * Remove a kernel binary from device memory
      *
-     * Cleans up test-specific resources while preserving device resources for reuse:
-     * - Frees kernel memory from global memory allocator
-     * - Clears kernel address cache
+     * Frees the device memory allocated for the kernel and removes the
+     * cached entry. This should be called during per-case cleanup.
      *
-     * @return 0 on success, error code on failure
+     * @param func_id   Function identifier to remove
      */
-    int clean_cache();
+    void remove_kernel_binary(int func_id);
 
     /**
      * Cleanup all resources

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -38,6 +38,7 @@ void device_free(void* dev_ptr);
 int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
 int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
 uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
+void remove_kernel_binary_wrapper(int func_id);
 
 /* ===========================================================================
  */
@@ -75,6 +76,7 @@ int init_runtime(RuntimeHandle runtime,
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
+        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
 
         LOG_DEBUG("About to call init_runtime_impl, r=%p", (void*)r);
 
@@ -157,6 +159,15 @@ uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size
     }
 }
 
+void remove_kernel_binary_wrapper(int func_id) {
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        runner.remove_kernel_binary(func_id);
+    } catch (...) {
+        // Ignore errors during cleanup
+    }
+}
+
 int launch_runtime(RuntimeHandle runtime,
     int aicpu_thread_num,
     int block_dim,
@@ -164,7 +175,8 @@ int launch_runtime(RuntimeHandle runtime,
     const uint8_t* aicpu_binary,
     size_t aicpu_size,
     const uint8_t* aicore_binary,
-    size_t aicore_size) {
+    size_t aicore_size,
+    int orch_thread_num) {
     if (runtime == NULL) {
         return -1;
     }
@@ -180,6 +192,7 @@ int launch_runtime(RuntimeHandle runtime,
 
         // Run the runtime (device initialization is handled internally)
         Runtime* r = static_cast<Runtime*>(runtime);
+        r->orch_thread_num = orch_thread_num;
         return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
         return -1;
@@ -194,10 +207,6 @@ int finalize_runtime(RuntimeHandle runtime) {
         Runtime* r = static_cast<Runtime*>(runtime);
         int rc = validate_runtime_impl(r);
 
-        // Clean cached resources to prepare for next test
-        DeviceRunner& runner = DeviceRunner::get();
-        runner.clean_cache();
-        
         // Call destructor (user will call free())
         r->~Runtime();
         return rc;

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -20,11 +20,16 @@
 #define __aicore__
 #endif
 
-// dcci (Data Cache Clean and Invalidate) - acquire fence in simulation
-// Hardware dcci invalidates cache to ensure fresh reads from shared memory.
-// In simulation, an acquire fence provides the equivalent ordering guarantee.
+// dcci (Data Cache Clean and Invalidate) - full fence in simulation
+// Hardware dcci has two roles:
+//   - without CACHELINE_OUT: invalidate (read from memory) -> acquire semantics
+//   - with CACHELINE_OUT: write-back/flush (write to memory) -> release semantics
+// On aarch64, acquire-only fences do NOT prevent store-store reordering across the
+// barrier, so using acquire for the flush direction causes a race: the AICPU can
+// observe the COND register FIN signal before perf_buf->count is visible.
+// Using seq_cst (dmb ish / full barrier) covers both directions safely.
 // Use variadic macro to support both 2-arg and 3-arg calls.
-#define dcci(...) std::atomic_thread_fence(std::memory_order_acquire)
+#define dcci(...) std::atomic_thread_fence(std::memory_order_seq_cst)
 
 // Cache coherency constants (no-op in simulation)
 #define ENTIRE_DATA_CACHE 0

--- a/src/a5/platform/sim/aicpu/cache_ops.cpp
+++ b/src/a5/platform/sim/aicpu/cache_ops.cpp
@@ -1,0 +1,7 @@
+#include <cstddef>
+
+#include "aicpu/platform_regs.h"
+
+void cache_invalidate_range(const void* /* addr */, size_t /* size */) {
+    // No-op on simulation: no hardware cache to invalidate
+}

--- a/src/a5/platform/sim/aicpu/spin_hint.h
+++ b/src/a5/platform/sim/aicpu/spin_hint.h
@@ -18,10 +18,10 @@
 
 #include <sched.h>
 
-#if defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
-#elif defined(__aarch64__)
+#if defined(__aarch64__)
 #define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#elif defined(__x86_64__)
+#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -151,13 +151,32 @@ int DeviceRunner::run(Runtime& runtime,
         return -1;
     }
 
-    // Validate even distribution: block_dim must be divisible by scheduler thread count
-    // When launch_aicpu_num == 4: 3 schedulers + 1 orchestrator (thread 3 has 0 cores)
-    int scheduler_thread_num = (launch_aicpu_num == 4) ? 3 : launch_aicpu_num;
-    if (block_dim % scheduler_thread_num != 0) {
-        LOG_ERROR("block_dim (%d) must be evenly divisible by scheduler_thread_num (%d)",
-                       block_dim, scheduler_thread_num);
+    // Validate orchestrator configuration
+    int scheduler_thread_num = launch_aicpu_num - runtime.orch_thread_num;
+
+    if (runtime.orch_thread_num > launch_aicpu_num) {
+        LOG_ERROR("orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)",
+                  runtime.orch_thread_num, launch_aicpu_num);
         return -1;
+    }
+
+    // Validate even core distribution for initial scheduler threads
+    // All-orchestrator mode (scheduler_thread_num == 0): cores assigned post-transition
+    if (scheduler_thread_num > 0) {
+        if (block_dim % scheduler_thread_num != 0) {
+            LOG_ERROR("block_dim (%d) must be evenly divisible by scheduler_thread_num (%d)",
+                      block_dim, scheduler_thread_num);
+            return -1;
+        }
+    } else {
+        LOG_INFO("All %d threads are orchestrators, cores will be assigned after orchestration completes",
+                 launch_aicpu_num);
+        // Post-transition: all threads become schedulers
+        if (block_dim % launch_aicpu_num != 0) {
+            LOG_WARN("block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
+                     "some threads will have different core counts after transition",
+                     block_dim, launch_aicpu_num);
+        }
     }
 
     // Ensure device is initialized
@@ -218,6 +237,8 @@ int DeviceRunner::run(Runtime& runtime,
             LOG_ERROR("init_performance_profiling failed: %d", rc);
             return rc;
         }
+        // Start memory management thread
+        perf_collector_.start_memory_manager();
     }
 
     // Allocate simulated register blocks for all AICore cores
@@ -300,11 +321,16 @@ int DeviceRunner::run(Runtime& runtime,
 
     LOG_INFO("All threads completed");
 
-    // Collect AICPU phase data and print performance data after execution completes
+    // Stop memory management, drain remaining buffers, collect phase data, export
     if (runtime.enable_profiling) {
+        perf_collector_.stop_memory_manager();
+        perf_collector_.drain_remaining_buffers();
         perf_collector_.collect_phase_data();
         export_swimlane_json();
     }
+
+    // Print handshake results at end of run
+    print_handshake_results();
 
     return 0;
 }
@@ -325,38 +351,11 @@ void DeviceRunner::print_handshake_results() {
     }
 }
 
-int DeviceRunner::clean_cache() {
-    // Skip if not initialized
-    if (device_id_ == -1) {
-        return 0;
-    }
-
-    // Only cleanup test-specific resources:
-
-    // 1. Close dlopen'd kernel libraries (different tests may have different kernels)
-    for (auto& pair : func_id_to_addr_) {
-        MappedKernel& kernel = pair.second;
-        if (kernel.dl_handle != nullptr) {
-            dlclose(kernel.dl_handle);
-            LOG_DEBUG("Closed dlopen kernel: func_id=%d", pair.first);
-            kernel.dl_handle = nullptr;
-            kernel.func_addr = 0;
-        }
-    }
-    func_id_to_addr_.clear();
-
-    LOG_INFO("DeviceRunner(sim): cache cleaned (test-specific resources only)");
-    return 0;
-}
-
 int DeviceRunner::finalize() {
     // Skip if already finalized
     if (device_id_ == -1 && aicpu_so_handle_ == nullptr && aicore_so_handle_ == nullptr) {
         return 0;
     }
-
-    // Print handshake results before cleanup
-    print_handshake_results();
 
     // Cleanup performance profiling
     if (perf_collector_.is_initialized()) {
@@ -369,14 +368,17 @@ int DeviceRunner::finalize() {
         perf_collector_.finalize(nullptr, free_cb, nullptr);
     }
 
-    // Close all dlopen'd kernel libraries
-    for (auto& pair : func_id_to_addr_) {
-        MappedKernel& kernel = pair.second;
-        if (kernel.dl_handle != nullptr) {
-            dlclose(kernel.dl_handle);
-            LOG_DEBUG("Closed dlopen kernel: func_id=%d", pair.first);
-            kernel.dl_handle = nullptr;
-            kernel.func_addr = 0;
+    // Kernel binaries should have been removed by validate_runtime_impl()
+    if (!func_id_to_addr_.empty()) {
+        LOG_ERROR("finalize() called with %zu kernel binaries still cached",
+                  func_id_to_addr_.size());
+        // Cleanup leaked handles
+        for (auto& pair : func_id_to_addr_) {
+            MappedKernel& kernel = pair.second;
+            if (kernel.dl_handle != nullptr) {
+                dlclose(kernel.dl_handle);
+                LOG_DEBUG("Closed leaked kernel: func_id=%d", pair.first);
+            }
         }
     }
     func_id_to_addr_.clear();
@@ -477,6 +479,21 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     return kernel.func_addr;
 }
 
+void DeviceRunner::remove_kernel_binary(int func_id) {
+    auto it = func_id_to_addr_.find(func_id);
+    if (it == func_id_to_addr_.end()) {
+        return;
+    }
+
+    MappedKernel& kernel = it->second;
+    if (kernel.dl_handle != nullptr) {
+        dlclose(kernel.dl_handle);
+        LOG_DEBUG("Removed kernel binary (dlclose): func_id=%d, handle=%p", func_id, kernel.dl_handle);
+    }
+
+    func_id_to_addr_.erase(it);
+}
+
 // =============================================================================
 // Performance Profiling Implementation
 // =============================================================================
@@ -488,9 +505,16 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
         return malloc(size);
     };
 
-    // Simulation: no registration needed (pass nullptr)
+    // Define free callback (a5sim: use free)
+    auto free_cb = [](void* dev_ptr, void* user_data) -> int {
+        (void)user_data;
+        free(dev_ptr);
+        return 0;
+    };
+
+    // Simulation: no registration needed (pass nullptr for register_cb)
     return perf_collector_.initialize(runtime, num_aicore, device_id,
-                                       alloc_cb, nullptr, nullptr);
+                                       alloc_cb, nullptr, free_cb, nullptr);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -157,15 +157,14 @@ public:
     int export_swimlane_json(const std::string& output_path = "outputs");
 
     /**
-     * Clean cached resources - lightweight cleanup between tests
+     * Remove a kernel binary from memory
      *
-     * Cleans up test-specific resources while preserving device resources for reuse:
-     * - Closes dlopen'd kernel libraries (different tests may have different kernels)
-     * - Clears kernel address cache
+     * Closes the dlopen handle and removes the cached entry.
+     * This should be called during per-case cleanup.
      *
-     * @return 0 on success, error code on failure
+     * @param func_id   Function identifier to remove
      */
-    int clean_cache();
+    void remove_kernel_binary(int func_id);
 
     /**
      * Cleanup all resources

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -41,6 +41,7 @@ void device_free(void* dev_ptr);
 int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
 int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
 uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
+void remove_kernel_binary_wrapper(int func_id);
 
 /* ===========================================================================
  * Runtime API Implementation
@@ -79,6 +80,7 @@ int init_runtime(RuntimeHandle runtime,
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
+        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
 
         // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
         int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
@@ -156,6 +158,15 @@ uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size
     }
 }
 
+void remove_kernel_binary_wrapper(int func_id) {
+    try {
+        DeviceRunner& runner = DeviceRunner::get();
+        runner.remove_kernel_binary(func_id);
+    } catch (...) {
+        // Ignore errors during cleanup
+    }
+}
+
 int launch_runtime(RuntimeHandle runtime,
                    int aicpu_thread_num,
                    int block_dim,
@@ -163,7 +174,8 @@ int launch_runtime(RuntimeHandle runtime,
                    const uint8_t* aicpu_binary,
                    size_t aicpu_size,
                    const uint8_t* aicore_binary,
-                   size_t aicore_size) {
+                   size_t aicore_size,
+                   int orch_thread_num) {
     if (runtime == NULL) {
         return -1;
     }
@@ -183,6 +195,7 @@ int launch_runtime(RuntimeHandle runtime,
         }
 
         Runtime* r = static_cast<Runtime*>(runtime);
+        r->orch_thread_num = orch_thread_num;
         return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
         return -1;
@@ -196,13 +209,6 @@ int finalize_runtime(RuntimeHandle runtime) {
     try {
         Runtime* r = static_cast<Runtime*>(runtime);
         int rc = validate_runtime_impl(r);
-
-        // Clean cached resources before finalization
-        DeviceRunner& runner = DeviceRunner::get();
-        runner.clean_cache();
-
-        // Finalize DeviceRunner (clears last_runtime_ to avoid dangling pointer)
-        runner.finalize();
 
         // Call destructor (user will call free())
         r->~Runtime();

--- a/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -1,6 +1,10 @@
 /**
  * @file performance_collector_aicpu.cpp
- * @brief AICPU performance data collection implementation
+ * @brief AICPU performance data collection implementation (SPSC free queue)
+ *
+ * Uses per-core PerfBufferState with SPSC free queues for O(1) buffer switching.
+ * Host memory manager dynamically allocates replacement buffers and pushes
+ * them into the free_queue. Device pops from free_queue when switching.
  */
 
 #include "aicpu/performance_collector_aicpu.h"
@@ -10,9 +14,17 @@
 
 #include <cstring>
 
-// Cached phase profiling pointers (set during init, used on hot path)
+// Cached pointers for hot-path access (set during init)
 static AicpuPhaseHeader* s_phase_header = nullptr;
-static AicpuPhaseRecord* s_phase_records[PLATFORM_MAX_AICPU_THREADS] = {};
+static PerfDataHeader* s_perf_header = nullptr;
+
+// Per-core PerfBufferState cache
+static PerfBufferState* s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
+
+// Per-thread PhaseBufferState cache
+static PhaseBufferState* s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
+static PhaseBuffer* s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
+
 static int s_orch_thread_idx = -1;
 
 /**
@@ -20,14 +32,18 @@ static int s_orch_thread_idx = -1;
  *
  * @param header PerfDataHeader pointer
  * @param thread_idx Thread index
- * @param core_index Core index
- * @param buffer_id Buffer ID (1 or 2)
+ * @param core_index Core index (or thread_idx for phase entries)
+ * @param buffer_ptr Device pointer to the full buffer
+ * @param buffer_seq Sequence number for ordering
+ * @param is_phase 0 = PerfRecord, 1 = Phase
  * @return 0 on success, -1 if queue full
  */
 static int enqueue_ready_buffer(PerfDataHeader* header,
                                  int thread_idx,
                                  uint32_t core_index,
-                                 uint32_t buffer_id) {
+                                 uint64_t buffer_ptr,
+                                 uint32_t buffer_seq,
+                                 uint32_t is_phase) {
     uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
     uint32_t current_tail = header->queue_tails[thread_idx];
     uint32_t current_head = header->queue_heads[thread_idx];
@@ -39,7 +55,9 @@ static int enqueue_ready_buffer(PerfDataHeader* header,
     }
 
     header->queues[thread_idx][current_tail].core_index = core_index;
-    header->queues[thread_idx][current_tail].buffer_id = buffer_id;
+    header->queues[thread_idx][current_tail].is_phase = is_phase;
+    header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
+    header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
     header->queue_tails[thread_idx] = next_tail;
 
     return 0;
@@ -52,23 +70,43 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
         return;
     }
 
-    PerfDataHeader* header = get_perf_header(perf_base);
-    DoubleBuffer* buffers = get_double_buffers(perf_base);
+    s_perf_header = get_perf_header(perf_base);
 
     int32_t task_count = runtime->get_task_count();
-    header->total_tasks = static_cast<uint32_t>(task_count);
+    s_perf_header->total_tasks = static_cast<uint32_t>(task_count);
 
-    LOG_INFO("Initializing performance profiling for %d cores", runtime->worker_count);
+    LOG_INFO("Initializing performance profiling for %d cores (free queue)", runtime->worker_count);
 
-    // Assign buffer1 to each core for initial writing
+    // Pop first buffer from free_queue for each core
     for (int i = 0; i < runtime->worker_count; i++) {
         Handshake* h = &runtime->workers[i];
-        DoubleBuffer* db = &buffers[i];
+        PerfBufferState* state = get_perf_buffer_state(perf_base, i);
 
-        h->perf_records_addr = (uint64_t)&db->buffer1;
-        db->buffer1_status = BufferStatus::WRITING;
+        s_perf_buffer_states[i] = state;
 
-        LOG_DEBUG("Core %d: assigned buffer1 (addr=0x%lx)", i, h->perf_records_addr);
+        // Pop first buffer from free_queue
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+
+            PerfBuffer* buf = (PerfBuffer*)buf_ptr;
+            buf->count = 0;
+            h->perf_records_addr = buf_ptr;
+
+            LOG_DEBUG("Core %d: popped initial buffer (addr=0x%lx)", i, buf_ptr);
+        } else {
+            LOG_ERROR("Core %d: free_queue is empty during init!", i);
+            state->current_buf_ptr = 0;
+            h->perf_records_addr = 0;
+        }
     }
 
     wmb();
@@ -87,126 +125,72 @@ void perf_aicpu_record_dispatch_and_finish_time(PerfRecord* record,
     wmb();
 }
 
-
 void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
     void* perf_base = (void*)runtime->perf_data_base;
     if (perf_base == nullptr) {
         return;
     }
 
-    rmb();
-
-    Handshake* h = &runtime->workers[core_id];
-    PerfDataHeader* header = get_perf_header(perf_base);
-    DoubleBuffer* db = get_core_double_buffer(perf_base, core_id);
-
-    uint64_t current_addr = h->perf_records_addr;
-    uint64_t buffer1_addr = (uint64_t)&db->buffer1;
-    uint64_t buffer2_addr = (uint64_t)&db->buffer2;
-
-    uint32_t full_buffer_id = 0;
-    PerfBuffer* full_buf = nullptr;
-    volatile BufferStatus* full_status_ptr = nullptr;
-    PerfBuffer* alternate_buf = nullptr;
-    volatile BufferStatus* alternate_status_ptr = nullptr;
-    uint32_t alternate_buffer_id = 0;
-
-    if (current_addr == buffer1_addr) {
-        full_buffer_id = 1;
-        full_buf = &db->buffer1;
-        full_status_ptr = &db->buffer1_status;
-        alternate_buf = &db->buffer2;
-        alternate_status_ptr = &db->buffer2_status;
-        alternate_buffer_id = 2;
-    } else if (current_addr == buffer2_addr) {
-        full_buffer_id = 2;
-        full_buf = &db->buffer2;
-        full_status_ptr = &db->buffer2_status;
-        alternate_buf = &db->buffer1;
-        alternate_status_ptr = &db->buffer1_status;
-        alternate_buffer_id = 1;
-    } else {
-        LOG_ERROR("Thread %d: Core %d has invalid perf_records_addr=0x%lx",
-                  thread_idx, core_id, current_addr);
+    PerfBufferState* state = s_perf_buffer_states[core_id];
+    if (state == nullptr) {
         return;
     }
 
-    LOG_INFO("Thread %d: Core %d buffer%u is full (count=%u)",
-             thread_idx, core_id, full_buffer_id, full_buf->count);
-
-    // Complete performance records by filling fanout information
-    // Use Runtime's method - each runtime provides its own implementation
+    // Complete performance records (fill fanout info)
+    PerfBuffer* full_buf = (PerfBuffer*)state->current_buf_ptr;
+    if (full_buf == nullptr) {
+        return;
+    }
     runtime->complete_perf_records(full_buf);
 
-    BufferStatus alternate_status = *alternate_status_ptr;
+    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)",
+             thread_idx, core_id, full_buf->count);
 
-    // Wait if alternate buffer is not ready
-    if (alternate_status != BufferStatus::IDLE) {
-        LOG_WARN("Thread %d: Core %d cannot switch, buffer%u status=%u, spinning until Host reads it",
-                 thread_idx, core_id, alternate_buffer_id, static_cast<uint32_t>(alternate_status));
-
-        constexpr uint64_t TIMEOUT_SECONDS = 2;
-
-        uint64_t start_time = get_sys_cnt_aicpu();
-        bool timeout = false;
-
-        while (true) {
-            rmb();
-            alternate_status = *alternate_status_ptr;
-            uint64_t current_time = get_sys_cnt_aicpu();
-            uint64_t elapsed = current_time - start_time;
-
-            if (alternate_status == BufferStatus::IDLE) {
-                LOG_INFO("Thread %d: Core %d buffer%u now idle, proceeding with switch",
-                         thread_idx, core_id, alternate_buffer_id);
-                break;
-            } 
-
-            if (elapsed >= TIMEOUT_SECONDS * PLATFORM_PROF_SYS_CNT_FREQ) {
-                LOG_ERROR("Thread %d: Core %d buffer%u timeout after %lu seconds (status=%u)",
-                         thread_idx, core_id, alternate_buffer_id, TIMEOUT_SECONDS,
-                         static_cast<uint32_t>(alternate_status));
-                LOG_ERROR("Forcing buffer%u to IDLE and discarding performance data to prevent deadlock",
-                         alternate_buffer_id);
-                timeout = true;
-                break;
-            }
-        }
-
-        // Discard full buffer data on timeout to avoid deadlock
-        if (timeout) {
-            full_buf->count = 0;
-            *full_status_ptr = BufferStatus::WRITING;
-
-            wmb();
-
-            LOG_ERROR("Thread %d: Core %d timeout - discarded buffer%u data, reusing it for writing",
-                     thread_idx, core_id, full_buffer_id);
-
-            return;
-        }
-    }
-
-    *full_status_ptr = BufferStatus::READY;
-    *alternate_status_ptr = BufferStatus::WRITING;
-
-    // Enqueue full buffer 
-    int enqueue_result = enqueue_ready_buffer(header, thread_idx, core_id, full_buffer_id);
-    if (enqueue_result != 0) {
-        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer%u (queue full), data lost!",
-                 thread_idx, core_id, full_buffer_id);
-        // Revert status changes since we failed to enqueue
-        *full_status_ptr = BufferStatus::WRITING;
-        *alternate_status_ptr = BufferStatus::IDLE;
+    // Enqueue to ReadyQueue
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
+                                   state->current_buf_ptr, seq, 0);
+    if (rc != 0) {
+        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
+                 thread_idx, core_id);
+        // Revert: discard data and keep writing
+        full_buf->count = 0;
+        wmb();
         return;
     }
 
-    LOG_INFO("Thread %d: Core %d enqueued buffer%u", thread_idx, core_id, full_buffer_id);
+    // Pop next buffer from free_queue
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
 
-    h->perf_records_addr = (uint64_t)alternate_buf;
+    if (head != tail) {
+        uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+        rmb();
+        state->free_queue.head = head + 1;
+        state->current_buf_ptr = new_buf_ptr;
+        state->current_buf_seq = seq + 1;
+        wmb();
 
-    LOG_INFO("Thread %d: Core %d switched to buffer%u",
-             thread_idx, core_id, alternate_buffer_id);
+        PerfBuffer* new_buf = (PerfBuffer*)new_buf_ptr;
+        new_buf->count = 0;
+
+        // Update handshake for AICore
+        Handshake* h = &runtime->workers[core_id];
+        h->perf_records_addr = new_buf_ptr;
+        wmb();
+
+        LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)",
+                 thread_idx, core_id, new_buf_ptr);
+    } else {
+        // No free buffer available, stop profiling
+        LOG_WARN("Thread %d: Core %d no free buffer available, stopping profiling",
+                 thread_idx, core_id);
+        state->current_buf_ptr = 0;
+        Handshake* h = &runtime->workers[core_id];
+        h->perf_records_addr = 0;
+        wmb();
+    }
 }
 
 void perf_aicpu_flush_buffers(Runtime* runtime,
@@ -224,64 +208,45 @@ void perf_aicpu_flush_buffers(Runtime* runtime,
 
     rmb();
 
-    PerfDataHeader* header = get_perf_header(perf_base);
-    DoubleBuffer* buffers = get_double_buffers(perf_base);
-
     LOG_INFO("Thread %d: Flushing performance buffers for %d cores", thread_idx, core_num);
 
     int flushed_count = 0;
 
     for (int i = 0; i < core_num; i++) {
         int core_id = cur_thread_cores[i];
-        Handshake* h = &runtime->workers[core_id];
-        DoubleBuffer* db = &buffers[core_id];
+        PerfBufferState* state = s_perf_buffer_states[core_id];
+        if (state == nullptr) continue;
 
-        uint64_t current_addr = h->perf_records_addr;
-        if (current_addr == 0) {
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) {
+            // No active buffer
             continue;
         }
 
-        uint64_t buf1_addr = (uint64_t)&db->buffer1;
-        uint64_t buf2_addr = (uint64_t)&db->buffer2;
+        PerfBuffer* buf = (PerfBuffer*)buf_ptr;
+        if (buf->count == 0) {
+            continue;
+        }
 
-        PerfBuffer* current_buf = nullptr;
-        volatile BufferStatus* current_status = nullptr;
-        uint32_t buffer_id = 0;
+        runtime->complete_perf_records(buf);
 
-        if (current_addr == buf1_addr) {
-            current_buf = &db->buffer1;
-            current_status = &db->buffer1_status;
-            buffer_id = 1;
-        } else if (current_addr == buf2_addr) {
-            current_buf = &db->buffer2;
-            current_status = &db->buffer2_status;
-            buffer_id = 2;
+        uint32_t seq = state->current_buf_seq;
+        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
+                                       buf_ptr, seq, 0);
+        if (rc == 0) {
+            LOG_INFO("Thread %d: Core %d flushed buffer with %u records",
+                     thread_idx, core_id, buf->count);
+            flushed_count++;
+            state->current_buf_ptr = 0;
+            wmb();
         } else {
-            LOG_WARN("Thread %d: Core %d perf_records_addr=0x%lx doesn't match buffer1=0x%lx or buffer2=0x%lx",
-                     thread_idx, core_id, current_addr, buf1_addr, buf2_addr);
-            continue;
-        }
-
-        uint32_t count = current_buf->count;
-
-        if (count > 0) {
-            runtime->complete_perf_records(current_buf);
-
-            *current_status = BufferStatus::READY;
-
-            int rc = enqueue_ready_buffer(header, thread_idx, core_id, buffer_id);
-            if (rc == 0) {
-                LOG_INFO("Thread %d: Core %d flushed buffer%d with %u records",
-                         thread_idx, core_id, buffer_id, count);
-                flushed_count++;
-            } else {
-                LOG_ERROR("Thread %d: Core %d failed to enqueue buffer%d (queue full), data lost!",
-                         thread_idx, core_id, buffer_id);
-                // Revert status since we failed to enqueue
-                *current_status = BufferStatus::WRITING;
-            }
+            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
+                     thread_idx, core_id);
         }
     }
+
+    wmb();
 
     LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed",
              thread_idx, flushed_count);
@@ -298,7 +263,7 @@ void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
     wmb();
 }
 
-void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads) {
+void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, int num_orch_threads) {
     void* perf_base = (void*)runtime->perf_data_base;
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize phase profiling");
@@ -306,49 +271,171 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads) {
     }
 
     s_phase_header = get_phase_header(perf_base, runtime->worker_count);
+    s_perf_header = get_perf_header(perf_base);
 
     s_phase_header->magic = AICPU_PHASE_MAGIC;
     s_phase_header->num_sched_threads = num_sched_threads;
     s_phase_header->records_per_thread = PLATFORM_PHASE_RECORDS_PER_THREAD;
-    s_phase_header->padding = 0;
+    s_phase_header->num_cores = 0;
 
-    for (int i = 0; i < PLATFORM_MAX_AICPU_THREADS; i++) {
-        s_phase_header->buffer_counts[i] = 0;
-    }
-
+    memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
     memset(&s_phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
 
     // Cache per-thread record pointers and clear buffers
-    // Include orchestrator slot (index = num_sched_threads) if within bounds
-    int total_threads = (num_sched_threads < PLATFORM_MAX_AICPU_THREADS)
-                        ? num_sched_threads + 1 : num_sched_threads;
+    // Include all threads: scheduler + orchestrator (orchestrators may become schedulers)
+    int total_threads = num_sched_threads + num_orch_threads;
+    if (total_threads > PLATFORM_MAX_AICPU_THREADS) {
+        total_threads = PLATFORM_MAX_AICPU_THREADS;
+    }
     for (int t = 0; t < total_threads; t++) {
-        s_phase_records[t] = get_phase_records(perf_base, runtime->worker_count, t);
-        memset(s_phase_records[t], 0, PLATFORM_PHASE_RECORDS_PER_THREAD * sizeof(AicpuPhaseRecord));
+        PhaseBufferState* state = get_phase_buffer_state(perf_base, runtime->worker_count, t);
+
+        s_phase_buffer_states[t] = state;
+
+        // Pop first buffer from free_queue
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+
+            PhaseBuffer* buf = (PhaseBuffer*)buf_ptr;
+            buf->count = 0;
+            s_current_phase_buf[t] = buf;
+
+            LOG_DEBUG("Thread %d: popped initial phase buffer (addr=0x%lx)", t, buf_ptr);
+        } else {
+            LOG_ERROR("Thread %d: phase free_queue is empty during init!", t);
+            state->current_buf_ptr = 0;
+            s_current_phase_buf[t] = nullptr;
+        }
+    }
+
+    // Clear remaining slots
+    for (int t = total_threads; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        s_phase_buffer_states[t] = nullptr;
+        s_current_phase_buf[t] = nullptr;
     }
 
     wmb();
 
-    LOG_INFO("Phase profiling initialized: %d scheduler threads (+1 orch), %d records/thread",
-             num_sched_threads, PLATFORM_PHASE_RECORDS_PER_THREAD);
+    LOG_INFO("Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread",
+             num_sched_threads, num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD);
+}
+
+/**
+ * Switch phase buffer when current buffer is full (free queue version)
+ *
+ * Enqueues the full buffer to ReadyQueue and pops the next buffer from free_queue.
+ * If no free buffer is available, sets s_current_phase_buf to nullptr so subsequent
+ * records are dropped (preserving already-enqueued data).
+ */
+static void switch_phase_buffer(int thread_idx) {
+    PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+    if (state == nullptr) return;
+
+    PhaseBuffer* full_buf = s_current_phase_buf[thread_idx];
+    if (full_buf == nullptr) return;
+
+    LOG_INFO("Thread %d: phase buffer is full (count=%u)",
+             thread_idx, full_buf->count);
+
+    // Enqueue to ReadyQueue
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
+                                   state->current_buf_ptr, seq, 1);
+    if (rc != 0) {
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data",
+                 thread_idx);
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Pop next buffer from free_queue
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head != tail) {
+        uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+        rmb();
+        state->free_queue.head = head + 1;
+        state->current_buf_ptr = new_buf_ptr;
+        state->current_buf_seq = seq + 1;
+        wmb();
+
+        PhaseBuffer* new_buf = (PhaseBuffer*)new_buf_ptr;
+        new_buf->count = 0;
+        s_current_phase_buf[thread_idx] = new_buf;
+
+        LOG_INFO("Thread %d: switched to new phase buffer", thread_idx);
+    } else {
+        // No free buffer available, drop subsequent records
+        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up",
+                 thread_idx);
+        s_current_phase_buf[thread_idx] = nullptr;
+        state->current_buf_ptr = 0;
+        wmb();
+    }
 }
 
 void perf_aicpu_record_phase(int thread_idx,
-                              AicpuPhaseId phase_id,
+    AicpuPhaseId phase_id,
                               uint64_t start_time, uint64_t end_time,
                               uint32_t loop_iter, uint32_t tasks_processed) {
     if (s_phase_header == nullptr) {
         return;
     }
 
-    uint32_t idx = s_phase_header->buffer_counts[thread_idx];
+    PhaseBuffer* buf = s_current_phase_buf[thread_idx];
 
-    if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
-        return;  // Buffer full, silently drop
+    // Try to recover from nullptr (no buffer was available on previous switch)
+    if (buf == nullptr) {
+        PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+        if (state == nullptr) return;
+
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = state->current_buf_seq + 1;
+            wmb();
+
+            buf = (PhaseBuffer*)buf_ptr;
+            buf->count = 0;
+            s_current_phase_buf[thread_idx] = buf;
+
+            LOG_INFO("Thread %d: recovered phase buffer", thread_idx);
+        }
+        if (buf == nullptr) return;  // Still no buffer available
     }
 
-    AicpuPhaseRecord* record = &s_phase_records[thread_idx][idx];
+    uint32_t idx = buf->count;
 
+    if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
+        // Buffer full, switch to next buffer
+        switch_phase_buffer(thread_idx);
+        buf = s_current_phase_buf[thread_idx];
+        if (buf == nullptr) return;  // No buffer available
+        idx = buf->count;
+        if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
+            return;  // Switch failed; drop this record
+        }
+    }
+
+    AicpuPhaseRecord* record = &buf->records[idx];
     record->start_time = start_time;
     record->end_time = end_time;
     record->loop_iter = loop_iter;
@@ -356,7 +443,7 @@ void perf_aicpu_record_phase(int thread_idx,
     record->tasks_processed = tasks_processed;
     record->padding = 0;
 
-    s_phase_header->buffer_counts[thread_idx] = idx + 1;
+    buf->count = idx + 1;
 }
 
 void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src) {
@@ -383,7 +470,69 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx) {
 
 void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
                                    uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx) {
+                                   uint32_t submit_idx, uint32_t task_id) {
     if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
-    perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, 0);
+    perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
+}
+
+void perf_aicpu_flush_phase_buffers(int thread_idx) {
+    if (s_phase_header == nullptr || s_perf_header == nullptr) {
+        return;
+    }
+
+    PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+    if (state == nullptr) return;
+
+    rmb();
+    uint64_t buf_ptr = state->current_buf_ptr;
+    if (buf_ptr == 0) {
+        // No active buffer
+        return;
+    }
+
+    PhaseBuffer* buf = (PhaseBuffer*)buf_ptr;
+    if (buf->count == 0) {
+        return;
+    }
+
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
+                                   buf_ptr, seq, 1);
+    if (rc == 0) {
+        LOG_INFO("Thread %d: flushed phase buffer with %u records",
+                 thread_idx, buf->count);
+        state->current_buf_ptr = 0;
+        s_current_phase_buf[thread_idx] = nullptr;
+        wmb();
+    } else {
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!",
+                 thread_idx);
+    }
+
+    wmb();
+}
+
+void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
+                                        const int* core_counts,
+                                        int num_threads,
+                                        int total_cores) {
+    if (s_phase_header == nullptr) {
+        return;
+    }
+
+    memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
+    s_phase_header->num_cores = static_cast<uint32_t>(total_cores);
+
+    for (int t = 0; t < num_threads; t++) {
+        for (int i = 0; i < core_counts[t]; i++) {
+            int core_id = core_assignments[t][i];
+            if (core_id >= 0 && core_id < PLATFORM_MAX_CORES) {
+                s_phase_header->core_to_thread[core_id] = static_cast<int8_t>(t);
+            }
+        }
+    }
+
+    wmb();
+
+    LOG_INFO("Core-to-thread mapping written: %d cores, %d threads", total_cores, num_threads);
 }

--- a/src/a5/platform/src/host/performance_collector.cpp
+++ b/src/a5/platform/src/host/performance_collector.cpp
@@ -1,6 +1,9 @@
 /**
  * @file performance_collector.cpp
  * @brief Platform-agnostic performance data collector implementation
+ *
+ * Implements ProfMemoryManager (dynamic buffer management thread) and
+ * PerformanceCollector (data collection and export).
  */
 
 #include "host/performance_collector.h"
@@ -17,10 +20,361 @@
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
 
+// =============================================================================
+// ProfMemoryManager Implementation
+// =============================================================================
+
+ProfMemoryManager::~ProfMemoryManager() {
+    if (running_.load()) {
+        stop();
+    }
+}
+
+void ProfMemoryManager::start(void* shared_mem_host, int num_cores, int num_phase_threads,
+                               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
+                               PerfFreeCallback free_cb, void* user_data, int device_id) {
+    shared_mem_host_ = shared_mem_host;
+    num_cores_ = num_cores;
+    num_phase_threads_ = num_phase_threads;
+    alloc_cb_ = alloc_cb;
+    register_cb_ = register_cb;
+    free_cb_ = free_cb;
+    user_data_ = user_data;
+    device_id_ = device_id;
+
+    running_.store(true);
+    mgmt_thread_ = std::thread(&ProfMemoryManager::mgmt_loop, this);
+
+    LOG_INFO("ProfMemoryManager started: %d cores, %d phase threads", num_cores, num_phase_threads);
+}
+
+void ProfMemoryManager::stop() {
+    running_.store(false);
+    if (mgmt_thread_.joinable()) {
+        mgmt_thread_.join();
+    }
+
+    // Drain remaining done_queue and free buffers
+    {
+        std::lock_guard<std::mutex> lock(done_mutex_);
+        while (!done_queue_.empty()) {
+            CopyDoneInfo info = done_queue_.front();
+            done_queue_.pop();
+            free_buffer(info.dev_buffer_ptr);
+        }
+    }
+
+    LOG_INFO("ProfMemoryManager stopped");
+}
+
+bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo& info) {
+    std::lock_guard<std::mutex> lock(ready_mutex_);
+    if (ready_queue_.empty()) {
+        return false;
+    }
+    info = ready_queue_.front();
+    ready_queue_.pop();
+    return true;
+}
+
+bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(ready_mutex_);
+    if (ready_cv_.wait_for(lock, timeout, [this]{ return !ready_queue_.empty(); })) {
+        info = ready_queue_.front();
+        ready_queue_.pop();
+        return true;
+    }
+    return false;
+}
+
+void ProfMemoryManager::notify_copy_done(const CopyDoneInfo& info) {
+    std::lock_guard<std::mutex> lock(done_mutex_);
+    done_queue_.push(info);
+}
+
+void* ProfMemoryManager::alloc_and_register(size_t size, void** host_ptr_out) {
+    void* dev_ptr = alloc_cb_(size, user_data_);
+    if (dev_ptr == nullptr) {
+        LOG_ERROR("ProfMemoryManager: alloc failed for %zu bytes", size);
+        *host_ptr_out = nullptr;
+        return nullptr;
+    }
+
+    if (register_cb_ != nullptr) {
+        void* host_ptr = nullptr;
+        int rc = register_cb_(dev_ptr, size, device_id_, user_data_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("ProfMemoryManager: register failed: %d", rc);
+            free_buffer(dev_ptr);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        *host_ptr_out = host_ptr;
+    } else {
+        // Simulation mode: dev_ptr == host_ptr
+        *host_ptr_out = dev_ptr;
+    }
+
+    dev_to_host_[dev_ptr] = *host_ptr_out;
+    return dev_ptr;
+}
+
+void ProfMemoryManager::free_buffer(void* dev_ptr) {
+    if (dev_ptr != nullptr && free_cb_ != nullptr) {
+        dev_to_host_.erase(dev_ptr);
+        free_cb_(dev_ptr, user_data_);
+    }
+}
+
+void* ProfMemoryManager::resolve_host_ptr(void* dev_ptr) {
+    if (register_cb_ == nullptr) {
+        return dev_ptr;  // Simulation mode: dev_ptr == host_ptr
+    }
+    auto it = dev_to_host_.find(dev_ptr);
+    if (it != dev_to_host_.end()) {
+        return it->second;
+    }
+    LOG_ERROR("ProfMemoryManager: no host mapping for dev_ptr=%p", dev_ptr);
+    return nullptr;
+}
+
+void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) {
+    dev_to_host_[dev_ptr] = host_ptr;
+}
+
+void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*thread_idx*/,
+                                              const ReadyQueueEntry& entry) {
+    bool is_phase = (entry.is_phase != 0);
+    uint64_t old_dev_ptr = entry.buffer_ptr;
+    uint32_t seq = entry.buffer_seq;
+
+    if (is_phase) {
+        uint32_t tidx = entry.core_index;
+        if (tidx >= static_cast<uint32_t>(PLATFORM_MAX_AICPU_THREADS)) {
+            LOG_ERROR("ProfMemoryManager: invalid phase entry: thread=%u", tidx);
+            return;
+        }
+
+        PhaseBufferState* state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
+
+        // Allocate new PhaseBuffer
+        void* host_ptr = nullptr;
+        void* new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
+        if (new_dev_ptr != nullptr) {
+            // Initialize new buffer
+            PhaseBuffer* new_buf = (PhaseBuffer*)host_ptr;
+            new_buf->count = 0;
+
+            // Push to free_queue (with overflow guard)
+            rmb();
+            uint32_t head_val = state->free_queue.head;
+            uint32_t tail = state->free_queue.tail;
+            if ((tail - head_val) >= PLATFORM_PROF_SLOT_COUNT) {
+                LOG_ERROR("ProfMemoryManager: phase free_queue overflow for thread %u", tidx);
+                free_buffer(new_dev_ptr);
+            } else {
+                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] = (uint64_t)new_dev_ptr;
+                wmb();
+                state->free_queue.tail = tail + 1;
+                wmb();
+            }
+        } else {
+            LOG_ERROR("ProfMemoryManager: phase buffer alloc failed, device may lose data");
+        }
+
+        // Resolve host pointer of old buffer
+        void* old_host_ptr = resolve_host_ptr((void*)old_dev_ptr);
+        if (old_host_ptr == nullptr) {
+            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p", (void*)old_dev_ptr);
+            return;
+        }
+
+        // Push old buffer to ready queue for main thread to copy
+        ReadyBufferInfo info;
+        info.type = ProfBufferType::PHASE;
+        info.index = tidx;
+        info.slot_idx = 0;  // Not used in free queue design
+        info.dev_buffer_ptr = (void*)old_dev_ptr;
+        info.host_buffer_ptr = old_host_ptr;
+        info.buffer_seq = seq;
+
+        {
+            std::lock_guard<std::mutex> lock(ready_mutex_);
+            ready_queue_.push(info);
+        }
+        ready_cv_.notify_one();
+
+    } else {
+        uint32_t core_index = entry.core_index;
+        if (core_index >= static_cast<uint32_t>(num_cores_)) {
+            LOG_ERROR("ProfMemoryManager: invalid perf entry: core=%u", core_index);
+            return;
+        }
+
+        PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, core_index);
+
+        // Allocate new PerfBuffer
+        void* host_ptr = nullptr;
+        void* new_dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
+        if (new_dev_ptr != nullptr) {
+            PerfBuffer* new_buf = (PerfBuffer*)host_ptr;
+            new_buf->count = 0;
+
+            // Push to free_queue (with overflow guard)
+            rmb();
+            uint32_t head_val = state->free_queue.head;
+            uint32_t tail = state->free_queue.tail;
+            if ((tail - head_val) >= PLATFORM_PROF_SLOT_COUNT) {
+                LOG_ERROR("ProfMemoryManager: perf free_queue overflow for core %u", core_index);
+                free_buffer(new_dev_ptr);
+            } else {
+                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] = (uint64_t)new_dev_ptr;
+                wmb();
+                state->free_queue.tail = tail + 1;
+                wmb();
+            }
+        } else {
+            LOG_ERROR("ProfMemoryManager: perf buffer alloc failed, device may lose data");
+        }
+
+        void* old_host_ptr = resolve_host_ptr((void*)old_dev_ptr);
+        if (old_host_ptr == nullptr) {
+            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p", (void*)old_dev_ptr);
+            return;
+        }
+
+        ReadyBufferInfo info;
+        info.type = ProfBufferType::PERF_RECORD;
+        info.index = core_index;
+        info.slot_idx = 0;  // Not used in free queue design
+        info.dev_buffer_ptr = (void*)old_dev_ptr;
+        info.host_buffer_ptr = old_host_ptr;
+        info.buffer_seq = seq;
+
+        {
+            std::lock_guard<std::mutex> lock(ready_mutex_);
+            ready_queue_.push(info);
+        }
+        ready_cv_.notify_one();
+    }
+}
+
+void ProfMemoryManager::mgmt_loop() {
+    PerfDataHeader* header = get_perf_header(shared_mem_host_);
+
+    while (running_.load()) {
+        // 1. Process done queue: free buffers that main thread has finished copying
+        {
+            std::lock_guard<std::mutex> lock(done_mutex_);
+            while (!done_queue_.empty()) {
+                CopyDoneInfo info = done_queue_.front();
+                done_queue_.pop();
+                free_buffer(info.dev_buffer_ptr);
+            }
+        }
+
+        // 2. Poll ReadyQueues from all AICPU threads
+        bool found_any = false;
+        for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+            rmb();
+            uint32_t head = header->queue_heads[t];
+            uint32_t tail = header->queue_tails[t];
+
+            // Validate indices to prevent OOB access from corrupted shared memory
+            if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                LOG_ERROR("mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)",
+                          t, head, tail, PLATFORM_PROF_READYQUEUE_SIZE);
+                continue;
+            }
+
+            while (head != tail) {
+                ReadyQueueEntry entry = header->queues[t][head];
+
+                process_ready_entry(header, t, entry);
+
+                head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
+                header->queue_heads[t] = head;
+                wmb();
+
+                found_any = true;
+
+                // Re-read tail in case more entries arrived
+                rmb();
+                tail = header->queue_tails[t];
+                if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                    LOG_ERROR("mgmt_loop: invalid tail for thread %d: %u", t, tail);
+                    break;
+                }
+            }
+        }
+
+        // 3. If nothing found, yield briefly to avoid busy-spinning
+        if (!found_any) {
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
+        }
+    }
+
+    // Final drain: process any remaining entries
+    PerfDataHeader* hdr = get_perf_header(shared_mem_host_);
+    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        rmb();
+        uint32_t head = hdr->queue_heads[t];
+        uint32_t tail = hdr->queue_tails[t];
+        if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u",
+                      t, head, tail);
+            continue;
+        }
+        while (head != tail) {
+            ReadyQueueEntry entry = hdr->queues[t][head];
+            process_ready_entry(hdr, t, entry);
+            head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
+            hdr->queue_heads[t] = head;
+            wmb();
+            rmb();
+            tail = hdr->queue_tails[t];
+            if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                LOG_ERROR("mgmt_loop drain: invalid tail for thread %d: %u", t, tail);
+                break;
+            }
+        }
+    }
+}
+
+// =============================================================================
+// PerformanceCollector Implementation
+// =============================================================================
+
 PerformanceCollector::~PerformanceCollector() {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_WARN("PerformanceCollector destroyed without finalize()");
     }
+}
+
+void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out) {
+    void* dev_ptr = alloc_cb_(size, user_data_);
+    if (dev_ptr == nullptr) {
+        LOG_ERROR("Failed to allocate buffer (%zu bytes)", size);
+        *host_ptr_out = nullptr;
+        return nullptr;
+    }
+
+    if (register_cb_ != nullptr) {
+        void* host_ptr = nullptr;
+        int rc = register_cb_(dev_ptr, size, device_id_, user_data_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("Buffer registration failed: %d", rc);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        *host_ptr_out = host_ptr;
+    } else {
+        *host_ptr_out = dev_ptr;
+    }
+
+    // Register mapping so ProfMemoryManager can resolve dev→host
+    memory_manager_.register_mapping(dev_ptr, *host_ptr_out);
+    return dev_ptr;
 }
 
 int PerformanceCollector::initialize(Runtime& runtime,
@@ -28,6 +382,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
                                       int device_id,
                                       PerfAllocCallback alloc_cb,
                                       PerfRegisterCallback register_cb,
+                                      PerfFreeCallback free_cb,
                                       void* user_data) {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
@@ -43,33 +398,32 @@ int PerformanceCollector::initialize(Runtime& runtime,
 
     device_id_ = device_id;
     num_aicore_ = num_aicore;
+    alloc_cb_ = alloc_cb;
+    register_cb_ = register_cb;
+    free_cb_ = free_cb;
+    user_data_ = user_data;
 
-    // Step 1: Calculate total memory size (with phase profiling region)
-    // All PLATFORM_MAX_AICPU_THREADS slots: scheduler threads + orchestrator thread
+    // Step 1: Calculate shared memory size (slot arrays only, no actual buffers)
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
     size_t total_size = calc_perf_data_size_with_phases(num_aicore, num_phase_threads);
-    size_t header_size = sizeof(PerfDataHeader);
-    size_t single_db_size = sizeof(DoubleBuffer);
-    size_t buffers_size = num_aicore * single_db_size;
 
-    LOG_DEBUG("Memory allocation plan:");
+    LOG_DEBUG("Shared memory allocation plan:");
     LOG_DEBUG("  Number of cores:      %d", num_aicore);
-    LOG_DEBUG("  Header size:          %zu bytes", header_size);
-    LOG_DEBUG("  Ready queue entries:  %d", PLATFORM_PROF_READYQUEUE_SIZE);
-    LOG_DEBUG("  Single DoubleBuffer:  %zu bytes", single_db_size);
-    LOG_DEBUG("  All DoubleBuffers:    %zu bytes", buffers_size);
-    LOG_DEBUG("  Total size:           %zu bytes (%zu KB, %zu MB)",
-              total_size, total_size / 1024, total_size / (1024 * 1024));
+    LOG_DEBUG("  Header size:          %zu bytes", sizeof(PerfDataHeader));
+    LOG_DEBUG("  PerfBufferState size: %zu bytes each", sizeof(PerfBufferState));
+    LOG_DEBUG("  PhaseBufferState size:%zu bytes each", sizeof(PhaseBufferState));
+    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)",
+              total_size, total_size / 1024);
 
-    // Step 2: Allocate device memory via callback
+    // Step 2: Allocate shared memory for slot arrays
     void* perf_dev_ptr = alloc_cb(total_size, user_data);
     if (perf_dev_ptr == nullptr) {
-        LOG_ERROR("Failed to allocate device memory for profiling (%zu bytes)", total_size);
+        LOG_ERROR("Failed to allocate shared memory (%zu bytes)", total_size);
         return -1;
     }
-    LOG_DEBUG("Allocated device memory: %p", perf_dev_ptr);
+    LOG_DEBUG("Allocated shared memory: %p", perf_dev_ptr);
 
-    // Step 3: Register to host mapping (optional, can be nullptr for simulation)
+    // Step 3: Register to host mapping (optional)
     void* perf_host_ptr = nullptr;
     if (register_cb != nullptr) {
         int rc = register_cb(perf_dev_ptr, total_size, device_id, user_data, &perf_host_ptr);
@@ -84,7 +438,6 @@ int PerformanceCollector::initialize(Runtime& runtime,
         }
         LOG_DEBUG("Mapped to host memory: %p", perf_host_ptr);
     } else {
-        // Simulation mode: both pointers point to same memory
         perf_host_ptr = perf_dev_ptr;
         LOG_DEBUG("Simulation mode: host_ptr = dev_ptr = %p", perf_host_ptr);
     }
@@ -105,32 +458,100 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("  num_cores:        %d", header->num_cores);
     LOG_DEBUG("  buffer_capacity:  %d", PLATFORM_PROF_BUFFER_SIZE);
     LOG_DEBUG("  queue capacity:   %d", PLATFORM_PROF_READYQUEUE_SIZE);
-    LOG_DEBUG("  num threads:      %d", PLATFORM_MAX_AICPU_THREADS);
 
-    // Step 5: Initialize all DoubleBuffers
-    DoubleBuffer* buffers = get_double_buffers(perf_host_ptr);
+    // Step 5: Initialize PerfBufferStates and pre-fill free_queues
     for (int i = 0; i < num_aicore; i++) {
-        DoubleBuffer* db = &buffers[i];
-        memset(&db->buffer1, 0, sizeof(PerfBuffer));
-        db->buffer1.count = 0;
-        db->buffer1_status = BufferStatus::IDLE;
-        memset(&db->buffer2, 0, sizeof(PerfBuffer));
-        db->buffer2.count = 0;
-        db->buffer2_status = BufferStatus::IDLE;
+        PerfBufferState* state = get_perf_buffer_state(perf_host_ptr, i);
+        memset(state, 0, sizeof(PerfBufferState));
+
+        state->free_queue.head = 0;
+        state->free_queue.tail = 0;
+        state->current_buf_ptr = 0;
+        state->current_buf_seq = 0;
+
+        // Pre-fill free_queue with PLATFORM_PROF_SLOT_COUNT buffers
+        for (int s = 0; s < PLATFORM_PROF_SLOT_COUNT; s++) {
+            void* host_buf_ptr = nullptr;
+            void* dev_buf_ptr = alloc_single_buffer(sizeof(PerfBuffer), &host_buf_ptr);
+            if (dev_buf_ptr == nullptr) {
+                LOG_ERROR("Failed to allocate PerfBuffer for core %d, buffer %d", i, s);
+                return -1;
+            }
+            // Initialize buffer
+            PerfBuffer* buf = (PerfBuffer*)host_buf_ptr;
+            memset(buf, 0, sizeof(PerfBuffer));
+            buf->count = 0;
+
+            // Push to free_queue
+            state->free_queue.buffer_ptrs[s] = (uint64_t)dev_buf_ptr;
+        }
+        wmb();
+        state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
+        wmb();
     }
-    LOG_DEBUG("Initialized %d DoubleBuffers (all status=0, idle)", num_aicore);
+    LOG_DEBUG("Initialized %d PerfBufferStates with %d buffers each",
+              num_aicore, PLATFORM_PROF_SLOT_COUNT);
+
+    // Step 6: Initialize PhaseBufferStates and pre-fill free_queues
+    for (int t = 0; t < num_phase_threads; t++) {
+        PhaseBufferState* state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
+        memset(state, 0, sizeof(PhaseBufferState));
+
+        state->free_queue.head = 0;
+        state->free_queue.tail = 0;
+        state->current_buf_ptr = 0;
+        state->current_buf_seq = 0;
+
+        // Pre-fill free_queue with PLATFORM_PROF_SLOT_COUNT buffers
+        for (int s = 0; s < PLATFORM_PROF_SLOT_COUNT; s++) {
+            void* host_buf_ptr = nullptr;
+            void* dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
+            if (dev_buf_ptr == nullptr) {
+                LOG_ERROR("Failed to allocate PhaseBuffer for thread %d, buffer %d", t, s);
+                return -1;
+            }
+            PhaseBuffer* buf = (PhaseBuffer*)host_buf_ptr;
+            memset(buf, 0, sizeof(PhaseBuffer));
+            buf->count = 0;
+
+            // Push to free_queue
+            state->free_queue.buffer_ptrs[s] = (uint64_t)dev_buf_ptr;
+        }
+        wmb();
+        state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
+        wmb();
+    }
+    LOG_DEBUG("Initialized %d PhaseBufferStates with %d buffers each",
+              num_phase_threads, PLATFORM_PROF_SLOT_COUNT);
 
     wmb();
 
-    // Step 6: Pass to Runtime
+    // Step 7: Pass base address to Runtime
     runtime.perf_data_base = (uint64_t)perf_dev_ptr;
     LOG_DEBUG("Set runtime.perf_data_base = 0x%lx", runtime.perf_data_base);
 
     perf_shared_mem_dev_ = perf_dev_ptr;
     perf_shared_mem_host_ = perf_host_ptr;
 
-    LOG_INFO("Performance profiling initialized");
+    LOG_INFO("Performance profiling initialized (dynamic buffer mode)");
     return 0;
+}
+
+void PerformanceCollector::start_memory_manager() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    memory_manager_.start(perf_shared_mem_host_, num_aicore_,
+                           PLATFORM_MAX_AICPU_THREADS,
+                           alloc_cb_, register_cb_, free_cb_,
+                           user_data_, device_id_);
+}
+
+void PerformanceCollector::stop_memory_manager() {
+    if (memory_manager_.is_running()) {
+        memory_manager_.stop();
+    }
 }
 
 void PerformanceCollector::poll_and_collect(int expected_tasks) {
@@ -141,8 +562,6 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     LOG_INFO("Collecting performance data");
 
     PerfDataHeader* header = get_perf_header(perf_shared_mem_host_);
-    DoubleBuffer* buffers = get_double_buffers(perf_shared_mem_host_);
-    int num_aicore = num_aicore_;
 
     const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);
     std::optional<std::chrono::steady_clock::time_point> idle_start;
@@ -165,8 +584,14 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             if (elapsed >= timeout_duration) {
                 LOG_ERROR("Timeout waiting for AICPU task count after %ld seconds",
                          std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
-                LOG_INFO("AICPU finally reported task count: %d", raw_total_tasks);
                 return;
+            }
+
+            // Check for ready buffers while waiting
+            ReadyBufferInfo info;
+            if (memory_manager_.try_pop_ready(info)) {
+                // Process it (even before we know expected_tasks)
+                // Will be counted below
             }
         }
     }
@@ -177,16 +602,27 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     int buffers_processed = 0;
 
     collected_perf_records_.clear();
-    collected_perf_records_.resize(num_aicore);
+    collected_perf_records_.resize(num_aicore_);
+
+    // Pre-allocate phase record storage
+    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    int num_sched_for_poll = 0;
+    if (phase_header->magic == AICPU_PHASE_MAGIC) {
+        num_sched_for_poll = phase_header->num_sched_threads;
+        if (num_sched_for_poll > PLATFORM_MAX_AICPU_THREADS) {
+            num_sched_for_poll = PLATFORM_MAX_AICPU_THREADS;
+        }
+        collected_phase_records_.clear();
+        collected_phase_records_.resize(num_sched_for_poll);
+        collected_orch_phase_records_.clear();
+    }
+
     idle_start.reset();
-    int empty_poll_count = 0;
     int last_logged_expected = -1;
 
-    int current_thread = 0;
-
     while (total_records_collected < expected_tasks) {
+        // Check for updated expected_tasks
         rmb();
-
         int current_expected = static_cast<int>(header->total_tasks);
         if (current_expected > expected_tasks) {
             expected_tasks = current_expected;
@@ -196,73 +632,69 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             }
         }
 
-        uint32_t head = header->queue_heads[current_thread];
-        uint32_t tail = header->queue_tails[current_thread];
+        ReadyBufferInfo info;
+        if (memory_manager_.wait_pop_ready(info, std::chrono::milliseconds(100))) {
+            idle_start.reset();
 
-        if (head == tail) {
-            current_thread = (current_thread + 1) % PLATFORM_MAX_AICPU_THREADS;
-
-            if (current_thread == 0) {
-                if (!idle_start.has_value()) {
-                    idle_start = std::chrono::steady_clock::now();
+            if (info.type == ProfBufferType::PERF_RECORD) {
+                PerfBuffer* buf = (PerfBuffer*)info.host_buffer_ptr;
+                rmb();
+                uint32_t count = buf->count;
+                if (count > PLATFORM_PROF_BUFFER_SIZE) {
+                    count = PLATFORM_PROF_BUFFER_SIZE;
                 }
 
-                empty_poll_count++;
-                if (empty_poll_count >= PLATFORM_PROF_EMPTY_POLLS_CHECK_NUM) {
-                    empty_poll_count = 0;
-                    auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
-                    if (elapsed >= timeout_duration) {
-                        LOG_ERROR("Performance data collection idle timeout after %ld seconds",
-                                 std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
-                        LOG_ERROR("Collected %d / %d records before timeout",
-                                 total_records_collected, expected_tasks);
-                        break;
+                uint32_t core_index = info.index;
+                if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_perf_records_[core_index].push_back(buf->records[i]);
+                    }
+                    total_records_collected += count;
+                }
+
+                LOG_DEBUG("Collected %u perf records from core %u (total: %d/%d)",
+                         count, core_index, total_records_collected, expected_tasks);
+
+            } else {
+                PhaseBuffer* buf = (PhaseBuffer*)info.host_buffer_ptr;
+                rmb();
+                uint32_t count = buf->count;
+                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                }
+
+                uint32_t tidx = info.index;
+                if (tidx < static_cast<uint32_t>(num_sched_for_poll)) {
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_phase_records_[tidx].push_back(buf->records[i]);
+                    }
+                } else {
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_orch_phase_records_.push_back(buf->records[i]);
                     }
                 }
+
+                LOG_DEBUG("Collected %u phase records from thread %u", count, tidx);
             }
-            continue;
+
+            // Notify memory manager to free old buffer
+            memory_manager_.notify_copy_done({info.dev_buffer_ptr});
+            buffers_processed++;
+
+        } else {
+            // Timeout on wait — check for overall timeout
+            if (!idle_start.has_value()) {
+                idle_start = std::chrono::steady_clock::now();
+            }
+            auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
+            if (elapsed >= timeout_duration) {
+                LOG_ERROR("Performance data collection idle timeout after %ld seconds",
+                         std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                LOG_ERROR("Collected %d / %d records before timeout",
+                         total_records_collected, expected_tasks);
+                break;
+            }
         }
-
-        idle_start.reset();
-        empty_poll_count = 0;
-
-        ReadyQueueEntry entry = header->queues[current_thread][head];
-        uint32_t core_index = entry.core_index;
-        uint32_t buffer_id = entry.buffer_id;
-
-        if (core_index >= static_cast<uint32_t>(num_aicore)) {
-            LOG_ERROR("Invalid core_index %u (max=%d)", core_index, num_aicore);
-            break;
-        }
-
-        LOG_DEBUG("Processing: thread=%d, core=%u, buffer=%u", current_thread, core_index, buffer_id);
-
-        DoubleBuffer* db = &buffers[core_index];
-        PerfBuffer* buf = nullptr;
-        volatile BufferStatus* status = nullptr;
-        get_buffer_and_status(db, buffer_id, &buf, &status);
-
-        rmb();
-        uint32_t count = buf->count;
-        LOG_DEBUG("  Records in buffer: %u", count);
-
-        for (uint32_t i = 0; i < count && i < PLATFORM_PROF_BUFFER_SIZE; i++) {
-            collected_perf_records_[core_index].push_back(buf->records[i]);
-            total_records_collected++;
-        }
-
-        buf->count = 0;
-        *status = BufferStatus::IDLE;
-        header->queue_heads[current_thread] = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
-        wmb();
-
-        buffers_processed++;
-
-        current_thread = (current_thread + 1) % PLATFORM_MAX_AICPU_THREADS;
-    }
-
-    if (last_logged_expected >= 0 && expected_tasks != last_logged_expected) {
-        LOG_INFO("Final expected_tasks: %d (orchestration complete)", expected_tasks);
     }
 
     LOG_INFO("Total buffers processed: %d", buffers_processed);
@@ -274,6 +706,77 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     }
 
     LOG_INFO("Performance data collection complete");
+}
+
+void PerformanceCollector::drain_remaining_buffers() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    // Ensure phase record storage is initialized
+    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    rmb();
+    int num_sched = 0;
+    if (phase_header->magic == AICPU_PHASE_MAGIC) {
+        num_sched = phase_header->num_sched_threads;
+        if (num_sched > PLATFORM_MAX_AICPU_THREADS) {
+            num_sched = PLATFORM_MAX_AICPU_THREADS;
+        }
+        if (collected_phase_records_.size() < static_cast<size_t>(num_sched)) {
+            collected_phase_records_.resize(num_sched);
+        }
+    }
+
+    int drained_perf = 0;
+    int drained_phase = 0;
+
+    ReadyBufferInfo info;
+    while (memory_manager_.try_pop_ready(info)) {
+        if (info.type == ProfBufferType::PERF_RECORD) {
+            PerfBuffer* buf = (PerfBuffer*)info.host_buffer_ptr;
+            rmb();
+            uint32_t count = buf->count;
+            if (count > PLATFORM_PROF_BUFFER_SIZE) {
+                count = PLATFORM_PROF_BUFFER_SIZE;
+            }
+            uint32_t core_index = info.index;
+            if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_perf_records_[core_index].push_back(buf->records[i]);
+                }
+                drained_perf += count;
+            }
+        } else {
+            PhaseBuffer* buf = (PhaseBuffer*)info.host_buffer_ptr;
+            rmb();
+            uint32_t count = buf->count;
+            if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+            }
+            uint32_t tidx = info.index;
+            if (tidx < static_cast<uint32_t>(num_sched)) {
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_phase_records_[tidx].push_back(buf->records[i]);
+                }
+            } else {
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_orch_phase_records_.push_back(buf->records[i]);
+                }
+            }
+            drained_phase += count;
+        }
+
+        memory_manager_.notify_copy_done({info.dev_buffer_ptr});
+    }
+
+    if (drained_perf > 0 || drained_phase > 0) {
+        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records",
+                 drained_perf, drained_phase);
+    }
+
+    if (drained_phase > 0) {
+        has_phase_data_ = true;
+    }
 }
 
 void PerformanceCollector::collect_phase_data() {
@@ -298,38 +801,58 @@ void PerformanceCollector::collect_phase_data() {
                   num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
         return;
     }
-    LOG_INFO("Collecting phase data: %d scheduler threads", num_sched_threads);
+    LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
 
-    // Read per-thread phase records
-    collected_phase_records_.clear();
-    collected_phase_records_.resize(num_sched_threads);
-
-    int total_phase_records = 0;
-    for (int t = 0; t < num_sched_threads; t++) {
-        uint32_t count = phase_header->buffer_counts[t];
-        if (count > PLATFORM_PHASE_RECORDS_PER_THREAD) {
-            count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-        }
-
-        AicpuPhaseRecord* records = get_phase_records(perf_shared_mem_host_, num_aicore_, t);
-        collected_phase_records_[t].assign(records, records + count);
-        total_phase_records += count;
-        LOG_INFO("  Thread %d: %u phase records", t, count);
+    int total_slots = (num_sched_threads < PLATFORM_MAX_AICPU_THREADS)
+                      ? num_sched_threads + 1 : num_sched_threads;
+    if (collected_phase_records_.size() < static_cast<size_t>(num_sched_threads)) {
+        collected_phase_records_.resize(num_sched_threads);
     }
 
-    // Read orchestrator per-task phase records (slot = num_sched_threads)
-    collected_orch_phase_records_.clear();
-    if (num_sched_threads < PLATFORM_MAX_AICPU_THREADS) {
-        uint32_t orch_count = phase_header->buffer_counts[num_sched_threads];
-        if (orch_count > PLATFORM_PHASE_RECORDS_PER_THREAD) {
-            orch_count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+    // Scan remaining PhaseBufferStates for active buffers with partial data.
+    // READY buffers were already enqueued to the ReadyQueue and collected via
+    // poll_and_collect() or drain_remaining_buffers(). Only current_buf_ptr
+    // contains partial data that was never enqueued (the active buffer when execution ended).
+    int total_phase_records = 0;
+    for (int t = 0; t < total_slots; t++) {
+        PhaseBufferState* state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr != 0) {
+            void* host_ptr = memory_manager_.resolve_host_ptr((void*)buf_ptr);
+            if (host_ptr == nullptr) {
+                LOG_ERROR("collect_phase_data: no host mapping for dev_ptr=%p (thread %d)",
+                          (void*)buf_ptr, t);
+                continue;
+            }
+            PhaseBuffer* pbuf = (PhaseBuffer*)host_ptr;
+            if (pbuf->count > 0) {
+                uint32_t count = pbuf->count;
+                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                }
+
+                if (t < num_sched_threads) {
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_phase_records_[t].push_back(pbuf->records[i]);
+                    }
+                } else {
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_orch_phase_records_.push_back(pbuf->records[i]);
+                    }
+                }
+                total_phase_records += count;
+            }
         }
-        if (orch_count > 0) {
-            AicpuPhaseRecord* orch_records = get_phase_records(perf_shared_mem_host_, num_aicore_, num_sched_threads);
-            collected_orch_phase_records_.assign(orch_records, orch_records + orch_count);
-            total_phase_records += orch_count;
-            LOG_INFO("  Orchestrator: %u per-task phase records", orch_count);
-        }
+    }
+
+    // Log per-thread totals
+    for (int t = 0; t < num_sched_threads; t++) {
+        LOG_INFO("  Thread %d: %zu phase records", t, collected_phase_records_[t].size());
+    }
+    if (!collected_orch_phase_records_.empty()) {
+        LOG_INFO("  Orchestrator: %zu per-task phase records", collected_orch_phase_records_.size());
     }
 
     // Read orchestrator summary
@@ -344,9 +867,26 @@ void PerformanceCollector::collect_phase_data() {
         LOG_INFO("  Orchestrator: no summary data");
     }
 
-    has_phase_data_ = (total_phase_records > 0 || orch_valid);
-    LOG_INFO("Phase data collection complete: %d records (%zu orch), orch_summary=%s",
-             total_phase_records, collected_orch_phase_records_.size(), orch_valid ? "yes" : "no");
+    // Check if drain_remaining_buffers() already accumulated some Phase records
+    bool has_accumulated = has_phase_data_;
+    if (!has_accumulated) {
+        for (const auto& v : collected_phase_records_) {
+            if (!v.empty()) { has_accumulated = true; break; }
+        }
+        if (!collected_orch_phase_records_.empty()) has_accumulated = true;
+    }
+    has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
+
+    // Read core-to-thread mapping
+    int num_cores = static_cast<int>(phase_header->num_cores);
+    if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
+        core_to_thread_.assign(phase_header->core_to_thread,
+                                phase_header->core_to_thread + num_cores);
+        LOG_INFO("  Core-to-thread mapping: %d cores", num_cores);
+    }
+
+    LOG_INFO("Phase data collection complete: %d remaining records, orch_summary=%s",
+             total_phase_records, orch_valid ? "yes" : "no");
 }
 
 int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
@@ -511,7 +1051,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                     case AicpuPhaseId::SCHED_COMPLETE:    phase_name = "complete"; break;
                     case AicpuPhaseId::SCHED_DISPATCH:    phase_name = "dispatch"; break;
                     case AicpuPhaseId::SCHED_SCAN:        phase_name = "scan"; break;
-                    case AicpuPhaseId::SCHED_EARLY_READY: phase_name = "early_ready"; break;
+                    case AicpuPhaseId::SCHED_IDLE_WAIT:   phase_name = "idle"; break;
                     default: break;
                 }
 
@@ -547,7 +1087,6 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
             outfile << "      \"heap\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
             outfile << "      \"insert\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
             outfile << "      \"fanin\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
-            outfile << "      \"finalize\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.finalize_cycle) << ",\n";
             outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
             outfile << "    }\n";
             outfile << "  }";
@@ -557,7 +1096,6 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         if (!collected_orch_phase_records_.empty()) {
             outfile << ",\n  \"aicpu_orchestrator_phases\": [\n";
 
-            // Map orchestrator phase IDs to names
             auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
                 switch (id) {
                     case AicpuPhaseId::ORCH_SYNC:      return "orch_sync";
@@ -582,12 +1120,23 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                         << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                         << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
                         << ", \"submit_idx\": " << pr.loop_iter
+                        << ", \"task_id\": " << static_cast<int32_t>(pr.tasks_processed)
                         << "}";
                 if (r < collected_orch_phase_records_.size() - 1) outfile << ",";
                 outfile << "\n";
             }
             outfile << "  ]";
         }
+    }
+
+    // Core-to-thread mapping
+    if (!core_to_thread_.empty()) {
+        outfile << ",\n  \"core_to_thread\": [";
+        for (size_t i = 0; i < core_to_thread_.size(); i++) {
+            outfile << static_cast<int>(core_to_thread_[i]);
+            if (i < core_to_thread_.size() - 1) outfile << ", ";
+        }
+        outfile << "]";
     }
 
     outfile << "\n}\n";
@@ -610,7 +1159,68 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
         return 0;
     }
 
+    // Stop memory manager if still running
+    stop_memory_manager();
+
     LOG_DEBUG("Cleaning up performance profiling resources");
+
+    // Free initial buffers that are still in the slot arrays
+    // (These were not freed by the memory manager because they were never replaced)
+    // The memory manager frees old buffers after copy; initial buffers in free_queues remain.
+    // Free all buffers in the free_queues and current_buf_ptr.
+    for (int i = 0; i < num_aicore_; i++) {
+        PerfBufferState* state = get_perf_buffer_state(perf_shared_mem_host_, i);
+
+        // Free current buffer if any
+        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
+            free_cb((void*)state->current_buf_ptr, user_data);
+        }
+
+        // Free all buffers in free_queue (limit iterations to max capacity)
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
+        while (head != tail && max_iters-- > 0) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            if (buf_ptr != 0 && free_cb != nullptr) {
+                free_cb((void*)buf_ptr, user_data);
+            }
+            head++;
+        }
+        if (head != tail) {
+            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)",
+                     i, head, tail);
+        }
+    }
+
+    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
+    for (int t = 0; t < num_phase_threads; t++) {
+        PhaseBufferState* state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+
+        // Free current buffer if any
+        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
+            free_cb((void*)state->current_buf_ptr, user_data);
+        }
+
+        // Free all buffers in free_queue (limit iterations to max capacity)
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
+        while (head != tail && max_iters-- > 0) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            if (buf_ptr != 0 && free_cb != nullptr) {
+                free_cb((void*)buf_ptr, user_data);
+            }
+            head++;
+        }
+        if (head != tail) {
+            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)",
+                     t, head, tail);
+        }
+    }
 
     // Unregister host mapping (optional)
     if (unregister_cb != nullptr && was_registered_) {
@@ -622,10 +1232,10 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
         LOG_DEBUG("Host mapping unregistered");
     }
 
-    // Free device memory
+    // Free shared memory (slot arrays)
     if (free_cb != nullptr && perf_shared_mem_dev_ != nullptr) {
         free_cb(perf_shared_mem_dev_, user_data);
-        LOG_DEBUG("Device memory freed");
+        LOG_DEBUG("Shared memory freed");
     }
 
     perf_shared_mem_dev_ = nullptr;
@@ -634,8 +1244,13 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
     collected_perf_records_.clear();
     collected_phase_records_.clear();
     collected_orch_phase_records_.clear();
+    core_to_thread_.clear();
     has_phase_data_ = false;
     device_id_ = -1;
+    alloc_cb_ = nullptr;
+    register_cb_ = nullptr;
+    free_cb_ = nullptr;
+    user_data_ = nullptr;
 
     LOG_DEBUG("Performance profiling cleanup complete");
     return 0;


### PR DESCRIPTION
Syncs a2a3 platform commits https://github.com/ChaoWao/simpler/commit/e83384b098e8ac0caf472fd23693f9b0a2d9d400 .. https://github.com/ChaoWao/simpler/commit/8d9942f2ba55958fdd019056e132f395c5ddb146 to a5, excluding
hardware-specific differences (core counts, AICPU thread limits,
register layout, AICore arch flags).

https://github.com/ChaoWao/simpler/commit/ab45f1047635f03569fcc5573c1fe51450524920 — cache_invalidate_range for inter-round AICPU cleanup
  - include/aicpu/platform_regs.h
  - onboard/aicpu/cache_ops.cpp (DC CIVAC implementation)
  - sim/aicpu/cache_ops.cpp (no-op stub)

https://github.com/ChaoWao/simpler/commit/0146071bf38b0e38bcaed254830044a7c41fa0ef — enforce aarch64-first guard order in cross-platform macros
  - sim/aicpu/spin_hint.h
  - sim/aicore/inner_kernel.h

https://github.com/ChaoWao/simpler/commit/0ace20a13c8312150a541021635944b2a741d76c — prevent weak AICPU symbols from polluting host .so table
  - sim/host/pto_runtime_c_api.cpp

https://github.com/ChaoWao/simpler/commit/c053c718a5de5337623555ece84b6f9399496438 — remove DeviceRunner::clean_cache(), move cleanup into run()
https://github.com/ChaoWao/simpler/commit/0ca30c43365b3b30f5bea0fbbb7f2830e9dba80b — add remove_kernel_binary API, fix stale pointer in cache
  - include/host/pto_runtime_c_api.h
  - onboard/host/device_runner.h, sim/host/device_runner.h
  - onboard/host/device_runner.cpp, sim/host/device_runner.cpp
  - onboard/host/pto_runtime_c_api.cpp, sim/host/pto_runtime_c_api.cpp

https://github.com/ChaoWao/simpler/commit/6d5023fcc06ac0fe2a1135629ea7697bcad0466b — add orch_thread_num parameter through full stack
https://github.com/ChaoWao/simpler/commit/d0e3404abafdadd61f4d332f36d9826be1e23dee — multiple orchestrators support
  - include/host/pto_runtime_c_api.h
  - onboard/host/pto_runtime_c_api.cpp, sim/host/pto_runtime_c_api.cpp
  - onboard/host/device_runner.cpp, sim/host/device_runner.cpp

https://github.com/ChaoWao/simpler/commit/87b1716bf9ee7df1d3f594b8b7d9eceb06aee91e — replace phase double-buffer with non-blocking ring buffer
https://github.com/ChaoWao/simpler/commit/d0e3404abafdadd61f4d332f36d9826be1e23dee — multiple orchestrators (perf collector extensions)
  - include/common/platform_config.h (PLATFORM_PHASE_RING_DEPTH)
  - include/common/perf_profiling.h (PhaseRingBuffer layout)
  - include/aicpu/performance_collector_aicpu.h
  - include/host/performance_collector.h
  - src/aicpu/performance_collector_aicpu.cpp
  - src/host/performance_collector.cpp

https://github.com/ChaoWao/simpler/commit/3108bc63544c8aba11e54718116363583cb58eb2 — print all compiled files when verbose
https://github.com/ChaoWao/simpler/commit/0c21fe1c100cc89e185a3fab3b7cabfd9122d009 — fix x86 host compile error
  - onboard/aicore/CMakeLists.txt, onboard/aicpu/CMakeLists.txt
  - onboard/host/CMakeLists.txt (also: aarch64-linux → CMAKE_SYSTEM_PROCESSOR)

https://github.com/ChaoWao/simpler/commit/8d9942f2ba55958fdd019056e132f395c5ddb146 — replace double-buffer with SPSC free queue and dynamic memory manager
  - include/common/platform_config.h (PLATFORM_PROF_SLOT_COUNT)
  - include/common/perf_profiling.h (PerfBufferState, PerfFreeQueue)
  - include/host/performance_collector.h (ProfMemoryManager)
  - src/aicpu/performance_collector_aicpu.cpp (free queue pop/push)
  - src/host/performance_collector.cpp (ProfMemoryManager thread)
  - onboard/host/device_runner.cpp (start/stop_memory_manager)
  - sim/host/device_runner.cpp (start/stop_memory_manager)