### PR TITLE
Add: port tensormap_and_ringbuffer runtime to a5 platform

### DIFF
--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -1,0 +1,132 @@
+#include "aicore/aicore.h"
+#include "runtime.h"
+#include "pto2_dispatch_payload.h"
+#include "common/perf_profiling.h"
+#include "aicore/performance_collector_aicore.h"
+#include "common/platform_config.h"  // Register-based communication
+
+/**
+ * Unified function pointer type for kernel dispatch
+ *
+ * All kernels follow the same signature: void kernel(__gm__ int64_t* args)
+ * This enables simple, switch-free dispatch.
+ */
+typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
+
+/**
+ * Execute task from PTO2DispatchPayload.
+ *
+ * Directly accesses PTO2DispatchPayload fields for task execution,
+ * matching ref_runtime implementation for a2a3 compatibility.
+ *
+ * @param task_ptr Pointer to PTO2DispatchPayload in global memory
+ */
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* task_ptr) {
+    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(task_ptr);
+    if (payload == nullptr || payload->function_bin_addr == 0) {
+        return;
+    }
+
+    UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
+    kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
+
+    // Ensure all memory writes are visible to other cores
+    pipe_barrier(PIPE_ALL);
+}
+
+/**
+ * AICore main execution loop
+ *
+ * Implements the AICPU-AICore register-based dispatch protocol:
+ * 1. Wait for AICPU ready signal via handshake buffer
+ * 2. Report physical core ID and core type, signal AICore ready
+ * 3. Poll DATA_MAIN_BASE register for task dispatch until exit signal
+ *
+ * Task dispatch uses PTO2DispatchPayload from per-core payload array.
+ * Supports performance profiling when runtime->enable_profiling is true.
+ *
+ * @param runtime Pointer to Runtime in global memory
+ * @param core_idx Core index (core ID)
+ * @param core_type Core type (AIC or AIV)
+ */
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type) {
+    __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[core_idx]);
+
+    // Phase 1: Wait for AICPU initialization signal
+    while (my_hank->aicpu_ready == 0) {
+        dcci(my_hank, SINGLE_CACHE_LINE);
+    }
+
+    // Clear stale EXIT_SIGNAL from previous round before entering main loop
+    write_reg(RegId::DATA_MAIN_BASE, 0);
+
+    // Phase 2: Report physical core ID and core type, signal ready
+    my_hank->physical_core_id = get_physical_core_id();
+    my_hank->core_type = core_type;
+    my_hank->aicore_done = core_idx + 1;  // Signal ready (use core_idx + 1 to avoid 0)
+
+    dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
+
+    // Report initial idle status via register
+    write_reg(RegId::COND, AICORE_IDLE_VALUE);
+
+    // Read per-core payload address from hank->task (written by AICPU before aicpu_ready)
+    __gm__ PTO2DispatchPayload* my_payload =
+        reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+
+    bool profiling_enabled = runtime->enable_profiling;
+    uint64_t kernel_ready_time = 0;
+    if (profiling_enabled) {
+        kernel_ready_time = get_sys_cnt_aicore();
+    }
+
+    // Phase 3: Main execution loop - poll register for tasks until exit signal
+    uint32_t task_id = 0;
+    uint32_t last_task_id = 0;
+
+    while (true) {
+        task_id = static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE));
+        if (task_id == AICORE_EXIT_SIGNAL) {
+            break;
+        }
+
+        // Execute task if new (task_id encoding: 0=idle, task_id+1=task)
+        if (task_id == 0 || task_id == last_task_id) {
+            SPIN_WAIT_HINT();
+            continue;
+        }
+
+        {
+            // Invalidate cache to read fresh payload written by AICPU
+            dcci(my_payload, ENTIRE_DATA_CACHE);
+
+            __gm__ PTO2DispatchPayload* payload = my_payload;
+
+            write_reg(RegId::COND, MAKE_ACK_VALUE(payload->task_id));
+
+            // Performance profiling: record start time
+            uint64_t start_time = 0;
+            if (profiling_enabled) {
+                start_time = get_sys_cnt_aicore();
+            }
+
+            // Execute the task
+            execute_task(reinterpret_cast<__gm__ void*>(payload));
+
+            // Performance profiling: record task execution
+            if (profiling_enabled) {
+                uint64_t end_time = get_sys_cnt_aicore();
+                __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
+                perf_aicore_record_task(perf_buf, payload->task_id, payload->kernel_id,
+                                       start_time, end_time, kernel_ready_time,
+                                       core_type);
+            }
+
+            last_task_id = task_id;
+            write_reg(RegId::COND, MAKE_FIN_VALUE(payload->task_id));
+        }
+    }
+
+    // Flush all dirty cache lines to HBM before kernel exit.
+    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1,0 +1,1896 @@
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <unistd.h>
+#ifdef __linux__
+#include <sched.h>
+#include <sys/mman.h>
+#endif
+
+#include "aicpu/device_log.h"
+#include "aicpu/device_time.h"
+#include "spin_hint.h"
+#include "runtime.h"
+#include "pto2_dispatch_payload.h"
+
+// Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
+#include "pto_runtime2.h"
+#include "pto_shared_memory.h"
+#include "pto_runtime2_types.h"
+
+// Performance profiling headers
+#include "aicpu/performance_collector_aicpu.h"
+#include "common/perf_profiling.h"
+#include "common/memory_barrier.h"
+#include "common/unified_log.h"
+
+// Register-based communication
+#include "common/platform_config.h"
+#include "aicpu/platform_regs.h"
+
+// Core type definitions
+#include "common/core_type.h"
+
+#if PTO2_PROFILING
+// Accumulated nanoseconds per sub-step
+#define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
+#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+#else
+#define CYCLE_COUNT_START()
+#define CYCLE_COUNT_LAP(acc)
+#endif
+
+// Device orchestration function signature (loaded via dlopen).
+// The orchestration .so receives a PTO2Runtime* (with ops table populated)
+// instead of a raw shared-memory pointer.
+typedef void (*DeviceOrchestrationFunc)(PTO2Runtime* rt, uint64_t* args, int32_t arg_count, int32_t orch_thread_num, int32_t orch_thread_index);
+
+// Config function exported by orchestration .so
+typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(uint64_t* args, int32_t arg_count);
+
+constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
+constexpr int32_t MAX_AIC_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD;
+constexpr int32_t MAX_AIV_PER_THREAD = PLATFORM_MAX_AIV_PER_THREAD;
+constexpr int32_t MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
+
+constexpr int32_t MAX_IDLE_ITERATIONS = 800000;  // ~20s idle then scheduler gives up (avoid long hang)
+constexpr int32_t STALL_LOG_INTERVAL = 50000;    // DEV_ALWAYS every N idle iters to debug hang
+constexpr int32_t STALL_DUMP_READY_MAX = 8;
+constexpr int32_t STALL_DUMP_WAIT_MAX = 4;
+constexpr int32_t STALL_DUMP_CORE_MAX = 8;
+constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
+constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
+
+// PTO2 device-mode state (per-core dispatch payloads)
+static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
+
+static PTO2Runtime *rt{nullptr};
+
+// Core information for discovery (with register address for fast dispatch)
+struct CoreInfo {
+    int32_t worker_id;              // Index in runtime.workers[]
+    uint32_t physical_core_id;  // Hardware physical core ID (from AICore)
+    uint64_t reg_addr;          // Cached register address for fast access
+    CoreType core_type;
+};
+
+struct CoreTypeTracker {
+    int32_t idle[MAX_CORES_PER_THREAD];
+    int32_t running[MAX_CORES_PER_THREAD];
+    int32_t idle_count;
+    int32_t running_count;
+
+    void move_idle_to_running(int32_t idx) {
+        running[running_count++] = idle[idx];
+        idle[idx] = idle[--idle_count];
+    }
+
+    void move_running_to_idle(int32_t idx) {
+        idle[idle_count++] = running[idx];
+        running[idx] = running[--running_count];
+    }
+};
+
+struct CoreStateTracker {
+    CoreTypeTracker by_type[2];  // indexed by static_cast<int32_t>(CoreType)
+
+    CoreTypeTracker& aic() { return by_type[0]; }
+    CoreTypeTracker& aiv() { return by_type[1]; }
+
+    template<CoreType CT>
+    CoreTypeTracker& get() { return by_type[static_cast<int32_t>(CT)]; }
+};
+
+struct AicpuExecutor {
+    int32_t orch_thread_num_;
+    int32_t sched_thread_num_;
+
+    // ===== Thread management state =====
+    std::atomic<int32_t> thread_idx_{0};
+    std::atomic<bool> initialized_{false};
+    std::atomic<bool> init_done_{false};
+    std::atomic<bool> init_failed_{false};
+    std::atomic<bool> finished_{false};
+
+    int32_t thread_num_{0};
+    int32_t cores_total_num_{0};
+    int32_t thread_cores_num_{0};  // Cores per scheduler thread (0 for orchestrator when thread_num_==4)
+    int32_t core_count_per_thread_[MAX_AICPU_THREADS];  // Actual core count per thread
+    int32_t core_assignments_[MAX_AICPU_THREADS][MAX_CORES_PER_THREAD];
+
+    // Core discovery arrays (with register addresses)
+    CoreInfo aic_cores_[MAX_CORES_PER_THREAD];
+    CoreInfo aiv_cores_[MAX_CORES_PER_THREAD];
+    int32_t aic_count_{0};
+    int32_t aiv_count_{0};
+
+    // Fast lookup: core_id -> reg_addr (for register-based dispatch)
+    uint64_t core_id_to_reg_addr_[MAX_CORES_PER_THREAD];
+
+    // Platform register base address array (set via get_platform_regs())
+    uint64_t regs_{0};
+
+    // Track executing task_id per core (AICPU_TASK_INVALID = idle)
+    int32_t executing_task_ids_[MAX_AICPU_THREADS][MAX_CORES_PER_THREAD];
+    CoreStateTracker trackers_[MAX_AICPU_THREADS];
+
+    // ===== Task queue state (managed by scheduler ready queues) =====
+
+    // Task execution tracking
+    std::atomic<int32_t> completed_tasks_{0};
+    int32_t total_tasks_{0};
+    std::atomic<int32_t> finished_count_{0};
+    // Device orchestration: set by Thread 3 when graph is built; workers wait for it
+    bool orchestrator_done_{false};
+    std::atomic<bool> pto2_init_done_{false};
+    std::atomic<bool> runtime_init_ready_{false};
+    std::atomic<bool> pto2_init_complete_{false};  // init block finished; others wait for this
+    std::atomic<int32_t> orch_finished_count_{0};      // Number of orchestrator threads that have finished
+
+    // ===== Dynamic core transition state =====
+    std::atomic<bool> transition_requested_{false};
+    std::atomic<int32_t> wait_reassign_{0};
+    std::atomic<bool> reassigned_{false};
+    std::atomic<bool> completed_{false};
+
+    // Orchestration SO handle - defer dlclose until all tasks complete
+    void* orch_so_handle_{nullptr};
+    char orch_so_path_[256]{};  // Path to orchestration SO file for cleanup
+
+    // Shared orchestration function pointer (loaded by first orch thread, used by all)
+    DeviceOrchestrationFunc orch_func_{nullptr};
+    uint64_t* orch_args_cached_{nullptr};
+    int32_t orch_arg_count_cached_{0};
+
+    // ===== Performance profiling state =====
+    uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];  // Per-core AICPU dispatch timestamp
+    uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER]; // Per-core total dispatched task counter (for buffer management)
+
+    // ===== Methods =====
+    int32_t init(Runtime* runtime);
+    int32_t handshake_all_cores(Runtime* runtime);
+    void assign_cores_to_threads();
+    void reassign_cores_for_all_threads();
+    int32_t resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx);
+    int32_t shutdown_aicore(Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num);
+    int32_t run(Runtime* runtime);
+    void deinit(Runtime* runtime);
+    void emergency_shutdown();
+    void diagnose_stuck_state(
+        Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank);
+
+    // Build PTO2DispatchPayload from PTO2TaskDescriptor.
+    template<CoreType CT>
+    void build_pto2_payload(PTO2DispatchPayload* out,
+        Runtime* runtime,
+        PTO2TaskDescriptor* task,
+        PTO2TaskPayload* task_payload) {
+        out->task_id = task->task_id;
+        out->kernel_id = task->kernel_id;
+        out->core_type = CT;
+        out->function_bin_addr = runtime->get_function_bin_addr(task->kernel_id);
+        int32_t n = 0;
+
+        for (int32_t i = 0; i < task_payload->param_count; i++) {
+            if (!task_payload->is_tensor[i]) {
+                out->args[n++] = task_payload->scalar_value[i];
+            } else {
+                out->args[n++] = reinterpret_cast<uint64_t>(&task_payload->tensors[i]);
+                task_payload->tensors[i].update_start_offset();
+            }
+        }
+
+        out->num_args = n;
+    }
+
+    // Template methods for Phase 1 and Phase 2
+    template <CoreType CT>
+    void check_running_cores_for_completion(int32_t thread_idx,
+        CoreTypeTracker& ct,
+        Handshake* hank,
+        int32_t* executing_task_ids,
+        int32_t& completed_this_turn,
+        int32_t& cur_thread_completed,
+        bool& made_progress,
+        int32_t deferred_release_ids[],
+        int32_t& deferred_release_count,
+        PTO2LocalReadyBuffer& local_buf
+#if PTO2_PROFILING
+        ,
+        bool profiling_enabled,
+        uint64_t& complete_probe_count,
+        uint64_t& complete_hit_count,
+        uint32_t& phase_complete_count,
+        uint64_t& notify_edges_total,
+        int32_t& notify_max_degree,
+        uint64_t& notify_tasks_enqueued,
+        uint64_t& fanin_edges_total,
+        int32_t& fanin_max_degree
+#endif
+#if PTO2_SCHED_PROFILING
+        ,
+        uint64_t& sched_complete_perf_cycle
+#endif
+    ) {
+        for (int32_t i = ct.running_count - 1; i >= 0; i--) {
+            int32_t core_id = ct.running[i];
+            uint64_t reg_addr = core_id_to_reg_addr_[core_id];
+
+            int32_t task_id = executing_task_ids[core_id];
+            uint64_t reg_val = read_reg(reg_addr, RegId::COND);
+            int32_t reg_task_id = EXTRACT_TASK_ID(reg_val);
+            int32_t reg_state = EXTRACT_TASK_STATE(reg_val);
+            bool done = reg_task_id == task_id && reg_state == TASK_FIN_STATE;
+#if PTO2_PROFILING
+            if (profiling_enabled) {
+                complete_probe_count++;
+                if (done) {
+                    complete_hit_count++;
+                }
+            }
+#endif
+
+            if (done) {
+                executing_task_ids[core_id] = AICPU_TASK_INVALID;
+#if PTO2_SCHED_PROFILING
+                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
+                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, thread_idx, &local_buf);
+                notify_edges_total += cstats.fanout_edges;
+                if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
+                notify_tasks_enqueued += cstats.tasks_enqueued;
+                phase_complete_count++;
+#elif PTO2_PROFILING
+                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
+                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, &local_buf);
+                notify_edges_total += cstats.fanout_edges;
+                if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
+                notify_tasks_enqueued += cstats.tasks_enqueued;
+                phase_complete_count++;
+#else
+                rt->scheduler.on_task_complete(task_id, &local_buf);
+#endif
+                if (deferred_release_count < 64) {
+                    deferred_release_ids[deferred_release_count++] = task_id;
+                } else {
+                    DEV_ALWAYS("Thread %d: release", thread_idx);
+                    while (deferred_release_count > 0) {
+#if PTO2_SCHED_PROFILING
+                        int32_t fe =
+                            rt->scheduler.on_task_release(deferred_release_ids[--deferred_release_count], thread_idx);
+#else
+                        int32_t fe = rt->scheduler.on_task_release(deferred_release_ids[--deferred_release_count]);
+#endif
+                        (void)fe;
+#if PTO2_PROFILING
+                        fanin_edges_total += fe;
+                        if (fe > fanin_max_degree) fanin_max_degree = fe;
+#endif
+                    }
+                }
+                ct.move_running_to_idle(i);
+
+#if PTO2_PROFILING
+                if (profiling_enabled) {
+#if PTO2_SCHED_PROFILING
+                    uint64_t t_perf_start = get_sys_cnt_aicpu();
+#endif
+                    Handshake* h = &hank[core_id];
+                    uint64_t finish_ts = get_sys_cnt_aicpu();
+                    PerfBuffer* perf_buf = (PerfBuffer*)h->perf_records_addr;
+                    rmb();
+                    uint32_t count = perf_buf->count;
+                    if (count > 0) {
+                        PerfRecord* record = &perf_buf->records[count - 1];
+                        if (record->task_id == static_cast<uint32_t>(payload->task_id)) {
+                            perf_aicpu_record_dispatch_and_finish_time(
+                                record, dispatch_timestamps_[core_id], finish_ts);
+                        }
+                    }
+#if PTO2_SCHED_PROFILING
+                    sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
+#endif
+                }
+#endif
+
+                DEV_DEBUG("Thread %d: %s core %d completed PTO2 task %d",
+                    thread_idx,
+                    CT == CoreType::AIC ? "AIC" : "AIV",
+                    core_id,
+                    task_id);
+                cur_thread_completed++;
+                completed_this_turn++;
+                made_progress = true;
+            }
+        }
+    }
+
+    template <CoreType CT>
+    void dispatch_ready_tasks_to_idle_cores(Runtime* runtime,
+        int32_t thread_idx,
+        CoreTypeTracker& ct,
+        int32_t* executing_task_ids,
+        bool& made_progress,
+        PTO2TaskDescriptor* task_descriptors,
+        PTO2TaskPayload* task_payloads,
+        int32_t window_mask
+#if PTO2_PROFILING
+        ,
+        bool profiling_enabled,
+        uint64_t& pop_hit,
+        uint64_t& pop_miss,
+        uint32_t& phase_dispatch_count
+#endif
+#if PTO2_SCHED_PROFILING
+        ,
+        uint64_t& sched_dispatch_pop_cycle,
+        uint64_t& sched_dispatch_setup_cycle
+#endif
+    ) {
+        if (ct.idle_count > 0 && rt->scheduler.ready_queues[static_cast<int32_t>(CT)].size() > 0) {
+            for (int32_t i = ct.idle_count - 1; i >= 0; i--) {
+                int32_t core_id = ct.idle[i];
+
+#if PTO2_SCHED_PROFILING
+                extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
+                uint64_t t_pop_start = get_sys_cnt_aicpu();
+                int32_t task_id = rt->scheduler.get_ready_task<CT>(
+                    g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]);
+                sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
+#else
+                int32_t task_id = rt->scheduler.get_ready_task<CT>();
+#endif
+                if (task_id >= 0) {
+#if PTO2_PROFILING
+                    pop_hit++;
+                    phase_dispatch_count++;
+#endif
+#if PTO2_SCHED_PROFILING
+                    uint64_t t_setup_start = get_sys_cnt_aicpu();
+#endif
+                    PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
+                    PTO2TaskPayload* task_pl = &task_payloads[task_id & window_mask];
+                    PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
+                    build_pto2_payload<CT>(payload, runtime, task, task_pl);
+#if PTO2_PROFILING
+                    if (profiling_enabled) {
+                        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                        if (core_dispatch_counts_[core_id] >= PLATFORM_PROF_BUFFER_SIZE) {
+                            perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
+                            core_dispatch_counts_[core_id] = 0;
+                        }
+                        core_dispatch_counts_[core_id]++;
+                    }
+#endif
+                    write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id + 1));
+                    ct.move_idle_to_running(i);
+                    executing_task_ids[core_id] = task_id;
+                    made_progress = true;
+#if PTO2_SCHED_PROFILING
+                    sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
+#endif
+                    DEV_DEBUG("Thread %d: Dispatching PTO2 task %d to %s core %d",
+                        thread_idx,
+                        task_id,
+                        CT == CoreType::AIC ? "AIC" : "AIV",
+                        core_id);
+                } else {
+#if PTO2_PROFILING
+                    pop_miss++;
+#endif
+                    break;
+                }
+            }
+        }
+    }
+};
+
+static AicpuExecutor g_aicpu_executor;
+
+// ===== AicpuExecutor Method Implementations =====
+
+/**
+ * Handshake with all cores and discover their types
+ * Sets up register addresses for fast dispatch.
+ */
+int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
+    Handshake* all_handshakes = (Handshake*)runtime->workers;
+    cores_total_num_ = runtime->worker_count;
+
+    // Validate cores_total_num_ before using as array index
+    if (cores_total_num_ == 0 || cores_total_num_ > MAX_CORES_PER_THREAD) {
+        DEV_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, MAX_CORES_PER_THREAD);
+        return -1;
+    }
+
+    aic_count_ = 0;
+    aiv_count_ = 0;
+
+    DEV_INFO("Handshaking with %d cores", cores_total_num_);
+
+    // Step 1: Write per-core payload addresses and send handshake signal
+    // task must be written BEFORE aicpu_ready so AICore sees it after waking up
+    for (int32_t i = 0; i < cores_total_num_; i++) {
+        all_handshakes[i].task = reinterpret_cast<uint64_t>(&s_pto2_payload_per_core[i]);
+        all_handshakes[i].aicpu_ready = 1;
+    }
+
+    // Get platform physical cores count for validation
+    uint32_t max_physical_cores_count = platform_get_physical_cores_count();
+
+    // Step 2: Wait for all cores to respond, collect core type and register addresses
+    bool handshake_failed = false;
+    for (int32_t i = 0; i < cores_total_num_; i++) {
+        Handshake* hank = &all_handshakes[i];
+        while (hank->aicore_done == 0) {
+        }
+
+        CoreType type = hank->core_type;
+        uint32_t physical_core_id = hank->physical_core_id;
+
+        // Validate physical_core_id before using as array index
+        if (physical_core_id >= max_physical_cores_count) {
+            DEV_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
+                      i, physical_core_id, max_physical_cores_count);
+            handshake_failed = true;
+            continue;
+        }
+
+        // Get register address using physical_core_id
+        uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
+        uint64_t reg_addr = regs[physical_core_id];
+
+        if (type == CoreType::AIC) {
+            aic_cores_[aic_count_].worker_id = i;
+            aic_cores_[aic_count_].physical_core_id = physical_core_id;
+            aic_cores_[aic_count_].reg_addr = reg_addr;
+            aic_cores_[aic_count_].core_type = type;
+            aic_count_++;
+            DEV_INFO("Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+        } else {
+            aiv_cores_[aiv_count_].worker_id = i;
+            aiv_cores_[aiv_count_].physical_core_id = physical_core_id;
+            aiv_cores_[aiv_count_].reg_addr = reg_addr;
+            aiv_cores_[aiv_count_].core_type = type;
+            aiv_count_++;
+            DEV_INFO("Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+        }
+
+        core_id_to_reg_addr_[i] = reg_addr;
+
+        // Initialize AICore registers after discovery (first round)
+        if (reg_addr != 0) {
+            platform_init_aicore_regs(reg_addr);
+        }
+    }
+
+    if (handshake_failed) {
+        emergency_shutdown();
+        return -1;
+    }
+
+    DEV_INFO("Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
+    return 0;
+}
+
+/**
+ * Assign discovered cores to scheduler threads
+ * (Aligned with host_build_graph mechanism)
+ */
+void AicpuExecutor::assign_cores_to_threads() {
+    // Determine how many cores each thread gets initially:
+    // - Mixed mode: distribute among scheduler threads only
+    // - All-orchestrator mode: distribute among all threads (they all transition to schedulers)
+    int32_t divisor = (sched_thread_num_ > 0) ? sched_thread_num_ : thread_num_;
+    int32_t aic_per_thread = aic_count_ / divisor;
+    int32_t aiv_per_thread = aiv_count_ / divisor;
+
+    DEV_INFO("Assigning cores: %d AIC per thread, %d AIV per thread", aic_per_thread, aiv_per_thread);
+
+    for (int32_t i = 0; i < thread_num_; i++) {
+        for (int32_t j = 0; j < MAX_CORES_PER_THREAD; j++) {
+            executing_task_ids_[i][j] = AICPU_TASK_INVALID;
+        }
+        trackers_[i].aic().running_count = 0;
+        trackers_[i].aiv().running_count = 0;
+        trackers_[i].aic().idle_count = 0;
+        trackers_[i].aiv().idle_count = 0;
+    }
+
+    for (int32_t t = 0; t < thread_num_; t++) {
+        if (sched_thread_num_ > 0 && t >= sched_thread_num_) {
+            // Orchestrator thread: no cores
+            core_count_per_thread_[t] = 0;
+            DEV_INFO("Thread %d: orchestrator (0 cores)", t);
+            continue;
+        }
+
+        int32_t core_idx = 0;
+
+        // Assign AIC cores
+        int32_t aic_start = t * aic_per_thread;
+        for (int32_t i = 0; i < aic_per_thread; i++) {
+            int32_t worker_id = aic_cores_[aic_start + i].worker_id;
+            core_assignments_[t][core_idx++] = worker_id;
+            trackers_[t].aic().idle[trackers_[t].aic().idle_count++] = worker_id;
+            DEV_INFO("Thread %d: assigned AIC worker_id=%d", t, worker_id);
+        }
+
+        // Assign AIV cores
+        int32_t aiv_start = t * aiv_per_thread;
+        for (int32_t i = 0; i < aiv_per_thread; i++) {
+            int32_t worker_id = aiv_cores_[aiv_start + i].worker_id;
+            core_assignments_[t][core_idx++] = worker_id;
+            trackers_[t].aiv().idle[trackers_[t].aiv().idle_count++] = worker_id;
+            DEV_INFO("Thread %d: assigned AIV worker_id=%d", t, worker_id);
+        }
+
+        core_count_per_thread_[t] = core_idx;
+
+        DEV_INFO("Thread %d: total %d cores", t, core_idx);
+    }
+
+    thread_cores_num_ = aic_per_thread + aiv_per_thread;
+}
+
+/**
+ * Reassign all cores evenly across all threads (schedulers + orchestrators).
+ * Called by the last orchestrator thread when orchestration completes.
+ * Writes into new_core_assignments_ / new_core_count_per_thread_.
+ */
+void AicpuExecutor::reassign_cores_for_all_threads() {
+    // Calculate how many AIC/AIV each thread should have
+
+    DEV_INFO("Reassigning cores for all %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_);
+
+    int32_t aic_running_cores[128];
+    int32_t aic_running_task_ids[128];
+    int32_t aic_idle_cores[128];
+    int32_t aic_running_cores_num = 0;
+    int32_t aic_idle_cores_num = 0;
+
+    int32_t aiv_running_cores[128];
+    int32_t aiv_running_task_ids[128];
+    int32_t aiv_idle_cores[128];
+    int32_t aiv_running_cores_num = 0;
+    int32_t aiv_idle_cores_num = 0;
+
+    for (int32_t i = 0; i < thread_num_; i++) {
+        core_count_per_thread_[i] = 0;
+        for (int32_t j = 0; j < trackers_[i].aic().running_count; j++) {
+            int32_t core_id = trackers_[i].aic().running[j];
+            aic_running_cores[aic_running_cores_num] = core_id;
+            aic_running_task_ids[aic_running_cores_num] = executing_task_ids_[i][core_id];
+            aic_running_cores_num++;
+        }
+        for (int32_t j = 0; j < trackers_[i].aic().idle_count; j++) {
+            aic_idle_cores[aic_idle_cores_num++] = trackers_[i].aic().idle[j];
+        }
+        for (int32_t j = 0; j < trackers_[i].aiv().running_count; j++) {
+            int32_t core_id = trackers_[i].aiv().running[j];
+            aiv_running_cores[aiv_running_cores_num] = core_id;
+            aiv_running_task_ids[aiv_running_cores_num] = executing_task_ids_[i][core_id];
+            aiv_running_cores_num++;
+        }
+        for (int32_t j = 0; j < trackers_[i].aiv().idle_count; j++) {
+            aiv_idle_cores[aiv_idle_cores_num++] = trackers_[i].aiv().idle[j];
+        }
+        trackers_[i].aic().running_count = 0;
+        trackers_[i].aic().idle_count = 0;
+        trackers_[i].aiv().running_count = 0;
+        trackers_[i].aiv().idle_count = 0;
+        for (int32_t j = 0; j < MAX_CORES_PER_THREAD; j++) {
+            executing_task_ids_[i][j] = AICPU_TASK_INVALID;
+        }
+    }
+    for (int32_t i = 0; i < aic_count_; i++) {
+        int32_t thread_idx = i % thread_num_;
+        int32_t core_id = aic_cores_[i].worker_id;
+        core_assignments_[thread_idx][core_count_per_thread_[thread_idx]++] = core_id;
+        bool found = false;
+        for (int32_t j = 0; j < aic_running_cores_num; j++) {
+            if (core_id == aic_running_cores[j]) {
+                trackers_[thread_idx].aic().running[trackers_[thread_idx].aic().running_count++] = core_id;
+                executing_task_ids_[thread_idx][core_id] = aic_running_task_ids[j];
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            for (int32_t j = 0; j < aic_idle_cores_num; j++) {
+                if (core_id == aic_idle_cores[j]) {
+                    trackers_[thread_idx].aic().idle[trackers_[thread_idx].aic().idle_count++] = core_id;
+                    break;
+                }
+            }
+        }
+    }
+    for (int32_t i = 0; i < aiv_count_; i++) {
+        int32_t thread_idx = i % thread_num_;
+        int32_t core_id = aiv_cores_[i].worker_id;
+        core_assignments_[thread_idx][core_count_per_thread_[thread_idx]++] = core_id;
+        bool found = false;
+        for (int32_t j = 0; j < aiv_running_cores_num; j++) {
+            if (core_id == aiv_running_cores[j]) {
+                trackers_[thread_idx].aiv().running[trackers_[thread_idx].aiv().running_count++] = core_id;
+                executing_task_ids_[thread_idx][core_id] = aiv_running_task_ids[j];
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            for (int32_t j = 0; j < aiv_idle_cores_num; j++) {
+                if (core_id == aiv_idle_cores[j]) {
+                    trackers_[thread_idx].aiv().idle[trackers_[thread_idx].aiv().idle_count++] = core_id;
+                    break;
+                }
+            }
+        }
+    }
+
+    // Log final distribution for verification
+    DEV_INFO("Core reassignment complete:");
+    for (int32_t t = 0; t < thread_num_; t++) {
+        DEV_INFO("  Thread %d: %d cores (AIC: running=%d idle=%d, AIV: running=%d idle=%d)",
+                 t, core_count_per_thread_[t],
+                 trackers_[t].aic().running_count, trackers_[t].aic().idle_count,
+                 trackers_[t].aiv().running_count, trackers_[t].aiv().idle_count);
+    }
+}
+
+int32_t AicpuExecutor::init(Runtime* runtime) {
+    bool expected = false;
+    if (!initialized_.compare_exchange_strong(expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
+        return 0;
+    }
+
+    DEV_INFO("AicpuExecutor: Initializing");
+
+    if (runtime == nullptr) {
+        DEV_ERROR("runtime is nullptr");
+        init_failed_.store(true, std::memory_order_release);
+        return -1;
+    }
+
+    // Read execution parameters from runtime
+    thread_num_ = runtime->sche_cpu_num;
+    orch_thread_num_ = runtime->orch_thread_num;
+    sched_thread_num_ = thread_num_ - orch_thread_num_;
+    if (thread_num_ == 0) thread_num_ = 1;
+
+    if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
+        DEV_ERROR("Invalid thread_num: %d", thread_num_);
+        init_failed_.store(true, std::memory_order_release);
+        return -1;
+    }
+
+    // Initialize core_id_to_reg_addr_ array to 0 before handshake
+    for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
+        core_id_to_reg_addr_[i] = 0;
+    }
+
+    // Use handshake mechanism to discover cores (aligned with host_build_graph)
+    int32_t rc = handshake_all_cores(runtime);
+    if (rc != 0) {
+        DEV_ERROR("handshake_all_cores failed");
+        init_failed_.store(true, std::memory_order_release);
+        return -1;
+    }
+
+    // Dynamically assign cores to threads
+    assign_cores_to_threads();
+
+    DEV_INFO("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num_);
+
+    // Initialize runtime execution state
+    // Task count comes from PTO2 shared memory
+    if (runtime->get_pto2_gm_sm_ptr()) {
+        auto* header = static_cast<PTO2SharedMemoryHeader*>(runtime->get_pto2_gm_sm_ptr());
+        int32_t pto2_count = header->current_task_index.load(std::memory_order_acquire);
+        total_tasks_ = pto2_count > 0 ? pto2_count : 0;
+    } else {
+        total_tasks_ = 0;
+    }
+    completed_tasks_.store(0, std::memory_order_release);
+    // Host orchestration: graph already built, no wait needed. Device orch: Thread 3 will set this.
+    bool orch_on_host = runtime->get_orch_built_on_host();
+    DEV_INFO("Init: orch_built_on_host=%d", orch_on_host ? 1 : 0);
+    orchestrator_done_ = orch_on_host;
+
+    // Initial ready tasks will be populated via scheduler ready queues
+
+    // Reset per-core dispatch timestamps and task counters
+    for (int32_t i = 0; i < RUNTIME_MAX_WORKER; i++) {
+        dispatch_timestamps_[i] = 0;
+        core_dispatch_counts_[i] = 0;
+    }
+
+    DEV_INFO("Init: PTO2 mode, task count from shared memory");
+
+    finished_count_.store(0, std::memory_order_release);
+
+    init_done_.store(true, std::memory_order_release);
+    DEV_INFO("AicpuExecutor: Init complete");
+    return 0;
+}
+
+/**
+ * Shutdown AICore - Send exit signal via registers to all AICore kernels
+ */
+int32_t AicpuExecutor::shutdown_aicore(Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num) {
+    (void)runtime;
+    if (core_num == 0) return 0;
+
+    DEV_INFO("Thread %d: Shutting down %d cores", thread_idx, core_num);
+
+    for (int32_t i = 0; i < core_num; i++) {
+        int32_t core_id = cur_thread_cores[i];
+        uint64_t reg_addr = core_id_to_reg_addr_[core_id];
+        if (reg_addr != 0) {
+            platform_deinit_aicore_regs(reg_addr);
+        } else {
+            DEV_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
+        }
+    }
+    DEV_INFO("Thread %d: Shutdown complete", thread_idx);
+    return 0;
+}
+
+int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx) {
+    int32_t &core_num = core_count_per_thread_[thread_idx];
+    int32_t* executing_task_ids = executing_task_ids_[thread_idx];
+    CoreStateTracker& tracker = trackers_[thread_idx];
+    DEV_INFO("Thread %d: resolve_and_dispatch_pto2 entry", thread_idx);
+
+    void* sm_base = runtime->get_pto2_gm_sm_ptr();
+    if (!sm_base) {
+        DEV_ERROR("PTO2 dispatch: sm_base is null");
+        return -1;
+    }
+    DEV_INFO("Thread %d: sm_base=%p", thread_idx, sm_base);
+
+    PTO2SharedMemoryHeader* header = static_cast<PTO2SharedMemoryHeader*>(sm_base);
+    DEV_INFO("Thread %d: header=%p, task_desc_offset=%d, window_size=%d",
+             thread_idx, (void*)header, header->task_descriptors_offset,
+             header->task_window_size);
+
+    PTO2TaskDescriptor* task_descriptors = reinterpret_cast<PTO2TaskDescriptor*>(
+        static_cast<char*>(sm_base) + header->task_descriptors_offset);
+    PTO2TaskPayload* task_payloads = reinterpret_cast<PTO2TaskPayload*>(
+        reinterpret_cast<char*>(task_descriptors) +
+        PTO2_ALIGN_UP(header->task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE));
+    DEV_INFO("Thread %d: task_descriptors=%p",
+             thread_idx, (void*)task_descriptors);
+
+    int32_t window_size = header->task_window_size;
+    if (window_size <= 0 || window_size > PTO2_TASK_WINDOW_SIZE) window_size = PTO2_TASK_WINDOW_SIZE;
+    int32_t window_mask = window_size - 1;
+
+    Handshake* hank = static_cast<Handshake*>(runtime->workers);
+    DEV_INFO("Thread %d: hank=%p, window_size=%d",
+             thread_idx, (void*)hank, window_size);
+
+    // One-time init: assign perf buffers (one thread does it; others wait)
+    if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
+        DEV_INFO("Thread %d: doing one-time init", thread_idx);
+
+#if PTO2_PROFILING
+        // Assign perf buffers to cores early so profiling captures all tasks
+        // (total_tasks written to header later when orchestrator completes)
+        if (runtime->enable_profiling) {
+            perf_aicpu_init_profiling(runtime);
+            // Initialize phase profiling for scheduler threads + orchestrator threads
+            perf_aicpu_init_phase_profiling(runtime, sched_thread_num_, orch_thread_num_);
+            perf_aicpu_set_orch_thread_idx(sched_thread_num_);
+        }
+#endif
+
+        DEV_INFO("Thread %d: one-time init done", thread_idx);
+        pto2_init_complete_.store(true, std::memory_order_release);
+    } else {
+        while (!pto2_init_complete_.load(std::memory_order_acquire)) {
+            SPIN_WAIT_HINT();
+        }
+    }
+
+    DEV_INFO("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, core_num);
+    int32_t cur_thread_completed = 0;
+    int32_t idle_iterations = 0;
+    int32_t last_progress_count = 0;
+#if PTO2_PROFILING
+    bool profiling_enabled = runtime->enable_profiling;
+#endif
+
+    // Scheduler profiling counters
+#if PTO2_PROFILING
+    uint64_t sched_scan_cycle = 0;
+    uint64_t sched_complete_cycle = 0;
+    uint64_t sched_dispatch_cycle = 0;
+    uint64_t sched_idle_cycle = 0;
+    uint64_t complete_probe_count = 0;
+    uint64_t complete_hit_count = 0;
+    uint64_t sched_loop_count = 0;
+    uint64_t notify_edges_total = 0;
+    int32_t  notify_max_degree = 0;
+    uint64_t notify_tasks_enqueued = 0;
+    uint64_t fanin_edges_total = 0;
+    int32_t  fanin_max_degree = 0;
+    uint64_t pop_hit = 0;
+    uint64_t pop_miss = 0;
+    uint32_t phase_complete_count = 0;
+    uint32_t phase_dispatch_count = 0;
+    uint64_t local_dispatch_count = 0;
+    uint64_t local_overflow_count = 0;
+#if PTO2_SCHED_PROFILING
+    uint64_t sched_complete_perf_cycle = 0;
+    uint64_t sched_dispatch_pop_cycle = 0;
+    uint64_t sched_dispatch_setup_cycle = 0;
+#endif
+#endif
+
+    // Local-first dispatch buffer (stack-allocated, one per scheduling thread).
+    // Initialized once; must be empty at the start of each iteration.
+    constexpr int LOCAL_READY_CAP = 64;
+    int32_t local_task_ids[LOCAL_READY_CAP];
+    PTO2LocalReadyBuffer local_buf;
+    local_buf.reset(local_task_ids, LOCAL_READY_CAP);
+    int32_t deferred_release_ids[128];
+    int32_t deferred_release_count = 0;
+
+    bool cores_released = false;
+
+    while (true) {
+        bool made_progress = false;
+#if PTO2_PROFILING
+        CYCLE_COUNT_START();
+        sched_loop_count++;
+        uint64_t _t0_phase = _t0;
+#endif
+        int32_t task_count = 0;
+        if (tracker.aic().running_count == 0 && tracker.aiv().running_count == 0) {
+            bool orch_done = orchestrator_done_;
+            if (orch_done) {
+                task_count = total_tasks_;
+                if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
+                    completed_.store(true, std::memory_order_release);
+                    DEV_INFO("Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed), task_count);
+                    break;
+                }
+            }
+        }
+
+        // Check for core transition request (execute once per thread)
+        if (!cores_released && transition_requested_.load(std::memory_order_acquire)) {
+            if (!reassigned_.load(std::memory_order_acquire)) {
+                wait_reassign_.fetch_add(1, std::memory_order_release);
+                while (!reassigned_.load(std::memory_order_acquire)) {
+                    if (completed_.load(std::memory_order_acquire)) {
+                        break;
+                    }
+                    SPIN_WAIT_HINT();
+                }
+                if (completed_.load(std::memory_order_acquire)) {
+                    break;
+                }
+            }
+            cores_released = true;
+        }
+
+#if PTO2_PROFILING
+        CYCLE_COUNT_LAP(sched_idle_cycle);
+#endif
+
+        // Process completed and dispatch FIRST to minimize Sched (dispatch→finish) latency.
+        // Sched time = finish_ts - dispatch_ts; recording finish_ts here at loop start reduces
+        // tail overhead (time from AICore done to AICPU recording finish).
+
+        // Phase 1: Check running cores for completion, process and move to idle
+        int32_t completed_this_turn = 0;
+
+        // Check AIC running cores
+        bool try_completed = false;
+        always_assert(local_buf.count == 0);  // Invariant: previous iteration fully consumed
+        if (tracker.aic().running_count > 0) {
+            try_completed = true;
+            check_running_cores_for_completion<CoreType::AIC>(
+                thread_idx, tracker.aic(), hank, executing_task_ids,
+                completed_this_turn, cur_thread_completed, made_progress,
+                deferred_release_ids, deferred_release_count,
+                local_buf
+#if PTO2_PROFILING
+                , profiling_enabled, complete_probe_count, complete_hit_count, phase_complete_count,
+                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                fanin_edges_total, fanin_max_degree
+#endif
+#if PTO2_SCHED_PROFILING
+                , sched_complete_perf_cycle
+#endif
+            );
+        }
+
+        // Check AIV running cores
+        if (tracker.aiv().running_count > 0) {
+            try_completed = true;
+            check_running_cores_for_completion<CoreType::AIV>(
+                thread_idx, tracker.aiv(), hank, executing_task_ids,
+                completed_this_turn, cur_thread_completed, made_progress,
+                deferred_release_ids, deferred_release_count,
+                local_buf
+#if PTO2_PROFILING
+                , profiling_enabled, complete_probe_count, complete_hit_count, phase_complete_count,
+                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                fanin_edges_total, fanin_max_degree
+#endif
+#if PTO2_SCHED_PROFILING
+                , sched_complete_perf_cycle
+#endif
+            );
+        }
+        if (completed_this_turn > 0) {
+            int32_t prev = completed_tasks_.fetch_add(completed_this_turn, std::memory_order_relaxed);
+            int32_t new_total = prev + completed_this_turn;
+            last_progress_count = new_total;
+            if (thread_idx == 0 && task_count > 0) {
+                if (new_total <= PROGRESS_VERBOSE_THRESHOLD
+                    || new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL
+                    || new_total >= task_count) {
+                    DEV_ALWAYS("PTO2 progress: completed=%d total=%d (%.1f%%)",
+                               new_total, task_count, 100.0 * new_total / task_count);
+                }
+            }
+        }
+
+#if PTO2_PROFILING
+        if (!try_completed) {
+            CYCLE_COUNT_LAP(sched_idle_cycle);
+        } else {
+            if (profiling_enabled && phase_complete_count > 0) {
+                perf_aicpu_record_phase(
+                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, sched_loop_count, phase_complete_count);
+                _t0_phase = _t1;
+                phase_complete_count = 0;
+            }
+            CYCLE_COUNT_LAP(sched_complete_cycle);
+        }
+#endif
+
+        // Phase 2: Local dispatch — match local_buf tasks to idle cores (zero MPMC operations)
+        // Phase 3: Global queue — push overflow to readyQ + fill remaining idle cores from readyQ
+        bool try_pushed = false;
+
+        // Local dispatch: drain local_buf, match to idle cores by type
+        int32_t overflow_ids[LOCAL_READY_CAP];
+        int overflow_count = 0;
+        while (local_buf.count > 0) {
+            int32_t task_id = local_buf.pop();
+            PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
+            CoreType ct_type = static_cast<CoreType>(task->worker_type);
+            CoreTypeTracker& ct = (ct_type == CoreType::AIC) ? tracker.aic() : tracker.aiv();
+
+            if (ct.idle_count > 0) {
+                try_pushed = true;
+                int32_t idle_idx = ct.idle_count - 1;
+                int32_t core_id = ct.idle[idle_idx];
+                PTO2TaskPayload* task_pl = &task_payloads[task_id & window_mask];
+                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
+                if (ct_type == CoreType::AIC) {
+                    build_pto2_payload<CoreType::AIC>(payload, runtime, task, task_pl);
+                } else {
+                    build_pto2_payload<CoreType::AIV>(payload, runtime, task, task_pl);
+                }
+#if PTO2_PROFILING
+                if (profiling_enabled) {
+                    dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    if (core_dispatch_counts_[core_id] >= PLATFORM_PROF_BUFFER_SIZE) {
+                        perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
+                        core_dispatch_counts_[core_id] = 0;
+                    }
+                    core_dispatch_counts_[core_id]++;
+                }
+                pop_hit++;
+                phase_dispatch_count++;
+                local_dispatch_count++;
+#endif
+                write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE,
+                          static_cast<uint64_t>(task_id + 1));
+                ct.move_idle_to_running(idle_idx);
+                executing_task_ids[core_id] = task_id;
+                made_progress = true;
+                DEV_DEBUG("Thread %d: Dispatching PTO2 task %d to core %d (local)",
+                          thread_idx, task_id, core_id);
+            } else {
+                overflow_ids[overflow_count++] = task_id;
+#if PTO2_PROFILING
+                local_overflow_count++;
+#endif
+            }
+        }
+
+        // Push overflow to global readyQ
+        for (int i = 0; i < overflow_count; i++) {
+            PTO2TaskDescriptor* task = &task_descriptors[overflow_ids[i] & window_mask];
+            rt->scheduler.ready_queues[task->worker_type].push(overflow_ids[i]);
+        }
+
+        // Global dispatch: fill remaining idle cores from global readyQ
+        // Process AIC cores if CUBE queue has tasks
+        if (tracker.aic().idle_count > 0 && rt->scheduler.ready_queues[PTO2_WORKER_CUBE].size() > 0) {
+            try_pushed = true;
+            dispatch_ready_tasks_to_idle_cores<CoreType::AIC>(
+                runtime, thread_idx, tracker.aic(), executing_task_ids, made_progress,
+                task_descriptors, task_payloads, window_mask
+#if PTO2_PROFILING
+                , profiling_enabled, pop_hit, pop_miss, phase_dispatch_count
+#endif
+#if PTO2_SCHED_PROFILING
+                , sched_dispatch_pop_cycle, sched_dispatch_setup_cycle
+#endif
+            );
+        }
+
+        // Process AIV cores if VECTOR queue has tasks
+        if (tracker.aiv().idle_count > 0 && rt->scheduler.ready_queues[PTO2_WORKER_VECTOR].size() > 0) {
+            try_pushed = true;
+            dispatch_ready_tasks_to_idle_cores<CoreType::AIV>(
+                runtime, thread_idx, tracker.aiv(), executing_task_ids, made_progress,
+                task_descriptors, task_payloads, window_mask
+#if PTO2_PROFILING
+                , profiling_enabled, pop_hit, pop_miss, phase_dispatch_count
+#endif
+#if PTO2_SCHED_PROFILING
+                , sched_dispatch_pop_cycle, sched_dispatch_setup_cycle
+#endif
+            );
+        }
+
+#if PTO2_PROFILING
+        if (!try_pushed) {
+            CYCLE_COUNT_LAP(sched_idle_cycle);
+        } else {
+            if (profiling_enabled && phase_dispatch_count > 0) {
+                perf_aicpu_record_phase(
+                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, sched_loop_count, phase_dispatch_count);
+                _t0_phase = _t1;
+                phase_dispatch_count = 0;
+            }
+            CYCLE_COUNT_LAP(sched_dispatch_cycle);
+#endif
+        }
+
+        if (made_progress) {
+            idle_iterations = 0;
+        } else {
+            // Batch deferred fanin releases during idle.
+            // Processing all pending releases at once advances the ring faster,
+            // freeing heap space for the orchestrator without blocking completion polling.
+            while (deferred_release_count > 0) {
+#if PTO2_SCHED_PROFILING
+                int32_t fe = rt->scheduler.on_task_release(deferred_release_ids[--deferred_release_count], thread_idx);
+#else
+                int32_t fe = rt->scheduler.on_task_release(deferred_release_ids[--deferred_release_count]);
+#endif
+                (void)fe;
+#if PTO2_PROFILING
+                fanin_edges_total += fe;
+                if (fe > fanin_max_degree) fanin_max_degree = fe;
+#endif
+            }
+            idle_iterations++;
+            if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
+                int32_t c = completed_tasks_.load(std::memory_order_relaxed);
+                DEV_ALWAYS("PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
+                           idle_iterations, c, task_count, last_progress_count);
+                // Scan all task slots to find truly stuck tasks using scheduler state
+                PTO2SchedulerState* sched = &rt->scheduler;
+                int32_t cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
+                for (int32_t si = 0; si < task_count; si++) {
+                    int32_t slot = si & window_mask;
+                    PTO2TaskState st = sched->task_state[slot].load(std::memory_order_relaxed);
+                    int32_t rc = sched->fanin_refcount[slot].load(std::memory_order_relaxed);
+                    int32_t fi = task_descriptors[slot].fanin_count;
+                    int32_t kid = task_descriptors[slot].kernel_id;
+                    if (st >= PTO2_TASK_COMPLETED) continue; // Already done
+                    if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) { cnt_inflight++; continue; }
+                    // PENDING
+                    if (rc >= fi) {
+                        // Ready (all deps satisfied) but not enqueued — this is the real bug
+                        cnt_ready++;
+                        if (cnt_ready <= STALL_DUMP_READY_MAX) {
+                            DEV_ALWAYS("  STUCK-READY  slot=%d kernel_id=%d refcount=%d fanin=%d state=%d",
+                                       slot, kid, rc, fi, (int32_t)st);
+                        }
+                    } else {
+                        cnt_waiting++;
+                        if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
+                            DEV_ALWAYS("  STUCK-WAIT   slot=%d kernel_id=%d refcount=%d fanin=%d state=%d",
+                                       slot, kid, rc, fi, (int32_t)st);
+                        }
+                    }
+                }
+                DEV_ALWAYS("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d",
+                           cnt_ready, cnt_waiting, cnt_inflight);
+                // Log this thread's dispatch state
+                int32_t total_idle = tracker.aic().idle_count + tracker.aiv().idle_count;
+                int32_t total_running = tracker.aic().running_count + tracker.aiv().running_count;
+                DEV_ALWAYS("  thread=%d idle_cores=%d (AIC=%d AIV=%d) running_cores=%d (AIC=%d AIV=%d) core_num=%d",
+                           thread_idx, total_idle, tracker.aic().idle_count, tracker.aiv().idle_count,
+                           total_running, tracker.aic().running_count, tracker.aiv().running_count, core_num);
+                // Dump AIC running cores
+                for (int32_t ci = 0; ci < tracker.aic().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
+                    int32_t cid = tracker.aic().running[ci];
+                    Handshake* hh = &hank[cid];
+                    int32_t hw_task_id = -1;
+                    int32_t hw_kernel = -1;
+                    if (hh->task != 0) {
+                        const PTO2DispatchPayload* pl = reinterpret_cast<const PTO2DispatchPayload*>((uintptr_t)hh->task);
+                        hw_task_id = pl->task_id;
+                        hw_kernel  = pl->kernel_id;
+                    }
+                    DEV_ALWAYS("    AIC core[%d] cid=%d sw_task=%d hw_task=%d hw_kernel=%d",
+                               ci, cid, executing_task_ids[cid], hw_task_id, hw_kernel);
+                }
+                // Dump AIV running cores
+                for (int32_t ci = 0; ci < tracker.aiv().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
+                    int32_t cid = tracker.aiv().running[ci];
+                    Handshake* hh = &hank[cid];
+                    int32_t hw_task_id = -1;
+                    int32_t hw_kernel = -1;
+                    if (hh->task != 0) {
+                        const PTO2DispatchPayload* pl = reinterpret_cast<const PTO2DispatchPayload*>((uintptr_t)hh->task);
+                        hw_task_id = pl->task_id;
+                        hw_kernel  = pl->kernel_id;
+                    }
+                    uint64_t cond_reg = read_reg(core_id_to_reg_addr_[cid], RegId::COND);
+                    DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d payload_task=%d kernel=%d",
+                               cid, (unsigned)cond_reg,
+                               EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
+                               executing_task_ids[cid], hw_task_id, hw_kernel);
+                }
+            }
+            if (idle_iterations > MAX_IDLE_ITERATIONS) {
+                DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+                return -1;
+            } else {
+                SPIN_WAIT_HINT();
+            }
+#if PTO2_PROFILING
+            if (profiling_enabled) {
+                perf_aicpu_record_phase(thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT,
+                                        _t0_phase, _t1, sched_loop_count, 0);
+                _t0_phase = _t1;
+            }
+            CYCLE_COUNT_LAP(sched_idle_cycle);
+#endif
+        }
+    }
+
+#if PTO2_PROFILING
+    // Scheduler summary logging (always print when PTO2_PROFILING=1)
+    uint64_t sched_total =
+        sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
+    if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
+
+#if PTO2_SCHED_PROFILING
+    // Two-level tree display: sub-phase breakdown within complete and dispatch
+    {
+        PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
+        uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
+        uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle)
+            ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle) : 0;
+        uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle)
+            ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) : 0;
+
+        DEV_ALWAYS("Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===",
+            thread_idx, cycles_to_us(sched_total), cur_thread_completed);
+
+        // Level 1: complete
+        double notify_avg = cur_thread_completed > 0
+            ? (double)notify_edges_total / cur_thread_completed : 0.0;
+        double fanin_avg = cur_thread_completed > 0
+            ? (double)fanin_edges_total / cur_thread_completed : 0.0;
+        DEV_ALWAYS("Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%llu, max_degree=%d, avg=%.1f]  [fanin: edges=%llu, max_degree=%d, avg=%.1f]",
+            thread_idx, cycles_to_us(sched_complete_cycle),
+            sched_complete_cycle * 100.0 / sched_total,
+            (unsigned long long)notify_edges_total, notify_max_degree, notify_avg,
+            (unsigned long long)fanin_edges_total, fanin_max_degree, fanin_avg);
+
+        // Level 2: complete sub-phases (percentage relative to complete)
+        uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
+        uint64_t complete_miss_count = (complete_probe_count > complete_hit_count)
+            ? (complete_probe_count - complete_hit_count) : 0;
+        double complete_hit_rate = complete_probe_count > 0
+            ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
+        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)  hit=%llu, miss=%llu, hit_rate=%.1f%%",
+            thread_idx, cycles_to_us(complete_poll),
+            complete_poll * 100.0 / c_parent,
+            (unsigned long long)complete_hit_count,
+            (unsigned long long)complete_miss_count,
+            complete_hit_rate);
+        DEV_ALWAYS("Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
+            thread_idx, cycles_to_us(sp.lock_cycle),
+            sp.lock_cycle * 100.0 / c_parent,
+            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
+            (unsigned long long)sp.lock_atomic_count);
+        DEV_ALWAYS("Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
+            thread_idx, cycles_to_us(sp.fanout_cycle),
+            sp.fanout_cycle * 100.0 / c_parent,
+            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
+            (unsigned long long)sp.fanout_atomic_count);
+        DEV_ALWAYS("Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%llu",
+            thread_idx, cycles_to_us(sp.fanin_cycle),
+            sp.fanin_cycle * 100.0 / c_parent,
+            (unsigned long long)sp.fanin_atomic_count);
+        DEV_ALWAYS("Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%llu",
+            thread_idx, cycles_to_us(sp.self_consumed_cycle),
+            sp.self_consumed_cycle * 100.0 / c_parent,
+            (unsigned long long)sp.self_atomic_count);
+        DEV_ALWAYS("Thread %d:     perf         : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(sched_complete_perf_cycle),
+            sched_complete_perf_cycle * 100.0 / c_parent);
+
+        // Level 1: dispatch
+        uint64_t pop_total = pop_hit + pop_miss;
+        double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
+        DEV_ALWAYS("Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%llu, miss=%llu, hit_rate=%.1f%%]",
+            thread_idx, cycles_to_us(sched_dispatch_cycle),
+            sched_dispatch_cycle * 100.0 / sched_total,
+            (unsigned long long)pop_hit,
+            (unsigned long long)pop_miss,
+            pop_hit_rate);
+        uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
+        uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
+        double local_hit_rate = total_dispatched > 0
+            ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
+        DEV_ALWAYS("Thread %d:     local_disp   : local=%llu, global=%llu, overflow=%llu, local_rate=%.1f%%",
+            thread_idx,
+            (unsigned long long)local_dispatch_count,
+            (unsigned long long)global_dispatch_count,
+            (unsigned long long)local_overflow_count,
+            local_hit_rate);
+
+        // Level 2: dispatch sub-phases (percentage relative to dispatch)
+        uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
+        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(dispatch_poll),
+            dispatch_poll * 100.0 / d_parent);
+        DEV_ALWAYS("Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
+            thread_idx, cycles_to_us(sched_dispatch_pop_cycle),
+            sched_dispatch_pop_cycle * 100.0 / d_parent,
+            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+            (unsigned long long)sp.pop_atomic_count);
+        DEV_ALWAYS("Thread %d:     setup        : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
+            sched_dispatch_setup_cycle * 100.0 / d_parent);
+
+        // Level 1: scan
+        DEV_ALWAYS("Thread %d:   scan           : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(sched_scan_cycle),
+            sched_scan_cycle * 100.0 / sched_total);
+
+        // Level 1: idle
+        DEV_ALWAYS("Thread %d:   idle           : %.3fus (%.1f%%)",
+            thread_idx, cycles_to_us(sched_idle_cycle),
+            sched_idle_cycle * 100.0 / sched_total);
+
+        // Average per completion
+        if (cur_thread_completed > 0) {
+            DEV_ALWAYS("Thread %d:   avg/complete   : %.3fus",
+                thread_idx, cycles_to_us(sched_complete_cycle) / cur_thread_completed);
+        }
+    }
+#endif
+    // Summary line (always print when PTO2_PROFILING=1)
+    DEV_ALWAYS("Thread %d: Scheduler summary: total_time=%.3fus, loops=%llu, tasks_scheduled=%d",
+        thread_idx,
+        cycles_to_us(sched_total),
+        (unsigned long long)sched_loop_count,
+        cur_thread_completed);
+#endif
+
+#if PTO2_PROFILING
+    // Flush performance buffers for cores managed by this thread
+    if (profiling_enabled) {
+        perf_aicpu_flush_buffers(runtime, thread_idx, core_assignments_[thread_idx], core_num);
+        perf_aicpu_flush_phase_buffers(thread_idx);
+    }
+#endif
+
+    return cur_thread_completed;
+}
+
+int32_t AicpuExecutor::run(Runtime* runtime) {
+    int32_t thread_idx = thread_idx_++;
+
+    DEV_ALWAYS("Thread %d: Start", thread_idx);
+
+    // Orchestrator threads: thread_idx >= sched_thread_num_
+    if (thread_idx >= sched_thread_num_) {
+        int32_t orch_idx = thread_idx - sched_thread_num_;
+        if (runtime->get_orch_built_on_host()) {
+            DEV_INFO("Thread %d: Host orchestration mode, no-op (orch_idx=%d)", thread_idx, orch_idx);
+        } else {
+            // First orchestrator thread (orch_idx == 0): load SO, create runtime
+            if (orch_idx == 0) {
+                DEV_INFO("Thread %d: Primary orchestrator, loading SO via dlopen", thread_idx);
+
+                const void* so_data = runtime->get_device_orch_so_data();
+                size_t so_size = runtime->get_device_orch_so_size();
+
+                if (so_data == nullptr || so_size == 0) {
+                    DEV_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
+                    return -1;
+                }
+
+                // Try multiple paths that may allow execution on AICPU
+                char so_path[256];
+                bool file_created = false;
+                const char* candidate_dirs[] = {
+                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device",
+                    "/usr/lib64",
+                    "/lib64",
+                    "/var/tmp",
+                    "/tmp"
+                };
+                const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
+
+                for (int32_t i = 0; i < num_candidates && !file_created; i++) {
+                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so",
+                             candidate_dirs[i], getpid());
+                    int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+                    if (fd < 0) {
+                        DEV_INFO("Thread %d: Cannot create SO at %s (errno=%d), trying next path",
+                                 thread_idx, so_path, errno);
+                        continue;
+                    }
+                    ssize_t written = write(fd, so_data, so_size);
+                    close(fd);
+                    if (written != static_cast<ssize_t>(so_size)) {
+                        DEV_INFO("Thread %d: Cannot write SO to %s (errno=%d), trying next path",
+                                 thread_idx, so_path, errno);
+                        unlink(so_path);
+                        continue;
+                    }
+                    file_created = true;
+                    DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+                }
+
+                if (!file_created) {
+                    DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
+                    return -1;
+                }
+
+                dlerror();
+                void* handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+                const char* dlopen_err = dlerror();
+                if (handle == nullptr) {
+                    DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
+                    unlink(so_path);
+                    return -1;
+                }
+                DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
+
+                dlerror();
+                auto config_func = reinterpret_cast<DeviceOrchestrationConfigFunc>(
+                    dlsym(handle, "aicpu_orchestration_config"));
+
+                dlerror();
+                DeviceOrchestrationFunc orch_func =
+                    reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
+                const char* dlsym_error = dlerror();
+                if (dlsym_error != nullptr) {
+                    DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
+                    dlclose(handle);
+                    unlink(so_path);
+                    return -1;
+                }
+                if (orch_func == nullptr) {
+                    DEV_ERROR("Thread %d: dlsym returned NULL for aicpu_orchestration_entry", thread_idx);
+                    dlclose(handle);
+                    unlink(so_path);
+                    return -1;
+                }
+
+                uint64_t* args = runtime->get_orch_args();
+                int32_t arg_count = runtime->get_orch_arg_count();
+                DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
+                for (int32_t i = 0; i < arg_count && i < 20; i++) {
+                    DEV_INFO("Thread %d: args[%d] = 0x%lx", thread_idx, i, args[i]);
+                }
+
+                uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
+                uint64_t heap_size = PTO2_HEAP_SIZE;
+                int32_t expected_arg_count = 0;
+                if (config_func) {
+                    PTO2OrchestrationConfig cfg = config_func(args, arg_count);
+                    expected_arg_count = cfg.expected_arg_count;
+                    DEV_INFO("Thread %d: Config: expected_args=%d", thread_idx, expected_arg_count);
+                } else {
+                    DEV_INFO("Thread %d: No config function, using defaults", thread_idx);
+                }
+
+                if (expected_arg_count > 0 && arg_count < expected_arg_count) {
+                    DEV_ERROR("Thread %d: arg_count %d < expected %d", thread_idx, arg_count, expected_arg_count);
+                    dlclose(handle);
+                    unlink(so_path);
+                    return -1;
+                }
+
+                if (runtime->pto2_task_window_size > 0) {
+                    task_window_size = runtime->pto2_task_window_size;
+                }
+                if (runtime->pto2_heap_size > 0) {
+                    heap_size = runtime->pto2_heap_size;
+                }
+                DEV_INFO("Thread %d: Ring sizes: task_window=%lu, heap=%lu",
+                         thread_idx, (unsigned long)task_window_size, (unsigned long)heap_size);
+
+                void* sm_ptr = runtime->get_pto2_gm_sm_ptr();
+                void* gm_heap = runtime->get_pto2_gm_heap_ptr();
+
+                uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+                PTO2SharedMemoryHandle* sm_handle =
+                    pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size,
+                                                heap_size);
+                if (!sm_handle) {
+                    DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
+                    dlclose(handle);
+                    unlink(so_path);
+                    return -1;
+                }
+
+                rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE,
+                                                 sm_handle, gm_heap, heap_size, orch_thread_num_);
+                if (!rt) {
+                    DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
+                    pto2_sm_destroy(sm_handle);
+                    dlclose(handle);
+                    unlink(so_path);
+                    return -1;
+                }
+
+                // Store shared state for other orchestrator threads
+                orch_func_ = orch_func;
+                orch_args_cached_ = args;
+                orch_arg_count_cached_ = arg_count;
+                orch_so_handle_ = handle;
+                snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
+
+                // All-orchestrator mode: primary orchestrator does one-time init
+                if (sched_thread_num_ == 0) {
+                    DEV_INFO("Thread %d: All-orchestrator mode, doing one-time init", thread_idx);
+                    if (runtime->enable_profiling) {
+                        perf_aicpu_init_profiling(runtime);
+                        // After transition, all threads become schedulers
+                        perf_aicpu_init_phase_profiling(runtime, thread_num_, orch_thread_num_);
+                        perf_aicpu_set_orch_thread_idx(0);
+                    }
+                    pto2_init_done_.store(true, std::memory_order_release);
+                    pto2_init_complete_.store(true, std::memory_order_release);
+                    DEV_INFO("Thread %d: One-time init done", thread_idx);
+                }
+
+                runtime_init_ready_.store(true, std::memory_order_release);
+            } else {
+                // Non-primary orchestrator: wait for primary to finish setup
+                while (!runtime_init_ready_.load(std::memory_order_acquire)) {
+                    SPIN_WAIT_HINT();
+                }
+            }
+
+            // Wait for scheduler's one-time init to complete
+            // (or primary orchestrator's init in all-orchestrator mode)
+            while (!pto2_init_complete_.load(std::memory_order_acquire)) {
+                SPIN_WAIT_HINT();
+            }
+
+            pto2_set_orch_thread_idx(orch_idx);
+
+            // Call orchestration function wrapped in an outer scope
+            DEV_ALWAYS("Thread %d: Calling aicpu_orchestration_entry from SO (orch_idx=%d/(0~%d))",
+                       thread_idx, orch_idx, orch_thread_num_ - 1);
+#if PTO2_PROFILING
+            DEV_ALWAYS("Thread=%d orch_start=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+            uint64_t orch_cycle_start = get_sys_cnt_aicpu();
+#endif
+            PTO2_SCOPE(rt) { orch_func_(rt, orch_args_cached_, orch_arg_count_cached_, orch_thread_num_, orch_idx); }
+#if PTO2_PROFILING
+            uint64_t orch_cycle_end = get_sys_cnt_aicpu();
+            DEV_ALWAYS("Thread %d: aicpu_orchestration_entry returned, cost %.3fus (orch_idx=%d)",
+                thread_idx, cycles_to_us(orch_cycle_end - orch_cycle_start), orch_idx);
+#endif
+
+            // Print orchestrator profiling data
+#if PTO2_ORCH_PROFILING
+            PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
+            uint64_t total = p.sync_cycle + p.alloc_cycle + p.params_cycle +
+                             p.lookup_cycle + p.heap_cycle + p.insert_cycle +
+                             p.fanin_cycle;
+            if (total == 0) total = 1;  // avoid div-by-zero
+            DEV_ALWAYS("Thread %d: === Orchestrator Profiling: %lld tasks, total=%.3fus ===", thread_idx,
+                     (long long)p.submit_count, cycles_to_us(total));
+            DEV_ALWAYS("Thread %d:   sync_tensormap : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.sync_cycle), p.sync_cycle * 100.0 / total);
+            DEV_ALWAYS("Thread %d:   task_ring_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                cycles_to_us(p.alloc_cycle), p.alloc_cycle * 100.0 / total,
+                cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle), cycles_to_us(p.alloc_wait_cycle),
+                (unsigned long long)p.alloc_atomic_count);
+            DEV_ALWAYS("Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%llu", thread_idx,
+                cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total,
+                (unsigned long long)p.params_atomic_count);
+            DEV_ALWAYS("Thread %d:   lookup+dep     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.lookup_cycle), p.lookup_cycle * 100.0 / total);
+            DEV_ALWAYS("Thread %d:   heap_alloc     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                cycles_to_us(p.heap_cycle), p.heap_cycle * 100.0 / total,
+                cycles_to_us(p.heap_cycle - p.heap_wait_cycle), cycles_to_us(p.heap_wait_cycle),
+                (unsigned long long)p.heap_atomic_count);
+            DEV_ALWAYS("Thread %d:   tensormap_ins  : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.insert_cycle), p.insert_cycle * 100.0 / total);
+            DEV_ALWAYS("Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu", thread_idx,
+                cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
+                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
+                (unsigned long long)p.fanin_atomic_count);
+            DEV_ALWAYS("Thread %d:   scope_end      : %.3fus  atomics=%llu", thread_idx,
+                cycles_to_us(p.scope_end_cycle),
+                (unsigned long long)p.scope_end_atomic_count);
+            DEV_ALWAYS("Thread %d:   avg/task       : %.3fus", thread_idx,
+                p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0);
+
+#if PTO2_TENSORMAP_PROFILING
+            PTO2TensorMapProfilingData tp = pto2_tensormap_get_profiling();
+            DEV_ALWAYS("Thread %d: === TensorMap Lookup Stats ===", thread_idx);
+            DEV_ALWAYS("Thread %d:   lookups        : %llu, inserts: %llu", thread_idx,
+                (unsigned long long)tp.lookup_count, (unsigned long long)tp.insert_count);
+            DEV_ALWAYS("Thread %d:   chain walked   : total=%llu, avg=%.1f, max=%d", thread_idx,
+                (unsigned long long)tp.lookup_chain_total,
+                tp.lookup_count > 0 ? (double)tp.lookup_chain_total / tp.lookup_count : 0.0,
+                tp.lookup_chain_max);
+            DEV_ALWAYS("Thread %d:   overlap checks : %llu, hits=%llu (%.1f%%)", thread_idx,
+                (unsigned long long)tp.overlap_checks, (unsigned long long)tp.overlap_hits,
+                tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0);
+#endif
+
+#if PTO2_PROFILING
+            // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
+            if (runtime->enable_profiling) {
+                AicpuOrchSummary orch_summary = {};
+                orch_summary.start_time = orch_cycle_start;
+                orch_summary.end_time = orch_cycle_end;
+                orch_summary.sync_cycle = p.sync_cycle;
+                orch_summary.alloc_cycle = p.alloc_cycle;
+                orch_summary.params_cycle = p.params_cycle;
+                orch_summary.lookup_cycle = p.lookup_cycle;
+                orch_summary.heap_cycle = p.heap_cycle;
+                orch_summary.insert_cycle = p.insert_cycle;
+                orch_summary.fanin_cycle = p.fanin_cycle;
+                orch_summary.scope_end_cycle = p.scope_end_cycle;
+                orch_summary.submit_count = p.submit_count;
+                perf_aicpu_write_orch_summary(&orch_summary);
+            }
+#endif
+#endif
+
+#if PTO2_PROFILING
+            // Write core-to-thread mapping (one-time, after orchestration)
+            if (runtime->enable_profiling) {
+                perf_aicpu_write_core_assignments(
+                    core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_);
+                // Flush orchestrator's phase record buffer
+                perf_aicpu_flush_phase_buffers(thread_idx);
+            }
+#endif
+
+            // Coordinate orchestrator completion
+            int32_t finished = orch_finished_count_.fetch_add(1, std::memory_order_acq_rel) + 1;
+            if (finished == orch_thread_num_) {
+                // Last orchestrator: signal completion and trigger core transition
+                pto2_rt_orchestration_done(rt);
+
+                void* sm = runtime->get_pto2_gm_sm_ptr();
+                PTO2SharedMemoryHeader* sm_header = static_cast<PTO2SharedMemoryHeader*>(sm);
+                int32_t pto2_task_count =
+                    sm_header ? sm_header->current_task_index.load(std::memory_order_acquire) : 0;
+#if PTO2_PROFILING
+                DEV_ALWAYS("PTO2 total submitted tasks = %d, already executed %d tasks", pto2_task_count, completed_tasks_.load(std::memory_order_acquire));
+#endif
+                total_tasks_ = pto2_task_count;
+                if (runtime->enable_profiling && pto2_task_count > 0) {
+                    perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
+                }
+                orchestrator_done_ = true;
+
+                // Compute new core assignments for all threads and initialize donated slots
+                DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
+#if PTO2_PROFILING
+                // Benchmark: record orchestrator end timestamp before waiting for schedulers
+                DEV_ALWAYS("BENCHMARK: thread=%d end=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+#endif
+                transition_requested_.store(true, std::memory_order_release);
+
+                // Wait for scheduler threads to acknowledge transition request
+                // All-orchestrator mode (sched_thread_num_ == 0): skip the wait
+                if (sched_thread_num_ > 0) {
+                    while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
+                        if (completed_.load(std::memory_order_acquire)) {
+                            break;
+                        }
+                        SPIN_WAIT_HINT();
+                    }
+                }
+                if (!completed_.load(std::memory_order_acquire)) {
+                    reassign_cores_for_all_threads();
+                    reassigned_.store(true, std::memory_order_release);
+                }
+            } else {
+                // Non-last orchestrator: wait for last orchestrator to finish setup
+                while (!transition_requested_.load(std::memory_order_acquire)) {
+                    SPIN_WAIT_HINT();
+                }
+                while (!reassigned_.load(std::memory_order_acquire)) {
+                    if (completed_.load(std::memory_order_acquire)) {
+                        break;
+                    }
+                    SPIN_WAIT_HINT();
+                }
+            }
+        }
+        DEV_INFO("Thread %d: Orchestrator completed (orch_idx=%d)", thread_idx, orch_idx);
+    }
+
+    // Scheduler thread
+    if (!completed_.load(std::memory_order_acquire)) {
+        DEV_ALWAYS("Thread %d: Starting PTO2 dispatch", thread_idx);
+        // Device orchestration: wait for primary orchestrator to initialize SM header
+        if (!runtime->get_orch_built_on_host()) {
+            while (!runtime_init_ready_.load(std::memory_order_acquire)) {
+                SPIN_WAIT_HINT();
+            }
+        }
+        always_assert(rt != nullptr);
+        int32_t completed = resolve_and_dispatch_pto2(runtime, thread_idx);
+        DEV_INFO("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
+
+        // After transition, use new core assignments for shutdown
+        const int32_t* shutdown_cores = core_assignments_[thread_idx];
+        int32_t shutdown_count = core_count_per_thread_[thread_idx];
+#if PTO2_PROFILING
+        // Benchmark: record scheduler end timestamp before shutdown cleanup
+        DEV_ALWAYS("Thread=%d end=%llu",
+                   thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+#endif
+        auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
+        if (rc != 0) {
+            return rc;
+        }
+    }
+
+    DEV_INFO("Thread %d: Completed", thread_idx);
+
+    // Check if this is the last thread to finish
+    int32_t prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
+    if (prev_finished + 1 == thread_num_) {
+        finished_.store(true, std::memory_order_release);
+        // Destroy PTO2 runtime and close orchestration SO (moved from orchestrator path)
+        if (!runtime->get_orch_built_on_host() && orch_so_handle_ != nullptr) {
+            pto2_runtime_destroy(rt);
+            dlclose(orch_so_handle_);
+            unlink(orch_so_path_);
+        }
+        DEV_ALWAYS("Thread %d: Last thread, marking executor finished", thread_idx);
+    }
+
+    return 0;
+}
+
+void AicpuExecutor::deinit(Runtime* runtime) {
+    // 1. Invalidate AICPU cache for Runtime address range.
+    //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
+    //    bypasses this cache. Invalidating now ensures next round reads from HBM.
+    cache_invalidate_range(runtime, sizeof(Runtime));
+
+    // Reset per-core dispatch timestamps and task counters
+    for (int32_t i = 0; i < RUNTIME_MAX_WORKER; i++) {
+        dispatch_timestamps_[i] = 0;
+        core_dispatch_counts_[i] = 0;
+    }
+
+    // Clear per-core dispatch payloads to prevent stale data on next round
+    memset(s_pto2_payload_per_core, 0, sizeof(s_pto2_payload_per_core));
+
+    completed_tasks_.store(0, std::memory_order_release);
+    total_tasks_ = 0;
+    finished_count_.store(0, std::memory_order_release);
+    orchestrator_done_ = false;
+    pto2_init_done_.store(false, std::memory_order_release);
+    pto2_init_complete_.store(false, std::memory_order_release);
+    runtime_init_ready_.store(false, std::memory_order_release);
+
+    // Reset core transition state
+    transition_requested_.store(false, std::memory_order_release);
+    wait_reassign_.store(0, std::memory_order_release);
+    reassigned_.store(false, std::memory_order_release);
+    completed_.store(false, std::memory_order_release);
+    orch_finished_count_.store(0, std::memory_order_release);
+
+    // Reset core discovery state
+    aic_count_ = 0;
+    aiv_count_ = 0;
+
+    // Reset register-related state
+    for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
+        core_id_to_reg_addr_[i] = 0;
+    }
+    for (int32_t i = 0; i < thread_num_; i++) {
+        for (int32_t j = 0; j < MAX_CORES_PER_THREAD; j++) {
+            executing_task_ids_[i][j] = AICPU_TASK_INVALID;
+        }
+    }
+    regs_ = 0;
+
+    // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
+    rt = nullptr;
+
+    DEV_INFO("DeInit: Runtime execution state reset");
+
+    initialized_.store(false, std::memory_order_release);
+    init_done_.store(false, std::memory_order_release);
+    init_failed_.store(false, std::memory_order_release);
+    thread_idx_.store(0, std::memory_order_release);
+    finished_.store(false, std::memory_order_release);
+
+    DEV_INFO("DeInit: AicpuExecutor reset complete");
+}
+
+void AicpuExecutor::emergency_shutdown() {
+    DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
+
+    for (int32_t i = 0; i < cores_total_num_; i++) {
+        if (core_id_to_reg_addr_[i] != 0) {
+            platform_deinit_aicore_regs(core_id_to_reg_addr_[i]);
+        }
+    }
+
+    DEV_WARN("Emergency shutdown complete");
+}
+
+void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
+                                         const int32_t* cur_thread_cores, int32_t core_num,
+                                         Handshake* hank) {
+    (void)runtime;
+    DEV_ALWAYS("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
+
+    int32_t completed = completed_tasks_.load(std::memory_order_acquire);
+    int32_t total = total_tasks_;
+    DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)",
+             completed, total, total > 0 ? completed * 100.0 / total : 0.0);
+
+    uint64_t aic_ready = 0, aiv_ready = 0;
+    if (rt) {
+        PTO2SchedulerState* sched = &rt->scheduler;
+        aic_ready = sched->ready_queues[PTO2_WORKER_CUBE].size();
+        aiv_ready = sched->ready_queues[PTO2_WORKER_VECTOR].size();
+    }
+    DEV_ALWAYS("Ready Queues: AIC=%lu, AIV=%lu", aic_ready, aiv_ready);
+
+    int32_t busy_cores = 0;
+    int32_t idle_cores = 0;
+
+    DEV_ALWAYS("Core Status:");
+    for (int32_t i = 0; i < core_num; i++) {
+        int32_t core_id = cur_thread_cores[i];
+        Handshake* h = &hank[core_id];
+        const char* core_type_str = core_type_to_string(h->core_type);
+
+        uint64_t reg_addr = core_id_to_reg_addr_[core_id];
+        uint64_t reg_val = read_reg(reg_addr, RegId::COND);
+        int32_t reg_task_id = EXTRACT_TASK_ID(reg_val);
+        int32_t reg_state = EXTRACT_TASK_STATE(reg_val);
+        int32_t task_id = executing_task_ids_[thread_idx][core_id];
+
+        if (reg_state != TASK_FIN_STATE || task_id >= 0) {
+            busy_cores++;
+            if (task_id >= 0) {
+                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
+                DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_task_id=%d, kernel_id=%d",
+                        core_id, core_type_str, reg_val, reg_task_id,
+                        reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
+                        payload->task_id, payload->kernel_id);
+            } else {
+                DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked",
+                        core_id, core_type_str, reg_val, reg_task_id,
+                        reg_state == TASK_FIN_STATE ? "FIN" : "ACK");
+            }
+        } else {
+            idle_cores++;
+        }
+    }
+
+    DEV_ALWAYS("Summary: %d busy, %d idle", busy_cores, idle_cores);
+
+    // Diagnose deadlock vs livelock
+    if (busy_cores == 0 && aic_ready == 0 && aiv_ready == 0 && completed < total) {
+        DEV_ALWAYS("*** DEADLOCK DETECTED ***");
+        DEV_ALWAYS("All cores idle, no ready tasks, but %d tasks incomplete", total - completed);
+        DEV_ALWAYS("Check PTO2 shared memory for task dependency state");
+    } else if (busy_cores > 0) {
+        DEV_ALWAYS("*** LIVELOCK / HUNG TASK ***");
+        DEV_ALWAYS("%d cores executing but no progress", busy_cores);
+    }
+
+    DEV_ALWAYS("========== END DIAGNOSTIC ==========");
+}
+
+// ===== Public Entry Point =====
+
+/**
+ * aicpu_execute - Main AICPU kernel execution entry point
+ *
+ * This is called by DynTileFwkBackendKernelServer in kernel.cpp.
+ * Orchestrates the complete task runtime execution:
+ * 1. Initialize executor (thread-safe, first thread only)
+ * 2. Wait for initialization to complete
+ * 3. Execute tasks on managed cores
+ * 4. Cleanup when last thread finishes
+ *
+ * @param runtime Pointer to Runtime structure
+ * @return 0 on success, non-zero on error
+ */
+extern "C" int32_t aicpu_execute(Runtime* runtime) {
+    if (runtime == nullptr) {
+        DEV_ERROR("%s", "Invalid argument: null Runtime pointer");
+        return -1;
+    }
+
+    DEV_INFO("%s", "aicpu_execute: Starting AICPU kernel execution");
+
+    // Get platform register addresses from platform-level global
+    g_aicpu_executor.regs_ = get_platform_regs();
+
+    g_aicpu_executor.init(runtime);
+
+    while (!g_aicpu_executor.init_done_.load(std::memory_order_acquire)) {
+        if (g_aicpu_executor.init_failed_.load(std::memory_order_acquire)) {
+            DEV_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
+            return -1;
+        }
+    }
+
+    int32_t rc = g_aicpu_executor.run(runtime);
+    if (rc != 0) {
+        DEV_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
+        return rc;
+    }
+
+    // Last thread cleans up
+    if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
+        DEV_INFO("aicpu_execute: Last thread finished, cleaning up");
+        g_aicpu_executor.deinit(runtime);
+    }
+
+    DEV_INFO("%s", "aicpu_execute: Kernel execution completed successfully");
+    return 0;
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/build_config.py
+++ b/src/a5/runtime/tensormap_and_ringbuffer/build_config.py
@@ -1,0 +1,30 @@
+# Tensormap and Ringbuffer Runtime build configuration
+# All paths are relative to this file's directory (src/runtime/tensormap_and_ringbuffer/)
+#
+# This is a device-orchestration runtime where:
+# - AICPU thread 3 runs the orchestrator (builds task graph on device)
+# - AICPU threads 0/1/2 run schedulers (dispatch tasks to AICore)
+# - AICore executes tasks via PTO2DispatchPayload
+#
+# The "orchestration" directory contains source files compiled into both
+# runtime targets AND the orchestration .so (e.g., tensor methods needed
+# by the Tensor constructor's validation logic).
+
+BUILD_CONFIG = {
+    "aicore": {
+        "include_dirs": ["runtime"],
+        "source_dirs": ["aicore", "orchestration"]
+    },
+    "aicpu": {
+        "include_dirs": ["runtime"],
+        "source_dirs": ["aicpu", "runtime", "orchestration"]
+    },
+    "host": {
+        "include_dirs": ["runtime"],
+        "source_dirs": ["host", "runtime", "orchestration"]
+    },
+    "orchestration": {
+        "include_dirs": ["runtime", "orchestration"],
+        "source_dirs": ["orchestration"]
+    }
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/ROADMAP.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/ROADMAP.md
@@ -1,0 +1,86 @@
+# PTO2 Runtime Roadmap: Advanced Scheduling Features
+
+This document outlines the planned features and architectural changes for the PTO2 runtime system, specifically focusing on advanced cluster-aware and block-level scheduling semantics.
+
+## 1. In-Cluster Function Group Scheduling
+
+**Goal:** Enable co-scheduling of multiple tasks onto the same physical hardware cluster to leverage local interconnects and optimize data locality.
+
+### Concept
+An **in-cluster function group** consists of all incore functions submitted between an `allocate_cluster()` and a `free_cluster()` call (or within a managed scope). The runtime treats this group as a co-scheduled unit: every task in the group executes on the **same physical cluster** (identified by a `clusterID`).
+
+### Required Architectural Changes
+
+#### 1. Task Descriptor Extension
+The `PTO2TaskDescriptor` will be extended to record function group membership:
+- `cluster_id` (int32_t): ID of the allocated cluster (-1 = unconstrained).
+- `group_id` (int32_t): Function group identifier.
+
+#### 2. Orchestration API Additions
+```cpp
+// Allocate a cluster. Blocks if no cluster is available.
+int32_t pto2_rt_allocate_cluster(PTO2Runtime* rt);
+
+// Release a cluster back to the free pool.
+void pto2_rt_free_cluster(PTO2Runtime* rt, int32_t cluster_id);
+
+// Submit a task constrained to a specific cluster.
+void pto2_rt_submit_task_clustered(PTO2Runtime* rt, int kernel_id,
+                                    int worker_type, PTOParam* params,
+                                    int n, int32_t cluster_id);
+```
+
+#### 3. Scheduler Enhancements
+- **Cluster ↔ Core mapping**: A static, platform-specific mapping from `cluster_id` to the set of physical cores (e.g., cluster 0 = {AIC0, AIV0, AIV1}).
+- **Cluster-Aware Dispatch**: When popping a task, if `cluster_id >= 0`, the scheduler dispatches it *only* to a core belonging to that specific cluster.
+- **Cluster Free Pool**: A ring or bitset tracking free clusters to handle allocation and release.
+- **Back-Pressure**: `pto2_rt_allocate_cluster` will implement a spin-wait pattern with deadlock detection, similar to the existing task and heap rings.
+
+---
+
+## 2. `block_incore` (SPMD → MPMD) Task Submission
+
+**Goal:** Support executing a single logical SPMD block function as multiple independent MPMD tasks across available cores.
+
+### Execution Model
+At the runtime level, the orchestration layer will **expand** a single `block_incore` call (with a specified `block_dim`) into `block_dim` individual tasks, each with a distinct `block_id`.
+
+```cpp
+// Orchestration expansion logic
+PTO2_SCOPE(rt) {
+    for (int bid = 0; bid < block_dim; bid++) {
+        // ... build params with make_scalar_param(bid) ...
+        pto2_rt_submit_task(rt, KERNEL_FUNC_ID, PTO2_WORKER_VECTOR, params, 4);
+    }
+}
+```
+
+### Future Optimization Path
+While the initial implementation will use O(N) expansion (submitting N individual task descriptors), future optimizations may include:
+- **Batch Descriptors**: A single descriptor containing a `block_dim` field.
+- **Group-Aware Dispatch**: The scheduler scans one descriptor and expands it into `block_dim` hardware dispatches.
+- **Shared-Tensor Optimization**: Reducing TensorMap entries by having one entry per logical tensor instead of per-block tensor.
+
+---
+
+## 3. `block_incore` as InCore Function (Cube + Vector)
+
+**Goal:** Allow a `block_incore` function to be a composite subgraph requiring both AIC (Cube) and AIV (Vector) cores working cooperatively on the same data block.
+
+### Execution Model
+When combined with cluster allocation, both the cube and vector tasks of each block are pinned to the **same cluster**. This ensures they execute on co-located cores and can utilize local interconnects (e.g., `PIPE_IN`/`PIPE_OUT`) without round-tripping to Global Memory.
+
+```cpp
+// Each block runs its cube and vector kernels on the same cluster
+int32_t cid = pto2_rt_allocate_cluster(rt);
+PTO2_SCOPE(rt) {
+    pto2_rt_submit_task_clustered(rt, CUBE_KERNEL, PTO2_WORKER_CUBE, ..., cid);
+    pto2_rt_submit_task_clustered(rt, VEC_KERNEL,  PTO2_WORKER_VECTOR, ..., cid);
+}
+pto2_rt_free_cluster(rt, cid);
+```
+
+### Data Structure Impact Summary
+- `PTO2TaskDescriptor`: Add `cluster_id`, `group_id`, `block_id`, `block_dim`.
+- `PTO2SharedMemoryHeader`: Add cluster free pool tracking.
+- **Scheduler**: Cluster-aware dispatch logic and cluster-to-core mapping tables.

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -1,0 +1,639 @@
+# PTO2 Runtime System Design
+
+## Overview
+
+PTO2 (Parallel Task Orchestration v2) is a runtime system for executing task graphs on Ascend AI processors. It coordinates four layers of execution:
+
+- **Host** (x86/ARM CPU): compiles kernels, allocates device memory, initializes the Runtime, and launches AICPU/AICore threads.
+- **AICPU** (device ARM cores): runs the orchestrator (task graph builder) and scheduler threads.
+- **AICore** (AI compute cores): executes kernel functions dispatched by the scheduler.
+- **Shared Memory** (Global Memory): ring buffers, task descriptors, heap, and TensorMap shared between orchestrator and schedulers.
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│                            Host (CPU)                                 │
+│  golden.py → code_runner.py → compile kernels → init Runtime          │
+│  → upload binaries → launch AICPU/AICore → collect results            │
+└───────────────────────────┬───────────────────────────────────────────┘
+                            │ device memory / GM
+┌───────────────────────────▼───────────────────────────────────────────┐
+│                     AICPU (4 threads)                                  │
+│  Thread 3: Orchestrator (builds task graph)                           │
+│  Threads 0-2: Schedulers (dispatch tasks to AICore)                   │
+│                                                                       │
+│  ┌─────────────────────────────────────────────────────────────────┐  │
+│  │                   Shared Memory (GM)                             │  │
+│  │  SharedMemoryHeader │ TaskDescriptors[] │ DepListPool           │  │
+│  │  GM Heap (output buffers)                                       │  │
+│  └─────────────────────────────────────────────────────────────────┘  │
+│                                                                       │
+│  Scheduler ──Handshake/Registers──► AICore workers (AIC + AIV)        │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 1. Runtime Variants
+
+Three runtime backends exist under `src/runtime/`, each representing a different orchestration and scheduling strategy.
+
+### 1.1 host_build_graph
+
+The host builds the complete task graph before launching device execution. The orchestration SO is loaded and executed on the host CPU.
+
+- **Task storage**: fixed `Task[]` array (up to 131072 tasks)
+- **Scheduling**: AICPU receives the pre-built graph and dispatches tasks by traversing dependencies
+- **Use case**: development and debugging; no device-side orchestration overhead
+
+### 1.2 aicpu_build_graph
+
+The orchestration runs on an AICPU thread, building the task graph on device. Supports concurrent build + schedule (`build_mode=1`).
+
+- **Task storage**: same `Task[]` array as host_build_graph
+- **AicpuBuildApi**: `add_task`, `add_successor_conditional`, `publish_task`, `device_malloc`
+- **Use case**: reduced host→device data transfer; graph can depend on device-side data
+
+### 1.3 tensormap_and_ringbuffer (PTO2)
+
+The primary production runtime. Uses ring buffers for task slots and output memory, with a TensorMap for automatic dependency tracking.
+
+- **Task storage**: `PTO2TaskDescriptor[]` in shared memory ring buffer
+- **Memory**: GM Heap ring for output buffer allocation
+- **Dependencies**: automatically derived from tensor read/write patterns via TensorMap
+- **Thread model**: 3 scheduler threads + 1 orchestrator thread on AICPU
+- **Use case**: production workloads; supports streaming, flow control, and large batch sizes
+
+---
+
+## 2. Platform Abstraction
+
+Two platform implementations exist under `src/platform/`, sharing a common interface.
+
+### 2.1 a2a3 (Real Ascend Hardware)
+
+| Component | Description |
+|-----------|-------------|
+| `device_runner.cpp` | Uses CANN APIs: `rtMalloc`, `rtMemcpy`, `rtLaunchKernel` |
+| `memory_allocator.cpp` | Wraps `rtMalloc`/`rtFree` with allocation tracking |
+| `aicore/kernel.cpp` | `KERNEL_ENTRY(aicore_kernel)` → `aicore_execute` |
+| `aicpu/kernel.cpp` | `DynTileFwkBackendKernelServer` entry → `aicpu_execute` |
+| `spin_hint.h` | ARM `wfe`/`yield` instructions for efficient spinning |
+
+### 2.2 a2a3sim (Thread Simulation)
+
+| Component | Description |
+|-----------|-------------|
+| `device_runner.cpp` | Uses `std::thread` to simulate AICPU/AICore |
+| `memory_allocator.cpp` | Wraps `malloc`/`free` |
+| `aicore/kernel.cpp` | `aicore_execute_wrapper` sets `g_sim_reg_base` per core |
+| `upload_kernel_binary` | `dlopen` kernel SO, `dlsym` entry point |
+
+### 2.3 Platform Constants (`platform_config.h`)
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `PLATFORM_MAX_BLOCKDIM` | 24 | Maximum blocks (each = 1 AIC + 2 AIV) |
+| `PLATFORM_MAX_AICPU_THREADS` | 4 | AICPU thread count (3 schedulers + 1 orchestrator) |
+| `PLATFORM_MAX_AIC_PER_THREAD` | 24 | Max AIC cores per scheduler thread |
+| `PLATFORM_MAX_AIV_PER_THREAD` | 48 | Max AIV cores per scheduler thread |
+| `PLATFORM_PROF_SYS_CNT_FREQ` | 50 MHz | System counter frequency for profiling |
+
+---
+
+## 3. Shared Memory Layout
+
+The orchestrator and schedulers communicate through a contiguous shared memory region in Global Memory (GM):
+
+```
+┌─────────────────────────────┐  offset 0
+│  PTO2SharedMemoryHeader     │  (flow control, config, sync flags)
+├─────────────────────────────┤  aligned
+│  PTO2TaskDescriptor[N]      │  N = task_window_size (default 65536)
+├─────────────────────────────┤  aligned
+│  PTO2DepListEntry[M+1]      │  M = dep_list_pool_size (entry 0 = NULL sentinel)
+└─────────────────────────────┘
+```
+
+### 3.1 SharedMemoryHeader Fields
+
+| Field | Writer | Reader | Purpose |
+|-------|--------|--------|---------|
+| `current_task_index` | Orchestrator | Scheduler | Next task ID to allocate (task ring head) |
+| `last_task_alive` | Scheduler | Orchestrator | Oldest still-active task (task ring tail) |
+| `heap_top` | Orchestrator | Scheduler | Heap ring allocation pointer |
+| `heap_tail` | Scheduler | Orchestrator | Heap ring reclamation pointer |
+| `heap_tail_gen` | Scheduler | Scheduler | Ticket counter for serialized `heap_tail` writes |
+| `orchestrator_done` | Orchestrator | Scheduler | Signals orchestration completion |
+| `task_window_size` | Init | Both | Number of task slots |
+| `heap_size` | Init | Both | Heap total size |
+| `dep_list_pool_size` | Init | Both | Dependency list pool size |
+| `task_descriptors_offset` | Init | Both | Offset to TaskDescriptor array in SM |
+| `dep_list_pool_offset` | Init | Both | Offset to DepListPool in SM |
+| `total_size` | Init | Both | Total shared memory size |
+| `graph_output_ptr` | Orchestrator | Host | Address of final output (packed buffer) |
+| `graph_output_size` | Orchestrator | Host | Size of final output in bytes |
+
+### 3.2 Size Calculation
+
+```
+total = ALIGN(Header) + ALIGN(window_size * sizeof(TaskDescriptor))
+      + ALIGN((dep_pool_size + 1) * sizeof(DepListEntry))
+```
+
+Alignment is 64 bytes (`PTO2_ALIGN_SIZE`).
+
+---
+
+## 4. Ring Buffer Mechanisms
+
+### 4.1 Task Ring
+
+The task ring manages task slot allocation with back-pressure flow control.
+
+**Structure** (`PTO2TaskRing`):
+- `descriptors`: pointer to `TaskDescriptor[]` in shared memory
+- `window_size`: number of slots (power of 2)
+- `current_index`: next task ID to allocate (monotonically increasing)
+- `last_alive_ptr`: pointer to `header->last_task_alive`
+
+**Slot mapping**: `slot = task_id & (window_size - 1)`
+
+**Allocation** (`pto2_task_ring_alloc`):
+```
+active_count = current_index - *last_alive_ptr
+if active_count < window_size - 1:
+    allocate slot, advance current_index
+else:
+    spin-wait (back-pressure from scheduler)
+```
+
+**Reclamation**: Scheduler threads advance `last_task_alive` via lock-free CAS when the oldest task reaches state CONSUMED (4). This frees slots for reuse.
+
+**Flow control**: When the ring is full, the orchestrator blocks until the scheduler advances `last_task_alive`. With `PTO2_RING_TASK_WINDOW=16` and 208 tasks, slots are recycled ~13 times each.
+
+### 4.2 Heap Ring
+
+The heap ring manages output buffer allocation from a circular GM heap.
+
+**Structure** (`PTO2HeapRing`):
+- `base`: GM heap base address
+- `size`: total heap size (default 1 GB)
+- `top`: allocation pointer (local to orchestrator)
+- `tail_ptr`: pointer to `header->heap_tail` (updated by scheduler)
+
+**Allocation**: Buffers are allocated contiguously from `top`. When reaching the end, allocation wraps to the beginning if `tail` has advanced far enough. Buffers never straddle the wrap-around boundary.
+
+**Reclamation**: When `last_task_alive` advances past a task, its `packed_buffer_end` is used to advance `heap_tail`, freeing the memory region.
+
+### 4.3 Dependency List Pool
+
+A simple bump allocator for `PTO2DepListEntry` nodes used in fanin/fanout linked lists.
+
+- **Entry 0**: NULL sentinel (`task_id=-1, next_offset=0`)
+- **Allocation**: `pool->top++`, wraps around when full
+- **Reclamation**: implicit — old entries become unreachable as `last_task_alive` advances
+
+### 4.4 Flow Control and Back-Pressure
+
+The ring buffer mechanism provides **flow control** between the orchestrator (producer) and the scheduler (consumer). When a ring is exhausted, the orchestrator **blocks** — it cannot submit new tasks or allocate more output memory until the scheduler reclaims slots/space by advancing the watermarks.
+
+**Task Ring back-pressure**: When `active_count = current_index - last_task_alive >= window_size - 1`, `pto2_task_ring_alloc` spin-waits until the scheduler completes tasks and advances `last_task_alive`.
+
+**Heap Ring back-pressure**: When the heap has insufficient contiguous space, `pto2_heap_ring_alloc` spin-waits until the scheduler advances `heap_tail` past completed tasks' output buffers.
+
+**TensorMap pool back-pressure**: When the entry pool is exhausted, `new_entry()` spin-waits on `pto2_orchestrator_sync_tensormap(force=true)` until cleanup frees entries (see Section 5.4).
+
+This back-pressure is essential for correctness with small ring sizes — for example, with `PTO2_RING_TASK_WINDOW=16` and 208 tasks, the orchestrator blocks ~192 times, each time waiting for the scheduler to drain completed tasks before continuing.
+
+### 4.5 Deadlock Detection
+
+A ring that is **too small** can cause a **deadlock**. The root cause is the scope mechanism: each task's `fanout_count` includes a reference from its owning scope. The scope reference is only released when `scope_end()` runs — but `scope_end()` is called by the orchestrator, which is blocked waiting for ring space. This creates a circular dependency:
+
+```
+Orchestrator blocked on task_ring_alloc (ring full)
+    → needs scheduler to advance last_task_alive
+    → needs tasks to reach CONSUMED state (fanout_count == 0)
+    → needs scope_end() to release scope reference
+    → needs orchestrator to continue
+    → DEADLOCK
+```
+
+The runtime detects this automatically by counting spin iterations in the allocation functions:
+
+**Periodic BLOCKED warnings** (every 10,000 spins):
+```
+[TaskRing] BLOCKED (Flow Control): current=208, last_alive=192, active=16/16 (100.0%), spins=10000
+[HeapRing] BLOCKED: requesting 4096 bytes, available=0, top=65536, tail=0, spins=10000
+```
+
+**Deadlock detection** (after 100,000 spins with no progress):
+```
+FATAL: Flow Control Deadlock Detected!
+Task Ring is FULL and no progress after 100000 spins.
+  - Active tasks:  16
+  - Window size:   16
+Root Cause:
+  Tasks cannot transition to CONSUMED state because fanout_count
+  includes 1 for the owning scope, and scope_end() requires the
+  orchestrator to continue — creating a circular dependency.
+Solution:
+  Recommended: 32 (at least 2x current active tasks)
+```
+
+The FATAL message is logged to the device log and the process exits. The solution is to increase the ring size so that it can hold at least all tasks within the largest parallel scope. For example, if a scope submits 13 tasks, `task_window >= 14` is required (13 + 1 to distinguish full from empty).
+
+**Sizing guideline**: `task_window_size` must be larger than the maximum number of tasks in any single `PTO2_SCOPE`. A safe choice is `2 × max_tasks_per_scope` or simply the default 65536 for production.
+
+---
+
+## 5. TensorMap and Automatic Dependency Tracking
+
+### 5.1 Purpose
+
+TensorMap maintains a mapping from tensor memory regions to their producer task IDs. When a new task reads a tensor (INPUT/INOUT), TensorMap automatically discovers the producer and establishes a dependency edge.
+
+### 5.2 Hash Table Design
+
+- **Key**: tensor base address (`buffer.addr`)
+- **Value**: producer task ID, with overlap detection for sub-regions
+- **Overlap**: `COVERED` (new region fully contains old) or `OTHER` (partial overlap)
+- Sub-tensors of the same base tensor hash to the same bucket, enabling overlap detection
+
+### 5.3 Entry Pool Management
+
+Unlike the Task Ring and Heap Ring, TensorMap entries are **not** managed by a ring buffer. Instead, a **fixed-size pool + free list** is used:
+
+1. **Free list first**: `free_entry_list[]` stores pointers to released entries. Allocation pops from here (O(1)).
+2. **Bump allocation**: if free list is empty, `entry_pool[next_entry_idx++]` allocates from the end of the pool.
+3. **Blocking reclaim**: if the pool is fully exhausted, `pto2_orchestrator_sync_tensormap(force=true)` reads the latest `last_task_alive` and calls `cleanup_retired` to batch-free all entries belonging to retired tasks, returning them to the free list.
+
+This design avoids the complexity of ring-based wrapping while still being bounded by `PTO2_TENSORMAP_POOL_SIZE` (default 65536 entries).
+
+### 5.4 Stale Entry Cleanup: Three-Layer Defense
+
+TensorMap must ensure entries for retired tasks (`producer_task_id < last_task_alive`) are removed, so that:
+- The pool does not grow unboundedly (capacity is finite)
+- Lookup performance does not degrade as stale entries accumulate in bucket chains
+
+Three complementary mechanisms achieve this:
+
+**Layer 1 — Chain Truncation during Lookup** (lazy, per-bucket):
+
+Since `insert` always prepends to the bucket head, entries in each bucket chain are in **descending task_id order**. When `pto2_tensormap_lookup` encounters the first stale entry (`producer_task_id < last_task_alive`), all subsequent entries in the chain are guaranteed stale too. The entire tail is truncated in one operation using `prev_in_bucket` pointers for O(1) unlinking.
+
+This guarantees lookup only traverses valid entries — O(valid_entries_in_bucket), not O(total_entries).
+
+**Layer 2 — Periodic Batch Cleanup** (`cleanup_retired`, per-task):
+
+Every time the orchestrator submits a task (Step 0 of `pto2_submit_task`), it calls `pto2_orchestrator_sync_tensormap`. When `last_task_alive` has advanced by more than `PTO2_TENSORMAP_CLEANUP_INTERVAL` (default 64) tasks since the last cleanup, `pto2_tensormap_cleanup_retired` runs:
+
+This uses the **per-task entry chain** (`task_entry_head[task_slot]`) — each task's entries are doubly-linked together at insert time via `next_in_task`/`prev_in_task`, allowing O(entries_per_task) cleanup without scanning the entire pool or all buckets. Freed entries are returned to `free_entry_list` for immediate reuse.
+
+**Layer 3 — Back-Pressure on Pool Exhaustion** (blocking):
+
+If both the free list and bump region are depleted, `new_entry()` blocks until `pto2_orchestrator_sync_tensormap(force=true)` frees entries by advancing `last_task_alive` through `cleanup_retired`.
+
+This forms a back-pressure mechanism analogous to the Task Ring's flow control.
+
+**Summary**:
+
+| Layer | Trigger | Method | Guarantees |
+|-------|---------|--------|------------|
+| Chain Truncation | Every lookup | Truncate stale tail of bucket chain | Lookup only visits valid entries |
+| Periodic Cleanup | Every 64 retired tasks | Walk per-task chains, free entries | Pool capacity reclaimed in bounded time |
+| Pool Back-Pressure | Pool exhausted | Block until scheduler advances watermark | Hard capacity bound, no OOM |
+
+In steady state, the number of valid TensorMap entries ≈ `active_tasks × avg_outputs_per_task`. With the default `task_window=65536` and `pool_size=65536`, this is well within bounds. With small windows (e.g., `task_window=16`), active entries are even fewer (~16 × a few), and cleanup runs frequently.
+
+### 5.5 Dependency Discovery Flow
+
+When `pto2_submit_task` processes parameters:
+
+1. **INPUT/INOUT**: `pto2_tensormap_lookup` searches for overlapping producers (with chain truncation)
+2. For each producer found: `pto2_add_consumer_to_producer` adds the dependency
+3. **OUTPUT/INOUT**: `pto2_tensormap_insert` registers the current task as the new producer at bucket head
+4. Stale entries are pruned lazily during lookup (Layer 1) and periodically by cleanup (Layer 2)
+
+---
+
+## 6. Task Descriptor and States
+
+### 6.1 PTO2TaskDescriptor
+
+| Field | Description |
+|-------|-------------|
+| `task_id` | Monotonically increasing ID |
+| `kernel_id` | Function ID (maps to compiled kernel binary) |
+| `worker_type` | CUBE (AIC), VECTOR (AIV), AI_CPU, or ACCELERATOR |
+| `fanin_head` | Head of fanin dependency list (pointer into DepListPool) |
+| `fanin_count` | Number of producer dependencies |
+| `fanout_lock` | Per-task spinlock for concurrent fanout modification |
+| `fanout_head` | Head of fanout consumer list (pointer, protected by `fanout_lock`) |
+| `fanout_count` | 1 (scope ref) + number of consumers |
+| `packed_buffer_base` | Start of packed buffer in GM Heap |
+| `packed_buffer_end` | End of packed buffer (for heap reclamation) |
+| `is_active` | Task slot is in use |
+| `params[16]` | Tensor and scalar parameters (`PTOParam` array) |
+| `param_count` | Number of valid parameters |
+
+### 6.2 Task State Machine
+
+```
+  [0] PENDING ──fanin satisfied──► [1] READY ──dispatch──► [2] RUNNING
+      ▲                                                         │
+      │                                                         ▼
+  slot recycled ◄── [4] CONSUMED ◄──fanout done── [3] COMPLETED
+```
+
+In the scheduler's `task_state[]` array (`std::atomic<PTO2TaskState>`):
+- **0 (PENDING)**: waiting for dependencies (`fanin_refcount < fanin_count`)
+- **1 (READY)**: all dependencies satisfied, waiting in ready queue
+- **2 (RUNNING)**: currently executing on a worker
+- **3 (COMPLETED)**: hardware execution complete, output may still be in use
+- **4 (CONSUMED)**: output fully consumed, buffers can be released
+
+---
+
+## 7. Orchestrator
+
+### 7.1 PTO2OrchestratorState
+
+The orchestrator runs on AICPU Thread 3 and builds the task graph by calling the user-provided orchestration function.
+
+Key members:
+- `task_ring`, `heap_ring`, `dep_pool`: ring buffer state
+- `tensor_map`, `tensor_pool`: dependency tracking
+- `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
+- `scheduler`: pointer to scheduler state (for simulated mode or `init_task_on_submit`)
+- `gm_heap_base`, `gm_heap_size`: GM heap for output buffers
+
+### 7.2 Task Submission Flow (`pto2_submit_task`)
+
+| Step | Operation |
+|------|-----------|
+| 0 | `pto2_orchestrator_sync_tensormap` — prune stale TensorMap entries |
+| 1 | `pto2_task_ring_alloc` — allocate task slot (may block on flow control) |
+| 2 | Initialize task descriptor, copy parameters |
+| 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers |
+| 4 | **Dependency**: `pto2_add_consumer_to_producer` for each producer found |
+| 5 | **Heap alloc**: `pto2_alloc_packed_buffer` for OUTPUT params (addr=0) |
+| 6 | **Insert**: register OUTPUT/INOUT params in TensorMap |
+| 7 | **Fanin**: finalize `fanin_count`; if `init_task_on_submit`, call scheduler's `init_task` |
+| 8 | **Publish**: `STORE_RELEASE(current_task_index)` makes task visible to scanners |
+
+### 7.3 Lock Protocol for Concurrent Dependency Setup
+
+The orchestrator and scheduler run concurrently. When adding a consumer to a producer's fanout list:
+
+1. **Orchestrator acquires** the producer's `fanout_lock` via `pto2_fanout_lock(task)` (CAS spin-lock)
+2. **Normal path**: prepend consumer to the producer's fanout list, increment `fanout_count`
+3. **Release** `fanout_lock`
+
+The scheduler's completion handler mirrors this:
+1. Mark `task_state[slot] = COMPLETED`
+2. **Acquire** `fanout_lock`, read `fanout_head`, **release** lock
+3. Traverse fanout list, incrementing each consumer's `fanin_refcount`
+4. Mark `task_state[slot] = CONSUMED` when `fanout_refcount` reaches `fanout_count`
+
+This lock protocol guarantees every consumer is accounted for exactly once.
+
+### 7.4 Scope Mechanism (`PTO2_SCOPE`)
+
+Scopes control the lifetime of intermediate buffers. Each scope:
+- Tracks tasks submitted within it via a flat `scope_tasks[]` buffer partitioned by `scope_begins[]`
+- On `scope_end`: increments `fanout_refcount` for scope tasks; when it reaches `fanout_count`, the task's packed buffer can be reclaimed
+
+```cpp
+PTO2_SCOPE(rt) {
+    // Tasks submitted here belong to this scope
+    pto2_rt_submit_task(rt, FUNC_QK, PTO2_WORKER_CUBE, params, n);
+    pto2_rt_submit_task(rt, FUNC_SF, PTO2_WORKER_VECTOR, params, n);
+}
+// scope_end: scope reference released from all tasks above
+```
+
+---
+
+## 8. Scheduler
+
+### 8.1 Thread Model
+
+With `aicpu_thread_num=4`, the AICPU runs 4 threads:
+
+| Thread | Role | Cores |
+|--------|------|-------|
+| 0 | Scheduler | 6 AIC + ~13 AIV |
+| 1 | Scheduler | 6 AIC + ~13 AIV |
+| 2 | Scheduler | 6 AIC + ~13 AIV |
+| 3 | Orchestrator | none |
+
+Core assignment: AICs and AIVs are divided equally among the 3 scheduler threads.
+
+### 8.2 Scheduler Main Loop
+
+Each scheduler thread runs a tight loop with two main phases:
+
+**Phase 1 — Completion Handling**:
+- Poll register `COND` on each managed core
+- When `TASK_FIN_STATE` detected: record completion timestamps, mark `task_state[slot] = COMPLETED`, acquire fanout lock, traverse fanout list (incrementing consumers' `fanin_refcount`), mark `task_state[slot] = CONSUMED`, advance `last_task_alive` watermark
+
+**Phase 2 — Dispatch**:
+- For each idle core: pop a task from the ready queue (lock-free MPMC Vyukov queue, one per worker type)
+- Build `PTO2DispatchPayload` from `TaskDescriptor`
+- Write task pointer to `Handshake.task`, signal AICore via register `DATA_MAIN_BASE`
+
+After these phases, the scheduler updates profiling headers and checks for termination (all tasks completed and orchestrator done).
+
+### 8.3 Ready Queue Design
+
+Ready queues use a lock-free bounded MPMC (Vyukov) design:
+
+- One `PTO2ReadyQueue` per worker type (4 types: CUBE, VECTOR, AI_CPU, ACCELERATOR)
+- **Push**: any thread (orchestrator via `init_task`, or scheduler on completion) pushes newly-ready tasks
+- **Pop**: scheduler threads pop from the queue matching the idle core's worker type
+- Per-slot sequence counters prevent ABA problems
+- `enqueue_pos` and `dequeue_pos` are on separate cache lines to avoid false sharing
+
+### 8.4 Watermark Advancement (last_task_alive)
+
+After a task reaches state CONSUMED (4), the scheduler tries to advance `last_task_alive`:
+
+```
+while la < current_task_index:
+    if task_state[la & mask] < CONSUMED: break
+    reset fanin_refcount[la & mask] = 0
+    CAS(last_task_alive, la, la+1)
+    advance heap_tail from task's packed_buffer_end
+    la++
+```
+
+This is lock-free (CAS-based) and multiple scheduler threads can attempt it concurrently. The `heap_tail_gen` ticket counter serializes `heap_tail` writes to ensure tasks' buffer regions are freed in order.
+
+---
+
+## 9. AICore Worker Interaction
+
+### 9.1 Handshake Protocol
+
+Each AICore worker has a `Handshake` struct in shared memory:
+
+| Field | Direction | Purpose |
+|-------|-----------|---------|
+| `task` | AICPU→AICore | Pointer to `PTO2DispatchPayload` |
+| `control` | AICPU→AICore | 0=normal, 1=shutdown |
+| `perf_records_addr` | AICPU→AICore | Performance buffer address |
+
+### 9.2 Register-Based Dispatch
+
+Instead of polling `Handshake.task_status`, the production protocol uses hardware registers:
+
+| Register | Direction | Usage |
+|----------|-----------|-------|
+| `DATA_MAIN_BASE` | AICPU→AICore | Write `task_id + 1` to dispatch; `EXIT_SIGNAL` to shut down |
+| `COND` | AICore→AICPU | `[bit31=state, bits30:0=task_id]`: ACK (state=0) or FIN (state=1) |
+
+**AICore execution loop**:
+1. Poll `DATA_MAIN_BASE` for non-zero value
+2. Read payload from `Handshake.task`
+3. Write ACK to `COND`
+4. Execute kernel function via `func_id_to_addr` lookup
+5. Write FIN to `COND`
+
+### 9.3 PTO2DispatchPayload
+
+Built by the scheduler from `PTO2TaskDescriptor`:
+
+| Field | Description |
+|-------|-------------|
+| `task_id` | Task identifier |
+| `kernel_id` | Function ID |
+| `function_bin_addr` | GM address of compiled kernel binary |
+| `num_args` | Number of arguments |
+| `args[]` | Tensor addresses and scalar values |
+
+---
+
+## 10. Kernel and Orchestration Loading
+
+### 10.1 Kernel Binary Loading
+
+1. **Host** compiles each kernel source (`.cpp`) into a binary (`.o` or `.so`)
+2. `host_api.upload_kernel_binary(func_id, binary, size)` uploads to GM
+3. The returned GM address is stored in `Runtime.func_id_to_addr_[func_id]`
+4. When dispatching, the scheduler copies this address into `PTO2DispatchPayload.function_bin_addr`
+
+### 10.2 Orchestration SO Loading
+
+1. **Host** compiles the orchestration source into a shared library (`.so`)
+2. The SO binary is embedded into `Runtime.device_orch_so_storage_[]` and copied to device
+3. **AICPU Thread 3** writes the SO to a temp file, calls `dlopen`
+4. `dlsym("aicpu_orchestration_config")` returns configuration (expected arg count)
+5. `dlsym("aicpu_orchestration_entry")` returns the orchestration function pointer
+6. Thread 3 creates a `PTO2Runtime`, calls the orchestration function within a `PTO2_SCOPE`
+7. After orchestration completes: `dlclose`, delete temp file
+
+### 10.3 Thread Startup Synchronization
+
+| Flag | Set by | Waited by | Purpose |
+|------|--------|-----------|---------|
+| `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
+| `pto2_init_done_` | First init thread | Others | One-time memset of arrays started (exchange guard) |
+| `pto2_init_complete_` | Init thread | Thread 3 + others | One-time init of per-task arrays done |
+
+Startup sequence:
+1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
+2. Scheduler threads: wait for `runtime_init_ready_` → one thread wins `pto2_init_done_` exchange → memset per-task arrays → set `pto2_init_complete_`; other threads wait for `pto2_init_complete_`
+3. Thread 3: wait for `pto2_init_complete_` → configure orchestrator-scheduler pointers
+4. Scheduler threads: enter main loop
+5. Thread 3: call orchestration function → set `orchestrator_done_`
+
+---
+
+## 11. PTO2 Orchestration API
+
+The orchestration API is defined in `pto_orchestration_api.h`. Orchestration code depends only on this header.
+
+### 11.1 Core API
+
+| Function/Macro | Purpose |
+|----------------|---------|
+| `pto2_rt_submit_task(rt, kernel_id, worker_type, params, n)` | Submit a task with parameters |
+| `PTO2_SCOPE(rt) { ... }` | RAII scope for buffer lifetime |
+| `pto2_rt_orchestration_done(rt)` | Signal orchestration complete |
+| `pto2_rt_init_tensor_pool(rt)` | Initialize tensor pool for `make_tensor()` |
+
+### 11.2 Parameter Construction
+
+| Function | Description |
+|----------|-------------|
+| `make_tensor_external(ptr, shapes, ndim, dtype)` | Wrap an existing device pointer as a tensor |
+| `make_tensor(shapes, ndim, dtype)` | Create an intermediate tensor (addr=0, allocated by runtime from heap) |
+| `make_input_param(tensor)` | INPUT parameter — read by the task |
+| `make_output_param(tensor)` | OUTPUT parameter — written by the task (auto-allocated if addr=0) |
+| `make_inout_param(tensor)` | INOUT parameter — read then written |
+| `make_scalar_param(value)` | 64-bit scalar parameter |
+
+### 11.3 Worker Types
+
+| Type | Target |
+|------|--------|
+| `PTO2_WORKER_CUBE` | AIC cores (matrix multiplication) |
+| `PTO2_WORKER_VECTOR` | AIV cores (vector operations) |
+| `PTO2_WORKER_AI_CPU` | AICPU (scalar ops, control flow) |
+| `PTO2_WORKER_ACCELERATOR` | Fixed-function accelerators (DMA, etc.) |
+
+### 11.4 Orchestration Export Interface
+
+Each orchestration `.so` must export:
+
+```cpp
+extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count);
+extern "C" void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count);
+```
+
+---
+
+## 12. Example: Batch Paged Attention
+
+### 12.1 Kernel Configuration (`kernel_config.py`)
+
+```python
+KERNELS = [
+    {"func_id": 0, "name": "QK",      "source": "aic/aic_qk_matmul.cpp",       "core_type": "aic"},
+    {"func_id": 1, "name": "SF",      "source": "aiv/aiv_softmax_prepare.cpp", "core_type": "aiv"},
+    {"func_id": 2, "name": "PV",      "source": "aic/aic_pv_matmul.cpp",       "core_type": "aic"},
+    {"func_id": 3, "name": "UP",      "source": "aiv/aiv_online_update.cpp",   "core_type": "aiv"},
+    {"func_id": 5, "name": "AIV_HUB", "source": "aiv/aiv_hub.cpp",            "core_type": "aiv"},
+]
+
+ORCHESTRATION = {
+    "source": "orchestration/paged_attention_orch.cpp",
+    "function_name": "aicpu_orchestration_entry",
+}
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 24,
+}
+```
+
+### 12.2 Orchestration Structure
+
+```cpp
+void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
+    // Unpack args: query, key_cache, value_cache, block_table, context_lens, out, config
+    for (q_idx = 0; q_idx < q_loop; q_idx++) {
+        for (batch_start = 0; batch_start < batch; batch_start += IN_CORE_BATCH) {
+            PTO2_SCOPE(rt) {
+                // Allocate accumulator tensors (oi, li, mi) via make_tensor()
+                // Submit AIV_HUB to initialize accumulators
+                for (bn = 0; bn < max_bn; bn++) {
+                    // Allocate intermediate tensors (sij, pij, mij, lij, oi_new)
+                    // Submit QK (CUBE) → SF (VECTOR) → PV (CUBE) → UP (VECTOR)
+                }
+            }
+        }
+    }
+}
+```

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -1,0 +1,167 @@
+# PTO2 Device Log Profiling Guide
+
+## How to Find Device Logs
+
+AICPU logs (via `DEV_ALWAYS`) are written by CANN's **dlog** subsystem and do **not** appear in the `run_example.py` terminal output. They are written to CANN's device log directory:
+
+```
+$HOME/ascend/log/debug/device-<device_id>/device-<pid>_<timestamp>.log
+```
+
+Each run produces a new log file (or appends to an existing one). Find the most recent file by modification time:
+
+```bash
+ls -lt $HOME/ascend/log/debug/device-<device_id>/ | head -5
+```
+
+## Log Structure Overview
+
+A single run produces two profiling blocks in the device log:
+
+| Block | Emitted by | Function | Content |
+|-------|-----------|----------|---------|
+| **Orchestrator Profiling** | Thread 3 (orchestrator) | `aicpu_orchestration_entry` | Time breakdown of graph construction on device |
+| **PTO2 Scheduler Summary** | Threads 0/1/2 (schedulers) | `resolve_and_dispatch_pto2` | Per-thread scheduling statistics, phase timing, and lock contention |
+
+All timing values are in microseconds (us), converted from AICPU cycle counters.
+
+---
+
+## Block 1: Orchestrator Profiling
+
+Thread 3 loads the orchestration `.so` via `dlopen`, calls `aicpu_orchestration_entry`, and prints a profiling summary after it returns.
+
+### Example (from a real run: batch=64, 16704 tasks)
+
+```
+Thread 3: Calling aicpu_orchestration_entry from SO
+aicpu_orchestration_entry ">>>>>> batch = 64"
+Thread 3: aicpu_orchestration_entry returned, cost 20943.940us
+Thread 3: === Orchestrator Profiling: 16704 tasks, total=14601.580us ===
+Thread 3:   sync_tensormap : 286.300us (2.0%)
+Thread 3:   task_ring_alloc: 380.400us (2.6%)
+Thread 3:   param_copy     : 2147.800us (14.7%)
+Thread 3:   lookup+dep     : 7290.300us (49.9%)
+Thread 3:   heap_alloc     : 701.500us (4.8%)
+Thread 3:   tensormap_ins  : 1890.380us (12.9%)
+Thread 3:   fanin+ready    : 1207.400us (8.3%)
+Thread 3:   finalize+SM    : 697.500us (4.8%)
+Thread 3:   scope_end      : 364.080us
+Thread 3:   avg/task       : 0.874us
+Thread 3: PTO2 total submitted tasks = 16704
+```
+
+### Field Reference
+
+| Field | Source (`pto_orchestrator.cpp`) | Description |
+|-------|-------------------------------|-------------|
+| **cost** | Wall-clock around `orch_func()` call | Total time including orchestration logic + scope overhead |
+| **total** | Sum of all sub-steps below | Accumulated time inside `pto2_submit_task` across all tasks |
+| **sync_tensormap** | `g_orch_sync_cycle` | TensorMap validity sync and optional cleanup before each submission |
+| **task_ring_alloc** | `g_orch_alloc_cycle` | Allocating a task slot from the task ring buffer |
+| **param_copy** | `g_orch_params_cycle` | Copying param descriptors + tensor descriptor copies into task-owned storage |
+| **lookup+dep** | `g_orch_lookup_cycle` | TensorMap lookup for inputs/inouts + building fanin/fanout dependency edges |
+| **heap_alloc** | `g_orch_heap_cycle` | Allocating packed output buffers from the heap ring |
+| **tensormap_ins** | `g_orch_insert_cycle` | Inserting output/inout tensors into the TensorMap |
+| **fanin+ready** | `g_orch_fanin_cycle` | Building the fanin list + checking if task is already ready (Step 5/5b) |
+| **scope_end** | `g_orch_scope_end_cycle` | `pto2_scope_end` overhead (notifying scheduler of scope completion) |
+| **avg/task** | `total / submit_count` | Average orchestrator time per task submission |
+
+### Interpreting the Numbers
+
+- **cost > total**: The difference is overhead outside `pto2_submit_task` (the orchestration user code itself, scope_begin/end, make_tensor calls, etc.).
+- **lookup+dep** is typically the dominant cost (~50%) because it involves TensorMap hash lookups and building dependency edges with spinlock-protected fanout list insertions.
+- **param_copy** scales with the number of parameters per task.
+- **avg/task < 1us** indicates efficient graph construction.
+
+---
+
+## Block 2: PTO2 Scheduler Summary
+
+Each of the 3 scheduler threads (Thread 0, 1, 2) prints its own summary after completing all tasks. The output has two sub-sections: **summary** and **phase breakdown**.
+
+### Example (Thread 0, from a different run: batch=1, 1044 tasks)
+
+```
+Thread 0: completed=352 tasks in 3477.420us (147 loops, 2.4 tasks/loop)
+Thread 0: --- Phase Breakdown ---
+Thread 0:   complete:    1485.020us (42.7%)  [fanout: edges=432, max_degree=2, avg=1.2]  [fanin: edges=320, max_degree=3, avg=0.9]
+Thread 0:   scan:        14.400us (0.4%)
+Thread 0:   dispatch:    1973.060us (56.7%)  [pop: hit=352, miss=3043, hit_rate=10.4%]
+Thread 0:   idle:        4.940us (0.1%)
+```
+
+### Summary Line
+
+```
+Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
+```
+
+| Field | Description |
+|-------|-------------|
+| **completed** | Number of tasks this thread processed to completion |
+| **Y us** | Total scheduler loop time (sum of all phase cycles) |
+| **Z loops** | Number of scheduler loop iterations |
+| **W tasks/loop** | Average tasks completed per loop iteration; higher = better throughput |
+
+### Phase Breakdown
+
+The scheduler loop runs four phases each iteration. Each phase's time is accumulated across all loop iterations.
+
+| Phase | What it does | Inline stats |
+|-------|-------------|-------------|
+| **complete** | Polls handshake on each managed core; when a core completes, traverses fanout list (notify consumers) and fanin list (release producers) via `on_task_complete` | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
+| **scan** | Updates the perf profiling header with latest scheduler state | — |
+| **dispatch** | For each idle core, pops a task from the ready queue via `pto2_scheduler_get_ready_task`, builds the dispatch payload, and writes the task to the core's handshake register | `pop`: `hit` = successful pops (task dispatched), `miss` = empty queue pops, `hit_rate` = hit/(hit+miss) |
+| **idle** | Scheduler loop iteration where no progress was made (no completions, no dispatches) | — |
+
+**Interpreting phase percentages:**
+
+- **dispatch** is typically the largest (~55-60%) because it includes ready-queue pops (with spinlock), payload construction, and cache flush (`dc cvac` + `dsb sy`).
+- **complete** is the second largest (~40-45%) because it traverses both fanout (CAS-based fanin decrement, conditional ready-queue push) and fanin (release_producer, check_consumed, ring pointer advancement).
+- **scan** is small (<1%) — only updates the perf header.
+- **idle** is negligible when tasks are flowing; high idle% indicates the scheduler is starved.
+
+**Interpreting pop hit_rate:**
+
+- **High hit_rate (>50%)**: Ready queue is well-supplied; dispatch is efficient.
+- **Low hit_rate (<10%)**: Ready queue is mostly empty when cores become idle. The bottleneck is upstream (orchestrator submission speed or fanout resolution latency), not dispatch itself.
+
+### Per-Task Averages
+
+Divide each thread's phase times by its `completed` count to get per-task scheduling cost:
+
+| Metric | Formula | Typical value |
+|--------|---------|---------------|
+| Scheduling overhead per task | total_time / completed | ~5-10 us/task |
+| Dispatch per task | dispatch_time / completed | ~3-6 us/task |
+| Complete per task | complete_time / completed | ~2-4 us/task |
+
+---
+
+## Cross-Referencing with Host Profiling
+
+When `--enable-profiling` is used, the host terminal prints a **Task Statistics by Function** table with `Total_Exec` (total AICore kernel execution time). Combined with device log data:
+
+| Metric | Source | Description |
+|--------|--------|-------------|
+| Avg kernel exec time | `Total_Exec / total_tasks` (host) | Time AICore spends executing each kernel |
+| Avg scheduling overhead | `sum(thread_total) / total_tasks` (device log) | Time AICPU spends scheduling each task |
+| Sched/Exec ratio | scheduling / execution | Scheduling overhead relative to kernel execution |
+
+A high sched/exec ratio (e.g., >3x) indicates that scheduling overhead dominates, and optimizations should target the scheduler's dispatch hot path (cache flush, payload construction) or upstream task flow.
+
+---
+
+## Quick Reference: Extracting Profiling Data
+
+```bash
+# Find the latest device log for device 2
+ls -t $HOME/ascend/log/debug/device-2/device-*.log | head -1
+
+# Extract orchestrator profiling (Thread 3)
+grep "Thread 3:" <logfile>
+
+# Extract scheduler profiling (Threads 0/1/2)
+grep -E "Thread [012]:" <logfile>
+```

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -1,0 +1,312 @@
+# PTO Runtime2 Profiling Levels
+
+This document describes the profiling macro hierarchy and logging control in the PTO Runtime2 system.
+
+## Overview
+
+PTO Runtime2 uses a hierarchical profiling system with compile-time macros to control profiling code compilation and log output. The `enable_profiling` runtime flag controls data collection (performance buffers, shared memory writes) but does NOT control log output.
+
+## Profiling Macro Hierarchy
+
+```
+PTO2_PROFILING (base level, default=0)
+├── PTO2_ORCH_PROFILING (orchestrator, default=0, requires PTO2_PROFILING=1)
+├── PTO2_SCHED_PROFILING (scheduler, default=0, requires PTO2_PROFILING=1)
+└── PTO2_TENSORMAP_PROFILING (tensormap, default=0, requires PTO2_PROFILING=1)
+```
+
+### Compile-Time Validation
+
+Each sub-level macro requires `PTO2_PROFILING=1`:
+
+```cpp
+#if PTO2_ORCH_PROFILING && !PTO2_PROFILING
+#error "PTO2_ORCH_PROFILING requires PTO2_PROFILING=1"
+#endif
+
+#if PTO2_SCHED_PROFILING && !PTO2_PROFILING
+#error "PTO2_SCHED_PROFILING requires PTO2_PROFILING=1"
+#endif
+
+#if PTO2_TENSORMAP_PROFILING && !PTO2_PROFILING
+#error "PTO2_TENSORMAP_PROFILING requires PTO2_PROFILING=1"
+#endif
+```
+
+## Profiling Levels
+
+### Level 0: No Profiling (PTO2_PROFILING=0)
+
+**What's compiled:**
+- Debug/diagnostic logs (always present)
+- Progress tracking
+- Stall detection
+- Deadlock/livelock detection
+
+**What's NOT compiled:**
+- All profiling counters
+- All profiling logs
+- Performance data collection
+
+**Log output:** 11 DEV_ALWAYS logs (debug/diagnostic only)
+
+---
+
+### Level 1: Basic Profiling (PTO2_PROFILING=1)
+
+**What's compiled:**
+- All profiling counters (cycles, task counts, loop counts)
+- Basic profiling summaries
+- Scheduler summary output
+- Orchestration completion time
+
+**What's NOT compiled:**
+- Detailed phase breakdowns
+- TensorMap statistics
+
+**Log output:** 13 DEV_ALWAYS logs
+- 11 debug/diagnostic logs (always present)
+- 2 basic profiling summaries:
+  - Orchestration completion time
+  - Total submitted tasks
+
+**Scheduler output:**
+```
+Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
+```
+
+**Note:** Scheduler summary always prints when `PTO2_PROFILING=1`, regardless of `enable_profiling` flag.
+
+---
+
+### Level 2: Scheduler Detailed Profiling (PTO2_SCHED_PROFILING=1)
+
+**Requires:** `PTO2_PROFILING=1`
+
+**What's compiled:**
+- All Level 1 features
+- Detailed scheduler phase counters
+- Phase-specific statistics (complete, scan, dispatch, idle)
+- Hit rate tracking (complete poll, ready queue pop)
+
+**Log output:** 18 DEV_ALWAYS logs (11 debug + 2 basic + 7 scheduler detailed - 2 replaced)
+- Replaces scheduler summary with detailed breakdown
+
+**Scheduler output:**
+```
+Thread X: === Scheduler Phase Breakdown: total=XXXus, XXX tasks ===
+Thread X:   complete       : XXXus (XX.X%)  [fanout: edges=XXX, max_degree=X, avg=X.X]  [fanin: edges=XXX, max_degree=X, avg=X.X]
+Thread X:     poll         : XXXus (XX.X%)  hit=XXX, miss=XXX, hit_rate=XX.X%
+Thread X:     otc_lock     : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:     otc_fanout   : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:     otc_fanin    : XXXus (XX.X%)  atomics=XXX
+Thread X:     otc_self     : XXXus (XX.X%)  atomics=XXX
+Thread X:     perf         : XXXus (XX.X%)
+Thread X:   dispatch       : XXXus (XX.X%)  [pop: hit=XXX, miss=XXX, hit_rate=XX.X%]
+Thread X:     poll         : XXXus (XX.X%)
+Thread X:     pop          : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:     setup        : XXXus (XX.X%)
+Thread X:   scan           : XXXus (XX.X%)
+Thread X:   idle           : XXXus (XX.X%)
+Thread X:   avg/complete   : XXXus
+Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
+```
+
+---
+
+### Level 3: Orchestrator Detailed Profiling (PTO2_ORCH_PROFILING=1)
+
+**Requires:** `PTO2_PROFILING=1`
+
+**What's compiled:**
+- All Level 1 features
+- Detailed orchestrator phase counters
+- Per-phase cycle tracking
+- Atomic operation counters
+- Wait time tracking
+
+**Log output:** 30 DEV_ALWAYS logs (11 debug + 2 basic + 1 scheduler summary + 17 orchestrator detailed - 1 replaced)
+- Replaces basic orchestration completion with detailed breakdown
+
+**Orchestrator output:**
+```
+Thread X: === Orchestrator Profiling: XXX tasks, total=XXXus ===
+Thread X:   sync_tensormap : XXXus (XX.X%)
+Thread X:   task_ring_alloc: XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:   param_copy     : XXXus (XX.X%)  atomics=XXX
+Thread X:   lookup+dep     : XXXus (XX.X%)
+Thread X:   heap_alloc     : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:   tensormap_ins  : XXXus (XX.X%)
+Thread X:   fanin+ready    : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:   finalize+SM    : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
+Thread X:   scope_end      : XXXus  atomics=XXX
+Thread X:   avg/task       : XXXus
+```
+
+**Note:** Orchestrator logs always print when `PTO2_ORCH_PROFILING=1`, regardless of `enable_profiling` flag.
+
+---
+
+### Level 4: TensorMap Profiling (PTO2_TENSORMAP_PROFILING=1)
+
+**Requires:** `PTO2_PROFILING=1` AND `PTO2_ORCH_PROFILING=1`
+
+**What's compiled:**
+- All Level 3 features
+- TensorMap lookup statistics
+- Hash chain walk tracking
+- Overlap check counters
+
+**Log output:** 34 DEV_ALWAYS logs (30 from Level 3 + 4 tensormap)
+
+**TensorMap output:**
+```
+Thread X: === TensorMap Lookup Stats ===
+Thread X:   lookups        : XXX, inserts: XXX
+Thread X:   chain walked   : total=XXX, avg=X.X, max=X
+Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
+```
+
+---
+
+## Runtime Flag: enable_profiling
+
+The `runtime->enable_profiling` flag controls **data collection**, NOT log output.
+
+### When enable_profiling=true:
+- Performance buffers are allocated and written
+- Per-task timing data is collected
+- Phase profiling data is recorded
+- Orchestrator summary is written to shared memory
+
+### When enable_profiling=false:
+- No performance data collection
+- No shared memory writes
+- Logs still print (controlled by macros only)
+
+### Usage:
+```cpp
+// Initialize runtime with profiling enabled
+runtime->enable_profiling = true;
+```
+
+---
+
+## Common Profiling Configurations
+
+### Development (default)
+```bash
+# No profiling overhead
+PTO2_PROFILING=0
+```
+
+### Basic Performance Monitoring
+```bash
+# Minimal overhead, summary logs only
+PTO2_PROFILING=1
+PTO2_ORCH_PROFILING=0
+PTO2_SCHED_PROFILING=0
+```
+
+### Scheduler Performance Analysis
+```bash
+# Detailed scheduler breakdown
+PTO2_PROFILING=1
+PTO2_ORCH_PROFILING=0
+PTO2_SCHED_PROFILING=1
+```
+
+### Orchestrator Performance Analysis
+```bash
+# Detailed orchestrator breakdown
+PTO2_PROFILING=1
+PTO2_ORCH_PROFILING=1
+PTO2_SCHED_PROFILING=0
+```
+
+### Full Profiling (maximum overhead)
+```bash
+# All profiling features enabled
+PTO2_PROFILING=1
+PTO2_ORCH_PROFILING=1
+PTO2_SCHED_PROFILING=1
+PTO2_TENSORMAP_PROFILING=1
+```
+
+---
+
+## Setting Profiling Macros
+
+### At compile time:
+```bash
+# In CMakeLists.txt or build command
+add_definitions(-DPTO2_PROFILING=1)
+add_definitions(-DPTO2_ORCH_PROFILING=1)
+```
+
+### In source code (before including headers):
+```cpp
+#define PTO2_PROFILING 1
+#define PTO2_ORCH_PROFILING 1
+#include "pto_runtime2_types.h"
+```
+
+---
+
+## Log Output Summary
+
+| Level | Macro Settings | DEV_ALWAYS Count | Description |
+|-------|---------------|------------------|-------------|
+| 0 | `PTO2_PROFILING=0` | 11 | Debug/diagnostic only |
+| 1 | `PTO2_PROFILING=1` | 13 | Basic summaries |
+| 2 | `+PTO2_SCHED_PROFILING=1` | 18 | Scheduler detailed |
+| 3 | `+PTO2_ORCH_PROFILING=1` | 30 | Orchestrator detailed |
+| 4 | `+PTO2_TENSORMAP_PROFILING=1` | 34 | TensorMap stats |
+
+---
+
+## Implementation Notes
+
+### Key Principles
+
+1. **Macros control compilation and logging**
+   - `#if PTO2_PROFILING` controls whether profiling code is compiled
+   - Logs print when macro is enabled, regardless of runtime flag
+
+2. **Runtime flag controls data collection**
+   - `enable_profiling` controls performance buffer allocation
+   - Controls shared memory writes for host-side export
+   - Does NOT control log output
+
+3. **Consistent behavior across components**
+   - Scheduler logs: macro-controlled only
+   - Orchestrator logs: macro-controlled only
+   - Data collection: runtime flag controlled
+
+### Code Locations
+
+- Macro definitions: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h`
+- Scheduler profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp` (lines 770-835)
+- Orchestrator profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp` (lines 1035-1105)
+- TensorMap profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h`
+
+---
+
+## Performance Impact
+
+### Compilation overhead:
+- Level 0: No overhead
+- Level 1: Minimal (counter increments, basic arithmetic)
+- Level 2-4: Low to moderate (additional counters, cycle measurements)
+
+### Runtime overhead:
+- Logging: Negligible (device logs are asynchronous)
+- Data collection (`enable_profiling=true`): Low to moderate
+  - Performance buffer writes
+  - Shared memory updates
+  - Per-task timing measurements
+
+### Recommendation:
+- Use Level 0 for production
+- Use Level 1-2 for performance monitoring
+- Use Level 3-4 for detailed performance analysis only

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_compile_info.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_compile_info.cpp
@@ -1,0 +1,18 @@
+#include "host/platform_compile_info.h"
+#include "host/runtime_compile_info.h"
+#include <string.h>
+
+extern "C" {
+
+ToolchainType get_incore_compiler(void) {
+    if (strcmp(get_platform(), "a2a3") == 0) return TOOLCHAIN_CCEC;
+    return TOOLCHAIN_HOST_GXX_15;
+}
+
+ToolchainType get_orchestration_compiler(void) {
+    // tensormap_and_ringbuffer: a2a3 needs aarch64 cross-compile (AICPU is aarch64)
+    if (strcmp(get_platform(), "a2a3") == 0) return TOOLCHAIN_AARCH64_GXX;
+    return TOOLCHAIN_HOST_GXX;
+}
+
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -1,0 +1,428 @@
+/**
+ * Runtime Builder - rt2 Implementation (Device Orchestration)
+ *
+ * Provides init_runtime_impl and validate_runtime_impl functions for rt2 runtime.
+ * Supports device orchestration where AICPU thread 3 runs the orchestrator.
+ *
+ * init_runtime_impl:
+ *   - Converts host pointers to device pointers based on arg_types
+ *   - Copies orchestration SO to device memory
+ *   - Sets up runtime state for device orchestration
+ *
+ * validate_runtime_impl:
+ *   - Copies recorded tensors back from device to host
+ *   - Frees device memory
+ */
+
+#include "../runtime/runtime.h"
+#include "../runtime/pto_shared_memory.h"
+#include "common/unified_log.h"
+#include "host/pto_runtime_c_api.h"  // For ArgType enum
+#include "common/platform_config.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cerrno>
+#include <sys/time.h>
+
+// Helper: return current time in milliseconds
+static long long _now_ms() {
+    struct timeval tv;
+    gettimeofday(&tv, nullptr);
+    return (long long)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+
+// Max args for device orchestration
+#define RT2_MAX_DEVICE_ARGS 32
+
+/**
+ * Parse an environment variable as uint64_t with optional power-of-2 constraint.
+ * Returns the parsed value on success, or 0 if unset or validation fails.
+ */
+static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool require_power_of_2) {
+    const char* env = std::getenv(name);
+    if (!env) return 0;
+    char* endptr;
+    errno = 0;
+    unsigned long long val = strtoull(env, &endptr, 10);
+    if (errno == ERANGE || endptr == env || *endptr != '\0' || val < min_val) {
+        LOG_WARN("%s=%s invalid (must be a valid integer >= %lu), ignored",
+                 name, env, (unsigned long)min_val);
+        return 0;
+    }
+    if (require_power_of_2 && (val & (val - 1)) != 0) {
+        LOG_WARN("%s=%s invalid (must be a power of 2, >= %lu), ignored",
+                 name, env, (unsigned long)min_val);
+        return 0;
+    }
+    return static_cast<uint64_t>(val);
+}
+
+/**
+ * Initialize a pre-allocated runtime for device orchestration.
+ *
+ * For rt2 runtime, orchestration runs on AICPU thread 3 (device-side).
+ * This function:
+ * - Converts host pointers to device pointers based on arg_types
+ * - Copies input data to device
+ * - Records output tensors for copy-back
+ * - Copies orchestration SO to device memory
+ * - Sets up runtime state for device orchestration
+ *
+ * @param runtime           Pointer to pre-constructed Runtime
+ * @param orch_so_binary    Orchestration shared library binary data
+ * @param orch_so_size      Size of orchestration SO binary in bytes
+ * @param orch_func_name    Name of the orchestration function (unused)
+ * @param func_args         Arguments for orchestration
+ * @param func_args_count   Number of arguments
+ * @param arg_types         Array describing each argument's type (ArgType enum)
+ * @param arg_sizes         Array of sizes for pointer arguments (0 for scalars)
+ * @return 0 on success, -1 on failure
+ */
+extern "C" int init_runtime_impl(Runtime *runtime,
+                    const uint8_t* orch_so_binary,
+                    size_t orch_so_size,
+                    const char* orch_func_name,
+                    uint64_t* func_args,
+                    int func_args_count,
+                    int* arg_types,
+                    uint64_t* arg_sizes,
+                    const int* kernel_func_ids,
+                    const uint8_t* const* kernel_binaries,
+                    const size_t* kernel_sizes,
+                    int kernel_count) {
+    // Suppress unused parameter warning
+    (void)orch_func_name;
+
+    // Validate inputs
+    if (runtime == nullptr) {
+        LOG_ERROR("Runtime pointer is null");
+        return -1;
+    }
+
+    // Register kernel binaries via platform-provided upload function
+    if (kernel_count > 0 && kernel_func_ids != nullptr &&
+        kernel_binaries != nullptr && kernel_sizes != nullptr) {
+        LOG_INFO("Registering %d kernel(s) in init_runtime_impl", kernel_count);
+        for (int i = 0; i < kernel_count; i++) {
+            uint64_t addr = runtime->host_api.upload_kernel_binary(
+                kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
+            if (addr == 0) {
+                LOG_ERROR("Failed to upload kernel binary for func_id=%d", kernel_func_ids[i]);
+                return -1;
+            }
+            runtime->set_function_bin_addr(kernel_func_ids[i], addr);
+        }
+    }
+
+    if (orch_so_binary == nullptr || orch_so_size == 0) {
+        LOG_ERROR("Orchestration SO binary is required for device orchestration");
+        return -1;
+    }
+
+    if (arg_types == nullptr || arg_sizes == nullptr) {
+        LOG_ERROR("arg_types and arg_sizes are required for device orchestration");
+        return -1;
+    }
+
+    if (func_args_count > RT2_MAX_DEVICE_ARGS) {
+        LOG_ERROR("Too many arguments: %d (max %d)", func_args_count, RT2_MAX_DEVICE_ARGS);
+        return -1;
+    }
+
+    LOG_INFO("RT2 init: %d arguments, device orchestration mode", func_args_count);
+
+    long long t_total_start = _now_ms();
+
+    // Convert host pointers to device pointers based on arg_types
+    uint64_t device_args[RT2_MAX_DEVICE_ARGS];
+
+    long long t_args_start = _now_ms();
+    for (int i = 0; i < func_args_count; i++) {
+        switch (arg_types[i]) {
+            case ARG_SCALAR:
+                // Scalar value, pass directly
+                device_args[i] = func_args[i];
+                break;
+
+            case ARG_INPUT_PTR: {
+                // Input pointer: allocate device memory, copy data
+                void* host_ptr = reinterpret_cast<void*>(func_args[i]);
+                size_t size = arg_sizes[i];
+
+                void* dev_ptr = runtime->host_api.device_malloc(size);
+                if (dev_ptr == nullptr) {
+                    LOG_ERROR("Failed to allocate device memory for arg %d", i);
+                    return -1;
+                }
+
+                int rc = runtime->host_api.copy_to_device(dev_ptr, host_ptr, size);
+                if (rc != 0) {
+                    LOG_ERROR("Failed to copy arg %d to device", i);
+                    runtime->host_api.device_free(dev_ptr);
+                    return -1;
+                }
+
+                device_args[i] = reinterpret_cast<uint64_t>(dev_ptr);
+                // Record for cleanup (no copy-back needed)
+                runtime->record_tensor_pair(nullptr, dev_ptr, size);
+                LOG_INFO("  Arg %d (input): %zu bytes at %p", i, size, dev_ptr);
+                break;
+            }
+
+            case ARG_OUTPUT_PTR: {
+                // Output pointer: allocate device memory, record for copy-back
+                void* host_ptr = reinterpret_cast<void*>(func_args[i]);
+                size_t size = arg_sizes[i];
+
+                void* dev_ptr = runtime->host_api.device_malloc(size);
+                if (dev_ptr == nullptr) {
+                    LOG_ERROR("Failed to allocate device memory for arg %d", i);
+                    return -1;
+                }
+
+                device_args[i] = reinterpret_cast<uint64_t>(dev_ptr);
+                // Record for copy-back during finalize
+                runtime->record_tensor_pair(host_ptr, dev_ptr, size);
+                LOG_INFO("  Arg %d (output): %zu bytes at %p", i, size, dev_ptr);
+                break;
+            }
+
+            case ARG_INOUT_PTR: {
+                // Input/output pointer: allocate, copy, record for copy-back
+                void* host_ptr = reinterpret_cast<void*>(func_args[i]);
+                size_t size = arg_sizes[i];
+
+                void* dev_ptr = runtime->host_api.device_malloc(size);
+                if (dev_ptr == nullptr) {
+                    LOG_ERROR("Failed to allocate device memory for arg %d", i);
+                    return -1;
+                }
+
+                int rc = runtime->host_api.copy_to_device(dev_ptr, host_ptr, size);
+                if (rc != 0) {
+                    LOG_ERROR("Failed to copy arg %d to device", i);
+                    runtime->host_api.device_free(dev_ptr);
+                    return -1;
+                }
+
+                device_args[i] = reinterpret_cast<uint64_t>(dev_ptr);
+                // Record for copy-back during finalize
+                runtime->record_tensor_pair(host_ptr, dev_ptr, size);
+                LOG_INFO("  Arg %d (inout): %zu bytes at %p", i, size, dev_ptr);
+                break;
+            }
+
+            default:
+                LOG_ERROR("Unknown arg_type %d for arg %d", arg_types[i], i);
+                return -1;
+        }
+    }
+    long long t_args_end = _now_ms();
+
+    // Copy orchestration SO to device memory (AICPU cannot access host memory)
+    long long t_so_start = _now_ms();
+    void* dev_so = runtime->host_api.device_malloc(orch_so_size);
+    if (dev_so == nullptr) {
+        LOG_ERROR("Failed to allocate device memory for orchestration SO");
+        return -1;
+    }
+    int rc = runtime->host_api.copy_to_device(dev_so, orch_so_binary, orch_so_size);
+    if (rc != 0) {
+        LOG_ERROR("Failed to copy orchestration SO to device");
+        runtime->host_api.device_free(dev_so);
+        return -1;
+    }
+    // Copy SO binary into Runtime's internal storage (device_orch_so_storage_)
+    // Pass the HOST pointer (orch_so_binary), not the device pointer (dev_so)
+    // AICPU Thread 3 will read from get_device_orch_so_data() which returns this storage
+    runtime->set_device_orch_so(orch_so_binary, orch_so_size);
+    runtime->record_tensor_pair(nullptr, dev_so, orch_so_size);
+    LOG_INFO("Orchestration SO: %zu bytes copied to device", orch_so_size);
+    long long t_so_end = _now_ms();
+
+    // Read ready queue shard count from environment for AICPU scheduler
+    {
+        const char* env_shards = std::getenv("PTO2_READY_QUEUE_SHARDS");
+        if (env_shards) {
+            char* endptr;
+            long val = strtol(env_shards, &endptr, 10);
+            if (endptr != env_shards && *endptr == '\0' && val >= 1 && val <= PLATFORM_MAX_AICPU_THREADS) {
+                runtime->ready_queue_shards = static_cast<int>(val);
+            } else {
+                LOG_WARN("PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d",
+                         env_shards, PLATFORM_MAX_AICPU_THREADS, RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
+                runtime->ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
+            }
+        }
+        LOG_INFO("Ready queue shards: %d", runtime->ready_queue_shards);
+    }
+
+    // Read ring buffer size overrides from environment
+    {
+        runtime->pto2_task_window_size  = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
+        runtime->pto2_heap_size         = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
+        if (runtime->pto2_task_window_size || runtime->pto2_heap_size) {
+            LOG_INFO("Ring buffer overrides: task_window=%lu heap=%lu",
+                     (unsigned long)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE),
+                     (unsigned long)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE));
+        }
+    }
+
+    // Resolve effective sizes (env override or compile-time default)
+    uint64_t eff_heap_size = runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE;
+    uint64_t eff_task_window_size = runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE;
+
+    // Allocate GM heap for orchestrator output buffers
+    long long t_heap_start = _now_ms();
+    void* gm_heap = runtime->host_api.device_malloc(eff_heap_size);
+    long long t_heap_end = _now_ms();
+    if (gm_heap == nullptr) {
+        LOG_ERROR("Failed to allocate GM heap");
+        return -1;
+    }
+    runtime->record_tensor_pair(nullptr, gm_heap, eff_heap_size);
+    runtime->set_pto2_gm_heap(gm_heap);
+
+    // Allocate PTO2 shared memory
+    long long t_sm_start = _now_ms();
+    uint64_t sm_size = pto2_sm_calculate_size(eff_task_window_size);
+    void* sm_ptr = runtime->host_api.device_malloc(sm_size);
+    long long t_sm_end = _now_ms();
+    if (sm_ptr == nullptr) {
+        LOG_ERROR("Failed to allocate PTO2 shared memory");
+        return -1;
+    }
+    runtime->set_pto2_gm_sm_ptr(sm_ptr);
+    runtime->record_tensor_pair(nullptr, sm_ptr, static_cast<size_t>(sm_size));
+
+    // Set up device orchestration state
+    runtime->set_orch_built_on_host(false);
+    runtime->set_orch_args(device_args, func_args_count);
+
+    LOG_INFO("Device orchestration ready: %d args", func_args_count);
+
+    long long t_total_end = _now_ms();
+    LOG_INFO("TIMING: args_malloc_copy = %lldms", t_args_end - t_args_start);
+    LOG_INFO("TIMING: orch_so_copy = %lldms", t_so_end - t_so_start);
+    LOG_INFO("TIMING: gm_heap_alloc(1GB) = %lldms", t_heap_end - t_heap_start);
+    LOG_INFO("TIMING: shared_mem_alloc = %lldms", t_sm_end - t_sm_start);
+    LOG_INFO("TIMING: total_init_runtime_impl = %lldms", t_total_end - t_total_start);
+
+    return 0;
+}
+
+/**
+ * Validate runtime results and cleanup.
+ *
+ * This function:
+ * 1. Copies recorded tensors from device back to host
+ * 2. Frees device memory for recorded tensors
+ * 3. Clears tensor pair state
+ *
+ * @param runtime  Pointer to Runtime
+ * @return 0 on success, -1 on failure
+ */
+extern "C" int validate_runtime_impl(Runtime *runtime) {
+    if (runtime == nullptr) {
+        LOG_ERROR("Runtime pointer is null");
+        return -1;
+    }
+
+    int rc = 0;
+
+    LOG_INFO("=== Copying Results Back to Host ===");
+
+    // Copy all recorded tensors from device back to host
+    TensorPair* tensor_pairs = runtime->get_tensor_pairs();
+    int tensor_pair_count = runtime->get_tensor_pair_count();
+
+    LOG_INFO("Tensor pairs to process: %d", tensor_pair_count);
+
+    // PTO2 (device orchestration): graph output may be in packed buffer
+    void* pto2_sm = runtime->get_pto2_gm_sm_ptr();
+    uint64_t graph_out_ptr = 0;
+    uint64_t graph_out_size = 0;
+
+    if (pto2_sm != nullptr) {
+        // Copy header from device to host to read graph_output_ptr/size
+        PTO2SharedMemoryHeader host_header;
+        int hdr_rc = runtime->host_api.copy_from_device(&host_header, pto2_sm, sizeof(PTO2SharedMemoryHeader));
+        if (hdr_rc == 0) {
+            graph_out_ptr = host_header.graph_output_ptr;
+            graph_out_size = host_header.graph_output_size;
+            if (graph_out_ptr != 0) {
+                LOG_INFO("Graph output buffer: ptr=0x%lx, size=%lu", (unsigned long)graph_out_ptr, (unsigned long)graph_out_size);
+            }
+        } else {
+            LOG_WARN("Failed to copy PTO2 header from device");
+        }
+    }
+
+    bool first_output_tensor = true;
+    for (int i = 0; i < tensor_pair_count; i++) {
+        const TensorPair& pair = tensor_pairs[i];
+
+        // Skip if device pointer is null
+        if (pair.dev_ptr == nullptr) {
+            LOG_WARN("Tensor %d has null device pointer, skipping", i);
+            continue;
+        }
+
+        // If host pointer is null, this is a device-only allocation (no copy-back)
+        if (pair.host_ptr == nullptr) {
+            LOG_INFO("Tensor %d: device-only allocation (no copy-back)", i);
+            continue;
+        }
+
+        void* src_ptr = pair.dev_ptr;
+        size_t copy_size = pair.size;
+
+        // Use graph_output_ptr for the first output tensor if available
+        if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
+            src_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(graph_out_ptr));
+            copy_size = static_cast<size_t>(graph_out_size);
+            LOG_INFO("Using packed output buffer for tensor %d", i);
+            first_output_tensor = false;
+        }
+
+        int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, src_ptr, copy_size);
+        if (copy_rc != 0) {
+            LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
+            rc = copy_rc;
+        } else {
+            LOG_INFO("Tensor %d: %zu bytes copied to host", i, pair.size);
+        }
+    }
+
+    // Cleanup device tensors
+    LOG_INFO("=== Cleaning Up ===");
+    for (int i = 0; i < tensor_pair_count; i++) {
+        if (tensor_pairs[i].dev_ptr != nullptr) {
+            runtime->host_api.device_free(tensor_pairs[i].dev_ptr);
+        }
+    }
+    LOG_INFO("Freed %d device allocations", tensor_pair_count);
+
+    // Cleanup kernel binaries
+    int kernel_count = runtime->get_registered_kernel_count();
+    for (int i = 0; i < kernel_count; i++) {
+        int func_id = runtime->get_registered_kernel_func_id(i);
+        runtime->host_api.remove_kernel_binary(func_id);
+        runtime->set_function_bin_addr(func_id, 0);
+    }
+    if (kernel_count > 0) {
+        LOG_INFO("Freed %d kernel binaries", kernel_count);
+    }
+    runtime->clear_registered_kernels();
+
+    // Clear tensor pairs
+    runtime->clear_tensor_pairs();
+
+    LOG_INFO("=== Finalize Complete ===");
+
+    return rc;
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -1,0 +1,154 @@
+#include "common.h"
+
+#ifdef __linux__
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstring>
+#include <vector>
+#endif
+
+/**
+ * 使用 addr2line 将地址转换为 文件:行号 信息
+ * 使用 -i 标志展开内联，返回第一行（最内层实际代码位置）
+ * 如果存在内联，同时通过 inline_chain 返回外层调用链
+ */
+#ifdef __linux__
+static std::string addr_to_line(const char* executable, void* addr,
+                                std::string* inline_chain = nullptr) {
+    char cmd[512];
+    snprintf(cmd, sizeof(cmd), "addr2line -e %s -f -C -p -i %p 2>/dev/null", executable, addr);
+
+    std::array<char, 256> buffer;
+    std::string raw_output;
+
+    FILE* pipe = popen(cmd, "r");
+    if (pipe) {
+        while (fgets(buffer.data(), buffer.size(), pipe) != nullptr) {
+            raw_output += buffer.data();
+        }
+        pclose(pipe);
+    }
+
+    if (raw_output.empty() || raw_output.find("??") != std::string::npos) {
+        return "";
+    }
+
+    // 按行分割
+    std::vector<std::string> lines;
+    size_t pos = 0;
+    while (pos < raw_output.size()) {
+        size_t nl = raw_output.find('\n', pos);
+        if (nl == std::string::npos) nl = raw_output.size();
+        std::string line = raw_output.substr(pos, nl - pos);
+        while (!line.empty() && line.back() == '\r') line.pop_back();
+        if (!line.empty()) lines.push_back(line);
+        pos = nl + 1;
+    }
+
+    if (lines.empty()) return "";
+
+    // 第一行是最内层的实际代码位置，后续行是外层内联调用者
+    if (inline_chain && lines.size() > 1) {
+        *inline_chain = "";
+        for (size_t j = 1; j < lines.size(); j++) {
+            *inline_chain += "    [inlined by] " + lines[j] + "\n";
+        }
+    }
+
+    return lines.front();
+}
+#endif
+
+/**
+ * 获取当前调用栈信息（包含文件路径和行号）
+ * 通过 dladdr 定位每个栈帧所在的共享库，并用相对地址调用 addr2line
+ */
+std::string get_stacktrace(int skip_frames) {
+    (void)skip_frames;  // May be unused on non-Linux platforms
+    std::string result;
+#ifdef __linux__
+    const int max_frames = 64;
+    void* buffer[max_frames];
+    int nframes = backtrace(buffer, max_frames);
+    char** symbols = backtrace_symbols(buffer, nframes);
+
+    if (symbols) {
+        result = "调用栈:\n";
+        for (int i = skip_frames; i < nframes; i++) {
+            std::string frame_info;
+
+            void* addr = (void*)((char*)buffer[i] - 1);
+
+            Dl_info dl_info;
+            std::string inline_chain;
+            if (dladdr(addr, &dl_info) && dl_info.dli_fname) {
+                void* rel_addr = (void*)((char*)addr - (char*)dl_info.dli_fbase);
+                std::string addr2line_result = addr_to_line(dl_info.dli_fname, rel_addr, &inline_chain);
+
+                if (addr2line_result.empty()) {
+                    addr2line_result = addr_to_line(dl_info.dli_fname, addr, &inline_chain);
+                }
+
+                if (!addr2line_result.empty()) {
+                    frame_info = std::string(dl_info.dli_fname) + ": " + addr2line_result;
+                }
+            }
+
+            if (frame_info.empty()) {
+                std::string frame(symbols[i]);
+
+                size_t start = frame.find('(');
+                size_t end = frame.find('+', start);
+                if (start != std::string::npos && end != std::string::npos) {
+                    std::string mangled = frame.substr(start + 1, end - start - 1);
+                    int status;
+                    char* demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &status);
+                    if (status == 0 && demangled) {
+                        frame = frame.substr(0, start + 1) + demangled + frame.substr(end);
+                        free(demangled);
+                    }
+                }
+                frame_info = frame;
+            }
+
+            char buf[16];
+            snprintf(buf, sizeof(buf), "  #%d ", i - skip_frames);
+            result += buf + frame_info + "\n";
+            if (!inline_chain.empty()) {
+                result += inline_chain;
+            }
+        }
+        free(symbols);
+    }
+#else
+    result = "(调用栈仅在 Linux 上可用)\n";
+#endif
+    return result;
+}
+
+// AssertionError 构造函数
+static std::string build_assert_message(const char* condition, const char* file, int line) {
+    std::string msg = "断言失败: " + std::string(condition) + "\n";
+    msg += "  位置: " + std::string(file) + ":" + std::to_string(line) + "\n";
+    msg += get_stacktrace(3);
+    return msg;
+}
+
+AssertionError::AssertionError(const char* condition, const char* file, int line)
+    : std::runtime_error(build_assert_message(condition, file, line)),
+      condition_(condition), file_(file), line_(line) {}
+
+[[noreturn]] void assert_impl(const char* condition, const char* file, int line) {
+    fprintf(stderr, "\n========================================\n");
+    fprintf(stderr, "断言失败: %s\n", condition);
+    fprintf(stderr, "位置: %s:%d\n", file, line);
+    fprintf(stderr, "%s", get_stacktrace(2).c_str());
+    fprintf(stderr, "========================================\n\n");
+    fflush(stderr);
+
+    throw AssertionError(condition, file, line);
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -1,0 +1,162 @@
+/**
+ * PTO Orchestration API - Slim header for orchestration .so files
+ *
+ * This header provides everything an orchestration source needs without
+ * pulling in runtime implementation headers.  The orchestration .so has
+ * zero link dependencies on runtime .cpp files; all runtime calls go
+ * through the PTO2RuntimeOps function-pointer table embedded in
+ * PTO2Runtime.
+ *
+ * Orchestration sources include ONLY this header:
+ *   #include "pto_orchestration_api.h"
+ *
+ * Runtime sources continue to use pto_runtime2.h (which defines the
+ * full PTO2Runtime struct with all internal fields).
+ */
+
+#ifndef PTO_ORCHESTRATION_API_H
+#define PTO_ORCHESTRATION_API_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+// Type headers needed by orchestration
+#include "pto_types.h"          // PTOParam, make_input_param, make_output_param, etc.
+#include "tensor.h"             // Tensor, make_tensor, make_tensor_external
+
+// Worker type constants (duplicated from pto_runtime2_types.h to avoid
+// pulling in the full types header with its internal structures)
+typedef enum {
+    PTO2_WORKER_CUBE = 0,
+    PTO2_WORKER_VECTOR = 1,
+    PTO2_WORKER_AI_CPU = 2,
+    PTO2_WORKER_ACCELERATOR = 3,
+    PTO2_NUM_WORKER_TYPES = 4
+} PTO2WorkerType;
+
+// =============================================================================
+// Ops Table and Opaque Runtime
+// =============================================================================
+
+/**
+ * Forward declaration — the orchestration sees PTO2Runtime as a partial
+ * struct whose first field is the ops pointer.  The full definition
+ * lives in pto_runtime2.h (used only by runtime .cpp files).
+ */
+typedef struct PTO2Runtime PTO2Runtime;
+
+/**
+ * Function-pointer table for runtime operations.
+ * Populated by the runtime; called by orchestration through inline wrappers.
+ */
+typedef struct PTO2RuntimeOps {
+    void (*submit_task)(PTO2Runtime* rt, int32_t kernel_id,
+                        PTO2WorkerType worker_type,
+                        PTOParam* params, int32_t num_params);
+    void (*scope_begin)(PTO2Runtime* rt);
+    void (*scope_end)(PTO2Runtime* rt);
+    void (*orchestration_done)(PTO2Runtime* rt);
+
+    // Logging (populated by runtime, called by orchestration)
+    void (*log_error)(const char* func, const char* fmt, ...);
+    void (*log_warn)(const char* func, const char* fmt, ...);
+    void (*log_info)(const char* func, const char* fmt, ...);
+    void (*log_debug)(const char* func, const char* fmt, ...);
+    void (*log_always)(const char* func, const char* fmt, ...);
+} PTO2RuntimeOps;
+
+/**
+ * Partial PTO2Runtime definition for orchestration.
+ *
+ * Only the ops pointer is visible.  The real struct (in pto_runtime2.h)
+ * has the same first field, so accessing rt->ops through this definition
+ * is well-defined (C struct layout guarantee).
+ */
+struct PTO2Runtime {
+    const PTO2RuntimeOps* ops;
+};
+
+// =============================================================================
+// Inline Convenience Wrappers (call through ops table)
+// =============================================================================
+
+static inline void pto2_rt_submit_task(PTO2Runtime* rt, int32_t kernel_id,
+                                        PTO2WorkerType worker_type,
+                                        PTOParam* params, int32_t num_params) {
+    rt->ops->submit_task(rt, kernel_id, worker_type, params, num_params);
+}
+
+static inline void pto2_rt_scope_begin(PTO2Runtime* rt) {
+    rt->ops->scope_begin(rt);
+}
+
+static inline void pto2_rt_scope_end(PTO2Runtime* rt) {
+    rt->ops->scope_end(rt);
+}
+
+static inline void pto2_rt_orchestration_done(PTO2Runtime* rt) {
+    rt->ops->orchestration_done(rt);
+}
+
+// =============================================================================
+// Logging Macros for Orchestration (call through ops table)
+// =============================================================================
+
+#define LOG_ERROR(rt, fmt, ...) (rt)->ops->log_error(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_WARN(rt, fmt, ...)  (rt)->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_INFO(rt, fmt, ...)  (rt)->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_DEBUG(rt, fmt, ...) (rt)->ops->log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_ALWAYS(rt, fmt, ...) (rt)->ops->log_always(__FUNCTION__, fmt, ##__VA_ARGS__)
+
+// =============================================================================
+// C++ Scope Guards and Macros
+// =============================================================================
+
+/**
+ * RAII Scope Guard (calls through ops table)
+ */
+class PTO2ScopeGuard {
+public:
+    PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) {
+        rt_->ops->scope_begin(rt_);
+    }
+    ~PTO2ScopeGuard() {
+        rt_->ops->scope_end(rt_);
+    }
+private:
+    PTO2Runtime* rt_;
+};
+
+#define _PTO2_CONCATENATE_IMPL(x, y) x ## y
+#define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
+
+#define PTO2_SCOPE_GUARD(rt) [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__)(rt)
+
+/**
+ * Scoped block macro:
+ *   PTO2_SCOPE(rt) {
+ *       pto2_rt_submit_task(rt, ...);
+ *   }
+ */
+#define PTO2_SCOPE(rt) if (PTO2_SCOPE_GUARD(rt); true)
+
+// =============================================================================
+// Orchestration Config
+// =============================================================================
+
+/**
+ * Configuration exported by orchestration .so via aicpu_orchestration_config().
+ * The executor reads these values to set up shared memory and runtime.
+ *
+ * This struct is defined identically in pto_runtime2.h (with an include
+ * guard) so the executor can use the same type without including this header.
+ */
+#ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
+#define PTO2_ORCHESTRATION_CONFIG_DEFINED
+struct PTO2OrchestrationConfig {
+    int         expected_arg_count;
+};
+#endif
+
+#endif // PTO_ORCHESTRATION_API_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/common.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/common.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdexcept>
+#include <string>
+
+/**
+ * 获取当前调用栈信息（包含文件路径和行号）
+ * 实现在 common.cpp 中
+ */
+std::string get_stacktrace(int skip_frames = 1);
+
+/**
+ * 断言失败异常，包含文件、行号、条件和调用栈信息
+ */
+class AssertionError : public std::runtime_error {
+public:
+    AssertionError(const char* condition, const char* file, int line);
+
+    const char* condition() const { return condition_; }
+    const char* file() const { return file_; }
+    int line() const { return line_; }
+
+private:
+    const char* condition_;
+    const char* file_;
+    int line_;
+};
+
+/**
+ * 断言失败时的处理函数
+ * 实现在 common.cpp 中
+ */
+[[noreturn]] void assert_impl(const char* condition, const char* file, int line);
+
+/**
+ * debug_assert 宏 - 在 debug 模式下检查条件，失败时抛出异常并打印调用栈
+ * 在 release 模式 (NDEBUG) 下为空操作
+ */
+#ifdef NDEBUG
+#define debug_assert(cond) ((void)0)
+#else
+#define debug_assert(cond)                          \
+    do {                                            \
+        if (!(cond)) {                              \
+            assert_impl(#cond, __FILE__, __LINE__); \
+        }                                           \
+    } while (0)
+#endif
+
+/**
+ * always_assert 宏 - 无论 debug 还是 release 模式都检查条件
+ */
+#define always_assert(cond)                         \
+    do {                                            \
+        if (!(cond)) {                              \
+            assert_impl(#cond, __FILE__, __LINE__); \
+        }                                           \
+    } while (0)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/data_type.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/data_type.h
@@ -1,0 +1,81 @@
+/**
+ * Data Type Definitions for Orchestration Build Graph Runtime
+ *
+ * Defines supported data types and helper functions for element size calculation.
+ */
+
+#ifndef ORCH_BUILD_GRAPH_DATA_TYPE_H
+#define ORCH_BUILD_GRAPH_DATA_TYPE_H
+
+#include <cstdint>
+
+/**
+ * Supported data types for tensor elements
+ */
+enum class DataType : uint32_t {
+    FLOAT32,   // 4 bytes
+    FLOAT16,   // 2 bytes
+    INT32,     // 4 bytes
+    INT16,     // 2 bytes
+    INT8,      // 1 byte
+    UINT8,     // 1 byte
+    BFLOAT16,  // 2 bytes
+    INT64,     // 8 bytes
+    UINT64,    // 8 bytes
+    DATA_TYPE_NUM,
+};
+
+/**
+ * Get the size in bytes of a single element of the given data type
+ *
+ * @param dtype Data type
+ * @return Size in bytes (0 for unknown types)
+ */
+inline uint64_t get_element_size(DataType dtype) {
+    // 这里的顺序要和enum的顺序严格一致
+    static uint64_t data_type_size[static_cast<int>(DataType::DATA_TYPE_NUM)] = {
+        4, // case DataType::FLOAT32
+        2, // DataType::FLOAT16
+        4, // DataType::INT32
+        2, // DataType::INT16
+        1, // DataType::INT8
+        1, // DataType::UINT8
+        2, // DataType::BFLOAT16
+        8, // DataType::INT64
+        8, // DataType::UINT64
+    };
+    return data_type_size[static_cast<int>(dtype)];
+}
+
+/**
+ * Get the name of a data type as a string
+ *
+ * @param dtype Data type
+ * @return String name of the data type
+ */
+inline const char* get_dtype_name(DataType dtype) {
+    switch (dtype) {
+        case DataType::FLOAT32:
+            return "FLOAT32";
+        case DataType::FLOAT16:
+            return "FLOAT16";
+        case DataType::INT32:
+            return "INT32";
+        case DataType::INT16:
+            return "INT16";
+        case DataType::INT8:
+            return "INT8";
+        case DataType::UINT8:
+            return "UINT8";
+        case DataType::BFLOAT16:
+            return "BFLOAT16";
+        case DataType::INT64:
+            return "INT64";
+        case DataType::UINT64:
+            return "UINT64";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+#endif  // ORCH_BUILD_GRAPH_DATA_TYPE_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -1,0 +1,34 @@
+/**
+ * @file pto2_dispatch_payload.h
+ * @brief Handshake dispatch payload aligned with runtime2 PTO2TaskDescriptor
+ *
+ * Shared between AICPU (pack from PTO2TaskDescriptor) and AICore (unpack to run kernel).
+ * When merging runtime2 into rt2, Handshake.task points to PTO2DispatchPayload.
+ */
+
+#ifndef RT2_PTO2_DISPATCH_PAYLOAD_H_
+#define RT2_PTO2_DISPATCH_PAYLOAD_H_
+
+#include <stdint.h>
+
+#include "common/core_type.h"
+
+/** Max arguments per task; must match RUNTIME_MAX_ARGS and PTO2_MAX_OUTPUTS */
+#ifndef PTO2_DISPATCH_MAX_ARGS
+#define PTO2_DISPATCH_MAX_ARGS 32
+#endif
+
+/**
+ * Dispatch payload: execution-relevant fields from PTO2TaskDescriptor.
+ * AICPU packs this from PTO2TaskDescriptor; AICore unpacks to run kernel.
+ */
+struct PTO2DispatchPayload {
+    int32_t task_id;           /**< Task ID (for completion_queue) */
+    int32_t kernel_id;         /**< InCore function id (debug/trace) */
+    CoreType core_type;        /**< AIC or AIV */
+    uint64_t function_bin_addr; /**< Kernel entry in GM: (UnifiedKernelFunc)function_bin_addr */
+    int32_t num_args;          /**< Number of valid args[] */
+    uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers) */
+};
+
+#endif  // RT2_PTO2_DISPATCH_PAYLOAD_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -1,0 +1,530 @@
+/**
+ * PTO Runtime2 - Orchestrator Implementation
+ *
+ * Implements orchestrator state management, scope handling, and task submission.
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#include "pto_orchestrator.h"
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/unified_log.h"
+#include "pto_runtime2_types.h"
+#include "pto_tensormap.h"
+#include "pto_types.h"
+#include "tensor.h"
+
+// =============================================================================
+// Orchestrator Profiling (compile-time toggle)
+// =============================================================================
+#if PTO2_PROFILING
+#include "aicpu/device_time.h"
+#include "aicpu/performance_collector_aicpu.h"
+// Weak fallback for builds that don't link device_time.cpp (e.g. host).
+// The strong symbol from platform/.../device_time.cpp wins in the AICPU build.
+//
+// IMPORTANT: visibility("hidden") is required to prevent the HOST .so from
+// exporting this weak fallback into the global dynamic symbol table via
+// RTLD_GLOBAL. Without it, when the AICPU .so is loaded and its PLT entry
+// for get_sys_cnt_aicpu is resolved, the dynamic linker finds the HOST .so's
+// weak definition first (already in global table) and uses it — returning 0.
+// With hidden visibility, the HOST .so does not export this symbol globally,
+// so the AICPU .so's PLT resolves to its own strong definition from
+// device_time.cpp.
+__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
+// Weak fallback for builds that don't link performance_collector_aicpu.cpp.
+// The strong symbol from the AICPU build wins when profiling is available.
+// Also hidden to prevent HOST .so from polluting the global symbol table.
+__attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
+    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
+// Accumulated nanoseconds per sub-step
+static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
+static uint64_t g_orch_alloc_cycle = 0;      // task ring alloc
+static uint64_t g_orch_params_cycle = 0;     // param copy
+static uint64_t g_orch_lookup_cycle = 0;     // tensormap lookup + dep building
+static uint64_t g_orch_heap_cycle = 0;       // heap alloc + output assign
+static uint64_t g_orch_insert_cycle = 0;     // tensormap insert
+static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
+static uint64_t g_orch_scope_end_cycle = 0;  // scope_end overhead
+static int64_t  g_orch_submit_count = 0;
+static uint32_t g_orch_submit_idx = 0;
+#if PTO2_ORCH_PROFILING
+uint64_t g_orch_alloc_wait_cycle = 0;
+uint64_t g_orch_heap_wait_cycle = 0;
+uint64_t g_orch_fanin_wait_cycle = 0;
+uint64_t g_orch_alloc_atomic_count = 0;
+uint64_t g_orch_params_atomic_count = 0;
+uint64_t g_orch_heap_atomic_count = 0;
+uint64_t g_orch_fanin_atomic_count = 0;
+uint64_t g_orch_finalize_atomic_count = 0;
+uint64_t g_orch_scope_end_atomic_count = 0;
+#elif PTO2_SCHED_PROFILING
+// When only PTO2_SCHED_PROFILING is enabled, shared methods still need
+// orch counters as targets for orchestrator-context calls.
+uint64_t g_orch_fanin_atomic_count = 0;
+uint64_t g_orch_fanin_wait_cycle = 0;
+uint64_t g_orch_finalize_atomic_count = 0;
+uint64_t g_orch_scope_end_atomic_count = 0;
+#endif
+#define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
+#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid) do { \
+    _t1 = get_sys_cnt_aicpu(); \
+    acc += (_t1 - _t0); \
+    _t0 = _t1; \
+} while(0)
+#else
+#define CYCLE_COUNT_START()
+#define CYCLE_COUNT_LAP(acc)
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)
+#endif
+
+// =============================================================================
+// Orchestrator Initialization
+// =============================================================================
+
+bool pto2_orchestrator_init(
+    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, uint64_t heap_size,
+    int32_t dep_pool_capacity) {
+    *orch = PTO2OrchestratorState{};
+
+    orch->sm_handle = sm_handle;
+    orch->gm_heap_base = gm_heap;
+    orch->gm_heap_size = heap_size;
+
+    // Initialize heap ring buffer
+    pto2_heap_ring_init(&orch->heap_ring, gm_heap, heap_size,
+                        &sm_handle->header->heap_tail,
+                        &sm_handle->header->heap_top);
+
+    // Initialize task ring buffer
+    pto2_task_ring_init(&orch->task_ring,
+        sm_handle->task_descriptors,
+        sm_handle->header->task_window_size,
+        &sm_handle->header->last_task_alive,
+        &sm_handle->header->current_task_index);
+
+    // Allocate and initialize dependency list pool (per-orchestrator, no shared memory)
+    PTO2DepListEntry* dep_entries = (PTO2DepListEntry*)calloc(dep_pool_capacity, sizeof(PTO2DepListEntry));
+    if (!dep_entries) {
+        return false;
+    }
+    pto2_dep_pool_init(&orch->dep_pool, dep_entries, dep_pool_capacity);
+    orch->dep_pool_cur_entry = nullptr;
+
+    // Initialize TensorMap
+    if (!orch->tensor_map.init_default()) {
+        free(dep_entries);
+        return false;
+    }
+    orch->tensor_map.orch = orch;
+    orch->tensormap_last_cleanup = 0;
+
+    // Initialize scope stack: one flat buffer for task IDs + one array for begin offsets
+    uint64_t max_depth = PTO2_MAX_SCOPE_DEPTH;
+    int32_t init_cap = PTO2_SCOPE_TASKS_INIT_CAP;
+    orch->scope_tasks = (int32_t*)malloc(init_cap * sizeof(int32_t));
+    orch->scope_begins = (int32_t*)malloc(max_depth * sizeof(int32_t));
+    if (!orch->scope_tasks || !orch->scope_begins) {
+        free(orch->scope_tasks);
+        free(orch->scope_begins);
+        free(dep_entries);
+        orch->tensor_map.destroy();
+        return false;
+    }
+    orch->scope_tasks_size = 0;
+    orch->scope_tasks_capacity = init_cap;
+    orch->scope_stack_top = -1;
+    orch->scope_stack_capacity = max_depth;
+
+    return true;
+}
+
+void pto2_orchestrator_destroy(PTO2OrchestratorState* orch) {
+    orch->tensor_map.destroy();
+
+    free(orch->dep_pool.base);
+    orch->dep_pool.base = NULL;
+
+    free(orch->scope_tasks);
+    orch->scope_tasks = NULL;
+    free(orch->scope_begins);
+    orch->scope_begins = NULL;
+}
+
+void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler) {
+    orch->scheduler = scheduler;
+    orch->init_task_on_submit = true;  // Default: initialize task on submit
+}
+
+void pto2_orchestrator_set_scheduler_mode(
+    PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler, bool init_on_submit) {
+    orch->scheduler = scheduler;
+    orch->init_task_on_submit = init_on_submit;
+}
+
+// =============================================================================
+// Scope Management
+// =============================================================================
+
+static void scope_tasks_push(PTO2OrchestratorState* orch, int32_t task_id) {
+    if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
+        int32_t new_cap = orch->scope_tasks_capacity * 2;
+        int32_t* new_buf = (int32_t*)realloc(orch->scope_tasks, new_cap * sizeof(int32_t));
+        assert(new_buf && "Failed to grow scope task buffer");
+        orch->scope_tasks = new_buf;
+        orch->scope_tasks_capacity = new_cap;
+    }
+    orch->scope_tasks[orch->scope_tasks_size++] = task_id;
+}
+
+void pto2_scope_begin(PTO2OrchestratorState* orch) {
+    assert(orch->scope_stack_top < (int32_t)(orch->scope_stack_capacity - 1) && "Scope stack overflow");
+
+    ++orch->scope_stack_top;
+    orch->scope_begins[orch->scope_stack_top] = orch->scope_tasks_size;
+}
+
+void pto2_scope_end(PTO2OrchestratorState* orch) {
+    assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
+
+#if PTO2_PROFILING
+    uint64_t _se0 = get_sys_cnt_aicpu();
+#endif
+
+    int32_t begin = orch->scope_begins[orch->scope_stack_top--];
+    int32_t count = orch->scope_tasks_size - begin;
+
+    if (orch->scheduler && count > 0) {
+        orch->scheduler->on_scope_end(&orch->scope_tasks[begin], count);
+    }
+
+    // Rewind the task buffer — these entries are no longer needed
+    orch->scope_tasks_size = begin;
+
+#if PTO2_PROFILING
+    uint64_t _se1 = get_sys_cnt_aicpu();
+    g_orch_scope_end_cycle += (_se1 - _se0);
+    // perf_aicpu_record_orch_phase(AicpuPhaseId::ORCH_SCOPE_END, _se0, _se1, g_orch_submit_idx, -1);
+#endif
+}
+
+// =============================================================================
+// Task Submission
+// =============================================================================
+void pto2_submit_task(
+    PTO2OrchestratorState* orch, int32_t kernel_id, PTO2WorkerType worker_type, PTOParam* params, int32_t num_params) {
+    CYCLE_COUNT_START();
+
+    // === STEP 0: Sync TensorMap validity and optional cleanup ===
+    orch->tensor_map.sync_tensormap();
+
+    CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, -1);
+
+    // Submission without an open scope is illegal
+    always_assert(orch->scope_stack_top >= 0 && "Cannot submit task outside a scope");
+
+    // === STEP 1: Allocate task slot from Task Ring (blocks until available) ===
+    auto& task_ring = orch->task_ring;
+    int32_t task_id = task_ring.pto2_task_ring_alloc();
+    int32_t slot = task_ring.get_task_slot(task_id);
+
+    PTO2TaskDescriptor& task = task_ring.get_task_by_slot(slot);
+    PTO2TaskPayload* payload = &orch->sm_handle->task_payloads[slot];
+
+    // Initialize task descriptor
+    task.task_id = task_id;
+    task.kernel_id = kernel_id;
+    task.worker_type = worker_type;
+    task.fanin_count = 0;
+    task.fanout_head = nullptr;
+    task.fanout_lock.store(0, std::memory_order_relaxed);
+    // Initial fanout_count = 1 (the owning scope holds one reference)
+    task.fanout_count = 1;
+    task.packed_buffer_base = NULL;
+    task.packed_buffer_end = NULL;
+
+    // Register this task in its owning scope
+    scope_tasks_push(orch, task_id);
+
+    CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, task_id);
+
+    // Temporary storage for fanin
+    int32_t fanin_temp[PTO2_MAX_INPUTS];
+    int32_t fanin_count = 0;
+
+    payload->param_count = num_params;
+    for (int i = 0; i < num_params; i++) {
+        payload->is_tensor[i] = params[i].type != PTOParamType::SCALAR;
+        if (payload->is_tensor[i]) {
+            payload->tensors[i].copy(*params[i].tensor);
+        } else {
+            payload->scalar_value[i] = params[i].scalar_value;
+        }
+    }
+
+    CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS, task_id);
+#if PTO2_ORCH_PROFILING
+    g_orch_params_atomic_count += 2;  // fanout_lock.store + fanout_count.store
+#endif
+
+    // Temporary storage for collecting output sizes
+    int32_t total_output_size = 0;
+    for (int i = 0; i < num_params; i++) {
+        if (params[i].type != PTOParamType::OUTPUT) {
+            continue;
+        }
+        // Only allocate from ring buffer when caller did not provide an address
+        if (payload->tensors[i].buffer.addr == 0) {
+            total_output_size += PTO2_ALIGN_UP(payload->tensors[i].buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
+        }
+    }
+
+    if (total_output_size > 0) {
+        task.packed_buffer_base = orch->pto2_alloc_packed_buffer(total_output_size);
+        task.packed_buffer_end = (char*)task.packed_buffer_base + total_output_size;
+    }
+    CYCLE_COUNT_LAP_RECORD(g_orch_heap_cycle, AicpuPhaseId::ORCH_HEAP, task_id);
+#if PTO2_ORCH_PROFILING
+    if (total_output_size > 0) {
+        g_orch_heap_atomic_count += 1;  // heap_top.store in pto2_alloc_packed_buffer
+    }
+#endif
+
+    // === STEP 2: First pass - set output addr and process tensor ===
+    int32_t offset = 0;
+    for (int i = 0; i < num_params; i++) {
+        PTOParamType ptype = params[i].type;
+
+        switch (ptype) {
+            case PTOParamType::INOUT:
+            case PTOParamType::INPUT: {
+                // Look up producer via TensorMap
+                PTO2LookupResult lookup_result;
+                orch->tensor_map.lookup(payload->tensors[i], lookup_result);
+
+                for (int r = 0; r < lookup_result.count; r++) {
+                    PTO2TensorMapEntry& entry = *lookup_result.entries[r].entry;
+                    auto overlap_status = lookup_result.entries[r].overlap_status;
+                    // Check if this producer is already in fanin list (avoid duplicates)
+                    int producer_task_id = entry.producer_task_id;
+                    bool already_added = false;
+                    for (int j = 0; j < fanin_count; j++) {
+                        if (fanin_temp[j] == producer_task_id) {
+                            already_added = true;
+                            break;
+                        }
+                    }
+
+                    if (!already_added) {
+                        // Add to fanin list (this task depends on producer)
+                        if (fanin_count < PTO2_MAX_INPUTS) {
+                            fanin_temp[fanin_count++] = producer_task_id;
+                        }
+                    }
+                    if (ptype == PTOParamType::INOUT && overlap_status == OverlapStatus::COVERED) {
+                        // inout因为会再次insert进tensor map，
+                        // 因此为了尽量减少依赖构建个数（尽可能构造链式依赖），当该tensor完全覆盖前面的tensor时，
+                        // 应将前面的tensor从tensor map中剔除。
+                        // 但是最开始的tensor除外，因为必须建立和最开始的task的依赖关系以保证tensor生命周期的正确管理
+                        if (!entry.with_alloc) {
+                            orch->tensor_map.remove_entry(entry);
+                        }
+                    }
+                }
+                break;
+            }
+
+            case PTOParamType::OUTPUT: {
+                auto& tensor = payload->tensors[i];
+                if (tensor.buffer.addr == 0) {
+                    uint64_t alloc_addr = reinterpret_cast<uint64_t>((char*)task.packed_buffer_base + offset);
+                    tensor.buffer.addr = alloc_addr;
+                    // Write back allocated address to caller's original Tensor
+                    params[i].tensor->buffer.addr = alloc_addr;
+                    offset += PTO2_ALIGN_UP(tensor.buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
+                }
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    CYCLE_COUNT_LAP_RECORD(g_orch_lookup_cycle, AicpuPhaseId::ORCH_LOOKUP, task_id);
+
+
+    // === STEP 4: Second pass - register outputs in TensorMap ===
+    for (int i = 0; i < num_params; i++) {
+        PTOParamType ptype = params[i].type;
+        if (ptype == PTOParamType::OUTPUT || ptype == PTOParamType::INOUT) {
+            // Register in TensorMap: this tensor is produced by task_id
+            orch->tensor_map.insert(payload->tensors[i], task_id, ptype == PTOParamType::OUTPUT);
+        }
+    }
+
+    CYCLE_COUNT_LAP_RECORD(g_orch_insert_cycle, AicpuPhaseId::ORCH_INSERT, task_id);
+
+    // === STEP 5: Finalize fanin list ===
+    // First build the fanin list
+    if (orch->scheduler) {
+        PTO2SchedulerState* sched = orch->scheduler;
+
+        // Initialize scheduler state BEFORE adding to producer fanout lists,
+        // so concurrent on_task_complete can safely access task_state/fanout_refcount.
+        sched->task_state[slot].store(PTO2_TASK_PENDING, std::memory_order_relaxed);
+        sched->fanout_refcount[slot].store(0, std::memory_order_relaxed);
+
+        auto& dep_pool = orch->dep_pool;
+        if (orch->dep_pool_cur_entry == nullptr) {
+            orch->dep_pool_cur_entry = &dep_pool.alloc();
+        }
+
+        int32_t early_finished = 0;
+        task.fanin_count = fanin_count + 1;  // +1 redundance for not being ready too early
+        payload->fanin_actual_count = fanin_count;
+        for (int i = 0; i < fanin_count; i++) {
+            payload->fanin_tasks[i] = fanin_temp[i];
+        }
+        for (int i = 0; i < fanin_count; i++) {
+            int32_t producer_task_id = fanin_temp[i];
+            // Add this task to producer's fanout list (with spinlock)
+            int32_t prod_slot = task_ring.get_task_slot(producer_task_id);
+            PTO2TaskDescriptor& producer = task_ring.get_task_by_slot(prod_slot);
+            orch->dep_pool_cur_entry->task_id = task_id;
+            orch->dep_pool_cur_entry->next = producer.fanout_head;
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+            pto2_fanout_lock(producer, g_orch_fanin_atomic_count, g_orch_fanin_wait_cycle);
+#else
+            pto2_fanout_lock(producer);
+#endif
+            // Normal path: prepend consumer to producer's fanout list
+            producer.fanout_count += 1;
+            int32_t prod_state = sched->task_state[prod_slot].load(std::memory_order_acquire);
+            if (prod_state >= PTO2_TASK_COMPLETED) {
+                // Early return optimization: if producer already completed, we can skip adding dependency and directly
+                // decrement fanin_count
+                early_finished++;
+            } else {
+                producer.fanout_head = orch->dep_pool_cur_entry;
+            }
+            pto2_fanout_unlock(producer);
+            if (producer.fanout_head == orch->dep_pool_cur_entry) {
+                orch->dep_pool_cur_entry = &dep_pool.alloc();
+            }
+        }
+        // Combined release: merge early_finished batch + init_task's +1 release
+        // into a single atomic fetch_add (saves one acq_rel cache-line bounce per task).
+        int32_t initial_refcount = early_finished + 1;  // +1 for the init release
+        int32_t new_rc = sched->fanin_refcount[slot].fetch_add(initial_refcount, std::memory_order_acq_rel)
+                         + initial_refcount;
+        if (new_rc >= fanin_count + 1) {
+            sched->ready_queues[task.worker_type].push(task_id);
+        }
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+        // Per producer: fetch_add(fanout_count) + load(task_state) + store(unlock) = 3 atomics
+        // Lock atomics (loads + CAS) are counted inside pto2_fanout_lock
+        g_orch_fanin_atomic_count += fanin_count * 3;
+        if (early_finished > 0) {
+            g_orch_fanin_atomic_count += 1;  // fanin_refcount.fetch_add
+        }
+#endif
+    }
+
+    CYCLE_COUNT_LAP_RECORD(g_orch_fanin_cycle, AicpuPhaseId::ORCH_FANIN, task_id);
+
+#if PTO2_PROFILING
+    orch->tasks_submitted++;
+    g_orch_submit_count++;
+    g_orch_submit_idx++;
+#endif
+}
+
+// =============================================================================
+// Flow Control
+// =============================================================================
+
+void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
+    int32_t total_tasks = orch->task_ring.current_index_ptr->load(std::memory_order_acquire);
+    LOG_INFO("=== [Orchestrator] total_tasks=%d ===", total_tasks);
+    orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
+}
+
+// =============================================================================
+// Debug Utilities
+// =============================================================================
+
+void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
+    LOG_INFO("=== Orchestrator Statistics ===");
+#if PTO2_PROFILING
+    LOG_INFO("Tasks submitted:     %lld", (long long)orch->tasks_submitted);
+    LOG_INFO("Buffers allocated:   %lld", (long long)orch->buffers_allocated);
+    LOG_INFO("Bytes allocated:     %lld", (long long)orch->bytes_allocated);
+#endif
+    LOG_INFO("Current scope depth: %d", orch->scope_stack_top + 1);
+    LOG_INFO("Task ring active:    %d", pto2_task_ring_active_count(&orch->task_ring));
+    LOG_INFO("Heap ring used:      %" PRIu64 " / %" PRIu64, orch->heap_ring.top_ptr->load(std::memory_order_relaxed), orch->heap_ring.size);
+    LOG_INFO("Dep pool used:       %d / %d", pto2_dep_pool_used(&orch->dep_pool), orch->dep_pool.capacity);
+    LOG_INFO("TensorMap valid:     %d", orch->tensor_map.valid_count());
+    LOG_INFO("===============================");
+}
+
+void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch) {
+    LOG_INFO("=== Scope Stack ===");
+    LOG_INFO("Depth: %d", orch->scope_stack_top + 1);
+
+    for (int i = 0; i <= orch->scope_stack_top; i++) {
+        int32_t begin = orch->scope_begins[i];
+        int32_t end = (i < orch->scope_stack_top) ? orch->scope_begins[i + 1] : orch->scope_tasks_size;
+        LOG_INFO("  [%d] tasks_owned = %d", i, end - begin);
+    }
+
+    LOG_INFO("==================");
+}
+
+#if PTO2_ORCH_PROFILING
+PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
+    PTO2OrchProfilingData d;
+    d.sync_cycle = g_orch_sync_cycle;
+    d.alloc_cycle = g_orch_alloc_cycle;
+    d.params_cycle = g_orch_params_cycle;
+    d.lookup_cycle = g_orch_lookup_cycle;
+    d.heap_cycle = g_orch_heap_cycle;
+    d.insert_cycle = g_orch_insert_cycle;
+    d.fanin_cycle = g_orch_fanin_cycle;
+    d.scope_end_cycle = g_orch_scope_end_cycle;
+    d.submit_count = g_orch_submit_count;
+    d.alloc_wait_cycle = g_orch_alloc_wait_cycle;
+    d.heap_wait_cycle = g_orch_heap_wait_cycle;
+    d.fanin_wait_cycle = g_orch_fanin_wait_cycle;
+    d.alloc_atomic_count = g_orch_alloc_atomic_count;
+    d.params_atomic_count = g_orch_params_atomic_count;
+    d.heap_atomic_count = g_orch_heap_atomic_count;
+    d.fanin_atomic_count = g_orch_fanin_atomic_count;
+    d.finalize_atomic_count = g_orch_finalize_atomic_count;
+    d.scope_end_atomic_count = g_orch_scope_end_atomic_count;
+
+    // Reset
+    g_orch_sync_cycle = g_orch_alloc_cycle = g_orch_params_cycle = 0;
+    g_orch_lookup_cycle = g_orch_heap_cycle = g_orch_insert_cycle = 0;
+    g_orch_fanin_cycle = g_orch_scope_end_cycle = 0;
+    g_orch_submit_count = 0;
+    g_orch_submit_idx = 0;
+    g_orch_alloc_wait_cycle = 0;
+    g_orch_heap_wait_cycle = 0;
+    g_orch_fanin_wait_cycle = 0;
+    g_orch_alloc_atomic_count = 0;
+    g_orch_params_atomic_count = 0;
+    g_orch_heap_atomic_count = 0;
+    g_orch_fanin_atomic_count = 0;
+    g_orch_finalize_atomic_count = 0;
+    g_orch_scope_end_atomic_count = 0;
+    return d;
+}
+#endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -1,0 +1,248 @@
+/**
+ * PTO Runtime2 - Orchestrator Interface
+ *
+ * The Orchestrator is responsible for:
+ * 1. Executing the orchestration function (Turing-complete control flow)
+ * 2. Allocating intermediate buffers from the heap
+ * 3. Submitting tasks via async InCore function calls
+ * 4. Building the dependency graph using TensorMap
+ * 5. Managing buffer scopes for lifecycle control
+ *
+ * The Orchestrator can run on either:
+ * - Host CPU (lower latency for complex control, easier debugging)
+ * - Device AI_CPU (lower latency for task submission)
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#ifndef PTO_ORCHESTRATOR_H
+#define PTO_ORCHESTRATOR_H
+
+#include "pto_ring_buffer.h"
+#include "pto_runtime2_types.h"
+#include "pto_scheduler.h"
+#include "pto_shared_memory.h"
+#include "pto_tensormap.h"
+#include "pto_types.h"
+
+// =============================================================================
+// Orchestrator State
+// =============================================================================
+
+/**
+ * Orchestrator state structure (private to Orchestrator)
+ *
+ * Contains all state needed for task graph construction and buffer management.
+ */
+struct PTO2OrchestratorState {
+    // === SHARED MEMORY ACCESS ===
+    PTO2SharedMemoryHandle* sm_handle;
+
+    // === RING BUFFERS ===
+    PTO2HeapRing heap_ring;    // Output buffer allocation
+    PTO2TaskRing task_ring;    // Task slot allocation
+    PTO2DepListPool dep_pool;  // Dependency list storage (per-orchestrator, no atomics needed)
+    PTO2DepListEntry* dep_pool_cur_entry;
+
+    // === TENSOR MAP (Private) ===
+    PTO2TensorMap tensor_map;        // Producer lookup
+    int32_t tensormap_last_cleanup;  // Last cleanup threshold
+
+    // === SCOPE STACK (Private) ===
+    // Single contiguous buffer of task IDs, partitioned by scope level.
+    // scope_begins[i] is the index into scope_tasks where scope i starts.
+    // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
+    int32_t* scope_tasks;          // Flat buffer of task IDs (all scopes concatenated)
+    int32_t scope_tasks_size;       // Number of task IDs currently in the buffer
+    int32_t scope_tasks_capacity;   // Allocated capacity of scope_tasks
+    int32_t* scope_begins;         // scope_begins[i] = start index of scope i in scope_tasks
+    int32_t scope_stack_top;       // Current top of stack (-1 = no scope open)
+    uint64_t scope_stack_capacity;   // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+
+    // === SCHEDULER REFERENCE ===
+    // Note: In simulated mode, orchestrator and scheduler share address space
+    // In real mode, they communicate via shared memory only
+    PTO2SchedulerState* scheduler;  // For simulated mode only
+    bool init_task_on_submit;       // If true, call scheduler_init_task on submit
+
+    // === GM HEAP (for output buffers) ===
+    void* gm_heap_base;    // Base address of GM heap
+    uint64_t gm_heap_size;   // Size of GM heap
+
+    // === STATISTICS ===
+#if PTO2_PROFILING
+    int64_t tasks_submitted;
+    int64_t buffers_allocated;
+    int64_t bytes_allocated;
+#endif
+
+    /**
+     * Allocate packed output buffer for a task
+     */
+    void* pto2_alloc_packed_buffer(int32_t total_size) {
+        if (total_size <= 0) {
+            return NULL;
+        }
+
+        void* buffer = heap_ring.pto2_heap_ring_alloc(total_size);
+
+#if PTO2_PROFILING
+        buffers_allocated++;
+        bytes_allocated += total_size;
+#endif
+
+        // heap_top is now updated atomically inside pto2_heap_ring_alloc via CAS
+
+        return buffer;
+    }
+};
+
+// =============================================================================
+// Orchestrator API
+// =============================================================================
+
+/**
+ * Initialize orchestrator state
+ *
+ * @param orch       Orchestrator state to initialize
+ * @param sm_handle  Shared memory handle
+ * @param gm_heap    GM heap memory for output buffers
+ * @param heap_size  Size of GM heap
+ * @return true on success
+ */
+bool pto2_orchestrator_init(
+    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, uint64_t heap_size,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+
+/**
+ * Destroy orchestrator state and free resources
+ */
+void pto2_orchestrator_destroy(PTO2OrchestratorState* orch);
+
+/**
+ * Set scheduler reference (for simulated mode)
+ */
+void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler);
+
+/**
+ * Set scheduler reference with mode control
+ *
+ * @param orch           Orchestrator state
+ * @param scheduler      Scheduler state
+ * @param init_on_submit If true, init task on submit (single-threaded mode)
+ *                       If false, scheduler thread polls for new tasks (multi-threaded)
+ */
+void pto2_orchestrator_set_scheduler_mode(
+    PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler, bool init_on_submit);
+
+// =============================================================================
+// Scope Management
+// =============================================================================
+
+/**
+ * Begin a new scope
+ *
+ * Pushes a new empty task list onto the scope stack.
+ * Tasks submitted while this scope is at the top of the stack are
+ * owned by it and have their fanout_count initialized to 1.
+ */
+void pto2_scope_begin(PTO2OrchestratorState* orch);
+
+/**
+ * End current scope
+ *
+ * Pops the top scope and increments fanout_refcount for each task
+ * directly owned by that scope.
+ * May trigger buffer release for tasks that are now fully consumed.
+ */
+void pto2_scope_end(PTO2OrchestratorState* orch);
+
+// =============================================================================
+// Task Submission
+// =============================================================================
+
+/**
+ * Submit a task with InCore function and parameters
+ *
+ * This is the main API for building the task graph:
+ * 1. Allocates task slot from TaskRing (blocks until available)
+ * 2. Allocates packed output buffer from HeapRing (blocks until available)
+ * 3. Looks up inputs in TensorMap to find dependencies
+ * 4. Updates producer's fanout_count/list (with spinlock)
+ * 5. Registers outputs in TensorMap
+ * 6. Initializes task state in scheduler
+ *
+ * @param orch        Orchestrator state
+ * @param kernel_id   InCore function ID
+ * @param worker_type Target worker type (CUBE, VECTOR, AI_CPU, ACCELERATOR)
+ * @param params      Array of task parameters
+ * @param num_params  Number of parameters
+ */
+void pto2_submit_task(PTO2OrchestratorState* orch,
+    int32_t kernel_id,
+    PTO2WorkerType worker_type,
+    PTOParam* params,
+    int32_t num_params);
+
+// =============================================================================
+// Flow Control
+// =============================================================================
+
+/**
+ * Mark orchestration as complete
+ *
+ * Signals to scheduler that no more tasks will be submitted.
+ */
+void pto2_orchestrator_done(PTO2OrchestratorState* orch);
+
+// =============================================================================
+// Debug Utilities
+// =============================================================================
+
+/**
+ * Print orchestrator statistics
+ */
+void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch);
+
+/**
+ * Print scope stack state
+ */
+void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch);
+
+// =============================================================================
+// Orchestrator Profiling Data
+// =============================================================================
+
+#if PTO2_ORCH_PROFILING
+struct PTO2OrchProfilingData {
+    uint64_t sync_cycle;
+    uint64_t alloc_cycle;
+    uint64_t params_cycle;
+    uint64_t lookup_cycle;
+    uint64_t heap_cycle;
+    uint64_t insert_cycle;
+    uint64_t fanin_cycle;
+    uint64_t scope_end_cycle;
+    int64_t  submit_count;
+    // Wait time tracking for blocking phases
+    uint64_t alloc_wait_cycle;      // Cycles spent waiting in task_ring_alloc
+    uint64_t heap_wait_cycle;       // Cycles spent waiting in heap_ring_alloc
+    uint64_t fanin_wait_cycle;      // Cycles spent waiting in fanout_lock
+    uint64_t finalize_wait_cycle;   // Cycles spent in ready queue push CAS retries
+    // Atomic operation counts per phase
+    uint64_t alloc_atomic_count;
+    uint64_t params_atomic_count;
+    uint64_t heap_atomic_count;
+    uint64_t fanin_atomic_count;
+    uint64_t finalize_atomic_count;
+    uint64_t scope_end_atomic_count;
+};
+
+/**
+ * Get and reset orchestrator profiling data.
+ * Returns accumulated profiling data and resets counters.
+ */
+PTO2OrchProfilingData pto2_orchestrator_get_profiling();
+#endif
+
+#endif  // PTO_ORCHESTRATOR_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -1,0 +1,62 @@
+/**
+ * PTO Runtime2 - Ring Buffer Implementation
+ *
+ * Implements HeapRing, TaskRing, and DepListPool ring buffers
+ * for zero-overhead memory management.
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#include "pto_ring_buffer.h"
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>  // for exit()
+#include "common/unified_log.h"
+
+// =============================================================================
+// Heap Ring Buffer Implementation
+// =============================================================================
+
+void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
+                          std::atomic<uint64_t>* tail_ptr,
+                          std::atomic<uint64_t>* top_ptr) {
+    ring->base = base;
+    ring->size = size;
+    ring->top_ptr = top_ptr;
+    ring->tail_ptr = tail_ptr;
+}
+
+// =============================================================================
+// Task Ring Buffer Implementation
+// =============================================================================
+
+void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
+                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr,
+                          std::atomic<int32_t>* current_index_ptr) {
+    ring->descriptors = descriptors;
+    ring->window_size = window_size;
+    ring->current_index_ptr = current_index_ptr;
+    ring->last_alive_ptr = last_alive_ptr;
+}
+
+// =============================================================================
+// Dependency List Pool Implementation
+// =============================================================================
+
+void pto2_dep_pool_init(PTO2DepListPool* pool, PTO2DepListEntry* base, int32_t capacity) {
+    pool->base = base;
+    pool->capacity = capacity;
+    pool->top = 1;  // Start from 1, 0 means NULL/empty
+
+    // Initialize entry 0 as NULL marker
+    pool->base[0].task_id = -1;
+    pool->base[0].next = nullptr;
+}
+
+int32_t pto2_dep_pool_used(PTO2DepListPool* pool) {
+    return pool->top - 1;
+}
+
+int32_t pto2_dep_pool_available(PTO2DepListPool* pool) {
+    return pool->capacity - pool->top;
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -1,0 +1,487 @@
+/**
+ * PTO Runtime2 - Ring Buffer Data Structures
+ * 
+ * Implements ring buffer designs for zero-overhead memory management:
+ * 
+ * 1. HeapRing - Output buffer allocation from GM Heap
+ *    - O(1) bump allocation
+ *    - Wrap-around at end, skip to beginning if buffer doesn't fit
+ *    - Implicit reclamation via heap_tail advancement
+ *    - Back-pressure: stalls when no space available
+ * 
+ * 2. TaskRing - Task slot allocation
+ *    - Fixed window size (TASK_WINDOW_SIZE)
+ *    - Wrap-around modulo window size
+ *    - Implicit reclamation via last_task_alive advancement
+ *    - Back-pressure: stalls when window is full
+ * 
+ * 3. DepListPool - Dependency list entry allocation
+ *    - Ring buffer for linked list entries
+ *    - O(1) prepend operation
+ *    - Implicit reclamation with task ring
+ * 
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#ifndef PTO_RING_BUFFER_H
+#define PTO_RING_BUFFER_H
+
+#include <inttypes.h>
+#include <stdlib.h>  // for exit()
+
+#include "pto_runtime2_types.h"
+#include "pto_shared_memory.h"
+#include "common/unified_log.h"
+
+// Set to 1 to enable periodic BLOCKED/Unblocked messages during spin-wait.
+#ifndef PTO2_SPIN_VERBOSE_LOGGING
+#define PTO2_SPIN_VERBOSE_LOGGING 1
+#endif
+
+// Block notification interval (in spin counts)
+#define PTO2_BLOCK_NOTIFY_INTERVAL  10000
+// Heap ring spin limit - after this, report deadlock and exit
+#define PTO2_HEAP_SPIN_LIMIT        100000
+
+// Flow control spin limit - if exceeded, likely deadlock due to scope/fanout_count
+#define PTO2_FLOW_CONTROL_SPIN_LIMIT  100000
+
+// =============================================================================
+// Heap Ring Buffer
+// =============================================================================
+
+/**
+ * Heap ring buffer structure
+ * 
+ * Allocates output buffers from a contiguous GM Heap.
+ * Wrap-around design with implicit reclamation.
+ */
+struct PTO2HeapRing {
+    void*    base;        // GM_Heap_Base pointer
+    uint64_t size;        // GM_Heap_Size (total heap size in bytes)
+    std::atomic<uint64_t>* top_ptr;  // Allocation pointer (shared atomic in SM header)
+
+    // Reference to shared memory tail (for back-pressure)
+    std::atomic<uint64_t>* tail_ptr;  // Points to header->heap_tail
+
+    /**
+     * Allocate memory from heap ring
+     *
+     * O(1) bump allocation with wrap-around.
+     * May STALL (spin-wait) if insufficient space (back-pressure).
+     * Never splits a buffer across the wrap-around boundary.
+     *
+     * @param size  Requested size in bytes
+     * @return Pointer to allocated memory, never NULL (stalls instead)
+     */
+    void* pto2_heap_ring_alloc(uint64_t size) {
+        // Align size for DMA efficiency
+        size = PTO2_ALIGN_UP(size, PTO2_ALIGN_SIZE);
+
+        // Spin-wait if insufficient space (back-pressure from Scheduler)
+        int spin_count = 0;
+#if PTO2_SPIN_VERBOSE_LOGGING
+        bool notified = false;
+#endif
+#if PTO2_ORCH_PROFILING
+        uint64_t wait_start = 0;
+        bool waiting = false;
+#endif
+
+        while (1) {
+            void* ptr = pto2_heap_ring_try_alloc(size);
+            if (ptr != NULL) {
+#if PTO2_SPIN_VERBOSE_LOGGING
+                if (notified) {
+                    LOG_INFO("[HeapRing] Unblocked after %d spins", spin_count);
+                }
+#endif
+#if PTO2_ORCH_PROFILING
+                if (waiting) {
+                    extern uint64_t g_orch_heap_wait_cycle;
+                    g_orch_heap_wait_cycle += (get_sys_cnt_aicpu() - wait_start);
+                }
+                {
+                    extern uint64_t g_orch_heap_atomic_count;
+                    g_orch_heap_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
+                }
+#endif
+                return ptr;
+            }
+
+            // No space available, spin-wait
+            spin_count++;
+#if PTO2_ORCH_PROFILING
+            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+#endif
+
+#if PTO2_SPIN_VERBOSE_LOGGING
+            // Periodic block notification
+            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count < PTO2_HEAP_SPIN_LIMIT) {
+                uint64_t tail = tail_ptr->load(std::memory_order_acquire);
+                uint64_t top = top_ptr->load(std::memory_order_acquire);
+                LOG_WARN("[HeapRing] BLOCKED: requesting %" PRIu64 " bytes"
+                     ", top=%" PRIu64 ", tail=%" PRIu64 ", spins=%d",
+                     size, top, tail, spin_count);
+                notified = true;
+            }
+#endif
+
+            if (spin_count >= PTO2_HEAP_SPIN_LIMIT) {
+                uint64_t tail = tail_ptr->load(std::memory_order_acquire);
+                uint64_t top = top_ptr->load(std::memory_order_acquire);
+                LOG_ERROR("========================================");
+                LOG_ERROR("FATAL: Heap Ring Deadlock Detected!");
+                LOG_ERROR("========================================");
+                LOG_ERROR("Orchestrator blocked waiting for heap space after %d spins.", spin_count);
+                LOG_ERROR("  - Requested:     %" PRIu64 " bytes", size);
+                LOG_ERROR("  - Heap top:      %" PRIu64, top);
+                LOG_ERROR("  - Heap tail:     %" PRIu64, tail);
+                LOG_ERROR("  - Heap size:     %" PRIu64, this->size);
+                LOG_ERROR("Solution: Increase PTO2_HEAP_SIZE (e.g. 256*1024 for 4 x 64KB outputs).");
+                LOG_ERROR("========================================");
+                exit(1);
+            }
+
+            SPIN_WAIT_HINT();
+        }
+    }
+
+    /**
+     * Try to allocate memory without stalling (thread-safe via CAS)
+     *
+     * @param size  Requested size in bytes
+     * @return Pointer to allocated memory, or NULL if no space
+     */
+    void* pto2_heap_ring_try_alloc(uint64_t alloc_size) {
+        // Align size for DMA efficiency
+        alloc_size = PTO2_ALIGN_UP(alloc_size, PTO2_ALIGN_SIZE);
+
+        while (true) {
+            uint64_t top = top_ptr->load(std::memory_order_acquire);
+            // Read latest tail from shared memory (Scheduler updates this)
+            uint64_t tail = tail_ptr->load(std::memory_order_acquire);
+            uint64_t new_top;
+            void* result;
+
+            if (top >= tail) {
+                // Case 1: top is at or ahead of tail (normal case)
+                uint64_t space_at_end = size - top;
+
+                if (space_at_end >= alloc_size) {
+                    new_top = top + alloc_size;
+                    result = (char*)base + top;
+                } else if (tail > alloc_size) {
+                    // Wrap to beginning
+                    new_top = alloc_size;
+                    result = base;
+                } else {
+                    return NULL;
+                }
+            } else {
+                // Case 2: top has wrapped, tail is ahead
+                uint64_t gap = tail - top;
+                if (gap >= alloc_size) {
+                    new_top = top + alloc_size;
+                    result = (char*)base + top;
+                } else {
+                    return NULL;
+                }
+            }
+
+            if (top_ptr->compare_exchange_weak(top, new_top,
+                    std::memory_order_acq_rel, std::memory_order_acquire)) {
+                return result;
+            }
+            // CAS failed, retry with updated top
+        }
+    }
+
+    /**
+     * Get available space in heap ring
+     */
+    uint64_t pto2_heap_ring_available() {
+        uint64_t top = top_ptr->load(std::memory_order_acquire);
+        uint64_t tail = tail_ptr->load(std::memory_order_acquire);
+
+        if (top >= tail) {
+            uint64_t at_end = size - top;
+            uint64_t at_begin = tail;
+            return at_end > at_begin ? at_end : at_begin;
+        } else {
+            return tail - top;
+        }
+    }
+};
+
+/**
+ * Initialize heap ring buffer
+ * 
+ * @param ring      Heap ring to initialize
+ * @param base      Base address of heap memory
+ * @param size      Total heap size in bytes
+ * @param tail_ptr  Pointer to shared memory heap_tail
+ */
+void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
+                          std::atomic<uint64_t>* tail_ptr,
+                          std::atomic<uint64_t>* top_ptr);
+
+// =============================================================================
+// Task Ring Buffer
+// =============================================================================
+
+/**
+ * Task ring buffer structure
+ * 
+ * Fixed-size sliding window for task management.
+ * Provides back-pressure when window is full.
+ */
+struct PTO2TaskRing {
+    PTO2TaskDescriptor* descriptors;  // Task descriptor array (from shared memory)
+    int32_t window_size;              // Window size (power of 2)
+    std::atomic<int32_t>* current_index_ptr;  // Shared atomic in SM header
+
+    // Reference to shared memory last_task_alive (for back-pressure)
+    std::atomic<int32_t>* last_alive_ptr;  // Points to header->last_task_alive
+
+    /**
+     * Allocate a task slot from task ring
+     *
+     * May STALL (spin-wait) if window is full (back-pressure).
+     * Initializes the task descriptor to default values.
+     *
+     * @return Allocated task ID (absolute, not wrapped)
+     */
+    int32_t pto2_task_ring_alloc() {
+        // Spin-wait if window is full (back-pressure from Scheduler)
+        int spin_count = 0;
+#if PTO2_SPIN_VERBOSE_LOGGING
+        bool notified = false;
+#endif
+#if PTO2_ORCH_PROFILING
+        uint64_t wait_start = 0;
+        bool waiting = false;
+#endif
+
+        while (1) {
+            int32_t task_id = pto2_task_ring_try_alloc();
+            if (task_id >= 0) {
+#if PTO2_SPIN_VERBOSE_LOGGING
+                if (notified) {
+                    LOG_INFO("[TaskRing] Unblocked after %d spins, task_id=%d", spin_count, task_id);
+                }
+#endif
+#if PTO2_ORCH_PROFILING
+                if (waiting) {
+                    extern uint64_t g_orch_alloc_wait_cycle;
+                    g_orch_alloc_wait_cycle += (get_sys_cnt_aicpu() - wait_start);
+                }
+                {
+                    extern uint64_t g_orch_alloc_atomic_count;
+                    g_orch_alloc_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
+                }
+#endif
+                return task_id;
+            }
+
+            // Window is full, spin-wait (with yield to prevent CPU starvation)
+            spin_count++;
+#if PTO2_ORCH_PROFILING
+            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+#endif
+
+#if PTO2_SPIN_VERBOSE_LOGGING
+            // Periodic block notification
+            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count < PTO2_FLOW_CONTROL_SPIN_LIMIT) {
+                int32_t last_alive = last_alive_ptr->load(std::memory_order_acquire);
+                int32_t current = current_index_ptr->load(std::memory_order_acquire);
+                int32_t active_count = current - last_alive;
+                LOG_WARN("[TaskRing] BLOCKED (Flow Control): current=%d, last_alive=%d, "
+                     "active=%d/%d (%.1f%%), spins=%d",
+                     current, last_alive, active_count, window_size,
+                     100.0 * active_count / window_size, spin_count);
+                notified = true;
+            }
+#endif
+
+            // Check for potential deadlock
+            if (spin_count >= PTO2_FLOW_CONTROL_SPIN_LIMIT) {
+                int32_t last_alive = last_alive_ptr->load(std::memory_order_acquire);
+                int32_t current = current_index_ptr->load(std::memory_order_acquire);
+                int32_t active_count = current - last_alive;
+
+                LOG_ERROR("========================================");
+                LOG_ERROR("FATAL: Flow Control Deadlock Detected!");
+                LOG_ERROR("========================================");
+                LOG_ERROR("Task Ring is FULL and no progress after %d spins.", spin_count);
+                LOG_ERROR("Flow Control Status:");
+                LOG_ERROR("  - Current task index:  %d", current);
+                LOG_ERROR("  - Last task alive:     %d", last_alive);
+                LOG_ERROR("  - Active tasks:        %d", active_count);
+                LOG_ERROR("  - Window size:         %d", window_size);
+                LOG_ERROR("  - Window utilization:  %.1f%%", 100.0 * active_count / window_size);
+                LOG_ERROR("Root Cause:");
+                LOG_ERROR("  Tasks cannot transition to CONSUMED state because:");
+                LOG_ERROR("  - fanout_count includes 1 for the owning scope");
+                LOG_ERROR("  - scope_end() requires orchestrator to continue");
+                LOG_ERROR("  - But orchestrator is blocked waiting for task ring space");
+                LOG_ERROR("  This creates a circular dependency (deadlock).");
+                LOG_ERROR("Solution:");
+                LOG_ERROR("  Current task_window_size: %d", window_size);
+                LOG_ERROR("  Default PTO2_TASK_WINDOW_SIZE: %d", PTO2_TASK_WINDOW_SIZE);
+                LOG_ERROR("  Recommended: %d (at least 2x current active tasks)", active_count * 2);
+                LOG_ERROR("  Option 1: Change PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");
+                LOG_ERROR("  Option 2: Use pto2_runtime_create_threaded_custom() with larger");
+                LOG_ERROR("            task_window_size parameter.");
+                LOG_ERROR("========================================");
+
+                // Abort program
+                exit(1);
+            }
+
+            SPIN_WAIT_HINT();
+        }
+    }
+
+    /**
+     * Try to allocate task slot without stalling (thread-safe via fetch_add)
+     *
+     * @return Task ID, or -1 if window is full
+     */
+    int32_t pto2_task_ring_try_alloc() {
+        // Optimistically allocate a task ID
+        int32_t task_id = current_index_ptr->fetch_add(1, std::memory_order_acq_rel);
+        int32_t last_alive = last_alive_ptr->load(std::memory_order_acquire);
+        int32_t active_count = task_id - last_alive;
+
+        // Check if there's room (leave at least 1 slot empty)
+        if (active_count < window_size - 1) {
+            int32_t slot = task_id & (window_size - 1);
+            PTO2TaskDescriptor* task = &descriptors[slot];
+            task->task_id = task_id;
+            return task_id;
+        }
+
+        // Window is full — roll back the optimistic increment
+        current_index_ptr->fetch_sub(1, std::memory_order_release);
+        return -1;
+    }
+
+    int32_t get_task_slot(int32_t task_id) const { return task_id & (window_size - 1); }
+
+    /**
+    * Get task descriptor by ID
+    */
+    PTO2TaskDescriptor& get_task(int32_t task_id) { return descriptors[task_id & (window_size - 1)]; }
+
+    /**
+    * Get task descriptor by task slot
+    */
+    PTO2TaskDescriptor& get_task_by_slot(int32_t task_slot) { return descriptors[task_slot]; }
+};
+
+/**
+ * Initialize task ring buffer
+ * 
+ * @param ring            Task ring to initialize
+ * @param descriptors     Task descriptor array from shared memory
+ * @param window_size     Window size (must be power of 2)
+ * @param last_alive_ptr  Pointer to shared memory last_task_alive
+ */
+void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
+                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr,
+                          std::atomic<int32_t>* current_index_ptr);
+
+/**
+ * Get number of active tasks in window
+ */
+static inline int32_t pto2_task_ring_active_count(PTO2TaskRing* ring) {
+    int32_t last_alive = ring->last_alive_ptr->load(std::memory_order_acquire);
+    return ring->current_index_ptr->load(std::memory_order_acquire) - last_alive;
+}
+
+/**
+ * Check if task ring has space for more tasks
+ */
+static inline bool pto2_task_ring_has_space(PTO2TaskRing* ring) {
+    int32_t active = pto2_task_ring_active_count(ring);
+    return active < ring->window_size - 1;
+}
+
+/**
+ * Get task descriptor by ID
+ */
+static inline PTO2TaskDescriptor* pto2_task_ring_get(PTO2TaskRing* ring, int32_t task_id) {
+    return &ring->descriptors[task_id & (ring->window_size - 1)];
+}
+
+// =============================================================================
+// Dependency List Pool
+// =============================================================================
+
+/**
+ * Dependency list pool structure
+ * 
+ * Ring buffer for allocating linked list entries.
+ * Supports O(1) prepend operation for fanin/fanout lists.
+ */
+struct PTO2DepListPool {
+    PTO2DepListEntry* base;   // Pool base address (from shared memory)
+    int32_t capacity;         // Total number of entries
+    int32_t top;              // Next allocation position (starts from 1, 0=NULL)
+
+    /**
+     * Allocate a single entry from the pool (single-thread per pool instance)
+     *
+     * @return Reference to allocated entry
+     */
+    PTO2DepListEntry& alloc() {
+        int32_t idx = top++;
+        if (idx >= capacity) {
+            top = 2;  // Wrap around (skip entry 0 = NULL marker)
+            idx = 1;
+        }
+        return base[idx];
+    }
+
+    /**
+     * Prepend a task ID to a dependency list
+     *
+     * O(1) operation: allocates new entry and links to current head.
+     *
+     * @param current_head  Current list head offset (0 = empty list)
+     * @param task_id       Task ID to prepend
+     * @return New head offset
+     */
+    PTO2DepListEntry* pto2_dep_list_prepend(PTO2DepListEntry* cur, int32_t task_id) {
+        PTO2DepListEntry& new_entry = alloc();
+        new_entry.task_id = task_id;
+        new_entry.next = cur;
+        return &new_entry;
+    }
+
+    /**
+    * Get entry by offset
+    */
+    PTO2DepListEntry* pto2_dep_pool_get(int32_t offset) {
+        if (offset <= 0) return NULL;
+        return &base[offset];
+    }
+};
+
+/**
+ * Initialize dependency list pool
+ * 
+ * @param pool      Pool to initialize
+ * @param base      Pool base address from shared memory
+ * @param capacity  Total number of entries
+ */
+void pto2_dep_pool_init(PTO2DepListPool* pool, PTO2DepListEntry* base, int32_t capacity);
+
+/**
+ * Get pool usage statistics
+ */
+int32_t pto2_dep_pool_used(PTO2DepListPool* pool);
+int32_t pto2_dep_pool_available(PTO2DepListPool* pool);
+
+#endif // PTO_RING_BUFFER_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -1,0 +1,202 @@
+/**
+ * PTO Runtime2 - Main Implementation
+ *
+ * Implements the unified runtime API that combines orchestrator and scheduler.
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#include "pto_runtime2.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "common/unified_log.h"
+
+// =============================================================================
+// Thread-local orchestrator index for multi-orchestrator dispatch
+// =============================================================================
+
+thread_local int pto2_current_orch_idx = 0;
+
+void pto2_set_orch_thread_idx(int idx) {
+    pto2_current_orch_idx = idx;
+}
+
+// =============================================================================
+// Orchestration Ops Table (function-pointer dispatch for orchestration .so)
+// =============================================================================
+
+static void submit_task_impl(PTO2Runtime* rt, int32_t kernel_id,
+                             PTO2WorkerType worker_type,
+                             PTOParam* params, int32_t num_params) {
+    pto2_submit_task(&rt->orchestrators[pto2_current_orch_idx], kernel_id, worker_type,
+                     params, num_params);
+}
+
+void pto2_rt_scope_begin(PTO2Runtime* rt) {
+    pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]);
+}
+
+void pto2_rt_scope_end(PTO2Runtime* rt) {
+    pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]);
+}
+
+void pto2_rt_orchestration_done(PTO2Runtime* rt) {
+    pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]);
+}
+
+static const PTO2RuntimeOps s_runtime_ops = {
+    .submit_task          = submit_task_impl,
+    .scope_begin          = pto2_rt_scope_begin,
+    .scope_end            = pto2_rt_scope_end,
+    .orchestration_done   = pto2_rt_orchestration_done,
+    .log_error            = unified_log_error,
+    .log_warn             = unified_log_warn,
+    .log_info             = unified_log_info,
+    .log_debug            = unified_log_debug,
+    .log_always           = unified_log_always,
+};
+
+// =============================================================================
+// Runtime Creation and Destruction
+// =============================================================================
+
+PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode) {
+    return pto2_runtime_create_custom(mode,
+                                       PTO2_TASK_WINDOW_SIZE,
+                                       PTO2_HEAP_SIZE);
+}
+
+PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
+                                         uint64_t task_window_size,
+                                         uint64_t heap_size) {
+    // Allocate runtime context
+    PTO2Runtime* rt = (PTO2Runtime*)calloc(1, sizeof(PTO2Runtime));
+    if (!rt) {
+        return NULL;
+    }
+
+    rt->ops = &s_runtime_ops;
+    rt->mode = mode;
+    rt->orch_count = 1;
+    rt->sm_handle = pto2_sm_create(task_window_size, heap_size);
+    if (!rt->sm_handle) {
+        free(rt);
+        return NULL;
+    }
+
+    // Allocate GM heap for output buffers
+    rt->gm_heap_size = heap_size;
+    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+        if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, heap_size) != 0) {
+            pto2_sm_destroy(rt->sm_handle);
+            free(rt);
+            return NULL;
+        }
+    #else
+        rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, heap_size);
+        if (!rt->gm_heap) {
+            pto2_sm_destroy(rt->sm_handle);
+            free(rt);
+            return NULL;
+        }
+    #endif
+    rt->gm_heap_owned = true;
+
+    // Initialize first orchestrator
+    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle,
+                                 rt->gm_heap, heap_size)) {
+        free(rt->gm_heap);
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+
+    // Initialize scheduler
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, rt->gm_heap)) {
+        pto2_orchestrator_destroy(&rt->orchestrators[0]);
+        free(rt->gm_heap);
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+
+    // Connect orchestrator to scheduler (for simulated mode)
+    pto2_orchestrator_set_scheduler(&rt->orchestrators[0], &rt->scheduler);
+
+    return rt;
+}
+
+PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
+                                          PTO2SharedMemoryHandle* sm_handle,
+                                          void* gm_heap,
+                                          uint64_t heap_size,
+                                          int orch_count) {
+    if (!sm_handle) return NULL;
+    if (orch_count < 1) orch_count = 1;
+    if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
+
+    PTO2Runtime* rt = (PTO2Runtime*)calloc(1, sizeof(PTO2Runtime));
+    if (!rt) return NULL;
+
+    rt->ops = &s_runtime_ops;
+    rt->mode = mode;
+    rt->sm_handle = sm_handle;
+    rt->gm_heap = gm_heap;
+    rt->gm_heap_size = heap_size > 0 ? heap_size : 0;
+    rt->gm_heap_owned = false;
+    rt->orch_count = orch_count;
+
+    // Initialize all orchestrator states
+    for (int i = 0; i < orch_count; i++) {
+        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle,
+                                    rt->gm_heap, rt->gm_heap_size)) {
+            for (int j = 0; j < i; j++) {
+                pto2_orchestrator_destroy(&rt->orchestrators[j]);
+            }
+            free(rt);
+            return NULL;
+        }
+    }
+
+    // Initialize scheduler
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, rt->gm_heap)) {
+        for (int i = 0; i < orch_count; i++) {
+            pto2_orchestrator_destroy(&rt->orchestrators[i]);
+        }
+        free(rt);
+        return NULL;
+    }
+
+    // Connect all orchestrators to scheduler
+    for (int i = 0; i < orch_count; i++) {
+        pto2_orchestrator_set_scheduler(&rt->orchestrators[i], &rt->scheduler);
+    }
+
+    return rt;
+}
+
+void pto2_runtime_destroy(PTO2Runtime* rt) {
+    if (!rt) return;
+
+    pto2_scheduler_destroy(&rt->scheduler);
+    for (int i = 0; i < rt->orch_count; i++) {
+        pto2_orchestrator_destroy(&rt->orchestrators[i]);
+    }
+
+    if (rt->gm_heap_owned && rt->gm_heap) {
+        free(rt->gm_heap);
+    }
+
+    if (rt->sm_handle) {
+        pto2_sm_destroy(rt->sm_handle);
+    }
+
+    free(rt);
+}
+
+void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode) {
+    if (rt) {
+        rt->mode = mode;
+    }
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -1,0 +1,280 @@
+/**
+ * PTO Runtime2 - Main Interface
+ *
+ * This is the main header for the PTO Runtime2 system.
+ * It provides a unified API for task graph construction and execution.
+ *
+ * Key Features:
+ * - Ring buffer based memory management (zero allocation overhead)
+ * - Lazy invalidation TensorMap for dependency discovery
+ * - Scope-based buffer lifecycle management
+ * - Per-task spinlocks for concurrent fanout updates
+ * - Orchestrator-Scheduler decoupling via shared memory
+ *
+ * Usage:
+ *   1. Create runtime: pto2_runtime_create()
+ *   2. Build task graph in orchestration function:
+ *      - pto2_scope_begin() / pto2_scope_end()
+ *      - pto2_submit_task()
+ *   3. Mark orchestration complete: pto2_orchestrator_done()
+ *   4. Destroy runtime: pto2_runtime_destroy()
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#ifndef PTO_RUNTIME2_H
+#define PTO_RUNTIME2_H
+
+#include "pto_runtime2_types.h"
+#include "pto_shared_memory.h"
+#include "pto_ring_buffer.h"
+#include "pto_tensormap.h"
+#include "pto_scheduler.h"
+#include "pto_orchestrator.h"
+
+// Maximum number of orchestrator threads supported
+constexpr int PTO2_MAX_ORCH_THREADS = 4;
+
+// =============================================================================
+// Runtime Context
+// =============================================================================
+
+/**
+ * Runtime execution mode
+ */
+enum PTO2RuntimeMode {
+    PTO2_MODE_EXECUTE = 0,    // Execute tasks on workers
+    PTO2_MODE_SIMULATE = 1,   // Simulate task execution with cycle counting
+    PTO2_MODE_GRAPH_ONLY = 2  // Build graph only, no execution
+};
+
+/**
+ * Function-pointer ops table for runtime operations.
+ *
+ * The orchestration .so calls runtime functions through this table
+ * (via pto_orchestration_api.h inline wrappers), so it has zero link
+ * dependencies on runtime .cpp files.
+ */
+typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
+
+struct PTO2RuntimeOps {
+    void (*submit_task)(PTO2Runtime* rt, int32_t kernel_id,
+                        PTO2WorkerType worker_type,
+                        PTOParam* params, int32_t num_params);
+    void (*scope_begin)(PTO2Runtime* rt);
+    void (*scope_end)(PTO2Runtime* rt);
+    void (*orchestration_done)(PTO2Runtime* rt);
+
+    // Logging (populated by runtime, called by orchestration)
+    void (*log_error)(const char* func, const char* fmt, ...);
+    void (*log_warn)(const char* func, const char* fmt, ...);
+    void (*log_info)(const char* func, const char* fmt, ...);
+    void (*log_debug)(const char* func, const char* fmt, ...);
+    void (*log_always)(const char* func, const char* fmt, ...);
+};
+
+/**
+ * PTO Runtime2 context
+ *
+ * Contains all state for orchestration and scheduling.
+ * In simulated mode, runs in single process with shared address space.
+ */
+struct PTO2Runtime {
+    // Ops table (first field — used by orchestration .so via function pointers)
+    const PTO2RuntimeOps*   ops;
+
+    // Components
+    PTO2SharedMemoryHandle* sm_handle;
+    PTO2OrchestratorState   orchestrators[PTO2_MAX_ORCH_THREADS];
+    int                     orch_count;     // Number of active orchestrator states
+    PTO2SchedulerState      scheduler;
+
+    // GM Heap for output buffers
+    void*                   gm_heap;
+    uint64_t                  gm_heap_size;
+    bool                    gm_heap_owned;  // True if we allocated it
+
+    // Mode
+    PTO2RuntimeMode         mode;
+
+    // Statistics
+    int64_t                 total_cycles;
+};
+
+// =============================================================================
+// Runtime Lifecycle API
+// =============================================================================
+
+/**
+ * Create a new runtime instance
+ *
+ * @param mode Execution mode
+ * @return Runtime context, or NULL on failure
+ */
+PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode);
+
+/**
+ * Create runtime with custom sizes
+ *
+ * @param mode             Execution mode
+ * @param task_window_size Number of task slots
+ * @param heap_size        Size of GM heap
+ * @return Runtime context, or NULL on failure
+ */
+PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
+                                         uint64_t task_window_size,
+                                         uint64_t heap_size);
+
+/**
+ * Create runtime from existing shared memory and GM heap (e.g. on device).
+ * Does not allocate sm_handle or gm_heap; caller owns them.
+ *
+ * @param mode      Execution mode
+ * @param sm_handle Pre-created shared memory handle (e.g. from pto2_sm_create_from_buffer)
+ * @param gm_heap   GM heap base for output buffers (or NULL if not used)
+ * @param heap_size GM heap size in bytes
+ * @return Runtime context, or NULL on failure
+ */
+PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
+                                          PTO2SharedMemoryHandle* sm_handle,
+                                          void* gm_heap,
+                                          uint64_t heap_size,
+                                          int orch_count = 1);
+
+/**
+ * Destroy runtime and free all resources
+ */
+void pto2_runtime_destroy(PTO2Runtime* rt);
+
+/**
+ * Set execution mode
+ */
+void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode);
+
+/**
+ * Set the orchestrator index for the current thread.
+ * Must be called before any orchestration API calls on a given thread.
+ */
+void pto2_set_orch_thread_idx(int idx);
+
+// =============================================================================
+// Orchestration API (called by orchestration function)
+// =============================================================================
+
+/**
+ * Begin a new scope
+ *
+ * All tasks submitted within this scope will have their lifetime
+ * bounded by the scope. When scope_end() is called, the scope
+ * releases its reference to all enclosed tasks.
+ */
+void pto2_rt_scope_begin(PTO2Runtime* rt);
+
+/**
+ * End current scope
+ *
+ * Releases scope reference for all tasks submitted since scope_begin().
+ * Tasks whose refcount reaches zero will have their buffers released.
+ */
+void pto2_rt_scope_end(PTO2Runtime* rt);
+
+/**
+ * Mark orchestration as complete
+ *
+ * Signals that no more tasks will be submitted.
+ */
+void pto2_rt_orchestration_done(PTO2Runtime* rt);
+
+/**
+ * Scope helper macros for C
+ *
+ * These macros provide scope management for C code.
+ * For C++, prefer using PTO2_SCOPE_GUARD or PTO2_SCOPE (see below).
+ *
+ * Usage (C):
+ *   PTO2_SCOPE_BEGIN(rt);
+ *   pto2_rt_submit_task(...);
+ *   pto2_rt_submit_task(...);
+ *   PTO2_SCOPE_END(rt);
+ */
+#define PTO2_SCOPE_BEGIN(rt) pto2_rt_scope_begin(rt)
+#define PTO2_SCOPE_END(rt)   pto2_rt_scope_end(rt)
+
+/**
+ * RAII Scope Guard for C++
+ *
+ * PTO2ScopeGuard is a C++ RAII wrapper that automatically manages scope lifetime.
+ * It calls pto2_rt_scope_begin() on construction and pto2_rt_scope_end() on destruction,
+ * ensuring proper cleanup even in error paths.
+ *
+ * Usage Option 1 - Direct instantiation (recommended):
+ *   PTO2ScopeGuard scope_guard(rt);
+ *   pto2_rt_submit_task(...);
+ *   pto2_rt_submit_task(...);
+ *   // scope automatically ends here when scope_guard destructor is called
+ *
+ * Usage Option 2 - Macro for anonymous guard:
+ *   PTO2_SCOPE_GUARD(rt);
+ *   pto2_rt_submit_task(...);
+ *   // scope automatically ends at end of current block
+ *
+ * Usage Option 3 - Scoped block with if statement:
+ *   PTO2_SCOPE(rt) {
+ *       pto2_rt_submit_task(...);
+ *       pto2_rt_submit_task(...);
+ *   } // scope automatically ends here
+ *
+ * Benefits:
+ * - Exception-safe: scope ends even if exceptions are thrown
+ * - Error-safe: no need to manually call PTO2_SCOPE_END in error paths
+ * - Cleaner code: less boilerplate, automatic cleanup
+ * - Less error-prone: impossible to forget scope cleanup
+ */
+class PTO2ScopeGuard {
+public:
+    PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) {
+        pto2_rt_scope_begin(rt_);
+    }
+    ~PTO2ScopeGuard() {
+        pto2_rt_scope_end(rt_);
+    }
+private:
+    PTO2Runtime* rt_;
+};
+
+/**
+ * Macro to create an anonymous scope guard with a unique name.
+ * The [[maybe_unused]] attribute suppresses warnings if the guard
+ * variable is not explicitly used.
+ *
+ * Example:
+ *   PTO2_SCOPE_GUARD(rt);
+ *   pto2_rt_submit_task(...);
+ */
+#define _PTO2_CONCATENATE_IMPL(x, y) x ## y
+#define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
+#define PTO2_SCOPE_GUARD(rt) [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__)(rt)
+
+/**
+ * Macro to create a scoped block with automatic scope management.
+ * Uses if-statement initialization (C++17) to create guard and execute block.
+ *
+ * Example:
+ *   PTO2_SCOPE(rt) {
+ *       pto2_rt_submit_task(...);
+ *   } // scope automatically ends here
+ */
+#define PTO2_SCOPE(rt) if (PTO2_SCOPE_GUARD(rt); true)
+
+/**
+ * Slim config struct exported by orchestration .so via aicpu_orchestration_config().
+ * Shared definition with pto_orchestration_api.h (same layout, guarded).
+ */
+#ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
+#define PTO2_ORCHESTRATION_CONFIG_DEFINED
+struct PTO2OrchestrationConfig {
+    int         expected_arg_count;
+};
+#endif
+
+#endif // PTO_RUNTIME2_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -1,0 +1,427 @@
+/**
+ * PTO Runtime2 - Core Type Definitions
+ *
+ * This header defines all fundamental types used by the PTO Runtime2 system:
+ * - Configuration constants
+ * - Worker types and task states
+ * - Tensor regions and task parameters
+ * - Task descriptors with fanin/fanout tracking
+ * - Dependency list entries
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#ifndef PTO_RUNTIME2_TYPES_H
+#define PTO_RUNTIME2_TYPES_H
+
+#include <atomic>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "pto_types.h"
+
+// =============================================================================
+// Profiling Configuration
+// =============================================================================
+
+#ifndef PTO2_PROFILING
+#define PTO2_PROFILING 1
+#endif
+
+#ifndef PTO2_ORCH_PROFILING
+#define PTO2_ORCH_PROFILING 0
+#endif
+
+#ifndef PTO2_SCHED_PROFILING
+#define PTO2_SCHED_PROFILING 0
+#endif
+
+#ifndef PTO2_TENSORMAP_PROFILING
+#define PTO2_TENSORMAP_PROFILING 0
+#endif
+
+#if PTO2_ORCH_PROFILING && !PTO2_PROFILING
+#error "PTO2_ORCH_PROFILING requires PTO2_PROFILING=1"
+#endif
+
+#if PTO2_SCHED_PROFILING && !PTO2_PROFILING
+#error "PTO2_SCHED_PROFILING requires PTO2_PROFILING=1"
+#endif
+
+#if PTO2_TENSORMAP_PROFILING && !PTO2_ORCH_PROFILING
+#error "PTO2_TENSORMAP_PROFILING requires PTO2_ORCH_PROFILING=1"
+#endif
+
+// =============================================================================
+// Configuration Constants
+// =============================================================================
+
+// Task management
+// NOTE: PTO2_TASK_WINDOW_SIZE is now the DEFAULT value only.
+// Actual window size is passed at runtime to pto2_runtime_create_threaded_custom().
+// Use pto2_task_slot(sched, task_id) for slot calculation.
+#define PTO2_TASK_WINDOW_SIZE     65536   // Default task window size (power of 2)
+
+// Memory pools
+#define PTO2_HEAP_SIZE            (1024 * 1024 * 1024)  // 1GB default heap
+#define PTO2_DEP_LIST_POOL_SIZE    65536    // Dependency list pool entries
+#define PTO2_TENSORMAP_POOL_SIZE   (65536)   // TensorMap entry pool
+#define PTO2_TENSORMAP_NUM_BUCKETS 65536    // Power of 2 for fast hash
+
+// Task parameters
+#define PTO2_MAX_OUTPUTS          16      // Maximum outputs per task
+#define PTO2_MAX_INPUTS           16      // Maximum inputs per task
+#define PTO2_MAX_INOUTS           8       // Maximum in-out params per task
+
+// Scope management
+#define PTO2_MAX_SCOPE_DEPTH      64      // Maximum nesting depth
+#define PTO2_SCOPE_TASKS_INIT_CAP 65536     // Initial capacity for scope task buffer
+
+// Ready queue
+#define PTO2_READY_QUEUE_SIZE     65536   // Per-worker-type queue size (16x larger to avoid queue full)
+
+// Memory alignment
+#define PTO2_ALIGN_SIZE           64      // Cache line alignment
+#define PTO2_PACKED_OUTPUT_ALIGN  1024    // Each output in packed buffer aligned to 1024B; gap is padding
+#define PTO2_ALIGN_UP(x, align)   (((x) + (align) - 1) & ~((align) - 1))
+
+// TensorMap cleanup interval
+#define PTO2_TENSORMAP_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
+
+// =============================================================================
+// Worker Types
+// =============================================================================
+
+/**
+ * Worker type enumeration
+ * Each worker type has its own ready queue for load balancing
+ */
+typedef enum {
+    PTO2_WORKER_CUBE = 0,       // AICore CUBE unit (matrix ops)
+    PTO2_WORKER_VECTOR = 1,     // AICore VECTOR unit (element-wise ops)
+    PTO2_WORKER_AI_CPU = 2,     // AI_CPU (scalar ops, control flow)
+    PTO2_WORKER_ACCELERATOR = 3,// Fixed-function accelerators (DMA, etc.)
+    PTO2_NUM_WORKER_TYPES = 4
+} PTO2WorkerType;
+
+// =============================================================================
+// Task States
+// =============================================================================
+
+/**
+ * Task state enumeration
+ *
+ * State transitions:
+ *   PENDING -> READY -> RUNNING -> COMPLETED -> CONSUMED
+ *
+ * Conditions:
+ *   PENDING->READY:     fanin_refcount == fanin_count
+ *   COMPLETED->CONSUMED: fanout_refcount == fanout_count && state == COMPLETED
+ */
+typedef enum {
+    PTO2_TASK_PENDING = 0,    // Waiting for dependencies (fanin_refcount < fanin_count)
+    PTO2_TASK_READY = 1,      // All dependencies satisfied, waiting in ready queue
+    PTO2_TASK_RUNNING = 2,    // Currently executing on a worker
+    PTO2_TASK_COMPLETED = 3,  // Execution finished, output may still be in use
+    PTO2_TASK_CONSUMED = 4    // Output fully consumed, buffers can be released
+} PTO2TaskState;
+
+// =============================================================================
+// Logical Tensor (for view/reshape/transpose operations)
+// =============================================================================
+
+/**
+ * Maximum dimensions supported for logical tensors
+ */
+#define PTO2_MAX_TENSOR_DIM   8
+
+/**
+ * Maximum depth of layout history for HBB overlap detection
+ * Simple (contiguous) tensor has depth=1, non-contiguous has depth>1
+ */
+#define PTO2_MAX_LAYOUT_DEPTH     8
+
+/**
+ * Layout operation type for HBB
+ */
+typedef enum {
+    PTO2_LAYOUT_VIEW = 0,         // View/slice: records bounding box
+    PTO2_LAYOUT_RESHAPE = 1,      // Reshape: records new shape
+    PTO2_LAYOUT_TRANSPOSE = 2     // Transpose: records permutation
+} PTO2LayoutOpType;
+
+/**
+ * Layout operation entry for HBB
+ * Each entry records one derivation step from the parent tensor.
+ */
+typedef struct {
+    PTO2LayoutOpType type;
+    union {
+        struct {  // PTO2_LAYOUT_VIEW
+            int64_t bbox_min;     // First byte accessed
+            int64_t bbox_max;     // Last byte accessed
+        } view;
+        struct {  // PTO2_LAYOUT_RESHAPE
+            int32_t ndim;
+            int64_t shape[PTO2_MAX_TENSOR_DIM];
+        } reshape;
+        struct {  // PTO2_LAYOUT_TRANSPOSE
+            int32_t ndim;
+            int32_t perm[PTO2_MAX_TENSOR_DIM];
+        } transpose;
+    };
+} PTO2LayoutOp;
+
+/**
+ * Tensor extraction type (for tracking how tensor was created)
+ */
+typedef enum {
+    PTO2_TENSOR_RAW = 0,           // Original raw tensor (owns storage)
+    PTO2_TENSOR_VIEW = 1,          // view() - subset selection, shared storage
+    PTO2_TENSOR_RESHAPE = 2,       // reshape() - shape change, shared storage
+    PTO2_TENSOR_TRANSPOSE = 3,     // transpose() - dimension permute, shared storage
+    PTO2_TENSOR_DEEP_VIEW = 4,     // deep_view() - copied subset, new storage
+    PTO2_TENSOR_DEEP_RESHAPE = 5,  // deep_reshape() - copied reshape, new storage
+    PTO2_TENSOR_DEEP_TRANSPOSE = 6 // deep_transpose() - copied transpose, new storage
+} PTO2TensorExtractionType;
+
+/**
+ * Raw tensor (storage provider)
+ *
+ * The raw tensor owns the actual memory allocation.
+ * Multiple logical tensors can share the same raw tensor (aliasing).
+ */
+typedef struct {
+    void*    base_ptr;        // Base pointer of allocated memory
+    int64_t  total_size;      // Total size in bytes
+    int32_t  refcount;        // Number of logical tensors referencing this storage
+                              // (for memory management, 0 = can be freed)
+} PTO2RawTensor;
+
+/**
+ * Logical tensor structure
+ *
+ * A "view" into raw tensor storage with specific layout.
+ * Supports multi-dimensional tensors with strides (for view/reshape/transpose).
+ *
+ * Memory footprint is determined by:
+ *   - storage_offset: byte offset from raw_base to first element
+ *   - shape[d]: number of elements in dimension d
+ *   - strides[d]: byte offset between consecutive elements in dimension d
+ *
+ * For element at indices [i0, i1, ..., i_{n-1}]:
+ *   byte_offset = storage_offset + sum(i_d * strides[d])
+ *
+ * Examples:
+ *   - Contiguous row-major (3,4): shape=[3,4], strides=[4*elem_size, elem_size]
+ *   - Transposed (4,3): shape=[4,3], strides=[elem_size, 4*elem_size]
+ *   - Sliced [1:3, 1:3]: offset adjusted, shape=[2,2], strides unchanged
+ */
+typedef struct {
+    // === Raw tensor reference (shared storage) ===
+    void*    raw_base;            // Pointer to raw tensor's base (for aliasing check)
+    int64_t  raw_total_size;      // Total size of raw tensor in bytes
+
+    // === Storage offset ===
+    int64_t  storage_offset;      // Byte offset from raw_base to first element
+
+    // === Shape and strides ===
+    int64_t  shape[PTO2_MAX_TENSOR_DIM];    // Size in each dimension
+    int64_t  strides[PTO2_MAX_TENSOR_DIM];  // Byte stride in each dimension
+    int32_t  ndim;                          // Number of dimensions (0 = scalar)
+
+    // === Precomputed bounding box (for fast overlap detection) ===
+    int64_t  min_byte_offset;     // First byte accessed (relative to raw_base)
+    int64_t  max_byte_offset;     // Last byte accessed (relative to raw_base)
+
+    // === Element info ===
+    int64_t  elem_size;           // Size of each element in bytes
+    int64_t  numel;               // Total number of elements
+
+    // === Extraction tracking ===
+    PTO2TensorExtractionType extraction_type;  // How this tensor was created
+    bool     is_contiguous;       // True if memory is contiguous (no gaps)
+                                  // Equivalent to layout_depth == 1
+
+    // === Layout history for HBB overlap detection ===
+    int32_t  layout_depth;                           // Number of layout ops (1=simple)
+    PTO2LayoutOp layout_ops[PTO2_MAX_LAYOUT_DEPTH];  // Derivation history
+
+} PTO2LogicalTensor;
+
+// =============================================================================
+// Dependency List Entry
+// =============================================================================
+
+/**
+ * Dependency list entry (singly-linked list node)
+ * Stored in DepListPool ring buffer
+ *
+ * Used for both fanin_list and fanout_list
+ */
+struct PTO2DepListEntry {
+    int32_t task_id;          // The dependent/dependency task ID
+    PTO2DepListEntry* next;      // next entry
+};
+
+// =============================================================================
+// Task Descriptor
+// =============================================================================
+
+/**
+ * Task descriptor structure
+ *
+ * Stored in the TaskDescriptor ring buffer in shared memory.
+ * Contains both static info (set at submission) and dynamic state.
+ *
+ * Concurrency notes:
+ * - fanout_head, fanout_count protected by fanout_lock (per-task spinlock)
+ * - fanin_count set once at submission, read-only after (hot path for ready check)
+ * - fanin_tasks stored in TaskPayload (cold path for release)
+ * - Other fields set by Orchestrator, read by Scheduler
+ */
+struct PTO2TaskDescriptor {
+    // Task identification
+    int32_t task_id;              // Unique task identifier (absolute, not wrapped)
+    int32_t kernel_id;            // InCore function to execute
+    int32_t worker_type;          // Target: CUBE, VECTOR, AI_CPU, ACCELERATOR
+    // Dependency lists (linked list heads - offsets into DepListPool)
+    // Fanin: producers this task depends on (set once at submission)
+    int32_t fanin_count;          // Number of producer dependencies
+
+    // Fanout: consumers that depend on this task (grows as consumers submit)
+    // PROTECTED BY fanout_lock
+    std::atomic<int32_t> fanout_lock; // Per-task spinlock (0=unlocked, 1=locked)
+    PTO2DepListEntry* fanout_head;    // Pointer to first fanout entry (nullptr = empty), PROTECTED BY fanout_lock
+    int32_t fanout_count;             // 1 (owning scope) + number of consumers
+
+    // Packed output buffer (all outputs packed into single contiguous buffer)
+    void*    packed_buffer_base;  // Start of packed buffer in GM Heap
+    void*    packed_buffer_end;   // End of packed buffer (for heap reclamation)
+};
+
+/**
+ * Task payload data (cold path - only accessed during orchestration and dispatch)
+ *
+ * Separated from PTO2TaskDescriptor to keep the descriptor cache-friendly
+ * for the scheduler's hot completion path (~80 bytes vs ~2912 bytes).
+ */
+struct PTO2TaskPayload {
+    Tensor tensors[16];
+    uint64_t scalar_value[16];
+    bool is_tensor[16];
+    int param_count{0};
+    int32_t fanin_tasks[PTO2_MAX_INPUTS];   // Producer task IDs (cold path, used by on_task_release)
+    int32_t fanin_actual_count{0};           // Actual fanin count (without the +1 redundance)
+};
+
+// =============================================================================
+// Cycle Cost Function Type
+// =============================================================================
+
+/**
+ * Cycle cost function pointer type
+ * Returns estimated cycle count for the InCore function
+ */
+typedef int64_t (*PTO2CycleCostFunc)(void** args, int32_t num_args);
+
+// =============================================================================
+// InCore Function Type
+// =============================================================================
+
+/**
+ * InCore function signature
+ * All InCore functions must match this signature
+ */
+typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
+
+// =============================================================================
+// Utility Macros
+// =============================================================================
+
+/**
+ * Memory barrier macros for different architectures
+ */
+#if defined(__aarch64__)
+    #define PTO2_MEMORY_BARRIER()     __asm__ __volatile__("dmb sy" ::: "memory")
+#elif defined(__x86_64__)
+    #define PTO2_MEMORY_BARRIER()     __asm__ __volatile__("mfence" ::: "memory")
+#else
+    #define PTO2_MEMORY_BARRIER()     __sync_synchronize()
+#endif
+
+// Spin-wait hint for AICPU threads.  On real hardware the AICPU has dedicated
+// ARM A55 cores — no OS yield is needed, so the hint is a no-op.  In simulation
+// all threads share host CPU cores, so we yield to prevent starvation.
+// This header is also compiled into the Host .so (for struct definitions only),
+// where the hint is never called — the fallback no-op keeps Host builds clean.
+#if __has_include("spin_hint.h")
+#include "spin_hint.h"
+#else
+#define SPIN_WAIT_HINT() ((void)0)
+#endif
+
+// =============================================================================
+// Per-task fanout spinlock helpers
+//
+// Used by BOTH the orchestrator (pto_orchestrator.cpp) and the scheduler
+// (aicpu_executor.cpp). Placing them here ensures both translation units use
+// identical acquire/release semantics.
+//
+// The fanout_lock MUST be held whenever reading or writing fanout_head /
+// fanout_count, because the orchestrator adds consumers concurrently with the
+// scheduler traversing the list after task completion.
+// =============================================================================
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+#include "aicpu/device_time.h"
+#endif
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+static inline void pto2_fanout_lock(PTO2TaskDescriptor& task,
+                                     uint64_t& atomic_count, uint64_t& wait_cycle) {
+    uint64_t t0 = get_sys_cnt_aicpu();
+    bool contended = false;
+    uint32_t atomic_ops = 0;
+
+    for (;;) {
+        while (task.fanout_lock.load(std::memory_order_acquire) != 0) {
+            contended = true;
+            atomic_ops++;  // each load = 1 atomic
+            SPIN_WAIT_HINT();
+        }
+        int32_t expected = 0;
+        if (task.fanout_lock.compare_exchange_weak(expected, 1,
+                                        std::memory_order_acquire, std::memory_order_relaxed)) {
+            atomic_ops++;  // successful CAS = 1 atomic
+            atomic_count += atomic_ops;
+            if (contended) {
+                wait_cycle += (get_sys_cnt_aicpu() - t0);
+            }
+            return;
+        }
+        contended = true;
+        atomic_ops++;  // failed CAS = 1 atomic
+    }
+}
+#endif
+
+static inline void pto2_fanout_lock(PTO2TaskDescriptor& task) {
+    for (;;) {
+        while (task.fanout_lock.load(std::memory_order_acquire) != 0) {
+            SPIN_WAIT_HINT();
+        }
+        int32_t expected = 0;
+        if (task.fanout_lock.compare_exchange_weak(expected, 1,
+                                        std::memory_order_acquire, std::memory_order_relaxed)) {
+            return;
+        }
+    }
+}
+
+static inline void pto2_fanout_unlock(PTO2TaskDescriptor& task) {
+    task.fanout_lock.store(0, std::memory_order_release);
+}
+
+#endif // PTO_RUNTIME2_TYPES_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -1,0 +1,228 @@
+/**
+ * PTO Runtime2 - Scheduler Implementation
+ *
+ * Implements scheduler state management, ready queues, and task lifecycle.
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#include "pto_scheduler.h"
+#include <inttypes.h>
+#include <new>
+#include <stdlib.h>
+#include <utility>
+#include "common/unified_log.h"
+
+// =============================================================================
+// Scheduler Profiling Counters
+// =============================================================================
+
+#if PTO2_SCHED_PROFILING
+#include "common/platform_config.h"
+
+uint64_t g_sched_lock_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_fanout_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_fanin_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_self_consumed_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_lock_wait_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_push_wait_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_pop_wait_cycle[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_lock_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_fanout_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_fanin_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_self_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_pop_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
+uint64_t g_sched_complete_count[PLATFORM_MAX_AICPU_THREADS] = {};
+
+PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
+    PTO2SchedProfilingData d;
+    d.lock_cycle = std::exchange(g_sched_lock_cycle[thread_idx], 0);
+    d.fanout_cycle = std::exchange(g_sched_fanout_cycle[thread_idx], 0);
+    d.fanin_cycle = std::exchange(g_sched_fanin_cycle[thread_idx], 0);
+    d.self_consumed_cycle = std::exchange(g_sched_self_consumed_cycle[thread_idx], 0);
+    d.lock_wait_cycle = std::exchange(g_sched_lock_wait_cycle[thread_idx], 0);
+    d.push_wait_cycle = std::exchange(g_sched_push_wait_cycle[thread_idx], 0);
+    d.pop_wait_cycle = std::exchange(g_sched_pop_wait_cycle[thread_idx], 0);
+    d.lock_atomic_count = std::exchange(g_sched_lock_atomic_count[thread_idx], 0);
+    d.fanout_atomic_count = std::exchange(g_sched_fanout_atomic_count[thread_idx], 0);
+    d.fanin_atomic_count = std::exchange(g_sched_fanin_atomic_count[thread_idx], 0);
+    d.self_atomic_count = std::exchange(g_sched_self_atomic_count[thread_idx], 0);
+    d.pop_atomic_count = std::exchange(g_sched_pop_atomic_count[thread_idx], 0);
+    d.complete_count = std::exchange(g_sched_complete_count[thread_idx], 0);
+    return d;
+}
+#endif
+
+// =============================================================================
+// Task State Names
+// =============================================================================
+
+const char* pto2_task_state_name(PTO2TaskState state) {
+    switch (state) {
+        case PTO2_TASK_PENDING:   return "PENDING";
+        case PTO2_TASK_READY:     return "READY";
+        case PTO2_TASK_RUNNING:   return "RUNNING";
+        case PTO2_TASK_COMPLETED: return "COMPLETED";
+        case PTO2_TASK_CONSUMED:  return "CONSUMED";
+        default:                  return "UNKNOWN";
+    }
+}
+
+// =============================================================================
+// Ready Queue Implementation
+// =============================================================================
+
+bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity) {
+    queue->slots = (PTO2ReadyQueueSlot*)malloc(capacity * sizeof(PTO2ReadyQueueSlot));
+    if (!queue->slots) {
+        return false;
+    }
+
+    queue->capacity = capacity;
+    queue->mask = capacity - 1;
+    queue->enqueue_pos.store(0, std::memory_order_relaxed);
+    queue->dequeue_pos.store(0, std::memory_order_relaxed);
+
+    for (uint64_t i = 0; i < capacity; i++) {
+        queue->slots[i].sequence.store((int64_t)i, std::memory_order_relaxed);
+        queue->slots[i].task_id = -1;
+    }
+
+    return true;
+}
+
+void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
+    if (queue->slots) {
+        free(queue->slots);
+        queue->slots = NULL;
+    }
+}
+
+// =============================================================================
+// Scheduler Initialization
+// =============================================================================
+
+bool pto2_scheduler_init(PTO2SchedulerState* sched,
+                          PTO2SharedMemoryHandle* sm_handle,
+                          void* heap_base) {
+    sched->sm_handle = sm_handle;
+    sched->heap_base = heap_base;
+    sched->task_state = nullptr;
+    sched->fanin_refcount = nullptr;
+    sched->fanout_refcount = nullptr;
+#if PTO2_PROFILING
+    sched->tasks_completed.store(0, std::memory_order_relaxed);
+    sched->tasks_consumed.store(0, std::memory_order_relaxed);
+#endif
+    sched->ring_advance_lock.store(0, std::memory_order_relaxed);
+
+    // Get runtime task_window_size from shared memory header
+    uint64_t window_size = sm_handle->header->task_window_size;
+    sched->task_window_size = window_size;
+    sched->task_window_mask = window_size - 1;  // For fast modulo (window_size must be power of 2)
+
+    // Initialize local copies of ring pointers
+    sched->last_task_alive = 0;
+    sched->last_heap_consumed = 0;
+    sched->heap_tail = 0;
+
+    // Allocate per-task state arrays (dynamically sized based on runtime window_size)
+    sched->task_state = new (std::nothrow) std::atomic<PTO2TaskState>[window_size];
+    if (!sched->task_state) {
+        return false;
+    }
+
+    sched->fanin_refcount = new (std::nothrow) std::atomic<int32_t>[window_size];
+    if (!sched->fanin_refcount) {
+        delete[] sched->task_state;
+        sched->task_state = nullptr;
+        return false;
+    }
+
+    sched->fanout_refcount = new (std::nothrow) std::atomic<int32_t>[window_size];
+    if (!sched->fanout_refcount) {
+        delete[] sched->fanin_refcount;
+        delete[] sched->task_state;
+        sched->fanin_refcount = nullptr;
+        sched->task_state = nullptr;
+        return false;
+    }
+
+    // Zero-initialize all per-task state arrays.
+    // new[] default-initializes std::atomic<T> which leaves values indeterminate.
+    // Scheduler logic (e.g. fanin_refcount fetch_add in release_fanin_and_check_ready)
+    // assumes slots start at zero before init_task writes them.
+    for (uint64_t i = 0; i < window_size; i++) {
+        sched->task_state[i].store(static_cast<PTO2TaskState>(0), std::memory_order_relaxed);
+        sched->fanin_refcount[i].store(0, std::memory_order_relaxed);
+        sched->fanout_refcount[i].store(0, std::memory_order_relaxed);
+    }
+
+    // Initialize ready queues
+    for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {
+        if (!pto2_ready_queue_init(&sched->ready_queues[i], PTO2_READY_QUEUE_SIZE)) {
+            // Cleanup on failure
+            for (int j = 0; j < i; j++) {
+                pto2_ready_queue_destroy(&sched->ready_queues[j]);
+            }
+            delete[] sched->fanout_refcount;
+            delete[] sched->fanin_refcount;
+            delete[] sched->task_state;
+            sched->fanout_refcount = nullptr;
+            sched->fanin_refcount = nullptr;
+            sched->task_state = nullptr;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
+    if (sched->task_state) {
+        delete[] sched->task_state;
+        sched->task_state = nullptr;
+    }
+
+    if (sched->fanin_refcount) {
+        delete[] sched->fanin_refcount;
+        sched->fanin_refcount = nullptr;
+    }
+
+    if (sched->fanout_refcount) {
+        delete[] sched->fanout_refcount;
+        sched->fanout_refcount = nullptr;
+    }
+
+    for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {
+        pto2_ready_queue_destroy(&sched->ready_queues[i]);
+    }
+}
+
+// =============================================================================
+// Debug Utilities
+// =============================================================================
+
+void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
+    LOG_INFO("=== Scheduler Statistics ===");
+    LOG_INFO("last_task_alive:   %d", sched->last_task_alive);
+    LOG_INFO("heap_tail:         %" PRIu64, sched->heap_tail);
+#if PTO2_PROFILING
+    LOG_INFO("tasks_completed:   %lld", (long long)sched->tasks_completed.load(std::memory_order_relaxed));
+    LOG_INFO("tasks_consumed:    %lld", (long long)sched->tasks_consumed.load(std::memory_order_relaxed));
+#endif
+    LOG_INFO("============================");
+}
+
+void pto2_scheduler_print_queues(PTO2SchedulerState* sched) {
+    LOG_INFO("=== Ready Queues ===");
+
+    const char* worker_names[] = {"CUBE", "VECTOR", "AI_CPU", "ACCELERATOR"};
+
+    for (int i = 0; i < PTO2_NUM_WORKER_TYPES; i++) {
+        LOG_INFO("  %s: count=%" PRIu64, worker_names[i],
+                 sched->ready_queues[i].size());
+    }
+
+    LOG_INFO("====================");
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -1,0 +1,709 @@
+/**
+ * PTO Runtime2 - Scheduler Interface
+ *
+ * The Scheduler is responsible for:
+ * 1. Maintaining per-worker-type ready queues
+ * 2. Tracking task state (PENDING -> READY -> RUNNING -> COMPLETED -> CONSUMED)
+ * 3. Managing fanin/fanout refcounts for dependency resolution
+ * 4. Advancing last_task_alive for heap reclamation
+ *
+ * The Scheduler runs on Device AI_CPU and processes:
+ * - Task state transitions based on fanin_refcount
+ * - Buffer lifecycle based on fanout_refcount
+ * - Ring pointer advancement for flow control
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#ifndef PTO_SCHEDULER_H
+#define PTO_SCHEDULER_H
+
+#include <atomic>
+
+#include "pto_runtime2_types.h"
+#include "pto_shared_memory.h"
+#include "pto_ring_buffer.h"
+
+#include "common/core_type.h"
+
+#if PTO2_SCHED_PROFILING
+#include "aicpu/device_time.h"
+#define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
+#define PTO2_SCHED_CYCLE_LAP(acc) do { _st1 = get_sys_cnt_aicpu(); acc += (_st1 - _st0); _st0 = _st1; } while(0)
+#endif
+
+// =============================================================================
+// Ready Queue (Lock-free bounded MPMC — Vyukov design)
+// =============================================================================
+
+/**
+ * Per-slot entry: sequence counter for ABA safety + task payload
+ */
+struct PTO2ReadyQueueSlot {
+    std::atomic<int64_t> sequence;
+    int32_t task_id;
+    int32_t _pad;
+};
+
+/**
+ * Thread-local ready buffer for local-first dispatch optimization.
+ *
+ * One buffer per scheduling thread (mixed worker types).
+ * Initialized once before the scheduling loop; must be empty at
+ * the start of each iteration (verified by always_assert).
+ *
+ * Phase 1 fills this buffer via on_task_complete().
+ * Phase 2 drains it: matched tasks dispatch to idle cores,
+ * unmatched tasks are stored in an overflow array for Phase 3.
+ * Phase 3 pushes overflow to global readyQ and fills remaining
+ * idle cores from global readyQ.
+ */
+struct PTO2LocalReadyBuffer {
+    int32_t* task_ids = nullptr;  // Points to caller's stack array
+    int count = 0;
+    int capacity = 0;
+
+    void reset(int32_t* buf, int cap) {
+        task_ids = buf;
+        count = 0;
+        capacity = cap;
+    }
+
+    bool try_push(int32_t task_id) {
+        if (task_ids && count < capacity) {
+            task_ids[count++] = task_id;
+            return true;
+        }
+        return false;
+    }
+
+    int32_t pop() {
+        return (count > 0) ? task_ids[--count] : -1;  // LIFO: better cache locality
+    }
+};
+
+/**
+ * Lock-free bounded MPMC queue (Dmitry Vyukov design)
+ *
+ * Key properties:
+ * - enqueue_pos and dequeue_pos on separate cache lines (no false sharing)
+ * - Per-slot sequence counter prevents ABA problem
+ * - Empty queue pop returns immediately (single atomic load, no lock)
+ * - CAS contention is split: producers only touch enqueue_pos,
+ *   consumers only touch dequeue_pos
+ */
+struct alignas(64) PTO2ReadyQueue {
+    PTO2ReadyQueueSlot* slots;
+    uint64_t capacity;
+    uint64_t mask;                          // capacity - 1
+    char _pad0[64 - 24];                   // Pad to own cache line
+
+    std::atomic<uint64_t> enqueue_pos;
+    char _pad1[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+
+    std::atomic<uint64_t> dequeue_pos;
+    char _pad2[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+
+    uint64_t size() {
+        uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
+        uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
+        return (e >= d) ? (e - d) : 0;
+    }
+
+    bool push(int32_t task_id) {
+        uint64_t pos;
+        PTO2ReadyQueueSlot* slot;
+        while (true) {
+            pos = enqueue_pos.load(std::memory_order_relaxed);
+            slot = &slots[pos & mask];
+            int64_t seq = slot->sequence.load(std::memory_order_acquire);
+            int64_t diff = seq - (int64_t)pos;
+            if (diff == 0) {
+                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
+                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                    break;
+                }
+            } else if (diff < 0) {
+                return false;  // Queue full
+            }
+        }
+
+        slot->task_id = task_id;
+        slot->sequence.store((int64_t)(pos + 1), std::memory_order_release);
+        return true;
+    }
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    bool push(int32_t task_id, uint64_t& atomic_count, uint64_t& wait_cycle) {
+        uint64_t pos;
+        PTO2ReadyQueueSlot* slot;
+        uint64_t t0 = get_sys_cnt_aicpu();
+        bool contended = false;
+        uint32_t atomic_ops = 0;
+        while (true) {
+            pos = enqueue_pos.load(std::memory_order_relaxed);
+            slot = &slots[pos & mask];
+            int64_t seq = slot->sequence.load(std::memory_order_acquire);
+            int64_t diff = seq - (int64_t)pos;
+            atomic_ops += 2;  // enqueue_pos.load + sequence.load
+            if (diff == 0) {
+                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
+                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                    atomic_ops++;  // successful CAS
+                    break;
+                }
+                contended = true;
+                atomic_ops++;  // failed CAS
+            } else if (diff < 0) {
+                return false;  // Queue full
+            } else {
+                contended = true;  // diff > 0: slot not yet released, spin
+            }
+        }
+        atomic_ops++;  // final sequence.store
+        atomic_count += atomic_ops;
+        if (contended) {
+            wait_cycle += (get_sys_cnt_aicpu() - t0);
+        }
+
+        slot->task_id = task_id;
+        slot->sequence.store((int64_t)(pos + 1), std::memory_order_release);
+        return true;
+    }
+#endif
+
+    int32_t pop() {
+        // Fast-path: skip slot load when queue is clearly empty
+        uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
+        uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
+        if (d >= e) {
+            return -1;
+        }
+
+        uint64_t pos;
+        PTO2ReadyQueueSlot* slot;
+        while (true) {
+            pos = dequeue_pos.load(std::memory_order_relaxed);
+            slot = &slots[pos & mask];
+            int64_t seq = slot->sequence.load(std::memory_order_acquire);
+            int64_t diff = seq - (int64_t)(pos + 1);
+            if (diff == 0) {
+                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
+                        std::memory_order_relaxed, std::memory_order_relaxed))
+                    break;
+            } else if (diff < 0) {
+                return -1;  // Queue empty
+            }
+        }
+
+        int32_t task_id = slot->task_id;
+        slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
+        return task_id;
+    }
+
+#if PTO2_SCHED_PROFILING
+    int32_t pop(uint64_t& atomic_count, uint64_t& wait_cycle) {
+        // Fast-path: skip slot load when queue is clearly empty
+        uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
+        uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
+        atomic_count += 2;  // dequeue_pos.load + enqueue_pos.load
+        if (d >= e) {
+            return -1;
+        }
+
+        uint64_t pos;
+        PTO2ReadyQueueSlot* slot;
+        uint64_t t0 = get_sys_cnt_aicpu();
+        bool contended = false;
+        uint32_t atomic_ops = 0;
+        while (true) {
+            pos = dequeue_pos.load(std::memory_order_relaxed);
+            slot = &slots[pos & mask];
+            int64_t seq = slot->sequence.load(std::memory_order_acquire);
+            int64_t diff = seq - (int64_t)(pos + 1);
+            atomic_ops += 2;  // dequeue_pos.load + sequence.load
+            if (diff == 0) {
+                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
+                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                    atomic_ops++;  // successful CAS
+                    break;
+                }
+                contended = true;
+                atomic_ops++;  // failed CAS
+            } else if (diff < 0) {
+                atomic_count += atomic_ops;
+                return -1;  // Queue empty
+            } else {
+                contended = true;
+            }
+        }
+        atomic_ops++;  // final sequence.store
+        atomic_count += atomic_ops;
+        if (contended) {
+            wait_cycle += (get_sys_cnt_aicpu() - t0);
+        }
+
+        int32_t task_id = slot->task_id;
+        slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
+        return task_id;
+    }
+#endif
+};
+
+// Cold-path ready queue operations (defined in pto_scheduler.cpp)
+bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity);
+void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
+
+// =============================================================================
+// Scheduler State
+// =============================================================================
+
+/**
+ * Statistics returned by on_task_complete
+ */
+struct PTO2CompletionStats {
+    int32_t fanout_edges;      // Number of fanout edges traversed (notify consumers)
+    int32_t tasks_enqueued;    // Number of consumers that became READY
+    int32_t fanin_edges;       // Number of fanin edges traversed (release producers)
+};
+
+/**
+ * Scheduler state structure
+ *
+ * Contains dynamic state updated during task execution.
+ * Separated from shared memory for cache efficiency.
+ * Hot-path methods are defined inline (implicitly inline as member functions).
+ */
+struct PTO2SchedulerState {
+    // Shared memory access
+    PTO2SharedMemoryHandle* sm_handle;
+
+    // Local copies of ring pointers (written to shared memory after update)
+    int32_t last_task_alive;      // Task ring tail (advances on COMPLETED for slot reuse)
+    int32_t last_heap_consumed;   // Heap watermark (advances on CONSUMED for buffer reuse)
+    uint64_t heap_tail;           // Heap ring tail (offset from heap_base)
+
+    // Heap base address (for converting absolute pointers to offsets)
+    void* heap_base;
+
+    // === DYNAMIC CONFIGURATION ===
+    uint64_t task_window_size;    // Task window size (power of 2)
+    uint64_t task_window_mask;    // task_window_size - 1 (for fast modulo)
+
+    // === PRIVATE DATA (not in shared memory) ===
+
+    // Per-task state arrays (dynamically allocated, indexed by task_id & task_window_mask)
+    std::atomic<PTO2TaskState>* task_state; // PENDING/READY/RUNNING/COMPLETED/CONSUMED
+    std::atomic<int32_t>* fanin_refcount;   // Dynamic: counts completed producers
+    std::atomic<int32_t>* fanout_refcount;  // Dynamic: counts released references
+
+    // Ready queues (one per worker type)
+    PTO2ReadyQueue ready_queues[PTO2_NUM_WORKER_TYPES];
+
+    // Statistics
+#if PTO2_PROFILING
+    std::atomic<int64_t> tasks_completed;
+    std::atomic<int64_t> tasks_consumed;
+#endif
+    std::atomic<int32_t> ring_advance_lock{0};  // Try-lock for advance_ring_pointers
+
+    // =========================================================================
+    // Inline hot-path methods
+    // =========================================================================
+
+    int32_t pto2_task_slot(int32_t task_id) {
+        return task_id & task_window_mask;
+    }
+
+    void sync_to_sm() {
+        PTO2SharedMemoryHeader* header = sm_handle->header;
+        header->last_task_alive.store(last_task_alive, std::memory_order_release);
+        header->heap_tail.store(heap_tail, std::memory_order_release);
+        header->heap_tail_gen.store(last_task_alive, std::memory_order_release);
+    }
+
+    void advance_ring_pointers() {
+        PTO2SharedMemoryHeader* header = sm_handle->header;
+        int32_t current_task_index = header->current_task_index.load(std::memory_order_acquire);
+
+        while (last_task_alive < current_task_index) {
+            int32_t slot = pto2_task_slot(last_task_alive);
+            if (task_state[slot].load(std::memory_order_acquire) != PTO2_TASK_CONSUMED) {
+                break;
+            }
+            last_task_alive++;
+        }
+
+        if (last_task_alive > 0) {
+            int32_t last_consumed_id = last_task_alive - 1;
+            PTO2TaskDescriptor* last_consumed = pto2_sm_get_task(sm_handle, last_consumed_id);
+            if (last_consumed->packed_buffer_end != NULL) {
+                heap_tail = (uint64_t)((char*)last_consumed->packed_buffer_end - (char*)heap_base);
+            }
+        }
+
+        sync_to_sm();
+    }
+
+    void check_and_handle_consumed(int32_t slot, PTO2TaskDescriptor& task) {
+        if (fanout_refcount[slot].load(std::memory_order_acquire) != task.fanout_count) return;
+
+        PTO2TaskState expected = PTO2_TASK_COMPLETED;
+        if (!task_state[slot].compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
+                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+            return;
+        }
+
+#if PTO2_PROFILING
+        tasks_consumed.fetch_add(1, std::memory_order_relaxed);
+#endif
+        fanout_refcount[slot].store(0, std::memory_order_release);
+        fanin_refcount[slot].store(0, std::memory_order_release);
+
+        // Try-lock — if another thread is advancing, it will scan our CONSUMED task
+        int32_t expected_lock = 0;
+        if (ring_advance_lock.compare_exchange_strong(expected_lock, 1,
+                std::memory_order_acquire, std::memory_order_relaxed)) {
+            advance_ring_pointers();
+            ring_advance_lock.store(0, std::memory_order_release);
+        }
+    }
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    void check_and_handle_consumed(int32_t task_id, PTO2TaskDescriptor& task,
+                                    uint64_t& atomic_count) {
+        int32_t slot = pto2_task_slot(task_id);
+
+        int32_t fc = task.fanout_count;
+        int32_t rc = fanout_refcount[slot].load(std::memory_order_acquire);
+
+        atomic_count += 2;  // fanout_count.load + fanout_refcount.load
+
+        if (rc != fc) return;
+
+        PTO2TaskState expected = PTO2_TASK_COMPLETED;
+        if (!task_state[slot].compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
+                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+            atomic_count += 1;  // failed CAS
+            return;
+        }
+
+        atomic_count += 1;  // successful CAS
+
+#if PTO2_PROFILING
+        tasks_consumed.fetch_add(1, std::memory_order_relaxed);
+#endif
+        fanout_refcount[slot].store(0, std::memory_order_release);
+        fanin_refcount[slot].store(0, std::memory_order_release);
+
+        atomic_count += 2;  // fanout_refcount.store + fanin_refcount.store
+
+        // Try-lock — if another thread is advancing, it will scan our CONSUMED task
+        int32_t expected_lock = 0;
+        if (ring_advance_lock.compare_exchange_strong(expected_lock, 1,
+                std::memory_order_acquire, std::memory_order_relaxed)) {
+            advance_ring_pointers();
+            ring_advance_lock.store(0, std::memory_order_release);
+            atomic_count += 2;  // try-lock CAS + unlock store
+        } else {
+            atomic_count += 1;  // failed try-lock CAS
+        }
+    }
+#endif
+
+    void release_producer(int32_t producer_id) {
+        int32_t slot = pto2_task_slot(producer_id);
+        PTO2TaskDescriptor& producer = pto2_sm_get_task_by_slot(sm_handle, slot);
+        fanout_refcount[slot].fetch_add(1, std::memory_order_acq_rel);
+        check_and_handle_consumed(slot, producer);
+    }
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    void release_producer(int32_t producer_id, uint64_t& atomic_count) {
+        int32_t slot = pto2_task_slot(producer_id);
+        PTO2TaskDescriptor& producer = pto2_sm_get_task_by_slot(sm_handle, slot);
+        fanout_refcount[slot].fetch_add(1, std::memory_order_acq_rel);
+        atomic_count += 1;  // fanout_refcount.fetch_add
+        check_and_handle_consumed(producer_id, producer, atomic_count);
+    }
+#endif
+
+    bool release_fanin_and_check_ready(int32_t task_id,
+                                        PTO2TaskDescriptor* task,
+                                        PTO2LocalReadyBuffer* local_buf = nullptr) {
+        int32_t slot = pto2_task_slot(task_id);
+
+        // Atomically increment fanin_refcount and check if all producers are done
+        // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
+        // release in init_task, making fanin_count visible — plain load suffices.
+        int32_t new_refcount = fanin_refcount[slot].fetch_add(1, std::memory_order_acq_rel) + 1;
+
+        if (new_refcount == task->fanin_count) {
+            // Local-first: try thread-local buffer before global queue
+            bool pushed_local = false;
+            if (local_buf) {
+                pushed_local = local_buf->try_push(task_id);
+            }
+            if (!pushed_local) {
+                ready_queues[task->worker_type].push(task_id);
+            }
+            return true;
+        }
+        return false;
+    }
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    bool release_fanin_and_check_ready(int32_t task_id, PTO2TaskDescriptor* task,
+                                        uint64_t& atomic_count, uint64_t& push_wait,
+                                        PTO2LocalReadyBuffer* local_buf = nullptr) {
+        int32_t slot = pto2_task_slot(task_id);
+
+        int32_t new_refcount = fanin_refcount[slot].fetch_add(1, std::memory_order_acq_rel) + 1;
+        atomic_count += 1;  // fanin_refcount.fetch_add
+
+        if (new_refcount == task->fanin_count) {
+            PTO2TaskState expected = PTO2_TASK_PENDING;
+            if (task_state[slot].compare_exchange_strong(
+                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
+                atomic_count += 1;  // CAS(task_state PENDING→READY)
+                // Local-first: try thread-local buffer before global queue
+                bool pushed_local = false;
+                if (local_buf) {
+                    pushed_local = local_buf->try_push(task_id);
+                }
+                if (!pushed_local) {
+                    ready_queues[task->worker_type].push(task_id, atomic_count, push_wait);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+#endif
+
+    void init_task(int32_t task_id, PTO2TaskDescriptor* task) {
+        int32_t slot = pto2_task_slot(task_id);
+
+        task_state[slot].store(PTO2_TASK_PENDING, std::memory_order_relaxed); // Orchestrator is the unique owner
+
+        // Reset fanout_refcount for new task lifecycle.
+        // Do NOT reset fanin_refcount — it may have been incremented by
+        // concurrent on_task_complete between Step 5 and Step 6.
+        fanout_refcount[slot].store(0, std::memory_order_relaxed);
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+        extern uint64_t g_orch_finalize_atomic_count;
+        extern uint64_t g_orch_finalize_wait_cycle;
+        release_fanin_and_check_ready(task_id, task,
+                                       g_orch_finalize_atomic_count, g_orch_finalize_wait_cycle);
+#else
+        release_fanin_and_check_ready(task_id, task);
+#endif
+    }
+
+    template<CoreType CT>
+    int32_t get_ready_task() {
+        return ready_queues[static_cast<int32_t>(CT)].pop();
+    }
+
+#if PTO2_SCHED_PROFILING
+    template<CoreType CT>
+    int32_t get_ready_task(uint64_t& atomic_count, uint64_t& wait_cycle) {
+        return ready_queues[static_cast<int32_t>(CT)].pop(atomic_count, wait_cycle);
+    }
+#endif
+
+    void on_scope_end(const int32_t* task_ids, int32_t count) {
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+        extern uint64_t g_orch_scope_end_atomic_count;
+        for (int32_t i = 0; i < count; i++) {
+            release_producer(task_ids[i], g_orch_scope_end_atomic_count);
+        }
+#else
+        for (int32_t i = 0; i < count; i++) {
+            release_producer(task_ids[i]);
+        }
+#endif
+    }
+
+#if PTO2_SCHED_PROFILING
+    PTO2CompletionStats on_task_complete(int32_t task_id, int thread_idx,
+                                          PTO2LocalReadyBuffer* local_buf = nullptr) {
+        PTO2CompletionStats stats = {0, 0, 0};
+#elif PTO2_PROFILING
+    PTO2CompletionStats on_task_complete(int32_t task_id,
+                                          PTO2LocalReadyBuffer* local_buf = nullptr) {
+        PTO2CompletionStats stats = {0, 0, 0};
+#else
+    void on_task_complete(int32_t task_id,
+                           PTO2LocalReadyBuffer* local_buf = nullptr) {
+#endif
+        int32_t slot = pto2_task_slot(task_id);
+        PTO2TaskDescriptor& task = pto2_sm_get_task_by_slot(sm_handle, task_id);
+
+#if PTO2_PROFILING
+        tasks_completed.fetch_add(1, std::memory_order_relaxed);
+#endif
+
+#if PTO2_SCHED_PROFILING
+        extern uint64_t g_sched_lock_cycle[], g_sched_fanout_cycle[];
+        extern uint64_t g_sched_self_consumed_cycle[];
+        extern uint64_t g_sched_lock_atomic_count[], g_sched_lock_wait_cycle[];
+        extern uint64_t g_sched_fanout_atomic_count[], g_sched_push_wait_cycle[];
+        extern uint64_t g_sched_self_atomic_count[];
+        extern uint64_t g_sched_complete_count[];
+        uint64_t lock_atomics = 0, lock_wait = 0;
+        PTO2_SCHED_CYCLE_START();
+#endif
+
+#if PTO2_SCHED_PROFILING
+        pto2_fanout_lock(task, lock_atomics, lock_wait);
+#else
+        pto2_fanout_lock(task);
+#endif
+        task_state[slot].store(PTO2_TASK_COMPLETED, std::memory_order_release);
+        PTO2DepListEntry* current = task.fanout_head;  // Protected by fanout_lock
+        pto2_fanout_unlock(task);
+
+#if PTO2_SCHED_PROFILING
+        lock_atomics += 2;  // state.store + unlock.store
+        g_sched_lock_atomic_count[thread_idx] += lock_atomics;
+        g_sched_lock_wait_cycle[thread_idx] += lock_wait;
+        PTO2_SCHED_CYCLE_LAP(g_sched_lock_cycle[thread_idx]);
+#endif
+
+        // Fanout: notify consumers
+#if PTO2_SCHED_PROFILING
+        uint64_t fanout_atomics = 0, push_wait = 0;
+#endif
+        while (current != nullptr) {
+            int32_t consumer_id = current->task_id;
+            PTO2TaskDescriptor* consumer = pto2_sm_get_task(sm_handle, consumer_id);
+#if PTO2_PROFILING
+            stats.fanout_edges++;
+#endif
+#if PTO2_SCHED_PROFILING
+            if (release_fanin_and_check_ready(consumer_id, consumer,
+                                               fanout_atomics, push_wait, local_buf)) {
+#if PTO2_PROFILING
+                stats.tasks_enqueued++;
+#endif
+            }
+#elif PTO2_PROFILING
+            if (release_fanin_and_check_ready(consumer_id, consumer, local_buf)) {
+                stats.tasks_enqueued++;
+            }
+#else
+            release_fanin_and_check_ready(consumer_id, consumer, local_buf);
+#endif
+            current = current->next;
+        }
+
+#if PTO2_SCHED_PROFILING
+        g_sched_fanout_atomic_count[thread_idx] += fanout_atomics;
+        g_sched_push_wait_cycle[thread_idx] += push_wait;
+        PTO2_SCHED_CYCLE_LAP(g_sched_fanout_cycle[thread_idx]);
+#endif
+
+#if PTO2_PROFILING
+        return stats;
+#endif
+    }
+
+    /**
+     * Cold path: release producers (fanin traversal) + check self for CONSUMED.
+     * Returns fanin edge count for profiling.
+     */
+
+#if PTO2_SCHED_PROFILING
+    int32_t on_task_release(int32_t task_id, int32_t thread_idx) {
+        PTO2_SCHED_CYCLE_START();
+        extern uint64_t g_sched_fanin_cycle[], g_sched_fanin_atomic_count[];
+        extern uint64_t g_sched_self_atomic_count[];
+        extern uint64_t g_sched_self_consumed_cycle[];
+        extern uint64_t g_sched_complete_count[];
+        uint64_t fanin_atomics = 0;
+#else
+    int32_t on_task_release(int32_t task_id) {
+#endif
+        int32_t slot = pto2_task_slot(task_id);
+        PTO2TaskPayload* payload = &sm_handle->task_payloads[slot];
+        int32_t fanin_edges = payload->fanin_actual_count;
+        for (int32_t i = 0; i < fanin_edges; i++) {
+#if PTO2_SCHED_PROFILING
+            release_producer(payload->fanin_tasks[i], fanin_atomics);
+#else
+            release_producer(payload->fanin_tasks[i]);
+#endif
+        }
+#if PTO2_SCHED_PROFILING
+        g_sched_fanin_atomic_count[thread_idx] += fanin_atomics;
+        PTO2_SCHED_CYCLE_LAP(g_sched_fanin_cycle[thread_idx]);
+#endif
+
+        // Self consumed check
+#if PTO2_SCHED_PROFILING
+        uint64_t self_atomics = 0;
+        check_and_handle_consumed(slot, task, self_atomics);
+        g_sched_self_atomic_count[thread_idx] += self_atomics;
+        PTO2_SCHED_CYCLE_LAP(g_sched_self_consumed_cycle[thread_idx]);
+        g_sched_complete_count[thread_idx]++;
+#else
+        check_and_handle_consumed(slot, pto2_sm_get_task_by_slot(sm_handle, slot));
+#endif
+        return fanin_edges;
+    }
+};
+
+// =============================================================================
+// Scheduler API (cold path, defined in pto_scheduler.cpp)
+// =============================================================================
+
+bool pto2_scheduler_init(PTO2SchedulerState* sched,
+                          PTO2SharedMemoryHandle* sm_handle,
+                          void* heap_base);
+void pto2_scheduler_destroy(PTO2SchedulerState* sched);
+
+// =============================================================================
+// Debug Utilities (cold path, defined in pto_scheduler.cpp)
+// =============================================================================
+
+void pto2_scheduler_print_stats(PTO2SchedulerState* sched);
+void pto2_scheduler_print_queues(PTO2SchedulerState* sched);
+const char* pto2_task_state_name(PTO2TaskState state);
+
+// =============================================================================
+// Scheduler Profiling Data
+// =============================================================================
+
+#if PTO2_SCHED_PROFILING
+struct PTO2SchedProfilingData {
+    // Sub-phase cycle breakdown within on_task_complete
+    uint64_t lock_cycle;           // pto2_fanout_lock + state store + unlock
+    uint64_t fanout_cycle;         // fanout traversal
+    uint64_t fanin_cycle;          // fanin traversal
+    uint64_t self_consumed_cycle;  // self check_and_handle_consumed
+
+    // Wait times
+    uint64_t lock_wait_cycle;      // spin-wait in fanout_lock
+    uint64_t push_wait_cycle;      // CAS contention in push()
+    uint64_t pop_wait_cycle;       // CAS contention in pop()
+
+    // Atomic counts per sub-phase
+    uint64_t lock_atomic_count;
+    uint64_t fanout_atomic_count;
+    uint64_t fanin_atomic_count;
+    uint64_t self_atomic_count;
+    uint64_t pop_atomic_count;
+
+    int64_t  complete_count;
+};
+
+/**
+ * Get and reset scheduler profiling data for a specific thread.
+ * Returns accumulated profiling data and resets counters.
+ */
+PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
+#endif
+
+#endif // PTO_SCHEDULER_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -1,0 +1,213 @@
+/**
+ * PTO Runtime2 - Shared Memory Implementation
+ * 
+ * Implements shared memory allocation, initialization, and management
+ * for Orchestrator-Scheduler communication.
+ * 
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#include "pto_shared_memory.h"
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include "common/unified_log.h"
+
+// =============================================================================
+// Size Calculation
+// =============================================================================
+
+uint64_t pto2_sm_calculate_size(uint64_t task_window_size) {
+    uint64_t size = 0;
+
+    // Header (aligned to cache line)
+    size += PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
+
+    // Task descriptors (hot: dependency metadata only)
+    size += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
+
+    // Task payloads (cold: tensors/scalars, only accessed during orchestration and dispatch)
+    size += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
+
+    return size;
+}
+
+// =============================================================================
+// Creation and Destruction
+// =============================================================================
+
+PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
+                                        uint64_t heap_size) {
+    // Allocate handle
+    PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
+    if (!handle) {
+        return NULL;
+    }
+
+    // Calculate total size
+    uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+
+    // Allocate shared memory (aligned for DMA efficiency)
+    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+        if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
+            free(handle);
+            return NULL;
+        }
+    #else
+        handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
+        if (!handle->sm_base) {
+            free(handle);
+            return NULL;
+        }
+    #endif
+
+    handle->sm_size = sm_size;
+    handle->is_owner = true;
+
+    // Initialize to zero
+    memset(handle->sm_base, 0, static_cast<size_t>(sm_size));
+
+    // Set up pointers
+    char* ptr = (char*)handle->sm_base;
+
+    // Header
+    handle->header = (PTO2SharedMemoryHeader*)ptr;
+    ptr += PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
+
+    // Task descriptors
+    handle->task_descriptors = (PTO2TaskDescriptor*)ptr;
+    ptr += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
+
+    // Task payloads (cold data)
+    handle->task_payloads = (PTO2TaskPayload*)ptr;
+
+    // Initialize header
+    pto2_sm_init_header(handle, task_window_size, heap_size);
+
+    return handle;
+}
+
+PTO2SharedMemoryHandle* pto2_sm_create_default(void) {
+    return pto2_sm_create(PTO2_TASK_WINDOW_SIZE,
+                          PTO2_HEAP_SIZE);
+}
+
+PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
+                                                    uint64_t sm_size,
+                                                    uint64_t task_window_size,
+                                                    uint64_t heap_size) {
+    if (!sm_base || sm_size == 0) return NULL;
+
+    uint64_t required = pto2_sm_calculate_size(task_window_size);
+    if (sm_size < required) return NULL;
+
+    PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
+    if (!handle) return NULL;
+
+    handle->sm_base = sm_base;
+    handle->sm_size = sm_size;
+    handle->is_owner = false;
+
+    char* ptr = (char*)sm_base;
+    handle->header = (PTO2SharedMemoryHeader*)ptr;
+    ptr += PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
+    handle->task_descriptors = (PTO2TaskDescriptor*)ptr;
+    ptr += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
+    handle->task_payloads = (PTO2TaskPayload*)ptr;
+
+    pto2_sm_init_header(handle, task_window_size, heap_size);
+    
+    return handle;
+}
+
+void pto2_sm_destroy(PTO2SharedMemoryHandle* handle) {
+    if (!handle) return;
+    
+    if (handle->is_owner && handle->sm_base) {
+        free(handle->sm_base);
+    }
+    
+    free(handle);
+}
+
+// =============================================================================
+// Initialization
+// =============================================================================
+// 
+// no need init data in pool, init pool data when used
+void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
+                          uint64_t task_window_size,
+                          uint64_t heap_size) {
+    PTO2SharedMemoryHeader* header = handle->header;
+
+    // Flow control pointers (start at 0)
+    header->current_task_index.store(0, std::memory_order_relaxed);
+    header->heap_top.store(0, std::memory_order_relaxed);
+    header->orchestrator_done.store(0, std::memory_order_relaxed);
+    header->last_task_alive.store(0, std::memory_order_relaxed);
+    header->heap_tail.store(0, std::memory_order_relaxed);
+    header->heap_tail_gen.store(0, std::memory_order_relaxed);
+
+    // Layout info
+    header->task_window_size = task_window_size;
+    header->heap_size = heap_size;
+
+    // Calculate offsets
+    uint64_t offset = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
+    header->task_descriptors_offset = offset;
+
+    header->total_size = handle->sm_size;
+    header->graph_output_ptr.store(0, std::memory_order_relaxed);
+    header->graph_output_size.store(0, std::memory_order_relaxed);
+}
+
+// =============================================================================
+// Debug Utilities
+// =============================================================================
+
+void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
+    if (!handle || !handle->header) return;
+
+    PTO2SharedMemoryHeader* h = handle->header;
+
+    LOG_INFO("=== PTO2 Shared Memory Layout ===");
+    LOG_INFO("Base address:       %p", handle->sm_base);
+    LOG_INFO("Total size:         %" PRIu64 " bytes", h->total_size);
+    LOG_INFO("Task window size:   %" PRIu64, h->task_window_size);
+    LOG_INFO("Heap size:          %" PRIu64 " bytes", h->heap_size);
+    LOG_INFO("Offsets:");
+    LOG_INFO("  TaskDescriptors:  %" PRIu64 " (0x%" PRIx64 ")", h->task_descriptors_offset, h->task_descriptors_offset);
+    LOG_INFO("Flow control:");
+    LOG_INFO("  heap_top:           %" PRIu64, h->heap_top.load(std::memory_order_acquire));
+    LOG_INFO("  heap_tail:          %" PRIu64, h->heap_tail.load(std::memory_order_acquire));
+    LOG_INFO("  current_task_index: %d", h->current_task_index.load(std::memory_order_acquire));
+    LOG_INFO("  orchestrator_done:  %d", h->orchestrator_done.load(std::memory_order_acquire));
+    LOG_INFO("  last_task_alive:    %d", h->last_task_alive.load(std::memory_order_acquire));
+    LOG_INFO("================================");
+}
+
+bool pto2_sm_validate(PTO2SharedMemoryHandle* handle) {
+    if (!handle) return false;
+    if (!handle->sm_base) return false;
+    if (!handle->header) return false;
+
+    PTO2SharedMemoryHeader* h = handle->header;
+
+    // Check that offsets are within bounds
+    if (h->task_descriptors_offset >= h->total_size) return false;
+
+    // Check pointer alignment
+    if ((uintptr_t)handle->task_descriptors % PTO2_ALIGN_SIZE != 0) return false;
+
+    // Check flow control pointer sanity
+    int32_t current_task_index = h->current_task_index.load(std::memory_order_acquire);
+    int32_t last_task_alive = h->last_task_alive.load(std::memory_order_acquire);
+    uint64_t heap_top = h->heap_top.load(std::memory_order_acquire);
+    uint64_t heap_tail = h->heap_tail.load(std::memory_order_acquire);
+    if (current_task_index < 0) return false;
+    if (last_task_alive < 0) return false;
+    if (heap_top > h->heap_size) return false;
+    if (heap_tail > h->heap_size) return false;
+
+    return true;
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -1,0 +1,191 @@
+/**
+ * PTO Runtime2 - Shared Memory Layout
+ *
+ * Defines the shared memory structure for Orchestrator-Scheduler communication.
+ *
+ * Memory Layout:
+ *   +---------------------------+
+ *   | SharedMemoryHeader        |  (flow control + sync)
+ *   +---------------------------+
+ *   | TaskDescriptor[]          |  (ring buffer)
+ *   +---------------------------+
+ *   | TaskPayload[]             |  (cold task data)
+ *   +---------------------------+
+ *
+ * Design principles:
+ * - Only data needed for Orchestrator<->Scheduler communication is here
+ * - TensorMap, scope_stack, ready_queues, dep_pool are in private memory
+ * - Flow control via atomic counters/flags (no locks needed for single-word R/W)
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#ifndef PTO_SHARED_MEMORY_H
+#define PTO_SHARED_MEMORY_H
+
+#include "pto_runtime2_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// Shared Memory Header
+// =============================================================================
+
+/**
+ * Shared memory header structure
+ * 
+ * Contains flow control pointers and layout information.
+ * Written/read by Orchestrator and Scheduler for synchronization.
+ */
+typedef struct {
+    // === FLOW CONTROL POINTERS ===
+
+    // Written by Orchestrator, Read by Scheduler
+    std::atomic<uint64_t> heap_top;           // Heap ring allocation pointer
+    std::atomic<int32_t> current_task_index;  // Task ring head (next to allocate)
+    std::atomic<int32_t> orchestrator_done;   // Flag: orchestration complete
+    
+    // Written by Scheduler, Read by Orchestrator (for back-pressure)
+    std::atomic<uint64_t> heap_tail;          // Heap ring free pointer (on-device, matches pto2_heap_ring_init)
+    std::atomic<int32_t> last_task_alive;     // Task ring tail (oldest active task)
+    std::atomic<int32_t> heap_tail_gen;       // Ticket counter for serialized heap_tail writes
+                                              // (ensures concurrent threads write in task order)
+
+    // === LAYOUT INFO (set once at init) ===
+    uint64_t task_window_size;            // PTO2_TASK_WINDOW_SIZE
+    uint64_t heap_size;                   // Total heap size
+
+    // Offsets into shared memory (relative to SM_Base)
+    uint64_t task_descriptors_offset;     // Offset to TaskDescriptor array
+
+    // Total shared memory size (for validation)
+    uint64_t total_size;
+
+    // Graph output for copy-back (set by orchestrator when using packed buffer)
+    // Host finalize copies from this address instead of dev_ptr when non-zero
+    std::atomic<uint64_t> graph_output_ptr;   // Address where final output was written (packed buffer)
+    std::atomic<uint64_t> graph_output_size;  // Size in bytes
+
+    // Padding to 128-byte cache line
+    uint64_t _padding[4];
+
+} PTO2SharedMemoryHeader;
+
+// =============================================================================
+// Shared Memory Handle
+// =============================================================================
+
+/**
+ * Handle for shared memory access
+ * Provides both Orchestrator and Scheduler views of the same memory
+ */
+typedef struct {
+    void*   sm_base;              // Base address of shared memory
+    uint64_t sm_size;             // Total size of shared memory
+
+    // Quick pointers into shared memory regions
+    PTO2SharedMemoryHeader* header;
+    PTO2TaskDescriptor*     task_descriptors;
+    PTO2TaskPayload*        task_payloads;
+    
+    // Ownership flag
+    bool    is_owner;             // True if this handle allocated the memory
+    
+} PTO2SharedMemoryHandle;
+
+// =============================================================================
+// Shared Memory API
+// =============================================================================
+
+/**
+ * Calculate required shared memory size
+ *
+ * @param task_window_size  Number of task slots
+ * @return Total bytes required
+ */
+uint64_t pto2_sm_calculate_size(uint64_t task_window_size);
+
+/**
+ * Create shared memory for Orchestrator and Scheduler
+ *
+ * @param task_window_size  Number of task slots
+ * @param heap_size         Heap size for output buffers
+ * @return Handle with both views, or NULL on failure
+ */
+PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
+                                        uint64_t heap_size);
+
+/**
+ * Create shared memory with default sizes
+ */
+PTO2SharedMemoryHandle* pto2_sm_create_default(void);
+
+/**
+ * Wrap an existing buffer as shared memory (e.g. device GM buffer).
+ * Caller owns the buffer; handle will not free sm_base.
+ *
+ * @param sm_base            Base address of pre-allocated buffer
+ * @param sm_size            Total size in bytes
+ * @param task_window_size   Number of task slots (must match buffer layout)
+ * @param heap_size          Heap size (for layout; buffer has no heap region)
+ * @return Handle, or NULL on failure
+ */
+PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
+                                                    uint64_t sm_size,
+                                                    uint64_t task_window_size,
+                                                    uint64_t heap_size);
+
+/**
+ * Destroy shared memory and free resources
+ */
+void pto2_sm_destroy(PTO2SharedMemoryHandle* handle);
+
+/**
+ * Initialize shared memory header with layout information
+ * Called after memory is allocated
+ */
+void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
+                          uint64_t task_window_size,
+                          uint64_t heap_size);
+
+/**
+ * Get task descriptor by task ID
+ * Uses runtime window_size for ring buffer indexing (not compile-time constant)
+ */
+static inline PTO2TaskDescriptor* pto2_sm_get_task(PTO2SharedMemoryHandle* handle,
+                                                    int32_t task_id) {
+    uint64_t window_mask = handle->header->task_window_size - 1;
+    return &handle->task_descriptors[task_id & window_mask];
+}
+
+/**
+ * Get task descriptor by task slot
+ * Uses runtime window_size for ring buffer indexing (not compile-time constant)
+ */
+static inline PTO2TaskDescriptor& pto2_sm_get_task_by_slot(PTO2SharedMemoryHandle* handle,
+                                                    int32_t slot) {
+    return handle->task_descriptors[slot];
+}
+
+// =============================================================================
+// Debug Utilities
+// =============================================================================
+
+/**
+ * Print shared memory layout info
+ */
+void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle);
+
+/**
+ * Validate shared memory integrity
+ * @return true if valid, false if corrupted
+ */
+bool pto2_sm_validate(PTO2SharedMemoryHandle* handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PTO_SHARED_MEMORY_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -1,0 +1,249 @@
+/**
+ * PTO Runtime2 - TensorMap Implementation
+ *
+ * Implements TensorMap with ring buffer pool, lazy invalidation,
+ * and chain truncation optimization.
+ *
+ * Key features:
+ * 1. O(1) insert at bucket head
+ * 2. O(valid_entries) lookup with chain truncation
+ * 3. Automatic stale entry cleanup during lookup
+ * 4. Periodic explicit cleanup for long chains
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#include "pto_tensormap.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+#include "common/unified_log.h"
+#include "pto_orchestrator.h"
+
+// =============================================================================
+// TensorMap Lookup Chain Length Statistics (compile-time toggle)
+// =============================================================================
+#if PTO2_TENSORMAP_PROFILING
+uint64_t g_lookup_chain_total = 0;
+uint64_t g_lookup_count = 0;
+int32_t  g_lookup_chain_max = 0;
+uint64_t g_lookup_overlap_checks = 0;
+uint64_t g_lookup_overlap_hits = 0;
+uint64_t g_insert_count = 0;
+#endif
+
+// =============================================================================
+// Initialization and Destruction
+// =============================================================================
+
+bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size) {
+    // Validate power of 2 for fast modulo
+    if ((new_num_buckets & (new_num_buckets - 1)) != 0) {
+        return false;  // num_buckets must be power of 2
+    }
+
+    // Allocate buckets
+    buckets = (PTO2TensorMapEntry**)malloc(new_num_buckets * sizeof(PTO2TensorMapEntry*));
+    if (!buckets) {
+        return false;
+    }
+
+    // Initialize all buckets to empty (-1)
+    for (int32_t i = 0; i < new_num_buckets; i++) {
+        buckets[i] = nullptr;
+    }
+
+    num_buckets = new_num_buckets;
+
+    // Allocate entry pool
+    entry_pool = (PTO2TensorMapEntry*)calloc(new_pool_size, sizeof(PTO2TensorMapEntry));
+    if (!entry_pool) {
+        free(buckets);
+        buckets = NULL;
+        return false;
+    }
+
+    // Allocate free entry list
+    free_entry_list = (PTO2TensorMapEntry**)calloc(new_pool_size, sizeof(PTO2TensorMapEntry*));
+    if (!free_entry_list) {
+        free(buckets);
+        free(entry_pool);
+        buckets = NULL;
+        entry_pool = NULL;
+        return false;
+    }
+
+    pool_size = new_pool_size;
+    next_entry_idx = 0;
+    free_num = 0;
+
+    // Initialize all entries as not in bucket
+    for (int32_t i = 0; i < pool_size; i++) {
+        entry_pool[i].bucket_index = -1;
+        entry_pool[i].next_in_bucket = nullptr;
+        entry_pool[i].prev_in_bucket = nullptr;
+        entry_pool[i].next_in_task = nullptr;
+        entry_pool[i].prev_in_task = nullptr;
+        entry_pool[i].producer_task_id = -1;
+    }
+
+    // Allocate per-task entry tracking
+    task_entry_head = (PTO2TensorMapEntry**)malloc(new_pool_size * sizeof(PTO2TensorMapEntry*));
+    if (!task_entry_head) {
+        free(entry_pool);
+        free(buckets);
+        free(free_entry_list);
+        entry_pool = NULL;
+        buckets = NULL;
+        free_entry_list = NULL;
+        return false;
+    }
+
+    // Initialize all task entry heads to -1 (no entries)
+    for (int32_t i = 0; i < PTO2_TASK_WINDOW_SIZE; i++) {
+        task_entry_head[i] = nullptr;
+    }
+
+    last_task_alive = 0;
+
+    return true;
+}
+
+bool PTO2TensorMap::init_default() {
+    return init(PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE);
+}
+
+void PTO2TensorMap::destroy() {
+    if (buckets) {
+        free(buckets);
+        buckets = NULL;
+    }
+
+    if (entry_pool) {
+        free(entry_pool);
+        entry_pool = NULL;
+    }
+
+    if (task_entry_head) {
+        free(task_entry_head);
+        task_entry_head = NULL;
+    }
+
+    if (free_entry_list) {
+        free(free_entry_list);
+        free_entry_list = NULL;
+    }
+}
+
+// =============================================================================
+// Debug Utilities
+// =============================================================================
+
+void PTO2TensorMap::print_stats() {
+    int32_t valid = 0;
+    int32_t stale = 0;
+    int32_t empty_buckets = 0;
+    int32_t max_chain = 0;
+    int64_t total_chain = 0;
+    int32_t non_empty_buckets = 0;
+
+    // Count entries
+    for (int32_t i = 0; i < pool_size; i++) {
+        if (entry_pool[i].bucket_index != -1) {
+            if (entry_valid(entry_pool[i])) {
+                valid++;
+            } else {
+                stale++;
+            }
+        }
+    }
+
+    // Count bucket stats
+    for (int32_t b = 0; b < num_buckets; b++) {
+        int32_t chain_len = 0;
+        auto cur_entry = buckets[b];
+
+        while (cur_entry != nullptr) {
+            chain_len++;
+            cur_entry = cur_entry->next_in_bucket;
+        }
+
+        if (chain_len == 0) {
+            empty_buckets++;
+        } else {
+            non_empty_buckets++;
+            total_chain += chain_len;
+            if (chain_len > max_chain) {
+                max_chain = chain_len;
+            }
+        }
+    }
+
+    LOG_INFO("=== TensorMap Statistics ===");
+    LOG_INFO("Pool size:           %d", pool_size);
+    LOG_INFO("Pool next entry idx: %d", next_entry_idx);
+    LOG_INFO("Pool free_num:       %d", free_num);
+    LOG_INFO("Num buckets:         %d", num_buckets);
+    LOG_INFO("Valid entries:       %d", valid);
+    LOG_INFO("Stale entries:       %d", stale);
+    LOG_INFO("Empty buckets:       %d", empty_buckets);
+    LOG_INFO("Max chain len:       %d", max_chain);
+    LOG_INFO("Avg chain len:       %.2f", non_empty_buckets > 0 ? (float)total_chain / non_empty_buckets : 0);
+    LOG_INFO("Last task alive:     %d", last_task_alive);
+    LOG_INFO("============================");
+}
+
+int32_t PTO2TensorMap::valid_count() {
+    int32_t count = 0;
+
+    for (int32_t i = 0; i < pool_size; i++) {
+        if (entry_pool[i].bucket_index != -1 && entry_valid(entry_pool[i])) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+void PTO2TensorMap::sync_tensormap() {
+    constexpr int MIN_FREE_NUM = 1024;
+    always_assert(orch != nullptr);
+    while(true) {
+        // Read current last_task_alive from shared memory
+        int32_t new_last_task_alive =
+            orch->sm_handle->header->last_task_alive.load(std::memory_order_acquire);
+        sync_validity(new_last_task_alive);
+        if ((pool_size - next_entry_idx + free_num < MIN_FREE_NUM) || new_last_task_alive - orch->tensormap_last_cleanup >= PTO2_TENSORMAP_CLEANUP_INTERVAL) {
+            cleanup_retired(orch->tensormap_last_cleanup, new_last_task_alive);
+            orch->tensormap_last_cleanup = new_last_task_alive;
+        } else {
+            break;
+        }
+    }
+}
+
+// =============================================================================
+// TensorMap Lookup Profiling
+// =============================================================================
+#if PTO2_TENSORMAP_PROFILING
+PTO2TensorMapProfilingData pto2_tensormap_get_profiling() {
+    PTO2TensorMapProfilingData d;
+    d.lookup_chain_total = g_lookup_chain_total;
+    d.lookup_count = g_lookup_count;
+    d.lookup_chain_max = g_lookup_chain_max;
+    d.overlap_checks = g_lookup_overlap_checks;
+    d.overlap_hits = g_lookup_overlap_hits;
+    d.insert_count = g_insert_count;
+
+    // Reset
+    g_lookup_chain_total = 0;
+    g_lookup_count = 0;
+    g_lookup_chain_max = 0;
+    g_lookup_overlap_checks = 0;
+    g_lookup_overlap_hits = 0;
+    g_insert_count = 0;
+    return d;
+}
+#endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -1,0 +1,436 @@
+/**
+ * PTO Runtime2 - TensorMap Interface
+ *
+ * TensorMap provides producer lookup for dependency discovery:
+ * - Maps Tensor -> producer task ID
+ * - Used by pto_submit_task() to find dependencies
+ *
+ * Key design features:
+ * 1. Ring buffer pool for entries (no malloc/free)
+ * 2. Lazy invalidation (entries become stale when producer retires)
+ * 3. Chain truncation optimization (truncate on first stale entry)
+ * 4. Per-task entry tracking for efficient cleanup
+ * 5. OVERLAP DETECTION: Detects dependencies for overlapping sub-regions
+ *
+ * Hash table with chaining:
+ * - buckets[] array of head offsets
+ * - Entries linked via next_in_bucket
+ * - Insert at head (newest first) for sorted chains
+ *
+ * CRITICAL: Hash only by base_ptr
+ * ==============================
+ * For overlap detection to work, ALL sub-regions of the same base tensor
+ * MUST be in the SAME hash bucket. This allows lookup to compare all
+ * potentially overlapping regions.
+ *
+ * Overlap detection: Two regions create a dependency if:
+ *   1. Same base_ptr (raw tensor pointer)
+ *   2. Byte ranges [offset, offset+size) intersect
+ *
+ * Based on: docs/runtime_buffer_manager_methods.md
+ */
+
+#pragma once
+
+#include "common.h"
+#include "pto_runtime2_types.h"
+#include "tensor.h"
+
+struct PTO2OrchestratorState;  // forward declare
+
+// =============================================================================
+// TensorMap Lookup Profiling (must precede inline lookup/insert methods)
+// =============================================================================
+#ifndef PTO2_TENSORMAP_PROFILING
+#define PTO2_TENSORMAP_PROFILING 0
+#endif
+
+#if PTO2_TENSORMAP_PROFILING
+extern uint64_t g_lookup_chain_total;
+extern uint64_t g_lookup_count;
+extern int32_t  g_lookup_chain_max;
+extern uint64_t g_lookup_overlap_checks;
+extern uint64_t g_lookup_overlap_hits;
+extern uint64_t g_insert_count;
+#endif
+
+// =============================================================================
+// TensorMap Structure
+// =============================================================================
+
+/**
+ * TensorMap entry structure
+ * Maps tensor region -> producer task ID
+ *
+ * Stored in ring buffer pool with lazy invalidation:
+ * - Entry is valid only if producer_task_id >= last_task_alive
+ * - Stale entries ignored during lookup
+ * - Pool wraps around, overwriting stale entries
+ *
+ * Chain truncation optimization:
+ * - Entries in bucket chains sorted by task_id (newest first)
+ * - When lookup hits stale entry, truncate rest of chain
+ */
+struct PTO2TensorMapEntry {
+    bool with_alloc{true};     // True if entry is task output, False if entry is task inout
+    int32_t producer_task_id;  // Task that produces this region
+    PTO2TensorMapEntry* next_in_bucket;    // Offset to next entry in hash bucket (-1 = end)
+    PTO2TensorMapEntry* prev_in_bucket;    // Offset to prev entry in hash bucket (-1 = head is buckets[bucket])
+    PTO2TensorMapEntry* next_in_task;      // Offset to next entry for same task (-1 = end)
+    PTO2TensorMapEntry* prev_in_task;      // Offset to prev entry for same task (-1 = head is task_entry_head[slot])
+    int32_t bucket_index;      // != -1 if entry is linked in a bucket chain
+                               // CRITICAL: Must be set -1 before overwriting!
+    Tensor tensor;             // Tensor descriptor key
+};
+
+/**
+ * Stack-allocated lookup result (avoids heap allocation per lookup)
+ */
+#define PTO2_LOOKUP_MAX_RESULTS 16
+// =============================================================================
+// TensorMap Lookup Chain Length Statistics (compile-time toggle)
+// =============================================================================
+struct PTO2LookupResult {
+    struct Entry {
+        PTO2TensorMapEntry* entry;
+        OverlapStatus overlap_status;
+    };
+    Entry entries[PTO2_LOOKUP_MAX_RESULTS];
+    int32_t count{0};
+
+    void push(PTO2TensorMapEntry* entry, OverlapStatus s) {
+        if (count < PTO2_LOOKUP_MAX_RESULTS) {
+            entries[count++] = {entry, s};
+        }
+    }
+};
+
+/**
+ * TensorMap structure
+ *
+ * Hash table with ring buffer entry pool and lazy invalidation.
+ */
+struct PTO2TensorMap {
+    // Hash table buckets (fixed size, power of 2)
+    PTO2TensorMapEntry** buckets;     // Array of offsets into entry_pool (-1 = empty)
+    int32_t num_buckets;  // Must be power of 2 for fast modulo
+
+    // Entry pool as ring buffer
+    PTO2TensorMapEntry* entry_pool;  // Ring buffer of entries
+    PTO2TensorMapEntry** free_entry_list;        // free entry ids
+    int32_t pool_size;               // Total pool capacity
+    int32_t next_entry_idx;          // id when next entry insert
+    int32_t free_num;                // free entry number in entry pool
+
+    // Per-task entry tracking (for efficient bucket cleanup)
+    PTO2TensorMapEntry** task_entry_head;  // Per-task head offset (-1 = no entries)
+                               // Indexed by task_id % TASK_WINDOW_SIZE
+
+    // Validity threshold (for lazy invalidation)
+    int32_t last_task_alive;  // Cached value from shared memory
+
+    PTO2OrchestratorState* orch{nullptr};
+
+    // new_entry目前不负责分配属性，仅分配内存
+    PTO2TensorMapEntry* new_entry() {
+        if (free_num > 0) {
+            PTO2TensorMapEntry* res = free_entry_list[--free_num];
+            debug_assert(res->bucket_index == -1);
+            return res;
+        }
+        always_assert(next_entry_idx < pool_size);
+        PTO2TensorMapEntry* res = &entry_pool[next_entry_idx++];
+        debug_assert(res->bucket_index == -1);
+        return res;
+    }
+
+    void free_entry(PTO2TensorMapEntry& entry) {
+        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+
+        // Update predecessor's next pointer (O(1) via prev_in_bucket)
+        if (entry.prev_in_bucket == nullptr) {
+            // Entry is the head of its bucket chain, update bucket head
+            // Must compute hash BEFORE clearing tensor
+            buckets[entry.bucket_index] = entry.next_in_bucket;
+        } else {
+            entry.prev_in_bucket->next_in_bucket = entry.next_in_bucket;
+        }
+
+        // Update successor's prev pointer
+        if (entry.next_in_bucket != nullptr) {
+            entry.next_in_bucket->prev_in_bucket = entry.prev_in_bucket;
+        }
+
+        // Clear tensor AFTER bucket chain manipulation (hash computation needs valid tensor)
+        entry.tensor = Tensor();
+
+        free_entry_list[free_num++] = &entry;
+        entry.bucket_index = -1;
+        entry.next_in_bucket = nullptr;
+        entry.prev_in_bucket = nullptr;
+        entry.next_in_task = nullptr;
+        entry.prev_in_task = nullptr;
+    }
+
+    // =============================================================================
+    // TensorMap API
+    // =============================================================================
+
+    /**
+     * Initialize TensorMap
+     *
+     * @param num_buckets Number of hash buckets (must be power of 2)
+     * @param pool_size   Size of entry pool
+     * @return true on success, false on allocation failure
+     */
+    bool init(int32_t num_buckets, int32_t pool_size);
+
+    /**
+     * Initialize TensorMap with default sizes
+     */
+    bool init_default();
+
+    /**
+     * Destroy TensorMap and free resources
+     */
+    void destroy();
+
+    /**
+     * Update validity threshold from shared memory
+     * Called periodically to refresh the lazy invalidation threshold.
+     *
+     * @param last_task_alive  Current value from shared memory
+     */
+    void sync_validity(int32_t last_task_alive) { this->last_task_alive = last_task_alive; }
+
+    /**
+     * Lookup producer for a tensor region
+     *
+     * Searches the hash table for a matching region.
+     * Returns producer entry if found and valid.
+     *
+     * Chain truncation: When first stale entry is found, truncates
+     * the rest of the chain (all subsequent entries are also stale).
+     *
+     * @param tensor  Tensor to look up
+     * @param result  Output: stack-allocated result buffer
+     */
+    void lookup(const Tensor& tensor, PTO2LookupResult& result) {
+        uint32_t bucket_index = hash(tensor.buffer.addr);
+        PTO2TensorMapEntry** prev_ptr = &buckets[bucket_index];  // For truncation
+        PTO2TensorMapEntry* cur_entry = *prev_ptr;
+
+        result.count = 0;
+#if PTO2_TENSORMAP_PROFILING
+        g_lookup_count++;
+        int32_t chain_len = 0;
+#endif
+
+        while (cur_entry != nullptr) {
+#if PTO2_TENSORMAP_PROFILING
+            chain_len++;
+#endif
+            // Check validity first
+            if (!entry_valid(*cur_entry)) {
+                // ========== STALE ENTRY: Truncate chain here ==========
+                // All subsequent entries are guaranteed to be stale too!
+                // Truncate: unlink this and all following entries
+                *prev_ptr = nullptr;  // Terminate chain at previous entry
+
+                // Mark truncated entries as not in bucket (for correct reuse)
+                while (cur_entry != nullptr) {
+                    PTO2TensorMapEntry* next_entry = cur_entry->next_in_bucket;
+                    remove_entry(*cur_entry);
+                    cur_entry = next_entry;
+                }
+                break;
+            }
+
+            // Entry is valid - check if regions OVERLAP (not just exact match)
+            // Since we hash only by base_ptr, all entries in this bucket have
+            // potential to overlap. We must check actual byte-range overlap.
+            if (tensor.buffer.addr == cur_entry->tensor.buffer.addr) {
+#if PTO2_TENSORMAP_PROFILING
+                g_lookup_overlap_checks++;
+#endif
+                auto overlap_status = tensor.is_overlap(cur_entry->tensor);
+                if (overlap_status != OverlapStatus::NO_OVERLAP) {
+                    result.push(cur_entry, overlap_status);
+#if PTO2_TENSORMAP_PROFILING
+                    g_lookup_overlap_hits++;
+#endif
+                }
+            }
+
+            // Move to next entry
+            prev_ptr = &cur_entry->next_in_bucket;
+            cur_entry = *prev_ptr;
+        }
+#if PTO2_TENSORMAP_PROFILING
+        g_lookup_chain_total += chain_len;
+        if (chain_len > g_lookup_chain_max) g_lookup_chain_max = chain_len;
+#endif
+    }
+
+    /**
+     * Insert a new entry (called when task produces output)
+     *
+     * Allocates from ring buffer pool, may overwrite stale entries.
+     * Inserts at head of hash bucket chain (maintains task_id ordering).
+     *
+     * @param tensor            Tensor produced
+     * @param producer_task_id  Task ID of producer
+     */
+    void insert(const Tensor& tensor, int32_t producer_task_id, bool with_alloc) {
+#if PTO2_TENSORMAP_PROFILING
+        g_insert_count++;
+#endif
+        // Allocate entry from ring buffer pool
+        PTO2TensorMapEntry* entry = new_entry();
+
+        // Initialize new entry
+        entry->tensor.copy(tensor);
+        entry->producer_task_id = producer_task_id;
+        entry->with_alloc = with_alloc;
+
+        // Insert at head of hash bucket (maintains task_id descending order)
+        entry->bucket_index = hash(tensor.buffer.addr);
+        entry->next_in_bucket = buckets[entry->bucket_index];
+        // Update old head's prev pointer
+        if (entry->next_in_bucket != nullptr) {
+            entry->next_in_bucket->prev_in_bucket = entry;
+        }
+        buckets[entry->bucket_index] = entry;
+        entry->prev_in_bucket = nullptr;  // New head has no predecessor
+
+        // Link to task's entry list (for cleanup)
+        int32_t task_slot = producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+        entry->next_in_task = task_entry_head[task_slot];
+        entry->prev_in_task = nullptr;  // New head has no predecessor
+        // Update old head's prev pointer
+        if (entry->next_in_task != nullptr) {
+            entry->next_in_task->prev_in_task = entry;
+        }
+        task_entry_head[task_slot] = entry;
+    }
+
+    /**
+     * Cleanup stale entries for retired tasks
+     *
+     * Called periodically by Orchestrator when last_task_alive advances.
+     * Removes entries from bucket chains for tasks in [old, new) range.
+     *
+     * @param old_last_task_alive  Previous threshold
+     * @param new_last_task_alive  New threshold
+     */
+    void cleanup_retired(int32_t old_last_task_alive, int32_t new_last_task_alive) {
+        // Iterate through retired tasks and remove their entries from bucket chains
+        for (int32_t task_id = old_last_task_alive; task_id < new_last_task_alive; task_id++) {
+            int32_t task_slot = task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+            PTO2TensorMapEntry* cur_entry = task_entry_head[task_slot];
+
+            while (cur_entry != nullptr) {
+                PTO2TensorMapEntry* next_entry = cur_entry->next_in_task;  // Save before clearing
+                // Only remove if this entry belongs to the retiring task
+                // (slot may have been reused by a newer task)
+                debug_assert(cur_entry->producer_task_id == task_id);
+                free_entry(*cur_entry);
+                cur_entry = next_entry;
+            }
+
+            // Clear task's entry head (slot will be reused by task_id + TASK_WINDOW_SIZE)
+            task_entry_head[task_slot] = nullptr;
+        }
+    }
+
+    // =============================================================================
+    // Internal Helpers (exposed for testing)
+    // =============================================================================
+
+    /**
+     * Compute hash for tensor addr
+     */
+    uint32_t hash(uint64_t key) {
+        // Improve distribution by mixing bits (pointers often have aligned low bits)
+        key = key ^ (key >> 16);
+        key = key ^ (key >> 32);
+
+        // Use bitwise AND for power-of-2 modulo (faster than %)
+        return (uint32_t)(key & (num_buckets - 1));
+    }
+
+    /**
+     * Check if entry is valid (producer has not retired)
+     */
+    bool entry_valid(const PTO2TensorMapEntry& entry) const {
+        return entry.producer_task_id >= last_task_alive;
+    }
+
+    void remove_entry(PTO2TensorMapEntry& entry) {
+        remove_from_task(entry);
+        free_entry(entry);
+    }
+
+    /**
+     * Remove entry from its task chain (O(1) with prev pointer)
+     * Called during pool wrap-around to unlink reused entries.
+     */
+    void remove_from_task(PTO2TensorMapEntry& entry) {
+        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+        // Update predecessor's next pointer (O(1) via prev_in_task)
+        if (entry.prev_in_task == nullptr) {
+            // Entry is the head of its task chain, update task_entry_head
+            int32_t task_slot = entry.producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+            task_entry_head[task_slot] = entry.next_in_task;
+        } else {
+            entry.prev_in_task->next_in_task = entry.next_in_task;
+        }
+
+        // Update successor's prev pointer
+        if (entry.next_in_task != nullptr) {
+            entry.next_in_task->prev_in_task = entry.prev_in_task;
+        }
+
+        entry.next_in_task = nullptr;
+        entry.prev_in_task = nullptr;
+    }
+
+    // =============================================================================
+    // Debug Utilities
+    // =============================================================================
+
+    /**
+     * Print TensorMap statistics
+     */
+    void print_stats();
+
+    /**
+     * Get count of valid entries
+     */
+    int32_t valid_count();
+
+    // =============================================================================
+    // TensorMap Synchronization
+    // =============================================================================
+
+    /**
+     * Sync TensorMap validity threshold from shared memory
+     *
+     * Called periodically to refresh the lazy invalidation threshold.
+     * Also triggers cleanup if threshold has advanced significantly.
+     */
+    void sync_tensormap();
+};
+
+#if PTO2_TENSORMAP_PROFILING
+struct PTO2TensorMapProfilingData {
+    uint64_t lookup_chain_total;
+    uint64_t lookup_count;
+    int32_t  lookup_chain_max;
+    uint64_t overlap_checks;
+    uint64_t overlap_hits;
+    uint64_t insert_count;
+};
+
+PTO2TensorMapProfilingData pto2_tensormap_get_profiling();
+#endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -1,0 +1,94 @@
+/**
+ * Orchestration Build Graph Types - Data structures for orchestration runtime extensions
+ *
+ * Standalone header defining orchestration-specific types for:
+ * - PTOParam: Parameter descriptor for pto_submit_task API
+ * - PTOWorkerType: Worker types for heterogeneous scheduling
+ *
+ * Tensor descriptor types (Tensor, PTOBufferHandle, PTOOverlapStrategy) are
+ * defined in tensor.h.
+ *
+ * This header is independent of orch_build_graph_runtime.h to allow inclusion from runtime.h
+ * without type conflicts (Handshake, TensorPair, HostApi).
+ */
+
+#ifndef ORCH_BUILD_GRAPH_PTO_TYPES_H
+#define ORCH_BUILD_GRAPH_PTO_TYPES_H
+
+#include <stdint.h>
+#include <assert.h>
+
+#include "tensor.h"
+
+// =============================================================================
+// Parameter Types (for pto_submit_task API)
+// =============================================================================
+
+/**
+ * Parameter Type - Distinguishes inputs, outputs, and in-place updates
+ */
+enum class PTOParamType : int32_t {
+    INPUT = 0,   // Read-only input buffer
+    OUTPUT = 1,  // Write-only output buffer (NULL addr: runtime allocates; non-NULL: use as-is)
+    INOUT = 2,   // Read-then-write: consumer of prior producer + modifier for downstream
+    SCALAR = 3   // Raw scalar value (no buffer, no dependency tracking)
+};
+
+/**
+ * Parameter Descriptor for pto_submit_task
+ *
+ * Holds a pointer to the caller's Tensor (reference semantics). The runtime
+ * copies the Tensor into the task descriptor for scheduler access, and
+ * writes allocated OUTPUT addresses back through the pointer.
+ *
+ * Example:
+ *   Tensor td_a = make_tensor_external(dev_a, size);
+ *   Tensor td_c = make_tensor(size);
+ *   PTOParam params[] = {
+ *       make_input_param(td_a),
+ *       make_output_param(td_c),
+ *   };
+ *   pto2_rt_submit_task(rt, func_id, worker_type, params, 2);
+ *   // td_c.buffer.addr is already updated via pointer write-back
+ */
+struct PTOParam {
+    PTOParamType type;         // PTOParamType::INPUT, PTOParamType::OUTPUT, or PTOParamType::SCALAR
+    Tensor* tensor{nullptr};   // Pointer to caller's Tensor (reference semantics)
+    uint64_t scalar_value{0};  // Raw value for PTOParamType::SCALAR (e.g., encoded float, int size)
+};
+
+// =============================================================================
+// Factory Helpers
+// =============================================================================
+
+static inline PTOParam make_scalar_param(uint64_t value) {
+    PTOParam p;
+    p.type = PTOParamType::SCALAR;
+    p.scalar_value = value;
+    return p;
+}
+
+static inline PTOParam make_input_param(Tensor& tensor) {
+    assert(tensor.buffer.addr != 0 && "INPUT param must have a non-NULL buffer address");
+    PTOParam p;
+    p.type = PTOParamType::INPUT;
+    p.tensor = &tensor;
+    return p;
+}
+
+static inline PTOParam make_output_param(Tensor& tensor) {
+    PTOParam p;
+    p.type = PTOParamType::OUTPUT;
+    p.tensor = &tensor;
+    return p;
+}
+
+static inline PTOParam make_inout_param(Tensor& tensor) {
+    assert(tensor.buffer.addr != 0 && "INOUT param must have a non-NULL buffer address");
+    PTOParam p;
+    p.type = PTOParamType::INOUT;
+    p.tensor = &tensor;
+    return p;
+}
+
+#endif  // ORCH_BUILD_GRAPH_PTO_TYPES_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -1,0 +1,193 @@
+/**
+ * Runtime Class - Implementation
+ *
+ * Device execution and handshake control.
+ * Task graph construction is handled by PTO2Runtime.
+ */
+
+#include "runtime.h"
+#include "pto_runtime2_types.h"
+#include "pto_shared_memory.h"
+#include "common/unified_log.h"
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+Runtime::Runtime() {
+    // NOTE: host_api is initialized in InitRuntime() (host-only code)
+    // because the CApi functions don't exist when compiled for device.
+
+    // Initialize handshake buffers
+    memset(workers, 0, sizeof(workers));
+    worker_count = 0;
+    sche_cpu_num = 1;
+    orch_thread_num = 1;
+    ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
+    pto2_task_window_size = 0;
+    pto2_heap_size = 0;
+
+    // Initialize tensor pairs
+    tensor_pair_count = 0;
+
+    // Initialize device orchestration state
+    orch_built_on_host_ = true;
+    pto2_gm_sm_ptr_ = nullptr;
+    pto2_gm_heap_ptr_ = nullptr;
+    orch_args_ = nullptr;
+    orch_arg_count_ = 0;
+
+    // Initialize device orchestration SO binary
+    device_orch_so_size_ = 0;
+
+    // Initialize kernel binary tracking
+    registered_kernel_count_ = 0;
+
+    // Initialize function address mapping
+    for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
+        func_id_to_addr_[i] = 0;
+    }
+}
+
+// =============================================================================
+// Tensor Pair Management
+// =============================================================================
+
+void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
+    if (tensor_pair_count >= RUNTIME_MAX_TENSOR_PAIRS) {
+        LOG_ERROR("[Runtime] Tensor pairs full (max=%d)", RUNTIME_MAX_TENSOR_PAIRS);
+        return;
+    }
+    tensor_pairs[tensor_pair_count].host_ptr = host_ptr;
+    tensor_pairs[tensor_pair_count].dev_ptr = dev_ptr;
+    tensor_pairs[tensor_pair_count].size = size;
+    tensor_pair_count++;
+    LOG_INFO("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
+}
+
+TensorPair* Runtime::get_tensor_pairs() {
+    return tensor_pairs;
+}
+
+int Runtime::get_tensor_pair_count() const {
+    return tensor_pair_count;
+}
+
+void Runtime::clear_tensor_pairs() {
+    tensor_pair_count = 0;
+}
+
+// =============================================================================
+// Device orchestration
+// =============================================================================
+
+bool Runtime::get_orch_built_on_host() const { return orch_built_on_host_; }
+void* Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
+void* Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
+uint64_t* Runtime::get_orch_args() const {
+    // Return embedded storage directly (not the pointer) so device code gets correct device address
+    // When Runtime is copied to device memory, computing address relative to 'this' gives valid device address
+    return orch_arg_count_ > 0 ? const_cast<uint64_t*>(orch_args_storage_) : nullptr;
+}
+int Runtime::get_orch_arg_count() const { return orch_arg_count_; }
+void Runtime::set_orch_built_on_host(bool v) { orch_built_on_host_ = v; }
+void Runtime::set_pto2_gm_sm_ptr(void* p) { pto2_gm_sm_ptr_ = p; }
+void Runtime::set_pto2_gm_heap(void* p) { pto2_gm_heap_ptr_ = p; }
+void Runtime::set_orch_args(uint64_t* args, int count) {
+    orch_arg_count_ = count <= RUNTIME_MAX_ARGS ? count : RUNTIME_MAX_ARGS;
+    if (args && orch_arg_count_ > 0) {
+        memcpy(orch_args_storage_, args, (size_t)orch_arg_count_ * sizeof(uint64_t));
+        // Note: We no longer store orch_args_ pointer as it would contain host address
+        // get_orch_args() now computes address from embedded storage directly
+    }
+}
+
+// Device orchestration SO binary (for dlopen on AICPU thread 3)
+// Copies data to internal storage to avoid lifetime issues with Python ctypes arrays
+void Runtime::set_device_orch_so(const void* data, size_t size) {
+    if (data == nullptr || size == 0) {
+        device_orch_so_size_ = 0;
+        return;
+    }
+    if (size > RUNTIME_MAX_ORCH_SO_SIZE) {
+        LOG_ERROR("[Runtime] Orchestration SO too large (%zu > %d)", size, RUNTIME_MAX_ORCH_SO_SIZE);
+        device_orch_so_size_ = 0;
+        return;
+    }
+    memcpy(device_orch_so_storage_, data, size);
+    device_orch_so_size_ = size;
+}
+
+const void* Runtime::get_device_orch_so_data() const {
+    return device_orch_so_size_ > 0 ? device_orch_so_storage_ : nullptr;
+}
+
+size_t Runtime::get_device_orch_so_size() const {
+    return device_orch_so_size_;
+}
+
+uint64_t Runtime::get_function_bin_addr(int func_id) const {
+    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
+    return func_id_to_addr_[func_id];
+}
+
+void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
+    if (func_id >= 0 && func_id < RUNTIME_MAX_FUNC_ID) {
+        func_id_to_addr_[func_id] = addr;
+        if (addr != 0 && registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
+            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
+        }
+    }
+}
+
+int Runtime::get_registered_kernel_count() const {
+    return registered_kernel_count_;
+}
+
+int Runtime::get_registered_kernel_func_id(int index) const {
+    if (index < 0 || index >= registered_kernel_count_) return -1;
+    return registered_kernel_func_ids_[index];
+}
+
+void Runtime::clear_registered_kernels() {
+    registered_kernel_count_ = 0;
+}
+
+// =============================================================================
+// Performance Profiling
+// =============================================================================
+
+void Runtime::complete_perf_records(PerfBuffer* perf_buf) {
+    // Get PTO2 shared memory context
+    void* sm_base = get_pto2_gm_sm_ptr();
+    if (sm_base == nullptr) {
+        // No PTO2 context, cannot complete records
+        return;
+    }
+
+    // Get PTO2 data structures
+    PTO2SharedMemoryHeader* header = static_cast<PTO2SharedMemoryHeader*>(sm_base);
+    PTO2TaskDescriptor* task_descriptors = reinterpret_cast<PTO2TaskDescriptor*>(
+        static_cast<char*>(sm_base) + header->task_descriptors_offset);
+    int32_t window_mask = header->task_window_size - 1;
+
+    uint32_t count = perf_buf->count;
+
+    for (uint32_t i = 0; i < count; i++) {
+        PerfRecord* record = &perf_buf->records[i];
+        int32_t task_id = record->task_id;
+
+        // Get TaskDescriptor from PTO2 shared memory
+        int32_t slot = task_id & window_mask;
+        PTO2TaskDescriptor* task = &task_descriptors[slot];
+
+        // Fill fanout information by traversing the linked list
+        record->fanout_count = 0;
+        PTO2DepListEntry* cur = task->fanout_head;
+
+        while (cur != nullptr && record->fanout_count < RUNTIME_MAX_FANOUT) {
+            record->fanout[record->fanout_count++] = cur->task_id;
+            cur = cur->next;
+        }
+    }
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -1,0 +1,278 @@
+/**
+ * Runtime Class - Device Execution and Handshake Control
+ *
+ * This class manages device-side execution through AICPU-AICore handshake
+ * protocol. Task graph construction is handled by PTO2Runtime; this class
+ * only handles:
+ * - Handshake buffers for AICPU-AICore communication
+ * - Execution parameters (block_dim, sche_cpu_num)
+ * - Tensor pair management for host-device memory tracking
+ * - Device orchestration state (pto2_gm_sm_ptr_, orch_args_)
+ * - Function address mapping (func_id_to_addr_)
+ *
+ * Task dispatch uses PTO2DispatchPayload from PTO2 shared memory.
+ */
+
+#ifndef RUNTIME_H
+#define RUNTIME_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>   // for fprintf, printf
+#include <string.h>  // for memset
+
+#include "common/core_type.h"
+#include "common/perf_profiling.h"
+#include "common/platform_config.h"
+#include "pto2_dispatch_payload.h"
+
+// =============================================================================
+// Configuration Macros
+// =============================================================================
+
+#define RUNTIME_MAX_ARGS 32
+#define RUNTIME_MAX_WORKER 72  // 24 AIC + 48 AIV cores
+#define RUNTIME_MAX_TENSOR_PAIRS 64
+#define RUNTIME_MAX_FUNC_ID 32
+#define RUNTIME_MAX_ORCH_SO_SIZE (4 * 1024 * 1024)  // 1MB max for orchestration SO
+
+// Default ready queue shards: one shard per worker thread (total minus orchestrator)
+constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 1;
+
+// =============================================================================
+// Data Structures
+// =============================================================================
+
+/**
+ * Handshake Structure - Shared between Host, AICPU, and AICore
+ *
+ * This structure facilitates communication and synchronization between
+ * AICPU and AICore during task execution.
+ *
+ * Protocol State Machine:
+ * 1. Initialization: AICPU sets aicpu_ready=1
+ * 2. Acknowledgment: AICore sets aicore_done=core_id+1
+ * 3. Task Dispatch: AICPU assigns task pointer and sets task_status=1
+ * 4. Task Execution: AICore reads task, executes, sets task_status=0
+ * 5. Task Completion: AICPU reads task_status=0, clears task=0
+ * 6. Shutdown: AICPU sets control=1, AICore exits
+ *
+ * Each AICore instance has its own handshake buffer to enable concurrent
+ * task execution across multiple cores.
+ */
+
+/**
+ * Handshake buffer for AICPU-AICore communication
+ *
+ * Each AICore has its own handshake buffer for synchronization with AICPU.
+ * The structure is cache-line aligned (64 bytes) to prevent false sharing
+ * between cores and optimize cache coherency operations.
+ *
+ * Field Access Patterns:
+ * - aicpu_ready: Written by AICPU, read by AICore
+ * - aicore_done: Written by AICore, read by AICPU
+ * - task: Written by AICPU, read by AICore (0 = no task, non-zero = PTO2DispatchPayload*)
+ * - task_status: Written by both (AICPU=1 on dispatch, AICore=0 on completion)
+ * - control: Written by AICPU, read by AICore (0 = continue, 1 = quit)
+ * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
+ */
+struct Handshake {
+    volatile uint32_t aicpu_ready;         // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;         // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                // Task pointer: 0=no task, non-zero=PTO2DispatchPayload*
+    volatile int32_t task_status;          // Task execution status: 0=idle, 1=busy
+    volatile int32_t control;              // Control signal: 0=execute, 1=quit
+    volatile CoreType core_type;           // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t perf_records_addr;   // Performance records address
+    volatile uint32_t perf_buffer_status;  // 0 = not full, 1 == full
+    volatile uint32_t physical_core_id;     // Physical core ID
+} __attribute__((aligned(64)));
+
+/**
+ * Tensor pair for tracking host-device memory mappings.
+ * Used for copy-back during finalize.
+ */
+struct TensorPair {
+    void* host_ptr;
+    void* dev_ptr;
+    size_t size;
+};
+
+/**
+ * Host API function pointers for device memory operations.
+ * Allows runtime to use pluggable device memory backends.
+ */
+struct HostApi {
+    void* (*device_malloc)(size_t size);
+    void (*device_free)(void* dev_ptr);
+    int (*copy_to_device)(void* dev_ptr, const void* host_ptr, size_t size);
+    int (*copy_from_device)(void* host_ptr, const void* dev_ptr, size_t size);
+    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t* bin_data, size_t bin_size);
+    void (*remove_kernel_binary)(int func_id);
+};
+
+/**
+ * Task structure - Compatibility stub for platform layer
+ *
+ * RT2 uses PTO2DispatchPayload instead of Task for task dispatch.
+ * This stub exists only for API compatibility with device_runner.cpp.
+ * Since get_task_count() returns 0, this struct is never actually used.
+ */
+struct Task {
+    int func_id;
+    uint64_t function_bin_addr;
+};
+
+// =============================================================================
+// Runtime Class
+// =============================================================================
+
+/**
+ * Runtime class for device execution and handshake control
+ *
+ * This class manages AICPU-AICore communication through handshake buffers.
+ * Task graph construction is handled by PTO2Runtime; this class only handles
+ * execution control and device orchestration state.
+ */
+class Runtime {
+public:
+    // Handshake buffers for AICPU-AICore communication
+    Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
+    int worker_count;                       // Number of active workers
+
+    // Execution parameters for AICPU scheduling
+    int sche_cpu_num;  // Number of AICPU threads for scheduling
+    int orch_thread_num;  // Number of orchestrator threads (default 1)
+    int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
+
+    // Ring buffer size overrides (0 = use compile-time defaults)
+    uint64_t pto2_task_window_size;
+    uint64_t pto2_heap_size;
+
+    // PTO2 integration: kernel_id -> GM function_bin_addr mapping
+    // NOTE: Made public for direct access from aicore code
+    uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
+
+    // Profiling support
+    bool enable_profiling;    // Enable profiling flag
+    uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
+
+private:
+    // Tensor pairs for host-device memory tracking
+    TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
+    int tensor_pair_count;
+
+    // Kernel binary tracking for cleanup
+    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
+    int registered_kernel_count_;
+
+    // Device orchestration: when false, orchestration runs on device (thread 3)
+    bool orch_built_on_host_;
+    void* pto2_gm_sm_ptr_;  // GM pointer to PTO2 shared memory (device)
+    void* pto2_gm_heap_ptr_;  // GM heap for orchestrator output buffers (device)
+    uint64_t* orch_args_;   // Arguments for device orchestration
+    int orch_arg_count_;
+    uint64_t orch_args_storage_[RUNTIME_MAX_ARGS];  // Copy of args for device
+
+    // Device orchestration SO binary (for dlopen on AICPU thread 3)
+    // Stored as a copy to avoid lifetime issues with Python ctypes arrays
+    uint8_t device_orch_so_storage_[RUNTIME_MAX_ORCH_SO_SIZE];
+    size_t device_orch_so_size_;
+
+public:
+    /**
+     * Constructor - zero-initialize all arrays
+     */
+    Runtime();
+
+    // =========================================================================
+    // Tensor Pair Management
+    // =========================================================================
+
+    /**
+     * Record a host-device tensor pair for copy-back during finalize.
+     */
+    void record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size);
+
+    /**
+     * Get pointer to tensor pairs array.
+     */
+    TensorPair* get_tensor_pairs();
+
+    /**
+     * Get number of recorded tensor pairs.
+     */
+    int get_tensor_pair_count() const;
+
+    /**
+     * Clear all recorded tensor pairs.
+     */
+    void clear_tensor_pairs();
+
+    // =========================================================================
+    // Performance Profiling
+    // =========================================================================
+
+    /**
+     * Fill fanout information for performance records
+     *
+     * Extracts task dependency data from the task graph and populates
+     * fanout arrays in performance records.
+     *
+     * @param perf_buf Performance buffer containing records to complete
+     */
+    void complete_perf_records(PerfBuffer* perf_buf);
+
+    // =========================================================================
+    // Device orchestration (for AICPU thread 3)
+    // =========================================================================
+
+    bool get_orch_built_on_host() const;
+    void* get_pto2_gm_sm_ptr() const;
+    void* get_pto2_gm_heap_ptr() const;
+    uint64_t* get_orch_args() const;
+    int get_orch_arg_count() const;
+    void set_orch_built_on_host(bool v);
+    void set_pto2_gm_sm_ptr(void* p);
+    void set_pto2_gm_heap(void* p);
+    void set_orch_args(uint64_t* args, int count);
+
+    // Device orchestration SO binary (for dlopen on AICPU thread 3)
+    void set_device_orch_so(const void* data, size_t size);
+    const void* get_device_orch_so_data() const;
+    size_t get_device_orch_so_size() const;
+
+    uint64_t get_function_bin_addr(int func_id) const;
+    void set_function_bin_addr(int func_id, uint64_t addr);
+
+    int get_registered_kernel_count() const;
+    int get_registered_kernel_func_id(int index) const;
+    void clear_registered_kernels();
+
+    // =========================================================================
+    // Deprecated API (for platform compatibility, always returns 0/nullptr)
+    // Task graph is now managed by PTO2Runtime, not Runtime
+    // =========================================================================
+
+    /** @deprecated Task count is now in PTO2 shared memory */
+    int get_task_count() const { return 0; }
+
+    /** @deprecated RT2 uses PTO2DispatchPayload, not Task. Always returns nullptr. */
+    Task* get_task(int) { return nullptr; }
+
+    /** @deprecated Use PTO2 dispatch mode */
+    bool get_use_pto2_dispatch() const { return true; }
+
+    /** @deprecated Use PTO2 dispatch mode */
+    void set_use_pto2_dispatch(bool) {}
+
+    // =========================================================================
+    // Host API (host-only, not copied to device)
+    // =========================================================================
+
+    // Host API function pointers for device memory operations
+    // NOTE: Placed at end of class to avoid affecting device memory layout
+    HostApi host_api;
+};
+
+#endif  // RUNTIME_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -1,0 +1,308 @@
+#pragma once
+
+#include <stdint.h>
+#include <memory.h>
+
+#include <sstream>
+
+#include "common.h"
+#include "data_type.h"
+
+constexpr int RUNTIME_MAX_TENSOR_DIMS = 5;
+
+/**
+ * Buffer Handle
+ *
+ * Represents a device memory buffer with address and total size in bytes.
+ * This is the underlying memory allocation that a Tensor describes access patterns for.
+ */
+struct PTOBufferHandle {
+    uint64_t addr;  // Device memory address (bytes)
+    uint64_t size;  // Total buffer size in bytes
+};
+
+enum class OverlapStatus {
+    NO_OVERLAP,
+    COVERED,
+    OTHER,
+};
+
+struct Segment {
+    uint64_t begin;
+    uint64_t end;
+
+    bool line_segment_intersection(const Segment& other) const { return end > other.begin && other.end > begin; }
+    bool contains(const Segment& other) const { return begin <= other.begin && other.end <= end; }
+};
+
+/**
+ * Tensor descriptor for Task input/output
+ *
+ * Describes a memory access pattern on Global Memory (GM) using
+ * raw_shapes (underlying buffer dimensions), shapes (current view dimensions),
+ * and offsets (multi-dimensional offset into the buffer).
+ *
+ * - `buffer` contains the underlying memory allocation (addr in bytes, size in bytes)
+ * - `raw_shapes[]`, `shapes[]`, `offsets[]` are in ELEMENTS
+ * - `dtype` specifies element type for interpreting buffer contents
+ *
+ * Example: buffer.addr=base, dtype=FLOAT32, raw_shapes=[10, 6], shapes=[3, 6], offsets=[1, 0]
+ * Memory access pattern:
+ *   - Start at buffer.addr + (1*6+0)*4 = buffer.addr + 24 bytes
+ *   - Inner dim: access 6 consecutive elements
+ *   - Outer dim: 3 rows with stride 6 elements (derived from raw_shapes[1])
+ */
+struct Tensor {
+    // === Data fields (same layout as former TensorData) ===
+    PTOBufferHandle buffer;                        // Underlying memory buffer (addr in bytes, size in bytes)
+    int32_t version;                               // Tensor version for overlap detection
+    uint64_t start_offset;                         // Cached 1D element offset (precomputed from raw_shapes + offsets)
+    uint64_t ndims;                                // Number of dimensions used
+    DataType dtype;                                // Data type of tensor elements
+    uint64_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
+    uint64_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
+    uint64_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
+
+    Tensor() = default;
+    Tensor(const Tensor&) = default;
+    Tensor& operator=(const Tensor&) = default;
+    Tensor(Tensor&&) = default;
+    Tensor& operator=(Tensor&&) = default;
+    ~Tensor() = default;
+
+    Tensor(void* addr,
+        uint64_t buffer_size_bytes,
+        const uint64_t raw_shapes[],
+        const uint64_t shapes[],
+        const uint64_t offsets[],
+        uint64_t ndims,
+        DataType dtype,
+        int32_t version) {
+        init(addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version);
+    }
+
+    // --- Initialization ---
+    void init(void* addr,
+        uint64_t buffer_size_bytes,
+        const uint64_t in_raw_shapes[],
+        const uint64_t in_shapes[],
+        const uint64_t in_offsets[],
+        uint64_t in_ndims,
+        DataType in_dtype,
+        int32_t in_version) {
+        buffer = {reinterpret_cast<uint64_t>(addr), buffer_size_bytes};
+        ndims = in_ndims;
+        dtype = in_dtype;
+        version = in_version;
+        for (uint64_t i = 0; i < in_ndims; i++) {
+            raw_shapes[i] = in_raw_shapes[i];
+            shapes[i] = in_shapes[i];
+            offsets[i] = in_offsets[i];
+        }
+    }
+
+    void init(const Tensor& other) {
+        buffer = other.buffer;
+        version = other.version;
+        ndims = other.ndims;
+        dtype = other.dtype;
+        for (uint64_t i = 0; i < ndims; i++) {
+            raw_shapes[i] = other.raw_shapes[i];
+            shapes[i] = other.shapes[i];
+            offsets[i] = other.offsets[i];
+        }
+    }
+
+    void init_with_view(const Tensor& other, const uint64_t view_shapes[], const uint64_t view_offsets[]) {
+        buffer = other.buffer;
+        ndims = other.ndims;
+        dtype = other.dtype;
+        version = other.version;
+        for (uint64_t i = 0; i < ndims; i++) {
+            raw_shapes[i] = other.raw_shapes[i];
+            shapes[i] = view_shapes[i];
+            offsets[i] = other.offsets[i] + view_offsets[i];
+        }
+    }
+
+    // --- Operations ---
+    void update_start_offset() {
+        uint64_t result = 0;
+        uint64_t stride = 1;
+        for (int i = static_cast<int>(ndims) - 1; i >= 0; i--) {
+            result += offsets[i] * stride;
+            stride *= raw_shapes[i];
+        }
+        start_offset = result;
+    }
+
+    void copy(const Tensor &other) {
+        init(other);
+    }
+
+    Tensor view(const uint64_t view_shapes[], const uint64_t view_offsets[]) const {
+        Tensor result;
+        result.init_with_view(*this, view_shapes, view_offsets);
+        return result;
+    }
+
+    bool is_contiguous() const {
+        if (ndims == 0) {
+            return true;
+        }
+        for (uint64_t i = 1; i < ndims; i++) {
+            if (shapes[i] != raw_shapes[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool valid_reshape(const uint64_t new_shapes[], uint64_t new_ndims) const {
+        uint64_t x = numel();
+        uint64_t y = 1;
+        for (size_t i = 0; i < new_ndims; i++) {
+            y *= new_shapes[i];
+        }
+        return x == y;
+    }
+
+    Tensor reshape(const uint64_t new_shapes[], uint64_t new_ndims) const {
+        debug_assert(valid_reshape(new_shapes, new_ndims));
+        always_assert(is_contiguous());
+        Tensor result;
+        result.copy(*this);
+        result.ndims = new_ndims;
+        for (uint64_t i = 0; i < new_ndims; i++) {
+            result.raw_shapes[i] = new_shapes[i];
+            result.shapes[i] = new_shapes[i];
+            result.offsets[i] = 0;
+        }
+        return result;
+    }
+
+    bool valid_transpose(uint64_t x, uint64_t y) const { return x < ndims && y < ndims; }
+
+    Tensor transpose(uint64_t x, uint64_t y) const {
+        debug_assert(valid_transpose(x, y));
+        Tensor result;
+        result.copy(*this);
+        std::swap(result.raw_shapes[x], result.raw_shapes[y]);
+        std::swap(result.shapes[x], result.shapes[y]);
+        std::swap(result.offsets[x], result.offsets[y]);
+        return result;
+    }
+
+    uint64_t numel() const {
+        if (ndims == 0) {
+            return 0;
+        }
+        uint64_t total = 1;
+        for (uint64_t i = 0; i < ndims; i++) {
+            total *= shapes[i];
+        }
+        return total;
+    }
+
+    bool is_same_memref(const Tensor& other) const { return buffer.addr == other.buffer.addr; }
+
+    OverlapStatus is_overlap(const Tensor& pre_task_output) const {
+        debug_assert(is_same_memref(pre_task_output));
+        debug_assert(version >= pre_task_output.version);
+        if (version > pre_task_output.version) {
+            return OverlapStatus::OTHER;
+        }
+        bool contains = true;
+        for (uint64_t i = 0; i < ndims; i++) {
+            Segment input_range_dim_i{offsets[i], offsets[i] + shapes[i]};
+            Segment output_range_dim_i{
+                pre_task_output.offsets[i], pre_task_output.offsets[i] + pre_task_output.shapes[i]};
+            if (!input_range_dim_i.line_segment_intersection(output_range_dim_i)) {
+                return OverlapStatus::NO_OVERLAP;
+            } else if (!input_range_dim_i.contains(output_range_dim_i)) {
+                contains = false;
+            }
+        }
+        if (contains) {
+            return OverlapStatus::COVERED;
+        }
+        return OverlapStatus::OTHER;
+    }
+
+    std::string dump() const {
+        std::stringstream ss;
+        std::string indent = "    ";
+        ss << "{" << std::endl;
+        ss << indent << "buffer.addr: " << buffer.addr << std::endl;
+        ss << indent << "buffer.size: " << buffer.size << " bytes" << std::endl;
+        ss << indent << "dtype: " << get_dtype_name(dtype) << std::endl;
+        ss << indent << "ndims: " << ndims << std::endl;
+        ss << indent << "version: " << version << std::endl;
+
+        ss << indent << "raw_shapes: [";
+        for (uint64_t i = 0; i < ndims; i++) {
+            if (i > 0) {
+                ss << ", ";
+            }
+            ss << raw_shapes[i];
+        }
+        ss << "]" << std::endl;
+        ss << indent << "shapes: [";
+        for (uint64_t i = 0; i < ndims; i++) {
+            if (i > 0) {
+                ss << ", ";
+            }
+            ss << shapes[i];
+        }
+        ss << "]" << std::endl;
+        ss << indent << "offsets: [";
+        for (uint64_t i = 0; i < ndims; i++) {
+            if (i > 0) {
+                ss << ", ";
+            }
+            ss << offsets[i];
+        }
+        ss << "]" << std::endl;
+        ss << "}" << std::endl;
+        return ss.str();
+    }
+};
+
+using TensorData = Tensor;
+
+// =============================================================================
+// Factory Helpers
+// =============================================================================
+/**
+ * Create a Tensor for pre-allocated external memory.
+ */
+static inline Tensor make_tensor_external(void* addr,
+    const uint64_t shapes[],
+    uint64_t ndims,
+    DataType dtype = DataType::FLOAT32,
+    int32_t version = 0) {
+    static uint64_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
+    uint64_t total = 1;
+    for (uint64_t i = 0; i < ndims; i++) {
+        total *= shapes[i];
+    }
+    return Tensor(addr, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version);
+}
+
+/**
+ * Create a Tensor for runtime-allocated output (addr=0).
+ * NO memory allocation: only records dtype, shape, and buffer.size in the Tensor struct.
+ * The runtime allocates from the heap ring and fills buffer.addr during pto2_submit_task
+ * when this tensor is passed as OUTPUT param. No buffer content is ever copied.
+ */
+static inline Tensor make_tensor(const uint64_t shapes[],
+    uint64_t ndims,
+    DataType dtype = DataType::FLOAT32,
+    int32_t version = 0) {
+    static uint64_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
+    uint64_t total = 1;
+    for (uint64_t i = 0; i < ndims; i++) {
+        total *= shapes[i];
+    }
+    return Tensor(0, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version);
+}


### PR DESCRIPTION
Copy src/a2a3/runtime/tensormap_and_ringbuffer/ to src/a5/runtime/, renaming the aicore_execute() parameter from block_idx to core_idx to match a5 naming conventions.