### PR TITLE
Refactor: slim dispatch payload and move build to AICPU dispatch time

### DIFF
--- a/src/a2a3/platform/include/aicore/performance_collector_aicore.h
+++ b/src/a2a3/platform/include/aicore/performance_collector_aicore.h
@@ -27,23 +27,22 @@
  * Writes performance metrics to the provided buffer. Buffer management
  * and status tracking are handled by AICPU.
  *
+ * AICore records task_id and timestamps only. AICPU fills func_id and
+ * core_type at completion time from TaskDescriptor.
+ *
  * @param perf_buf Performance buffer pointer
  * @param task_id Task ID
- * @param func_id Function ID
  * @param start_time Start timestamp
  * @param end_time End timestamp
  * @param kernel_ready_time Kernel ready timestamp
- * @param core_type Core type (AIC/AIV)
  */
 __aicore__ __attribute__((always_inline))
 static inline void perf_aicore_record_task(
     __gm__ PerfBuffer* perf_buf,
     uint32_t task_id,
-    uint32_t func_id,
     uint64_t start_time,
     uint64_t end_time,
-    uint64_t kernel_ready_time,
-    CoreType core_type) {
+    uint64_t kernel_ready_time) {
 
     // Read current buffer count
     dcci(&perf_buf->count, SINGLE_CACHE_LINE);
@@ -55,13 +54,11 @@ static inline void perf_aicore_record_task(
 
     __gm__ PerfRecord* record = &perf_buf->records[idx];
 
-    // Write record data
+    // Write record data (func_id and core_type filled by AICPU at completion)
     record->start_time = start_time;
     record->end_time = end_time;
     record->kernel_ready_time = kernel_ready_time;
     record->task_id = task_id;
-    record->func_id = func_id;
-    record->core_type = core_type;
 
     perf_buf->count = idx + 1;
 

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -70,9 +70,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, task_ptr->task_id, task_ptr->func_id,
-                                      start_time, end_time, kernel_ready_time,
-                                      core_type);
+                perf_aicore_record_task(perf_buf, actual_task_id,
+                                      start_time, end_time, kernel_ready_time);
             }
 
             last_task_id = task_id;

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -645,6 +645,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     if (count > 0) {
                         PerfRecord* record = &perf_buf->records[count - 1];
                         if (record->task_id == static_cast<uint32_t>(completed_task_id)) {
+                            record->func_id = runtime.tasks[completed_task_id].func_id;
+                            record->core_type = h->core_type;
                             perf_aicpu_record_dispatch_and_finish_time(
                                 record, dispatch_timestamps_[core_id], finish_ts);
                         }
@@ -780,6 +782,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     if (count > 0) {
                         PerfRecord* record = &perf_buf->records[count - 1];
                         if (record->task_id == static_cast<uint32_t>(completed_task_id)) {
+                            record->func_id = runtime.tasks[completed_task_id].func_id;
+                            record->core_type = h->core_type;
                             perf_aicpu_record_dispatch_and_finish_time(
                                 record, dispatch_timestamps_[core_id], finish_ts);
                         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -16,13 +16,11 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
 /**
  * Execute task from PTO2DispatchPayload.
  *
- * Directly accesses PTO2DispatchPayload fields for task execution,
- * matching ref_runtime implementation for a2a3 compatibility.
+ * Reads function_bin_addr and args from the dispatch payload.
  *
- * @param task_ptr Pointer to PTO2DispatchPayload in global memory
+ * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* task_ptr) {
-    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(task_ptr);
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
@@ -42,8 +40,8 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* 
  * 2. Report physical core ID and core type, signal AICore ready
  * 3. Poll DATA_MAIN_BASE register for task dispatch until exit signal
  *
- * Task dispatch uses PTO2DispatchPayload from per-core payload array.
- * Supports performance profiling when runtime->enable_profiling is true.
+ * Task dispatch reads PTO2DispatchPayload address from Handshake.task.
+ * Task ID is derived from the register value (task_id + 1 encoding).
  *
  * @param runtime Pointer to Runtime in global memory
  * @param block_idx Block index (core ID)
@@ -74,10 +72,6 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     // Report initial idle status via register
     write_reg(RegId::COND, AICORE_IDLE_VALUE);
 
-    // Read per-core payload address from hank->task (written by AICPU before aicpu_ready)
-    __gm__ PTO2DispatchPayload* my_payload =
-        reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
-
     bool profiling_enabled = runtime->enable_profiling;
     uint64_t kernel_ready_time = 0;
     if (profiling_enabled) {
@@ -85,28 +79,33 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     }
 
     // Phase 3: Main execution loop - poll register for tasks until exit signal
-    uint32_t task_id = 0;
-    uint32_t last_task_id = 0;
+    // Register encoding: 0=idle, task_id+1=task, AICORE_EXIT_SIGNAL=exit
+    uint32_t reg_val = 0;
+    uint32_t last_reg_val = 0;
 
     while (true) {
-        task_id = static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE));
-        if (task_id == AICORE_EXIT_SIGNAL) {
+        reg_val = static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE));
+        if (reg_val == AICORE_EXIT_SIGNAL) {
             break;
         }
 
-        // Execute task if new (task_id encoding: 0=idle, task_id+1=task)
-        if (task_id == 0 || task_id == last_task_id) {
+        // Execute task if new (reg_val encoding: 0=idle, task_id+1=task)
+        if (reg_val == 0 || reg_val == last_reg_val) {
             SPIN_WAIT_HINT();
             continue;
         }
 
         {
-            // Invalidate cache to read fresh payload written by AICPU
-            dcci(my_payload, ENTIRE_DATA_CACHE);
+            uint32_t task_id = reg_val - 1;  // Decode: register holds task_id + 1
 
-            __gm__ PTO2DispatchPayload* payload = my_payload;
+            // Invalidate entire data cache to read fresh payload and hank->task
+            dcci(my_hank, ENTIRE_DATA_CACHE);
 
-            write_reg(RegId::COND, MAKE_ACK_VALUE(payload->mixed_task_id));
+            // Read per-task dispatch payload address (updated by AICPU each dispatch)
+            __gm__ PTO2DispatchPayload* payload =
+                reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+
+            write_reg(RegId::COND, MAKE_ACK_VALUE(task_id));
 
             // Performance profiling: record start time
             uint64_t start_time = 0;
@@ -115,19 +114,19 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             }
 
             // Execute the task
-            execute_task(reinterpret_cast<__gm__ void*>(payload));
+            execute_task(payload);
 
             // Performance profiling: record task execution
+            // (func_id and core_type are filled by AICPU at completion time)
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, payload->mixed_task_id, payload->kernel_id,
-                                       start_time, end_time, kernel_ready_time,
-                                       core_type);
+                perf_aicore_record_task(perf_buf, task_id,
+                                       start_time, end_time, kernel_ready_time);
             }
 
-            last_task_id = task_id;
-            write_reg(RegId::COND, MAKE_FIN_VALUE(payload->mixed_task_id));
+            last_reg_val = reg_val;
+            write_reg(RegId::COND, MAKE_FIN_VALUE(task_id));
         }
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -70,10 +70,13 @@ constexpr int32_t STALL_DUMP_CORE_MAX = 8;
 constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
 constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
 
-// PTO2 device-mode state (per-core dispatch payloads)
+static PTO2Runtime *rt{nullptr};
+
+// Per-core dispatch payload storage (one per physical core)
 static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
 
-static PTO2Runtime *rt{nullptr};
+// Per-core subtask slot tracking (which PTO2SubtaskSlot is running on each core)
+static PTO2SubtaskSlot s_executing_subslot[RUNTIME_MAX_WORKER];
 
 // Core information for discovery (with register address for fast dispatch)
 struct CoreInfo {
@@ -229,31 +232,22 @@ struct AicpuExecutor {
     void diagnose_stuck_state(
         Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank);
 
-    // Build PTO2DispatchPayload from PTO2TaskDescriptor for a specific subtask slot.
+    // Build slim PTO2DispatchPayload: only function_bin_addr + args.
+    // Metadata (mixed_task_id, subslot, kernel_id, core_type) stays in TaskDescriptor.
     void build_pto2_payload(PTO2DispatchPayload* out,
         Runtime* runtime,
-        PTO2TaskDescriptor* task,
-        PTO2TaskPayload* task_payload,
-        PTO2SubtaskSlot subslot,
-        CoreType core_type) {
-        int32_t slot_idx = static_cast<int32_t>(subslot);
-        out->mixed_task_id = task->mixed_task_id;
-        out->subslot = subslot;
-        out->kernel_id = task->kernel_id[slot_idx];
-        out->core_type = core_type;
-        out->function_bin_addr = runtime->get_function_bin_addr(task->kernel_id[slot_idx]);
+        int32_t kernel_id,
+        PTO2TaskPayload* task_pl) {
+        out->function_bin_addr = runtime->get_function_bin_addr(kernel_id);
         int32_t n = 0;
-
-        for (int32_t i = 0; i < task_payload->param_count; i++) {
-            if (!task_payload->is_tensor[i]) {
-                out->args[n++] = task_payload->scalar_value[i];
+        for (int32_t i = 0; i < task_pl->param_count; i++) {
+            if (!task_pl->is_tensor[i]) {
+                out->args[n++] = task_pl->scalar_value[i];
             } else {
-                out->args[n++] = reinterpret_cast<uint64_t>(&task_payload->tensors[i]);
-                task_payload->tensors[i].update_start_offset();
+                out->args[n++] = reinterpret_cast<uint64_t>(&task_pl->tensors[i]);
+                task_pl->tensors[i].update_start_offset();
             }
         }
-
-        out->num_args = n;
     }
 
     // Template methods for Phase 1 and Phase 2
@@ -306,9 +300,8 @@ struct AicpuExecutor {
 
             if (done) {
                 executing_task_ids[core_id] = AICPU_TASK_INVALID;
-                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
-                int32_t mixed_task_id = payload->mixed_task_id;
-                PTO2SubtaskSlot subslot = payload->subslot;
+                int32_t mixed_task_id = task_id;
+                PTO2SubtaskSlot subslot = s_executing_subslot[core_id];
 
                 // Two-stage completion: mark subtask done, then handle mixed-task completion
                 bool mixed_complete = rt->scheduler.on_subtask_complete(mixed_task_id, subslot);
@@ -361,7 +354,13 @@ struct AicpuExecutor {
                     uint32_t count = perf_buf->count;
                     if (count > 0) {
                         PerfRecord* record = &perf_buf->records[count - 1];
-                        if (record->task_id == static_cast<uint32_t>(payload->mixed_task_id)) {
+                        if (record->task_id == static_cast<uint32_t>(task_id)) {
+                            // Fill metadata that AICore doesn't know
+                            PTO2TaskDescriptor* td = &rt->sm_handle->task_descriptors[
+                                task_id & (rt->sm_handle->header->task_window_size - 1)];
+                            int32_t perf_slot_idx = static_cast<int32_t>(s_executing_subslot[core_id]);
+                            record->func_id = td->kernel_id[perf_slot_idx];
+                            record->core_type = CT;
                             perf_aicpu_record_dispatch_and_finish_time(
                                 record, dispatch_timestamps_[core_id], finish_ts);
                         }
@@ -480,7 +479,9 @@ struct AicpuExecutor {
 #endif
     ) {
         PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
-        build_pto2_payload(payload, runtime, task, task_pl, subslot, core_type);
+        int32_t slot_idx = static_cast<int32_t>(subslot);
+        build_pto2_payload(payload, runtime, task->kernel_id[slot_idx], task_pl);
+        s_executing_subslot[core_id] = subslot;
 #if PTO2_PROFILING
         if (profiling_enabled) {
             dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
@@ -816,6 +817,10 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
         dispatch_timestamps_[i] = 0;
         core_dispatch_counts_[i] = 0;
     }
+
+    // Clear per-core dispatch payloads and subslot tracking
+    memset(s_pto2_payload_per_core, 0, sizeof(s_pto2_payload_per_core));
+    memset(s_executing_subslot, 0, sizeof(s_executing_subslot));
 
     DEV_INFO("Init: PTO2 mode, task count from shared memory");
 
@@ -1292,33 +1297,32 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 // Dump AIC running cores
                 for (int32_t ci = 0; ci < tracker.aic().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
                     int32_t cid = tracker.aic().running[ci];
-                    Handshake* hh = &hank[cid];
-                    int32_t hw_task_id = -1;
+                    int32_t sw_tid = executing_task_ids[cid];
                     int32_t hw_kernel = -1;
-                    if (hh->task != 0) {
-                        const PTO2DispatchPayload* pl = reinterpret_cast<const PTO2DispatchPayload*>((uintptr_t)hh->task);
-                        hw_task_id = pl->mixed_task_id;
-                        hw_kernel  = pl->kernel_id;
+                    if (sw_tid >= 0) {
+                        int32_t diag_slot = static_cast<int32_t>(s_executing_subslot[cid]);
+                        hw_kernel = task_descriptors[sw_tid & window_mask].kernel_id[diag_slot];
                     }
-                    DEV_ALWAYS("    AIC core[%d] cid=%d sw_task=%d hw_task=%d hw_kernel=%d",
-                               ci, cid, executing_task_ids[cid], hw_task_id, hw_kernel);
+                    uint64_t cond_reg = read_reg(core_id_to_reg_addr_[cid], RegId::COND);
+                    DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
+                               cid, (unsigned)cond_reg,
+                               EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
+                               sw_tid, hw_kernel);
                 }
                 // Dump AIV running cores
                 for (int32_t ci = 0; ci < tracker.aiv().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
                     int32_t cid = tracker.aiv().running[ci];
-                    Handshake* hh = &hank[cid];
-                    int32_t hw_task_id = -1;
+                    int32_t sw_tid = executing_task_ids[cid];
                     int32_t hw_kernel = -1;
-                    if (hh->task != 0) {
-                        const PTO2DispatchPayload* pl = reinterpret_cast<const PTO2DispatchPayload*>((uintptr_t)hh->task);
-                        hw_task_id = pl->mixed_task_id;
-                        hw_kernel  = pl->kernel_id;
+                    if (sw_tid >= 0) {
+                        int32_t diag_slot = static_cast<int32_t>(s_executing_subslot[cid]);
+                        hw_kernel = task_descriptors[sw_tid & window_mask].kernel_id[diag_slot];
                     }
                     uint64_t cond_reg = read_reg(core_id_to_reg_addr_[cid], RegId::COND);
-                    DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d payload_task=%d kernel=%d",
+                    DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
                                cid, (unsigned)cond_reg,
                                EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
-                               executing_task_ids[cid], hw_task_id, hw_kernel);
+                               sw_tid, hw_kernel);
                 }
                 // Dump cluster state
                 for (int32_t cli = 0; cli < tracker.cluster_count && cli < STALL_DUMP_CORE_MAX; cli++) {
@@ -1872,8 +1876,9 @@ void AicpuExecutor::deinit(Runtime* runtime) {
         core_dispatch_counts_[i] = 0;
     }
 
-    // Clear per-core dispatch payloads to prevent stale data on next round
+    // Clear per-core dispatch payloads and subslot tracking
     memset(s_pto2_payload_per_core, 0, sizeof(s_pto2_payload_per_core));
+    memset(s_executing_subslot, 0, sizeof(s_executing_subslot));
 
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_ = 0;
@@ -1972,11 +1977,16 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
         if (reg_state != TASK_FIN_STATE || task_id >= 0) {
             busy_cores++;
             if (task_id >= 0) {
-                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
+                int32_t kernel_id = -1;
+                if (rt && rt->sm_handle) {
+                    int32_t wmask = rt->sm_handle->header->task_window_size - 1;
+                    int32_t diag_slot = static_cast<int32_t>(s_executing_subslot[core_id]);
+                    kernel_id = rt->sm_handle->task_descriptors[task_id & wmask].kernel_id[diag_slot];
+                }
                 DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_task_id=%d, kernel_id=%d",
                         core_id, core_type_str, reg_val, reg_task_id,
                         reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
-                        payload->mixed_task_id, payload->kernel_id);
+                        task_id, kernel_id);
             } else {
                 DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked",
                         core_id, core_type_str, reg_val, reg_task_id,

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -1,9 +1,13 @@
 /**
  * @file pto2_dispatch_payload.h
- * @brief Handshake dispatch payload aligned with runtime2 PTO2TaskDescriptor
+ * @brief Minimal dispatch payload for AICore kernel execution
  *
- * Shared between AICPU (pack from PTO2TaskDescriptor) and AICore (unpack to run kernel).
- * When merging runtime2 into rt2, Handshake.task points to PTO2DispatchPayload.
+ * Shared between AICPU (builds in-place) and AICore (reads to run kernel).
+ * Handshake.task points to PTO2DispatchPayload embedded in PTO2TaskPayload.
+ *
+ * Only contains fields AICore needs to execute: function address + arguments.
+ * Metadata (task_id, kernel_id, core_type) lives in PTO2TaskDescriptor and
+ * is accessed by AICPU when needed (profiling, diagnostics).
  */
 
 #ifndef RT2_PTO2_DISPATCH_PAYLOAD_H_
@@ -11,26 +15,19 @@
 
 #include <stdint.h>
 
-#include "common/core_type.h"
-#include "pto_submit_types.h"
-
 /** Max arguments per task; must match RUNTIME_MAX_ARGS and PTO2_MAX_OUTPUTS */
 #ifndef PTO2_DISPATCH_MAX_ARGS
 #define PTO2_DISPATCH_MAX_ARGS 32
 #endif
 
 /**
- * Dispatch payload: execution-relevant fields from PTO2TaskDescriptor.
- * AICPU packs this from PTO2TaskDescriptor; AICore unpacks to run kernel.
+ * Dispatch payload: minimal execution interface for AICore.
+ * Layout: function_bin_addr followed by args[].
+ * AICore reads function_bin_addr, casts to UnifiedKernelFunc, calls with args.
  */
 struct PTO2DispatchPayload {
-    int32_t mixed_task_id;     /**< Mixed-task ID (for completion aggregation) */
-    PTO2SubtaskSlot subslot;   /**< Which subtask slot this dispatch represents */
-    int32_t kernel_id;         /**< InCore function id (debug/trace) */
-    CoreType core_type;        /**< AIC or AIV */
     uint64_t function_bin_addr; /**< Kernel entry in GM: (UnifiedKernelFunc)function_bin_addr */
-    int32_t num_args;          /**< Number of valid args[] */
-    uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers) */
+    uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers + scalars) */
 };
 
 #endif  // RT2_PTO2_DISPATCH_PAYLOAD_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -21,6 +21,7 @@
 
 #include "pto_types.h"
 #include "pto_submit_types.h"
+#include "pto2_dispatch_payload.h"
 
 // =============================================================================
 // Profiling Configuration
@@ -317,6 +318,7 @@ struct PTO2TaskDescriptor {
  * for the scheduler's hot completion path (~80 bytes vs ~2912 bytes).
  */
 struct PTO2TaskPayload {
+    PTO2DispatchPayload dispatch;  // function_bin_addr + args[], built in-place at dispatch time
     Tensor tensors[16];
     uint64_t scalar_value[16];
     bool is_tensor[16];


### PR DESCRIPTION
## Summary
- Slim `PTO2DispatchPayload` to only `function_bin_addr` + `args[]` — metadata (`mixed_task_id`, `subslot`, `kernel_id`, `core_type`) stays in `TaskDescriptor`, accessed by AICPU when needed
- AICore derives `task_id` from register value; AICPU fills profiling metadata (`func_id`, `core_type`) at completion time from `TaskDescriptor`
- Add per-core `s_executing_subslot[]` tracking for mixed-task subtask completion (replaces payload-based metadata lookup)
- `build_pto2_payload()` now takes `kernel_id` parameter directly, compatible with per-slot `kernel_id[]` array

## Testing
- [x] Simulation tests pass (`./ci.sh -p a2a3sim`)
- [x] Hardware tests pass (requires Ascend device)