### PR TITLE
Refactor: standardize register init, idle sentinel, and exit handshake

### DIFF
--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -208,9 +208,15 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = 25;
 #define MAKE_ACK_VALUE(task_id)    ((uint64_t)((task_id) & TASK_ID_MASK))
 #define MAKE_FIN_VALUE(task_id)    ((uint64_t)(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
 
-// This value is RESERVED and must never be used as a real task ID.
+// These values are RESERVED and must never be used as real task IDs.
+// Valid task IDs: 0 to 0x7FFFFFEF (2147483631)
 #define AICORE_IDLE_TASK_ID        0x7FFFFFFFU
 #define AICORE_IDLE_VALUE          MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
+
+#define AICORE_EXIT_TASK_ID        0x7FFFFFFEU
+#define AICORE_EXITED_VALUE        MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
+
+#define AICPU_IDLE_TASK_ID         0x7FFFFFFDU
 
 // =============================================================================
 // Task State Constants

--- a/src/a2a3/platform/src/aicpu/platform_regs.cpp
+++ b/src/a2a3/platform/src/aicpu/platform_regs.cpp
@@ -61,13 +61,19 @@ void platform_init_aicore_regs(uint64_t reg_addr) {
     write_reg(reg_addr, RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_OPEN);
 
     // Initialize task dispatch register to idle state
-    write_reg(reg_addr, RegId::DATA_MAIN_BASE, 0);
+    write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
 }
 
 void platform_deinit_aicore_regs(uint64_t reg_addr) {
     // Send exit signal to AICore
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
 
+    // Wait for AICore to acknowledge exit by writing AICORE_EXITED_VALUE to COND
+    while (read_reg(reg_addr, RegId::COND) != AICORE_EXITED_VALUE) {
+    }
+
+    // Initialize task dispatch register to idle state
+    write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
     // Close fast path control
     write_reg(reg_addr, RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_CLOSE);
 }

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
@@ -117,6 +117,8 @@ struct Handshake {
     volatile uint64_t perf_records_addr; // Performance records address
     volatile uint32_t perf_buffer_status; // 0 = not full, 1 == full
     volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -19,47 +19,49 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
-    // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
-    // across rounds. DATA_MAIN_BASE still holds the EXIT_SIGNAL from the previous
-    // round, so clear it before the handshake wait. Clearing after the wait would
-    // race with AICPU, which may finish all tasks and write a new EXIT_SIGNAL while
-    // this thread is descheduled between the wait and the clear.
-    write_reg(RegId::DATA_MAIN_BASE, 0);
-
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
-        dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+        dcci(my_hank, SINGLE_CACHE_LINE);
     }
 
-    // Report physical core ID and core type for AICPU
+    // Phase 2: Report physical core ID, signal ready
     my_hank->physical_core_id = get_physical_core_id();
+    my_hank->aicore_regs_ready = 1;
+    dcci(&my_hank->aicore_regs_ready, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    while (my_hank->aicpu_regs_ready == 0) {
+        dcci(&my_hank->aicpu_regs_ready, SINGLE_CACHE_LINE);
+    }
+    // Report initial idle status via register
+    write_reg(RegId::COND, AICORE_IDLE_VALUE);
+
+    // Phase 3: Report core type, signal ready
     my_hank->core_type = core_type;
     STORE_RELEASE_FENCE();
     my_hank->aicore_done = block_idx + 1;
 
-    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
-
-    write_reg(RegId::COND, AICORE_IDLE_VALUE);
+    dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     bool profiling_enabled = runtime->enable_profiling;
     uint64_t kernel_ready_time = get_sys_cnt_aicore();
 
-    volatile uint32_t task_id = 0;
-    volatile uint32_t last_task_id = 0;
+    volatile uint32_t task_id = AICPU_IDLE_TASK_ID;
+    volatile uint32_t last_task_id = AICPU_IDLE_TASK_ID;
 
     while (true) {
         task_id = static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE));
         if (task_id == AICORE_EXIT_SIGNAL) {
+            // Signal exit acknowledgment to AICPU
+            write_reg(RegId::COND, AICORE_EXITED_VALUE);
             break;
         }
 
-        if (task_id == 0 || task_id == last_task_id) {
+        if (task_id == AICPU_IDLE_TASK_ID || task_id == last_task_id) {
             SPIN_WAIT_HINT();
             continue;
         }
 
         {
-            uint32_t actual_task_id = task_id - 1;
+            uint32_t actual_task_id = task_id;
             write_reg(RegId::COND, MAKE_ACK_VALUE(actual_task_id));
 
             __gm__ Task* task_ptr = &(runtime->tasks[actual_task_id]);
@@ -81,5 +83,5 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     }
 
     // Flush all dirty cache lines to HBM before kernel exit.
-    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+    dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 }

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -97,7 +97,7 @@ struct AicpuExecutor {
     int shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores);
     int run(Runtime* runtime);
     void deinit(Runtime* runtime);
-    void emergency_shutdown();
+    void emergency_shutdown(Runtime* runtime);
     void diagnose_stuck_state(
         Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num, Handshake* hank);
 
@@ -207,7 +207,7 @@ inline bool AicpuExecutor::try_dispatch_task(int core_id,
     // Set state before writing register to avoid race with AICore ACK
     pending_task_ids_[core_id] = task_id;
 
-    write_reg(reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id + 1));
+    write_reg(reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id));
 
     return true;
 }
@@ -326,12 +326,11 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     for (int i = 0; i < cores_total_num_; i++) {
         Handshake* hank = &all_handshakes[i];
 
-        // Wait for aicore_done signal
-        while (hank->aicore_done == 0) {
+        // Wait for aicore_regs_ready signal
+        while (hank->aicore_regs_ready == 0) {
             // Busy wait for core response
         }
 
-        CoreType type = hank->core_type;
         uint32_t physical_core_id = hank->physical_core_id;
 
         // Validate physical_core_id before using as array index
@@ -345,6 +344,15 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         // Get register address using physical_core_id
         uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
         uint64_t reg_addr = regs[physical_core_id];
+
+        // Initialize AICore registers after discovery (first round)
+        platform_init_aicore_regs(reg_addr);
+        hank->aicpu_regs_ready = 1;
+
+        while (hank->aicore_done == 0) {
+        }
+
+        CoreType type = hank->core_type;
 
         if (type == CoreType::AIC) {
             aic_cores_[aic_count_].worker_id = i;
@@ -370,15 +378,10 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
             core_type_to_string(type),
             physical_core_id,
             reg_addr);
-
-        // Initialize AICore registers after discovery (first round)
-        if (reg_addr != 0) {
-            platform_init_aicore_regs(reg_addr);
-        }
     }
 
     if (handshake_failed) {
-        emergency_shutdown();
+        emergency_shutdown(runtime);
         return -1;
     }
 
@@ -1065,10 +1068,12 @@ void AicpuExecutor::deinit(Runtime* runtime) {
     LOG_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown() {
+void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
     LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-
+    Handshake* all_handshakes = (Handshake*)runtime->workers;
     for (int i = 0; i < cores_total_num_; i++) {
+        Handshake* hank = &all_handshakes[i];
+        hank->aicpu_regs_ready = 1;
         if (core_id_to_reg_addr_[i] != 0) {
             platform_deinit_aicore_regs(core_id_to_reg_addr_[i]);
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -110,6 +110,8 @@ struct Handshake {
     volatile uint64_t perf_records_addr;    // Performance records address
     volatile uint32_t perf_buffer_status;   // 0 = not full, 1 = full
     volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -54,69 +54,64 @@ __aicore__ __attribute__((always_inline)) static void execute_task(
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
-    // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
-    // across rounds. DATA_MAIN_BASE still holds the EXIT_SIGNAL from the previous
-    // round, so clear it before the handshake wait. Clearing after the wait would
-    // race with AICPU, which may finish all tasks and write a new EXIT_SIGNAL while
-    // this thread is descheduled between the wait and the clear.
-    write_reg(RegId::DATA_MAIN_BASE, 0);
-
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, SINGLE_CACHE_LINE);
     }
 
-    // Phase 2: Report physical core ID and core type, signal ready
+    // Phase 2: Report physical core ID, signal ready
     my_hank->physical_core_id = get_physical_core_id();
+    my_hank->aicore_regs_ready = 1;
+    dcci(&my_hank->aicore_regs_ready, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    while (my_hank->aicpu_regs_ready == 0) {
+        dcci(&my_hank->aicpu_regs_ready, SINGLE_CACHE_LINE);
+    }
+    // Report initial idle status via register
+    write_reg(RegId::COND, AICORE_IDLE_VALUE);
+
+    // Phase 3: Report core type, signal ready
     my_hank->core_type = core_type;
     STORE_RELEASE_FENCE();
     my_hank->aicore_done = block_idx + 1;  // Signal ready (use block_idx + 1 to avoid 0)
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
-    // Report initial idle status via register
-    write_reg(RegId::COND, AICORE_IDLE_VALUE);
+    // Cache payload address (set once by AICPU during initialization, never changes)
+    __gm__ PTO2DispatchPayload* payload =
+        reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
-    uint64_t kernel_ready_time = 0;
-    if (profiling_enabled) {
-        kernel_ready_time = get_sys_cnt_aicore();
-    }
+    uint64_t kernel_ready_time = get_sys_cnt_aicore();
 
-    // Phase 3: Main execution loop - poll register for tasks until exit signal
-    // Register encoding: 0=idle, task_id+1=task, AICORE_EXIT_SIGNAL=exit
-    uint32_t reg_val = 0;
-    uint32_t last_reg_val = 0;
+    // Phase 4: Main execution loop - poll register for tasks until exit signal
+    // Register encoding: AICPU_IDLE_TASK_ID=idle, task_id=task, AICORE_EXIT_SIGNAL=exit
+    uint32_t reg_val = AICPU_IDLE_TASK_ID;
+    uint32_t last_reg_val = AICPU_IDLE_TASK_ID;
 
     while (true) {
         reg_val = static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE));
         if (reg_val == AICORE_EXIT_SIGNAL) {
+            // Signal exit acknowledgment to AICPU
+            write_reg(RegId::COND, AICORE_EXITED_VALUE);
             break;
         }
 
-        // Execute task if new (reg_val encoding: 0=idle, task_id+1=task)
-        if (reg_val == 0 || reg_val == last_reg_val) {
+        // Execute task if new (reg_val encoding: AICPU_IDLE_TASK_ID=idle, task_id=task)
+        if (reg_val == AICPU_IDLE_TASK_ID || reg_val == last_reg_val) {
             SPIN_WAIT_HINT();
             continue;
         }
 
         {
-            uint32_t task_id = reg_val - 1;  // Decode: register holds task_id + 1
+            uint32_t task_id = reg_val;  // Decode: register holds task_id directly
 
-            // Invalidate entire data cache to read fresh payload and hank->task
-            dcci(my_hank, ENTIRE_DATA_CACHE);
-
-            // Read per-task dispatch payload address (updated by AICPU each dispatch)
-            __gm__ PTO2DispatchPayload* payload =
-                reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+            // Invalidate payload buffer (AICPU updates its content each dispatch)
+            dcci(payload, ENTIRE_DATA_CACHE);
 
             write_reg(RegId::COND, MAKE_ACK_VALUE(task_id));
 
             // Performance profiling: record start time
-            uint64_t start_time = 0;
-            if (profiling_enabled) {
-                start_time = get_sys_cnt_aicore();
-            }
+            uint64_t start_time = get_sys_cnt_aicore();
 
             // Execute the task
             execute_task(payload, pipe_sync_fn);
@@ -136,5 +131,5 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     }
 
     // Flush all dirty cache lines to HBM before kernel exit.
-    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+    dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -242,7 +242,7 @@ struct AicpuExecutor {
     int32_t shutdown_aicore(Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num);
     int32_t run(Runtime* runtime);
     void deinit(Runtime* runtime);
-    void emergency_shutdown();
+    void emergency_shutdown(Runtime* runtime);
     void diagnose_stuck_state(
         Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank);
 
@@ -530,7 +530,7 @@ struct AicpuExecutor {
             dispatch_seq_by_core_[core_id]++;
             reg_task_id = dispatch_seq_by_core_[core_id] & TASK_ID_MASK;
         }
-        write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE, static_cast<uint64_t>(reg_task_id + 1));
+        write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE, static_cast<uint64_t>(reg_task_id));
 
         CoreTypeTracker& ct = tracker.by_type[static_cast<int32_t>(core_type)];
         int32_t idle_idx = ct.find_idle_index(core_id);
@@ -577,10 +577,10 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     bool handshake_failed = false;
     for (int32_t i = 0; i < cores_total_num_; i++) {
         Handshake* hank = &all_handshakes[i];
-        while (hank->aicore_done == 0) {
+
+        while (hank->aicore_regs_ready == 0) {
         }
 
-        CoreType type = hank->core_type;
         uint32_t physical_core_id = hank->physical_core_id;
 
         // Validate physical_core_id before using as array index
@@ -594,6 +594,15 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         // Get register address using physical_core_id
         uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
         uint64_t reg_addr = regs[physical_core_id];
+
+        // Initialize AICore registers after discovery (first round)
+        platform_init_aicore_regs(reg_addr);
+        hank->aicpu_regs_ready = 1;
+
+        while (hank->aicore_done == 0) {
+        }
+
+        CoreType type = hank->core_type;
 
         if (type == CoreType::AIC) {
             aic_cores_[aic_count_].worker_id = i;
@@ -612,15 +621,10 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         }
 
         core_id_to_reg_addr_[i] = reg_addr;
-
-        // Initialize AICore registers after discovery (first round)
-        if (reg_addr != 0) {
-            platform_init_aicore_regs(reg_addr);
-        }
     }
 
     if (handshake_failed) {
-        emergency_shutdown();
+        emergency_shutdown(runtime);
         return -1;
     }
 
@@ -1986,10 +1990,12 @@ void AicpuExecutor::deinit(Runtime* runtime) {
     DEV_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown() {
+void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
     DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-
+    Handshake* all_handshakes = (Handshake*)runtime->workers;
     for (int32_t i = 0; i < cores_total_num_; i++) {
+        Handshake* hank = &all_handshakes[i];
+        hank->aicpu_regs_ready = 1;
         if (core_id_to_reg_addr_[i] != 0) {
             platform_deinit_aicore_regs(core_id_to_reg_addr_[i]);
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -502,11 +502,11 @@ Instead of polling `Handshake.task_status`, the production protocol uses hardwar
 
 | Register | Direction | Usage |
 |----------|-----------|-------|
-| `DATA_MAIN_BASE` | AICPU→AICore | Write `task_id + 1` to dispatch; `EXIT_SIGNAL` to shut down |
+| `DATA_MAIN_BASE` | AICPU→AICore | Write `task_id` to dispatch (idle=0x7FFFFFFD); `EXIT_SIGNAL` to shut down |
 | `COND` | AICore→AICPU | `[bit31=state, bits30:0=task_id]`: ACK (state=0) or FIN (state=1) |
 
 **AICore execution loop**:
-1. Poll `DATA_MAIN_BASE` for non-zero value
+1. Poll `DATA_MAIN_BASE` for value != AICPU_IDLE_TASK_ID
 2. Read payload from `Handshake.task`
 3. Write ACK to `COND`
 4. Execute kernel function via `func_id_to_addr` lookup

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -86,6 +86,8 @@ struct Handshake {
     volatile uint64_t perf_records_addr;   // Performance records address
     volatile uint32_t perf_buffer_status;  // 0 = not full, 1 == full
     volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -238,9 +238,15 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = PLATFORM_NUM_DIES * PLATFORM_AI
 #define MAKE_ACK_VALUE(task_id)    ((uint64_t)((task_id) & TASK_ID_MASK))
 #define MAKE_FIN_VALUE(task_id)    ((uint64_t)(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
 
-// This value is RESERVED and must never be used as a real task ID.
+// These values are RESERVED and must never be used as real task IDs.
+// Valid task IDs: 0 to 0x7FFFFFEF (2147483631)
 #define AICORE_IDLE_TASK_ID        0x7FFFFFFFU
 #define AICORE_IDLE_VALUE          MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
+
+#define AICORE_EXIT_TASK_ID        0x7FFFFFFEU
+#define AICORE_EXITED_VALUE        MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
+
+#define AICPU_IDLE_TASK_ID         0x7FFFFFFDU
 
 // =============================================================================
 // Task State Constants

--- a/src/a5/platform/src/aicpu/platform_regs.cpp
+++ b/src/a5/platform/src/aicpu/platform_regs.cpp
@@ -24,12 +24,19 @@ uint64_t get_platform_regs() {
 
 void platform_init_aicore_regs(uint64_t reg_addr) {
     // Initialize task dispatch register to idle state
-    write_reg(reg_addr, RegId::DATA_MAIN_BASE, 0);
+    write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
 }
 
 void platform_deinit_aicore_regs(uint64_t reg_addr) {
     // Send exit signal to AICore
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
+
+    // Wait for AICore to acknowledge exit by writing AICORE_EXITED_VALUE to COND
+    while (read_reg(reg_addr, RegId::COND) != AICORE_EXITED_VALUE) {
+    }
+
+    // Initialize task dispatch register to idle state
+    write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
 }
 
 uint32_t platform_get_physical_cores_count() {

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -19,50 +19,49 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[core_idx]);
 
-    // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
-    // across rounds. DATA_MAIN_BASE still holds the EXIT_SIGNAL from the previous
-    // round, so clear it before the handshake wait. Clearing after the wait would
-    // race with AICPU, which may finish all tasks and write a new EXIT_SIGNAL while
-    // this thread is descheduled between the wait and the clear.
-    write_reg(RegId::DATA_MAIN_BASE, 0);
-
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
-        dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+        dcci(my_hank, SINGLE_CACHE_LINE);
     }
 
-    // Clear stale EXIT_SIGNAL from previous round before entering main loop
-    write_reg(RegId::DATA_MAIN_BASE, 0);
-
-    // Report physical core ID and core type for AICPU
+    // Phase 2: Report physical core ID, signal ready
     my_hank->physical_core_id = get_physical_core_id();
+    my_hank->aicore_regs_ready = 1;
+    dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    while (my_hank->aicpu_regs_ready == 0) {
+        dcci(my_hank, SINGLE_CACHE_LINE);
+    }
+    // Report initial idle status via register
+    write_reg(RegId::COND, AICORE_IDLE_VALUE);
+
+    // Phase 3: Report core type, signal ready
     my_hank->core_type = core_type;
     STORE_RELEASE_FENCE();
     my_hank->aicore_done = core_idx + 1;
 
-    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
-
-    write_reg(RegId::COND, AICORE_IDLE_VALUE);
+    dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     bool profiling_enabled = runtime->enable_profiling;
     uint64_t kernel_ready_time = get_sys_cnt_aicore();
 
-    volatile uint32_t task_id = 0;
-    volatile uint32_t last_task_id = 0;
+    volatile uint32_t task_id = AICPU_IDLE_TASK_ID;
+    volatile uint32_t last_task_id = AICPU_IDLE_TASK_ID;
 
     while (true) {
         task_id = static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE));
         if (task_id == AICORE_EXIT_SIGNAL) {
+            // Signal exit acknowledgment to AICPU
+            write_reg(RegId::COND, AICORE_EXITED_VALUE);
             break;
         }
 
-        if (task_id == 0 || task_id == last_task_id) {
+        if (task_id == AICPU_IDLE_TASK_ID || task_id == last_task_id) {
             SPIN_WAIT_HINT();
             continue;
         }
 
         {
-            uint32_t actual_task_id = task_id - 1;
+            uint32_t actual_task_id = task_id;
             write_reg(RegId::COND, MAKE_ACK_VALUE(actual_task_id));
 
             __gm__ Task* task_ptr = &(runtime->tasks[actual_task_id]);

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -97,7 +97,7 @@ struct AicpuExecutor {
     int shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores);
     int run(Runtime* runtime);
     void deinit(Runtime* runtime);
-    void emergency_shutdown();
+    void emergency_shutdown(Runtime* runtime);
     void diagnose_stuck_state(
         Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num, Handshake* hank);
 
@@ -207,7 +207,7 @@ inline bool AicpuExecutor::try_dispatch_task(int core_id,
     // Set state before writing register to avoid race with AICore ACK
     pending_task_ids_[core_id] = task_id;
 
-    write_reg(reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id + 1));
+    write_reg(reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id));
 
     return true;
 }
@@ -326,12 +326,11 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     for (int i = 0; i < cores_total_num_; i++) {
         Handshake* hank = &all_handshakes[i];
 
-        // Wait for aicore_done signal
-        while (hank->aicore_done == 0) {
+        // Wait for aicore_regs_ready signal
+        while (hank->aicore_regs_ready == 0) {
             // Busy wait for core response
         }
 
-        CoreType type = hank->core_type;
         uint32_t physical_core_id = hank->physical_core_id;
 
         // Validate physical_core_id before using as array index
@@ -345,6 +344,15 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         // Get register address using physical_core_id
         uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
         uint64_t reg_addr = regs[physical_core_id];
+
+        // Initialize AICore registers after discovery (first round)
+        platform_init_aicore_regs(reg_addr);
+        hank->aicpu_regs_ready = 1;
+
+        while (hank->aicore_done == 0) {
+        }
+
+        CoreType type = hank->core_type;
 
         if (type == CoreType::AIC) {
             aic_cores_[aic_count_].worker_id = i;
@@ -370,15 +378,10 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
             core_type_to_string(type),
             physical_core_id,
             reg_addr);
-
-        // Initialize AICore registers after discovery (first round)
-        if (reg_addr != 0) {
-            platform_init_aicore_regs(reg_addr);
-        }
     }
 
     if (handshake_failed) {
-        emergency_shutdown();
+        emergency_shutdown(runtime);
         return -1;
     }
 
@@ -1061,10 +1064,12 @@ void AicpuExecutor::deinit(Runtime* runtime) {
     LOG_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown() {
+void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
     LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-
+    Handshake* all_handshakes = (Handshake*)runtime->workers;
     for (int i = 0; i < cores_total_num_; i++) {
+        Handshake* hank = &all_handshakes[i];
+        hank->aicpu_regs_ready = 1;
         if (core_id_to_reg_addr_[i] != 0) {
             platform_deinit_aicore_regs(core_id_to_reg_addr_[i]);
         }

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -110,6 +110,8 @@ struct Handshake {
     volatile uint64_t perf_records_addr;    // Performance records address
     volatile uint32_t perf_buffer_status;   // 0 = not full, 1 = full
     volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -58,59 +58,56 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
         dcci(my_hank, SINGLE_CACHE_LINE);
     }
 
-    // Clear stale EXIT_SIGNAL from previous round before entering main loop
-    write_reg(RegId::DATA_MAIN_BASE, 0);
-
-    // Phase 2: Report physical core ID and core type, signal ready
+    // Phase 2: Report physical core ID, signal ready
     my_hank->physical_core_id = get_physical_core_id();
+    my_hank->aicore_regs_ready = 1;
+    dcci(&my_hank->aicore_regs_ready, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    while (my_hank->aicpu_regs_ready == 0) {
+        dcci(&my_hank->aicpu_regs_ready, SINGLE_CACHE_LINE);
+    }
+    // Report initial idle status via register
+    write_reg(RegId::COND, AICORE_IDLE_VALUE);
+
+    // Phase 3: Report core type, signal ready
     my_hank->core_type = core_type;
     STORE_RELEASE_FENCE();
     my_hank->aicore_done = core_idx + 1;  // Signal ready (use core_idx + 1 to avoid 0)
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
-    // Report initial idle status via register
-    write_reg(RegId::COND, AICORE_IDLE_VALUE);
-
     // Read per-core payload address from hank->task (written by AICPU before aicpu_ready)
-    __gm__ PTO2DispatchPayload* my_payload =
+    __gm__ PTO2DispatchPayload* payload =
         reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
-    uint64_t kernel_ready_time = 0;
-    if (profiling_enabled) {
-        kernel_ready_time = get_sys_cnt_aicore();
-    }
+    uint64_t kernel_ready_time = get_sys_cnt_aicore();
 
-    // Phase 3: Main execution loop - poll register for tasks until exit signal
-    uint32_t task_id = 0;
-    uint32_t last_task_id = 0;
+    // Phase 4: Main execution loop - poll register for tasks until exit signal
+    uint32_t task_id = AICPU_IDLE_TASK_ID;
+    uint32_t last_task_id = AICPU_IDLE_TASK_ID;
 
     while (true) {
         task_id = static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE));
         if (task_id == AICORE_EXIT_SIGNAL) {
+            // Signal exit acknowledgment to AICPU
+            write_reg(RegId::COND, AICORE_EXITED_VALUE);
             break;
         }
 
-        // Execute task if new (task_id encoding: 0=idle, task_id+1=task)
-        if (task_id == 0 || task_id == last_task_id) {
+        // Execute task if new (task_id encoding: AICPU_IDLE_TASK_ID=idle, task_id=task)
+        if (task_id == AICPU_IDLE_TASK_ID || task_id == last_task_id) {
             SPIN_WAIT_HINT();
             continue;
         }
 
         {
             // Invalidate cache to read fresh payload written by AICPU
-            dcci(my_payload, ENTIRE_DATA_CACHE);
-
-            __gm__ PTO2DispatchPayload* payload = my_payload;
+            dcci(payload, ENTIRE_DATA_CACHE);
 
             write_reg(RegId::COND, MAKE_ACK_VALUE(payload->task_id));
 
             // Performance profiling: record start time
-            uint64_t start_time = 0;
-            if (profiling_enabled) {
-                start_time = get_sys_cnt_aicore();
-            }
+            uint64_t start_time = get_sys_cnt_aicore();
 
             // Execute the task
             execute_task(reinterpret_cast<__gm__ void*>(payload), pipe_sync_fn);
@@ -130,5 +127,5 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     }
 
     // Flush all dirty cache lines to HBM before kernel exit.
-    dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+    dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -184,7 +184,7 @@ struct AicpuExecutor {
     int32_t shutdown_aicore(Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num);
     int32_t run(Runtime* runtime);
     void deinit(Runtime* runtime);
-    void emergency_shutdown();
+    void emergency_shutdown(Runtime* runtime);
     void diagnose_stuck_state(
         Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank);
 
@@ -391,7 +391,7 @@ struct AicpuExecutor {
                         core_dispatch_counts_[core_id]++;
                     }
 #endif
-                    write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id + 1));
+                    write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id));
                     ct.move_idle_to_running(i);
                     executing_task_ids[core_id] = task_id;
                     made_progress = true;
@@ -451,10 +451,9 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     bool handshake_failed = false;
     for (int32_t i = 0; i < cores_total_num_; i++) {
         Handshake* hank = &all_handshakes[i];
-        while (hank->aicore_done == 0) {
+        while (hank->aicore_regs_ready == 0) {
         }
 
-        CoreType type = hank->core_type;
         uint32_t physical_core_id = hank->physical_core_id;
 
         // Validate physical_core_id before using as array index
@@ -468,6 +467,15 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         // Get register address using physical_core_id
         uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
         uint64_t reg_addr = regs[physical_core_id];
+
+        // Initialize AICore registers after discovery (first round)
+        platform_init_aicore_regs(reg_addr);
+        hank->aicpu_regs_ready = 1;
+
+        while (hank->aicore_done == 0) {
+        }
+
+        CoreType type = hank->core_type;
 
         if (type == CoreType::AIC) {
             aic_cores_[aic_count_].worker_id = i;
@@ -486,15 +494,10 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         }
 
         core_id_to_reg_addr_[i] = reg_addr;
-
-        // Initialize AICore registers after discovery (first round)
-        if (reg_addr != 0) {
-            platform_init_aicore_regs(reg_addr);
-        }
     }
 
     if (handshake_failed) {
-        emergency_shutdown();
+        emergency_shutdown(runtime);
         return -1;
     }
 
@@ -1021,7 +1024,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 local_dispatch_count++;
 #endif
                 write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE,
-                          static_cast<uint64_t>(task_id + 1));
+                          static_cast<uint64_t>(task_id));
                 ct.move_idle_to_running(idle_idx);
                 executing_task_ids[core_id] = task_id;
                 made_progress = true;
@@ -1766,10 +1769,12 @@ void AicpuExecutor::deinit(Runtime* runtime) {
     DEV_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown() {
+void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
     DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-
+    Handshake* all_handshakes = (Handshake*)runtime->workers;
     for (int32_t i = 0; i < cores_total_num_; i++) {
+        Handshake* hank = &all_handshakes[i];
+        hank->aicpu_regs_ready = 1;
         if (core_id_to_reg_addr_[i] != 0) {
             platform_deinit_aicore_regs(core_id_to_reg_addr_[i]);
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -489,11 +489,11 @@ Instead of polling `Handshake.task_status`, the production protocol uses hardwar
 
 | Register | Direction | Usage |
 |----------|-----------|-------|
-| `DATA_MAIN_BASE` | AICPU→AICore | Write `task_id + 1` to dispatch; `EXIT_SIGNAL` to shut down |
+| `DATA_MAIN_BASE` | AICPU→AICore | Write `task_id` to dispatch (idle=0x7FFFFFFD); `EXIT_SIGNAL` to shut down |
 | `COND` | AICore→AICPU | `[bit31=state, bits30:0=task_id]`: ACK (state=0) or FIN (state=1) |
 
 **AICore execution loop**:
-1. Poll `DATA_MAIN_BASE` for non-zero value
+1. Poll `DATA_MAIN_BASE` for value != AICPU_IDLE_TASK_ID
 2. Read payload from `Handshake.task`
 3. Write ACK to `COND`
 4. Execute kernel function via `func_id_to_addr` lookup

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -86,6 +86,8 @@ struct Handshake {
     volatile uint64_t perf_records_addr;   // Performance records address
     volatile uint32_t perf_buffer_status;  // 0 = not full, 1 == full
     volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**


### PR DESCRIPTION
- Replace task_id+1 dispatch encoding with direct task_id; change
  DATA_MAIN_BASE idle sentinel from 0 to AICPU_IDLE_TASK_ID (0x7FFFFFFD)
  to eliminate the race where zeroed device memory aliased task_id=0
  before register initialization
- Add two-phase register init handshake via new Handshake fields:
  AICore sets aicore_regs_ready after reporting physical_core_id;
  AICPU calls platform_init_aicore_regs then sets aicpu_regs_ready;
  AICore then writes AICORE_IDLE_VALUE to COND to signal readiness
- Add clean exit acknowledgment: AICore writes AICORE_EXITED_VALUE to
  COND on exit; platform_deinit_aicore_regs spins until this is seen
  before closing registers
- Add AICORE_EXIT_TASK_ID (0x7FFFFFFE), AICORE_EXITED_VALUE, and
  AICPU_IDLE_TASK_ID (0x7FFFFFFD) to platform_config.h
- Pass Runtime* to emergency_shutdown so it can unblock AICore cores
  stuck waiting on aicpu_regs_ready before sending exit signals
- Apply consistently across a2a3 and a5 platforms, host_build_graph
  and tensormap_and_ringbuffer runtimes