### PR TITLE
Fix: add STORE_RELEASE_FENCE to prevent sim-mode handshake hang on aarch64

### DIFF
--- a/src/a2a3/platform/onboard/aicore/inner_kernel.h
+++ b/src/a2a3/platform/onboard/aicore/inner_kernel.h
@@ -23,6 +23,9 @@
 // SPIN_WAIT_HINT - no-op on real hardware (AICore has dedicated polling support)
 #define SPIN_WAIT_HINT() ((void)0)
 
+// STORE_RELEASE_FENCE - no-op on real hardware (dcci handles cache coherency)
+#define STORE_RELEASE_FENCE() ((void)0)
+
 /**
  * Read an AICore register via SPR access
  *

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -55,6 +55,18 @@
 #define SPIN_WAIT_HINT() sched_yield()
 #endif
 
+// STORE_RELEASE_FENCE - store-store barrier to prevent reordering of data writes
+// (physical_core_id, core_type) past the signal write (aicore_done) in handshake.
+// Without this fence, aarch64 can reorder stores to different addresses, causing
+// AICPU to read stale physical_core_id after observing aicore_done != 0.
+#if defined(__aarch64__)
+#define STORE_RELEASE_FENCE() __asm__ volatile("dmb ishst" ::: "memory")
+#elif defined(__x86_64__)
+#define STORE_RELEASE_FENCE() __asm__ volatile("" ::: "memory")
+#else
+#define STORE_RELEASE_FENCE() std::atomic_thread_fence(std::memory_order_release)
+#endif
+
 // =============================================================================
 // System Counter Simulation
 // =============================================================================

--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -59,6 +59,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
 
     // Phase 2: Signal AICore is ready and report core type
     my_hank->core_type = core_type;        // Report core type to AICPU
+    STORE_RELEASE_FENCE();
     my_hank->aicore_done = block_idx + 1;  // Signal ready (use block_idx + 1 to avoid 0)
 
     // Phase 3: Main execution loop - poll for tasks until quit signal

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -35,6 +35,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     // Report physical core ID and core type for AICPU
     my_hank->physical_core_id = get_physical_core_id();
     my_hank->core_type = core_type;
+    STORE_RELEASE_FENCE();
     my_hank->aicore_done = block_idx + 1;
 
     dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -65,6 +65,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     // Phase 2: Report physical core ID and core type, signal ready
     my_hank->physical_core_id = get_physical_core_id();
     my_hank->core_type = core_type;
+    STORE_RELEASE_FENCE();
     my_hank->aicore_done = block_idx + 1;  // Signal ready (use block_idx + 1 to avoid 0)
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);

--- a/src/a5/platform/onboard/aicore/inner_kernel.h
+++ b/src/a5/platform/onboard/aicore/inner_kernel.h
@@ -23,6 +23,9 @@
 // SPIN_WAIT_HINT - no-op on real hardware (AICore has dedicated polling support)
 #define SPIN_WAIT_HINT() ((void)0)
 
+// STORE_RELEASE_FENCE - no-op on real hardware (dcci handles cache coherency)
+#define STORE_RELEASE_FENCE() ((void)0)
+
 /**
  * Read an AICore register via SPR access
  *

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -54,6 +54,18 @@
 #define SPIN_WAIT_HINT() sched_yield()
 #endif
 
+// STORE_RELEASE_FENCE - store-store barrier to prevent reordering of data writes
+// (physical_core_id, core_type) past the signal write (aicore_done) in handshake.
+// Without this fence, aarch64 can reorder stores to different addresses, causing
+// AICPU to read stale physical_core_id after observing aicore_done != 0.
+#if defined(__aarch64__)
+#define STORE_RELEASE_FENCE() __asm__ volatile("dmb ishst" ::: "memory")
+#elif defined(__x86_64__)
+#define STORE_RELEASE_FENCE() __asm__ volatile("" ::: "memory")
+#else
+#define STORE_RELEASE_FENCE() std::atomic_thread_fence(std::memory_order_release)
+#endif
+
 // =============================================================================
 // System Counter Simulation
 // =============================================================================

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -38,6 +38,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     // Report physical core ID and core type for AICPU
     my_hank->physical_core_id = get_physical_core_id();
     my_hank->core_type = core_type;
+    STORE_RELEASE_FENCE();
     my_hank->aicore_done = core_idx + 1;
 
     dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -63,6 +63,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     // Phase 2: Report physical core ID and core type, signal ready
     my_hank->physical_core_id = get_physical_core_id();
     my_hank->core_type = core_type;
+    STORE_RELEASE_FENCE();
     my_hank->aicore_done = core_idx + 1;  // Signal ready (use core_idx + 1 to avoid 0)
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);


### PR DESCRIPTION
On aarch64 sim hosts, stores to different addresses can be hardware-reordered, causing AICPU to read stale physical_core_id after observing aicore_done != 0, leading to register-address collisions and hangs

- Add STORE_RELEASE_FENCE() macro to prevent store reordering between data fields (physical_core_id, core_type) and the signal field (aicore_done) in the AICore-AICPU handshake

- Macro expands to dmb ishst (aarch64), compiler fence (x86_64), or std::atomic_thread_fence(std::memory_order_release) (fallback); no-op on real hardware where dcci handles coherency