### PR TITLE
Feat: Add fatal error reporting and emergency shutdown for AICPU runtime

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -60,6 +60,7 @@ constexpr int32_t MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 
 constexpr int32_t MAX_IDLE_ITERATIONS = 800000;  // ~20s idle then scheduler gives up (avoid long hang)
 constexpr int32_t STALL_LOG_INTERVAL = 50000;    // DEV_ALWAYS every N idle iters to debug hang
+constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
 constexpr int32_t STALL_DUMP_WAIT_MAX = 4;
 constexpr int32_t STALL_DUMP_CORE_MAX = 8;
@@ -1006,6 +1007,20 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         if (tracker.aic().running_count == 0 && tracker.aiv().running_count == 0) {
             bool orch_done = orchestrator_done_;
             if (orch_done) {
+                // Check for orchestrator fatal error — exit immediately
+                int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
+                if (orch_err != PTO2_ERROR_NONE) {
+                    DEV_ERROR("Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
+                               "completed_tasks=%d, total_tasks=%d",
+                               thread_idx, orch_err,
+                               completed_tasks_.load(std::memory_order_relaxed),
+                               total_tasks_);
+                    emergency_shutdown(runtime);
+                    completed_.store(true, std::memory_order_release);
+                    break;
+                }
+
+                // Normal exit: all tasks complete
                 task_count = total_tasks_;
                 if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
                     completed_.store(true, std::memory_order_release);
@@ -1287,6 +1302,21 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #endif
             }
             idle_iterations++;
+
+            // Check for orchestrator fatal error during idle (every 1024 iterations)
+            // orch_error_code is set in shared memory by the orchestrator's spin loop
+            // BEFORE orchestrator_done_ is set, so this catches errors earlier.
+            if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
+                int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
+                if (orch_err != PTO2_ERROR_NONE) {
+                    DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores",
+                               thread_idx, orch_err);
+                    emergency_shutdown(runtime);
+                    completed_.store(true, std::memory_order_release);
+                    break;
+                }
+            }
+
             if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
                 int32_t c = completed_tasks_.load(std::memory_order_relaxed);
                 DEV_ALWAYS("PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
@@ -1844,28 +1874,49 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
                 }
                 orchestrator_done_ = true;
+                {
+                    int32_t orch_err = 0;
+                    void* sm = runtime->get_pto2_gm_sm_ptr();
+                    if (sm) {
+                        orch_err = static_cast<PTO2SharedMemoryHeader*>(sm)->orch_error_code.load(
+                            std::memory_order_relaxed);
+                    }
 
-                // Compute new core assignments for all threads and initialize donated slots
-                DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
-#if PTO2_PROFILING
-                // Benchmark: record orchestrator end timestamp before waiting for schedulers
-                DEV_ALWAYS("BENCHMARK: thread=%d end=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
-#endif
-                transition_requested_.store(true, std::memory_order_release);
-
-                // Wait for scheduler threads to acknowledge transition request
-                // All-orchestrator mode (sched_thread_num_ == 0): skip the wait
-                if (sched_thread_num_ > 0) {
-                    while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
-                        if (completed_.load(std::memory_order_acquire)) {
-                            break;
-                        }
-                        SPIN_WAIT_HINT();
+                    // Fatal error: shutdown AICore immediately before core transition.
+                    if (orch_err != PTO2_ERROR_NONE) {
+                        emergency_shutdown(runtime);
+                        completed_.store(true, std::memory_order_release);
                     }
                 }
-                if (!completed_.load(std::memory_order_acquire)) {
-                    reassign_cores_for_all_threads();
+
+                // Skip core transition on fatal error — cores already shut down above
+                if (completed_.load(std::memory_order_acquire)) {
+                    // Signal transition to unblock scheduler threads waiting at core transition
+                    transition_requested_.store(true, std::memory_order_release);
                     reassigned_.store(true, std::memory_order_release);
+                } else {
+                    // Compute new core assignments for all threads and initialize donated slots
+                    DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
+#if PTO2_PROFILING
+                    // Benchmark: record orchestrator end timestamp before waiting for schedulers
+                    DEV_ALWAYS("BENCHMARK: thread=%d end=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+#endif
+                    transition_requested_.store(true, std::memory_order_release);
+
+                    // Wait for scheduler threads to acknowledge transition request
+                    // All-orchestrator mode (sched_thread_num_ == 0): skip the wait
+                    if (sched_thread_num_ > 0) {
+                        while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
+                            if (completed_.load(std::memory_order_acquire)) {
+                                break;
+                            }
+                            SPIN_WAIT_HINT();
+                        }
+                    }
+                    if (!completed_.load(std::memory_order_acquire)) {
+                        reassign_cores_for_all_threads();
+                        reassigned_.store(true, std::memory_order_release);
+                    }
                 }
             } else {
                 // Non-last orchestrator: wait for last orchestrator to finish setup
@@ -1895,18 +1946,26 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
         always_assert(rt != nullptr);
         int32_t completed = resolve_and_dispatch_pto2(runtime, thread_idx);
         DEV_INFO("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
+    }
 
-        // After transition, use new core assignments for shutdown
+    // Always shutdown AICore — even if completed_ was already true.
+    // platform_deinit_aicore_regs is idempotent; orchestrator threads have
+    // core_count_per_thread_ == 0 so they skip the loop harmlessly.
+    {
         const int32_t* shutdown_cores = core_assignments_[thread_idx];
         int32_t shutdown_count = core_count_per_thread_[thread_idx];
 #if PTO2_PROFILING
         // Benchmark: record scheduler end timestamp before shutdown cleanup
-        DEV_ALWAYS("Thread=%d end=%llu",
-                   thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+        if (shutdown_count > 0) {
+            DEV_ALWAYS("Thread=%d end=%llu",
+                       thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+        }
 #endif
-        auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
-        if (rc != 0) {
-            return rc;
+        if (shutdown_count > 0) {
+            auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
+            if (rc != 0) {
+                return rc;
+            }
         }
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -47,6 +47,7 @@ typedef struct PTO2RuntimeOps {
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
     void (*orchestration_done)(PTO2Runtime* rt);
+    bool (*is_fatal)(PTO2Runtime* rt);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char* func, const char* fmt, ...);
@@ -106,6 +107,10 @@ static inline void pto2_rt_scope_end(PTO2Runtime* rt) {
 
 static inline void pto2_rt_orchestration_done(PTO2Runtime* rt) {
     rt->ops->orchestration_done(rt);
+}
+
+static inline bool pto2_rt_is_fatal(PTO2Runtime* rt) {
+    return rt->ops->is_fatal(rt);
 }
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -110,6 +110,7 @@ bool pto2_orchestrator_init(
     orch->sm_handle = sm_handle;
     orch->gm_heap_base = gm_heap;
     orch->gm_heap_size = heap_size * PTO2_MAX_RING_DEPTH;
+    orch->fatal = false;
 
     // Initialize per-ring resources
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -120,6 +121,7 @@ bool pto2_orchestrator_init(
         pto2_heap_ring_init(&orch->rings[r].heap_ring, ring_heap_base, heap_size,
                             &sm_handle->header->rings[r].fc.heap_tail,
                             &sm_handle->header->rings[r].fc.heap_top);
+        orch->rings[r].heap_ring.error_code_ptr = &sm_handle->header->orch_error_code;
 
         // Initialize task ring buffer
         pto2_task_ring_init(&orch->rings[r].task_ring,
@@ -127,6 +129,7 @@ bool pto2_orchestrator_init(
             sm_handle->header->rings[r].task_window_size,
             &sm_handle->header->rings[r].fc.last_task_alive,
             &sm_handle->header->rings[r].fc.current_task_index);
+        orch->rings[r].task_ring.error_code_ptr = &sm_handle->header->orch_error_code;
 
         // Allocate and initialize dependency list pool (per-ring)
         PTO2DepListEntry* dep_entries = (PTO2DepListEntry*)calloc(dep_pool_capacity, sizeof(PTO2DepListEntry));
@@ -138,6 +141,7 @@ bool pto2_orchestrator_init(
             return false;
         }
         pto2_dep_pool_init(&orch->rings[r].dep_pool, dep_entries, dep_pool_capacity);
+        orch->rings[r].dep_pool.error_code_ptr = &sm_handle->header->orch_error_code;
         orch->dep_pool_cur_entries[r] = nullptr;
         orch->dep_pool_last_reclaimed[r] = 0;
     }
@@ -292,6 +296,7 @@ static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState *tas
 }
 
 void pto2_scope_begin(PTO2OrchestratorState* orch) {
+    if (orch->fatal) { return; }
     assert(orch->scope_stack_top < (int32_t)(orch->scope_stack_capacity - 1) && "Scope stack overflow");
 
     ++orch->scope_stack_top;
@@ -299,6 +304,7 @@ void pto2_scope_begin(PTO2OrchestratorState* orch) {
 }
 
 void pto2_scope_end(PTO2OrchestratorState* orch) {
+    if (orch->fatal) { return; }
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
 
 #if PTO2_ORCH_PROFILING
@@ -327,6 +333,9 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
 // =============================================================================
 void pto2_submit_mixed_task(
     PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, PTOParam* params, int32_t num_params) {
+    // Fast path after fatal error — all subsequent submits are no-ops
+    if (orch->fatal) { return; }
+
     CYCLE_COUNT_START();
 
     // === Validate submit inputs ===
@@ -393,12 +402,16 @@ void pto2_submit_mixed_task(
             LOG_ERROR("     Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2>");
             LOG_ERROR("  3. Split work across multiple scopes");
             LOG_ERROR("========================================");
-            exit(1);
+            orch->sm_handle->header->orch_error_code.store(
+                PTO2_ERROR_SCOPE_DEADLOCK, std::memory_order_release);
+            orch->fatal = true;
+            return;
         }
     }
 
     // === STEP 1: Allocate task slot from Task Ring (blocks until available) ===
     int32_t local_id = task_ring.pto2_task_ring_alloc();
+    if (local_id < 0) { orch->fatal = true; return; }
     int32_t slot = task_ring.get_task_slot(local_id);
     PTO2TaskId mixed_task_id =
         pto2_make_task_id(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id));
@@ -474,6 +487,7 @@ void pto2_submit_mixed_task(
 
     if (total_output_size > 0) {
         task.packed_buffer_base = orch->pto2_alloc_packed_buffer(total_output_size);
+        if (!task.packed_buffer_base) { orch->fatal = true; return; }
         task.packed_buffer_end = (char*)task.packed_buffer_base + total_output_size;
     }
     CYCLE_COUNT_LAP_RECORD(g_orch_heap_cycle, AicpuPhaseId::ORCH_HEAP, local_id);
@@ -571,7 +585,7 @@ void pto2_submit_mixed_task(
 
         auto& dep_pool = orch->rings[ring_id].dep_pool;
         if (orch->dep_pool_cur_entries[ring_id] == nullptr) {
-            orch->dep_pool_cur_entries[ring_id] = &dep_pool.alloc();
+            orch->dep_pool_cur_entries[ring_id] = dep_pool.alloc();
         }
 
         int32_t early_finished = 0;
@@ -609,7 +623,7 @@ void pto2_submit_mixed_task(
             }
             pto2_fanout_unlock(producer_slot_state);
             if (producer_slot_state.fanout_head == orch->dep_pool_cur_entries[ring_id]) {
-                orch->dep_pool_cur_entries[ring_id] = &dep_pool.alloc();
+                orch->dep_pool_cur_entries[ring_id] = dep_pool.alloc();
             }
         }
         // Combined release: merge early_finished batch with the +1 init release

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -72,6 +72,11 @@ struct PTO2OrchestratorState {
     void* gm_heap_base;    // Base address of GM heap
     uint64_t gm_heap_size;   // Total size of GM heap (all rings)
 
+    // === FATAL ERROR ===
+    // Fatal error flag (single-thread access by orchestrator, no atomic needed)
+    // Cross-thread notification uses shared memory orch_error_code (atomic)
+    bool fatal;
+
     // === STATISTICS ===
 #if PTO2_PROFILING
     int64_t tasks_submitted;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -27,7 +27,6 @@
 #define PTO_RING_BUFFER_H
 
 #include <inttypes.h>
-#include <stdlib.h>  // for exit()
 
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
@@ -67,6 +66,9 @@ struct PTO2HeapRing {
     // Reference to shared memory tail (for back-pressure)
     std::atomic<uint64_t>* tail_ptr;  // Points to header->heap_tail
 
+    // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
+    std::atomic<int32_t>* error_code_ptr = nullptr;
+
     /**
      * Allocate memory from heap ring
      *
@@ -75,7 +77,7 @@ struct PTO2HeapRing {
      * Never splits a buffer across the wrap-around boundary.
      *
      * @param size  Requested size in bytes
-     * @return Pointer to allocated memory, never NULL (stalls instead)
+     * @return Pointer to allocated memory, or nullptr on fatal error
      */
     void* pto2_heap_ring_alloc(uint64_t size) {
         // Align size for DMA efficiency
@@ -160,7 +162,10 @@ struct PTO2HeapRing {
                 LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %lu)",
                           (unsigned long)(this->size * 2));
                 LOG_ERROR("========================================");
-                exit(1);
+                if (error_code_ptr) {
+                    error_code_ptr->store(PTO2_ERROR_HEAP_RING_DEADLOCK, std::memory_order_release);
+                }
+                return nullptr;
             }
 
             SPIN_WAIT_HINT();
@@ -264,6 +269,9 @@ struct PTO2TaskRing {
     // Reference to shared memory last_task_alive (for back-pressure)
     std::atomic<int32_t>* last_alive_ptr;  // Points to header->last_task_alive
 
+    // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
+    std::atomic<int32_t>* error_code_ptr = nullptr;
+
     /**
      * Allocate a task slot from task ring
      *
@@ -361,7 +369,10 @@ struct PTO2TaskRing {
                 LOG_ERROR("  Compile-time: PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");
                 LOG_ERROR("  Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2> (e.g. %d)", active_count * 2);
                 LOG_ERROR("========================================");
-                exit(1);
+                if (error_code_ptr) {
+                    error_code_ptr->store(PTO2_ERROR_FLOW_CONTROL_DEADLOCK, std::memory_order_release);
+                }
+                return -1;
             }
 
             SPIN_WAIT_HINT();
@@ -458,12 +469,15 @@ struct PTO2DepListPool {
     int32_t tail;             // Linear first-alive counter (entries before this are dead)
     int32_t high_water;       // Peak concurrent usage (top - tail)
 
+    // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
+    std::atomic<int32_t>* error_code_ptr = nullptr;
+
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)
      *
-     * @return Reference to allocated entry
+     * @return Pointer to allocated entry, or nullptr on fatal error
      */
-    PTO2DepListEntry& alloc() {
+    PTO2DepListEntry* alloc() {
         int32_t used = top - tail;
         if (used >= capacity) {
             LOG_ERROR("========================================");
@@ -478,13 +492,16 @@ struct PTO2DepListPool {
             LOG_ERROR("  Compile-time: PTO2_DEP_LIST_POOL_SIZE in pto_runtime2_types.h");
             LOG_ERROR("  Runtime env:  PTO2_RING_DEP_POOL=%d", capacity * 2);
             LOG_ERROR("========================================");
-            exit(1);
+            if (error_code_ptr) {
+                error_code_ptr->store(PTO2_ERROR_DEP_POOL_OVERFLOW, std::memory_order_release);
+            }
+            return nullptr;
         }
         int32_t idx = top % capacity;
         top++;
         used++;
         if (used > high_water) high_water = used;
-        return base[idx];
+        return &base[idx];
     }
 
     /**
@@ -507,10 +524,11 @@ struct PTO2DepListPool {
      * @return New head offset
      */
     PTO2DepListEntry* pto2_dep_list_prepend(PTO2DepListEntry* cur, PTO2TaskSlotState* slot_state) {
-        PTO2DepListEntry& new_entry = alloc();
-        new_entry.slot_state = slot_state;
-        new_entry.next = cur;
-        return &new_entry;
+        PTO2DepListEntry* new_entry = alloc();
+        if (!new_entry) return nullptr;
+        new_entry->slot_state = slot_state;
+        new_entry->next = cur;
+        return new_entry;
     }
 
     /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -44,11 +44,16 @@ void pto2_rt_orchestration_done(PTO2Runtime* rt) {
     pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]);
 }
 
+static bool is_fatal_impl(PTO2Runtime* rt) {
+    return rt->orchestrators[pto2_current_orch_idx].fatal;
+}
+
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task          = submit_task_impl,
     .scope_begin          = pto2_rt_scope_begin,
     .scope_end            = pto2_rt_scope_end,
     .orchestration_done   = pto2_rt_orchestration_done,
+    .is_fatal             = is_fatal_impl,
     .log_error            = unified_log_error,
     .log_warn             = unified_log_warn,
     .log_info             = unified_log_info,

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -64,6 +64,7 @@ struct PTO2RuntimeOps {
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
     void (*orchestration_done)(PTO2Runtime* rt);
+    bool (*is_fatal)(PTO2Runtime* rt);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char* func, const char* fmt, ...);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -56,6 +56,20 @@
 #endif
 
 // =============================================================================
+// AICPU Error Codes (written to shared memory for Host-side diagnosis)
+// =============================================================================
+
+// Orchestrator errors (1-99): detected in orchestrator thread
+#define PTO2_ERROR_NONE                       0
+#define PTO2_ERROR_SCOPE_DEADLOCK             1
+#define PTO2_ERROR_HEAP_RING_DEADLOCK         2
+#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK      3
+#define PTO2_ERROR_DEP_POOL_OVERFLOW          4
+
+// Scheduler errors (100+): detected in scheduler threads
+#define PTO2_ERROR_SCHEDULER_TIMEOUT          100
+
+// =============================================================================
 // Configuration Constants
 // =============================================================================
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -191,6 +191,12 @@ void pto2_sm_init_header_per_ring(
     header->total_size = handle->sm_size;
     header->graph_output_ptr.store(0, std::memory_order_relaxed);
     header->graph_output_size.store(0, std::memory_order_relaxed);
+
+    // Error reporting
+    header->orch_error_code.store(PTO2_ERROR_NONE, std::memory_order_relaxed);
+    header->sched_error_bitmap.store(0, std::memory_order_relaxed);
+    header->sched_error_code.store(PTO2_ERROR_NONE, std::memory_order_relaxed);
+    header->sched_error_thread.store(-1, std::memory_order_relaxed);
 }
 
 // =============================================================================
@@ -218,6 +224,11 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
         LOG_INFO("  last_task_alive:  %d", h->rings[r].fc.last_task_alive.load(std::memory_order_acquire));
     }
     LOG_INFO("orchestrator_done:  %d", h->orchestrator_done.load(std::memory_order_acquire));
+    LOG_INFO("Error state:");
+    LOG_INFO("  orch_error_code:    %d", h->orch_error_code.load(std::memory_order_relaxed));
+    LOG_INFO("  sched_error_bitmap: 0x%x", h->sched_error_bitmap.load(std::memory_order_relaxed));
+    LOG_INFO("  sched_error_code:   %d", h->sched_error_code.load(std::memory_order_relaxed));
+    LOG_INFO("  sched_error_thread: %d", h->sched_error_thread.load(std::memory_order_relaxed));
     LOG_INFO("================================");
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -81,7 +81,7 @@ struct PTO2SharedMemoryRingHeader {
  *
  * Contains per-ring flow control and global layout information.
  */
-struct PTO2SharedMemoryHeader {
+struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     // === PER-RING FLOW CONTROL + LAYOUT INFO (set once at init) ===
     PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
 
@@ -96,7 +96,21 @@ struct PTO2SharedMemoryHeader {
     std::atomic<uint64_t> graph_output_ptr;   // Address where final output was written (packed buffer)
     std::atomic<uint64_t> graph_output_size;  // Size in bytes
 
+    // === ERROR REPORTING ===
+
+    // Orchestrator fatal error code (Orchestrator → Scheduler, AICPU → Host)
+    // Non-zero signals fatal error. Written by orchestrator, read by scheduler and host.
+    std::atomic<int32_t> orch_error_code;
+
+    // Scheduler error state (Scheduler → Host, independent of orchestrator)
+    // Written by scheduler threads on timeout; read by orchestrator and host.
+    std::atomic<int32_t> sched_error_bitmap;   // Bit X set = thread X had error
+    std::atomic<int32_t> sched_error_code;     // Last scheduler error code (last-writer-wins)
+    std::atomic<int32_t> sched_error_thread;   // Thread index of last error writer
 };
+
+static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
+              "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)");
 
 // =============================================================================
 // Shared Memory Handle

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -16,7 +16,6 @@
 #define ORCH_BUILD_GRAPH_PTO_TYPES_H
 
 #include <stdint.h>
-#include <assert.h>
 
 #include "tensor.h"
 
@@ -69,7 +68,6 @@ static inline PTOParam make_scalar_param(uint64_t value) {
 }
 
 static inline PTOParam make_input_param(Tensor& tensor) {
-    assert(tensor.buffer.addr != 0 && "INPUT param must have a non-NULL buffer address");
     PTOParam p;
     p.type = PTOParamType::INPUT;
     p.tensor = &tensor;
@@ -84,7 +82,6 @@ static inline PTOParam make_output_param(Tensor& tensor) {
 }
 
 static inline PTOParam make_inout_param(Tensor& tensor) {
-    assert(tensor.buffer.addr != 0 && "INOUT param must have a non-NULL buffer address");
     PTOParam p;
     p.type = PTOParamType::INOUT;
     p.tensor = &tensor;


### PR DESCRIPTION
## Summary
- Replace `exit(1)` calls in AICPU orchestrator/ring buffers with structured error codes written to shared memory, enabling graceful shutdown instead of abrupt process termination
- Add emergency shutdown path: when a fatal error is detected, orchestrator and scheduler threads send EXIT_SIGNAL to all AICore cores and terminate cleanly
- Add host-side error diagnosis: on AICPU stream sync failure, host reads error codes from shared memory and prints actionable diagnostics

## Key Changes
- `pto_runtime2_types.h`: Define error code constants (scope deadlock, heap ring deadlock, flow control deadlock, dep pool overflow, scheduler timeout)
- `pto_shared_memory.h/cpp`: Add `orch_error_code`, `sched_error_bitmap`, `sched_error_code`, `sched_error_thread` fields to shared memory header
- `pto_ring_buffer.h`: Replace `exit(1)` in heap ring, task ring, and dep pool with error code reporting via shared memory; return nullptr/-1 on failure
- `pto_orchestrator.cpp/h`: Add `fatal` flag to orchestrator state; all submit/scope operations become no-ops after fatal error
- `aicpu_executor.cpp`: Make `total_tasks_` and `orchestrator_done_` atomic; add fatal error checks in scheduler dispatch loop; handle dead schedulers during core transition wait
- `aicore_executor.cpp`: Periodically check `Handshake.control` during idle spins for host-initiated shutdown fallback
- `device_runner.cpp`: On AICPU sync failure, read error codes from device shared memory and send quit signal to AICore via handshake buffers
- `runtime_maker.cpp`: Add `pto2_print_error_diagnosis()` for structured error reporting during validation
- `pto_types.h`: Remove overly strict `assert` on INPUT/INOUT param buffer addresses (valid for orchestrator-allocated outputs)