### PR TITLE
Support: unify GitHub workflow skills with cross-fork detection

### DIFF
--- a/.claude/lib/github/checkout-fork-branch.md
+++ b/.claude/lib/github/checkout-fork-branch.md
@@ -1,6 +1,6 @@
 # Checkout Fork Branch
 
-Create or switch to a local working branch for a cross-fork PR, and set `BRANCH_NAME` to the correct push refspec.
+Create or switch to a local working branch for a cross-fork PR, set upstream tracking, and set `BRANCH_NAME` to the correct push refspec.
 
 **Requires:** `PR_NUMBER`, `PUSH_REMOTE`, `HEAD_BRANCH` (set by [detect-permission](detect-permission.md)).
 
@@ -15,8 +15,11 @@ else
   git checkout "$LOCAL_BRANCH"
 fi
 
+# Set upstream tracking so github-pr can auto-detect the push target
+git branch --set-upstream-to="$PUSH_REMOTE/$HEAD_BRANCH" "$LOCAL_BRANCH"
+
 # Set refspec so commit-and-push pushes local branch to the fork's remote branch
-# e.g. git push --force-with-lease pr-176 pr-176-work:feat/batch-counter
+# e.g. git push --force-with-lease authorname pr-176-work:feat/batch-counter
 BRANCH_NAME="$LOCAL_BRANCH:$HEAD_BRANCH"
 ```
 

--- a/.claude/lib/github/commit-and-push.md
+++ b/.claude/lib/github/commit-and-push.md
@@ -42,12 +42,18 @@ COMMITS_AHEAD=$(git rev-list HEAD --not "$BASE_REF" --count 2>/dev/null || echo 
 
 ### Squash procedure (when `COMMITS_AHEAD > 1`)
 
-1. Soft-reset to base:
+1. Collect other human authors before squashing (to preserve attribution):
+   ```bash
+   CURRENT_USER_EMAIL=$(git config user.email)
+   OTHER_AUTHORS=$(git log "$BASE_REF"..HEAD --format='%aN <%aE>' \
+     | grep -v -F "<$CURRENT_USER_EMAIL>" | sort -u)
+   ```
+2. Soft-reset to base:
    ```bash
    git reset --soft "$BASE_REF"
    ```
-2. All changes are now staged. Delegate to `/git-commit` to create a single commit with a proper message based on the combined diff.
-3. **Re-verify** the count:
+3. All changes are now staged. Delegate to `/git-commit` to create a single commit with a proper message based on the combined diff. If `OTHER_AUTHORS` is non-empty, append `Co-authored-by:` trailers for each human author.
+4. **Re-verify** the count:
    ```bash
    COMMITS_AHEAD=$(git rev-list HEAD --not "$BASE_REF" --count)
    # Must be exactly 1. If not, something went wrong — do NOT push.

--- a/.claude/lib/github/common-issues.md
+++ b/.claude/lib/github/common-issues.md
@@ -14,3 +14,61 @@ Troubleshooting reference for GitHub workflows.
 | PR is merged | Exit — cannot modify merged PR |
 | No unresolved comments | Inform user all comments resolved; exit |
 | No push access | Ask PR author to enable "Allow edits from maintainers" |
+
+## Shell Escaping Pitfalls
+
+### `gh api --jq` with `!=`
+
+Bash history expansion treats `!` as special. Use single quotes for jq expressions:
+
+```bash
+# BAD — bash escapes != to \!=
+gh api ... --jq ".[] | select(.position != null)"
+
+# GOOD — single quotes prevent expansion
+gh api ... --jq '.[] | select(.position != null)'
+```
+
+### `gh api -f body=` with special characters
+
+Always use single quotes for body text to avoid issues with backticks, `$`, `!`, etc.:
+
+```bash
+# BAD — backticks and $ get interpreted
+gh api ... -f body="Fixed — changed to \`grep -F \"<$EMAIL>\"\`"
+
+# GOOD — single quotes, no escaping needed
+gh api ... -f body='Fixed — changed to grep -F for precise matching.'
+```
+
+If the body must contain single quotes, use a heredoc or keep the message simple.
+
+### `gh api graphql` with variables
+
+Do NOT use `-f`/`-F` flags to pass GraphQL `$variables`. Bash mangles `$` signs even inside single-quoted query strings when combined with `-f` flags. Instead, inline values directly:
+
+```bash
+# BAD — $owner/$repo/$number clash with bash
+gh api graphql -f owner="ChaoWao" -f repo="simpler" -F number=276 \
+  -f query='query($owner: String!, $repo: String!, $number: Int!) { ... }'
+
+# GOOD — inline values, no variables
+gh api graphql -f query='query {
+  repository(owner: "'"$PR_REPO_OWNER"'", name: "'"$PR_REPO_NAME"'") {
+    pullRequest(number: '"$PR_NUMBER"') { ... }
+  }
+}'
+```
+
+### `gh api` output piped to python
+
+`gh api` may output extra lines beyond the JSON payload. Do NOT pipe to `python3 -c "json.load(sys.stdin)"`. Use `--jq` or `jq` instead:
+
+```bash
+# BAD — python chokes on extra lines
+gh api ... 2>&1 | python3 -c "import json, sys; json.load(sys.stdin)"
+
+# GOOD — use --jq inline or pipe to jq
+gh api ... --jq '.data.repository'
+gh api ... | jq '.data.repository'
+```

--- a/.claude/lib/github/detect-permission.md
+++ b/.claude/lib/github/detect-permission.md
@@ -42,10 +42,16 @@ case "$PERMISSION" in
     WORK_BRANCH="$HEAD_BRANCH"
     ;;
   maintainer)
-    FORK_REMOTE="pr-$PR_NUMBER"
-    if ! git remote | grep -q "^${FORK_REMOTE}$"; then
-      git remote add "$FORK_REMOTE" \
-        "git@github.com:$HEAD_REPO_OWNER/$HEAD_REPO_NAME.git"
+    if [ "$HEAD_REPO_OWNER" = "$UPSTREAM_OWNER" ]; then
+      # PR branch is on canonical repo — use upstream
+      FORK_REMOTE="upstream"
+    else
+      # PR branch is on a fork — use author name as remote
+      FORK_REMOTE="$HEAD_REPO_OWNER"
+      if ! git remote | grep -q "^${FORK_REMOTE}$"; then
+        git remote add "$FORK_REMOTE" \
+          "git@github.com:$HEAD_REPO_OWNER/$HEAD_REPO_NAME.git"
+      fi
     fi
     git fetch "$FORK_REMOTE" "$HEAD_BRANCH"
     PUSH_REMOTE="$FORK_REMOTE"
@@ -56,8 +62,4 @@ esac
 
 ## Cleanup After Push
 
-```bash
-if [ "$PERMISSION" = "maintainer" ]; then
-  git remote remove "$FORK_REMOTE" 2>/dev/null || true
-fi
-```
+Do NOT remove the fork remote — it is reused by upstream tracking for auto-detection in `/github-pr` and `/address-pr-comments`.

--- a/.claude/lib/github/fetch-comments.md
+++ b/.claude/lib/github/fetch-comments.md
@@ -2,12 +2,13 @@
 
 Fetches all unresolved review threads for a given PR.
 
+**Important:** Inline values directly into the GraphQL query string. Do NOT use `-f`/`-F` flags with GraphQL `$variables` — bash mangles the `$` signs. See [common-issues](./common-issues.md) for details.
+
 ```bash
-COMMENTS_JSON=$(gh api graphql -f owner="$PR_REPO_OWNER" -f repo="$PR_REPO_NAME" -F number=$PR_NUMBER \
-  -f query='
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $number) {
+gh api graphql -f query='
+query {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: NUMBER) {
       reviewThreads(first: 100) {
         nodes {
           id
@@ -29,21 +30,22 @@ query($owner: String!, $repo: String!, $number: Int!) {
       }
     }
   }
-}')
+}'
+```
 
-# Filter to unresolved threads only
-UNRESOLVED=$(echo "$COMMENTS_JSON" | jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)')
+Replace `OWNER`, `REPO`, `NUMBER` with actual values (e.g., `"ChaoWao"`, `"simpler"`, `276`).
 
-# Check if we hit the pagination limit
-THREAD_COUNT=$(echo "$COMMENTS_JSON" | jq '.data.repository.pullRequest.reviewThreads.nodes | length')
-if [ "$THREAD_COUNT" -eq 100 ]; then
-  echo "Warning: PR has 100+ review threads. Some threads may not be fetched."
-  echo "Consider manually checking the PR for additional unresolved comments."
-fi
+Use `--jq` to filter unresolved threads:
+
+```bash
+gh api graphql -f query='...' \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)]'
 ```
 
 **Limits:**
-- `reviewThreads(first: 100)`: Fetches up to 100 threads. PRs with more threads will show a warning.
-- `comments(first: 50)`: Fetches up to 50 comments per thread. Sufficient for most review discussions.
+- `reviewThreads(first: 100)`: Fetches up to 100 threads.
+- `comments(first: 50)`: Fetches up to 50 comments per thread.
 
-Output: JSON array of unresolved threads with their comments.
+Output: JSON array of unresolved threads. Each thread has:
+- `id` — GraphQL node ID (for resolving via mutation)
+- `comments.nodes[].databaseId` — REST API ID (for replying)

--- a/.claude/lib/github/lookup-pr.md
+++ b/.claude/lib/github/lookup-pr.md
@@ -1,6 +1,6 @@
 # Lookup PR
 
-Find PR by number, branch name, or list all open PRs.
+Find PR by number, branch name, or list all open PRs. Always use `$PR_REPO_OWNER/$PR_REPO_NAME` (the canonical repo).
 
 ## By PR Number
 
@@ -11,8 +11,30 @@ gh pr view $PR_NUMBER --repo "$PR_REPO_OWNER/$PR_REPO_NAME" \
 
 ## By Branch Name
 
+For owner (origin IS canonical): search directly by branch name.
+
 ```bash
 gh pr list --repo "$PR_REPO_OWNER/$PR_REPO_NAME" --head "$BRANCH_NAME" \
+  --json number,title,state
+```
+
+For fork contributor: prefix with fork owner so GitHub matches the correct head.
+
+```bash
+gh pr list --repo "$PR_REPO_OWNER/$PR_REPO_NAME" \
+  --head "$PR_HEAD_PREFIX$BRANCH_NAME" \
+  --json number,title,state
+```
+
+`$PR_HEAD_PREFIX` is `""` for owner, `"myuser:"` for fork (set by Setup).
+
+## By Upstream Tracking (cross-fork auto-detect)
+
+When on a `pr-*-work` branch with upstream tracking to a fork remote:
+
+```bash
+gh pr list --repo "$PR_REPO_OWNER/$PR_REPO_NAME" \
+  --head "$UPSTREAM_REMOTE:$HEAD_BRANCH" \
   --json number,title,state
 ```
 

--- a/.claude/lib/github/setup.md
+++ b/.claude/lib/github/setup.md
@@ -14,62 +14,61 @@ If not authenticated, tell user to run `gh auth login` and stop.
 
 Detects repository role, remotes, and current state. Sets standard variables used by all skills.
 
-### Parse Remotes
+### Canonical Repo
 
 ```bash
-# Get remote URLs
-ORIGIN_URL=$(git remote get-url origin 2>/dev/null || echo "")
-UPSTREAM_URL=$(git remote get-url upstream 2>/dev/null || echo "")
+UPSTREAM_OWNER="ChaoWao"
+UPSTREAM_NAME="simpler"
+UPSTREAM_REPO="$UPSTREAM_OWNER/$UPSTREAM_NAME"
+DEFAULT_BRANCH="main"
+```
 
-# Validate origin exists
+### Ensure Upstream Remote
+
+```bash
+if ! git remote | grep -q "^upstream$"; then
+  git remote add upstream "https://github.com/$UPSTREAM_REPO.git"
+fi
+git fetch upstream
+```
+
+### Parse Origin
+
+```bash
+ORIGIN_URL=$(git remote get-url origin 2>/dev/null || echo "")
+
 if [ -z "$ORIGIN_URL" ]; then
   echo "Error: No 'origin' remote found"
   exit 1
 fi
 
-# Get default branch
-DEFAULT_BRANCH=$(git remote show origin | sed -n 's/.*HEAD branch: \(.*\)/\1/p')
-
-# Parse origin → REPO_OWNER / REPO_NAME
 REPO_OWNER=$(echo "$ORIGIN_URL" | sed -n 's#.*[:/]\([^/]*\)/\([^/]*\)\.git.*#\1#p')
 REPO_NAME=$(echo "$ORIGIN_URL" | sed -n 's#.*[:/]\([^/]*\)/\([^/]*\)\.git.*#\2#p')
-
-# Parse upstream (if exists)
-if [ -n "$UPSTREAM_URL" ]; then
-  UPSTREAM_OWNER=$(echo "$UPSTREAM_URL" | sed -n 's#.*[:/]\([^/]*\)/\([^/]*\)\.git.*#\1#p')
-  UPSTREAM_NAME=$(echo "$UPSTREAM_URL" | sed -n 's#.*[:/]\([^/]*\)/\([^/]*\)\.git.*#\2#p')
-fi
 ```
 
 ### Determine Role
 
+`BASE_REF` is always `upstream/main` since upstream always points to the canonical repo.
+
 ```bash
-if [ -n "$UPSTREAM_URL" ]; then
-  # Fork contributor
-  ROLE="fork"
-  BASE_REF="upstream/$DEFAULT_BRANCH"
-  PUSH_REMOTE="origin"
-  PR_REPO_OWNER="$UPSTREAM_OWNER"
-  PR_REPO_NAME="$UPSTREAM_NAME"
-  PR_HEAD_PREFIX="$REPO_OWNER:"
-else
-  # Repo owner
+BASE_REF="upstream/$DEFAULT_BRANCH"
+PUSH_REMOTE="origin"
+PR_REPO_OWNER="$UPSTREAM_OWNER"
+PR_REPO_NAME="$UPSTREAM_NAME"
+
+if [ "$REPO_OWNER" = "$UPSTREAM_OWNER" ] && [ "$REPO_NAME" = "$UPSTREAM_NAME" ]; then
   ROLE="owner"
-  BASE_REF="origin/$DEFAULT_BRANCH"
-  PUSH_REMOTE="origin"
-  PR_REPO_OWNER="$REPO_OWNER"
-  PR_REPO_NAME="$REPO_NAME"
   PR_HEAD_PREFIX=""
+else
+  ROLE="fork"
+  PR_HEAD_PREFIX="$REPO_OWNER:"
 fi
 ```
 
-### Fetch Remotes
+### Fetch Origin
 
 ```bash
 git fetch origin
-if [ "$ROLE" = "fork" ]; then
-  git fetch upstream
-fi
 ```
 
 ### Gather State
@@ -84,4 +83,14 @@ else
 fi
 ```
 
-See [README.md](README.md) for the full list of variables set by this procedure.
+### Variables Set
+
+| Variable | Owner | Fork |
+| -------- | ----- | ---- |
+| `ROLE` | `"owner"` | `"fork"` |
+| `BASE_REF` | `upstream/main` | `upstream/main` |
+| `PUSH_REMOTE` | `origin` | `origin` |
+| `PR_REPO_OWNER` | `ChaoWao` | `ChaoWao` |
+| `PR_REPO_NAME` | `simpler` | `simpler` |
+| `PR_HEAD_PREFIX` | `""` | `"myuser:"` |
+| `DEFAULT_BRANCH` | `main` | `main` |

--- a/.claude/skills/address-pr-comments/SKILL.md
+++ b/.claude/skills/address-pr-comments/SKILL.md
@@ -14,13 +14,25 @@ Accept PR number (`123`, `#123`), branch name (`feature-branch`), or no input (a
 ## Setup
 
 1. [Setup](../../lib/github/setup.md) — authenticate and detect context (role, remotes, state)
+2. **Auto-detect cross-fork PR context**: If no PR number provided, check upstream tracking to detect cross-fork push target:
+   ```bash
+   UPSTREAM=$(git rev-parse --abbrev-ref "@{upstream}" 2>/dev/null || echo "")
+   if [ -n "$UPSTREAM" ]; then
+     UPSTREAM_REMOTE=$(echo "$UPSTREAM" | cut -d'/' -f1)
+     if [ "$UPSTREAM_REMOTE" != "origin" ] && [ "$UPSTREAM_REMOTE" != "upstream" ]; then
+       PUSH_REMOTE="$UPSTREAM_REMOTE"
+       HEAD_BRANCH=$(echo "$UPSTREAM" | cut -d'/' -f2-)
+     fi
+   fi
+   ```
 
 ## Step 1: Match Input to PR
 
 Use [lookup-pr](../../lib/github/lookup-pr.md) to find the PR.
 
 - If PR number or branch name provided: use "By PR number" or "By branch name" lookup
-- If no input: auto-detect from current branch, or list open PRs for user selection
+- If no input and cross-fork detected (from step 2): search with `--head "$UPSTREAM_REMOTE:$HEAD_BRANCH"`
+- If no input and no cross-fork: auto-detect from current branch, or list open PRs for user selection
 
 Validate PR state: OPEN (continue), CLOSED (warn), MERGED (exit).
 
@@ -89,7 +101,23 @@ Then run [commit-and-push](../../lib/github/commit-and-push.md):
 
 ## Step 8: Reply and Resolve
 
-Use [reply-and-resolve](../../lib/github/reply-and-resolve.md) for each comment.
+For each comment, **both steps are mandatory** (see [reply-and-resolve](../../lib/github/reply-and-resolve.md)):
+
+1. **Reply** using the comment's `databaseId`:
+   ```bash
+   gh api "repos/${PR_REPO_OWNER}/${PR_REPO_NAME}/pulls/${PR_NUMBER}/comments/${COMMENT_DATABASE_ID}/replies" \
+     -f body='Fixed — description of change'
+   ```
+
+2. **Resolve the thread** using the thread's GraphQL node `id` (from fetch-comments, NOT the databaseId):
+   ```bash
+   gh api graphql -f query='
+   mutation { resolveReviewThread(input: {threadId: "THREAD_NODE_ID"}) {
+     thread { isResolved }
+   }}'
+   ```
+
+**Important:** The thread `id` comes from `reviewThreads.nodes[].id` in the fetch-comments GraphQL response. Each thread contains comments — use the thread's `id` to resolve, and the comment's `databaseId` to reply.
 
 ## Checklist
 
@@ -104,3 +132,5 @@ Use [reply-and-resolve](../../lib/github/reply-and-resolve.md) for each comment.
 ## Remember
 
 **Not all comments require code changes.** Evaluate against `.claude/rules/` first. When in doubt, consult user.
+
+**Shell escaping:** See [common-issues](../../lib/github/common-issues.md) for `gh api` quoting pitfalls (use single quotes for `--jq` and `-f body=`).

--- a/.claude/skills/checkout-pr/SKILL.md
+++ b/.claude/skills/checkout-pr/SKILL.md
@@ -34,14 +34,21 @@ Validate PR state: OPEN (continue), CLOSED (warn user), MERGED (exit).
 
 ## Step 2: Add Remote (if needed)
 
-```bash
-FORK_REMOTE="pr-$PR_NUMBER"
+If the PR head is on the canonical repo (`$HEAD_REPO_OWNER == $UPSTREAM_OWNER`), use the existing `upstream` remote. Otherwise, use the PR author's username as the remote name.
 
-if git remote | grep -q "^${FORK_REMOTE}$"; then
-  echo "Remote '$FORK_REMOTE' already exists, fetching latest..."
+```bash
+if [ "$HEAD_REPO_OWNER" = "$UPSTREAM_OWNER" ]; then
+  # PR branch is on the canonical repo — use upstream
+  FORK_REMOTE="upstream"
 else
-  git remote add "$FORK_REMOTE" \
-    "git@github.com:$HEAD_REPO_OWNER/$HEAD_REPO_NAME.git"
+  # PR branch is on a fork — use author name as remote
+  FORK_REMOTE="$HEAD_REPO_OWNER"
+  if git remote | grep -q "^${FORK_REMOTE}$"; then
+    echo "Remote '$FORK_REMOTE' already exists, fetching latest..."
+  else
+    git remote add "$FORK_REMOTE" \
+      "git@github.com:$HEAD_REPO_OWNER/$HEAD_REPO_NAME.git"
+  fi
 fi
 
 git fetch "$FORK_REMOTE" "$HEAD_BRANCH"
@@ -62,4 +69,4 @@ Checked out PR #$PR_NUMBER ($PR_AUTHOR)
   Push:   PUSH_REMOTE=$FORK_REMOTE  BRANCH_NAME=$LOCAL_BRANCH:$HEAD_BRANCH
 ```
 
-Remind user that `/github-pr $PR_NUMBER` and `/address-pr-comments $PR_NUMBER` will pick up the correct push target automatically.
+Remind user that `/github-pr` and `/address-pr-comments` will pick up the correct push target automatically (via upstream tracking).

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -9,7 +9,7 @@ Fetch GitHub issue, create branch, plan, and implement the fix.
 
 ## Workflow
 
-1. Check gh CLI authentication
+1. Setup (authenticate + detect role)
 2. Fetch issue content
 3. Assign issue to me
 4. Create issue branch
@@ -17,26 +17,22 @@ Fetch GitHub issue, create branch, plan, and implement the fix.
 6. Implement the fix
 7. Run tests (use `testing` skill)
 8. Commit changes (use `git-commit` skill)
+9. Create PR (use `github-pr` skill)
 
-## Step 1: Check gh CLI Authentication
+## Step 1: Setup
 
-```bash
-gh auth status
-```
+1. [Setup](../../lib/github/setup.md) — authenticate and detect context (role, remotes, state)
 
-**If not authenticated**, prompt user:
-
-```text
-gh CLI is not authenticated. Please run: gh auth login
-```
-
-Stop here if not authenticated.
+This sets `ROLE` (owner/fork), `BASE_REF`, `PUSH_REMOTE`, `DEFAULT_BRANCH`, `PR_REPO_OWNER`, `PR_REPO_NAME`, and `PR_HEAD_PREFIX`.
 
 ## Step 2: Fetch Issue Content
 
+Use `PR_REPO_OWNER/PR_REPO_NAME` as the issue repo (upstream for fork contributors, origin for owners):
+
 ```bash
-gh issue view ISSUE_NUMBER
-gh issue view ISSUE_NUMBER --json number,title,body,state,labels
+gh issue view ISSUE_NUMBER --repo "$PR_REPO_OWNER/$PR_REPO_NAME"
+gh issue view ISSUE_NUMBER --repo "$PR_REPO_OWNER/$PR_REPO_NAME" \
+  --json number,title,body,state,labels
 ```
 
 **Parse**: Issue number, title, description, state (open/closed), labels
@@ -48,7 +44,8 @@ gh issue view ISSUE_NUMBER --json number,title,body,state,labels
 Before assigning, check if someone is already working on the issue:
 
 ```bash
-gh issue view ISSUE_NUMBER --json assignees --jq '.assignees[].login'
+gh issue view ISSUE_NUMBER --repo "$PR_REPO_OWNER/$PR_REPO_NAME" \
+  --json assignees --jq '.assignees[].login'
 ```
 
 **If assigned to current user**: Continue — already claimed.
@@ -58,14 +55,12 @@ gh issue view ISSUE_NUMBER --json assignees --jq '.assignees[].login'
 **If unassigned**: Assign to yourself (best-effort — skip gracefully if permissions are insufficient):
 
 ```bash
-gh issue edit ISSUE_NUMBER --add-assignee @me
+gh issue edit ISSUE_NUMBER --repo "$PR_REPO_OWNER/$PR_REPO_NAME" --add-assignee @me
 ```
 
 If the assignment fails due to permissions, continue with the workflow — do not block.
 
 ## Step 4: Create Issue Branch
-
-**Branch naming**: `fix/issue-{number}-{short-description}`
 
 Use a prefix that matches the issue type:
 
@@ -78,12 +73,12 @@ Use a prefix that matches the issue type:
 | Other | `support/` |
 
 ```bash
-git checkout main && git pull origin main
+git checkout "$BASE_REF"
 BRANCH_NAME="fix/issue-${ISSUE_NUM}-short-description"
 git checkout -b "$BRANCH_NAME"
 ```
 
-**Important**: Always branch from `origin/main`. Never use other remotes.
+**Important**: Always branch from `$BASE_REF` (detected by Setup). For owners this is `origin/main`, for fork contributors this is `upstream/main`.
 
 ## Step 5: Enter Plan Mode
 
@@ -130,6 +125,14 @@ Fixes #ISSUE_NUMBER
 Detailed explanation of the fix.
 ```
 
+## Step 9: Create PR
+
+```text
+/github-pr
+```
+
+This will automatically detect the role (owner/fork) and create the PR against the correct repo with the right `--head` prefix.
+
 ## Common Issue Types
 
 | Type | Approach |
@@ -141,14 +144,15 @@ Detailed explanation of the fix.
 
 ## Checklist
 
-- [ ] gh CLI authenticated
+- [ ] Setup completed (role and remotes detected)
 - [ ] Issue content fetched and understood
 - [ ] Issue assignment attempted (best-effort)
-- [ ] Issue branch created from latest `origin/main`
+- [ ] Issue branch created from `$BASE_REF`
 - [ ] Plan created and approved
 - [ ] Fix implemented following `.claude/rules/`
 - [ ] Tests passing
 - [ ] Changes committed with issue reference (`Fixes #N`)
+- [ ] PR created via `/github-pr`
 
 ## Remember
 

--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -108,7 +108,16 @@ x  Support: update stuff           # Vague, no body for multi-file change
 
 ## Co-Author Policy
 
-**Never** add AI co-author lines (e.g., `Co-Authored-By:`). Commits reflect human authorship only.
+**Never** add AI co-author lines. Commits reflect human authorship only.
+
+**Exception — squash with multiple human authors:** When squashing commits from different people (e.g., updating someone else's PR), preserve all other human authors with `Co-authored-by:` trailers — one per author. This is passed in by `commit-and-push` when it detects other authors before squashing.
+
+```text
+Fix: resolve cross-pipeline race in softmax_prepare
+
+Co-authored-by: Alice <alice@example.com>
+Co-authored-by: Bob <bob@example.com>
+```
 
 ## Post-Commit Verification
 

--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -12,8 +12,23 @@ Accept optional PR number (`123`, `#123`) to update a specific PR, or no input (
 ## Setup
 
 1. [Setup](../../lib/github/setup.md) — authenticate and detect context (role, remotes, state)
-2. [Lookup PR](../../lib/github/lookup-pr.md) by PR number (if provided) or branch name to check for existing PR
-3. **If PR number provided:** Run [detect-permission](../../lib/github/detect-permission.md) to setup cross-fork push target
+2. **Auto-detect cross-fork PR context**: If no PR number provided and on a `pr-*-work` branch, check upstream tracking to detect cross-fork push target:
+   ```bash
+   if [ -z "$PR_NUMBER" ]; then
+     UPSTREAM=$(git rev-parse --abbrev-ref "@{upstream}" 2>/dev/null || echo "")
+     if [ -n "$UPSTREAM" ]; then
+       UPSTREAM_REMOTE=$(echo "$UPSTREAM" | cut -d'/' -f1)
+       # Check if upstream remote is NOT origin/upstream (i.e. it's a fork remote)
+       if [ "$UPSTREAM_REMOTE" != "origin" ] && [ "$UPSTREAM_REMOTE" != "upstream" ]; then
+         PUSH_REMOTE="$UPSTREAM_REMOTE"
+         HEAD_BRANCH=$(echo "$UPSTREAM" | cut -d'/' -f2-)
+         BRANCH_NAME="$BRANCH_NAME:$HEAD_BRANCH"
+       fi
+     fi
+   fi
+   ```
+3. [Lookup PR](../../lib/github/lookup-pr.md) by PR number (if provided) or by upstream head branch (`$HEAD_BRANCH` with `--head "$UPSTREAM_REMOTE:$HEAD_BRANCH"` for cross-fork) or by local branch name to check for existing PR
+4. **If PR number provided:** Run [detect-permission](../../lib/github/detect-permission.md) to setup cross-fork push target
 
 ## Route
 
@@ -136,7 +151,7 @@ gh pr edit --title "Updated title" --body "Updated body"
 - [ ] Changes committed via `/git-commit`
 - [ ] Exactly 1 valid commit ahead of base
 - [ ] Rebased onto `$BASE_REF`
-- [ ] Force-pushed to `origin`
+- [ ] Force-pushed to `$PUSH_REMOTE`
 - [ ] PR title/body updated (if commit changed)
 
 ---


### PR DESCRIPTION
## Summary
- Hardcode canonical repo (ChaoWao/simpler) in setup.md, auto-add upstream remote, detect owner vs fork by comparing origin URL
- Unify `BASE_REF` to `upstream/main` for all roles — owner and fork always rebase to the same canonical main
- Add upstream tracking in checkout-fork-branch so `/github-pr` and `/address-pr-comments` auto-detect cross-fork push target without arguments
- Use author username as fork remote name instead of `pr-$NUMBER`
- Preserve human co-authors when squashing cross-fork commits
- Fix lookup-pr to include `PR_HEAD_PREFIX` for fork contributor searches
- Handle PR head on canonical repo by reusing upstream remote instead of creating duplicates
- Unify fix-issue to use shared Setup lib and delegate PR creation to `/github-pr`

## Testing
- [ ] Workflow skills are documentation only — no runtime tests needed