### PR TITLE
Fix: avoid dep pool waste on early-finished producers and fix slot lo…

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -397,8 +397,6 @@ void pto2_submit_task(
             // Add this task to producer's fanout list (with spinlock)
             int32_t prod_slot = task_ring.get_task_slot(producer_task_id);
             PTO2TaskDescriptor& producer = task_ring.get_task_by_slot(prod_slot);
-            orch->dep_pool_cur_entry->task_id = task_id;
-            orch->dep_pool_cur_entry->next = producer.fanout_head;
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
             pto2_fanout_lock(producer, g_orch_fanin_atomic_count, g_orch_fanin_wait_cycle);
 #else
@@ -412,6 +410,8 @@ void pto2_submit_task(
                 // decrement fanin_count
                 early_finished++;
             } else {
+                orch->dep_pool_cur_entry->task_id = task_id;
+                orch->dep_pool_cur_entry->next = producer.fanout_head;
                 producer.fanout_head = orch->dep_pool_cur_entry;
             }
             pto2_fanout_unlock(producer);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -539,7 +539,7 @@ struct PTO2SchedulerState {
                            PTO2LocalReadyBuffer* local_buf = nullptr) {
 #endif
         int32_t slot = pto2_task_slot(task_id);
-        PTO2TaskDescriptor& task = pto2_sm_get_task_by_slot(sm_handle, task_id);
+        PTO2TaskDescriptor& task = pto2_sm_get_task_by_slot(sm_handle, slot);
 
 #if PTO2_PROFILING
         tasks_completed.fetch_add(1, std::memory_order_relaxed);


### PR DESCRIPTION
…okup

- Move dep_pool_cur_entry writes inside the else branch so entries are only consumed when the producer has not already completed
- Fix on_task_complete passing task_id instead of slot to pto2_sm_get_task_by_slot