### PR TITLE
Refactor pipeline sync: replace PipeSyncFunc with FULL_MEMORY_BARRIER

### DIFF
--- a/examples/a2a3/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/a2a3/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -87,4 +87,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(dstGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/host_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/a2a3/host_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -50,4 +50,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(outGlobal, outTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/host_build_graph/matmul/kernels/aic/kernel_matmul.cpp
+++ b/examples/a2a3/host_build_graph/matmul/kernels/aic/kernel_matmul.cpp
@@ -103,4 +103,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     // TSTORE: Store result to GM
     TSTORE(dstGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/host_build_graph/matmul/kernels/aiv/kernel_add_exp.cpp
+++ b/examples/a2a3/host_build_graph/matmul/kernels/aiv/kernel_add_exp.cpp
@@ -71,4 +71,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/host_build_graph/matmul/kernels/aiv/kernel_log_sqrt.cpp
+++ b/examples/a2a3/host_build_graph/matmul/kernels/aiv/kernel_log_sqrt.cpp
@@ -65,4 +65,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add.cpp
@@ -69,4 +69,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -73,4 +73,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
@@ -69,4 +69,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -98,6 +98,9 @@ static __aicore__ void gemm_tile_impl(
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(dstGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -58,4 +58,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(outGlobal, outTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -78,6 +78,9 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(oiGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -79,6 +79,9 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(sijGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -217,6 +217,8 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
             TSTORE(oiGlobal, oiTile);
         }
     }
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -104,6 +104,9 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     TSTORE(mijGlobal, maxTile);
     TSTORE(lijGlobal, sumTile);
     TSTORE(pijGlobal, pijF16Tile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp
@@ -73,4 +73,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+    
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -75,4 +75,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+    
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_mul.cpp
@@ -73,4 +73,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+    
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/src/a2a3/platform/include/aicore/aicore.h
+++ b/src/a2a3/platform/include/aicore/aicore.h
@@ -44,10 +44,4 @@
 
 #include "inner_kernel.h"
 
-// =============================================================================
-// Pipeline Synchronization Function Pointer Type
-// =============================================================================
-
-typedef void (*PipeSyncFunc)();
-
 #endif  // PLATFORM_AICORE_H_

--- a/src/a2a3/platform/onboard/aicore/inner_kernel.h
+++ b/src/a2a3/platform/onboard/aicore/inner_kernel.h
@@ -26,6 +26,9 @@
 // STORE_RELEASE_FENCE - no-op on real hardware (dcci handles cache coherency)
 #define STORE_RELEASE_FENCE() ((void)0)
 
+// FULL_MEMORY_BARRIER - no-op on real hardware (dcci handles full cache coherency)
+#define FULL_MEMORY_BARRIER() ((void)0)
+
 /**
  * Read an AICore register via SPR access
  *

--- a/src/a2a3/platform/onboard/aicore/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicore/kernel.cpp
@@ -21,23 +21,7 @@ class Runtime;
 [[block_local]] int block_idx;
 [[block_local]] CoreType core_type;
 
-extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn);
-
-/**
- * Pipeline synchronization function
- *
- * AIV cores: Wait for PIPE_MTE3 (store pipeline)
- * AIC cores: Wait for PIPE_FIX (cube unit pipeline)
- */
- __aicore__ inline void pipe_sync_aiv() {
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-}
-
-__aicore__ inline void pipe_sync_aic() {
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-}
+extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
 
 /**
  * Kernel entry point with control loop
@@ -64,6 +48,5 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime
     core_type = CoreType::AIC;
 #endif
 
-    PipeSyncFunc pipe_sync_fn = (core_type == CoreType::AIV) ? pipe_sync_aiv : pipe_sync_aic;
-    aicore_execute(runtime, block_idx, core_type, pipe_sync_fn);
+    aicore_execute(runtime, block_idx, core_type);
 }

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -63,6 +63,11 @@
 #define STORE_RELEASE_FENCE() std::atomic_thread_fence(std::memory_order_release)
 #endif
 
+// FULL_MEMORY_BARRIER - full memory barrier preventing all load/store reordering.
+// Used after kernel execution to ensure all writes are visible before signalling
+// completion. Equivalent to dmb ish (aarch64) / mfence (x86).
+#define FULL_MEMORY_BARRIER() __sync_synchronize()
+
 // =============================================================================
 // System Counter Simulation
 // =============================================================================
@@ -114,7 +119,7 @@ extern thread_local uint32_t g_sim_physical_core_id;
  */
 inline uint64_t read_reg(RegId reg) {
     uint32_t offset = reg_offset(reg);
-    __sync_synchronize();
+    FULL_MEMORY_BARRIER();
     return static_cast<uint64_t>(
         *reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset));
 }
@@ -129,7 +134,7 @@ inline void write_reg(RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
     *reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset) =
         static_cast<uint32_t>(value);
-    __sync_synchronize();
+    FULL_MEMORY_BARRIER();
 }
 
 /**

--- a/src/a2a3/platform/sim/aicore/kernel.cpp
+++ b/src/a2a3/platform/sim/aicore/kernel.cpp
@@ -18,19 +18,8 @@ thread_local volatile uint8_t* g_sim_reg_base = nullptr;
 thread_local uint32_t g_sim_physical_core_id = 0;
 
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
-void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn);
+void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
 
-
-/**
- * Pipeline synchronization function - simulation version
- *
- * In simulation, set_flag/wait_flag are both __sync_synchronize(),
- * so this becomes a simple memory barrier regardless of core type.
- * We keep a simple implementation for architectural consistency with onboard.
- */
- inline void pipe_sync() {
-    __sync_synchronize();
-}
 // Wrapper with extern "C" for dlsym lookup
 // NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
 extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs) {
@@ -44,5 +33,5 @@ extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, C
 
     g_sim_physical_core_id = physical_core_id;
 
-    aicore_execute(runtime, block_idx, core_type, pipe_sync);
+    aicore_execute(runtime, block_idx, core_type);
 }

--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -27,9 +27,8 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  * All kernels unpack their own arguments from the args array.
  *
  * @param task Pointer to task in global memory (null during initialization)
- * @param pipe_sync_fn Compile-time determined pipeline sync function (AIC or AIV specific)
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task, PipeSyncFunc pipe_sync_fn) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task) {
     // Null task pointer indicates no work assigned (initialization state)
     if (task == nullptr) {
         return;
@@ -45,11 +44,10 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
     // All kernels have signature: void kernel(__gm__ int64_t* args)
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)task->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
-
-    pipe_sync_fn();
+    FULL_MEMORY_BARRIER();
 }
 
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
@@ -74,7 +72,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
         // Execute task if assigned (task != 0 means valid Task* pointer)
         if (my_hank->task_status == 1 && my_hank->task != 0) {
             __gm__ Task* task_ptr = reinterpret_cast<__gm__ Task*>(my_hank->task);
-            execute_task(task_ptr, pipe_sync_fn);
+            execute_task(task_ptr);
             // Mark task as complete (task_status: 0=idle, 1=busy)
             my_hank->task_status = 0;
         }

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -6,17 +6,16 @@
 
 typedef void (*KernelFunc)(__gm__ int64_t*);
 
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task, PipeSyncFunc pipe_sync_fn) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task) {
     if (task->function_bin_addr == 0) {
         return;
     }
     KernelFunc kernel = (KernelFunc)task->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
-
-    pipe_sync_fn();
+    FULL_MEMORY_BARRIER();
 }
 
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
@@ -67,7 +66,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             __gm__ Task* task_ptr = &(runtime->tasks[actual_task_id]);
             uint64_t start_time = get_sys_cnt_aicore();
 
-            execute_task(task_ptr, pipe_sync_fn);
+            execute_task(task_ptr);
 
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -19,11 +19,9 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  * Reads function_bin_addr and args from the dispatch payload.
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
- * @param pipe_sync_fn Compile-time determined pipeline sync function (AIC or AIV specific)
  */
 __aicore__ __attribute__((always_inline)) static void execute_task(
-    __gm__ PTO2DispatchPayload* payload,
-    PipeSyncFunc pipe_sync_fn
+    __gm__ PTO2DispatchPayload* payload
 ) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
@@ -31,8 +29,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(
 
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
-
-    pipe_sync_fn();
+    FULL_MEMORY_BARRIER();
 }
 
 /**
@@ -49,9 +46,8 @@ __aicore__ __attribute__((always_inline)) static void execute_task(
  * @param runtime Pointer to Runtime in global memory
  * @param block_idx Block index (core ID)
  * @param core_type Core type (AIC or AIV)
- * @param pipe_sync_fn Compile-time determined pipeline sync function (AIC or AIV specific)
  */
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
@@ -114,7 +110,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             uint64_t start_time = get_sys_cnt_aicore();
 
             // Execute the task
-            execute_task(payload, pipe_sync_fn);
+            execute_task(payload);
 
             // Performance profiling: record task execution
             // (func_id and core_type are filled by AICPU at completion time)

--- a/src/a5/platform/include/aicore/aicore.h
+++ b/src/a5/platform/include/aicore/aicore.h
@@ -44,10 +44,4 @@
 
 #include "inner_kernel.h"
 
-// =============================================================================
-// Pipeline Synchronization Function Pointer Type
-// =============================================================================
-
-typedef void (*PipeSyncFunc)();
-
 #endif  // PLATFORM_AICORE_H_

--- a/src/a5/platform/onboard/aicore/inner_kernel.h
+++ b/src/a5/platform/onboard/aicore/inner_kernel.h
@@ -26,6 +26,9 @@
 // STORE_RELEASE_FENCE - no-op on real hardware (dcci handles cache coherency)
 #define STORE_RELEASE_FENCE() ((void)0)
 
+// FULL_MEMORY_BARRIER - no-op on real hardware (dcci handles full cache coherency)
+#define FULL_MEMORY_BARRIER() ((void)0)
+
 /**
  * Read an AICore register via SPR access
  *

--- a/src/a5/platform/onboard/aicore/kernel.cpp
+++ b/src/a5/platform/onboard/aicore/kernel.cpp
@@ -21,16 +21,7 @@ class Runtime;
 [[block_local]] int block_idx;
 [[block_local]] CoreType core_type;
 
-extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn);
-
-/**
- * Pipeline synchronization function
- *
- * On DAV_3510 (npu_arch_3101), set_flag/wait_flag always syncs PIPE_M→PIPE_V
- * regardless of the pipe parameters.
- */
-__aicore__ inline void pipe_sync() {
-}
+extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
 
 /**
  * Kernel entry point with control loop
@@ -57,6 +48,5 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime
     core_type = CoreType::AIC;
 #endif
 
-    PipeSyncFunc pipe_sync_fn = pipe_sync;
-    aicore_execute(runtime, block_idx, core_type, pipe_sync_fn);
+    aicore_execute(runtime, block_idx, core_type);
 }

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -62,6 +62,11 @@
 #define STORE_RELEASE_FENCE() std::atomic_thread_fence(std::memory_order_release)
 #endif
 
+// FULL_MEMORY_BARRIER - full memory barrier preventing all load/store reordering.
+// Used after kernel execution to ensure all writes are visible before signalling
+// completion. Equivalent to dmb ish (aarch64) / mfence (x86).
+#define FULL_MEMORY_BARRIER() __sync_synchronize()
+
 // =============================================================================
 // System Counter Simulation
 // =============================================================================
@@ -118,7 +123,7 @@ inline uint64_t read_reg(RegId reg) {
     volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
         sparse_reg_ptr(g_sim_reg_base, offset));
 
-    __sync_synchronize();
+    FULL_MEMORY_BARRIER();
     return static_cast<uint64_t>(*ptr);
 }
 
@@ -136,7 +141,7 @@ inline void write_reg(RegId reg, uint64_t value) {
         sparse_reg_ptr(g_sim_reg_base, offset));
 
     *ptr = static_cast<uint32_t>(value);
-    __sync_synchronize();
+    FULL_MEMORY_BARRIER();
 }
 
 /**

--- a/src/a5/platform/sim/aicore/kernel.cpp
+++ b/src/a5/platform/sim/aicore/kernel.cpp
@@ -18,19 +18,7 @@ thread_local volatile uint8_t* g_sim_reg_base = nullptr;
 thread_local uint32_t g_sim_physical_core_id = 0;
 
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
-void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn);
-
-
-/**
- * Pipeline synchronization function - simulation version
- *
- * In simulation, set_flag/wait_flag are both __sync_synchronize(),
- * so this becomes a simple memory barrier regardless of core type.
- * We keep a simple implementation for architectural consistency with onboard.
- */
- inline void pipe_sync() {
-    __sync_synchronize();
-}
+void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
 
 // Wrapper with extern "C" for dlsym lookup
 // NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
@@ -45,5 +33,5 @@ extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, C
 
     g_sim_physical_core_id = physical_core_id;
 
-    aicore_execute(runtime, block_idx, core_type, pipe_sync);
+    aicore_execute(runtime, block_idx, core_type);
 }

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -6,17 +6,16 @@
 
 typedef void (*KernelFunc)(__gm__ int64_t*);
 
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task, PipeSyncFunc pipe_sync_fn) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task) {
     if (task->function_bin_addr == 0) {
         return;
     }
     KernelFunc kernel = (KernelFunc)task->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
-
-    pipe_sync_fn();
+    FULL_MEMORY_BARRIER();
 }
 
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[core_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
@@ -67,7 +66,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             __gm__ Task* task_ptr = &(runtime->tasks[actual_task_id]);
             uint64_t start_time = get_sys_cnt_aicore();
 
-            execute_task(task_ptr, pipe_sync_fn);
+            execute_task(task_ptr);
 
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -20,9 +20,8 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  * matching ref_runtime implementation for a2a3 compatibility.
  *
  * @param task_ptr Pointer to PTO2DispatchPayload in global memory
- * @param pipe_sync_fn Compile-time determined pipeline sync function (AIC or AIV specific)
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* task_ptr, PipeSyncFunc pipe_sync_fn) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* task_ptr) {
     __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(task_ptr);
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
@@ -30,8 +29,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* 
 
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
-
-    pipe_sync_fn();
+    FULL_MEMORY_BARRIER();
 }
 
 /**
@@ -48,9 +46,8 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* 
  * @param runtime Pointer to Runtime in global memory
  * @param core_idx Core index (core ID)
  * @param core_type Core type (AIC or AIV)
- * @param pipe_sync_fn Compile-time determined pipeline sync function (AIC or AIV specific)
  */
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type, PipeSyncFunc pipe_sync_fn) {
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[core_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
@@ -110,7 +107,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             uint64_t start_time = get_sys_cnt_aicore();
 
             // Execute the task
-            execute_task(reinterpret_cast<__gm__ void*>(payload), pipe_sync_fn);
+            execute_task(reinterpret_cast<__gm__ void*>(payload));
 
             // Performance profiling: record task execution
             if (profiling_enabled) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -101,6 +101,9 @@ static __aicore__ void gemm_tile_impl(
 
     set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
     wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -60,6 +60,9 @@ static __aicore__ void tile_add_impl(
     TSTORE(outGlobal, outTile);
     set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
     wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -80,6 +80,9 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(oiGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -81,6 +81,9 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(sijGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -219,6 +219,8 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
             TSTORE(oiGlobal, oiTile);
         }
     }
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -109,6 +109,9 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     TSTORE(mijGlobal, maxTile);
     TSTORE(lijGlobal, sumTile);
     TSTORE(pijGlobal, pijBf16Tile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -94,6 +94,9 @@ static __aicore__ void pv_matmul_n_impl(
     set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     TSTORE(oiGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -89,6 +89,8 @@ static __aicore__ void qk_matmul_n_impl(
             pipe_barrier(PIPE_ALL);
         }
     }
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -219,6 +219,8 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
             TSTORE(oiGlobal, oiTile);
         }
     }
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -196,6 +196,9 @@ static __aicore__ void softmax_prepare_n_impl(
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(lijGlobalDN, sumDN);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {


### PR DESCRIPTION
- Add FULL_MEMORY_BARRIER() macro to platform headers:
  - Sim: maps to __sync_synchronize() for full load/store barrier
  - Onboard: no-op (dcci handles cache coherency on real hardware)
  - Replace bare __sync_synchronize() calls in read_reg/write_reg with macro

- Remove PipeSyncFunc function pointer type and all call sites:
  - Drop PipeSyncFunc typedef from platform include headers (a2a3, a5)
  - Update aicore_execute() signature across all runtimes to remove pipe_sync_fn parameter (tensormap_and_ringbuffer, aicpu_build_graph, host_build_graph for both a2a3 and a5)
  - Replace pipe_sync_fn() call in execute_task() with FULL_MEMORY_BARRIER()

- Add pipe_sync() calls at end of all AICore/AIV kernel functions across all examples (a2a3 and a5: vector_example, bgemm, matmul, paged_attention, benchmark variants) to ensure pipeline completion before returning