### PR TITLE
Reproduce TASSIGN simulation issue in paged_attention softmax_prepare

### DIFF
--- a/examples/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -91,29 +91,32 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     // Use TFILLPAD_INPLACE for the main fill, then patch with SetValue for
     // cases where TFILLPAD's vcopy broadcast path fails at small N.
     TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+    set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
     // Patch: SetValue ensures correctness for valid_len <= N/2 where
     // TFILLPAD's PadRightRemainingRows vcopy has a hardware issue.
-    if (valid_len < static_cast<uint64_t>(N)) {
-        // Cross-pipeline sync: wait for PIPE_V vcopy in TFILLPAD to complete
-        // before PIPE_S scalar SetValue writes to the same UB addresses.
-        // Without this, PIPE_V vcopy and PIPE_S SetValue race on UB memory,
-        // causing sporadic FAIL when vcopy finishes after SetValue.
-        // Pattern from TFillPad.hpp Handle32BAlignedPad_Byte (PtoSetWaitFlag).
-        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
-        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
-        constexpr float NEG_INF = -__builtin_huge_valf();
-        for (int r = 0; r < M; r++) {
-            for (uint64_t c = valid_len; c < N; c++) {
-                sijTile.SetValue(static_cast<uint32_t>(r * N + c), NEG_INF);
-            }
-        }
-        // Ensure PIPE_S scalar UB writes are visible to subsequent PIPE_V ops.
-        // dsb(DSB_UB) is a hardware-only intrinsic; in simulation there are no
-        // real pipelines so the barrier is unnecessary and DSB_UB is undefined.
-#ifdef DSB_UB
-        dsb(DSB_UB);
-#endif
-    }
+//     if (valid_len < static_cast<uint64_t>(N)) {
+//         // Cross-pipeline sync: wait for PIPE_V vcopy in TFILLPAD to complete
+//         // before PIPE_S scalar SetValue writes to the same UB addresses.
+//         // Without this, PIPE_V vcopy and PIPE_S SetValue race on UB memory,
+//         // causing sporadic FAIL when vcopy finishes after SetValue.
+//         // Pattern from TFillPad.hpp Handle32BAlignedPad_Byte (PtoSetWaitFlag).
+//         set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+//         wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+//         constexpr float NEG_INF = -__builtin_huge_valf();
+//         for (int r = 0; r < M; r++) {
+//             for (uint64_t c = valid_len; c < N; c++) {
+//                 sijTile.SetValue(static_cast<uint32_t>(r * N + c), NEG_INF);
+//             }
+//         }
+//         // Ensure PIPE_S scalar UB writes are visible to subsequent PIPE_V ops.
+//         // dsb(DSB_UB) is a hardware-only intrinsic; in simulation there are no
+//         // real pipelines so the barrier is unnecessary and DSB_UB is undefined.
+// #ifdef DSB_UB
+//         dsb(DSB_UB);
+// #endif
+//     }
+    
 
     TMULS(sijTile, sijTile, scale_value);
     pipe_barrier(PIPE_V);


### PR DESCRIPTION
## Summary

- Disable the `SetValue` padding-correction patch in `aiv_softmax_prepare.cpp`
  to expose a TASSIGN-related simulation failure in the paged_attention example.
- The `SetValue` loop (which compensated for a TFILLPAD_INPLACE vcopy hardware
  issue at `valid_len <= N/2`) is commented out, while the unconditional
  PIPE_V→PIPE_S sync barrier is retained after `TFILLPAD_INPLACE`.
- This provides a minimal, self-contained reproduction case under
  `examples/tensormap_and_ringbuffer/paged_attention` for investigating the
  TASSIGN simulator behavior.

## Reproduce

```
python examples/scripts/run_example.py \
    -k examples/tensormap_and_ringbuffer/paged_attention/kernels \
    -g examples/tensormap_and_ringbuffer/paged_attention/golden.py \
-p a2a3sim
```