### PR TITLE
Fix: benchmark timing for multi-orchestrator cases in parse_timing

### DIFF
--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -108,16 +108,27 @@ parse_timing() {
     fi
 
     echo "$timing" | awk '
-    /orch_start=/ {
-        if (round > 0 && max_end > 0) {
-            elapsed = max_end - orch_start
-            results[round - 1] = elapsed / 50.0
+    function flush_round() {
+        if (round >= 0 && max_end > 0 && min_start > 0) {
+            results[round] = (max_end - min_start) / 50.0
             count++
         }
-        round++
+    }
+    BEGIN { round = 0; min_start = 0; max_end = 0; count = 0 }
+    /orch_start=/ {
+        match($0, /Thread=([0-9]+)/, tm)
+        tid = tm[1] + 0
+        if (tid in seen) {
+            flush_round()
+            round++
+            min_start = 0
+            max_end = 0
+            delete seen
+        }
+        seen[tid] = 1
         match($0, /orch_start=([0-9]+)/, m)
-        orch_start = m[1] + 0
-        max_end = 0
+        val = m[1] + 0
+        if (min_start == 0 || val < min_start) min_start = val
     }
     /end=/ {
         match($0, /end=([0-9]+)/, m)
@@ -125,10 +136,7 @@ parse_timing() {
         if (val > max_end) max_end = val
     }
     END {
-        if (round > 0 && max_end > 0) {
-            results[round - 1] = (max_end - orch_start) / 50.0
-            count++
-        }
+        flush_round()
         if (count == 0) { print "  (no rounds parsed)"; exit 1 }
 
         printf "  %-8s  %12s\n", "Round", "Elapsed (us)"


### PR DESCRIPTION
## Summary

- Fix `parse_timing` in `tools/benchmark_rounds.sh` to correctly
  measure per-round elapsed time when multiple orchestrator threads
  run concurrently within a single round
- Detect round boundaries via Thread ID recurrence instead of
  treating every `orch_start` line as a new round
- Compute elapsed as `max(end) - min(orch_start)` across all
  threads in a round, reflecting actual wall-clock time

## Background

For single-orchestrator examples the old parser worked fine — each
round had exactly one `orch_start` / `end` pair. In multi-orchestrator
cases, however, N threads each emit their own `orch_start` and `end`
within the same round. The old code mistakenly counted each
`orch_start` as a separate round and used only the last start
timestamp, producing incorrect per-round timings and inflated round
counts.

## What changed

`tools/benchmark_rounds.sh` — `parse_timing()` awk block:

| Aspect | Before | After |
|---|---|---|
| Round boundary | Every `orch_start` line | A previously-seen Thread ID reappears |
| Start timestamp | Single `orch_start` value (last seen) | `min(orch_start)` across all threads in the round |
| End timestamp | `max(end)` (unchanged) | `max(end)` (unchanged) |
| Elapsed formula | `max_end - orch_start` | `max_end - min_start` |

Refactored the round-finalization logic into a `flush_round()` awk
function to eliminate duplication between the round-boundary handler
and the `END` block.