### PR TITLE
Refactor: replace pipe_barrier with core-specific sync functions

### DIFF
--- a/src/a2a3/platform/include/aicore/aicore.h
+++ b/src/a2a3/platform/include/aicore/aicore.h
@@ -44,4 +44,10 @@
 
 #include "inner_kernel.h"
 
+// =============================================================================
+// Pipeline Synchronization Function Pointer Type
+// =============================================================================
+
+typedef void (*PipeSyncFunc)();
+
 #endif  // PLATFORM_AICORE_H_

--- a/src/a2a3/platform/onboard/aicore/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicore/kernel.cpp
@@ -21,7 +21,23 @@ class Runtime;
 [[block_local]] int block_idx;
 [[block_local]] CoreType core_type;
 
-extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
+extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn);
+
+/**
+ * Pipeline synchronization function
+ *
+ * AIV cores: Wait for PIPE_MTE3 (store pipeline)
+ * AIC cores: Wait for PIPE_FIX (cube unit pipeline)
+ */
+ __aicore__ inline void pipe_sync_aiv() {
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+}
+
+__aicore__ inline void pipe_sync_aic() {
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+}
 
 /**
  * Kernel entry point with control loop
@@ -47,5 +63,7 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime
     block_idx = get_block_idx();
     core_type = CoreType::AIC;
 #endif
-    aicore_execute(runtime, block_idx, core_type);
+
+    PipeSyncFunc pipe_sync_fn = (core_type == CoreType::AIV) ? pipe_sync_aiv : pipe_sync_aic;
+    aicore_execute(runtime, block_idx, core_type, pipe_sync_fn);
 }

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -36,10 +36,6 @@
 #define SINGLE_CACHE_LINE 0
 #define CACHELINE_OUT 0
 
-// pipe_barrier - memory barrier in simulation (hardware pipeline synchronization)
-#define PIPE_ALL 0
-#define pipe_barrier(pipe) __sync_synchronize()
-
 // SPIN_WAIT_HINT - CPU pause hint + OS yield for idle polling loops in simulation.
 // In simulation, all AICore/AICPU threads share a small number of host CPU cores.
 // The CPU hint (pause/yield) reduces pipeline waste, and sched_yield() lets the OS

--- a/src/a2a3/platform/sim/aicore/kernel.cpp
+++ b/src/a2a3/platform/sim/aicore/kernel.cpp
@@ -18,8 +18,19 @@ thread_local volatile uint8_t* g_sim_reg_base = nullptr;
 thread_local uint32_t g_sim_physical_core_id = 0;
 
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
-void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
+void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn);
 
+
+/**
+ * Pipeline synchronization function - simulation version
+ *
+ * In simulation, set_flag/wait_flag are both __sync_synchronize(),
+ * so this becomes a simple memory barrier regardless of core type.
+ * We keep a simple implementation for architectural consistency with onboard.
+ */
+ inline void pipe_sync() {
+    __sync_synchronize();
+}
 // Wrapper with extern "C" for dlsym lookup
 // NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
 extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs) {
@@ -33,5 +44,5 @@ extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, C
 
     g_sim_physical_core_id = physical_core_id;
 
-    aicore_execute(runtime, block_idx, core_type);
+    aicore_execute(runtime, block_idx, core_type, pipe_sync);
 }

--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -27,8 +27,9 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  * All kernels unpack their own arguments from the args array.
  *
  * @param task Pointer to task in global memory (null during initialization)
+ * @param pipe_sync_fn Compile-time determined pipeline sync function (AIC or AIV specific)
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task, PipeSyncFunc pipe_sync_fn) {
     // Null task pointer indicates no work assigned (initialization state)
     if (task == nullptr) {
         return;
@@ -45,11 +46,10 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)task->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
 
-    // Ensure all memory writes are visible to other cores
-    pipe_barrier(PIPE_ALL);
+    pipe_sync_fn();
 }
 
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
@@ -74,7 +74,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
         // Execute task if assigned (task != 0 means valid Task* pointer)
         if (my_hank->task_status == 1 && my_hank->task != 0) {
             __gm__ Task* task_ptr = reinterpret_cast<__gm__ Task*>(my_hank->task);
-            execute_task(task_ptr);
+            execute_task(task_ptr, pipe_sync_fn);
             // Mark task as complete (task_status: 0=idle, 1=busy)
             my_hank->task_status = 0;
         }

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -6,18 +6,17 @@
 
 typedef void (*KernelFunc)(__gm__ int64_t*);
 
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task, PipeSyncFunc pipe_sync_fn) {
     if (task->function_bin_addr == 0) {
         return;
     }
     KernelFunc kernel = (KernelFunc)task->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
 
-    // Ensure all memory writes are visible to other cores
-    pipe_barrier(PIPE_ALL);
+    pipe_sync_fn();
 }
 
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
@@ -66,7 +65,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             __gm__ Task* task_ptr = &(runtime->tasks[actual_task_id]);
             uint64_t start_time = get_sys_cnt_aicore();
 
-            execute_task(task_ptr);
+            execute_task(task_ptr, pipe_sync_fn);
 
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -19,8 +19,12 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  * Reads function_bin_addr and args from the dispatch payload.
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
+ * @param pipe_sync_fn Compile-time determined pipeline sync function (AIC or AIV specific)
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
+__aicore__ __attribute__((always_inline)) static void execute_task(
+    __gm__ PTO2DispatchPayload* payload,
+    PipeSyncFunc pipe_sync_fn
+) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
@@ -28,8 +32,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
 
-    // Ensure all memory writes are visible to other cores
-    pipe_barrier(PIPE_ALL);
+    pipe_sync_fn();
 }
 
 /**
@@ -46,8 +49,9 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * @param runtime Pointer to Runtime in global memory
  * @param block_idx Block index (core ID)
  * @param core_type Core type (AIC or AIV)
+ * @param pipe_sync_fn Compile-time determined pipeline sync function (AIC or AIV specific)
  */
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
@@ -115,7 +119,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             }
 
             // Execute the task
-            execute_task(payload);
+            execute_task(payload, pipe_sync_fn);
 
             // Performance profiling: record task execution
             // (func_id and core_type are filled by AICPU at completion time)

--- a/src/a5/platform/include/aicore/aicore.h
+++ b/src/a5/platform/include/aicore/aicore.h
@@ -44,4 +44,10 @@
 
 #include "inner_kernel.h"
 
+// =============================================================================
+// Pipeline Synchronization Function Pointer Type
+// =============================================================================
+
+typedef void (*PipeSyncFunc)();
+
 #endif  // PLATFORM_AICORE_H_

--- a/src/a5/platform/onboard/aicore/kernel.cpp
+++ b/src/a5/platform/onboard/aicore/kernel.cpp
@@ -21,7 +21,23 @@ class Runtime;
 [[block_local]] int block_idx;
 [[block_local]] CoreType core_type;
 
-extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
+extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn);
+
+/**
+ * Pipeline synchronization function
+ *
+ * AIV cores: Wait for PIPE_MTE3 (store pipeline)
+ * AIC cores: Wait for PIPE_FIX (cube unit pipeline)
+ */
+ __aicore__ inline void pipe_sync_aiv() {
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+}
+
+__aicore__ inline void pipe_sync_aic() {
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+}
 
 /**
  * Kernel entry point with control loop
@@ -47,5 +63,7 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime
     block_idx = get_block_idx();
     core_type = CoreType::AIC;
 #endif
-    aicore_execute(runtime, block_idx, core_type);
+
+    PipeSyncFunc pipe_sync_fn = (core_type == CoreType::AIV) ? pipe_sync_aiv : pipe_sync_aic;
+    aicore_execute(runtime, block_idx, core_type, pipe_sync_fn);
 }

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -36,10 +36,6 @@
 #define SINGLE_CACHE_LINE 0
 #define CACHELINE_OUT 0
 
-// pipe_barrier - memory barrier in simulation (hardware pipeline synchronization)
-#define PIPE_ALL 0
-#define pipe_barrier(pipe) __sync_synchronize()
-
 // SPIN_WAIT_HINT - CPU pause hint + OS yield for idle polling loops in simulation.
 // In simulation, all AICore/AICPU threads share a small number of host CPU cores.
 // The CPU hint (pause/yield) reduces pipeline waste, and sched_yield() lets the OS

--- a/src/a5/platform/sim/aicore/kernel.cpp
+++ b/src/a5/platform/sim/aicore/kernel.cpp
@@ -18,7 +18,19 @@ thread_local volatile uint8_t* g_sim_reg_base = nullptr;
 thread_local uint32_t g_sim_physical_core_id = 0;
 
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
-void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
+void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn);
+
+
+/**
+ * Pipeline synchronization function - simulation version
+ *
+ * In simulation, set_flag/wait_flag are both __sync_synchronize(),
+ * so this becomes a simple memory barrier regardless of core type.
+ * We keep a simple implementation for architectural consistency with onboard.
+ */
+ inline void pipe_sync() {
+    __sync_synchronize();
+}
 
 // Wrapper with extern "C" for dlsym lookup
 // NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
@@ -33,5 +45,5 @@ extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, C
 
     g_sim_physical_core_id = physical_core_id;
 
-    aicore_execute(runtime, block_idx, core_type);
+    aicore_execute(runtime, block_idx, core_type, pipe_sync);
 }

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -6,18 +6,17 @@
 
 typedef void (*KernelFunc)(__gm__ int64_t*);
 
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task, PipeSyncFunc pipe_sync_fn) {
     if (task->function_bin_addr == 0) {
         return;
     }
     KernelFunc kernel = (KernelFunc)task->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
 
-    // Ensure all memory writes are visible to other cores
-    pipe_barrier(PIPE_ALL);
+    pipe_sync_fn();
 }
 
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[core_idx]);
 
     // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
@@ -69,7 +68,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             __gm__ Task* task_ptr = &(runtime->tasks[actual_task_id]);
             uint64_t start_time = get_sys_cnt_aicore();
 
-            execute_task(task_ptr);
+            execute_task(task_ptr, pipe_sync_fn);
 
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -20,8 +20,9 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  * matching ref_runtime implementation for a2a3 compatibility.
  *
  * @param task_ptr Pointer to PTO2DispatchPayload in global memory
+ * @param pipe_sync_fn Compile-time determined pipeline sync function (AIC or AIV specific)
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* task_ptr) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* task_ptr, PipeSyncFunc pipe_sync_fn) {
     __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(task_ptr);
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
@@ -30,8 +31,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* 
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
 
-    // Ensure all memory writes are visible to other cores
-    pipe_barrier(PIPE_ALL);
+    pipe_sync_fn();
 }
 
 /**
@@ -48,8 +48,9 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* 
  * @param runtime Pointer to Runtime in global memory
  * @param core_idx Core index (core ID)
  * @param core_type Core type (AIC or AIV)
+ * @param pipe_sync_fn Compile-time determined pipeline sync function (AIC or AIV specific)
  */
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[core_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
@@ -112,7 +113,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             }
 
             // Execute the task
-            execute_task(reinterpret_cast<__gm__ void*>(payload));
+            execute_task(reinterpret_cast<__gm__ void*>(payload), pipe_sync_fn);
 
             // Performance profiling: record task execution
             if (profiling_enabled) {


### PR DESCRIPTION
- Add PipeSyncFunc typedef and compile-time determined pipe sync
- AIV cores sync PIPE_MTE3, AIC cores sync PIPE_FIX
- Pass sync function pointer through aicore_execute chain
- Remove generic PIPE_ALL barrier macro from simulation platform
- Maintain same memory barrier semantics in simulation (pipe_sync)