### PR TITLE
Fix: support batch=256 by doubling task window and fixing deferred release

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -345,6 +345,7 @@ struct AicpuExecutor {
                             if (fe > fanin_max_degree) fanin_max_degree = fe;
 #endif
                         }
+                        deferred_release_ids[deferred_release_count++] = mixed_task_id;
                     }
                 }
                 ct.move_running_to_idle(i);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -62,7 +62,7 @@
 // NOTE: PTO2_TASK_WINDOW_SIZE is now the DEFAULT value only.
 // Actual window size is passed at runtime to pto2_runtime_create_threaded_custom().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
-#define PTO2_TASK_WINDOW_SIZE     65536   // Default task window size (power of 2)
+#define PTO2_TASK_WINDOW_SIZE     131072  // Default task window size (power of 2)
 
 // Memory pools
 #define PTO2_HEAP_SIZE            (1024 * 1024 * 1024)  // 1GB default heap

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -295,6 +295,7 @@ struct AicpuExecutor {
                         if (fe > fanin_max_degree) fanin_max_degree = fe;
 #endif
                     }
+                    deferred_release_ids[deferred_release_count++] = task_id;
                 }
                 ct.move_running_to_idle(i);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -61,7 +61,7 @@
 // NOTE: PTO2_TASK_WINDOW_SIZE is now the DEFAULT value only.
 // Actual window size is passed at runtime to pto2_runtime_create_threaded_custom().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
-#define PTO2_TASK_WINDOW_SIZE     65536   // Default task window size (power of 2)
+#define PTO2_TASK_WINDOW_SIZE     131072  // Default task window size (power of 2)
 
 // Memory pools
 #define PTO2_HEAP_SIZE            (1024 * 1024 * 1024)  // 1GB default heap

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -13,7 +13,7 @@ ATOL = 1e-3
 
 ALL_CASES = {
     "Case1": {
-        "batch": 64,
+        "batch": 256,
         "num_heads": 16,
         "kv_head_num": 1,
         "head_dim": 128,


### PR DESCRIPTION

- Double PTO2_TASK_WINDOW_SIZE from 65536 to 131072 on both a2a3 and a5
- Add deferred task ID tracking in AICPU executor for completed tasks on both platforms (a2a3 uses mixed_task_id, a5 uses task_id)
- Update paged attention golden test batch size from 64 to 256