### PR TITLE
Refactor: isolate profiling updates by macro level and remove dead init-on-submit path

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -267,17 +267,17 @@ struct AicpuExecutor {
 #if PTO2_PROFILING
         ,
         bool profiling_enabled,
+        uint32_t& phase_complete_count
+#endif
+#if PTO2_SCHED_PROFILING
+        ,
         uint64_t& complete_probe_count,
         uint64_t& complete_hit_count,
-        uint32_t& phase_complete_count,
         uint64_t& notify_edges_total,
         int32_t& notify_max_degree,
         uint64_t& notify_tasks_enqueued,
         uint64_t& fanin_edges_total,
-        int32_t& fanin_max_degree
-#endif
-#if PTO2_SCHED_PROFILING
-        ,
+        int32_t& fanin_max_degree,
         uint64_t& sched_complete_perf_cycle
 #endif
     ) {
@@ -290,7 +290,7 @@ struct AicpuExecutor {
             int32_t reg_task_id = EXTRACT_TASK_ID(reg_val);
             int32_t reg_state = EXTRACT_TASK_STATE(reg_val);
             bool done = reg_task_id == task_id && reg_state == TASK_FIN_STATE;
-#if PTO2_PROFILING
+#if PTO2_SCHED_PROFILING
             if (profiling_enabled) {
                 complete_probe_count++;
                 if (done) {
@@ -314,14 +314,11 @@ struct AicpuExecutor {
                     if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
                     notify_tasks_enqueued += cstats.tasks_enqueued;
                     phase_complete_count++;
-#elif PTO2_PROFILING
-                    PTO2CompletionStats cstats = rt->scheduler.on_mixed_task_complete(slot_state, local_bufs);
-                    notify_edges_total += cstats.fanout_edges;
-                    if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
-                    notify_tasks_enqueued += cstats.tasks_enqueued;
-                    phase_complete_count++;
 #else
                     rt->scheduler.on_mixed_task_complete(slot_state, local_bufs);
+#if PTO2_PROFILING
+                    phase_complete_count++;
+#endif
 #endif
                     if (deferred_release_count < 256) {
                         deferred_release_slot_states[deferred_release_count++] = &slot_state;
@@ -336,7 +333,7 @@ struct AicpuExecutor {
                                 rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
                             (void)fe;
-#if PTO2_PROFILING
+#if PTO2_SCHED_PROFILING
                             fanin_edges_total += fe;
                             if (fe > fanin_max_degree) fanin_max_degree = fe;
 #endif
@@ -442,10 +439,8 @@ struct AicpuExecutor {
     }
 
     PTO2TaskSlotState* pop_ready_task(PTO2ResourceShape shape, int32_t thread_idx
-#if PTO2_PROFILING
-        , uint64_t& pop_hit, uint64_t& pop_miss
-#endif
 #if PTO2_SCHED_PROFILING
+        , uint64_t& pop_hit, uint64_t& pop_miss
         , uint64_t& sched_dispatch_pop_cycle
 #endif
     ) {
@@ -460,11 +455,11 @@ struct AicpuExecutor {
         PTO2TaskSlotState* slot_state = rt->scheduler.get_ready_task(shape);
 #endif
         if (slot_state) {
-#if PTO2_PROFILING
+#if PTO2_SCHED_PROFILING
             pop_hit++;
 #endif
         } else {
-#if PTO2_PROFILING
+#if PTO2_SCHED_PROFILING
             pop_miss++;
 #endif
         }
@@ -916,9 +911,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     uint64_t sched_complete_cycle = 0;
     uint64_t sched_dispatch_cycle = 0;
     uint64_t sched_idle_cycle = 0;
+    uint64_t sched_loop_count = 0;
+    uint32_t phase_complete_count = 0;
+    uint32_t phase_dispatch_count = 0;
+#if PTO2_SCHED_PROFILING
     uint64_t complete_probe_count = 0;
     uint64_t complete_hit_count = 0;
-    uint64_t sched_loop_count = 0;
     uint64_t notify_edges_total = 0;
     int32_t  notify_max_degree = 0;
     uint64_t notify_tasks_enqueued = 0;
@@ -926,11 +924,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     int32_t  fanin_max_degree = 0;
     uint64_t pop_hit = 0;
     uint64_t pop_miss = 0;
-    uint32_t phase_complete_count = 0;
-    uint32_t phase_dispatch_count = 0;
     uint64_t local_dispatch_count = 0;
     uint64_t local_overflow_count = 0;
-#if PTO2_SCHED_PROFILING
     uint64_t sched_complete_perf_cycle = 0;
     uint64_t sched_dispatch_pop_cycle = 0;
     uint64_t sched_dispatch_setup_cycle = 0;
@@ -1009,12 +1004,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 deferred_release_slot_states, deferred_release_count,
                 local_bufs
 #if PTO2_PROFILING
-                , profiling_enabled, complete_probe_count, complete_hit_count, phase_complete_count,
-                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree
+                , profiling_enabled, phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
-                , sched_complete_perf_cycle
+                , complete_probe_count, complete_hit_count,
+                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
 #endif
             );
         }
@@ -1028,12 +1023,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 deferred_release_slot_states, deferred_release_count,
                 local_bufs
 #if PTO2_PROFILING
-                , profiling_enabled, complete_probe_count, complete_hit_count, phase_complete_count,
-                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree
+                , profiling_enabled, phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
-                , sched_complete_perf_cycle
+                , complete_probe_count, complete_hit_count,
+                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
 #endif
             );
         }
@@ -1115,11 +1110,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         );
                     }
 #if PTO2_PROFILING
-                    pop_hit++;
                     phase_dispatch_count++;
-                    local_dispatch_count++;
 #endif
 #if PTO2_SCHED_PROFILING
+                    pop_hit++;
+                    local_dispatch_count++;
                     sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
                     made_progress = true;
@@ -1130,7 +1125,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         ci);
                 } else {
                     overflow_ptrs[overflow_count++] = slot_state;
-#if PTO2_PROFILING
+#if PTO2_SCHED_PROFILING
                     local_overflow_count++;
 #endif
                 }
@@ -1154,10 +1149,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 if (ci < 0) break;
 
                 PTO2TaskSlotState* slot_state = pop_ready_task(shape, thread_idx
-#if PTO2_PROFILING
-                    , pop_hit, pop_miss
-#endif
 #if PTO2_SCHED_PROFILING
+                    , pop_hit, pop_miss
                     , sched_dispatch_pop_cycle
 #endif
                 );
@@ -1238,7 +1231,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
                 (void)fe;
-#if PTO2_PROFILING
+#if PTO2_SCHED_PROFILING
                 fanin_edges_total += fe;
                 if (fe > fanin_max_degree) fanin_max_degree = fe;
 #endif
@@ -1624,6 +1617,12 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     unlink(so_path);
                     return -1;
                 }
+
+#if PTO2_PROFILING
+                for (int i = 0; i < orch_thread_num_; i++) {
+                    rt->orchestrators[i].enable_profiling = runtime->enable_profiling;
+                }
+#endif
 
                 // Wire up slot_states pointer for profiling (complete_perf_records)
                 runtime->set_pto2_slot_states_ptr(rt->scheduler.slot_states);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -9,10 +9,12 @@ PTO Runtime2 uses a hierarchical profiling system with compile-time macros to co
 ## Profiling Macro Hierarchy
 
 ```
-PTO2_PROFILING (base level, default=0)
+PTO2_PROFILING (base level, default=1)
 ├── PTO2_ORCH_PROFILING (orchestrator, default=0, requires PTO2_PROFILING=1)
+|   └──PTO2_TENSORMAP_PROFILING (tensormap, default=0, requires PTO2_ORCH_PROFILING=1)
 ├── PTO2_SCHED_PROFILING (scheduler, default=0, requires PTO2_PROFILING=1)
-└── PTO2_TENSORMAP_PROFILING (tensormap, default=0, requires PTO2_PROFILING=1)
+└── --enable-profiling (Dump profiling merged swimlane json file for visualization, requires PTO2_PROFILING=1)
+
 ```
 
 ### Compile-Time Validation
@@ -28,8 +30,8 @@ Each sub-level macro requires `PTO2_PROFILING=1`:
 #error "PTO2_SCHED_PROFILING requires PTO2_PROFILING=1"
 #endif
 
-#if PTO2_TENSORMAP_PROFILING && !PTO2_PROFILING
-#error "PTO2_TENSORMAP_PROFILING requires PTO2_PROFILING=1"
+#if PTO2_TENSORMAP_PROFILING && !PTO2_ORCH_PROFILING
+#error "PTO2_TENSORMAP_PROFILING requires PTO2_ORCH_PROFILING=1"
 #endif
 ```
 
@@ -194,7 +196,7 @@ runtime->enable_profiling = true;
 
 ## Common Profiling Configurations
 
-### Development (default)
+### Development (minimal overhead)
 ```bash
 # No profiling overhead
 PTO2_PROFILING=0

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -23,7 +23,7 @@
 // =============================================================================
 // Orchestrator Profiling (compile-time toggle)
 // =============================================================================
-#if PTO2_PROFILING
+#if PTO2_ORCH_PROFILING
 #include "aicpu/device_time.h"
 #include "aicpu/performance_collector_aicpu.h"
 // Weak fallback for builds that don't link device_time.cpp (e.g. host).
@@ -43,7 +43,7 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // Also hidden to prevent HOST .so from polluting the global symbol table.
 __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
     AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
-// Accumulated nanoseconds per sub-step
+// Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // task ring alloc
 static uint64_t g_orch_params_cycle = 0;     // param copy
@@ -54,7 +54,6 @@ static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
 static uint64_t g_orch_scope_end_cycle = 0;  // scope_end overhead
 static int64_t  g_orch_submit_count = 0;
 static uint32_t g_orch_submit_idx = 0;
-#if PTO2_ORCH_PROFILING
 uint64_t g_orch_alloc_wait_cycle = 0;
 uint64_t g_orch_heap_wait_cycle = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
@@ -64,14 +63,6 @@ uint64_t g_orch_heap_atomic_count = 0;
 uint64_t g_orch_fanin_atomic_count = 0;
 uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
-#elif PTO2_SCHED_PROFILING
-// When only PTO2_SCHED_PROFILING is enabled, shared methods still need
-// orch counters as targets for orchestrator-context calls.
-uint64_t g_orch_fanin_atomic_count = 0;
-uint64_t g_orch_fanin_wait_cycle = 0;
-uint64_t g_orch_finalize_atomic_count = 0;
-uint64_t g_orch_scope_end_atomic_count = 0;
-#endif
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
 #define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
 #define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                    \
@@ -80,6 +71,26 @@ uint64_t g_orch_scope_end_atomic_count = 0;
         acc += (_t1 - _t0);                                                           \
         perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
         _t0 = _t1;                                                                    \
+    } while (0)
+#elif PTO2_PROFILING
+#include "aicpu/device_time.h"
+#include "aicpu/performance_collector_aicpu.h"
+__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
+__attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
+    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
+// submit_idx needed for swimlane task_id tagging (no cycle accumulation at this level)
+static uint32_t g_orch_submit_idx = 0;
+#define CYCLE_COUNT_START()                                                           \
+    bool _prof_active = orch->enable_profiling;                                       \
+    uint64_t _t0 = _prof_active ? get_sys_cnt_aicpu() : 0, _t1 = 0
+#define CYCLE_COUNT_LAP(acc) do { } while(0)
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                    \
+    do {                                                                              \
+        if (_prof_active) {                                                           \
+            _t1 = get_sys_cnt_aicpu();                                                \
+            perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
+            _t0 = _t1;                                                                \
+        }                                                                             \
     } while (0)
 #else
 #define CYCLE_COUNT_START()
@@ -163,14 +174,8 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState* orch) {
 
 void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler) {
     orch->scheduler = scheduler;
-    orch->init_task_on_submit = true;  // Default: initialize task on submit
 }
 
-void pto2_orchestrator_set_scheduler_mode(
-    PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler, bool init_on_submit) {
-    orch->scheduler = scheduler;
-    orch->init_task_on_submit = init_on_submit;
-}
 
 // =============================================================================
 // Scope Management
@@ -197,7 +202,7 @@ void pto2_scope_begin(PTO2OrchestratorState* orch) {
 void pto2_scope_end(PTO2OrchestratorState* orch) {
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
 
-#if PTO2_PROFILING
+#if PTO2_ORCH_PROFILING
     uint64_t _se0 = get_sys_cnt_aicpu();
 #endif
 
@@ -211,7 +216,7 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
     // Rewind the task buffer — these entries are no longer needed
     orch->scope_tasks_size = begin;
 
-#if PTO2_PROFILING
+#if PTO2_ORCH_PROFILING
     uint64_t _se1 = get_sys_cnt_aicpu();
     g_orch_scope_end_cycle += (_se1 - _se0);
     // perf_aicpu_record_orch_phase(AicpuPhaseId::ORCH_SCOPE_END, _se0, _se1, g_orch_submit_idx, -1);
@@ -481,7 +486,7 @@ void pto2_submit_mixed_task(
             PTO2TaskSlotState& producer_slot_state = sched->slot_states[prod_slot];
             orch->dep_pool_cur_entry->slot_state = &cur_slot_state;
             orch->dep_pool_cur_entry->next = producer_slot_state.fanout_head;
-#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+#if PTO2_ORCH_PROFILING
             pto2_fanout_lock(producer_slot_state, g_orch_fanin_atomic_count, g_orch_fanin_wait_cycle);
 #else
             pto2_fanout_lock(producer_slot_state);
@@ -501,7 +506,7 @@ void pto2_submit_mixed_task(
                 orch->dep_pool_cur_entry = &dep_pool.alloc();
             }
         }
-        // Combined release: merge early_finished batch + init_task's +1 release
+        // Combined release: merge early_finished batch with the +1 init release
         // into a single atomic fetch_add (saves one acq_rel cache-line bounce per task).
         int32_t initial_refcount = early_finished + 1;  // +1 for the init release
         int32_t new_rc = cur_slot_state.fanin_refcount.fetch_add(initial_refcount, std::memory_order_acq_rel)
@@ -510,7 +515,7 @@ void pto2_submit_mixed_task(
             PTO2ResourceShape shape = pto2_active_mask_to_shape(active_mask);
             sched->ready_queues[static_cast<int32_t>(shape)].push(&cur_slot_state);
         }
-#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+#if PTO2_ORCH_PROFILING
         // Per producer: fetch_add(fanout_count) + load(task_state) + store(unlock) = 3 atomics
         // Lock atomics (loads + CAS) are counted inside pto2_fanout_lock
         g_orch_fanin_atomic_count += fanin_count * 3;
@@ -527,7 +532,9 @@ void pto2_submit_mixed_task(
 
 #if PTO2_PROFILING
     orch->tasks_submitted++;
+#if PTO2_ORCH_PROFILING
     g_orch_submit_count++;
+#endif
     g_orch_submit_idx++;
 #endif
 }
@@ -544,6 +551,9 @@ void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
              orch->dep_pool.top - orch->dep_pool.tail,
              orch->dep_pool.high_water, orch->dep_pool.capacity);
     orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
+#if !PTO2_ORCH_PROFILING && PTO2_PROFILING
+    g_orch_submit_idx = 0;
+#endif
 }
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -65,7 +65,10 @@ struct PTO2OrchestratorState {
     // Note: In simulated mode, orchestrator and scheduler share address space
     // In real mode, they communicate via shared memory only
     PTO2SchedulerState* scheduler;  // For simulated mode only
-    bool init_task_on_submit;       // If true, call scheduler_init_task on submit
+#if PTO2_PROFILING
+    // Runtime profiling switch copied from Runtime::enable_profiling.
+    bool enable_profiling;
+#endif
 
     // === GM HEAP (for output buffers) ===
     void* gm_heap_base;    // Base address of GM heap
@@ -126,16 +129,6 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState* orch);
  */
 void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler);
 
-/**
- * Set scheduler reference with mode control
- *
- * @param orch           Orchestrator state
- * @param scheduler      Scheduler state
- * @param init_on_submit If true, init task on submit (single-threaded mode)
- *                       If false, scheduler thread polls for new tasks (multi-threaded)
- */
-void pto2_orchestrator_set_scheduler_mode(
-    PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler, bool init_on_submit);
 
 // =============================================================================
 // Scope Management
@@ -229,7 +222,6 @@ struct PTO2OrchProfilingData {
     uint64_t alloc_wait_cycle;      // Cycles spent waiting in task_ring_alloc
     uint64_t heap_wait_cycle;       // Cycles spent waiting in heap_ring_alloc
     uint64_t fanin_wait_cycle;      // Cycles spent waiting in fanout_lock
-    uint64_t finalize_wait_cycle;   // Cycles spent in ready queue push CAS retries
     // Atomic operation counts per phase
     uint64_t alloc_atomic_count;
     uint64_t params_atomic_count;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -130,7 +130,7 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
     // Zero-initialize all per-task slot state fields.
     // new[] default-initializes std::atomic<T> which leaves values indeterminate.
     // Scheduler logic (e.g. fanin_refcount fetch_add in release_fanin_and_check_ready)
-    // assumes slots start at zero before init_task writes them.
+    // assumes slots start at zero before the orchestrator's init release.
     for (uint64_t i = 0; i < sm_handle->header->task_window_size; i++) {
         sched->slot_states[i].fanout_lock.store(0, std::memory_order_relaxed);
         sched->slot_states[i].fanout_count = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -420,7 +420,7 @@ struct PTO2SchedulerState {
                                         PTO2LocalReadyBuffer* local_bufs = nullptr) {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
-        // release in init_task, making fanin_count visible — plain load suffices.
+        // init release, making fanin_count visible — plain load suffices.
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
 
         if (new_refcount == slot_state.fanin_count) {
@@ -508,7 +508,7 @@ struct PTO2SchedulerState {
     }
 
     void on_scope_end(PTO2TaskSlotState** task_slot_states, int32_t count) {
-#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+#if PTO2_ORCH_PROFILING
         extern uint64_t g_orch_scope_end_atomic_count;
         for (int32_t i = 0; i < count; i++) {
             release_producer(*task_slot_states[i], g_orch_scope_end_atomic_count);
@@ -541,7 +541,7 @@ struct PTO2SchedulerState {
      * (i.e., on_subtask_complete returned true).
      * Handles fanout notification, fanin release, and self-consumption check.
      */
-#if PTO2_SCHED_PROFILING || PTO2_PROFILING
+#if PTO2_SCHED_PROFILING
     PTO2CompletionStats
 #else
     void
@@ -552,7 +552,7 @@ struct PTO2SchedulerState {
 #endif
 
         PTO2LocalReadyBuffer* local_bufs = nullptr) {
-#if PTO2_SCHED_PROFILING || PTO2_PROFILING
+#if PTO2_SCHED_PROFILING
         PTO2CompletionStats stats = {0, 0, 0, true};
 #endif
 #if PTO2_SCHED_PROFILING
@@ -585,18 +585,10 @@ struct PTO2SchedulerState {
 #endif
         while (current != nullptr) {
             PTO2TaskSlotState& consumer_slot = *current->slot_state;
-#if PTO2_PROFILING
-            stats.fanout_edges++;
-#endif
 #if PTO2_SCHED_PROFILING
+            stats.fanout_edges++;
             if (release_fanin_and_check_ready(consumer_slot,
                                                fanout_atomics, push_wait, local_bufs)) {
-#if PTO2_PROFILING
-                stats.tasks_enqueued++;
-#endif
-            }
-#elif PTO2_PROFILING
-            if (release_fanin_and_check_ready(consumer_slot, local_bufs)) {
                 stats.tasks_enqueued++;
             }
 #else
@@ -609,9 +601,6 @@ struct PTO2SchedulerState {
         g_sched_fanout_atomic_count[thread_idx] += fanout_atomics;
         g_sched_push_wait_cycle[thread_idx] += push_wait;
         PTO2_SCHED_CYCLE_LAP(g_sched_fanout_cycle[thread_idx]);
-#endif
-
-#if PTO2_PROFILING
         return stats;
 #endif
     }


### PR DESCRIPTION
- Move scheduler detailed counters/stats updates under PTO2_SCHED_PROFILING only
  to avoid hot-path writes when only base profiling is enabled
- Restrict orchestrator cycle accumulation and orch-only counters to
  PTO2_ORCH_PROFILING; keep base PTO2_PROFILING for swimlane phase tagging only
- Add perf_aicpu_phase_active() and guard orchestrator phase timestamp reads
  so enable_profiling=false no longer incurs unnecessary timer-read overhead
- Include g_orch_finalize_wait_cycle in orch profiling export/reset path
- Remove unused init_task_on_submit mode APIs/comments to align with current
  slot_state-based scheduler flow and simplify code paths
- Update profiling level docs to reflect corrected dependencies/defaults