### PR TITLE
Add: --clone-protocol argument for pto-isa clone URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Run simulation examples (a2a3sim)
-        run: ./ci.sh -p a2a3sim -c 1b22fea -t 600
+        run: ./ci.sh -p a2a3sim -c 1b22fea -t 600 --clone-protocol https
 
   run-example-on-a5sim:
     runs-on: ${{ matrix.os }}
@@ -107,7 +107,7 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Run simulation examples (a5sim)
-        run: ./ci.sh -p a5sim -c 1b22fea -t 600
+        run: ./ci.sh -p a5sim -c 1b22fea -t 600 --clone-protocol https
 
   run-example-on-device:
     runs-on: self-hosted
@@ -120,4 +120,4 @@ jobs:
       - name: Run on-device examples
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          source ${ASCEND_HOME_PATH}/bin/setenv.bash && ./ci.sh -p a2a3 -d ${DEVICE_RANGE} --parallel -c 1b22fea -t 600
+          source ${ASCEND_HOME_PATH}/bin/setenv.bash && ./ci.sh -p a2a3 -d ${DEVICE_RANGE} --parallel -c 1b22fea -t 600 --clone-protocol https

--- a/README.md
+++ b/README.md
@@ -70,10 +70,20 @@ python examples/scripts/run_example.py -k examples/host_build_graph/vector_examp
                                        -p a2a3sim
 ```
 
+By default, the auto-clone uses SSH (`git@github.com:...`). In CI or environments without SSH keys, use `--clone-protocol https`:
+```bash
+python examples/scripts/run_example.py -k examples/host_build_graph/vector_example/kernels \
+                                       -g examples/host_build_graph/vector_example/golden.py \
+                                       -p a2a3sim --clone-protocol https
+```
+
 **Manual Setup** (if auto-setup fails or you prefer manual control):
 ```bash
-# Clone pto-isa manually
+# Clone pto-isa manually (SSH)
 mkdir -p examples/scripts/_deps
+git clone --branch main git@github.com:PTO-ISA/pto-isa.git examples/scripts/_deps/pto-isa
+
+# Or use HTTPS
 git clone --branch main https://github.com/PTO-ISA/pto-isa.git examples/scripts/_deps/pto-isa
 
 # Set environment variable (optional - auto-detected if in standard location)
@@ -89,7 +99,7 @@ export PTO_ISA_ROOT=/path/to/your/pto-isa
 **Troubleshooting:**
 - If git is not available: Clone pto-isa manually and set `PTO_ISA_ROOT`
 - If clone fails due to network: Try again or clone manually
-- For CI/CD: Either rely on auto-clone or pre-clone in CI steps
+- If SSH clone fails (e.g., in CI): Use `--clone-protocol https` or clone manually with HTTPS
 
 Note: For the simulation platform (`a2a3sim`), PTO ISA headers are optional and only needed if your kernels use PTO ISA intrinsics.
 

--- a/ci.sh
+++ b/ci.sh
@@ -7,6 +7,7 @@ PARALLEL=false
 RUNTIME=""
 PTO_ISA_COMMIT=""
 TIMEOUT=600  # 10 minutes default
+CLONE_PROTOCOL="https"  # Default to HTTPS in CI
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -28,6 +29,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -t|--timeout)
             TIMEOUT="$2"
+            shift 2
+            ;;
+        --clone-protocol)
+            CLONE_PROTOCOL="$2"
             shift 2
             ;;
         --parallel)
@@ -317,7 +322,7 @@ run_task() {
     local -a cmd
     cmd=(python examples/scripts/run_example.py
         -k "${dir}/kernels" -g "${dir}/golden.py"
-        -p "$platform" "${commit_flag[@]}")
+        -p "$platform" --clone-protocol "$CLONE_PROTOCOL" "${commit_flag[@]}")
     [[ -n "$device_id" ]] && cmd+=(-d "$device_id")
 
     # Progress to stdout (not captured in log)

--- a/examples/a2a3/host_build_graph/vector_example/README.md
+++ b/examples/a2a3/host_build_graph/vector_example/README.md
@@ -206,12 +206,7 @@ The simulation platform (a2a3sim) emulates the AICPU/AICore execution model:
 
 ### Kernel Compilation Failed (a2a3)
 
-The test framework auto-clones pto-isa on first run. If this fails, clone it manually:
-```bash
-mkdir -p examples/scripts/_deps
-git clone --branch main https://github.com/PTO-ISA/pto-isa.git examples/scripts/_deps/pto-isa
-```
-Or set PTO_ISA_ROOT to an existing installation:
+The test framework auto-clones pto-isa on first run. If this fails, see [Test Framework Documentation](../../../scripts/README.md) for clone options, or set PTO_ISA_ROOT to an existing installation:
 ```bash
 export PTO_ISA_ROOT=/path/to/pto-isa
 ```

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -56,6 +56,7 @@ python examples/scripts/run_example.py \
 | `--verbose` | `-v` | Enable verbose output (equivalent to `--log-level debug`) | False |
 | `--silent` | | Enable silent mode (equivalent to `--log-level error`) | False |
 | `--log-level` | | Set log level: `error`, `warn`, `info`, `debug` | `info` |
+| `--clone-protocol` | | Git protocol for cloning pto-isa: `ssh` or `https` | `ssh` |
 
 ### Platform Description
 

--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -151,10 +151,19 @@ def _is_git_available() -> bool:
         return False
 
 
-_PTO_ISA_REPO = "https://github.com/PTO-ISA/pto-isa.git"
+_PTO_ISA_HTTPS = "https://github.com/PTO-ISA/pto-isa.git"
+_PTO_ISA_SSH = "git@github.com:PTO-ISA/pto-isa.git"
 
 
-def _clone_pto_isa(verbose: bool = False, commit: Optional[str] = None) -> bool:
+def _pto_isa_repo_url(clone_protocol: str = "ssh") -> str:
+    """Return the pto-isa clone URL for the given protocol."""
+    if clone_protocol == "https":
+        return _PTO_ISA_HTTPS
+    return _PTO_ISA_SSH
+
+
+def _clone_pto_isa(verbose: bool = False, commit: Optional[str] = None,
+                   clone_protocol: str = "ssh") -> bool:
     """
     Clone pto-isa repository, optionally at a specific commit.
 
@@ -188,10 +197,11 @@ def _clone_pto_isa(verbose: bool = False, commit: Optional[str] = None) -> bool:
             logger.info(f"Cloning pto-isa to {clone_path}...")
             logger.info("This may take a few moments on first run...")
 
+        repo_url = _pto_isa_repo_url(clone_protocol)
         result = subprocess.run(
             [
                 "git", "clone",
-                _PTO_ISA_REPO,
+                repo_url,
                 str(clone_path)
             ],
             capture_output=True,
@@ -281,7 +291,8 @@ def _update_pto_isa_to_latest(clone_path: Path, verbose: bool = False) -> None:
         logger.warning(f"Unexpected error updating pto-isa: {e}")
 
 
-def _ensure_pto_isa_root(verbose: bool = False, commit: Optional[str] = None) -> Optional[str]:
+def _ensure_pto_isa_root(verbose: bool = False, commit: Optional[str] = None,
+                         clone_protocol: str = "ssh") -> Optional[str]:
     """
     Ensure PTO_ISA_ROOT is available, either from environment or cloned repo.
 
@@ -314,11 +325,13 @@ def _ensure_pto_isa_root(verbose: bool = False, commit: Optional[str] = None) ->
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with open(lock_path, "w") as lock_fd:
         fcntl.flock(lock_fd, fcntl.LOCK_EX)
-        return _ensure_pto_isa_root_locked(clone_path, verbose=verbose, commit=commit)
+        return _ensure_pto_isa_root_locked(clone_path, verbose=verbose, commit=commit,
+                                          clone_protocol=clone_protocol)
 
 
 def _ensure_pto_isa_root_locked(
-    clone_path: Path, verbose: bool = False, commit: Optional[str] = None
+    clone_path: Path, verbose: bool = False, commit: Optional[str] = None,
+    clone_protocol: str = "ssh",
 ) -> Optional[str]:
     """Inner logic for _ensure_pto_isa_root, called while holding the file lock."""
 
@@ -326,14 +339,15 @@ def _ensure_pto_isa_root_locked(
     if not _is_pto_isa_cloned():
         if verbose:
             logger.info("PTO_ISA_ROOT not set, cloning pto-isa repository...")
-        if not _clone_pto_isa(verbose=verbose, commit=commit):
+        if not _clone_pto_isa(verbose=verbose, commit=commit,
+                              clone_protocol=clone_protocol):
             # Another parallel process may have completed the clone
             if not _is_pto_isa_cloned():
                 if verbose:
                     logger.warning("Failed to automatically clone pto-isa.")
                     logger.warning("You can manually clone it with:")
                     logger.warning(f"  mkdir -p {clone_path.parent}")
-                    logger.warning(f"  git clone {_PTO_ISA_REPO} {clone_path}")
+                    logger.warning(f"  git clone {_pto_isa_repo_url(clone_protocol)} {clone_path}")
                     logger.warning("Or set PTO_ISA_ROOT to an existing pto-isa installation:")
                     logger.warning("  export PTO_ISA_ROOT=/path/to/pto-isa")
                 return None
@@ -434,6 +448,7 @@ class CodeRunner:
         pto_isa_commit: Optional[str] = None,
         build_dir: Optional[str] = None,
         repeat_rounds: Optional[int] = None,
+        clone_protocol: str = "ssh",
     ):
         # Setup logging if not already configured (e.g., when used directly, not via run_example.py)
         _setup_logging_if_needed()
@@ -447,6 +462,7 @@ class CodeRunner:
         # Resolve device ID
         self.device_id = device_id if device_id is not None else 0
         self.pto_isa_commit = pto_isa_commit
+        self.clone_protocol = clone_protocol
         self.build_dir = build_dir
 
         # Load configurations
@@ -727,7 +743,8 @@ class CodeRunner:
         from elf_parser import extract_text_section
 
         # Auto-setup PTO_ISA_ROOT if needed (for all platforms, since kernels may use PTO ISA headers)
-        pto_isa_root = _ensure_pto_isa_root(verbose=True, commit=self.pto_isa_commit)
+        pto_isa_root = _ensure_pto_isa_root(verbose=True, commit=self.pto_isa_commit,
+                                          clone_protocol=self.clone_protocol)
         if pto_isa_root is None:
             raise EnvironmentError(
                 "PTO_ISA_ROOT could not be resolved.\n"
@@ -951,11 +968,13 @@ class CodeRunner:
 
 def create_code_runner(kernels_dir, golden_path, device_id=None, platform="a2a3",
                        enable_profiling=False, run_all_cases=False, case_name=None,
-                       pto_isa_commit=None, build_dir=None, repeat_rounds=None):
+                       pto_isa_commit=None, build_dir=None, repeat_rounds=None,
+                       clone_protocol="ssh"):
     """Factory: creates a CodeRunner based on kernel_config."""
     return CodeRunner(kernels_dir=kernels_dir, golden_path=golden_path,
                       device_id=device_id, platform=platform,
                       enable_profiling=enable_profiling,
                       run_all_cases=run_all_cases, case_name=case_name,
                       pto_isa_commit=pto_isa_commit, build_dir=build_dir,
-                      repeat_rounds=repeat_rounds)
+                      repeat_rounds=repeat_rounds,
+                      clone_protocol=clone_protocol)

--- a/examples/scripts/run_example.py
+++ b/examples/scripts/run_example.py
@@ -41,6 +41,7 @@ if python_dir.exists():
 golden_dir = project_root / "golden"
 if golden_dir.exists():
     sys.path.insert(0, str(golden_dir))
+sys.path.insert(0, str(script_dir))
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +185,13 @@ Golden.py interface:
         help="Number of rounds to run per case (overrides kernel_config RUNTIME_CONFIG['rounds'])"
     )
 
+    parser.add_argument(
+        "--clone-protocol",
+        choices=["ssh", "https"],
+        default="ssh",
+        help="Git protocol for cloning pto-isa (default: ssh)"
+    )
+
     args = parser.parse_args()
 
     if args.all and args.case:
@@ -219,9 +227,6 @@ Golden.py interface:
     # Set environment variable for C++ side
     os.environ['PTO_LOG_LEVEL'] = log_level_str
 
-    # Add script_dir for code_runner (now co-located)
-    sys.path.insert(0, str(script_dir))
-
     # Validate paths
     kernels_path = Path(args.kernels)
     golden_path = Path(args.golden)
@@ -254,6 +259,7 @@ Golden.py interface:
             pto_isa_commit=args.pto_isa_commit,
             build_dir=args.savetemp,
             repeat_rounds=args.rounds,
+            clone_protocol=args.clone_protocol,
         )
 
         # Snapshot existing device logs before the run so we can identify the


### PR DESCRIPTION
## Summary
- Switch default pto-isa clone URL to SSH for developer convenience
- Add `set_clone_protocol()` to `code_runner.py` with SSH/HTTPS URL constants
- Add `--clone-protocol {ssh,https}` CLI arg to `run_example.py` (default: ssh)
- Add `--clone-protocol` flag to `ci.sh` (default: https for CI environments)
- Pass `--clone-protocol https` in `ci.yml` for GitHub Actions
- Update docs to show both SSH and HTTPS clone options

## Testing
- [ ] `python examples/scripts/run_example.py --help` shows `--clone-protocol`
- [ ] `--clone-protocol https` clones via HTTPS successfully
- [ ] Simulation tests pass with `./ci.sh -p a2a3sim`