### PR TITLE
Refactor: slim dispatch payload and move build to AICPU dispatch time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-example-on-a2a3sim:
+  run-example-on-sim:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -56,58 +56,8 @@ jobs:
           pip install pytest
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
-      - name: Run simulation examples (a2a3sim)
+      - name: Run simulation examples
         run: ./ci.sh -p a2a3sim -c 1b22fea -t 600
-
-  run-example-on-a5sim:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.10']
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up C++ compiler
-        run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            sudo apt-get update
-            sudo apt-get install -y g++-15 || sudo apt-get install -y g++
-            if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
-          else
-            brew install gcc@15 || brew install gcc
-            if command -v g++-15; then
-              echo "CXX=g++-15" >> $GITHUB_ENV
-            else
-              echo "CXX=g++" >> $GITHUB_ENV
-            fi
-          fi
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Cache pip packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          pip install numpy
-          pip install ml_dtypes
-          pip install pytest
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-
-      - name: Run simulation examples (a5sim)
-        run: ./ci.sh -p a5sim -c 1b22fea -t 600
 
   run-example-on-device:
     runs-on: self-hosted

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ python examples/scripts/run_example.py -k examples/host_build_graph/vector_examp
 ```bash
 # Clone pto-isa manually
 mkdir -p examples/scripts/_deps
-git clone --branch main https://github.com/PTO-ISA/pto-isa.git examples/scripts/_deps/pto-isa
+git clone --branch master https://gitcode.com/cann/pto-isa.git examples/scripts/_deps/pto-isa
 
 # Set environment variable (optional - auto-detected if in standard location)
 export PTO_ISA_ROOT=$(pwd)/examples/scripts/_deps/pto-isa

--- a/examples/host_build_graph/vector_example/README.md
+++ b/examples/host_build_graph/vector_example/README.md
@@ -209,7 +209,7 @@ The simulation platform (a2a3sim) emulates the AICPU/AICore execution model:
 The test framework auto-clones pto-isa on first run. If this fails, clone it manually:
 ```bash
 mkdir -p examples/scripts/_deps
-git clone --branch main https://github.com/PTO-ISA/pto-isa.git examples/scripts/_deps/pto-isa
+git clone --branch master https://gitcode.com/cann/pto-isa.git examples/scripts/_deps/pto-isa
 ```
 Or set PTO_ISA_ROOT to an existing installation:
 ```bash

--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -151,7 +151,7 @@ def _is_git_available() -> bool:
         return False
 
 
-_PTO_ISA_REPO = "https://github.com/PTO-ISA/pto-isa.git"
+_PTO_ISA_REPO = "https://gitcode.com/cann/pto-isa.git"
 
 
 def _clone_pto_isa(verbose: bool = False, commit: Optional[str] = None) -> bool:

--- a/src/a2a3/platform/include/aicore/performance_collector_aicore.h
+++ b/src/a2a3/platform/include/aicore/performance_collector_aicore.h
@@ -27,23 +27,22 @@
  * Writes performance metrics to the provided buffer. Buffer management
  * and status tracking are handled by AICPU.
  *
+ * AICore records task_id and timestamps only. AICPU fills func_id and
+ * core_type at completion time from TaskDescriptor.
+ *
  * @param perf_buf Performance buffer pointer
  * @param task_id Task ID
- * @param func_id Function ID
  * @param start_time Start timestamp
  * @param end_time End timestamp
  * @param kernel_ready_time Kernel ready timestamp
- * @param core_type Core type (AIC/AIV)
  */
 __aicore__ __attribute__((always_inline))
 static inline void perf_aicore_record_task(
     __gm__ PerfBuffer* perf_buf,
     uint32_t task_id,
-    uint32_t func_id,
     uint64_t start_time,
     uint64_t end_time,
-    uint64_t kernel_ready_time,
-    CoreType core_type) {
+    uint64_t kernel_ready_time) {
 
     // Read current buffer count
     dcci(&perf_buf->count, SINGLE_CACHE_LINE);
@@ -55,13 +54,11 @@ static inline void perf_aicore_record_task(
 
     __gm__ PerfRecord* record = &perf_buf->records[idx];
 
-    // Write record data
+    // Write record data (func_id and core_type filled by AICPU at completion)
     record->start_time = start_time;
     record->end_time = end_time;
     record->kernel_ready_time = kernel_ready_time;
     record->task_id = task_id;
-    record->func_id = func_id;
-    record->core_type = core_type;
 
     perf_buf->count = idx + 1;
 

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -20,17 +20,13 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
-    // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
-    // across rounds. DATA_MAIN_BASE still holds the EXIT_SIGNAL from the previous
-    // round, so clear it before the handshake wait. Clearing after the wait would
-    // race with AICPU, which may finish all tasks and write a new EXIT_SIGNAL while
-    // this thread is descheduled between the wait and the clear.
-    write_reg(RegId::DATA_MAIN_BASE, 0);
-
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     }
+
+    // Clear stale EXIT_SIGNAL from previous round before entering main loop
+    write_reg(RegId::DATA_MAIN_BASE, 0);
 
     // Report physical core ID and core type for AICPU
     my_hank->physical_core_id = get_physical_core_id();
@@ -70,9 +66,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, task_ptr->task_id, task_ptr->func_id,
-                                      start_time, end_time, kernel_ready_time,
-                                      core_type);
+                perf_aicore_record_task(perf_buf, actual_task_id,
+                                      start_time, end_time, kernel_ready_time);
             }
 
             last_task_id = task_id;

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -645,6 +645,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     if (count > 0) {
                         PerfRecord* record = &perf_buf->records[count - 1];
                         if (record->task_id == static_cast<uint32_t>(completed_task_id)) {
+                            record->func_id = runtime.tasks[completed_task_id].func_id;
+                            record->core_type = h->core_type;
                             perf_aicpu_record_dispatch_and_finish_time(
                                 record, dispatch_timestamps_[core_id], finish_ts);
                         }
@@ -780,6 +782,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     if (count > 0) {
                         PerfRecord* record = &perf_buf->records[count - 1];
                         if (record->task_id == static_cast<uint32_t>(completed_task_id)) {
+                            record->func_id = runtime.tasks[completed_task_id].func_id;
+                            record->core_type = h->core_type;
                             perf_aicpu_record_dispatch_and_finish_time(
                                 record, dispatch_timestamps_[core_id], finish_ts);
                         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -16,13 +16,11 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
 /**
  * Execute task from PTO2DispatchPayload.
  *
- * Directly accesses PTO2DispatchPayload fields for task execution,
- * matching ref_runtime implementation for a2a3 compatibility.
+ * Reads function_bin_addr and args from the dispatch payload.
  *
- * @param task_ptr Pointer to PTO2DispatchPayload in global memory
+ * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* task_ptr) {
-    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(task_ptr);
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
@@ -42,8 +40,8 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* 
  * 2. Report physical core ID and core type, signal AICore ready
  * 3. Poll DATA_MAIN_BASE register for task dispatch until exit signal
  *
- * Task dispatch uses PTO2DispatchPayload from per-core payload array.
- * Supports performance profiling when runtime->enable_profiling is true.
+ * Task dispatch reads PTO2DispatchPayload address from Handshake.task.
+ * Task ID is derived from the register value (task_id + 1 encoding).
  *
  * @param runtime Pointer to Runtime in global memory
  * @param block_idx Block index (core ID)
@@ -52,17 +50,13 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
-    // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
-    // across rounds. DATA_MAIN_BASE still holds the EXIT_SIGNAL from the previous
-    // round, so clear it before the handshake wait. Clearing after the wait would
-    // race with AICPU, which may finish all tasks and write a new EXIT_SIGNAL while
-    // this thread is descheduled between the wait and the clear.
-    write_reg(RegId::DATA_MAIN_BASE, 0);
-
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, SINGLE_CACHE_LINE);
     }
+
+    // Clear stale EXIT_SIGNAL from previous round before entering main loop
+    write_reg(RegId::DATA_MAIN_BASE, 0);
 
     // Phase 2: Report physical core ID and core type, signal ready
     my_hank->physical_core_id = get_physical_core_id();
@@ -74,10 +68,6 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     // Report initial idle status via register
     write_reg(RegId::COND, AICORE_IDLE_VALUE);
 
-    // Read per-core payload address from hank->task (written by AICPU before aicpu_ready)
-    __gm__ PTO2DispatchPayload* my_payload =
-        reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
-
     bool profiling_enabled = runtime->enable_profiling;
     uint64_t kernel_ready_time = 0;
     if (profiling_enabled) {
@@ -85,28 +75,33 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     }
 
     // Phase 3: Main execution loop - poll register for tasks until exit signal
-    uint32_t task_id = 0;
-    uint32_t last_task_id = 0;
+    // Register encoding: 0=idle, task_id+1=task, AICORE_EXIT_SIGNAL=exit
+    uint32_t reg_val = 0;
+    uint32_t last_reg_val = 0;
 
     while (true) {
-        task_id = static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE));
-        if (task_id == AICORE_EXIT_SIGNAL) {
+        reg_val = static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE));
+        if (reg_val == AICORE_EXIT_SIGNAL) {
             break;
         }
 
-        // Execute task if new (task_id encoding: 0=idle, task_id+1=task)
-        if (task_id == 0 || task_id == last_task_id) {
+        // Execute task if new (reg_val encoding: 0=idle, task_id+1=task)
+        if (reg_val == 0 || reg_val == last_reg_val) {
             SPIN_WAIT_HINT();
             continue;
         }
 
         {
-            // Invalidate cache to read fresh payload written by AICPU
-            dcci(my_payload, ENTIRE_DATA_CACHE);
+            uint32_t task_id = reg_val - 1;  // Decode: register holds task_id + 1
 
-            __gm__ PTO2DispatchPayload* payload = my_payload;
+            // Invalidate entire data cache to read fresh payload and hank->task
+            dcci(my_hank, ENTIRE_DATA_CACHE);
 
-            write_reg(RegId::COND, MAKE_ACK_VALUE(payload->task_id));
+            // Read per-task dispatch payload address (updated by AICPU each dispatch)
+            __gm__ PTO2DispatchPayload* payload =
+                reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+
+            write_reg(RegId::COND, MAKE_ACK_VALUE(task_id));
 
             // Performance profiling: record start time
             uint64_t start_time = 0;
@@ -115,19 +110,19 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             }
 
             // Execute the task
-            execute_task(reinterpret_cast<__gm__ void*>(payload));
+            execute_task(payload);
 
             // Performance profiling: record task execution
+            // (func_id and core_type are filled by AICPU at completion time)
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, payload->task_id, payload->kernel_id,
-                                       start_time, end_time, kernel_ready_time,
-                                       core_type);
+                perf_aicore_record_task(perf_buf, task_id,
+                                       start_time, end_time, kernel_ready_time);
             }
 
-            last_task_id = task_id;
-            write_reg(RegId::COND, MAKE_FIN_VALUE(payload->task_id));
+            last_reg_val = reg_val;
+            write_reg(RegId::COND, MAKE_FIN_VALUE(task_id));
         }
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -70,9 +70,6 @@ constexpr int32_t STALL_DUMP_CORE_MAX = 8;
 constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
 constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
 
-// PTO2 device-mode state (per-core dispatch payloads)
-static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
-
 static PTO2Runtime *rt{nullptr};
 
 // Core information for discovery (with register address for fast dispatch)
@@ -188,28 +185,20 @@ struct AicpuExecutor {
     void diagnose_stuck_state(
         Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank);
 
-    // Build PTO2DispatchPayload from PTO2TaskDescriptor.
-    template<CoreType CT>
-    void build_pto2_payload(PTO2DispatchPayload* out,
-        Runtime* runtime,
-        PTO2TaskDescriptor* task,
-        PTO2TaskPayload* task_payload) {
-        out->task_id = task->task_id;
-        out->kernel_id = task->kernel_id;
-        out->core_type = CT;
-        out->function_bin_addr = runtime->get_function_bin_addr(task->kernel_id);
+    static inline void build_dispatch_inplace(
+        PTO2TaskPayload* task_pl, int32_t kernel_id, Runtime* runtime)
+    {
+        auto& dp = task_pl->dispatch;
+        dp.function_bin_addr = runtime->get_function_bin_addr(kernel_id);
         int32_t n = 0;
-
-        for (int32_t i = 0; i < task_payload->param_count; i++) {
-            if (!task_payload->is_tensor[i]) {
-                out->args[n++] = task_payload->scalar_value[i];
+        for (int32_t i = 0; i < task_pl->param_count; i++) {
+            if (!task_pl->is_tensor[i]) {
+                dp.args[n++] = task_pl->scalar_value[i];
             } else {
-                out->args[n++] = reinterpret_cast<uint64_t>(&task_payload->tensors[i]);
-                task_payload->tensors[i].update_start_offset();
+                dp.args[n++] = reinterpret_cast<uint64_t>(&task_pl->tensors[i]);
+                task_pl->tensors[i].update_start_offset();
             }
         }
-
-        out->num_args = n;
     }
 
     // Template methods for Phase 1 and Phase 2
@@ -223,7 +212,7 @@ struct AicpuExecutor {
         bool& made_progress,
         int32_t deferred_release_ids[],
         int32_t& deferred_release_count,
-        PTO2LocalReadyBuffer* local_bufs
+        PTO2LocalReadyBuffer& local_buf
 #if PTO2_PROFILING
         ,
         bool profiling_enabled,
@@ -262,21 +251,19 @@ struct AicpuExecutor {
             if (done) {
                 executing_task_ids[core_id] = AICPU_TASK_INVALID;
 #if PTO2_SCHED_PROFILING
-                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
-                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, thread_idx, local_bufs);
+                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, thread_idx, &local_buf);
                 notify_edges_total += cstats.fanout_edges;
                 if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
                 notify_tasks_enqueued += cstats.tasks_enqueued;
                 phase_complete_count++;
 #elif PTO2_PROFILING
-                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
-                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, local_bufs);
+                PTO2CompletionStats cstats = rt->scheduler.on_task_complete(task_id, &local_buf);
                 notify_edges_total += cstats.fanout_edges;
                 if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
                 notify_tasks_enqueued += cstats.tasks_enqueued;
                 phase_complete_count++;
 #else
-                rt->scheduler.on_task_complete(task_id, local_bufs);
+                rt->scheduler.on_task_complete(task_id, &local_buf);
 #endif
                 if (deferred_release_count < 64) {
                     deferred_release_ids[deferred_release_count++] = task_id;
@@ -310,7 +297,12 @@ struct AicpuExecutor {
                     uint32_t count = perf_buf->count;
                     if (count > 0) {
                         PerfRecord* record = &perf_buf->records[count - 1];
-                        if (record->task_id == static_cast<uint32_t>(payload->task_id)) {
+                        if (record->task_id == static_cast<uint32_t>(task_id)) {
+                            // Fill metadata that AICore doesn't know
+                            PTO2TaskDescriptor* td = &rt->sm_handle->task_descriptors[
+                                task_id & (rt->sm_handle->header->task_window_size - 1)];
+                            record->func_id = td->kernel_id;
+                            record->core_type = CT;
                             perf_aicpu_record_dispatch_and_finish_time(
                                 record, dispatch_timestamps_[core_id], finish_ts);
                         }
@@ -341,16 +333,13 @@ struct AicpuExecutor {
         bool& made_progress,
         PTO2TaskDescriptor* task_descriptors,
         PTO2TaskPayload* task_payloads,
-        int32_t window_mask,
-        PTO2LocalReadyBuffer* local_bufs
+        int32_t window_mask
 #if PTO2_PROFILING
         ,
         bool profiling_enabled,
         uint64_t& pop_hit,
         uint64_t& pop_miss,
-        uint32_t& phase_dispatch_count,
-        uint64_t& local_dispatch_count,
-        uint64_t& local_overflow_count
+        uint32_t& phase_dispatch_count
 #endif
 #if PTO2_SCHED_PROFILING
         ,
@@ -358,76 +347,61 @@ struct AicpuExecutor {
         uint64_t& sched_dispatch_setup_cycle
 #endif
     ) {
-        constexpr int ct_idx = static_cast<int>(CT);
+        if (ct.idle_count > 0 && rt->scheduler.ready_queues[static_cast<int32_t>(CT)].size() > 0) {
+            for (int32_t i = ct.idle_count - 1; i >= 0; i--) {
+                int32_t core_id = ct.idle[i];
 
-        for (int32_t i = ct.idle_count - 1; i >= 0; i--) {
-            int32_t core_id = ct.idle[i];
-
-#if PTO2_PROFILING
-            int local_count_before = local_bufs[ct_idx].count;
-#endif
 #if PTO2_SCHED_PROFILING
-            extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
-            uint64_t t_pop_start = get_sys_cnt_aicpu();
-            int32_t task_id = rt->scheduler.get_ready_task<CT>(
-                local_bufs,
-                g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]);
-            sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
+                extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
+                uint64_t t_pop_start = get_sys_cnt_aicpu();
+                int32_t task_id = rt->scheduler.get_ready_task<CT>(
+                    g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]);
+                sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
 #else
-            int32_t task_id = rt->scheduler.get_ready_task<CT>(local_bufs);
+                int32_t task_id = rt->scheduler.get_ready_task<CT>();
 #endif
-            if (task_id >= 0) {
+                if (task_id >= 0) {
 #if PTO2_PROFILING
-                pop_hit++;
-                phase_dispatch_count++;
-                if (local_bufs[ct_idx].count < local_count_before) {
-                    local_dispatch_count++;
-                }
+                    pop_hit++;
+                    phase_dispatch_count++;
 #endif
 #if PTO2_SCHED_PROFILING
-                uint64_t t_setup_start = get_sys_cnt_aicpu();
+                    uint64_t t_setup_start = get_sys_cnt_aicpu();
 #endif
-                PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
-                PTO2TaskPayload* task_pl = &task_payloads[task_id & window_mask];
-                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
-                build_pto2_payload<CT>(payload, runtime, task, task_pl);
+                    PTO2TaskPayload* task_pl = &task_payloads[task_id & window_mask];
+                    PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
+                    build_dispatch_inplace(task_pl, task->kernel_id, runtime);
+                    Handshake* workers = static_cast<Handshake*>(runtime->workers);
+                    workers[core_id].task = reinterpret_cast<uint64_t>(&task_pl->dispatch);
 #if PTO2_PROFILING
-                if (profiling_enabled) {
-                    dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
-                    if (core_dispatch_counts_[core_id] >= PLATFORM_PROF_BUFFER_SIZE) {
-                        perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
-                        core_dispatch_counts_[core_id] = 0;
+                    if (profiling_enabled) {
+                        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                        if (core_dispatch_counts_[core_id] >= PLATFORM_PROF_BUFFER_SIZE) {
+                            perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
+                            core_dispatch_counts_[core_id] = 0;
+                        }
+                        core_dispatch_counts_[core_id]++;
                     }
-                    core_dispatch_counts_[core_id]++;
-                }
 #endif
-                write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id + 1));
-                ct.move_idle_to_running(i);
-                executing_task_ids[core_id] = task_id;
-                made_progress = true;
+                    write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id + 1));
+                    ct.move_idle_to_running(i);
+                    executing_task_ids[core_id] = task_id;
+                    made_progress = true;
 #if PTO2_SCHED_PROFILING
-                sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
+                    sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
-                DEV_DEBUG("Thread %d: Dispatching PTO2 task %d to %s core %d",
-                    thread_idx,
-                    task_id,
-                    CT == CoreType::AIC ? "AIC" : "AIV",
-                    core_id);
-            } else {
+                    DEV_DEBUG("Thread %d: Dispatching PTO2 task %d to %s core %d",
+                        thread_idx,
+                        task_id,
+                        CT == CoreType::AIC ? "AIC" : "AIV",
+                        core_id);
+                } else {
 #if PTO2_PROFILING
-                pop_miss++;
+                    pop_miss++;
 #endif
-                break;
+                    break;
+                }
             }
-        }
-
-        // Drain remaining local tasks to global queue (idle cores exhausted)
-        while (local_bufs[ct_idx].count > 0) {
-            int32_t task_id = local_bufs[ct_idx].pop();
-            rt->scheduler.ready_queues[ct_idx].push(task_id);
-#if PTO2_PROFILING
-            local_overflow_count++;
-#endif
         }
     }
 };
@@ -458,7 +432,7 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     // Step 1: Write per-core payload addresses and send handshake signal
     // task must be written BEFORE aicpu_ready so AICore sees it after waking up
     for (int32_t i = 0; i < cores_total_num_; i++) {
-        all_handshakes[i].task = reinterpret_cast<uint64_t>(&s_pto2_payload_per_core[i]);
+        all_handshakes[i].task = 0;  // Will be set per-dispatch to point to task's dispatch payload
         all_handshakes[i].aicpu_ready = 1;
     }
 
@@ -875,14 +849,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #endif
 #endif
 
-    // Local-first dispatch buffers (stack-allocated, one per CoreType per scheduling thread).
+    // Local-first dispatch buffer (stack-allocated, one per scheduling thread).
     // Initialized once; must be empty at the start of each iteration.
-    constexpr int LOCAL_READY_CAP_PER_TYPE = 64;
-    int32_t local_aic_ids[LOCAL_READY_CAP_PER_TYPE];
-    int32_t local_aiv_ids[LOCAL_READY_CAP_PER_TYPE];
-    PTO2LocalReadyBuffer local_bufs[PTO2_LOCAL_DISPATCH_TYPE_NUM];  // [0]=AIC, [1]=AIV
-    local_bufs[0].reset(local_aic_ids, LOCAL_READY_CAP_PER_TYPE);
-    local_bufs[1].reset(local_aiv_ids, LOCAL_READY_CAP_PER_TYPE);
+    constexpr int LOCAL_READY_CAP = 64;
+    int32_t local_task_ids[LOCAL_READY_CAP];
+    PTO2LocalReadyBuffer local_buf;
+    local_buf.reset(local_task_ids, LOCAL_READY_CAP);
     int32_t deferred_release_ids[128];
     int32_t deferred_release_count = 0;
 
@@ -938,14 +910,14 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
         // Check AIC running cores
         bool try_completed = false;
-        always_assert(local_bufs[0].count == 0 && local_bufs[1].count == 0);  // Invariant: previous iteration fully consumed
+        always_assert(local_buf.count == 0);  // Invariant: previous iteration fully consumed
         if (tracker.aic().running_count > 0) {
             try_completed = true;
             check_running_cores_for_completion<CoreType::AIC>(
                 thread_idx, tracker.aic(), hank, executing_task_ids,
                 completed_this_turn, cur_thread_completed, made_progress,
                 deferred_release_ids, deferred_release_count,
-                local_bufs
+                local_buf
 #if PTO2_PROFILING
                 , profiling_enabled, complete_probe_count, complete_hit_count, phase_complete_count,
                 notify_edges_total, notify_max_degree, notify_tasks_enqueued,
@@ -964,7 +936,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 thread_idx, tracker.aiv(), hank, executing_task_ids,
                 completed_this_turn, cur_thread_completed, made_progress,
                 deferred_release_ids, deferred_release_count,
-                local_bufs
+                local_buf
 #if PTO2_PROFILING
                 , profiling_enabled, complete_probe_count, complete_hit_count, phase_complete_count,
                 notify_edges_total, notify_max_degree, notify_tasks_enqueued,
@@ -1003,22 +975,69 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         }
 #endif
 
-        // Dispatch: local queue first (zero MPMC operations), then global readyQ
+        // Phase 2: Local dispatch — match local_buf tasks to idle cores (zero MPMC operations)
+        // Phase 3: Global queue — push overflow to readyQ + fill remaining idle cores from readyQ
         bool try_pushed = false;
 
-        // Process AIC cores: local AIC buffer + global CUBE queue
-        // Enter when local buffer has tasks (even if no idle cores, to drain to global queue)
-        // or when idle cores can be filled from global queue
-        if (local_bufs[0].count > 0 ||
-            (tracker.aic().idle_count > 0 && rt->scheduler.ready_queues[PTO2_WORKER_CUBE].size() > 0)) {
+        // Local dispatch: drain local_buf, match to idle cores by type
+        int32_t overflow_ids[LOCAL_READY_CAP];
+        int overflow_count = 0;
+        while (local_buf.count > 0) {
+            int32_t task_id = local_buf.pop();
+            PTO2TaskDescriptor* task = &task_descriptors[task_id & window_mask];
+            CoreType ct_type = static_cast<CoreType>(task->worker_type);
+            CoreTypeTracker& ct = (ct_type == CoreType::AIC) ? tracker.aic() : tracker.aiv();
+
+            if (ct.idle_count > 0) {
+                try_pushed = true;
+                int32_t idle_idx = ct.idle_count - 1;
+                int32_t core_id = ct.idle[idle_idx];
+                PTO2TaskPayload* task_pl = &task_payloads[task_id & window_mask];
+                build_dispatch_inplace(task_pl, task->kernel_id, runtime);
+                hank[core_id].task = reinterpret_cast<uint64_t>(&task_pl->dispatch);
+#if PTO2_PROFILING
+                if (profiling_enabled) {
+                    dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    if (core_dispatch_counts_[core_id] >= PLATFORM_PROF_BUFFER_SIZE) {
+                        perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
+                        core_dispatch_counts_[core_id] = 0;
+                    }
+                    core_dispatch_counts_[core_id]++;
+                }
+                pop_hit++;
+                phase_dispatch_count++;
+                local_dispatch_count++;
+#endif
+                write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE,
+                          static_cast<uint64_t>(task_id + 1));
+                ct.move_idle_to_running(idle_idx);
+                executing_task_ids[core_id] = task_id;
+                made_progress = true;
+                DEV_DEBUG("Thread %d: Dispatching PTO2 task %d to core %d (local)",
+                          thread_idx, task_id, core_id);
+            } else {
+                overflow_ids[overflow_count++] = task_id;
+#if PTO2_PROFILING
+                local_overflow_count++;
+#endif
+            }
+        }
+
+        // Push overflow to global readyQ
+        for (int i = 0; i < overflow_count; i++) {
+            PTO2TaskDescriptor* task = &task_descriptors[overflow_ids[i] & window_mask];
+            rt->scheduler.ready_queues[task->worker_type].push(overflow_ids[i]);
+        }
+
+        // Global dispatch: fill remaining idle cores from global readyQ
+        // Process AIC cores if CUBE queue has tasks
+        if (tracker.aic().idle_count > 0 && rt->scheduler.ready_queues[PTO2_WORKER_CUBE].size() > 0) {
             try_pushed = true;
             dispatch_ready_tasks_to_idle_cores<CoreType::AIC>(
                 runtime, thread_idx, tracker.aic(), executing_task_ids, made_progress,
-                task_descriptors, task_payloads, window_mask,
-                local_bufs
+                task_descriptors, task_payloads, window_mask
 #if PTO2_PROFILING
                 , profiling_enabled, pop_hit, pop_miss, phase_dispatch_count
-                , local_dispatch_count, local_overflow_count
 #endif
 #if PTO2_SCHED_PROFILING
                 , sched_dispatch_pop_cycle, sched_dispatch_setup_cycle
@@ -1026,17 +1045,14 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             );
         }
 
-        // Process AIV cores: local AIV buffer + global VECTOR queue
-        if (local_bufs[1].count > 0 ||
-            (tracker.aiv().idle_count > 0 && rt->scheduler.ready_queues[PTO2_WORKER_VECTOR].size() > 0)) {
+        // Process AIV cores if VECTOR queue has tasks
+        if (tracker.aiv().idle_count > 0 && rt->scheduler.ready_queues[PTO2_WORKER_VECTOR].size() > 0) {
             try_pushed = true;
             dispatch_ready_tasks_to_idle_cores<CoreType::AIV>(
                 runtime, thread_idx, tracker.aiv(), executing_task_ids, made_progress,
-                task_descriptors, task_payloads, window_mask,
-                local_bufs
+                task_descriptors, task_payloads, window_mask
 #if PTO2_PROFILING
                 , profiling_enabled, pop_hit, pop_miss, phase_dispatch_count
-                , local_dispatch_count, local_overflow_count
 #endif
 #if PTO2_SCHED_PROFILING
                 , sched_dispatch_pop_cycle, sched_dispatch_setup_cycle
@@ -1119,33 +1135,27 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 // Dump AIC running cores
                 for (int32_t ci = 0; ci < tracker.aic().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
                     int32_t cid = tracker.aic().running[ci];
-                    Handshake* hh = &hank[cid];
-                    int32_t hw_task_id = -1;
+                    int32_t sw_tid = executing_task_ids[cid];
                     int32_t hw_kernel = -1;
-                    if (hh->task != 0) {
-                        const PTO2DispatchPayload* pl = reinterpret_cast<const PTO2DispatchPayload*>((uintptr_t)hh->task);
-                        hw_task_id = pl->task_id;
-                        hw_kernel  = pl->kernel_id;
+                    if (sw_tid >= 0) {
+                        hw_kernel = task_descriptors[sw_tid & window_mask].kernel_id;
                     }
-                    DEV_ALWAYS("    AIC core[%d] cid=%d sw_task=%d hw_task=%d hw_kernel=%d",
-                               ci, cid, executing_task_ids[cid], hw_task_id, hw_kernel);
+                    DEV_ALWAYS("    AIC core[%d] cid=%d sw_task=%d hw_kernel=%d",
+                               ci, cid, sw_tid, hw_kernel);
                 }
                 // Dump AIV running cores
                 for (int32_t ci = 0; ci < tracker.aiv().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
                     int32_t cid = tracker.aiv().running[ci];
-                    Handshake* hh = &hank[cid];
-                    int32_t hw_task_id = -1;
+                    int32_t sw_tid = executing_task_ids[cid];
                     int32_t hw_kernel = -1;
-                    if (hh->task != 0) {
-                        const PTO2DispatchPayload* pl = reinterpret_cast<const PTO2DispatchPayload*>((uintptr_t)hh->task);
-                        hw_task_id = pl->task_id;
-                        hw_kernel  = pl->kernel_id;
+                    if (sw_tid >= 0) {
+                        hw_kernel = task_descriptors[sw_tid & window_mask].kernel_id;
                     }
                     uint64_t cond_reg = read_reg(core_id_to_reg_addr_[cid], RegId::COND);
-                    DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d payload_task=%d kernel=%d",
+                    DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
                                cid, (unsigned)cond_reg,
                                EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
-                               executing_task_ids[cid], hw_task_id, hw_kernel);
+                               sw_tid, hw_kernel);
                 }
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
@@ -1691,9 +1701,6 @@ void AicpuExecutor::deinit(Runtime* runtime) {
         core_dispatch_counts_[i] = 0;
     }
 
-    // Clear per-core dispatch payloads to prevent stale data on next round
-    memset(s_pto2_payload_per_core, 0, sizeof(s_pto2_payload_per_core));
-
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_ = 0;
     finished_count_.store(0, std::memory_order_release);
@@ -1787,11 +1794,15 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
         if (reg_state != TASK_FIN_STATE || task_id >= 0) {
             busy_cores++;
             if (task_id >= 0) {
-                PTO2DispatchPayload* payload = &s_pto2_payload_per_core[core_id];
+                int32_t kernel_id = -1;
+                if (rt && rt->sm_handle) {
+                    int32_t wmask = rt->sm_handle->header->task_window_size - 1;
+                    kernel_id = rt->sm_handle->task_descriptors[task_id & wmask].kernel_id;
+                }
                 DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_task_id=%d, kernel_id=%d",
                         core_id, core_type_str, reg_val, reg_task_id,
                         reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
-                        payload->task_id, payload->kernel_id);
+                        task_id, kernel_id);
             } else {
                 DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked",
                         core_id, core_type_str, reg_val, reg_task_id,

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -1,9 +1,13 @@
 /**
  * @file pto2_dispatch_payload.h
- * @brief Handshake dispatch payload aligned with runtime2 PTO2TaskDescriptor
+ * @brief Minimal dispatch payload for AICore kernel execution
  *
- * Shared between AICPU (pack from PTO2TaskDescriptor) and AICore (unpack to run kernel).
- * When merging runtime2 into rt2, Handshake.task points to PTO2DispatchPayload.
+ * Shared between AICPU (builds in-place) and AICore (reads to run kernel).
+ * Handshake.task points to PTO2DispatchPayload embedded in PTO2TaskPayload.
+ *
+ * Only contains fields AICore needs to execute: function address + arguments.
+ * Metadata (task_id, kernel_id, core_type) lives in PTO2TaskDescriptor and
+ * is accessed by AICPU when needed (profiling, diagnostics).
  */
 
 #ifndef RT2_PTO2_DISPATCH_PAYLOAD_H_
@@ -11,24 +15,19 @@
 
 #include <stdint.h>
 
-#include "common/core_type.h"
-
 /** Max arguments per task; must match RUNTIME_MAX_ARGS and PTO2_MAX_OUTPUTS */
 #ifndef PTO2_DISPATCH_MAX_ARGS
 #define PTO2_DISPATCH_MAX_ARGS 32
 #endif
 
 /**
- * Dispatch payload: execution-relevant fields from PTO2TaskDescriptor.
- * AICPU packs this from PTO2TaskDescriptor; AICore unpacks to run kernel.
+ * Dispatch payload: minimal execution interface for AICore.
+ * Layout: function_bin_addr followed by args[].
+ * AICore reads function_bin_addr, casts to UnifiedKernelFunc, calls with args.
  */
 struct PTO2DispatchPayload {
-    int32_t task_id;           /**< Task ID (for completion_queue) */
-    int32_t kernel_id;         /**< InCore function id (debug/trace) */
-    CoreType core_type;        /**< AIC or AIV */
     uint64_t function_bin_addr; /**< Kernel entry in GM: (UnifiedKernelFunc)function_bin_addr */
-    int32_t num_args;          /**< Number of valid args[] */
-    uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers) */
+    uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers + scalars) */
 };
 
 #endif  // RT2_PTO2_DISPATCH_PAYLOAD_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -359,7 +359,6 @@ void pto2_submit_task(
 
     CYCLE_COUNT_LAP_RECORD(g_orch_lookup_cycle, AicpuPhaseId::ORCH_LOOKUP, task_id);
 
-
     // === STEP 4: Second pass - register outputs in TensorMap ===
     for (int i = 0; i < num_params; i++) {
         PTOParamType ptype = params[i].type;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -20,6 +20,7 @@
 #include <stddef.h>
 
 #include "pto_types.h"
+#include "pto2_dispatch_payload.h"
 
 // =============================================================================
 // Profiling Configuration
@@ -308,6 +309,7 @@ struct PTO2TaskDescriptor {
  * for the scheduler's hot completion path (~80 bytes vs ~2912 bytes).
  */
 struct PTO2TaskPayload {
+    PTO2DispatchPayload dispatch;  // function_bin_addr + args[], built in-place at dispatch time
     Tensor tensors[16];
     uint64_t scalar_value[16];
     bool is_tensor[16];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -48,17 +48,16 @@ struct PTO2ReadyQueueSlot {
 /**
  * Thread-local ready buffer for local-first dispatch optimization.
  *
- * Two buffers per scheduling thread, one per CoreType (AIC=0, AIV=1).
+ * One buffer per scheduling thread (mixed worker types).
  * Initialized once before the scheduling loop; must be empty at
  * the start of each iteration (verified by always_assert).
  *
- * Phase 1 fills per-CoreType buffers via on_task_complete().
- * dispatch_ready_tasks_to_idle_cores drains them: local-first via
- * get_ready_task, then remaining tasks pushed to global readyQ.
+ * Phase 1 fills this buffer via on_task_complete().
+ * Phase 2 drains it: matched tasks dispatch to idle cores,
+ * unmatched tasks are stored in an overflow array for Phase 3.
+ * Phase 3 pushes overflow to global readyQ and fills remaining
+ * idle cores from global readyQ.
  */
-// Number of CoreType values eligible for local dispatch (AIC=0, AIV=1)
-static constexpr int PTO2_LOCAL_DISPATCH_TYPE_NUM = 2;
-
 struct PTO2LocalReadyBuffer {
     int32_t* task_ids = nullptr;  // Points to caller's stack array
     int count = 0;
@@ -431,7 +430,7 @@ struct PTO2SchedulerState {
 
     bool release_fanin_and_check_ready(int32_t task_id,
                                         PTO2TaskDescriptor* task,
-                                        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+                                        PTO2LocalReadyBuffer* local_buf = nullptr) {
         int32_t slot = pto2_task_slot(task_id);
 
         // Atomically increment fanin_refcount and check if all producers are done
@@ -440,10 +439,10 @@ struct PTO2SchedulerState {
         int32_t new_refcount = fanin_refcount[slot].fetch_add(1, std::memory_order_acq_rel) + 1;
 
         if (new_refcount == task->fanin_count) {
-            // Local-first: try per-CoreType thread-local buffer before global queue
+            // Local-first: try thread-local buffer before global queue
             bool pushed_local = false;
-            if (local_bufs && task->worker_type >= 0 && task->worker_type < PTO2_LOCAL_DISPATCH_TYPE_NUM) {
-                pushed_local = local_bufs[task->worker_type].try_push(task_id);
+            if (local_buf) {
+                pushed_local = local_buf->try_push(task_id);
             }
             if (!pushed_local) {
                 ready_queues[task->worker_type].push(task_id);
@@ -456,7 +455,7 @@ struct PTO2SchedulerState {
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
     bool release_fanin_and_check_ready(int32_t task_id, PTO2TaskDescriptor* task,
                                         uint64_t& atomic_count, uint64_t& push_wait,
-                                        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+                                        PTO2LocalReadyBuffer* local_buf = nullptr) {
         int32_t slot = pto2_task_slot(task_id);
 
         int32_t new_refcount = fanin_refcount[slot].fetch_add(1, std::memory_order_acq_rel) + 1;
@@ -467,10 +466,10 @@ struct PTO2SchedulerState {
             if (task_state[slot].compare_exchange_strong(
                     expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
                 atomic_count += 1;  // CAS(task_state PENDING→READY)
-                // Local-first: try per-CoreType thread-local buffer before global queue
+                // Local-first: try thread-local buffer before global queue
                 bool pushed_local = false;
-                if (local_bufs && task->worker_type >= 0 && task->worker_type < PTO2_LOCAL_DISPATCH_TYPE_NUM) {
-                    pushed_local = local_bufs[task->worker_type].try_push(task_id);
+                if (local_buf) {
+                    pushed_local = local_buf->try_push(task_id);
                 }
                 if (!pushed_local) {
                     ready_queues[task->worker_type].push(task_id, atomic_count, push_wait);
@@ -507,29 +506,10 @@ struct PTO2SchedulerState {
         return ready_queues[static_cast<int32_t>(CT)].pop();
     }
 
-    template<CoreType CT>
-    int32_t get_ready_task(PTO2LocalReadyBuffer* local_bufs) {
-        constexpr int ct = static_cast<int>(CT);
-        if (local_bufs && local_bufs[ct].count > 0) {
-            return local_bufs[ct].pop();
-        }
-        return ready_queues[ct].pop();
-    }
-
 #if PTO2_SCHED_PROFILING
     template<CoreType CT>
     int32_t get_ready_task(uint64_t& atomic_count, uint64_t& wait_cycle) {
         return ready_queues[static_cast<int32_t>(CT)].pop(atomic_count, wait_cycle);
-    }
-
-    template<CoreType CT>
-    int32_t get_ready_task(PTO2LocalReadyBuffer* local_bufs,
-                           uint64_t& atomic_count, uint64_t& wait_cycle) {
-        constexpr int ct = static_cast<int>(CT);
-        if (local_bufs && local_bufs[ct].count > 0) {
-            return local_bufs[ct].pop();
-        }
-        return ready_queues[ct].pop(atomic_count, wait_cycle);
     }
 #endif
 
@@ -548,15 +528,15 @@ struct PTO2SchedulerState {
 
 #if PTO2_SCHED_PROFILING
     PTO2CompletionStats on_task_complete(int32_t task_id, int thread_idx,
-                                          PTO2LocalReadyBuffer* local_bufs = nullptr) {
+                                          PTO2LocalReadyBuffer* local_buf = nullptr) {
         PTO2CompletionStats stats = {0, 0, 0};
 #elif PTO2_PROFILING
     PTO2CompletionStats on_task_complete(int32_t task_id,
-                                          PTO2LocalReadyBuffer* local_bufs = nullptr) {
+                                          PTO2LocalReadyBuffer* local_buf = nullptr) {
         PTO2CompletionStats stats = {0, 0, 0};
 #else
     void on_task_complete(int32_t task_id,
-                           PTO2LocalReadyBuffer* local_bufs = nullptr) {
+                           PTO2LocalReadyBuffer* local_buf = nullptr) {
 #endif
         int32_t slot = pto2_task_slot(task_id);
         PTO2TaskDescriptor& task = pto2_sm_get_task_by_slot(sm_handle, slot);
@@ -604,17 +584,17 @@ struct PTO2SchedulerState {
 #endif
 #if PTO2_SCHED_PROFILING
             if (release_fanin_and_check_ready(consumer_id, consumer,
-                                               fanout_atomics, push_wait, local_bufs)) {
+                                               fanout_atomics, push_wait, local_buf)) {
 #if PTO2_PROFILING
                 stats.tasks_enqueued++;
 #endif
             }
 #elif PTO2_PROFILING
-            if (release_fanin_and_check_ready(consumer_id, consumer, local_bufs)) {
+            if (release_fanin_and_check_ready(consumer_id, consumer, local_buf)) {
                 stats.tasks_enqueued++;
             }
 #else
-            release_fanin_and_check_ready(consumer_id, consumer, local_bufs);
+            release_fanin_and_check_ready(consumer_id, consumer, local_buf);
 #endif
             current = current->next;
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -68,7 +68,7 @@ typedef struct {
     std::atomic<uint64_t> graph_output_ptr;   // Address where final output was written (packed buffer)
     std::atomic<uint64_t> graph_output_size;  // Size in bytes
 
-    // Padding to 128-byte cache line
+    // Padding to cache line
     uint64_t _padding[4];
 
 } PTO2SharedMemoryHeader;

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -20,13 +20,6 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[core_idx]);
 
-    // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
-    // across rounds. DATA_MAIN_BASE still holds the EXIT_SIGNAL from the previous
-    // round, so clear it before the handshake wait. Clearing after the wait would
-    // race with AICPU, which may finish all tasks and write a new EXIT_SIGNAL while
-    // this thread is descheduled between the wait and the clear.
-    write_reg(RegId::DATA_MAIN_BASE, 0);
-
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);

--- a/tests/device_tests/tensormap_and_ringbuffer/batch_paged_attention/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/batch_paged_attention/golden.py
@@ -13,12 +13,12 @@ ATOL = 1e-3
 
 ALL_CASES = {
     "Case1": {
-        "batch": 256,
+        "batch": 64,
         "num_heads": 16,
         "kv_head_num": 1,
         "head_dim": 128,
         "block_size": 128,
-        "context_len": 8192,
+        "context_len": 8193,
         "max_model_len": 32768,
         "dtype": "bfloat16",
     },
@@ -32,13 +32,14 @@ ALL_CASES = {
         "max_model_len": 32768,
         "dtype": "bfloat16",
     },
-    "Case3": {
+    "CaseVarSeq": {
         "batch": 64,
-        "num_heads": 64,
+        "num_heads": 16,
         "kv_head_num": 1,
-        "head_dim": 256,
-        "block_size": 64,
-        "context_len": 8192,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 8193,
+        "context_lens_list": [8193, 4096, 1024, 256, 8000, 512, 2048, 7777],
         "max_model_len": 32768,
         "dtype": "bfloat16",
     },

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -13,12 +13,12 @@ ATOL = 1e-3
 
 ALL_CASES = {
     "Case1": {
-        "batch": 256,
+        "batch": 64,
         "num_heads": 16,
         "kv_head_num": 1,
         "head_dim": 128,
         "block_size": 128,
-        "context_len": 8192,
+        "context_len": 8193,
         "max_model_len": 32768,
         "dtype": "bfloat16",
     },
@@ -27,16 +27,6 @@ ALL_CASES = {
         "num_heads": 64,
         "kv_head_num": 1,
         "head_dim": 128,
-        "block_size": 64,
-        "context_len": 8192,
-        "max_model_len": 32768,
-        "dtype": "bfloat16",
-    },
-    "Case3": {
-        "batch": 64,
-        "num_heads": 64,
-        "kv_head_num": 1,
-        "head_dim": 256,
         "block_size": 64,
         "context_len": 8192,
         "max_model_len": 32768,

--- a/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
+++ b/tests/device_tests/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
@@ -24,14 +24,13 @@ ATOL = 1e-3
 # All test cases - production scale
 ALL_CASES = {
     "Case1": {
-        "batch": 256,
+        "batch": 64,
         "num_heads": 16,
         "kv_head_num": 1,
         "head_dim": 128,
         "block_size": 128,
-        "context_len": 8192,
+        "context_len": 8193,
         "max_model_len": 32768,
-        "dtype": "bfloat16",
     },
     "Case2": {
         "batch": 64,
@@ -41,17 +40,6 @@ ALL_CASES = {
         "block_size": 64,
         "context_len": 8192,
         "max_model_len": 32768,
-        "dtype": "bfloat16",
-    },
-    "Case3": {
-        "batch": 64,
-        "num_heads": 64,
-        "kv_head_num": 1,
-        "head_dim": 256,
-        "block_size": 64,
-        "context_len": 8192,
-        "max_model_len": 32768,
-        "dtype": "bfloat16",
     },
 }
 
@@ -67,7 +55,6 @@ def generate_inputs(params: dict) -> list:
     block_size = params["block_size"]
     context_len = params["context_len"]
     max_model_len = params["max_model_len"]
-    dtype = getattr(torch, params.get("dtype", "bfloat16"))
 
     max_num_blocks_per_req = max_model_len // block_size
     cur_valid_blocks = (context_len + block_size - 1) // block_size
@@ -90,15 +77,15 @@ def generate_inputs(params: dict) -> list:
         dtype=torch.int64,
     )
 
-    query_raw = torch.empty(batch, 1, num_heads * head_dim).uniform_(-0.5, 0.5).to(dtype)
-    query_raw = query_raw.reshape(batch, num_heads, head_dim)
+    query_bf16 = torch.empty(batch, 1, num_heads * head_dim).uniform_(-0.5, 0.5).to(torch.bfloat16)
+    query_bf16 = query_bf16.reshape(batch, num_heads, head_dim)
 
-    key_raw = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-0.5, 0.5).to(dtype)
-    value_raw = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-1, 1).to(dtype)
+    key_bf16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-0.5, 0.5).to(torch.bfloat16)
+    value_bf16 = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-1, 1).to(torch.bfloat16)
 
-    query = query_raw.flatten()
-    key_cache = key_raw.flatten()
-    value_cache = value_raw.flatten()
+    query = query_bf16.flatten()
+    key_cache = key_bf16.flatten()
+    value_cache = value_bf16.flatten()
     block_table_flat = block_table.flatten()
     out = torch.zeros(batch * num_heads * head_dim, dtype=torch.float32)
 
@@ -146,7 +133,6 @@ def paged_attention(
         out: (batch * num_heads, head_dim) float32
     """
     assert num_kv_heads == 1
-    input_dtype = query.dtype
     batch, num_heads_dim, head_dim = query.shape
     _, block_size, _, _ = key_cache.shape
 
@@ -203,7 +189,7 @@ def paged_attention(
             pij = torch.exp(sij - mij)
             pij = pij.masked_fill(~valid_mask, 0.0)
             pij = pij.masked_fill(~batch_mask, 0.0)
-            pij = pij.to(input_dtype).to(torch.float32)
+            pij = pij.to(torch.bfloat16).to(torch.float32)
             lij = pij.sum(dim=-1, keepdim=True)  # (batch, q_tile_size, 1)
 
             # PV matmul: (batch, q_tile_size, head_dim)


### PR DESCRIPTION
## Summary
- Move dispatch payload construction from orchestrator submit time to AICPU dispatch time (in-place into `TaskPayload.dispatch`), keeping orchestrator lean while maintaining zero-copy dispatch
- Slim `PTO2DispatchPayload` to only `function_bin_addr` + `args[]` — AICore derives `task_id` from register value, AICPU fills profiling metadata (`func_id`, `core_type`) at completion time from `TaskDescriptor`
- Remove `func_id_to_addr` table from shared memory header (AICPU resolves addresses directly from `Runtime`)

## Testing
- [x] Simulation tests pass (`./ci.sh -p a2a3sim` — 11/11)
- [ ] Hardware tests pass (requires Ascend device)