### PR TITLE
Refactor: unify orchestrator phase profiling into per-thread collection

### DIFF
--- a/src/a2a3/platform/include/common/perf_profiling.h
+++ b/src/a2a3/platform/include/common/perf_profiling.h
@@ -236,6 +236,7 @@ enum class AicpuPhaseId : uint32_t {
     SCHED_DISPATCH    = 1,  // Dispatch ready tasks to idle cores
     SCHED_SCAN        = 2,  // Incremental scan for root tasks
     SCHED_IDLE_WAIT   = 3,  // Idle/spinning (no progress)
+    SCHED_PHASE_COUNT = 4,  // Sentinel: number of scheduler phases
     // Orchestrator phases (16-24)
     ORCH_SYNC      = 16,  // tensormap sync
     ORCH_ALLOC     = 17,  // task_ring_alloc

--- a/src/a2a3/platform/include/host/performance_collector.h
+++ b/src/a2a3/platform/include/host/performance_collector.h
@@ -360,9 +360,8 @@ private:
     // Collected data (per-core vectors, indexed by core_index)
     std::vector<std::vector<PerfRecord>> collected_perf_records_;
 
-    // AICPU phase profiling data
+    // AICPU phase profiling data (per-thread, mixed sched + orch records)
     std::vector<std::vector<AicpuPhaseRecord>> collected_phase_records_;
-    std::vector<AicpuPhaseRecord> collected_orch_phase_records_;
     AicpuOrchSummary collected_orch_summary_{};
     bool has_phase_data_{false};
 

--- a/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -25,7 +25,7 @@ static PerfBufferState* s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
 static PhaseBufferState* s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
 static PhaseBuffer* s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
-static int s_orch_thread_idx = -1;
+static __thread int s_orch_thread_idx = -1;
 
 /**
  * Enqueue ready buffer to per-thread queue

--- a/src/a2a3/platform/src/host/performance_collector.cpp
+++ b/src/a2a3/platform/src/host/performance_collector.cpp
@@ -345,6 +345,15 @@ void ProfMemoryManager::mgmt_loop() {
 // PerformanceCollector Implementation
 // =============================================================================
 
+/**
+ * Check if a phase ID belongs to a scheduler phase (vs orchestrator phase).
+ * Scheduler phases: SCHED_COMPLETE(0), SCHED_DISPATCH(1), SCHED_SCAN(2), SCHED_IDLE_WAIT(3)
+ * Orchestrator phases: ORCH_SYNC(16) through ORCH_SCOPE_END(24)
+ */
+static bool is_scheduler_phase(AicpuPhaseId id) {
+    return static_cast<uint32_t>(id) < static_cast<uint32_t>(AicpuPhaseId::SCHED_PHASE_COUNT);
+}
+
 PerformanceCollector::~PerformanceCollector() {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_WARN("PerformanceCollector destroyed without finalize()");
@@ -613,8 +622,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             num_sched_for_poll = PLATFORM_MAX_AICPU_THREADS;
         }
         collected_phase_records_.clear();
-        collected_phase_records_.resize(num_sched_for_poll);
-        collected_orch_phase_records_.clear();
+        collected_phase_records_.resize(PLATFORM_MAX_AICPU_THREADS);
     }
 
     idle_start.reset();
@@ -664,14 +672,8 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 }
 
                 uint32_t tidx = info.index;
-                if (tidx < static_cast<uint32_t>(num_sched_for_poll)) {
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_phase_records_[tidx].push_back(buf->records[i]);
-                    }
-                } else {
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_orch_phase_records_.push_back(buf->records[i]);
-                    }
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_phase_records_[tidx].push_back(buf->records[i]);
                 }
 
                 LOG_DEBUG("Collected %u phase records from thread %u", count, tidx);
@@ -722,9 +724,6 @@ void PerformanceCollector::drain_remaining_buffers() {
         if (num_sched > PLATFORM_MAX_AICPU_THREADS) {
             num_sched = PLATFORM_MAX_AICPU_THREADS;
         }
-        if (collected_phase_records_.size() < static_cast<size_t>(num_sched)) {
-            collected_phase_records_.resize(num_sched);
-        }
     }
 
     int drained_perf = 0;
@@ -754,14 +753,8 @@ void PerformanceCollector::drain_remaining_buffers() {
                 count = PLATFORM_PHASE_RECORDS_PER_THREAD;
             }
             uint32_t tidx = info.index;
-            if (tidx < static_cast<uint32_t>(num_sched)) {
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_phase_records_[tidx].push_back(buf->records[i]);
-                }
-            } else {
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_orch_phase_records_.push_back(buf->records[i]);
-                }
+            for (uint32_t i = 0; i < count; i++) {
+                collected_phase_records_[tidx].push_back(buf->records[i]);
             }
             drained_phase += count;
         }
@@ -803,11 +796,7 @@ void PerformanceCollector::collect_phase_data() {
     }
     LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
 
-    int total_slots = (num_sched_threads < PLATFORM_MAX_AICPU_THREADS)
-                      ? num_sched_threads + 1 : num_sched_threads;
-    if (collected_phase_records_.size() < static_cast<size_t>(num_sched_threads)) {
-        collected_phase_records_.resize(num_sched_threads);
-    }
+    int total_slots = PLATFORM_MAX_AICPU_THREADS;
 
     // Scan remaining PhaseBufferStates for active buffers with partial data.
     // READY buffers were already enqueued to the ReadyQueue and collected via
@@ -833,14 +822,8 @@ void PerformanceCollector::collect_phase_data() {
                     count = PLATFORM_PHASE_RECORDS_PER_THREAD;
                 }
 
-                if (t < num_sched_threads) {
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_phase_records_[t].push_back(pbuf->records[i]);
-                    }
-                } else {
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_orch_phase_records_.push_back(pbuf->records[i]);
-                    }
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_phase_records_[t].push_back(pbuf->records[i]);
                 }
                 total_phase_records += count;
             }
@@ -848,11 +831,16 @@ void PerformanceCollector::collect_phase_data() {
     }
 
     // Log per-thread totals
-    for (int t = 0; t < num_sched_threads; t++) {
-        LOG_INFO("  Thread %d: %zu phase records", t, collected_phase_records_[t].size());
-    }
-    if (!collected_orch_phase_records_.empty()) {
-        LOG_INFO("  Orchestrator: %zu per-task phase records", collected_orch_phase_records_.size());
+    for (size_t t = 0; t < collected_phase_records_.size(); t++) {
+        if (!collected_phase_records_[t].empty()) {
+            size_t sched_count = 0, orch_count = 0;
+            for (const auto& r : collected_phase_records_[t]) {
+                if (is_scheduler_phase(r.phase_id)) sched_count++;
+                else orch_count++;
+            }
+            LOG_INFO("  Thread %zu: %zu records (sched=%zu, orch=%zu)",
+                     t, collected_phase_records_[t].size(), sched_count, orch_count);
+        }
     }
 
     // Read orchestrator summary
@@ -873,7 +861,6 @@ void PerformanceCollector::collect_phase_data() {
         for (const auto& v : collected_phase_records_) {
             if (!v.empty()) { has_accumulated = true; break; }
         }
-        if (!collected_orch_phase_records_.empty()) has_accumulated = true;
     }
     has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
 
@@ -957,11 +944,6 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                 }
             }
         }
-        for (const auto& pr : collected_orch_phase_records_) {
-            if (pr.start_time > 0 && pr.start_time < base_time_cycles) {
-                base_time_cycles = pr.start_time;
-            }
-        }
         if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC &&
             collected_orch_summary_.start_time > 0 &&
             collected_orch_summary_.start_time < base_time_cycles) {
@@ -1036,34 +1018,50 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
     // Step 8: Write phase profiling data (version 2)
     if (has_phase_data_) {
-        // AICPU scheduler phases
+        auto sched_phase_name = [](AicpuPhaseId id) -> const char* {
+            switch (id) {
+                case AicpuPhaseId::SCHED_COMPLETE:    return "complete";
+                case AicpuPhaseId::SCHED_DISPATCH:    return "dispatch";
+                case AicpuPhaseId::SCHED_SCAN:        return "scan";
+                case AicpuPhaseId::SCHED_IDLE_WAIT:   return "idle";
+                default: return "unknown";
+            }
+        };
+
+        auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
+            switch (id) {
+                case AicpuPhaseId::ORCH_SYNC:      return "orch_sync";
+                case AicpuPhaseId::ORCH_ALLOC:     return "orch_alloc";
+                case AicpuPhaseId::ORCH_PARAMS:    return "orch_params";
+                case AicpuPhaseId::ORCH_LOOKUP:    return "orch_lookup";
+                case AicpuPhaseId::ORCH_HEAP:      return "orch_heap";
+                case AicpuPhaseId::ORCH_INSERT:    return "orch_insert";
+                case AicpuPhaseId::ORCH_FANIN:     return "orch_fanin";
+                case AicpuPhaseId::ORCH_FINALIZE:  return "orch_finalize";
+                case AicpuPhaseId::ORCH_SCOPE_END: return "orch_scope_end";
+                default: return "unknown";
+            }
+        };
+
+        // AICPU scheduler phases (filtered from unified collected_phase_records_)
         outfile << ",\n  \"aicpu_scheduler_phases\": [\n";
         for (size_t t = 0; t < collected_phase_records_.size(); t++) {
             outfile << "    [\n";
-            const auto& thread_records = collected_phase_records_[t];
-            for (size_t r = 0; r < thread_records.size(); r++) {
-                const auto& pr = thread_records[r];
+            bool first = true;
+            for (const auto& pr : collected_phase_records_[t]) {
+                if (!is_scheduler_phase(pr.phase_id)) continue;
                 double start_us = cycles_to_us(pr.start_time - base_time_cycles);
                 double end_us = cycles_to_us(pr.end_time - base_time_cycles);
-
-                const char* phase_name = "unknown";
-                switch (pr.phase_id) {
-                    case AicpuPhaseId::SCHED_COMPLETE:    phase_name = "complete"; break;
-                    case AicpuPhaseId::SCHED_DISPATCH:    phase_name = "dispatch"; break;
-                    case AicpuPhaseId::SCHED_SCAN:        phase_name = "scan"; break;
-                    case AicpuPhaseId::SCHED_IDLE_WAIT:   phase_name = "idle"; break;
-                    default: break;
-                }
-
+                if (!first) outfile << ",\n";
                 outfile << "      {\"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                         << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                        << ", \"phase\": \"" << phase_name << "\""
+                        << ", \"phase\": \"" << sched_phase_name(pr.phase_id) << "\""
                         << ", \"loop_iter\": " << pr.loop_iter
                         << ", \"tasks_processed\": " << pr.tasks_processed
                         << "}";
-                if (r < thread_records.size() - 1) outfile << ",";
-                outfile << "\n";
+                first = false;
             }
+            if (!first) outfile << "\n";
             outfile << "    ]";
             if (t < collected_phase_records_.size() - 1) outfile << ",";
             outfile << "\n";
@@ -1092,37 +1090,35 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
             outfile << "  }";
         }
 
-        // Per-task orchestrator phase records
-        if (!collected_orch_phase_records_.empty()) {
+        // Per-task orchestrator phase records (filtered from unified collected_phase_records_)
+        bool has_orch_phases = false;
+        for (const auto& v : collected_phase_records_) {
+            for (const auto& r : v) {
+                if (!is_scheduler_phase(r.phase_id)) { has_orch_phases = true; break; }
+            }
+            if (has_orch_phases) break;
+        }
+        if (has_orch_phases) {
             outfile << ",\n  \"aicpu_orchestrator_phases\": [\n";
-
-            auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
-                switch (id) {
-                    case AicpuPhaseId::ORCH_SYNC:      return "orch_sync";
-                    case AicpuPhaseId::ORCH_ALLOC:     return "orch_alloc";
-                    case AicpuPhaseId::ORCH_PARAMS:    return "orch_params";
-                    case AicpuPhaseId::ORCH_LOOKUP:    return "orch_lookup";
-                    case AicpuPhaseId::ORCH_HEAP:      return "orch_heap";
-                    case AicpuPhaseId::ORCH_INSERT:    return "orch_insert";
-                    case AicpuPhaseId::ORCH_FANIN:     return "orch_fanin";
-                    case AicpuPhaseId::ORCH_FINALIZE:  return "orch_finalize";
-                    case AicpuPhaseId::ORCH_SCOPE_END: return "orch_scope_end";
-                    default: return "unknown";
+            for (size_t t = 0; t < collected_phase_records_.size(); t++) {
+                outfile << "    [\n";
+                bool first = true;
+                for (const auto& pr : collected_phase_records_[t]) {
+                    if (is_scheduler_phase(pr.phase_id)) continue;
+                    double start_us = cycles_to_us(pr.start_time - base_time_cycles);
+                    double end_us = cycles_to_us(pr.end_time - base_time_cycles);
+                    if (!first) outfile << ",\n";
+                    outfile << "      {\"phase\": \"" << orch_phase_name(pr.phase_id) << "\""
+                            << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
+                            << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
+                            << ", \"submit_idx\": " << pr.loop_iter
+                            << ", \"task_id\": " << static_cast<int32_t>(pr.tasks_processed)
+                            << "}";
+                    first = false;
                 }
-            };
-
-            for (size_t r = 0; r < collected_orch_phase_records_.size(); r++) {
-                const auto& pr = collected_orch_phase_records_[r];
-                double start_us = cycles_to_us(pr.start_time - base_time_cycles);
-                double end_us = cycles_to_us(pr.end_time - base_time_cycles);
-
-                outfile << "    {\"phase\": \"" << orch_phase_name(pr.phase_id) << "\""
-                        << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
-                        << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                        << ", \"submit_idx\": " << pr.loop_iter
-                        << ", \"task_id\": " << static_cast<int32_t>(pr.tasks_processed)
-                        << "}";
-                if (r < collected_orch_phase_records_.size() - 1) outfile << ",";
+                if (!first) outfile << "\n";
+                outfile << "    ]";
+                if (t < collected_phase_records_.size() - 1) outfile << ",";
                 outfile << "\n";
             }
             outfile << "  ]";
@@ -1243,7 +1239,6 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
     was_registered_ = false;
     collected_perf_records_.clear();
     collected_phase_records_.clear();
-    collected_orch_phase_records_.clear();
     core_to_thread_.clear();
     has_phase_data_ = false;
     device_id_ = -1;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1684,6 +1684,13 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 
             pto2_set_orch_thread_idx(orch_idx);
 
+#if PTO2_PROFILING
+            // Each orchestrator thread sets its own phase buffer index (thread-local)
+            if (runtime->enable_profiling) {
+                perf_aicpu_set_orch_thread_idx(thread_idx);
+            }
+#endif
+
             // Call orchestration function wrapped in an outer scope
             DEV_ALWAYS("Thread %d: Calling aicpu_orchestration_entry from SO (orch_idx=%d/(0~%d))",
                        thread_idx, orch_idx, orch_thread_num_ - 1);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -74,11 +74,13 @@ uint64_t g_orch_scope_end_atomic_count = 0;
 #endif
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
 #define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
-#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid) do { \
-    _t1 = get_sys_cnt_aicpu(); \
-    acc += (_t1 - _t0); \
-    _t0 = _t1; \
-} while(0)
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                    \
+    do {                                                                              \
+        _t1 = get_sys_cnt_aicpu();                                                    \
+        acc += (_t1 - _t0);                                                           \
+        perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
+        _t0 = _t1;                                                                    \
+    } while (0)
 #else
 #define CYCLE_COUNT_START()
 #define CYCLE_COUNT_LAP(acc)

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/kernel_config.py
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/kernel_config.py
@@ -31,5 +31,6 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
+    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/tools/swimlane_converter.py
+++ b/tools/swimlane_converter.py
@@ -625,15 +625,31 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
             "pid": 4
         })
 
-        # Thread name metadata
-        events.append({
-            "args": {"name": "Orchestrator"},
-            "cat": "__metadata",
-            "name": "thread_name",
-            "ph": "M",
-            "pid": 4,
-            "tid": 4000
-        })
+        # Normalize orchestrator_phases: support both per-thread nested format
+        # (list of lists) and legacy flat format (list of dicts)
+        orch_threads = orchestrator_phases if orchestrator_phases else []
+
+        # Thread name metadata for each orchestrator thread
+        for orch_idx in range(len(orch_threads)):
+            tid = 4000 + orch_idx
+            name = f"Orch_{orch_idx}"
+            events.append({
+                "args": {"name": name},
+                "cat": "__metadata",
+                "name": "thread_name",
+                "ph": "M",
+                "pid": 4,
+                "tid": tid
+            })
+        if not orch_threads and orchestrator_data:
+            events.append({
+                "args": {"name": "Orchestrator"},
+                "cat": "__metadata",
+                "name": "thread_name",
+                "ph": "M",
+                "pid": 4,
+                "tid": 4000
+            })
 
     if orchestrator_phases:
         # Per-task orchestrator phase bars
@@ -649,39 +665,41 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
             "orch_scope_end": "generic_work",
         }
 
-        for record in orchestrator_phases:
-            phase = record.get("phase", "unknown")
-            start_us = record["start_time_us"]
-            end_us = record["end_time_us"]
-            dur = end_us - start_us
-            submit_idx = record.get("submit_idx", 0)
-            task_id = record.get("task_id", -1)
+        for orch_idx, thread_records in enumerate(orch_threads):
+            tid = 4000 + orch_idx
+            for record in thread_records:
+                phase = record.get("phase", "unknown")
+                start_us = record["start_time_us"]
+                end_us = record["end_time_us"]
+                dur = end_us - start_us
+                submit_idx = record.get("submit_idx", 0)
+                task_id = record.get("task_id", -1)
 
-            # Strip "orch_" prefix for display name
-            display_name = phase.replace("orch_", "") if phase.startswith("orch_") else phase
+                # Strip "orch_" prefix for display name
+                display_name = phase.replace("orch_", "") if phase.startswith("orch_") else phase
 
-            # Show task_id in name for task-specific phases
-            if task_id >= 0:
-                label = f"{display_name}(t{task_id})"
-            else:
-                label = f"{display_name}({submit_idx})"
+                # Show task_id in name for task-specific phases
+                if task_id >= 0:
+                    label = f"{display_name}(t{task_id})"
+                else:
+                    label = f"{display_name}({submit_idx})"
 
-            event = {
-                "args": {
-                    "phase": phase,
-                    "submit_idx": submit_idx,
-                    "task_id": task_id
-                },
-                "cat": "orchestrator",
-                "cname": orch_phase_colors.get(phase, "generic_work"),
-                "name": label,
-                "ph": "X",
-                "pid": 4,
-                "tid": 4000,
-                "ts": start_us,
-                "dur": dur
-            }
-            events.append(event)
+                event = {
+                    "args": {
+                        "phase": phase,
+                        "submit_idx": submit_idx,
+                        "task_id": task_id
+                    },
+                    "cat": "orchestrator",
+                    "cname": orch_phase_colors.get(phase, "generic_work"),
+                    "name": label,
+                    "ph": "X",
+                    "pid": 4,
+                    "tid": tid,
+                    "ts": start_us,
+                    "dur": dur
+                }
+                events.append(event)
 
     elif orchestrator_data:
         # Fallback: cumulative summary as single bar
@@ -851,13 +869,14 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
     # Orchestrator FINALIZE → Scheduler DISPATCH arrows (per task_id)
     if orchestrator_phases and scheduler_phases:
-        # Collect orch_finalize records keyed by task_id
+        # Flatten per-thread orch phases and track source thread
         orch_finalize_by_task = {}
-        for record in orchestrator_phases:
-            if record.get("phase") == "orch_finalize":
-                tid = record.get("task_id", -1)
-                if tid >= 0:
-                    orch_finalize_by_task[tid] = record
+        for orch_idx, thread_records in enumerate(orch_threads):
+            for record in thread_records:
+                if record.get("phase") == "orch_finalize":
+                    task_id = record.get("task_id", -1)
+                    if task_id >= 0:
+                        orch_finalize_by_task[task_id] = (record, orch_idx)
 
         # Use core_to_sched_thread mapping (built above) to find the correct
         # scheduler thread for each task's core.
@@ -871,7 +890,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                 if dispatch_us <= 0:
                     continue
 
-                finalize_rec = orch_finalize_by_task[tid]
+                finalize_rec, orch_idx = orch_finalize_by_task[tid]
                 # Use finalize start_time: init_task() runs at the beginning of FINALIZE,
                 # making the task dispatchable before FINALIZE ends. Using start avoids
                 # reverse arrows when the scheduler dispatches during FINALIZE.
@@ -881,6 +900,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
                 if matched_thread is not None:
                     sched_tid = 3000 + matched_thread
+                    orch_tid = 4000 + orch_idx
 
                     # Flow: Orchestrator finalize start → Scheduler DISPATCH
                     events.append({
@@ -889,7 +909,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                         "name": "orch→dispatch",
                         "ph": "s",
                         "pid": 4,
-                        "tid": 4000,
+                        "tid": orch_tid,
                         "ts": finalize_start_us
                     })
                     events.append({
@@ -1037,7 +1057,9 @@ Examples:
             if orchestrator_data:
                 print(f"  Orchestrator: {orchestrator_data.get('submit_count', 0)} tasks")
             if orchestrator_phases:
-                print(f"  Orchestrator phases: {len(orchestrator_phases)} per-task records")
+                total_orch = sum(len(t) for t in orchestrator_phases)
+                print(f"  Orchestrator threads: {len(orchestrator_phases)}")
+                print(f"  Total orchestrator phase records: {total_orch}")
             if core_to_thread:
                 print(f"  Core-to-thread mapping: {len(core_to_thread)} cores")
 


### PR DESCRIPTION
- Remove separate collected_orch_phase_records_ vector; all phase records (scheduler + orchestrator) now go into collected_phase_records_ indexed by thread, distinguished via is_scheduler_phase() helper
- Add SCHED_PHASE_COUNT sentinel to AicpuPhaseId enum for phase filtering
- Make s_orch_thread_idx thread-local so each orchestrator thread tracks its own phase buffer independently
- Wire up CYCLE_COUNT_LAP_RECORD macro to actually emit per-phase records via perf_aicpu_record_orch_phase()
- Set per-thread phase buffer index in aicpu_executor for orch threads
- Update swimlane_converter to handle per-thread nested orchestrator phase format and emit per-thread trace lanes in Chrome trace output
- Add orch_thread_num to alternating_matmul_add test config