### PR TITLE
Fix: DepListPool ring buffer reclamation to prevent batch=256 hang

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -117,9 +117,10 @@ bool pto2_orchestrator_init(
     }
     pto2_dep_pool_init(&orch->dep_pool, dep_entries, dep_pool_capacity);
     orch->dep_pool_cur_entry = nullptr;
+    orch->dep_pool_last_reclaimed = 0;
 
     // Initialize TensorMap
-    if (!orch->tensor_map.init_default()) {
+    if (!orch->tensor_map.init_default(sm_handle->header->task_window_size)) {
         free(dep_entries);
         return false;
     }
@@ -241,6 +242,20 @@ void pto2_submit_mixed_task(
 
     // === STEP 0: Sync TensorMap validity and optional cleanup ===
     orch->tensor_map.sync_tensormap();
+
+    // Reclaim dead dep pool entries based on scheduler's last_task_alive
+    {
+        int32_t last_alive = orch->sm_handle->header->last_task_alive.load(std::memory_order_acquire);
+        if (last_alive > orch->dep_pool_last_reclaimed && last_alive > 0) {
+            int32_t newest_consumed = last_alive - 1;
+            int32_t slot_rc = orch->task_ring.get_task_slot(newest_consumed);
+            int32_t mark = orch->sm_handle->task_payloads[slot_rc].dep_pool_mark;
+            if (mark > 0) {
+                orch->dep_pool.advance_tail(mark);
+            }
+            orch->dep_pool_last_reclaimed = last_alive;
+        }
+    }
 
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, -1);
 
@@ -458,6 +473,9 @@ void pto2_submit_mixed_task(
 #endif
     }
 
+    // Record dep pool watermark for this task (used by tail reclamation)
+    payload->dep_pool_mark = orch->dep_pool.top;
+
     CYCLE_COUNT_LAP_RECORD(g_orch_fanin_cycle, AicpuPhaseId::ORCH_FANIN, task_id);
 
 #if PTO2_PROFILING
@@ -474,6 +492,10 @@ void pto2_submit_mixed_task(
 void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
     int32_t total_tasks = orch->task_ring.current_index_ptr->load(std::memory_order_acquire);
     LOG_INFO("=== [Orchestrator] total_tasks=%d ===", total_tasks);
+    LOG_INFO("=== [DepPool] top=%d tail=%d used=%d high_water=%d capacity=%d ===",
+             orch->dep_pool.top, orch->dep_pool.tail,
+             orch->dep_pool.top - orch->dep_pool.tail,
+             orch->dep_pool.high_water, orch->dep_pool.capacity);
     orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -44,6 +44,7 @@ struct PTO2OrchestratorState {
     PTO2TaskRing task_ring;    // Task slot allocation
     PTO2DepListPool dep_pool;  // Dependency list storage (per-orchestrator, no atomics needed)
     PTO2DepListEntry* dep_pool_cur_entry;
+    int32_t dep_pool_last_reclaimed;  // last_task_alive value at last reclamation
 
     // === TENSOR MAP (Private) ===
     PTO2TensorMap tensor_map;        // Producer lookup

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -47,6 +47,8 @@ void pto2_dep_pool_init(PTO2DepListPool* pool, PTO2DepListEntry* base, int32_t c
     pool->base = base;
     pool->capacity = capacity;
     pool->top = 1;  // Start from 1, 0 means NULL/empty
+    pool->tail = 1; // Match initial top (no reclaimable entries yet)
+    pool->high_water = 0;
 
     // Initialize entry 0 as NULL marker
     pool->base[0].task_id = -1;
@@ -54,9 +56,9 @@ void pto2_dep_pool_init(PTO2DepListPool* pool, PTO2DepListEntry* base, int32_t c
 }
 
 int32_t pto2_dep_pool_used(PTO2DepListPool* pool) {
-    return pool->top - 1;
+    return pool->top - pool->tail;
 }
 
 int32_t pto2_dep_pool_available(PTO2DepListPool* pool) {
-    return pool->capacity - pool->top;
+    return pool->capacity - (pool->top - pool->tail);
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -421,14 +421,20 @@ static inline PTO2TaskDescriptor* pto2_task_ring_get(PTO2TaskRing* ring, int32_t
 
 /**
  * Dependency list pool structure
- * 
- * Ring buffer for allocating linked list entries.
- * Supports O(1) prepend operation for fanin/fanout lists.
+ *
+ * True ring buffer for allocating linked list entries.
+ * Entries are reclaimed when their producer tasks become CONSUMED,
+ * as tracked by the orchestrator via dep_pool_mark per task.
+ *
+ * Linear counters (top, tail) grow monotonically; the physical index
+ * is obtained via modulo: base[linear_index % capacity].
  */
 struct PTO2DepListPool {
-    PTO2DepListEntry* base;   // Pool base address (from shared memory)
+    PTO2DepListEntry* base;   // Pool base address
     int32_t capacity;         // Total number of entries
-    int32_t top;              // Next allocation position (starts from 1, 0=NULL)
+    int32_t top;              // Linear next-allocation counter (starts from 1)
+    int32_t tail;             // Linear first-alive counter (entries before this are dead)
+    int32_t high_water;       // Peak concurrent usage (top - tail)
 
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)
@@ -436,12 +442,33 @@ struct PTO2DepListPool {
      * @return Reference to allocated entry
      */
     PTO2DepListEntry& alloc() {
-        int32_t idx = top++;
-        if (idx >= capacity) {
-            top = 2;  // Wrap around (skip entry 0 = NULL marker)
-            idx = 1;
+        int32_t used = top - tail;
+        if (used >= capacity) {
+            LOG_ERROR("========================================");
+            LOG_ERROR("FATAL: Dependency Pool Overflow!");
+            LOG_ERROR("========================================");
+            LOG_ERROR("DepListPool exhausted: %d entries alive (capacity=%d).", used, capacity);
+            LOG_ERROR("  - Pool top:      %d (linear)", top);
+            LOG_ERROR("  - Pool tail:     %d (linear)", tail);
+            LOG_ERROR("  - High water:    %d", high_water);
+            LOG_ERROR("========================================");
+            exit(1);
         }
+        int32_t idx = top % capacity;
+        top++;
+        used++;
+        if (used > high_water) high_water = used;
         return base[idx];
+    }
+
+    /**
+     * Advance the tail pointer, reclaiming dead entries.
+     * Called by the orchestrator based on last_task_alive advancement.
+     */
+    void advance_tail(int32_t new_tail) {
+        if (new_tail > tail) {
+            tail = new_tail;
+        }
     }
 
     /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -80,7 +80,7 @@
 #define PTO2_SCOPE_TASKS_INIT_CAP 65536     // Initial capacity for scope task buffer
 
 // Ready queue
-#define PTO2_READY_QUEUE_SIZE     65536   // Per-shape queue size (16x larger to avoid queue full)
+#define PTO2_READY_QUEUE_SIZE     65536   // Per-shape queue size
 
 // Memory alignment
 #define PTO2_ALIGN_SIZE           64      // Cache line alignment
@@ -323,6 +323,7 @@ struct PTO2TaskPayload {
     int param_count{0};
     int32_t fanin_tasks[PTO2_MAX_INPUTS];   // Producer task IDs (cold path, used by on_task_release)
     int32_t fanin_actual_count{0};           // Actual fanin count (without the +1 redundance)
+    int32_t dep_pool_mark{0};                // Dep pool top after this task's submission (for reclamation)
 };
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -38,7 +38,7 @@ uint64_t g_insert_count = 0;
 // Initialization and Destruction
 // =============================================================================
 
-bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size) {
+bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, int32_t new_task_window_size) {
     // Validate power of 2 for fast modulo
     if ((new_num_buckets & (new_num_buckets - 1)) != 0) {
         return false;  // num_buckets must be power of 2
@@ -90,7 +90,7 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size) {
     }
 
     // Allocate per-task entry tracking
-    task_entry_head = (PTO2TensorMapEntry**)malloc(new_pool_size * sizeof(PTO2TensorMapEntry*));
+    task_entry_head = (PTO2TensorMapEntry**)malloc(new_task_window_size * sizeof(PTO2TensorMapEntry*));
     if (!task_entry_head) {
         free(entry_pool);
         free(buckets);
@@ -102,17 +102,19 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size) {
     }
 
     // Initialize all task entry heads to -1 (no entries)
-    for (int32_t i = 0; i < PTO2_TASK_WINDOW_SIZE; i++) {
+    for (int32_t i = 0; i < new_task_window_size; i++) {
         task_entry_head[i] = nullptr;
     }
+
+    task_window_size = new_task_window_size;
 
     last_task_alive = 0;
 
     return true;
 }
 
-bool PTO2TensorMap::init_default() {
-    return init(PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE);
+bool PTO2TensorMap::init_default(int32_t new_task_window_size) {
+    return init(PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE, new_task_window_size);
 }
 
 void PTO2TensorMap::destroy() {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -124,7 +124,8 @@ struct PTO2TensorMap {
 
     // Per-task entry tracking (for efficient bucket cleanup)
     PTO2TensorMapEntry** task_entry_head;  // Per-task head offset (-1 = no entries)
-                               // Indexed by task_id % TASK_WINDOW_SIZE
+                               // Indexed by task_id % task_window_size
+    int32_t task_window_size;  // Runtime task window size (for slot masking)
 
     // Validity threshold (for lazy invalidation)
     int32_t last_task_alive;  // Cached value from shared memory
@@ -183,12 +184,12 @@ struct PTO2TensorMap {
      * @param pool_size   Size of entry pool
      * @return true on success, false on allocation failure
      */
-    bool init(int32_t num_buckets, int32_t pool_size);
+    bool init(int32_t num_buckets, int32_t pool_size, int32_t task_window_size);
 
     /**
      * Initialize TensorMap with default sizes
      */
-    bool init_default();
+    bool init_default(int32_t task_window_size);
 
     /**
      * Destroy TensorMap and free resources
@@ -304,7 +305,7 @@ struct PTO2TensorMap {
         entry->prev_in_bucket = nullptr;  // New head has no predecessor
 
         // Link to task's entry list (for cleanup)
-        int32_t task_slot = producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+        int32_t task_slot = producer_task_id & (task_window_size - 1);
         entry->next_in_task = task_entry_head[task_slot];
         entry->prev_in_task = nullptr;  // New head has no predecessor
         // Update old head's prev pointer
@@ -326,7 +327,7 @@ struct PTO2TensorMap {
     void cleanup_retired(int32_t old_last_task_alive, int32_t new_last_task_alive) {
         // Iterate through retired tasks and remove their entries from bucket chains
         for (int32_t task_id = old_last_task_alive; task_id < new_last_task_alive; task_id++) {
-            int32_t task_slot = task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+            int32_t task_slot = task_id & (task_window_size - 1);
             PTO2TensorMapEntry* cur_entry = task_entry_head[task_slot];
 
             while (cur_entry != nullptr) {
@@ -380,7 +381,7 @@ struct PTO2TensorMap {
         // Update predecessor's next pointer (O(1) via prev_in_task)
         if (entry.prev_in_task == nullptr) {
             // Entry is the head of its task chain, update task_entry_head
-            int32_t task_slot = entry.producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+            int32_t task_slot = entry.producer_task_id & (task_window_size - 1);
             task_entry_head[task_slot] = entry.next_in_task;
         } else {
             entry.prev_in_task->next_in_task = entry.next_in_task;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -117,9 +117,10 @@ bool pto2_orchestrator_init(
     }
     pto2_dep_pool_init(&orch->dep_pool, dep_entries, dep_pool_capacity);
     orch->dep_pool_cur_entry = nullptr;
+    orch->dep_pool_last_reclaimed = 0;
 
     // Initialize TensorMap
-    if (!orch->tensor_map.init_default()) {
+    if (!orch->tensor_map.init_default(sm_handle->header->task_window_size)) {
         free(dep_entries);
         return false;
     }
@@ -224,6 +225,20 @@ void pto2_submit_task(
 
     // === STEP 0: Sync TensorMap validity and optional cleanup ===
     orch->tensor_map.sync_tensormap();
+
+    // Reclaim dead dep pool entries based on scheduler's last_task_alive
+    {
+        int32_t last_alive = orch->sm_handle->header->last_task_alive.load(std::memory_order_acquire);
+        if (last_alive > orch->dep_pool_last_reclaimed && last_alive > 0) {
+            int32_t newest_consumed = last_alive - 1;
+            int32_t slot_rc = orch->task_ring.get_task_slot(newest_consumed);
+            int32_t mark = orch->sm_handle->task_payloads[slot_rc].dep_pool_mark;
+            if (mark > 0) {
+                orch->dep_pool.advance_tail(mark);
+            }
+            orch->dep_pool_last_reclaimed = last_alive;
+        }
+    }
 
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, -1);
 
@@ -437,6 +452,9 @@ void pto2_submit_task(
 #endif
     }
 
+    // Record dep pool watermark for this task (used by tail reclamation)
+    payload->dep_pool_mark = orch->dep_pool.top;
+
     CYCLE_COUNT_LAP_RECORD(g_orch_fanin_cycle, AicpuPhaseId::ORCH_FANIN, task_id);
 
 #if PTO2_PROFILING
@@ -453,6 +471,10 @@ void pto2_submit_task(
 void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
     int32_t total_tasks = orch->task_ring.current_index_ptr->load(std::memory_order_acquire);
     LOG_INFO("=== [Orchestrator] total_tasks=%d ===", total_tasks);
+    LOG_INFO("=== [DepPool] top=%d tail=%d used=%d high_water=%d capacity=%d ===",
+             orch->dep_pool.top, orch->dep_pool.tail,
+             orch->dep_pool.top - orch->dep_pool.tail,
+             orch->dep_pool.high_water, orch->dep_pool.capacity);
     orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
 }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -43,6 +43,7 @@ struct PTO2OrchestratorState {
     PTO2TaskRing task_ring;    // Task slot allocation
     PTO2DepListPool dep_pool;  // Dependency list storage (per-orchestrator, no atomics needed)
     PTO2DepListEntry* dep_pool_cur_entry;
+    int32_t dep_pool_last_reclaimed;  // last_task_alive value at last reclamation
 
     // === TENSOR MAP (Private) ===
     PTO2TensorMap tensor_map;        // Producer lookup

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -47,6 +47,8 @@ void pto2_dep_pool_init(PTO2DepListPool* pool, PTO2DepListEntry* base, int32_t c
     pool->base = base;
     pool->capacity = capacity;
     pool->top = 1;  // Start from 1, 0 means NULL/empty
+    pool->tail = 1; // Match initial top (no reclaimable entries yet)
+    pool->high_water = 0;
 
     // Initialize entry 0 as NULL marker
     pool->base[0].task_id = -1;
@@ -54,9 +56,9 @@ void pto2_dep_pool_init(PTO2DepListPool* pool, PTO2DepListEntry* base, int32_t c
 }
 
 int32_t pto2_dep_pool_used(PTO2DepListPool* pool) {
-    return pool->top - 1;
+    return pool->top - pool->tail;
 }
 
 int32_t pto2_dep_pool_available(PTO2DepListPool* pool) {
-    return pool->capacity - pool->top;
+    return pool->capacity - (pool->top - pool->tail);
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -421,14 +421,20 @@ static inline PTO2TaskDescriptor* pto2_task_ring_get(PTO2TaskRing* ring, int32_t
 
 /**
  * Dependency list pool structure
- * 
- * Ring buffer for allocating linked list entries.
- * Supports O(1) prepend operation for fanin/fanout lists.
+ *
+ * True ring buffer for allocating linked list entries.
+ * Entries are reclaimed when their producer tasks become CONSUMED,
+ * as tracked by the orchestrator via dep_pool_mark per task.
+ *
+ * Linear counters (top, tail) grow monotonically; the physical index
+ * is obtained via modulo: base[linear_index % capacity].
  */
 struct PTO2DepListPool {
-    PTO2DepListEntry* base;   // Pool base address (from shared memory)
+    PTO2DepListEntry* base;   // Pool base address
     int32_t capacity;         // Total number of entries
-    int32_t top;              // Next allocation position (starts from 1, 0=NULL)
+    int32_t top;              // Linear next-allocation counter (starts from 1)
+    int32_t tail;             // Linear first-alive counter (entries before this are dead)
+    int32_t high_water;       // Peak concurrent usage (top - tail)
 
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)
@@ -436,12 +442,33 @@ struct PTO2DepListPool {
      * @return Reference to allocated entry
      */
     PTO2DepListEntry& alloc() {
-        int32_t idx = top++;
-        if (idx >= capacity) {
-            top = 2;  // Wrap around (skip entry 0 = NULL marker)
-            idx = 1;
+        int32_t used = top - tail;
+        if (used >= capacity) {
+            LOG_ERROR("========================================");
+            LOG_ERROR("FATAL: Dependency Pool Overflow!");
+            LOG_ERROR("========================================");
+            LOG_ERROR("DepListPool exhausted: %d entries alive (capacity=%d).", used, capacity);
+            LOG_ERROR("  - Pool top:      %d (linear)", top);
+            LOG_ERROR("  - Pool tail:     %d (linear)", tail);
+            LOG_ERROR("  - High water:    %d", high_water);
+            LOG_ERROR("========================================");
+            exit(1);
         }
+        int32_t idx = top % capacity;
+        top++;
+        used++;
+        if (used > high_water) high_water = used;
         return base[idx];
+    }
+
+    /**
+     * Advance the tail pointer, reclaiming dead entries.
+     * Called by the orchestrator based on last_task_alive advancement.
+     */
+    void advance_tail(int32_t new_tail) {
+        if (new_tail > tail) {
+            tail = new_tail;
+        }
     }
 
     /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -79,7 +79,7 @@
 #define PTO2_SCOPE_TASKS_INIT_CAP 65536     // Initial capacity for scope task buffer
 
 // Ready queue
-#define PTO2_READY_QUEUE_SIZE     65536   // Per-worker-type queue size (16x larger to avoid queue full)
+#define PTO2_READY_QUEUE_SIZE     65536   // Per-worker-type queue size
 
 // Memory alignment
 #define PTO2_ALIGN_SIZE           64      // Cache line alignment
@@ -314,6 +314,7 @@ struct PTO2TaskPayload {
     int param_count{0};
     int32_t fanin_tasks[PTO2_MAX_INPUTS];   // Producer task IDs (cold path, used by on_task_release)
     int32_t fanin_actual_count{0};           // Actual fanin count (without the +1 redundance)
+    int32_t dep_pool_mark{0};                // Dep pool top after this task's submission (for reclamation)
 };
 
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -38,7 +38,7 @@ uint64_t g_insert_count = 0;
 // Initialization and Destruction
 // =============================================================================
 
-bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size) {
+bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, int32_t new_task_window_size) {
     // Validate power of 2 for fast modulo
     if ((new_num_buckets & (new_num_buckets - 1)) != 0) {
         return false;  // num_buckets must be power of 2
@@ -90,7 +90,7 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size) {
     }
 
     // Allocate per-task entry tracking
-    task_entry_head = (PTO2TensorMapEntry**)malloc(new_pool_size * sizeof(PTO2TensorMapEntry*));
+    task_entry_head = (PTO2TensorMapEntry**)malloc(new_task_window_size * sizeof(PTO2TensorMapEntry*));
     if (!task_entry_head) {
         free(entry_pool);
         free(buckets);
@@ -102,17 +102,19 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size) {
     }
 
     // Initialize all task entry heads to -1 (no entries)
-    for (int32_t i = 0; i < PTO2_TASK_WINDOW_SIZE; i++) {
+    for (int32_t i = 0; i < new_task_window_size; i++) {
         task_entry_head[i] = nullptr;
     }
+
+    task_window_size = new_task_window_size;
 
     last_task_alive = 0;
 
     return true;
 }
 
-bool PTO2TensorMap::init_default() {
-    return init(PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE);
+bool PTO2TensorMap::init_default(int32_t new_task_window_size) {
+    return init(PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE, new_task_window_size);
 }
 
 void PTO2TensorMap::destroy() {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -124,7 +124,8 @@ struct PTO2TensorMap {
 
     // Per-task entry tracking (for efficient bucket cleanup)
     PTO2TensorMapEntry** task_entry_head;  // Per-task head offset (-1 = no entries)
-                               // Indexed by task_id % TASK_WINDOW_SIZE
+                               // Indexed by task_id % task_window_size
+    int32_t task_window_size;  // Runtime task window size (for slot masking)
 
     // Validity threshold (for lazy invalidation)
     int32_t last_task_alive;  // Cached value from shared memory
@@ -183,12 +184,12 @@ struct PTO2TensorMap {
      * @param pool_size   Size of entry pool
      * @return true on success, false on allocation failure
      */
-    bool init(int32_t num_buckets, int32_t pool_size);
+    bool init(int32_t num_buckets, int32_t pool_size, int32_t task_window_size);
 
     /**
      * Initialize TensorMap with default sizes
      */
-    bool init_default();
+    bool init_default(int32_t task_window_size);
 
     /**
      * Destroy TensorMap and free resources
@@ -304,7 +305,7 @@ struct PTO2TensorMap {
         entry->prev_in_bucket = nullptr;  // New head has no predecessor
 
         // Link to task's entry list (for cleanup)
-        int32_t task_slot = producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+        int32_t task_slot = producer_task_id & (task_window_size - 1);
         entry->next_in_task = task_entry_head[task_slot];
         entry->prev_in_task = nullptr;  // New head has no predecessor
         // Update old head's prev pointer
@@ -326,7 +327,7 @@ struct PTO2TensorMap {
     void cleanup_retired(int32_t old_last_task_alive, int32_t new_last_task_alive) {
         // Iterate through retired tasks and remove their entries from bucket chains
         for (int32_t task_id = old_last_task_alive; task_id < new_last_task_alive; task_id++) {
-            int32_t task_slot = task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+            int32_t task_slot = task_id & (task_window_size - 1);
             PTO2TensorMapEntry* cur_entry = task_entry_head[task_slot];
 
             while (cur_entry != nullptr) {
@@ -380,7 +381,7 @@ struct PTO2TensorMap {
         // Update predecessor's next pointer (O(1) via prev_in_task)
         if (entry.prev_in_task == nullptr) {
             // Entry is the head of its task chain, update task_entry_head
-            int32_t task_slot = entry.producer_task_id & (PTO2_TASK_WINDOW_SIZE - 1);
+            int32_t task_slot = entry.producer_task_id & (task_window_size - 1);
             task_entry_head[task_slot] = entry.next_in_task;
         } else {
             entry.prev_in_task->next_in_task = entry.next_in_task;

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -23,7 +23,7 @@ ALL_CASES = {
         "dtype": "bfloat16",
     },
     "Case2": {
-        "batch": 64,
+        "batch": 256,
         "num_heads": 64,
         "kv_head_num": 1,
         "head_dim": 128,


### PR DESCRIPTION
The DepListPool was a monotonic bump allocator that never reclaimed entries. With batch=256 (~66k tasks, ~133k dep entries needed), the pool silently wrapped at capacity=65536, overwriting live fanout list nodes. Corrupted fanout links caused missed fanin notifications, leaving tasks permanently PENDING and deadlocking the TaskRing.

- Convert DepListPool to a true ring buffer with tail reclamation and modular physical indexing (top % capacity)
- Reclaim dead entries in submit_mixed_task based on last_task_alive via per-task dep_pool_mark watermarks
- Add fatal error on overflow instead of silent data corruption
- Fix TensorMap to use runtime task_window_size instead of hardcoded PTO2_TASK_WINDOW_SIZE for slot masking and allocation
- Update paged_attention test to batch=256

Verified: 10/10 runs pass on a2a3 hardware (batch=256, both cases).