### PR TITLE
[WIP] feat(benchmark): add round_idx to profiling logs for accurate multi-orchestrator timing

### DIFF
--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -915,6 +915,7 @@ class CodeRunner:
                     aicpu_binary=aicpu_binary,
                     aicore_binary=aicore_binary,
                     orch_thread_num=self.orch_thread_num,
+                    round_idx=round_idx,
                 )
 
                 runtime.finalize()

--- a/python/bindings.py
+++ b/python/bindings.py
@@ -134,6 +134,7 @@ class RuntimeLibraryLoader:
             POINTER(c_uint8),   # aicore_binary
             c_size_t,           # aicore_size
             c_int,              # orch_thread_num
+            c_int,              # round_idx
         ]
         self.lib.launch_runtime.restype = c_int
 
@@ -478,6 +479,7 @@ def launch_runtime(
     aicpu_binary: bytes,
     aicore_binary: bytes,
     orch_thread_num: int = 1,
+    round_idx: int = 0,
 ) -> None:
     """
 
@@ -494,6 +496,7 @@ def launch_runtime(
         aicpu_binary: Binary data of AICPU shared object
         aicore_binary: Binary data of AICore kernel
         orch_thread_num: Number of orchestrator threads (default 1)
+        round_idx: Current round index, 0-based (default 0)
 
     Raises:
         RuntimeError: If not initialized or execution fails
@@ -517,6 +520,7 @@ def launch_runtime(
         aicore_array,
         len(aicore_binary),
         orch_thread_num,
+        round_idx,
     )
     if rc != 0:
         raise RuntimeError(f"launch_runtime failed: {rc}")

--- a/src/a2a3/platform/include/host/pto_runtime_c_api.h
+++ b/src/a2a3/platform/include/host/pto_runtime_c_api.h
@@ -161,6 +161,7 @@ int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
  * @param aicore_binary    AICore kernel binary data
  * @param aicore_size      Size of AICore binary in bytes
  * @param orch_thread_num  Number of orchestrator threads (default 1)
+ * @param round_idx        Current round index (0-based, for benchmark logging)
  * @return 0 on success, error code on failure
  */
 int launch_runtime(RuntimeHandle runtime,
@@ -171,7 +172,8 @@ int launch_runtime(RuntimeHandle runtime,
     size_t aicpu_size,
     const uint8_t* aicore_binary,
     size_t aicore_size,
-    int orch_thread_num);
+    int orch_thread_num,
+    int round_idx);
 
 /**
  * Finalize and cleanup a runtime instance.

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -176,7 +176,8 @@ int launch_runtime(RuntimeHandle runtime,
     size_t aicpu_size,
     const uint8_t* aicore_binary,
     size_t aicore_size,
-    int orch_thread_num) {
+    int orch_thread_num,
+    int round_idx) {
     if (runtime == NULL) {
         return -1;
     }
@@ -193,6 +194,7 @@ int launch_runtime(RuntimeHandle runtime,
         // Run the runtime (device initialization is handled internally)
         Runtime* r = static_cast<Runtime*>(runtime);
         r->orch_thread_num = orch_thread_num;
+        r->round_idx = round_idx;
         return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
         return -1;

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -175,7 +175,8 @@ int launch_runtime(RuntimeHandle runtime,
                    size_t aicpu_size,
                    const uint8_t* aicore_binary,
                    size_t aicore_size,
-                   int orch_thread_num) {
+                   int orch_thread_num,
+                   int round_idx) {
     if (runtime == NULL) {
         return -1;
     }
@@ -196,6 +197,7 @@ int launch_runtime(RuntimeHandle runtime,
 
         Runtime* r = static_cast<Runtime*>(runtime);
         r->orch_thread_num = orch_thread_num;
+        r->round_idx = round_idx;
         return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
         return -1;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1676,7 +1676,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             DEV_ALWAYS("Thread %d: Calling aicpu_orchestration_entry from SO (orch_idx=%d/(0~%d))",
                        thread_idx, orch_idx, orch_thread_num_ - 1);
 #if PTO2_PROFILING
-            DEV_ALWAYS("Thread=%d orch_start=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+            DEV_ALWAYS("Thread=%d round=%d orch_start=%llu", thread_idx, runtime->round_idx, (unsigned long long)get_sys_cnt_aicpu());
             uint64_t orch_cycle_start = get_sys_cnt_aicpu();
 #endif
             PTO2_SCOPE(rt) { orch_func_(rt, orch_args_cached_, orch_arg_count_cached_, orch_thread_num_, orch_idx); }
@@ -1786,7 +1786,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
 #if PTO2_PROFILING
                 // Benchmark: record orchestrator end timestamp before waiting for schedulers
-                DEV_ALWAYS("BENCHMARK: thread=%d end=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+                DEV_ALWAYS("BENCHMARK: thread=%d round=%d end=%llu", thread_idx, runtime->round_idx, (unsigned long long)get_sys_cnt_aicpu());
 #endif
                 transition_requested_.store(true, std::memory_order_release);
 
@@ -1838,8 +1838,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
         int32_t shutdown_count = core_count_per_thread_[thread_idx];
 #if PTO2_PROFILING
         // Benchmark: record scheduler end timestamp before shutdown cleanup
-        DEV_ALWAYS("Thread=%d end=%llu",
-                   thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+        DEV_ALWAYS("Thread=%d round=%d end=%llu",
+                   thread_idx, runtime->round_idx, (unsigned long long)get_sys_cnt_aicpu());
 #endif
         auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
         if (rc != 0) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -143,6 +143,7 @@ public:
     // Execution parameters for AICPU scheduling
     int sche_cpu_num;  // Number of AICPU threads for scheduling
     int orch_thread_num;  // Number of orchestrator threads (default 1)
+    int round_idx;  // Current round index (set by host each round, used in benchmark logs)
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)

--- a/src/a5/platform/include/host/pto_runtime_c_api.h
+++ b/src/a5/platform/include/host/pto_runtime_c_api.h
@@ -161,6 +161,7 @@ int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
  * @param aicore_binary    AICore kernel binary data
  * @param aicore_size      Size of AICore binary in bytes
  * @param orch_thread_num  Number of orchestrator threads (default 1)
+ * @param round_idx        Current round index (0-based, for benchmark logging)
  * @return 0 on success, error code on failure
  */
 int launch_runtime(RuntimeHandle runtime,
@@ -171,7 +172,8 @@ int launch_runtime(RuntimeHandle runtime,
     size_t aicpu_size,
     const uint8_t* aicore_binary,
     size_t aicore_size,
-    int orch_thread_num);
+    int orch_thread_num,
+    int round_idx);
 
 /**
  * Finalize and cleanup a runtime instance.

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -176,7 +176,8 @@ int launch_runtime(RuntimeHandle runtime,
     size_t aicpu_size,
     const uint8_t* aicore_binary,
     size_t aicore_size,
-    int orch_thread_num) {
+    int orch_thread_num,
+    int round_idx) {
     if (runtime == NULL) {
         return -1;
     }
@@ -193,6 +194,7 @@ int launch_runtime(RuntimeHandle runtime,
         // Run the runtime (device initialization is handled internally)
         Runtime* r = static_cast<Runtime*>(runtime);
         r->orch_thread_num = orch_thread_num;
+        r->round_idx = round_idx;
         return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
         return -1;

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -175,7 +175,8 @@ int launch_runtime(RuntimeHandle runtime,
                    size_t aicpu_size,
                    const uint8_t* aicore_binary,
                    size_t aicore_size,
-                   int orch_thread_num) {
+                   int orch_thread_num,
+                   int round_idx) {
     if (runtime == NULL) {
         return -1;
     }
@@ -196,6 +197,7 @@ int launch_runtime(RuntimeHandle runtime,
 
         Runtime* r = static_cast<Runtime*>(runtime);
         r->orch_thread_num = orch_thread_num;
+        r->round_idx = round_idx;
         return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
         return -1;

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1518,7 +1518,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             DEV_ALWAYS("Thread %d: Calling aicpu_orchestration_entry from SO (orch_idx=%d/(0~%d))",
                        thread_idx, orch_idx, orch_thread_num_ - 1);
 #if PTO2_PROFILING
-            DEV_ALWAYS("Thread=%d orch_start=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+            DEV_ALWAYS("Thread=%d round=%d orch_start=%llu", thread_idx, runtime->round_idx, (unsigned long long)get_sys_cnt_aicpu());
             uint64_t orch_cycle_start = get_sys_cnt_aicpu();
 #endif
             PTO2_SCOPE(rt) { orch_func_(rt, orch_args_cached_, orch_arg_count_cached_, orch_thread_num_, orch_idx); }
@@ -1628,7 +1628,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
 #if PTO2_PROFILING
                 // Benchmark: record orchestrator end timestamp before waiting for schedulers
-                DEV_ALWAYS("BENCHMARK: thread=%d end=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+                DEV_ALWAYS("BENCHMARK: thread=%d round=%d end=%llu", thread_idx, runtime->round_idx, (unsigned long long)get_sys_cnt_aicpu());
 #endif
                 transition_requested_.store(true, std::memory_order_release);
 
@@ -1680,8 +1680,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
         int32_t shutdown_count = core_count_per_thread_[thread_idx];
 #if PTO2_PROFILING
         // Benchmark: record scheduler end timestamp before shutdown cleanup
-        DEV_ALWAYS("Thread=%d end=%llu",
-                   thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+        DEV_ALWAYS("Thread=%d round=%d end=%llu",
+                   thread_idx, runtime->round_idx, (unsigned long long)get_sys_cnt_aicpu());
 #endif
         auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
         if (rc != 0) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -143,6 +143,7 @@ public:
     // Execution parameters for AICPU scheduling
     int sche_cpu_num;  // Number of AICPU threads for scheduling
     int orch_thread_num;  // Number of orchestrator threads (default 1)
+    int round_idx;  // Current round index (set by host each round, used in benchmark logs)
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)

--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -20,9 +20,9 @@ RUN_EXAMPLE="$PROJECT_ROOT/examples/scripts/run_example.py"
 EXAMPLES=(
     alternating_matmul_add
     benchmark_bgemm
+    paged_attention
     paged_attention_unroll
     batch_paged_attention
-    paged_attention
 )
 
 # ---------------------------------------------------------------------------
@@ -100,7 +100,7 @@ parse_timing() {
     local log_file="$1"
 
     local timing
-    timing=$(grep -E 'Thread=[0-9]+ (orch_start|end)=' "$log_file" || true)
+    timing=$(grep -E 'round=[0-9]+.*(orch_start|end)=' "$log_file" || true)
 
     if [[ -z "$timing" ]]; then
         echo "  (no benchmark timing data — was PTO2_PROFILING enabled?)"
@@ -109,34 +109,39 @@ parse_timing() {
 
     echo "$timing" | awk '
     /orch_start=/ {
-        if (round > 0 && max_end > 0) {
-            elapsed = max_end - orch_start
-            results[round - 1] = elapsed / 50.0
-            count++
-        }
-        round++
-        match($0, /orch_start=([0-9]+)/, m)
-        orch_start = m[1] + 0
-        max_end = 0
+        match($0, /round=([0-9]+)/, mr)
+        r = mr[1] + 0
+        match($0, /orch_start=([0-9]+)/, ms)
+        val = ms[1] + 0
+        if (!(r in min_start) || val < min_start[r]) min_start[r] = val
+        if (r > max_round) max_round = r
     }
     /end=/ {
-        match($0, /end=([0-9]+)/, m)
-        val = m[1] + 0
-        if (val > max_end) max_end = val
+        match($0, /round=([0-9]+)/, mr)
+        r = mr[1] + 0
+        match($0, /end=([0-9]+)/, me)
+        val = me[1] + 0
+        if (!(r in max_end) || val > max_end[r]) max_end[r] = val
+        if (r > max_round) max_round = r
     }
     END {
-        if (round > 0 && max_end > 0) {
-            results[round - 1] = (max_end - orch_start) / 50.0
-            count++
+        count = 0
+        for (r = 0; r <= max_round; r++) {
+            if ((r in min_start) && (r in max_end)) {
+                results[r] = (max_end[r] - min_start[r]) / 50.0
+                count++
+            }
         }
         if (count == 0) { print "  (no rounds parsed)"; exit 1 }
 
         printf "  %-8s  %12s\n", "Round", "Elapsed (us)"
         printf "  %-8s  %12s\n", "-----", "------------"
         sum_v = 0
-        for (i = 0; i < count; i++) {
-            printf "  %-8d  %12.1f\n", i, results[i]
-            sum_v += results[i]
+        for (r = 0; r <= max_round; r++) {
+            if ((r in min_start) && (r in max_end)) {
+                printf "  %-8d  %12.1f\n", r, results[r]
+                sum_v += results[r]
+            }
         }
         printf "\n  Avg: %.1f us  (%d rounds)\n", sum_v / count, count
     }'


### PR DESCRIPTION
## Summary

- Thread `round_idx` through the full call stack (`code_runner.py` →
  `bindings.py` → `pto_runtime_c_api` → `Runtime` → `aicpu_executor`)
  so every profiling log line carries an explicit round identifier.
- Update `benchmark_rounds.sh` parsing logic to group `orch_start` /
  `end` timestamps by `round=N` instead of relying on sequential
  ordering, computing `min(orch_start)` and `max(end)` per round for
  correct wall-clock elapsed time.

## Motivation

`tools/benchmark_rounds.sh` measures per-round execution time by
parsing `orch_start` and `end` timestamps from runtime logs. When
multiple orchestrator threads are active, their log lines interleave
non-deterministically, causing the old sequential parser to assign
timestamps to the wrong rounds and produce incorrect results.

By tagging each log line with an explicit `round=<idx>`, the parser
can reliably associate all start/end timestamps with their correct
round regardless of thread interleaving.