### PR TITLE
Fix: Remove pipe sync in AICore kernel

### DIFF
--- a/src/a5/platform/onboard/aicore/kernel.cpp
+++ b/src/a5/platform/onboard/aicore/kernel.cpp
@@ -26,17 +26,10 @@ extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, Co
 /**
  * Pipeline synchronization function
  *
- * AIV cores: Wait for PIPE_MTE3 (store pipeline)
- * AIC cores: Wait for PIPE_FIX (cube unit pipeline)
+ * On DAV_3510 (npu_arch_3101), set_flag/wait_flag always syncs PIPE_M→PIPE_V
+ * regardless of the pipe parameters.
  */
- __aicore__ inline void pipe_sync_aiv() {
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-}
-
-__aicore__ inline void pipe_sync_aic() {
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+__aicore__ inline void pipe_sync() {
 }
 
 /**
@@ -64,6 +57,6 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime
     core_type = CoreType::AIC;
 #endif
 
-    PipeSyncFunc pipe_sync_fn = (core_type == CoreType::AIV) ? pipe_sync_aiv : pipe_sync_aic;
+    PipeSyncFunc pipe_sync_fn = pipe_sync;
     aicore_execute(runtime, block_idx, core_type, pipe_sync_fn);
 }


### PR DESCRIPTION
● The a5 kernel.cpp was copied from a2a3 without adaptation for DAV_3510.
  PIPE_FIX (value 10) is invalid on this architecture:
  - dav-c310-vec: bisheng compiler rejects it as 1st param to set_flag
    (valid range [0,1],[4,5]), blocking AICore build entirely
  - dav-c310-cube: compiler accepts it, but hardware raises
    ACL_ERROR_RT_AICORE_EXCEPTION (507015) at runtime

  Remove both pipe_sync_aiv/pipe_sync_aic. 
  This works because on npu_arch_3101, set_flag/wait_flag
  always syncs PIPE_M→PIPE_V regardless of the pipe parameters passed.