### PR TITLE
Fix: use SSH protocol for upstream remote URL

### DIFF
--- a/.claude/lib/github/setup.md
+++ b/.claude/lib/github/setup.md
@@ -27,7 +27,7 @@ DEFAULT_BRANCH="main"
 
 ```bash
 if ! git remote | grep -q "^upstream$"; then
-  git remote add upstream "https://github.com/$UPSTREAM_REPO.git"
+  git remote add upstream "git@github.com:$UPSTREAM_REPO.git"
 fi
 git fetch upstream
 ```


### PR DESCRIPTION
## Summary
- Update upstream remote URL in setup instructions from HTTPS to SSH protocol to match the configured git operations protocol

## Testing
- [ ] Docs-only change, no tests required