### PR TITLE
Refactor: move AICPU cluster affinity from runtime to platform layer

### DIFF
--- a/src/a2a3/platform/include/aicpu/platform_aicpu_affinity.h
+++ b/src/a2a3/platform/include/aicpu/platform_aicpu_affinity.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstdint>
+
+// Returns true if this thread should call aicpu_execute().
+// Returns false if this thread should exit (dropped).
+// logical_count: desired active threads (from runtime.sche_cpu_num)
+// total_launched: actual threads launched (PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)
+bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched);

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -40,6 +40,14 @@ constexpr int PLATFORM_AIV_CORES_PER_BLOCKDIM = 2;
  */
 constexpr int PLATFORM_MAX_AICPU_THREADS = 4;
 
+/**
+ * Maximum AICPU launch threads (physical)
+ * Upper bound for the number of AICPU threads that can be launched by Host.
+ * Can be larger than PLATFORM_MAX_AICPU_THREADS to allow threads to be dropped
+ * from scheduling while still participating in affinity (e.g. 6 launch, 4 active).
+ */
+constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 6;
+
 // =============================================================================
 // Derived Platform Limits
 // =============================================================================

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -2,11 +2,11 @@
 
 #include "common/unified_log.h"
 #include "common/kernel_args.h"
+#include "common/platform_config.h"
 #include "aicpu/device_log.h"
 #include "aicpu/platform_regs.h"
-
-// Forward declaration (no need for full runtime.h)
-class Runtime;
+#include "aicpu/platform_aicpu_affinity.h"
+#include "runtime.h"
 
 // Forward declaration of aicpu_execute (implemented in aicpu_executor.cpp)
 extern "C" int aicpu_execute(Runtime *arg);
@@ -70,6 +70,13 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
 
     // Store platform regs before calling aicpu_execute
     set_platform_regs(k_args->regs);
+
+    // Affinity gate: drop excess threads before entering runtime
+    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num,
+                                      PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
+        LOG_INFO("Thread dropped by cluster affinity");
+        return 0;
+    }
 
     LOG_INFO("%s", "DynTileFwkBackendKernelServer: Calling aicpu_execute with Runtime");
     int rc = aicpu_execute(runtime);

--- a/src/a2a3/platform/onboard/aicpu/platform_aicpu_affinity.cpp
+++ b/src/a2a3/platform/onboard/aicpu/platform_aicpu_affinity.cpp
@@ -1,0 +1,140 @@
+#include "aicpu/platform_aicpu_affinity.h"
+
+#include <atomic>
+#include <cstdint>
+#ifdef __linux__
+#include <sched.h>
+#endif
+
+#include "common/unified_log.h"
+
+static constexpr int32_t AICPU_CORES_PER_CHIP = 8;
+static constexpr int32_t MAX_CLUSTERS = 2;
+static constexpr int32_t CPUS_PER_CLUSTER = 4;
+static constexpr int32_t MAX_GATE_THREADS = 8;
+
+static std::atomic<uint64_t> s_cpumask{0};
+static std::atomic<int32_t> s_reported{0};
+static std::atomic<int32_t> s_gate_init{0};
+static std::atomic<int32_t> s_gate_ready{0};
+
+static int32_t s_thread_cpu[MAX_GATE_THREADS];
+static bool s_thread_survive[MAX_GATE_THREADS];
+
+static inline int32_t popcount64(uint64_t v) {
+    return __builtin_popcountll(static_cast<unsigned long long>(v));
+}
+
+bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched) {
+    if (logical_count >= total_launched) {
+        return true;
+    }
+
+    // Assign thread index
+    int32_t idx = s_reported.fetch_add(1, std::memory_order_acq_rel);
+
+    // Report CPU
+#if defined(__aarch64__)
+    int32_t cpu = sched_getcpu();
+#elif defined(__x86_64__)
+    int32_t cpu = sched_getcpu();
+#else
+    int32_t cpu = -1;
+#endif
+
+    int32_t normalized_cpu = -1;
+    if (cpu >= 0) {
+        if (cpu < 63) {
+            s_cpumask.fetch_or(1ULL << cpu, std::memory_order_release);
+        }
+        normalized_cpu = cpu % AICPU_CORES_PER_CHIP;
+    }
+    if (idx < MAX_GATE_THREADS) {
+        s_thread_cpu[idx] = normalized_cpu;
+    }
+
+    // Barrier: wait until all total_launched threads have reported
+    while (popcount64(s_cpumask.load(std::memory_order_acquire)) < total_launched &&
+           s_reported.load(std::memory_order_acquire) < total_launched) {
+    }
+
+    // CAS winner does cluster classification
+    int32_t expected = 0;
+    if (s_gate_init.compare_exchange_strong(expected, 1,
+            std::memory_order_acq_rel, std::memory_order_acquire)) {
+        // Initialize survive flags
+        for (int32_t i = 0; i < total_launched; ++i) {
+            s_thread_survive[i] = false;
+        }
+
+        struct ClusterInfo {
+            int32_t count{0};
+            int32_t tids[MAX_GATE_THREADS];
+        };
+        ClusterInfo clusters[MAX_CLUSTERS];
+
+        for (int32_t tid = 0; tid < total_launched; ++tid) {
+            int32_t c = s_thread_cpu[tid];
+            if (c < 0) continue;
+            int32_t cluster_id = c / CPUS_PER_CLUSTER;
+            if (cluster_id < 0 || cluster_id >= MAX_CLUSTERS) continue;
+            ClusterInfo& info = clusters[cluster_id];
+            if (info.count < MAX_GATE_THREADS) info.tids[info.count++] = tid;
+        }
+
+        int32_t major_id = (clusters[0].count >= clusters[1].count) ? 0 : 1;
+        int32_t minor_id = 1 - major_id;
+        int32_t major_cnt = clusters[major_id].count;
+        int32_t minor_cnt = clusters[minor_id].count;
+
+        LOG_INFO("AICPU affinity gate: major=%d(cnt=%d) minor=%d(cnt=%d) logical=%d",
+                 major_id, major_cnt, minor_id, minor_cnt, logical_count);
+
+        if (major_cnt == logical_count && minor_cnt == (total_launched - logical_count)) {
+            // Expected topology: major cluster threads survive
+            for (int32_t i = 0; i < clusters[major_id].count; ++i) {
+                s_thread_survive[clusters[major_id].tids[i]] = true;
+            }
+        } else {
+            // Unexpected topology: fall back to first logical_count threads
+            LOG_WARN("AICPU affinity gate: unexpected topology (major=%d minor=%d), "
+                     "falling back to index-based cutoff",
+                     major_cnt, minor_cnt);
+            for (int32_t i = 0; i < logical_count && i < total_launched; ++i) {
+                s_thread_survive[i] = true;
+            }
+        }
+
+        s_gate_ready.store(1, std::memory_order_release);
+    }
+
+    // Wait for classification to complete
+    while (s_gate_ready.load(std::memory_order_acquire) == 0) {
+    }
+
+    bool survive = (idx < total_launched) ? s_thread_survive[idx] : false;
+
+    // Last thread resets state for next invocation
+    int32_t finished = s_reported.load(std::memory_order_acquire);
+    (void)finished;
+    // Reset is deferred: the statics persist but are re-initialized by the CAS winner
+    // on next call. We reset the atomics after all threads have read their result.
+    // Use a second atomic counter for cleanup.
+    static std::atomic<int32_t> s_cleanup{0};
+    int32_t cleanup_idx = s_cleanup.fetch_add(1, std::memory_order_acq_rel);
+    if (cleanup_idx + 1 == total_launched) {
+        s_cpumask.store(0, std::memory_order_release);
+        s_reported.store(0, std::memory_order_release);
+        s_gate_init.store(0, std::memory_order_release);
+        s_gate_ready.store(0, std::memory_order_release);
+        s_cleanup.store(0, std::memory_order_release);
+    }
+
+    if (!survive) {
+        LOG_INFO("AICPU affinity gate: thread idx=%d cpu=%d DROPPED", idx, normalized_cpu);
+    } else {
+        LOG_INFO("AICPU affinity gate: thread idx=%d cpu=%d ACTIVE", idx, normalized_cpu);
+    }
+
+    return survive;
+}

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -304,11 +304,10 @@ int DeviceRunner::run(Runtime& runtime,
     }
 
     // Validate even core distribution for initial scheduler threads
-    // All-orchestrator mode (scheduler_thread_num == 0): cores assigned post-transition
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
-            LOG_ERROR("block_dim (%d) must be evenly divisible by scheduler_thread_num (%d)",
-                      block_dim, scheduler_thread_num);
+            LOG_ERROR("block_dim (%d) not evenly divisible by scheduler_thread_num (%d)",
+                     block_dim, scheduler_thread_num);
             return -1;
         }
     } else {
@@ -413,8 +412,8 @@ int DeviceRunner::run(Runtime& runtime,
     }
 
     std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServer===" << '\n';
-    // Launch AICPU main kernel
-    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", launch_aicpu_num);
+    // Launch AICPU main kernel (over-launch for affinity gate)
+    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
         if (kernel_args_.args.regs != 0) {

--- a/src/a2a3/platform/sim/aicpu/platform_aicpu_affinity.cpp
+++ b/src/a2a3/platform/sim/aicpu/platform_aicpu_affinity.cpp
@@ -1,0 +1,32 @@
+#include "aicpu/platform_aicpu_affinity.h"
+
+#include <atomic>
+#include <cstdint>
+
+#include "common/unified_log.h"
+
+static std::atomic<int32_t> s_thread_counter{0};
+static std::atomic<int32_t> s_cleanup_counter{0};
+
+bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched) {
+    if (logical_count >= total_launched) {
+        return true;
+    }
+
+    int32_t idx = s_thread_counter.fetch_add(1, std::memory_order_acq_rel);
+    bool survive = (idx < logical_count);
+
+    if (!survive) {
+        LOG_INFO("AICPU affinity gate (sim): thread idx=%d DROPPED (logical=%d, launched=%d)",
+                 idx, logical_count, total_launched);
+    }
+
+    // Last thread resets state for next invocation
+    int32_t cleanup_idx = s_cleanup_counter.fetch_add(1, std::memory_order_acq_rel);
+    if (cleanup_idx + 1 == total_launched) {
+        s_thread_counter.store(0, std::memory_order_release);
+        s_cleanup_counter.store(0, std::memory_order_release);
+    }
+
+    return survive;
+}

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -32,6 +32,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/host_log.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/unified_log_host.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/performance_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../aicpu/platform_aicpu_affinity.cpp"
 )
 
 if(DEFINED CUSTOM_SOURCE_DIRS)

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "device_runner.h"
+#include "aicpu/platform_aicpu_affinity.h"
 
 // Function pointer types for dynamically loaded executors
 typedef int (*aicpu_execute_func_t)(Runtime* runtime);
@@ -139,7 +140,7 @@ int DeviceRunner::run(Runtime& runtime,
 
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", 
+        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]",
                        launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
         return -1;
     }
@@ -161,11 +162,10 @@ int DeviceRunner::run(Runtime& runtime,
     }
 
     // Validate even core distribution for initial scheduler threads
-    // All-orchestrator mode (scheduler_thread_num == 0): cores assigned post-transition
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
-            LOG_ERROR("block_dim (%d) must be evenly divisible by scheduler_thread_num (%d)",
-                      block_dim, scheduler_thread_num);
+            LOG_ERROR("block_dim (%d) not evenly divisible by scheduler_thread_num (%d)",
+                     block_dim, scheduler_thread_num);
             return -1;
         }
     } else {
@@ -274,11 +274,15 @@ int DeviceRunner::run(Runtime& runtime,
     // Set platform regs in the AICPU .so before launching threads
     set_platform_regs_func_(kernel_args_.regs);
 
-    // Launch AICPU threads
-    LOG_INFO("Launching %d AICPU thread(s)", launch_aicpu_num);
+    // Launch AICPU threads (over-launch for affinity gate)
+    constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+    LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
     std::vector<std::thread> aicpu_threads;
-    for (int i = 0; i < launch_aicpu_num; i++) {
-        aicpu_threads.emplace_back([this, &runtime]() {
+    for (int i = 0; i < over_launch; i++) {
+        aicpu_threads.emplace_back([this, &runtime, launch_aicpu_num, over_launch]() {
+            if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
+                return;
+            }
             aicpu_execute_func_(&runtime);
         });
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -4,15 +4,11 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <mutex>
-#include <string>
-#include <thread>
 
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <unistd.h>
 #ifdef __linux__
-#include <sched.h>
 #include <sys/mman.h>
 #endif
 
@@ -668,7 +664,7 @@ void AicpuExecutor::assign_cores_to_threads() {
  * Writes into new_core_assignments_ / new_core_count_per_thread_.
  */
 void AicpuExecutor::reassign_cores_for_all_threads() {
-    DEV_INFO("Reassigning cores (cluster-aligned) for all %d threads: %d AIC, %d AIV",
+    DEV_INFO("Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV",
              thread_num_, aic_count_, aiv_count_);
 
     // Collect running/idle state from all threads before reassignment
@@ -1500,7 +1496,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 
     DEV_ALWAYS("Thread %d: Start", thread_idx);
 
-    // Orchestrator threads: thread_idx >= sched_thread_num_
+    // Orchestrator check
     if (thread_idx >= sched_thread_num_) {
         int32_t orch_idx = thread_idx - sched_thread_num_;
         if (runtime->get_orch_built_on_host()) {


### PR DESCRIPTION
## Summary
- Move cluster affinity logic (6-thread launch, 4-active) from runtime (`aicpu_executor.cpp`) to platform layer
- **Onboard**: new `platform_aicpu_affinity.cpp` detects clusters via `sched_getcpu()`, drops minor-cluster threads
- **Sim**: new `platform_aicpu_affinity.cpp` uses simple index-based cutoff
- Platform calls the affinity gate before `aicpu_execute()` — runtime stays topology-agnostic
- Remove ~130 lines of affinity code from `aicpu_executor.cpp` (`ThreadRole`, `apply_simpler_aicpu_affinity()`, etc.)
- Revert `aicpu_thread_num` from 6 back to 4 (platform handles over-launch transparently)

## Testing
- [x] Simulation tests pass (`./ci.sh -p a2a3sim` — 12/12 pass)
- [ ] Hardware tests pass (`./ci.sh -p a2a3 -d 4-7 --parallel`)