### PR TITLE
[WIP] Fix: guard SCHED/ORCH profiling variables at correct macro levels

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -227,20 +227,27 @@ struct AicpuExecutor {
 #if PTO2_PROFILING
         ,
         bool profiling_enabled,
+#if PTO2_SCHED_PROFILING
         uint64_t& complete_probe_count,
         uint64_t& complete_hit_count,
-        uint32_t& phase_complete_count,
+#endif
+        uint32_t& phase_complete_count
+#if PTO2_SCHED_PROFILING
+        ,
         uint64_t& notify_edges_total,
         int32_t& notify_max_degree,
         uint64_t& notify_tasks_enqueued,
         uint64_t& fanin_edges_total,
         int32_t& fanin_max_degree
 #endif
+#endif
 #if PTO2_SCHED_PROFILING
         ,
         uint64_t& sched_complete_perf_cycle
 #endif
     ) {
+        // Avoid unused-parameter warnings when profiling is disabled.
+        (void)hank;
         for (int32_t i = ct.running_count - 1; i >= 0; i--) {
             int32_t core_id = ct.running[i];
             uint64_t reg_addr = core_id_to_reg_addr_[core_id];
@@ -250,7 +257,7 @@ struct AicpuExecutor {
             int32_t reg_task_id = EXTRACT_TASK_ID(reg_val);
             int32_t reg_state = EXTRACT_TASK_STATE(reg_val);
             bool done = reg_task_id == task_id && reg_state == TASK_FIN_STATE;
-#if PTO2_PROFILING
+#if PTO2_PROFILING && PTO2_SCHED_PROFILING
             if (profiling_enabled) {
                 complete_probe_count++;
                 if (done) {
@@ -270,10 +277,7 @@ struct AicpuExecutor {
                 phase_complete_count++;
 #elif PTO2_PROFILING
                 PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
-                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, &local_buf);
-                notify_edges_total += cstats.fanout_edges;
-                if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
-                notify_tasks_enqueued += cstats.tasks_enqueued;
+                (void)rt->scheduler.on_task_complete(task_id, &local_buf);
                 phase_complete_count++;
 #else
                 rt->scheduler.on_task_complete(task_id, &local_buf);
@@ -290,7 +294,7 @@ struct AicpuExecutor {
                         int32_t fe = rt->scheduler.on_task_release(deferred_release_ids[--deferred_release_count]);
 #endif
                         (void)fe;
-#if PTO2_PROFILING
+#if PTO2_PROFILING && PTO2_SCHED_PROFILING
                         fanin_edges_total += fe;
                         if (fe > fanin_max_degree) fanin_max_degree = fe;
 #endif
@@ -345,8 +349,10 @@ struct AicpuExecutor {
 #if PTO2_PROFILING
         ,
         bool profiling_enabled,
+#if PTO2_SCHED_PROFILING
         uint64_t& pop_hit,
         uint64_t& pop_miss,
+#endif
         uint32_t& phase_dispatch_count
 #endif
 #if PTO2_SCHED_PROFILING
@@ -370,7 +376,9 @@ struct AicpuExecutor {
 #endif
                 if (task_id >= 0) {
 #if PTO2_PROFILING
+#if PTO2_SCHED_PROFILING
                     pop_hit++;
+#endif
                     phase_dispatch_count++;
 #endif
 #if PTO2_SCHED_PROFILING
@@ -403,7 +411,7 @@ struct AicpuExecutor {
                         CT == CoreType::AIC ? "AIC" : "AIV",
                         core_id);
                 } else {
-#if PTO2_PROFILING
+#if PTO2_PROFILING && PTO2_SCHED_PROFILING
                     pop_miss++;
 #endif
                     break;
@@ -835,9 +843,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     uint64_t sched_complete_cycle = 0;
     uint64_t sched_dispatch_cycle = 0;
     uint64_t sched_idle_cycle = 0;
+    uint64_t sched_loop_count = 0;
+    uint32_t phase_complete_count = 0;
+    uint32_t phase_dispatch_count = 0;
+#if PTO2_SCHED_PROFILING
     uint64_t complete_probe_count = 0;
     uint64_t complete_hit_count = 0;
-    uint64_t sched_loop_count = 0;
     uint64_t notify_edges_total = 0;
     int32_t  notify_max_degree = 0;
     uint64_t notify_tasks_enqueued = 0;
@@ -845,11 +856,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     int32_t  fanin_max_degree = 0;
     uint64_t pop_hit = 0;
     uint64_t pop_miss = 0;
-    uint32_t phase_complete_count = 0;
-    uint32_t phase_dispatch_count = 0;
     uint64_t local_dispatch_count = 0;
     uint64_t local_overflow_count = 0;
-#if PTO2_SCHED_PROFILING
     uint64_t sched_complete_perf_cycle = 0;
     uint64_t sched_dispatch_pop_cycle = 0;
     uint64_t sched_dispatch_setup_cycle = 0;
@@ -916,19 +924,29 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         int32_t completed_this_turn = 0;
 
         // Check AIC running cores
+#if PTO2_PROFILING
         bool try_completed = false;
+#endif
         always_assert(local_buf.count == 0);  // Invariant: previous iteration fully consumed
         if (tracker.aic().running_count > 0) {
+#if PTO2_PROFILING
             try_completed = true;
+#endif
             check_running_cores_for_completion<CoreType::AIC>(
                 thread_idx, tracker.aic(), hank, executing_task_ids,
                 completed_this_turn, cur_thread_completed, made_progress,
                 deferred_release_ids, deferred_release_count,
                 local_buf
 #if PTO2_PROFILING
-                , profiling_enabled, complete_probe_count, complete_hit_count, phase_complete_count,
-                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                , profiling_enabled
+#if PTO2_SCHED_PROFILING
+                , complete_probe_count, complete_hit_count
+#endif
+                , phase_complete_count
+#if PTO2_SCHED_PROFILING
+                , notify_edges_total, notify_max_degree, notify_tasks_enqueued,
                 fanin_edges_total, fanin_max_degree
+#endif
 #endif
 #if PTO2_SCHED_PROFILING
                 , sched_complete_perf_cycle
@@ -938,16 +956,24 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
         // Check AIV running cores
         if (tracker.aiv().running_count > 0) {
+#if PTO2_PROFILING
             try_completed = true;
+#endif
             check_running_cores_for_completion<CoreType::AIV>(
                 thread_idx, tracker.aiv(), hank, executing_task_ids,
                 completed_this_turn, cur_thread_completed, made_progress,
                 deferred_release_ids, deferred_release_count,
                 local_buf
 #if PTO2_PROFILING
-                , profiling_enabled, complete_probe_count, complete_hit_count, phase_complete_count,
-                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                , profiling_enabled
+#if PTO2_SCHED_PROFILING
+                , complete_probe_count, complete_hit_count
+#endif
+                , phase_complete_count
+#if PTO2_SCHED_PROFILING
+                , notify_edges_total, notify_max_degree, notify_tasks_enqueued,
                 fanin_edges_total, fanin_max_degree
+#endif
 #endif
 #if PTO2_SCHED_PROFILING
                 , sched_complete_perf_cycle
@@ -968,23 +994,33 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             }
         }
 
+        // Complete-phase profiling (only when enabled)
 #if PTO2_PROFILING
-        if (!try_completed) {
-            CYCLE_COUNT_LAP(sched_idle_cycle);
-        } else {
-            if (profiling_enabled && phase_complete_count > 0) {
-                perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, sched_loop_count, phase_complete_count);
-                _t0_phase = _t1;
-                phase_complete_count = 0;
+        if (profiling_enabled) {
+            if (!try_completed) {
+                CYCLE_COUNT_LAP(sched_idle_cycle);
+            } else {
+                CYCLE_COUNT_LAP(sched_complete_cycle);
+                if (phase_complete_count > 0) {
+                    perf_aicpu_record_phase(
+                        thread_idx,
+                        AicpuPhaseId::SCHED_COMPLETE,
+                        _t0_phase,
+                        _t1,
+                        sched_loop_count,
+                        phase_complete_count);
+                    _t0_phase = _t1;
+                    phase_complete_count = 0;
+                }
             }
-            CYCLE_COUNT_LAP(sched_complete_cycle);
         }
 #endif
 
         // Phase 2: Local dispatch — match local_buf tasks to idle cores (zero MPMC operations)
         // Phase 3: Global queue — push overflow to readyQ + fill remaining idle cores from readyQ
+#if PTO2_PROFILING
         bool try_pushed = false;
+#endif
 
         // Local dispatch: drain local_buf, match to idle cores by type
         int32_t overflow_ids[LOCAL_READY_CAP];
@@ -996,7 +1032,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             CoreTypeTracker& ct = (ct_type == CoreType::AIC) ? tracker.aic() : tracker.aiv();
 
             if (ct.idle_count > 0) {
+#if PTO2_PROFILING
                 try_pushed = true;
+#endif
                 int32_t idle_idx = ct.idle_count - 1;
                 int32_t core_id = ct.idle[idle_idx];
                 PTO2TaskPayload* task_pl = &task_payloads[task_id & window_mask];
@@ -1015,9 +1053,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     }
                     core_dispatch_counts_[core_id]++;
                 }
-                pop_hit++;
                 phase_dispatch_count++;
+#if PTO2_SCHED_PROFILING
+                pop_hit++;
                 local_dispatch_count++;
+#endif
 #endif
                 write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE,
                           static_cast<uint64_t>(task_id + 1));
@@ -1028,7 +1068,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                           thread_idx, task_id, core_id);
             } else {
                 overflow_ids[overflow_count++] = task_id;
-#if PTO2_PROFILING
+#if PTO2_PROFILING && PTO2_SCHED_PROFILING
                 local_overflow_count++;
 #endif
             }
@@ -1043,12 +1083,18 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Global dispatch: fill remaining idle cores from global readyQ
         // Process AIC cores if CUBE queue has tasks
         if (tracker.aic().idle_count > 0 && rt->scheduler.ready_queues[PTO2_WORKER_CUBE].size() > 0) {
+#if PTO2_PROFILING
             try_pushed = true;
+#endif
             dispatch_ready_tasks_to_idle_cores<CoreType::AIC>(
                 runtime, thread_idx, tracker.aic(), executing_task_ids, made_progress,
                 task_descriptors, task_payloads, window_mask
 #if PTO2_PROFILING
-                , profiling_enabled, pop_hit, pop_miss, phase_dispatch_count
+                , profiling_enabled
+#if PTO2_SCHED_PROFILING
+                , pop_hit, pop_miss
+#endif
+                , phase_dispatch_count
 #endif
 #if PTO2_SCHED_PROFILING
                 , sched_dispatch_pop_cycle, sched_dispatch_setup_cycle
@@ -1058,12 +1104,18 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
         // Process AIV cores if VECTOR queue has tasks
         if (tracker.aiv().idle_count > 0 && rt->scheduler.ready_queues[PTO2_WORKER_VECTOR].size() > 0) {
+#if PTO2_PROFILING
             try_pushed = true;
+#endif
             dispatch_ready_tasks_to_idle_cores<CoreType::AIV>(
                 runtime, thread_idx, tracker.aiv(), executing_task_ids, made_progress,
                 task_descriptors, task_payloads, window_mask
 #if PTO2_PROFILING
-                , profiling_enabled, pop_hit, pop_miss, phase_dispatch_count
+                , profiling_enabled
+#if PTO2_SCHED_PROFILING
+                , pop_hit, pop_miss
+#endif
+                , phase_dispatch_count
 #endif
 #if PTO2_SCHED_PROFILING
                 , sched_dispatch_pop_cycle, sched_dispatch_setup_cycle
@@ -1071,19 +1123,27 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             );
         }
 
+        // Dispatch-phase profiling (only when enabled)
 #if PTO2_PROFILING
-        if (!try_pushed) {
-            CYCLE_COUNT_LAP(sched_idle_cycle);
-        } else {
-            if (profiling_enabled && phase_dispatch_count > 0) {
-                perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, sched_loop_count, phase_dispatch_count);
-                _t0_phase = _t1;
-                phase_dispatch_count = 0;
+        if (profiling_enabled) {
+            if (!try_pushed) {
+                CYCLE_COUNT_LAP(sched_idle_cycle);
+            } else {
+                CYCLE_COUNT_LAP(sched_dispatch_cycle);
+                if (phase_dispatch_count > 0) {
+                    perf_aicpu_record_phase(
+                        thread_idx,
+                        AicpuPhaseId::SCHED_DISPATCH,
+                        _t0_phase,
+                        _t1,
+                        sched_loop_count,
+                        phase_dispatch_count);
+                    _t0_phase = _t1;
+                    phase_dispatch_count = 0;
+                }
             }
-            CYCLE_COUNT_LAP(sched_dispatch_cycle);
-#endif
         }
+#endif
 
         if (made_progress) {
             idle_iterations = 0;
@@ -1098,7 +1158,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 int32_t fe = rt->scheduler.on_task_release(deferred_release_ids[--deferred_release_count]);
 #endif
                 (void)fe;
-#if PTO2_PROFILING
+#if PTO2_PROFILING && PTO2_SCHED_PROFILING
                 fanin_edges_total += fe;
                 if (fe > fanin_max_degree) fanin_max_degree = fe;
 #endif
@@ -1183,11 +1243,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             }
 #if PTO2_PROFILING
             if (profiling_enabled) {
+                CYCLE_COUNT_LAP(sched_idle_cycle);
                 perf_aicpu_record_phase(thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT,
                                         _t0_phase, _t1, sched_loop_count, 0);
                 _t0_phase = _t1;
             }
-            CYCLE_COUNT_LAP(sched_idle_cycle);
 #endif
         }
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -9,15 +9,18 @@ PTO Runtime2 uses a hierarchical profiling system with compile-time macros to co
 ## Profiling Macro Hierarchy
 
 ```
-PTO2_PROFILING (base level, default=0)
+PTO2_PROFILING (base level, default=1)
 ├── PTO2_ORCH_PROFILING (orchestrator, default=0, requires PTO2_PROFILING=1)
+|   └── PTO2_TENSORMAP_PROFILING (tensormap, default=0, requires PTO2_ORCH_PROFILING=1)
 ├── PTO2_SCHED_PROFILING (scheduler, default=0, requires PTO2_PROFILING=1)
-└── PTO2_TENSORMAP_PROFILING (tensormap, default=0, requires PTO2_PROFILING=1)
+└── dump merged_swimlane_*.json (requires --enable-profiling)
+
 ```
+
 
 ### Compile-Time Validation
 
-Each sub-level macro requires `PTO2_PROFILING=1`:
+Each sub-level macro requires its parent macro:
 
 ```cpp
 #if PTO2_ORCH_PROFILING && !PTO2_PROFILING
@@ -28,8 +31,8 @@ Each sub-level macro requires `PTO2_PROFILING=1`:
 #error "PTO2_SCHED_PROFILING requires PTO2_PROFILING=1"
 #endif
 
-#if PTO2_TENSORMAP_PROFILING && !PTO2_PROFILING
-#error "PTO2_TENSORMAP_PROFILING requires PTO2_PROFILING=1"
+#if PTO2_TENSORMAP_PROFILING && !PTO2_ORCH_PROFILING
+#error "PTO2_TENSORMAP_PROFILING requires PTO2_ORCH_PROFILING=1"
 #endif
 ```
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -23,7 +23,7 @@
 // =============================================================================
 // Orchestrator Profiling (compile-time toggle)
 // =============================================================================
-#if PTO2_PROFILING
+#if PTO2_ORCH_PROFILING
 #include "aicpu/device_time.h"
 #include "aicpu/performance_collector_aicpu.h"
 // Weak fallback for builds that don't link device_time.cpp (e.g. host).
@@ -43,7 +43,7 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // Also hidden to prevent HOST .so from polluting the global symbol table.
 __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
     AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
-// Accumulated nanoseconds per sub-step
+// Accumulated cycles per sub-step (only needed when orch profiling is on)
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // task ring alloc
 static uint64_t g_orch_params_cycle = 0;     // param copy
@@ -54,7 +54,6 @@ static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
 static uint64_t g_orch_scope_end_cycle = 0;  // scope_end overhead
 static int64_t  g_orch_submit_count = 0;
 static uint32_t g_orch_submit_idx = 0;
-#if PTO2_ORCH_PROFILING
 uint64_t g_orch_alloc_wait_cycle = 0;
 uint64_t g_orch_heap_wait_cycle = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
@@ -64,21 +63,27 @@ uint64_t g_orch_heap_atomic_count = 0;
 uint64_t g_orch_fanin_atomic_count = 0;
 uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
-#elif PTO2_SCHED_PROFILING
-// When only PTO2_SCHED_PROFILING is enabled, shared methods still need
-// orch counters as targets for orchestrator-context calls.
-uint64_t g_orch_fanin_atomic_count = 0;
-uint64_t g_orch_fanin_wait_cycle = 0;
-uint64_t g_orch_finalize_atomic_count = 0;
-uint64_t g_orch_scope_end_atomic_count = 0;
-#endif
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
 #define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
 #define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid) do { \
     _t1 = get_sys_cnt_aicpu(); \
     acc += (_t1 - _t0); \
+    perf_aicpu_record_orch_phase(phase_id, _t0, _t1, g_orch_submit_idx, tid); \
     _t0 = _t1; \
 } while(0)
+#elif PTO2_SCHED_PROFILING
+// When only PTO2_SCHED_PROFILING is enabled, pto_scheduler/pto_runtime2_types
+// still call get_sys_cnt_aicpu(). Host build does not link device_time.cpp,
+// so provide a weak fallback (AICPU build gets strong symbol from device_time.cpp).
+__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
+// Shared methods still need orch counters as targets for orchestrator-context calls.
+uint64_t g_orch_fanin_atomic_count = 0;
+uint64_t g_orch_fanin_wait_cycle = 0;
+uint64_t g_orch_finalize_atomic_count = 0;
+uint64_t g_orch_scope_end_atomic_count = 0;
+#define CYCLE_COUNT_START()
+#define CYCLE_COUNT_LAP(acc)
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)
 #else
 #define CYCLE_COUNT_START()
 #define CYCLE_COUNT_LAP(acc)
@@ -194,7 +199,7 @@ void pto2_scope_begin(PTO2OrchestratorState* orch) {
 void pto2_scope_end(PTO2OrchestratorState* orch) {
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
 
-#if PTO2_PROFILING
+#if PTO2_ORCH_PROFILING
     uint64_t _se0 = get_sys_cnt_aicpu();
 #endif
 
@@ -208,10 +213,10 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
     // Rewind the task buffer — these entries are no longer needed
     orch->scope_tasks_size = begin;
 
-#if PTO2_PROFILING
+#if PTO2_ORCH_PROFILING
     uint64_t _se1 = get_sys_cnt_aicpu();
     g_orch_scope_end_cycle += (_se1 - _se0);
-    // perf_aicpu_record_orch_phase(AicpuPhaseId::ORCH_SCOPE_END, _se0, _se1, g_orch_submit_idx, -1);
+    perf_aicpu_record_orch_phase(AicpuPhaseId::ORCH_SCOPE_END, _se0, _se1, g_orch_submit_idx, -1);
 #endif
 }
 
@@ -441,6 +446,8 @@ void pto2_submit_task(
 
 #if PTO2_PROFILING
     orch->tasks_submitted++;
+#endif
+#if PTO2_ORCH_PROFILING
     g_orch_submit_count++;
     g_orch_submit_idx++;
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -547,11 +547,8 @@ struct PTO2SchedulerState {
 
 #if PTO2_SCHED_PROFILING
         extern uint64_t g_sched_lock_cycle[], g_sched_fanout_cycle[];
-        extern uint64_t g_sched_self_consumed_cycle[];
         extern uint64_t g_sched_lock_atomic_count[], g_sched_lock_wait_cycle[];
         extern uint64_t g_sched_fanout_atomic_count[], g_sched_push_wait_cycle[];
-        extern uint64_t g_sched_self_atomic_count[];
-        extern uint64_t g_sched_complete_count[];
         uint64_t lock_atomics = 0, lock_wait = 0;
         PTO2_SCHED_CYCLE_START();
 #endif
@@ -644,7 +641,8 @@ struct PTO2SchedulerState {
         // Self consumed check
 #if PTO2_SCHED_PROFILING
         uint64_t self_atomics = 0;
-        check_and_handle_consumed(slot, task, self_atomics);
+        PTO2TaskDescriptor& task = pto2_sm_get_task_by_slot(sm_handle, slot);
+        check_and_handle_consumed(task_id, task, self_atomics);
         g_sched_self_atomic_count[thread_idx] += self_atomics;
         PTO2_SCHED_CYCLE_LAP(g_sched_self_consumed_cycle[thread_idx]);
         g_sched_complete_count[thread_idx]++;


### PR DESCRIPTION
Eliminate unnecessary overhead when PTO2_SCHED_PROFILING=0 or PTO2_ORCH_PROFILING=0 but PTO2_PROFILING=1.

Previously, variables only consumed at higher profiling levels (PTO2_SCHED_PROFILING, PTO2_ORCH_PROFILING) were being updated unconditionally whenever PTO2_PROFILING=1. This caused wasted work per hot-path operation:
- ~5 counter updates per task completion in the scheduler
- ~8 get_sys_cnt_aicpu() timer calls per task submission in the orchestrator (plus 8 global variable writes)

Changes:
- aicpu_executor.cpp: guard SCHED-only variables (complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, pop_hit, pop_miss, local_dispatch_count, local_overflow_count) with #if PTO2_SCHED_PROFILING; also guard fanin_edges_total update
- pto_orchestrator.cpp: move CYCLE_COUNT_* macros and all g_orch_* cycle/atomic globals under #if PTO2_ORCH_PROFILING; keep only shared fanin/finalize/scope-end atomics accessible under PTO2_SCHED_PROFILING; split pto2_submit_task() counter block to keep tasks_submitted under PTO2_PROFILING and orch-only counters under PTO2_ORCH_PROFILING
- pto_scheduler.h: remove stale extern declarations; fix check_and_handle_consumed() to pass task_id instead of slot
- docs/profiling_levels.md: update to reflect corrected behavior