### PR TITLE
feat(runtime): Add scope deadlock detection in orchestrator

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -264,6 +264,39 @@ void pto2_submit_mixed_task(
     // Submission without an open scope is illegal
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit task outside a scope");
 
+    // === Scope deadlock pre-check ===
+    // Tasks within a scope hold a fanout_count reference released only at scope_end.
+    // If scope task count >= window_size, no slots can ever be reclaimed → deadlock.
+    {
+        int32_t scope_task_count = orch->scope_tasks_size - orch->scope_begins[orch->scope_stack_top];
+        if (scope_task_count >= orch->task_ring.window_size - 1) {
+            int32_t total_submitted = orch->task_ring.current_index_ptr->load(std::memory_order_acquire);
+            int32_t last_alive = orch->task_ring.last_alive_ptr->load(std::memory_order_acquire);
+            int32_t active_count = total_submitted - last_alive;
+
+            LOG_ERROR("========================================");
+            LOG_ERROR("FATAL: Scope Deadlock Detected!");
+            LOG_ERROR("========================================");
+            LOG_ERROR("Tasks in current scope (%d) >= task_window_size (%d).",
+                      scope_task_count, orch->task_ring.window_size);
+            LOG_ERROR("  scope_depth:        %d", orch->scope_stack_top + 1);
+            LOG_ERROR("  scope_task_count:   %d", scope_task_count);
+            LOG_ERROR("  total_submitted:    %d", total_submitted);
+            LOG_ERROR("  last_task_alive:    %d", last_alive);
+            LOG_ERROR("  active_tasks:       %d / %d", active_count, orch->task_ring.window_size);
+            LOG_ERROR("Root Cause:");
+            LOG_ERROR("  Tasks within a scope hold a fanout_count reference that is only");
+            LOG_ERROR("  released at scope_end. When scope task count >= window_size,");
+            LOG_ERROR("  no slots can be reclaimed -> deadlock.");
+            LOG_ERROR("Solution:");
+            LOG_ERROR("  1. Reduce tasks per scope (use batching/unroll)");
+            LOG_ERROR("  2. Increase PTO2_TASK_WINDOW_SIZE (current: %d)", orch->task_ring.window_size);
+            LOG_ERROR("  3. Split work across multiple scopes");
+            LOG_ERROR("========================================");
+            exit(1);
+        }
+    }
+
     // === STEP 1: Allocate task slot from Task Ring (blocks until available) ===
     auto& task_ring = orch->task_ring;
     int32_t task_id = task_ring.pto2_task_ring_alloc();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -68,7 +68,7 @@ typedef struct {
     std::atomic<uint64_t> graph_output_ptr;   // Address where final output was written (packed buffer)
     std::atomic<uint64_t> graph_output_size;  // Size in bytes
 
-    // Padding to 128-byte cache line
+    // Padding to cache-line-aligned size (ALIGN_UP to PTO2_ALIGN_SIZE)
     uint64_t _padding[4];
 
 } PTO2SharedMemoryHeader;


### PR DESCRIPTION
## Summary

- Add a pre-check in `pto2_submit_mixed_task()` to detect scope deadlock **before** entering the `task_ring_alloc()` spin-wait
- When tasks in a single scope >= `window_size`, the orchestrator now exits immediately with detailed diagnostics instead of spinning 100k iterations and printing a generic "Flow Control Deadlock" message

## Background

Tasks within a scope hold a `fanout_count` reference that is only released at `scope_end()`. If the number of tasks in a single scope reaches `window_size`, no task ring slots can ever be reclaimed, causing a permanent deadlock. Previously this manifested as a 100k-iteration spin timeout with no root cause information.

## Changes

- **`pto_orchestrator.cpp`**: Add scope deadlock pre-check after `scope_stack_top` validation and before `task_ring_alloc()`. Logs scope depth, task count, active tasks, root cause explanation, and resolution suggestions
- **`pto_shared_memory.h`**: Fix padding comment for accuracy

## Reproduction

To trigger the deadlock (e.g., using `alternating_matmul_add` with a small window):

    PTO2_RING_TASK_WINDOW=32 python examples/scripts/run_example.py \
        -k examples/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels \
        -g examples/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/golden.py \
        -p a2a3sim

**Before** (commit `27cbdac`): Spins 100k iterations, prints generic "Flow Control Deadlock FATAL"

**After** (this PR): Detects immediately, prints:

    FATAL: Scope Deadlock Detected!
    Tasks in current scope (31) >= task_window_size (32).
      scope_depth:        1
      scope_task_count:   31
      active_tasks:       31 / 32
    Root Cause:
      Tasks within a scope hold a fanout_count reference that is only
      released at scope_end. When scope task count >= window_size,
      no slots can be reclaimed -> deadlock.
    Solution:
      1. Reduce tasks per scope (use batching/unroll)
      2. Increase PTO2_TASK_WINDOW_SIZE (current: 32)
      3. Split work across multiple scopes