### PR TITLE
Refactor: shrink Tensor fields to uint32_t and reorder for cache loca…

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -98,11 +98,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
         if (bn_b > max_bn) max_bn = bn_b;
     }
 
-    uint64_t query_shapes[2] = {batch * num_heads, head_dim};
+    uint32_t query_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
     uint64_t kv_total_rows = key_cache_size / (head_dim * elem_size);
-    uint64_t key_cache_shapes[2] = {kv_total_rows, head_dim};
-    uint64_t value_cache_shapes[2] = {kv_total_rows, head_dim};
-    uint64_t out_shapes[2] = {batch * num_heads, head_dim};
+    uint32_t key_cache_shapes[2] = {(uint32_t)kv_total_rows, (uint32_t)head_dim};
+    uint32_t value_cache_shapes[2] = {(uint32_t)kv_total_rows, (uint32_t)head_dim};
+    uint32_t out_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
 
     Tensor query = make_tensor_external(host_query, query_shapes, 2, data_type);
     Tensor key_cache = make_tensor_external(host_key_cache, key_cache_shapes, 2, data_type);
@@ -124,8 +124,8 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
             uint64_t batch_start = chunk_idx * IN_CORE_BATCH;
 
             PTO2_SCOPE(rt) {
-                uint64_t oi_acc_shapes[2] = {chunk_bc * q_tile, head_dim};
-                uint64_t scalar_acc_shapes[1] = {chunk_bc * q_tile};
+                uint32_t oi_acc_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)head_dim};
+                uint32_t scalar_acc_shapes[1] = {(uint32_t)(chunk_bc * q_tile)};
                 Tensor oi_batch = make_tensor(oi_acc_shapes, 2, DataType::FLOAT32);
                 Tensor li_batch = make_tensor(scalar_acc_shapes, 1, DataType::FLOAT32);
                 Tensor mi_batch = make_tensor(scalar_acc_shapes, 1, DataType::FLOAT32);
@@ -138,9 +138,9 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                 pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_hub, 3);
 
                 for (uint64_t bn = 0; bn < max_bn; bn++) {
-                    uint64_t sij_shapes[2] = {chunk_bc * q_tile, block_size};
-                    uint64_t vec_shapes[1] = {chunk_bc * q_tile};
-                    uint64_t oi_new_shapes[2] = {chunk_bc * q_tile, head_dim};
+                    uint32_t sij_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)block_size};
+                    uint32_t vec_shapes[1] = {(uint32_t)(chunk_bc * q_tile)};
+                    uint32_t oi_new_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)head_dim};
 
                     Tensor sij_b = make_tensor(sij_shapes, 2, DataType::FLOAT32);
                     Tensor pij_b = make_tensor(sij_shapes, 2, data_type);

--- a/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -39,7 +39,7 @@ static constexpr int GRID_K = 4;
 static constexpr int GRID_N = 4;
 static constexpr int BATCH = 2;
 
-static constexpr uint64_t TILE_ELEMS = TILE * TILE;           // 4096 elements
+static constexpr uint32_t TILE_ELEMS = TILE * TILE;           // 4096 elements
 static constexpr uint64_t TILE_BYTES = TILE_ELEMS * sizeof(float);  // 16384 bytes
 
 // Args layout: [ptr_A, ptr_B, ptr_C, size_A, size_B, size_C, elem_count]
@@ -78,39 +78,39 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                   GRID_M, GRID_K, GRID_N, BATCH, TILE);
 
     // Create 1D external tensors for the full A, B, C arrays
-    uint64_t ext_A_shapes[1] = {size_A / sizeof(float)};
+    uint32_t ext_A_shapes[1] = {(uint32_t)(size_A / sizeof(float))};
     Tensor ext_A = make_tensor_external(dev_A, ext_A_shapes, 1, DataType::FLOAT32);
-    uint64_t ext_B_shapes[1] = {size_B / sizeof(float)};
+    uint32_t ext_B_shapes[1] = {(uint32_t)(size_B / sizeof(float))};
     Tensor ext_B = make_tensor_external(dev_B, ext_B_shapes, 1, DataType::FLOAT32);
-    uint64_t ext_C_shapes[1] = {size_C / sizeof(float)};
+    uint32_t ext_C_shapes[1] = {(uint32_t)(size_C / sizeof(float))};
     Tensor ext_C = make_tensor_external(dev_C, ext_C_shapes, 1, DataType::FLOAT32);
 
-    uint64_t tile_shapes[1] = {TILE_ELEMS};
+    uint32_t tile_shapes[1] = {TILE_ELEMS};
 
     for (int batch = 0; batch < BATCH; batch++) {
         for (int m_idx = 0; m_idx < GRID_M; m_idx++) {
             for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
                 PTO2_SCOPE(rt) {
-                    uint64_t c_elem_offset =
-                        ((uint64_t)batch * GRID_M * GRID_N +
-                         (uint64_t)m_idx * GRID_N +
-                         (uint64_t)n_idx) * TILE_ELEMS;
-                    uint64_t c_view_offsets[1] = {c_elem_offset};
+                    uint32_t c_elem_offset =
+                        ((uint32_t)batch * GRID_M * GRID_N +
+                         (uint32_t)m_idx * GRID_N +
+                         (uint32_t)n_idx) * TILE_ELEMS;
+                    uint32_t c_view_offsets[1] = {c_elem_offset};
                     Tensor C_view = ext_C.view(tile_shapes, c_view_offsets);
 
                     for (int k_idx = 0; k_idx < GRID_K; k_idx++) {
-                        uint64_t a_elem_offset =
-                            ((uint64_t)batch * GRID_M * GRID_K +
-                             (uint64_t)m_idx * GRID_K +
-                             (uint64_t)k_idx) * TILE_ELEMS;
-                        uint64_t b_elem_offset =
-                            ((uint64_t)batch * GRID_K * GRID_N +
-                             (uint64_t)k_idx * GRID_N +
-                             (uint64_t)n_idx) * TILE_ELEMS;
+                        uint32_t a_elem_offset =
+                            ((uint32_t)batch * GRID_M * GRID_K +
+                             (uint32_t)m_idx * GRID_K +
+                             (uint32_t)k_idx) * TILE_ELEMS;
+                        uint32_t b_elem_offset =
+                            ((uint32_t)batch * GRID_K * GRID_N +
+                             (uint32_t)k_idx * GRID_N +
+                             (uint32_t)n_idx) * TILE_ELEMS;
 
-                        uint64_t a_view_offsets[1] = {a_elem_offset};
+                        uint32_t a_view_offsets[1] = {a_elem_offset};
                         Tensor A_view = ext_A.view(tile_shapes, a_view_offsets);
-                        uint64_t b_view_offsets[1] = {b_elem_offset};
+                        uint32_t b_view_offsets[1] = {b_elem_offset};
                         Tensor B_view = ext_B.view(tile_shapes, b_view_offsets);
                         Tensor P = make_tensor(tile_shapes, 1, DataType::FLOAT32);
 

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -61,7 +61,7 @@
 #define ARG_SIZE_N  28
 #define ARG_SIZE_O  29
 
-static constexpr uint64_t TILE_ELEMS = 128 * 128;
+static constexpr uint32_t TILE_ELEMS = 128 * 128;
 
 extern "C" {
 
@@ -102,20 +102,20 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
     LOG_INFO(rt, "[mixed_orch] num_iters=%d", num_iters);
 
     // Input tensors (shared across all tasks)
-    uint64_t ab_shapes[1] = {TILE_ELEMS};
+    uint32_t ab_shapes[1] = {TILE_ELEMS};
     Tensor ext_A = make_tensor_external(dev_A, ab_shapes, 1, DataType::FLOAT32);
     Tensor ext_B = make_tensor_external(dev_B, ab_shapes, 1, DataType::FLOAT32);
 
-    uint64_t de_shapes[1] = {TILE_ELEMS};
+    uint32_t de_shapes[1] = {TILE_ELEMS};
     Tensor ext_D = make_tensor_external(dev_D, de_shapes, 1, DataType::FLOAT32);
     Tensor ext_E = make_tensor_external(dev_E, de_shapes, 1, DataType::FLOAT32);
 
-    uint64_t gh_shapes[1] = {TILE_ELEMS};
+    uint32_t gh_shapes[1] = {TILE_ELEMS};
     Tensor ext_G = make_tensor_external(dev_G, gh_shapes, 1, DataType::FLOAT32);
     Tensor ext_H = make_tensor_external(dev_H, gh_shapes, 1, DataType::FLOAT32);
 
     // Output tensors (full buffers, one slice per iteration)
-    uint64_t out_shapes[1] = {(uint64_t)num_iters * TILE_ELEMS};
+    uint32_t out_shapes[1] = {(uint32_t)num_iters * TILE_ELEMS};
     Tensor ext_C = make_tensor_external(dev_C, out_shapes, 1, DataType::FLOAT32);
     Tensor ext_F = make_tensor_external(dev_F, out_shapes, 1, DataType::FLOAT32);
     Tensor ext_I = make_tensor_external(dev_I, out_shapes, 1, DataType::FLOAT32);
@@ -128,8 +128,8 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
 
     for (int i = 0; i < num_iters; i++) {
         PTO2_SCOPE(rt) {
-            uint64_t view_shapes[1] = {TILE_ELEMS};
-            uint64_t view_offsets[1] = {(uint64_t)i * TILE_ELEMS};
+            uint32_t view_shapes[1] = {TILE_ELEMS};
+            uint32_t view_offsets[1] = {(uint32_t)i * TILE_ELEMS};
 
             Tensor C_view = ext_C.view(view_shapes, view_offsets);
             Tensor F_view = ext_F.view(view_shapes, view_offsets);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -102,11 +102,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
              (unsigned long)batch, (unsigned long)b_start, (unsigned long)b_end);
 
     // Compute actual tensor shapes from buffer sizes (not from max block_num)
-    uint64_t query_shapes[2] = {batch * num_heads, head_dim};
+    uint32_t query_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
     uint64_t kv_total_rows = key_cache_size / (head_dim * elem_size);
-    uint64_t key_cache_shapes[2] = {kv_total_rows, head_dim};
-    uint64_t value_cache_shapes[2] = {kv_total_rows, head_dim};
-    uint64_t out_shapes[2] = {batch * num_heads, head_dim};
+    uint32_t key_cache_shapes[2] = {(uint32_t)kv_total_rows, (uint32_t)head_dim};
+    uint32_t value_cache_shapes[2] = {(uint32_t)kv_total_rows, (uint32_t)head_dim};
+    uint32_t out_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
     Tensor query = make_tensor_external(host_query, query_shapes, 2, data_type);
     Tensor key_cache = make_tensor_external(host_key_cache, key_cache_shapes, 2, data_type);
     Tensor value_cache = make_tensor_external(host_value_cache, value_cache_shapes, 2, data_type);
@@ -121,19 +121,19 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             PTO2_SCOPE(rt) {
-                uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
-                uint64_t oi_shapes[2] = {q_tile, head_dim};
-                uint64_t li_shapes[1] = {q_tile};
-                uint64_t mi_shapes[1] = {q_tile};
+                uint32_t cur_offset = (uint32_t)(b_idx * q_head_num + q_idx * q_tile);
+                uint32_t oi_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t li_shapes[1] = {(uint32_t)q_tile};
+                uint32_t mi_shapes[1] = {(uint32_t)q_tile};
                 Tensor oi = make_tensor(oi_shapes, 2, DataType::FLOAT32);
                 Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32);
                 Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32);
 
-                uint64_t qi_shapes[2] = {q_tile, head_dim};
-                uint64_t qi_offsets[2] = {cur_offset, 0};
+                uint32_t qi_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t qi_offsets[2] = {cur_offset, 0};
                 Tensor qi = query.view(qi_shapes, qi_offsets);
-                uint64_t out_view_shapes[2] = {q_tile, head_dim};
-                uint64_t out_view_offsets[2] = {cur_offset, 0};
+                uint32_t out_view_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t out_view_offsets[2] = {cur_offset, 0};
                 Tensor out_view = out.view(out_view_shapes, out_view_offsets);
 
                 PTOParam params_inplace[] = {
@@ -146,12 +146,12 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
                     uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
                     uint64_t valid_len = block_size < (cur_seq - bn * block_size) ? block_size : (cur_seq - bn * block_size);
-                    uint64_t kv_shapes[2] = {block_size, head_dim};
-                    uint64_t kv_offsets[2] = {cur_block_idx * block_size, 0};
+                    uint32_t kv_shapes[2] = {(uint32_t)block_size, (uint32_t)head_dim};
+                    uint32_t kv_offsets[2] = {(uint32_t)(cur_block_idx * block_size), 0};
                     Tensor kj = key_cache.view(kv_shapes, kv_offsets);
                     Tensor vj = value_cache.view(kv_shapes, kv_offsets);
 
-                    uint64_t sij_shapes[2] = {q_tile, block_size};
+                    uint32_t sij_shapes[2] = {(uint32_t)q_tile, (uint32_t)block_size};
                     Tensor sij = make_tensor(sij_shapes, 2, DataType::FLOAT32);
                     Tensor pij_f16 = make_tensor(sij_shapes, 2, data_type);
 
@@ -162,8 +162,8 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                     };
                     pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk, 3); // c1
 
-                    uint64_t sij_valid_shapes[2] = {q_tile, valid_len};
-                    uint64_t sij_valid_offsets[2] = {0, 0};
+                    uint32_t sij_valid_shapes[2] = {(uint32_t)q_tile, (uint32_t)valid_len};
+                    uint32_t sij_valid_offsets[2] = {0, 0};
                     Tensor sij_valid = sij.view(sij_valid_shapes, sij_valid_offsets);
                     Tensor li = make_tensor(li_shapes, 1, DataType::FLOAT32);
                     Tensor mi = make_tensor(mi_shapes, 1, DataType::FLOAT32);
@@ -176,7 +176,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                     };
                     pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf, 5); // v1
 
-                    uint64_t oi_tmp_shapes[2] = {q_tile, head_dim};
+                    uint32_t oi_tmp_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
                     Tensor oi_tmp = make_tensor(oi_tmp_shapes, 2, DataType::FLOAT32);
 
                     PTOParam params_pv[] = {

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -93,12 +93,12 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
 
     LOG_INFO(rt, "===============SIZE=%d", SIZE);
 
-    uint64_t ext_shapes[1] = {(uint64_t)SIZE};
+    uint32_t ext_shapes[1] = {(uint32_t)SIZE};
     Tensor ext_a = make_tensor_external(arg_a_ptr, ext_shapes, 1, DataType::FLOAT32);
     Tensor ext_b = make_tensor_external(arg_b_ptr, ext_shapes, 1, DataType::FLOAT32);
     Tensor ext_f = make_tensor_external(arg_f_ptr, ext_shapes, 1, DataType::FLOAT32);
 
-    uint64_t inter_shapes[1] = {(uint64_t)SIZE};
+    uint32_t inter_shapes[1] = {(uint32_t)SIZE};
     Tensor c = make_tensor(inter_shapes, 1, DataType::FLOAT32);  // c = a + b
 
     // t0: c = a + b (kernel_id=0, kernel_add) [outer scope]

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -36,7 +36,7 @@ struct Segment {
 };
 
 /**
- * Tensor descriptor for Task input/output
+ * Tensor descriptor for Task input/output (128B = 2 cache lines)
  *
  * Describes a memory access pattern on Global Memory (GM) using
  * raw_shapes (underlying buffer dimensions), shapes (current view dimensions),
@@ -46,22 +46,21 @@ struct Segment {
  * - `raw_shapes[]`, `shapes[]`, `offsets[]` are in ELEMENTS
  * - `dtype` specifies element type for interpreting buffer contents
  *
- * Example: buffer.addr=base, dtype=FLOAT32, raw_shapes=[10, 6], shapes=[3, 6], offsets=[1, 0]
- * Memory access pattern:
- *   - Start at buffer.addr + (1*6+0)*4 = buffer.addr + 24 bytes
- *   - Inner dim: access 6 consecutive elements
- *   - Outer dim: 3 rows with stride 6 elements (derived from raw_shapes[1])
+ * Layout: cache line 1 holds hot-path fields (buffer, start_offset, version,
+ * dtype, ndims, shapes); cache line 2 holds warm-path fields (raw_shapes, offsets).
  */
-struct Tensor {
-    // === Data fields (same layout as former TensorData) ===
+struct alignas(64) Tensor {
+    // === Cache line 1 (64B) — hot path ===
     PTOBufferHandle buffer;                        // Underlying memory buffer (addr in bytes, size in bytes)
-    int32_t version;                               // Tensor version for overlap detection
     uint64_t start_offset;                         // Cached 1D element offset (precomputed from raw_shapes + offsets)
-    uint64_t ndims;                                // Number of dimensions used
+    int32_t version;                               // Tensor version for overlap detection
     DataType dtype;                                // Data type of tensor elements
-    uint64_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
-    uint64_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
-    uint64_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
+    uint32_t ndims;                                // Number of dimensions used
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
+
+    // === Cache line 2 (64B) — warm path ===
+    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
+    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
 
     Tensor() = default;
     Tensor(const Tensor&) = default;
@@ -72,10 +71,10 @@ struct Tensor {
 
     Tensor(void* addr,
         uint64_t buffer_size_bytes,
-        const uint64_t raw_shapes[],
-        const uint64_t shapes[],
-        const uint64_t offsets[],
-        uint64_t ndims,
+        const uint32_t raw_shapes[],
+        const uint32_t shapes[],
+        const uint32_t offsets[],
+        uint32_t ndims,
         DataType dtype,
         int32_t version) {
         init(addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version);
@@ -84,17 +83,17 @@ struct Tensor {
     // --- Initialization ---
     void init(void* addr,
         uint64_t buffer_size_bytes,
-        const uint64_t in_raw_shapes[],
-        const uint64_t in_shapes[],
-        const uint64_t in_offsets[],
-        uint64_t in_ndims,
+        const uint32_t in_raw_shapes[],
+        const uint32_t in_shapes[],
+        const uint32_t in_offsets[],
+        uint32_t in_ndims,
         DataType in_dtype,
         int32_t in_version) {
         buffer = {reinterpret_cast<uint64_t>(addr), buffer_size_bytes};
         ndims = in_ndims;
         dtype = in_dtype;
         version = in_version;
-        for (uint64_t i = 0; i < in_ndims; i++) {
+        for (uint32_t i = 0; i < in_ndims; i++) {
             raw_shapes[i] = in_raw_shapes[i];
             shapes[i] = in_shapes[i];
             offsets[i] = in_offsets[i];
@@ -103,22 +102,23 @@ struct Tensor {
 
     void init(const Tensor& other) {
         buffer = other.buffer;
+        start_offset = other.start_offset;
         version = other.version;
         ndims = other.ndims;
         dtype = other.dtype;
-        for (uint64_t i = 0; i < ndims; i++) {
+        for (uint32_t i = 0; i < ndims; i++) {
             raw_shapes[i] = other.raw_shapes[i];
             shapes[i] = other.shapes[i];
             offsets[i] = other.offsets[i];
         }
     }
 
-    void init_with_view(const Tensor& other, const uint64_t view_shapes[], const uint64_t view_offsets[]) {
+    void init_with_view(const Tensor& other, const uint32_t view_shapes[], const uint32_t view_offsets[]) {
         buffer = other.buffer;
         ndims = other.ndims;
         dtype = other.dtype;
         version = other.version;
-        for (uint64_t i = 0; i < ndims; i++) {
+        for (uint32_t i = 0; i < ndims; i++) {
             raw_shapes[i] = other.raw_shapes[i];
             shapes[i] = view_shapes[i];
             offsets[i] = other.offsets[i] + view_offsets[i];
@@ -140,7 +140,7 @@ struct Tensor {
         init(other);
     }
 
-    Tensor view(const uint64_t view_shapes[], const uint64_t view_offsets[]) const {
+    Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[]) const {
         Tensor result;
         result.init_with_view(*this, view_shapes, view_offsets);
         return result;
@@ -150,7 +150,7 @@ struct Tensor {
         if (ndims == 0) {
             return true;
         }
-        for (uint64_t i = 1; i < ndims; i++) {
+        for (uint32_t i = 1; i < ndims; i++) {
             if (shapes[i] != raw_shapes[i]) {
                 return false;
             }
@@ -158,22 +158,22 @@ struct Tensor {
         return true;
     }
 
-    bool valid_reshape(const uint64_t new_shapes[], uint64_t new_ndims) const {
+    bool valid_reshape(const uint32_t new_shapes[], uint32_t new_ndims) const {
         uint64_t x = numel();
         uint64_t y = 1;
-        for (size_t i = 0; i < new_ndims; i++) {
+        for (uint32_t i = 0; i < new_ndims; i++) {
             y *= new_shapes[i];
         }
         return x == y;
     }
 
-    Tensor reshape(const uint64_t new_shapes[], uint64_t new_ndims) const {
+    Tensor reshape(const uint32_t new_shapes[], uint32_t new_ndims) const {
         debug_assert(valid_reshape(new_shapes, new_ndims));
         always_assert(is_contiguous());
         Tensor result;
         result.copy(*this);
         result.ndims = new_ndims;
-        for (uint64_t i = 0; i < new_ndims; i++) {
+        for (uint32_t i = 0; i < new_ndims; i++) {
             result.raw_shapes[i] = new_shapes[i];
             result.shapes[i] = new_shapes[i];
             result.offsets[i] = 0;
@@ -181,9 +181,9 @@ struct Tensor {
         return result;
     }
 
-    bool valid_transpose(uint64_t x, uint64_t y) const { return x < ndims && y < ndims; }
+    bool valid_transpose(uint32_t x, uint32_t y) const { return x < ndims && y < ndims; }
 
-    Tensor transpose(uint64_t x, uint64_t y) const {
+    Tensor transpose(uint32_t x, uint32_t y) const {
         debug_assert(valid_transpose(x, y));
         Tensor result;
         result.copy(*this);
@@ -198,7 +198,7 @@ struct Tensor {
             return 0;
         }
         uint64_t total = 1;
-        for (uint64_t i = 0; i < ndims; i++) {
+        for (uint32_t i = 0; i < ndims; i++) {
             total *= shapes[i];
         }
         return total;
@@ -213,10 +213,10 @@ struct Tensor {
             return OverlapStatus::OTHER;
         }
         bool contains = true;
-        for (uint64_t i = 0; i < ndims; i++) {
-            Segment input_range_dim_i{offsets[i], offsets[i] + shapes[i]};
+        for (uint32_t i = 0; i < ndims; i++) {
+            Segment input_range_dim_i{offsets[i], offsets[i] + (uint64_t)shapes[i]};
             Segment output_range_dim_i{
-                pre_task_output.offsets[i], pre_task_output.offsets[i] + pre_task_output.shapes[i]};
+                pre_task_output.offsets[i], pre_task_output.offsets[i] + (uint64_t)pre_task_output.shapes[i]};
             if (!input_range_dim_i.line_segment_intersection(output_range_dim_i)) {
                 return OverlapStatus::NO_OVERLAP;
             } else if (!input_range_dim_i.contains(output_range_dim_i)) {
@@ -240,7 +240,7 @@ struct Tensor {
         ss << indent << "version: " << version << std::endl;
 
         ss << indent << "raw_shapes: [";
-        for (uint64_t i = 0; i < ndims; i++) {
+        for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
                 ss << ", ";
             }
@@ -248,7 +248,7 @@ struct Tensor {
         }
         ss << "]" << std::endl;
         ss << indent << "shapes: [";
-        for (uint64_t i = 0; i < ndims; i++) {
+        for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
                 ss << ", ";
             }
@@ -256,7 +256,7 @@ struct Tensor {
         }
         ss << "]" << std::endl;
         ss << indent << "offsets: [";
-        for (uint64_t i = 0; i < ndims; i++) {
+        for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
                 ss << ", ";
             }
@@ -268,6 +268,8 @@ struct Tensor {
     }
 };
 
+static_assert(sizeof(Tensor) == 128, "Tensor must be exactly 2 cache lines (128 bytes)");
+
 using TensorData = Tensor;
 
 // =============================================================================
@@ -277,13 +279,13 @@ using TensorData = Tensor;
  * Create a Tensor for pre-allocated external memory.
  */
 static inline Tensor make_tensor_external(void* addr,
-    const uint64_t shapes[],
-    uint64_t ndims,
+    const uint32_t shapes[],
+    uint32_t ndims,
     DataType dtype = DataType::FLOAT32,
     int32_t version = 0) {
-    static uint64_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
+    static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
     uint64_t total = 1;
-    for (uint64_t i = 0; i < ndims; i++) {
+    for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
     return Tensor(addr, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version);
@@ -295,13 +297,13 @@ static inline Tensor make_tensor_external(void* addr,
  * The runtime allocates from the heap ring and fills buffer.addr during pto2_submit_task
  * when this tensor is passed as OUTPUT param. No buffer content is ever copied.
  */
-static inline Tensor make_tensor(const uint64_t shapes[],
-    uint64_t ndims,
+static inline Tensor make_tensor(const uint32_t shapes[],
+    uint32_t ndims,
     DataType dtype = DataType::FLOAT32,
     int32_t version = 0) {
-    static uint64_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
+    static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
     uint64_t total = 1;
-    for (uint64_t i = 0; i < ndims; i++) {
+    for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
     return Tensor(0, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -84,18 +84,18 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
     int num_matmul_groups = total_matmul_tasks / matmul_batch;
     int num_add_groups = total_add_tasks / add_batch;
 
-    uint64_t ext_A_shapes[1] = {size_A / sizeof(float)};
+    uint32_t ext_A_shapes[1] = {(uint32_t)(size_A / sizeof(float))};
     Tensor ext_A = make_tensor_external(dev_A, ext_A_shapes, 1, DataType::FLOAT32);
-    uint64_t ext_B_shapes[1] = {size_B / sizeof(float)};
+    uint32_t ext_B_shapes[1] = {(uint32_t)(size_B / sizeof(float))};
     Tensor ext_B = make_tensor_external(dev_B, ext_B_shapes, 1, DataType::FLOAT32);
-    uint64_t ext_C_shapes[1] = {size_C / sizeof(float)};
+    uint32_t ext_C_shapes[1] = {(uint32_t)(size_C / sizeof(float))};
     Tensor ext_C = make_tensor_external(dev_C, ext_C_shapes, 1, DataType::FLOAT32);
 
-    uint64_t ext_X_shapes[1] = {size_X / sizeof(float)};
+    uint32_t ext_X_shapes[1] = {(uint32_t)(size_X / sizeof(float))};
     Tensor ext_X = make_tensor_external(dev_X, ext_X_shapes, 1, DataType::FLOAT32);
-    uint64_t ext_Y_shapes[1] = {size_Y / sizeof(float)};
+    uint32_t ext_Y_shapes[1] = {(uint32_t)(size_Y / sizeof(float))};
     Tensor ext_Y = make_tensor_external(dev_Y, ext_Y_shapes, 1, DataType::FLOAT32);
-    uint64_t ext_Z_shapes[1] = {size_Z / sizeof(float)};
+    uint32_t ext_Z_shapes[1] = {(uint32_t)(size_Z / sizeof(float))};
     Tensor ext_Z = make_tensor_external(dev_Z, ext_Z_shapes, 1, DataType::FLOAT32);
 
     int total_matmul = 0;
@@ -110,8 +110,8 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
             uint64_t offset = (uint64_t)start_task_idx * MATMUL_ELEMS;
             uint64_t group_size = (uint64_t)matmul_batch * MATMUL_ELEMS;
 
-            uint64_t matmul_group_shapes[1] = {group_size};
-            uint64_t view_offsets[1] = {offset};
+            uint32_t matmul_group_shapes[1] = {(uint32_t)group_size};
+            uint32_t view_offsets[1] = {(uint32_t)offset};
 
             Tensor A_view = ext_A.view(matmul_group_shapes, view_offsets);
             Tensor B_view = ext_B.view(matmul_group_shapes, view_offsets);
@@ -131,8 +131,8 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
             uint64_t offset = (uint64_t)start_task_idx * ADD_ELEMS;
             uint64_t group_size = (uint64_t)add_batch * ADD_ELEMS;
 
-            uint64_t add_group_shapes[1] = {group_size};
-            uint64_t view_offsets[1] = {offset};
+            uint32_t add_group_shapes[1] = {(uint32_t)group_size};
+            uint32_t view_offsets[1] = {(uint32_t)offset};
 
             Tensor X_view = ext_X.view(add_group_shapes, view_offsets);
             Tensor Y_view = ext_Y.view(add_group_shapes, view_offsets);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -98,11 +98,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
         if (bn_b > max_bn) max_bn = bn_b;
     }
 
-    uint64_t query_shapes[2] = {batch * num_heads, head_dim};
+    uint32_t query_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
     uint64_t kv_total_rows = key_cache_size / (head_dim * elem_size);
-    uint64_t key_cache_shapes[2] = {kv_total_rows, head_dim};
-    uint64_t value_cache_shapes[2] = {kv_total_rows, head_dim};
-    uint64_t out_shapes[2] = {batch * num_heads, head_dim};
+    uint32_t key_cache_shapes[2] = {(uint32_t)kv_total_rows, (uint32_t)head_dim};
+    uint32_t value_cache_shapes[2] = {(uint32_t)kv_total_rows, (uint32_t)head_dim};
+    uint32_t out_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
 
     Tensor query = make_tensor_external(host_query, query_shapes, 2, data_type);
     Tensor key_cache = make_tensor_external(host_key_cache, key_cache_shapes, 2, data_type);
@@ -124,8 +124,8 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
             uint64_t batch_start = chunk_idx * IN_CORE_BATCH;
 
             PTO2_SCOPE(rt) {
-                uint64_t oi_acc_shapes[2] = {chunk_bc * q_tile, head_dim};
-                uint64_t scalar_acc_shapes[1] = {chunk_bc * q_tile};
+                uint32_t oi_acc_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)head_dim};
+                uint32_t scalar_acc_shapes[1] = {(uint32_t)(chunk_bc * q_tile)};
                 Tensor oi_batch = make_tensor(oi_acc_shapes, 2, DataType::FLOAT32);
                 Tensor li_batch = make_tensor(scalar_acc_shapes, 1, DataType::FLOAT32);
                 Tensor mi_batch = make_tensor(scalar_acc_shapes, 1, DataType::FLOAT32);
@@ -139,9 +139,9 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
 
                 for (uint64_t bn = 0; bn < max_bn; bn++) {
                     PTO2_SCOPE(rt) {
-                        uint64_t sij_shapes[2] = {chunk_bc * q_tile, block_size};
-                        uint64_t vec_shapes[1] = {chunk_bc * q_tile};
-                        uint64_t oi_new_shapes[2] = {chunk_bc * q_tile, head_dim};
+                        uint32_t sij_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)block_size};
+                        uint32_t vec_shapes[1] = {(uint32_t)(chunk_bc * q_tile)};
+                        uint32_t oi_new_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)head_dim};
 
                         Tensor sij_b = make_tensor(sij_shapes, 2, DataType::FLOAT32);
                         Tensor pij_b = make_tensor(sij_shapes, 2, data_type);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -80,20 +80,20 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
              tile_size, grid_m, grid_n, grid_k, num_groups, incore_loop);
 
     // Create 1D external tensors for the full A, B, C arrays
-    uint64_t ext_A_shapes[1] = {size_A / sizeof(float)};
+    uint32_t ext_A_shapes[1] = {(uint32_t)(size_A / sizeof(float))};
     Tensor ext_A = make_tensor_external(dev_A, ext_A_shapes, 1, DataType::FLOAT32);
-    uint64_t ext_B_shapes[1] = {size_B / sizeof(float)};
+    uint32_t ext_B_shapes[1] = {(uint32_t)(size_B / sizeof(float))};
     Tensor ext_B = make_tensor_external(dev_B, ext_B_shapes, 1, DataType::FLOAT32);
-    uint64_t ext_C_shapes[1] = {size_C / sizeof(float)};
+    uint32_t ext_C_shapes[1] = {(uint32_t)(size_C / sizeof(float))};
     Tensor ext_C = make_tensor_external(dev_C, ext_C_shapes, 1, DataType::FLOAT32);
 
     // Wrap config as a device tensor so AICore kernels can read tile_size directly
-    uint64_t config_shapes[1] = {4};  // [tile_size, grid_k, num_groups, incore_loop]
+    uint32_t config_shapes[1] = {4};  // [tile_size, grid_k, num_groups, incore_loop]
     Tensor ext_config = make_tensor_external(dev_config, config_shapes, 1, DataType::INT64);
 
-    uint64_t tile_shapes[1] = {tile_elems};
+    uint32_t tile_shapes[1] = {(uint32_t)tile_elems};
     uint64_t group_tile_elems = (uint64_t)incore_loop * tile_elems;
-    uint64_t group_shapes[1] = {group_tile_elems};
+    uint32_t group_shapes[1] = {(uint32_t)group_tile_elems};
 
     int total_gemm = 0;
     int total_add = 0;
@@ -102,8 +102,8 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
     // C layout:   [incore_loop * num_groups, tile_size, tile_size]
     for (int group_idx = 0; group_idx < num_groups; group_idx++) {
         PTO2_SCOPE(rt) {
-            uint64_t c_elem_offset = (uint64_t)group_idx * group_tile_elems;
-            uint64_t c_view_offsets[1] = {c_elem_offset};
+            uint32_t c_elem_offset = (uint32_t)((uint64_t)group_idx * group_tile_elems);
+            uint32_t c_view_offsets[1] = {c_elem_offset};
             Tensor C_view = ext_C.view(group_shapes, c_view_offsets);
 
             for (int k_idx = 0; k_idx < grid_k; k_idx++) {
@@ -112,9 +112,9 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
                 uint64_t ab_offset =
                     ((uint64_t)group_idx * grid_k + (uint64_t)k_idx) * group_tile_elems;
 
-                uint64_t a_view_offsets[1] = {ab_offset};
+                uint32_t a_view_offsets[1] = {(uint32_t)ab_offset};
                 Tensor A_view = ext_A.view(group_shapes, a_view_offsets);
-                uint64_t b_view_offsets[1] = {ab_offset};
+                uint32_t b_view_offsets[1] = {(uint32_t)ab_offset};
                 Tensor B_view = ext_B.view(group_shapes, b_view_offsets);
                 Tensor P = make_tensor(group_shapes, 1, DataType::FLOAT32);
 

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -118,10 +118,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     // key_cache_size = batch * block_num * block_size * head_dim * data_type
     // value_cache_size = batch * block_num * block_size * head_dim * data_type
     // out = batch * num_heads * head_dim * data_type
-    uint64_t query_shapes[2] = {batch * num_heads, head_dim};
-    uint64_t key_cache_shapes[2] = {batch * block_num * block_size, head_dim};
-    uint64_t value_cache_shapes[2] = {batch * block_num * block_size, head_dim};
-    uint64_t out_shapes[2] = {batch * num_heads, head_dim};
+    uint32_t query_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
+    uint32_t key_cache_shapes[2] = {(uint32_t)(batch * block_num * block_size), (uint32_t)head_dim};
+    uint32_t value_cache_shapes[2] = {(uint32_t)(batch * block_num * block_size), (uint32_t)head_dim};
+    uint32_t out_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
     Tensor query = make_tensor_external(host_query, query_shapes, 2, data_type);
     Tensor key_cache = make_tensor_external(host_key_cache, key_cache_shapes, 2, data_type);
     Tensor value_cache = make_tensor_external(host_value_cache, value_cache_shapes, 2, data_type);
@@ -144,19 +144,19 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                 CYCLE_COUNT_LAP(prof_scope);
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
 
-                uint64_t oi_shapes[2] = {q_tile, head_dim};
-                uint64_t li_shapes[1] = {q_tile};
-                uint64_t mi_shapes[1] = {q_tile};
+                uint32_t oi_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t li_shapes[1] = {(uint32_t)q_tile};
+                uint32_t mi_shapes[1] = {(uint32_t)q_tile};
                 Tensor oi = make_tensor(oi_shapes, 2, DataType::FLOAT32);
                 Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32);
                 Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32);
                 prof_make_count += 3;
                 CYCLE_COUNT_LAP(prof_make_tensor);
-                uint64_t qi_shapes[2] = {q_tile, head_dim};
-                uint64_t qi_offsets[2] = {cur_offset, 0};
+                uint32_t qi_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t qi_offsets[2] = {(uint32_t)cur_offset, 0};
                 Tensor qi = query.view(qi_shapes, qi_offsets);
-                uint64_t out_view_shapes[2] = {q_tile, head_dim};
-                uint64_t out_view_offsets[2] = {cur_offset, 0};
+                uint32_t out_view_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t out_view_offsets[2] = {(uint32_t)cur_offset, 0};
                 Tensor out_view = out.view(out_view_shapes, out_view_offsets);
                 prof_view_count += 2;
                 CYCLE_COUNT_LAP(prof_tensor_view);
@@ -176,14 +176,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     uint64_t valid_len = std::min(block_size, cur_seq - bn * block_size);
                     CYCLE_COUNT_LAP(prof_param_extract);
 
-                    uint64_t kv_shapes[2] = {block_size, head_dim};
-                    uint64_t kv_offsets[2] = {cur_block_idx * block_size, 0};
+                    uint32_t kv_shapes[2] = {(uint32_t)block_size, (uint32_t)head_dim};
+                    uint32_t kv_offsets[2] = {(uint32_t)(cur_block_idx * block_size), 0};
                     Tensor kj = key_cache.view(kv_shapes, kv_offsets);
                     Tensor vj = value_cache.view(kv_shapes, kv_offsets);
                     prof_view_count += 2;
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
-                    uint64_t sij_shapes[2] = {q_tile, block_size};
+                    uint32_t sij_shapes[2] = {(uint32_t)q_tile, (uint32_t)block_size};
                     Tensor sij = make_tensor(sij_shapes, 2, DataType::FLOAT32);
                     Tensor pij_f16 = make_tensor(sij_shapes, 2, data_type);
                     prof_make_count += 2;
@@ -199,8 +199,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
-                    uint64_t sij_valid_shapes[2] = {q_tile, valid_len};
-                    uint64_t sij_valid_offsets[2] = {0, 0};
+                    uint32_t sij_valid_shapes[2] = {(uint32_t)q_tile, (uint32_t)valid_len};
+                    uint32_t sij_valid_offsets[2] = {0, 0};
                     Tensor sij_valid = sij.view(sij_valid_shapes, sij_valid_offsets);
                     prof_view_count += 1;
                     CYCLE_COUNT_LAP(prof_tensor_view);
@@ -222,7 +222,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
-                    uint64_t oi_tmp_shapes[2] = {q_tile, head_dim};
+                    uint32_t oi_tmp_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
                     Tensor oi_tmp = make_tensor(oi_tmp_shapes, 2, DataType::FLOAT32);
                     prof_make_count += 1;
                     CYCLE_COUNT_LAP(prof_make_tensor);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -117,10 +117,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
 
     LOG_ALWAYS(rt, ">>>>>> batch = %lu", (unsigned long)batch);
 
-    uint64_t query_shapes[2] = {batch * num_heads, head_dim};
-    uint64_t key_cache_shapes[2] = {batch * block_num * block_size, head_dim};
-    uint64_t value_cache_shapes[2] = {batch * block_num * block_size, head_dim};
-    uint64_t out_shapes[2] = {batch * num_heads, head_dim};
+    uint32_t query_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
+    uint32_t key_cache_shapes[2] = {(uint32_t)(batch * block_num * block_size), (uint32_t)head_dim};
+    uint32_t value_cache_shapes[2] = {(uint32_t)(batch * block_num * block_size), (uint32_t)head_dim};
+    uint32_t out_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
     Tensor query = make_tensor_external(host_query, query_shapes, 2, data_type);
     Tensor key_cache = make_tensor_external(host_key_cache, key_cache_shapes, 2, data_type);
     Tensor value_cache = make_tensor_external(host_value_cache, value_cache_shapes, 2, data_type);
@@ -135,20 +135,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
                 CYCLE_COUNT_START();
 
-                uint64_t oi_shapes[2] = {q_tile, head_dim};
-                uint64_t li_shapes[1] = {q_tile};
-                uint64_t mi_shapes[1] = {q_tile};
+                uint32_t oi_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t li_shapes[1] = {(uint32_t)q_tile};
+                uint32_t mi_shapes[1] = {(uint32_t)q_tile};
                 Tensor oi = make_tensor(oi_shapes, 2, DataType::FLOAT32);
                 Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32);
                 Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32);
                 prof_make_count += 3;
                 CYCLE_COUNT_LAP(prof_make_tensor);
 
-                uint64_t qi_shapes[2] = {q_tile, head_dim};
-                uint64_t qi_offsets[2] = {cur_offset, 0};
+                uint32_t qi_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t qi_offsets[2] = {(uint32_t)cur_offset, 0};
                 Tensor qi = query.view(qi_shapes, qi_offsets);
-                uint64_t out_view_shapes[2] = {q_tile, head_dim};
-                uint64_t out_view_offsets[2] = {cur_offset, 0};
+                uint32_t out_view_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t out_view_offsets[2] = {(uint32_t)cur_offset, 0};
                 Tensor out_view = out.view(out_view_shapes, out_view_offsets);
                 prof_view_count += 2;
                 CYCLE_COUNT_LAP(prof_tensor_view);
@@ -178,7 +178,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     uint64_t valid_len_last = std::min(block_size, cur_seq - last_block_seq_start);
 
                     // === Task 1: Batched QK matmul ===
-                    uint64_t sij_buf_shapes[2] = {q_tile, n_blocks * block_size};
+                    uint32_t sij_buf_shapes[2] = {(uint32_t)q_tile, (uint32_t)(n_blocks * block_size)};
                     Tensor sij_buf = make_tensor(sij_buf_shapes, 2, DataType::FLOAT32);
                     prof_make_count += 1;
                     CYCLE_COUNT_LAP(prof_make_tensor);
@@ -203,7 +203,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     CYCLE_COUNT_LAP(prof_submit_task);
 
                     // === Task 2: Two-pass softmax over all blocks in group ===
-                    uint64_t pij_buf_shapes[2] = {q_tile, n_blocks * block_size};
+                    uint32_t pij_buf_shapes[2] = {(uint32_t)q_tile, (uint32_t)(n_blocks * block_size)};
                     Tensor pij_buf = make_tensor(pij_buf_shapes, 2, data_type);
                     Tensor mi = make_tensor(mi_shapes, 1, DataType::FLOAT32);
                     Tensor li = make_tensor(li_shapes, 1, DataType::FLOAT32);
@@ -225,7 +225,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     CYCLE_COUNT_LAP(prof_submit_task);
 
                     // === Task 3: SplitK PV matmul (accumulated P @ V) ===
-                    uint64_t oi_new_shapes[2] = {q_tile, head_dim};
+                    uint32_t oi_new_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
                     Tensor oi_new = make_tensor(oi_new_shapes, 2, DataType::FLOAT32);
                     prof_make_count += 1;
                     CYCLE_COUNT_LAP(prof_make_tensor);


### PR DESCRIPTION
…lity

- Change ndims, shapes[], raw_shapes[], offsets[] from uint64_t to uint32_t in Tensor struct (168B -> 128B, 2 cache lines)
- Reorder fields: hot-path (buffer, start_offset, version, dtype, ndims, shapes) in cache line 1; warm-path (raw_shapes, offsets) in cache line 2
- Update all tensormap_and_ringbuffer orchestration files to use uint32_t for shape/offset arrays passed to Tensor APIs