### PR TITLE
Sync: Port a2a3 platform improvements to a5

### DIFF
--- a/src/a5/platform/include/common/perf_profiling.h
+++ b/src/a5/platform/include/common/perf_profiling.h
@@ -236,6 +236,7 @@ enum class AicpuPhaseId : uint32_t {
     SCHED_DISPATCH    = 1,  // Dispatch ready tasks to idle cores
     SCHED_SCAN        = 2,  // Incremental scan for root tasks
     SCHED_IDLE_WAIT   = 3,  // Idle/spinning (no progress)
+    SCHED_PHASE_COUNT = 4,  // Sentinel: number of scheduler phases
     // Orchestrator phases (16-24)
     ORCH_SYNC      = 16,  // tensormap sync
     ORCH_ALLOC     = 17,  // task_ring_alloc

--- a/src/a5/platform/include/common/unified_log.h
+++ b/src/a5/platform/include/common/unified_log.h
@@ -11,6 +11,8 @@
 #ifndef PLATFORM_UNIFIED_LOG_H_
 #define PLATFORM_UNIFIED_LOG_H_
 
+#include <string.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -26,12 +28,14 @@ void unified_log_always(const char* func, const char* fmt, ...);
 }
 #endif
 
+#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+
 // Convenience macros (automatically capture function name)
-#define LOG_ERROR(fmt, ...) unified_log_error(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_WARN(fmt, ...)  unified_log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_INFO(fmt, ...)  unified_log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_DEBUG(fmt, ...) unified_log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_ALWAYS(fmt, ...) unified_log_always(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_ERROR(fmt, ...) unified_log_error(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...)  unified_log_warn(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...)  unified_log_info(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_DEBUG(fmt, ...) unified_log_debug(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_ALWAYS(fmt, ...) unified_log_always(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 
 #endif  // PLATFORM_UNIFIED_LOG_H_
 

--- a/src/a5/platform/include/host/performance_collector.h
+++ b/src/a5/platform/include/host/performance_collector.h
@@ -360,9 +360,8 @@ private:
     // Collected data (per-core vectors, indexed by core_index)
     std::vector<std::vector<PerfRecord>> collected_perf_records_;
 
-    // AICPU phase profiling data
+    // AICPU phase profiling data (per-thread, mixed sched + orch records)
     std::vector<std::vector<AicpuPhaseRecord>> collected_phase_records_;
-    std::vector<AicpuPhaseRecord> collected_orch_phase_records_;
     AicpuOrchSummary collected_orch_summary_{};
     bool has_phase_data_{false};
 

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -42,10 +42,11 @@
 // scheduler give time slices to threads doing real work (e.g., kernel execution),
 // preventing starvation-induced timeouts on resource-constrained CI runners.
 #include <sched.h>
-#if defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
-#elif defined(__aarch64__)
+
+#if defined(__aarch64__)
 #define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#elif defined(__x86_64__)
+#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif

--- a/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -25,7 +25,7 @@ static PerfBufferState* s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
 static PhaseBufferState* s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
 static PhaseBuffer* s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
-static int s_orch_thread_idx = -1;
+static __thread int s_orch_thread_idx = -1;
 
 /**
  * Enqueue ready buffer to per-thread queue

--- a/src/a5/platform/src/host/performance_collector.cpp
+++ b/src/a5/platform/src/host/performance_collector.cpp
@@ -345,6 +345,15 @@ void ProfMemoryManager::mgmt_loop() {
 // PerformanceCollector Implementation
 // =============================================================================
 
+/**
+ * Check if a phase ID belongs to a scheduler phase (vs orchestrator phase).
+ * Scheduler phases: SCHED_COMPLETE(0), SCHED_DISPATCH(1), SCHED_SCAN(2), SCHED_IDLE_WAIT(3)
+ * Orchestrator phases: ORCH_SYNC(16) through ORCH_SCOPE_END(24)
+ */
+static bool is_scheduler_phase(AicpuPhaseId id) {
+    return static_cast<uint32_t>(id) < static_cast<uint32_t>(AicpuPhaseId::SCHED_PHASE_COUNT);
+}
+
 PerformanceCollector::~PerformanceCollector() {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_WARN("PerformanceCollector destroyed without finalize()");
@@ -613,8 +622,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             num_sched_for_poll = PLATFORM_MAX_AICPU_THREADS;
         }
         collected_phase_records_.clear();
-        collected_phase_records_.resize(num_sched_for_poll);
-        collected_orch_phase_records_.clear();
+        collected_phase_records_.resize(PLATFORM_MAX_AICPU_THREADS);
     }
 
     idle_start.reset();
@@ -664,14 +672,8 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 }
 
                 uint32_t tidx = info.index;
-                if (tidx < static_cast<uint32_t>(num_sched_for_poll)) {
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_phase_records_[tidx].push_back(buf->records[i]);
-                    }
-                } else {
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_orch_phase_records_.push_back(buf->records[i]);
-                    }
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_phase_records_[tidx].push_back(buf->records[i]);
                 }
 
                 LOG_DEBUG("Collected %u phase records from thread %u", count, tidx);
@@ -722,9 +724,6 @@ void PerformanceCollector::drain_remaining_buffers() {
         if (num_sched > PLATFORM_MAX_AICPU_THREADS) {
             num_sched = PLATFORM_MAX_AICPU_THREADS;
         }
-        if (collected_phase_records_.size() < static_cast<size_t>(num_sched)) {
-            collected_phase_records_.resize(num_sched);
-        }
     }
 
     int drained_perf = 0;
@@ -754,14 +753,8 @@ void PerformanceCollector::drain_remaining_buffers() {
                 count = PLATFORM_PHASE_RECORDS_PER_THREAD;
             }
             uint32_t tidx = info.index;
-            if (tidx < static_cast<uint32_t>(num_sched)) {
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_phase_records_[tidx].push_back(buf->records[i]);
-                }
-            } else {
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_orch_phase_records_.push_back(buf->records[i]);
-                }
+            for (uint32_t i = 0; i < count; i++) {
+                collected_phase_records_[tidx].push_back(buf->records[i]);
             }
             drained_phase += count;
         }
@@ -803,11 +796,7 @@ void PerformanceCollector::collect_phase_data() {
     }
     LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
 
-    int total_slots = (num_sched_threads < PLATFORM_MAX_AICPU_THREADS)
-                      ? num_sched_threads + 1 : num_sched_threads;
-    if (collected_phase_records_.size() < static_cast<size_t>(num_sched_threads)) {
-        collected_phase_records_.resize(num_sched_threads);
-    }
+    int total_slots = PLATFORM_MAX_AICPU_THREADS;
 
     // Scan remaining PhaseBufferStates for active buffers with partial data.
     // READY buffers were already enqueued to the ReadyQueue and collected via
@@ -833,14 +822,8 @@ void PerformanceCollector::collect_phase_data() {
                     count = PLATFORM_PHASE_RECORDS_PER_THREAD;
                 }
 
-                if (t < num_sched_threads) {
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_phase_records_[t].push_back(pbuf->records[i]);
-                    }
-                } else {
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_orch_phase_records_.push_back(pbuf->records[i]);
-                    }
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_phase_records_[t].push_back(pbuf->records[i]);
                 }
                 total_phase_records += count;
             }
@@ -848,11 +831,16 @@ void PerformanceCollector::collect_phase_data() {
     }
 
     // Log per-thread totals
-    for (int t = 0; t < num_sched_threads; t++) {
-        LOG_INFO("  Thread %d: %zu phase records", t, collected_phase_records_[t].size());
-    }
-    if (!collected_orch_phase_records_.empty()) {
-        LOG_INFO("  Orchestrator: %zu per-task phase records", collected_orch_phase_records_.size());
+    for (size_t t = 0; t < collected_phase_records_.size(); t++) {
+        if (!collected_phase_records_[t].empty()) {
+            size_t sched_count = 0, orch_count = 0;
+            for (const auto& r : collected_phase_records_[t]) {
+                if (is_scheduler_phase(r.phase_id)) sched_count++;
+                else orch_count++;
+            }
+            LOG_INFO("  Thread %zu: %zu records (sched=%zu, orch=%zu)",
+                     t, collected_phase_records_[t].size(), sched_count, orch_count);
+        }
     }
 
     // Read orchestrator summary
@@ -873,7 +861,6 @@ void PerformanceCollector::collect_phase_data() {
         for (const auto& v : collected_phase_records_) {
             if (!v.empty()) { has_accumulated = true; break; }
         }
-        if (!collected_orch_phase_records_.empty()) has_accumulated = true;
     }
     has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
 
@@ -957,11 +944,6 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                 }
             }
         }
-        for (const auto& pr : collected_orch_phase_records_) {
-            if (pr.start_time > 0 && pr.start_time < base_time_cycles) {
-                base_time_cycles = pr.start_time;
-            }
-        }
         if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC &&
             collected_orch_summary_.start_time > 0 &&
             collected_orch_summary_.start_time < base_time_cycles) {
@@ -1036,34 +1018,50 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
     // Step 8: Write phase profiling data (version 2)
     if (has_phase_data_) {
-        // AICPU scheduler phases
+        auto sched_phase_name = [](AicpuPhaseId id) -> const char* {
+            switch (id) {
+                case AicpuPhaseId::SCHED_COMPLETE:    return "complete";
+                case AicpuPhaseId::SCHED_DISPATCH:    return "dispatch";
+                case AicpuPhaseId::SCHED_SCAN:        return "scan";
+                case AicpuPhaseId::SCHED_IDLE_WAIT:   return "idle";
+                default: return "unknown";
+            }
+        };
+
+        auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
+            switch (id) {
+                case AicpuPhaseId::ORCH_SYNC:      return "orch_sync";
+                case AicpuPhaseId::ORCH_ALLOC:     return "orch_alloc";
+                case AicpuPhaseId::ORCH_PARAMS:    return "orch_params";
+                case AicpuPhaseId::ORCH_LOOKUP:    return "orch_lookup";
+                case AicpuPhaseId::ORCH_HEAP:      return "orch_heap";
+                case AicpuPhaseId::ORCH_INSERT:    return "orch_insert";
+                case AicpuPhaseId::ORCH_FANIN:     return "orch_fanin";
+                case AicpuPhaseId::ORCH_FINALIZE:  return "orch_finalize";
+                case AicpuPhaseId::ORCH_SCOPE_END: return "orch_scope_end";
+                default: return "unknown";
+            }
+        };
+
+        // AICPU scheduler phases (filtered from unified collected_phase_records_)
         outfile << ",\n  \"aicpu_scheduler_phases\": [\n";
         for (size_t t = 0; t < collected_phase_records_.size(); t++) {
             outfile << "    [\n";
-            const auto& thread_records = collected_phase_records_[t];
-            for (size_t r = 0; r < thread_records.size(); r++) {
-                const auto& pr = thread_records[r];
+            bool first = true;
+            for (const auto& pr : collected_phase_records_[t]) {
+                if (!is_scheduler_phase(pr.phase_id)) continue;
                 double start_us = cycles_to_us(pr.start_time - base_time_cycles);
                 double end_us = cycles_to_us(pr.end_time - base_time_cycles);
-
-                const char* phase_name = "unknown";
-                switch (pr.phase_id) {
-                    case AicpuPhaseId::SCHED_COMPLETE:    phase_name = "complete"; break;
-                    case AicpuPhaseId::SCHED_DISPATCH:    phase_name = "dispatch"; break;
-                    case AicpuPhaseId::SCHED_SCAN:        phase_name = "scan"; break;
-                    case AicpuPhaseId::SCHED_IDLE_WAIT:   phase_name = "idle"; break;
-                    default: break;
-                }
-
+                if (!first) outfile << ",\n";
                 outfile << "      {\"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                         << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                        << ", \"phase\": \"" << phase_name << "\""
+                        << ", \"phase\": \"" << sched_phase_name(pr.phase_id) << "\""
                         << ", \"loop_iter\": " << pr.loop_iter
                         << ", \"tasks_processed\": " << pr.tasks_processed
                         << "}";
-                if (r < thread_records.size() - 1) outfile << ",";
-                outfile << "\n";
+                first = false;
             }
+            if (!first) outfile << "\n";
             outfile << "    ]";
             if (t < collected_phase_records_.size() - 1) outfile << ",";
             outfile << "\n";
@@ -1092,37 +1090,35 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
             outfile << "  }";
         }
 
-        // Per-task orchestrator phase records
-        if (!collected_orch_phase_records_.empty()) {
+        // Per-task orchestrator phase records (filtered from unified collected_phase_records_)
+        bool has_orch_phases = false;
+        for (const auto& v : collected_phase_records_) {
+            for (const auto& r : v) {
+                if (!is_scheduler_phase(r.phase_id)) { has_orch_phases = true; break; }
+            }
+            if (has_orch_phases) break;
+        }
+        if (has_orch_phases) {
             outfile << ",\n  \"aicpu_orchestrator_phases\": [\n";
-
-            auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
-                switch (id) {
-                    case AicpuPhaseId::ORCH_SYNC:      return "orch_sync";
-                    case AicpuPhaseId::ORCH_ALLOC:     return "orch_alloc";
-                    case AicpuPhaseId::ORCH_PARAMS:    return "orch_params";
-                    case AicpuPhaseId::ORCH_LOOKUP:    return "orch_lookup";
-                    case AicpuPhaseId::ORCH_HEAP:      return "orch_heap";
-                    case AicpuPhaseId::ORCH_INSERT:    return "orch_insert";
-                    case AicpuPhaseId::ORCH_FANIN:     return "orch_fanin";
-                    case AicpuPhaseId::ORCH_FINALIZE:  return "orch_finalize";
-                    case AicpuPhaseId::ORCH_SCOPE_END: return "orch_scope_end";
-                    default: return "unknown";
+            for (size_t t = 0; t < collected_phase_records_.size(); t++) {
+                outfile << "    [\n";
+                bool first = true;
+                for (const auto& pr : collected_phase_records_[t]) {
+                    if (is_scheduler_phase(pr.phase_id)) continue;
+                    double start_us = cycles_to_us(pr.start_time - base_time_cycles);
+                    double end_us = cycles_to_us(pr.end_time - base_time_cycles);
+                    if (!first) outfile << ",\n";
+                    outfile << "      {\"phase\": \"" << orch_phase_name(pr.phase_id) << "\""
+                            << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
+                            << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
+                            << ", \"submit_idx\": " << pr.loop_iter
+                            << ", \"task_id\": " << static_cast<int32_t>(pr.tasks_processed)
+                            << "}";
+                    first = false;
                 }
-            };
-
-            for (size_t r = 0; r < collected_orch_phase_records_.size(); r++) {
-                const auto& pr = collected_orch_phase_records_[r];
-                double start_us = cycles_to_us(pr.start_time - base_time_cycles);
-                double end_us = cycles_to_us(pr.end_time - base_time_cycles);
-
-                outfile << "    {\"phase\": \"" << orch_phase_name(pr.phase_id) << "\""
-                        << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
-                        << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                        << ", \"submit_idx\": " << pr.loop_iter
-                        << ", \"task_id\": " << static_cast<int32_t>(pr.tasks_processed)
-                        << "}";
-                if (r < collected_orch_phase_records_.size() - 1) outfile << ",";
+                if (!first) outfile << "\n";
+                outfile << "    ]";
+                if (t < collected_phase_records_.size() - 1) outfile << ",";
                 outfile << "\n";
             }
             outfile << "  ]";
@@ -1243,7 +1239,6 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
     was_registered_ = false;
     collected_perf_records_.clear();
     collected_phase_records_.clear();
-    collected_orch_phase_records_.clear();
     core_to_thread_.clear();
     has_phase_data_ = false;
     device_id_ = -1;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -83,6 +83,7 @@ struct PTO2HeapRing {
 
         // Spin-wait if insufficient space (back-pressure from Scheduler)
         int spin_count = 0;
+        uint64_t prev_tail = tail_ptr->load(std::memory_order_acquire);
 #if PTO2_SPIN_VERBOSE_LOGGING
         bool notified = false;
 #endif
@@ -118,29 +119,42 @@ struct PTO2HeapRing {
             if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
 #endif
 
+            // Progress detection: reset spin counter if heap_tail advances
+            uint64_t cur_tail = tail_ptr->load(std::memory_order_acquire);
+            if (cur_tail != prev_tail) {
+#if PTO2_SPIN_VERBOSE_LOGGING
+                LOG_INFO("[HeapRing] Progress: tail %" PRIu64 " -> %" PRIu64 " (reset spin_count=%d)",
+                         prev_tail, cur_tail, spin_count);
+#endif
+                spin_count = 0;
+                prev_tail = cur_tail;
+            }
+
 #if PTO2_SPIN_VERBOSE_LOGGING
             // Periodic block notification
-            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count < PTO2_HEAP_SPIN_LIMIT) {
-                uint64_t tail = tail_ptr->load(std::memory_order_acquire);
+            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 && spin_count < PTO2_HEAP_SPIN_LIMIT) {
                 uint64_t top = top_ptr->load(std::memory_order_acquire);
                 LOG_WARN("[HeapRing] BLOCKED: requesting %" PRIu64 " bytes"
                      ", top=%" PRIu64 ", tail=%" PRIu64 ", spins=%d",
-                     size, top, tail, spin_count);
+                     size, top, cur_tail, spin_count);
                 notified = true;
             }
 #endif
 
             if (spin_count >= PTO2_HEAP_SPIN_LIMIT) {
-                uint64_t tail = tail_ptr->load(std::memory_order_acquire);
                 uint64_t top = top_ptr->load(std::memory_order_acquire);
                 LOG_ERROR("========================================");
                 LOG_ERROR("FATAL: Heap Ring Deadlock Detected!");
                 LOG_ERROR("========================================");
-                LOG_ERROR("Orchestrator blocked waiting for heap space after %d spins.", spin_count);
+                LOG_ERROR("Orchestrator blocked waiting for heap space after %d spins (no tail progress).", spin_count);
                 LOG_ERROR("  - Requested:     %" PRIu64 " bytes", size);
                 LOG_ERROR("  - Heap top:      %" PRIu64, top);
-                LOG_ERROR("  - Heap tail:     %" PRIu64, tail);
+                LOG_ERROR("  - Heap tail:     %" PRIu64 " (stuck here)", cur_tail);
                 LOG_ERROR("  - Heap size:     %" PRIu64, this->size);
+                LOG_ERROR("  - Available:     %" PRIu64 " bytes", pto2_heap_ring_available());
+                LOG_ERROR("Diagnosis:");
+                LOG_ERROR("  heap_tail is not advancing, which means last_task_alive");
+                LOG_ERROR("  is stuck. Check TaskRing diagnostics for root cause.");
                 LOG_ERROR("Solution: Increase heap size or investigate task stall.");
                 LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
                 LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %lu)",


### PR DESCRIPTION
  - Unify scheduler/orchestrator phase records into per-thread storage, eliminating separate collected_orch_phase_records_ vector
  - Add SCHED_PHASE_COUNT sentinel and is_scheduler_phase() helper
  - Make s_orch_thread_idx thread-local for concurrent orchestrators
  - Add progress detection to HeapRing spin-wait with improved deadlock diagnostics
  - Prepend [filename:line] to LOG_* macro output
  - Reorder preprocessor branches to place __aarch64__ first (codestyle)