### PR TITLE
Refactor PTOParam to aggregated container and add orchestrator data prefetch

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -130,12 +130,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                 Tensor li_batch = make_tensor(scalar_acc_shapes, 1, DataType::FLOAT32);
                 Tensor mi_batch = make_tensor(scalar_acc_shapes, 1, DataType::FLOAT32);
 
-                PTOParam params_hub[] = {
-                    make_output_param(oi_batch),
-                    make_output_param(li_batch),
-                    make_output_param(mi_batch),
-                };
-                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_hub, 3);
+                PTOParam params_hub;
+                params_hub.add_output(oi_batch);
+                params_hub.add_output(li_batch);
+                params_hub.add_output(mi_batch);
+                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_hub);
 
                 for (uint64_t bn = 0; bn < max_bn; bn++) {
                     uint32_t sij_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)block_size};
@@ -148,63 +147,59 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                     Tensor lij_b = make_tensor(vec_shapes, 1, DataType::FLOAT32);
                     Tensor oi_new_b = make_tensor(oi_new_shapes, 2, DataType::FLOAT32);
 
-                    PTOParam params_qk[] = {
-                        make_input_param(query),
-                        make_input_param(key_cache),
-                        make_output_param(sij_b),
-                        make_scalar_param(bt_addr),
-                        make_scalar_param(chunk_bc),
-                        make_scalar_param(bn),
-                        make_scalar_param(q_offset),
-                        make_scalar_param(block_num),
-                        make_scalar_param(num_heads),
-                        make_scalar_param(batch_start),
-                    };
-                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk, 10);
+                    PTOParam params_qk;
+                    params_qk.add_input(query);
+                    params_qk.add_input(key_cache);
+                    params_qk.add_output(sij_b);
+                    params_qk.add_scalar(bt_addr);
+                    params_qk.add_scalar(chunk_bc);
+                    params_qk.add_scalar(bn);
+                    params_qk.add_scalar(q_offset);
+                    params_qk.add_scalar(block_num);
+                    params_qk.add_scalar(num_heads);
+                    params_qk.add_scalar(batch_start);
+                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk);
 
-                    PTOParam params_sf[] = {
-                        make_input_param(sij_b),
-                        make_output_param(pij_b),
-                        make_output_param(mij_b),
-                        make_output_param(lij_b),
-                        make_scalar_param(float_to_u64(scale_value)),
-                        make_scalar_param(cl_addr),
-                        make_scalar_param(chunk_bc),
-                        make_scalar_param(bn),
-                        make_scalar_param(batch_start),
-                    };
-                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf, 9);
+                    PTOParam params_sf;
+                    params_sf.add_input(sij_b);
+                    params_sf.add_output(pij_b);
+                    params_sf.add_output(mij_b);
+                    params_sf.add_output(lij_b);
+                    params_sf.add_scalar(float_to_u64(scale_value));
+                    params_sf.add_scalar(cl_addr);
+                    params_sf.add_scalar(chunk_bc);
+                    params_sf.add_scalar(bn);
+                    params_sf.add_scalar(batch_start);
+                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf);
 
-                    PTOParam params_pv[] = {
-                        make_input_param(pij_b),
-                        make_input_param(value_cache),
-                        make_output_param(oi_new_b),
-                        make_scalar_param(bt_addr),
-                        make_scalar_param(chunk_bc),
-                        make_scalar_param(bn),
-                        make_scalar_param(block_num),
-                        make_scalar_param(batch_start),
-                    };
-                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv, 8);
+                    PTOParam params_pv;
+                    params_pv.add_input(pij_b);
+                    params_pv.add_input(value_cache);
+                    params_pv.add_output(oi_new_b);
+                    params_pv.add_scalar(bt_addr);
+                    params_pv.add_scalar(chunk_bc);
+                    params_pv.add_scalar(bn);
+                    params_pv.add_scalar(block_num);
+                    params_pv.add_scalar(batch_start);
+                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv);
 
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn == max_bn - 1) ? 1 : 0;
-                    PTOParam params_up[] = {
-                        make_input_param(mij_b),
-                        make_input_param(lij_b),
-                        make_input_param(oi_new_b),
-                        make_inout_param(mi_batch),
-                        make_inout_param(li_batch),
-                        make_output_param(oi_batch),
-                        make_output_param(out),
-                        make_scalar_param(is_first),
-                        make_scalar_param(is_last),
-                        make_scalar_param(chunk_bc),
-                        make_scalar_param(q_offset),
-                        make_scalar_param(num_heads),
-                        make_scalar_param(batch_start),
-                    };
-                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up, 13);
+                    PTOParam params_up;
+                    params_up.add_input(mij_b);
+                    params_up.add_input(lij_b);
+                    params_up.add_input(oi_new_b);
+                    params_up.add_inout(mi_batch);
+                    params_up.add_inout(li_batch);
+                    params_up.add_output(oi_batch);
+                    params_up.add_output(out);
+                    params_up.add_scalar(is_first);
+                    params_up.add_scalar(is_last);
+                    params_up.add_scalar(chunk_bc);
+                    params_up.add_scalar(q_offset);
+                    params_up.add_scalar(num_heads);
+                    params_up.add_scalar(batch_start);
+                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up);
                 }
             }
         }

--- a/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -115,21 +115,19 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                         Tensor P = make_tensor(tile_shapes, 1, DataType::FLOAT32);
 
                         // P = A[m,k] @ B[k,n]
-                        PTOParam params_gemm[] = {
-                            make_input_param(A_view),
-                            make_input_param(B_view),
-                            make_output_param(P),
-                        };
+                        PTOParam params_gemm;
+                        params_gemm.add_input(A_view);
+                        params_gemm.add_input(B_view);
+                        params_gemm.add_output(P);
                         pto2_rt_submit_aic_task(rt, FUNC_GEMM_TILE,
-                                           params_gemm, 3); // gemm
+                                           params_gemm); // gemm
 
                         // C[m,n] += P
-                        PTOParam params_add[] = {
-                            make_inout_param(C_view),
-                            make_input_param(P),
-                        };
+                        PTOParam params_add;
+                        params_add.add_inout(C_view);
+                        params_add.add_input(P);
                         pto2_rt_submit_aiv_task(rt, FUNC_TILE_ADD,
-                                           params_add, 2); // add
+                                           params_add); // add
                     }
                 }
             }

--- a/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
@@ -30,7 +30,20 @@ Validate `arg_count` in `aicpu_orchestration_config` and interpret pointers as d
 1. Call `pto2_rt_init_tensor_pool(rt)` at the start of `aicpu_orchestration_entry`.
 2. Wrap orchestration in scopes with `PTO2_SCOPE(rt)` to control tensor lifetimes.
 3. Use `make_tensor_external` for input/output buffers and `make_tensor` for intermediates.
-4. Build `PTOParam` arrays with `make_input_param`, `make_output_param`, `make_inout_param`, and `make_scalar_param`.
+4. Build `PTOParam` with `add_input`, `add_output`, `add_inout` for tensors and `add_scalar` for scalars.
+   > **Constraint**: All tensor parameters (`add_input` / `add_output` / `add_inout`) **must** be added before any scalar parameters (`add_scalar` / `add_scalars`). Violating this order will trigger an assertion failure. This is because the runtime dispatches tensor arguments first in kernel args, followed by scalars, and the layout must match.
+   ```cpp
+   // Correct
+   PTOParam p;
+   p.add_input(a);
+   p.add_output(b);
+   p.add_scalar(val);    // scalars after all tensors
+
+   // Wrong — triggers assertion
+   PTOParam p;
+   p.add_scalar(val);    // scalar added too early
+   p.add_input(a);       // assertion: "scalar must add after all tensor added"
+   ```
 5. Submit tasks with one of:
    - `pto2_rt_submit_aic_task(rt, kernel_id, params, num_params)` — AIC (CUBE) task
    - `pto2_rt_submit_aiv_task(rt, kernel_id, params, num_params)` — AIV (VECTOR) task

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -147,38 +147,35 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                 mk.aic_kernel_id = FUNC_MATMUL;
                 mk.aiv0_kernel_id = FUNC_ADD;
                 mk.aiv1_kernel_id = FUNC_MUL;
-                PTOParam params[9] = {
-                    make_input_param(ext_A),
-                    make_input_param(ext_B),
-                    make_output_param(C_view),
-                    make_input_param(ext_D),
-                    make_input_param(ext_E),
-                    make_output_param(F_view),
-                    make_input_param(ext_G),
-                    make_input_param(ext_H),
-                    make_output_param(I_view),
-                };
-                pto2_rt_submit_task(rt, mk, params, 9);
+                PTOParam params;
+                params.add_input(ext_A);
+                params.add_input(ext_B);
+                params.add_output(C_view);
+                params.add_input(ext_D);
+                params.add_input(ext_E);
+                params.add_output(F_view);
+                params.add_input(ext_G);
+                params.add_input(ext_H);
+                params.add_output(I_view);
+                pto2_rt_submit_task(rt, mk, params);
             }
 
             // 2. AIC_ONLY: standalone matmul
             {
-                PTOParam params[3] = {
-                    make_input_param(ext_A),
-                    make_input_param(ext_B),
-                    make_output_param(J_view),
-                };
-                pto2_rt_submit_aic_task(rt, FUNC_MATMUL, params, 3);
+                PTOParam params;
+                params.add_input(ext_A);
+                params.add_input(ext_B);
+                params.add_output(J_view);
+                pto2_rt_submit_aic_task(rt, FUNC_MATMUL, params);
             }
 
             // 3. AIV_X1: standalone add
             {
-                PTOParam params[3] = {
-                    make_input_param(ext_D),
-                    make_input_param(ext_E),
-                    make_output_param(K_view),
-                };
-                pto2_rt_submit_aiv_task(rt, FUNC_ADD_STANDALONE, params, 3);
+                PTOParam params;
+                params.add_input(ext_D);
+                params.add_input(ext_E);
+                params.add_output(K_view);
+                pto2_rt_submit_aiv_task(rt, FUNC_ADD_STANDALONE, params);
             }
 
             // 4. AIV_X2: add (AIV0) + mul (AIV1)
@@ -186,15 +183,14 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                 MixedKernels mk;
                 mk.aiv0_kernel_id = FUNC_ADD_STANDALONE;
                 mk.aiv1_kernel_id = FUNC_MUL_STANDALONE;
-                PTOParam params[6] = {
-                    make_input_param(ext_D),
-                    make_input_param(ext_E),
-                    make_output_param(L_view),
-                    make_input_param(ext_G),
-                    make_input_param(ext_H),
-                    make_output_param(M_view),
-                };
-                pto2_rt_submit_task(rt, mk, params, 6);
+                PTOParam params;
+                params.add_input(ext_D);
+                params.add_input(ext_E);
+                params.add_output(L_view);
+                params.add_input(ext_G);
+                params.add_input(ext_H);
+                params.add_output(M_view);
+                pto2_rt_submit_task(rt, mk, params);
             }
 
             // 5. AIC_AIV_X1: matmul (AIC) + add (AIV0)
@@ -202,15 +198,14 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                 MixedKernels mk;
                 mk.aic_kernel_id = FUNC_MATMUL;
                 mk.aiv0_kernel_id = FUNC_ADD;
-                PTOParam params[6] = {
-                    make_input_param(ext_A),
-                    make_input_param(ext_B),
-                    make_output_param(N_view),
-                    make_input_param(ext_D),
-                    make_input_param(ext_E),
-                    make_output_param(O_view),
-                };
-                pto2_rt_submit_task(rt, mk, params, 6);
+                PTOParam params;
+                params.add_input(ext_A);
+                params.add_input(ext_B);
+                params.add_output(N_view);
+                params.add_input(ext_D);
+                params.add_input(ext_E);
+                params.add_output(O_view);
+                pto2_rt_submit_task(rt, mk, params);
             }
         }
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -108,15 +108,15 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[1]);
+    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[3]);
     union {
         uint64_t u;
         float f;
     } scale_conv;
-    scale_conv.u = static_cast<uint64_t>(args[1]);
+    scale_conv.u = static_cast<uint64_t>(args[4]);
     float scale_value = scale_conv.f;
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[4]);
 
     softmax_prepare_impl<16, 16>(sij, scale_value, pij, mij, lij);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -136,12 +136,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                 uint32_t out_view_offsets[2] = {cur_offset, 0};
                 Tensor out_view = out.view(out_view_shapes, out_view_offsets);
 
-                PTOParam params_inplace[] = {
-                    make_output_param(oi),
-                    make_output_param(li_update),
-                    make_output_param(mi_update),
-                };
-                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_inplace, 3); // create_inplace
+                PTOParam params_inplace;
+                params_inplace.add_output(oi);
+                params_inplace.add_output(li_update);
+                params_inplace.add_output(mi_update);
+                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_inplace); // create_inplace
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
                     uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
@@ -155,52 +154,48 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                     Tensor sij = make_tensor(sij_shapes, 2, DataType::FLOAT32);
                     Tensor pij_f16 = make_tensor(sij_shapes, 2, data_type);
 
-                    PTOParam params_qk[] = {
-                        make_input_param(qi),
-                        make_input_param(kj),
-                        make_output_param(sij),
-                    };
-                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk, 3); // c1
+                    PTOParam params_qk;
+                    params_qk.add_input(qi);
+                    params_qk.add_input(kj);
+                    params_qk.add_output(sij);
+                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk); // c1
 
                     uint32_t sij_valid_shapes[2] = {(uint32_t)q_tile, (uint32_t)valid_len};
                     uint32_t sij_valid_offsets[2] = {0, 0};
                     Tensor sij_valid = sij.view(sij_valid_shapes, sij_valid_offsets);
                     Tensor li = make_tensor(li_shapes, 1, DataType::FLOAT32);
                     Tensor mi = make_tensor(mi_shapes, 1, DataType::FLOAT32);
-                    PTOParam params_sf[] = {
-                        make_input_param(sij_valid),
-                        make_scalar_param(float_to_u64(scale_value)),
-                        make_output_param(pij_f16),
-                        make_output_param(mi),
-                        make_output_param(li),
-                    };
-                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf, 5); // v1
+                    PTOParam params_sf;
+                    params_sf.add_input(sij_valid);
+                    params_sf.add_output(pij_f16);
+                    params_sf.add_output(mi);
+                    params_sf.add_output(li);
+                    params_sf.add_scalar(float_to_u64(scale_value));
+                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf); // v1
 
                     uint32_t oi_tmp_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
                     Tensor oi_tmp = make_tensor(oi_tmp_shapes, 2, DataType::FLOAT32);
 
-                    PTOParam params_pv[] = {
-                        make_input_param(pij_f16),
-                        make_input_param(vj),
-                        make_output_param(oi_tmp),
-                    };
-                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv, 3); // c2
+                    PTOParam params_pv;
+                    params_pv.add_input(pij_f16);
+                    params_pv.add_input(vj);
+                    params_pv.add_output(oi_tmp);
+                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv); // c2
 
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
 
-                    PTOParam params_up[] = {
-                        make_input_param(mi),
-                        make_input_param(li),
-                        make_input_param(oi_tmp),
-                        make_inout_param(mi_update),
-                        make_inout_param(li_update),
-                        make_inout_param(oi),
-                        make_output_param(out_view),
-                        make_scalar_param(is_first),
-                        make_scalar_param(is_last),
-                    };
-                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up, 9); // v2
+                    PTOParam params_up;
+                    params_up.add_input(mi);
+                    params_up.add_input(li);
+                    params_up.add_input(oi_tmp);
+                    params_up.add_inout(mi_update);
+                    params_up.add_inout(li_update);
+                    params_up.add_inout(oi);
+                    params_up.add_output(out_view);
+                    params_up.add_scalar(is_first);
+                    params_up.add_scalar(is_last);
+                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up); // v2
                 }
             }
         }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -30,14 +30,14 @@ using namespace pto;
  * Unified signature: all arguments passed via int64_t array
  * @param args  Argument array:
  *              args[0] = src pointer (input tensor)
- *              args[1] = scalar value (as uint64_t, needs conversion to float)
- *              args[2] = out pointer (output tensor)
+ *              args[1] = out pointer (output tensor)
+ *              args[2] = scalar value (as uint64_t, needs conversion to float)
  *              args[3] = size (number of elements)
  */
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
     // Unpack arguments (Tensor* pointers from runtime)
     __gm__ Tensor* src_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
     __gm__ float* src = reinterpret_cast<__gm__ float*>(src_tensor->buffer.addr) + src_tensor->start_offset;
     __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
@@ -46,7 +46,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         uint64_t u64;
         float f32;
     } converter;
-    converter.u64 = args[1];
+    converter.u64 = args[2];
     float scalar = converter.f32;
 
     // Configuration: float, 128, 128, 128, 128

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -102,12 +102,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
     Tensor c = make_tensor(inter_shapes, 1, DataType::FLOAT32);  // c = a + b
 
     // t0: c = a + b (kernel_id=0, kernel_add) [outer scope]
-    PTOParam params_t0[] = {
-        make_input_param(ext_a),
-        make_input_param(ext_b),
-        make_output_param(c),
-    };
-    pto2_rt_submit_aiv_task(rt, 0, params_t0, 3); // kernel_add
+    PTOParam params_t0;
+    params_t0.add_input(ext_a);
+    params_t0.add_input(ext_b);
+    params_t0.add_output(c);
+    pto2_rt_submit_aiv_task(rt, 0, params_t0); // kernel_add
 
     // Inner scope: owns t1, t2, t3, t4; intermediates d, e, g release on scope end.
     // c flows in from outer scope (outer-scope tensors are visible to inner scopes).
@@ -117,39 +116,35 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
         Tensor g = make_tensor(inter_shapes, 1, DataType::FLOAT32);  // g = d * e
 
         // t1: d = c + 1 (kernel_id=1, kernel_add_scalar)
-        PTOParam params_t1[] = {
-            make_input_param(c),
-            make_scalar_param(float_to_u64(1.0f)),
-            make_output_param(d),
-            make_scalar_param((uint64_t)3),
-        };
-        pto2_rt_submit_aiv_task(rt, 1, params_t1, 3); // kernel_add_scalar
+        PTOParam params_t1;
+        params_t1.add_input(c);
+        params_t1.add_output(d);
+        params_t1.add_scalar(float_to_u64(1.0f));
+        params_t1.add_scalar((uint64_t)3);
+        pto2_rt_submit_aiv_task(rt, 1, params_t1); // kernel_add_scalar
 
         // t2: e = c + 2 (kernel_id=1, kernel_add_scalar)
-        PTOParam params_t2[] = {
-            make_input_param(c),
-            make_scalar_param(float_to_u64(2.0f)),
-            make_output_param(e),
-            make_scalar_param((uint64_t)3),
-        };
-        pto2_rt_submit_aiv_task(rt, 1, params_t2, 3); // kernel_add_scalar
+        PTOParam params_t2;
+        params_t2.add_input(c);
+        params_t2.add_output(e);
+        params_t2.add_scalar(float_to_u64(2.0f));
+        params_t2.add_scalar((uint64_t)3);
+        pto2_rt_submit_aiv_task(rt, 1, params_t2); // kernel_add_scalar
 
         // t3: g = d * e (kernel_id=2, kernel_mul)
-        PTOParam params_t3[] = {
-            make_input_param(d),
-            make_input_param(e),
-            make_output_param(g),
-            make_scalar_param((uint64_t)3),
-        };
-        pto2_rt_submit_aiv_task(rt, 2, params_t3, 3); // kernel_mul
+        PTOParam params_t3;
+        params_t3.add_input(d);
+        params_t3.add_input(e);
+        params_t3.add_output(g);
+        params_t3.add_scalar((uint64_t)3);
+        pto2_rt_submit_aiv_task(rt, 2, params_t3); // kernel_mul
 
         // t4: f = g + c (kernel_id=0, kernel_add)
-        PTOParam params_t4[] = {
-            make_input_param(g),
-            make_input_param(c),
-            make_output_param(ext_f),
-        };
-        pto2_rt_submit_aiv_task(rt, 0, params_t4, 3); // kernel_add
+        PTOParam params_t4;
+        params_t4.add_input(g);
+        params_t4.add_input(c);
+        params_t4.add_output(ext_f);
+        pto2_rt_submit_aiv_task(rt, 0, params_t4); // kernel_add
     }  // inner scope ends: releases d, e, g
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -249,18 +249,18 @@ struct AicpuExecutor {
 
     // Build slim PTO2DispatchPayload: only function_bin_addr + args.
     // Metadata (mixed_task_id, subslot, kernel_id, core_type) stays in TaskDescriptor.
+    // Dispatch order: tensor args first, then scalar args.
     void build_pto2_payload(PTO2DispatchPayload& out,
         int32_t kernel_id,
         PTO2TaskPayload& task_pl) {
         out.function_bin_addr = get_function_bin_addr(kernel_id);
         int32_t n = 0;
-        for (int32_t i = 0; i < task_pl.param_count; i++) {
-            if (!task_pl.is_tensor[i]) {
-                out.args[n++] = task_pl.scalar_value[i];
-            } else {
-                out.args[n++] = reinterpret_cast<uint64_t>(&task_pl.tensors[i]);
-                task_pl.tensors[i].update_start_offset();
-            }
+        for (int32_t i = 0; i < task_pl.tensor_count; i++) {
+            task_pl.tensors[i].update_start_offset();
+            out.args[n++] = reinterpret_cast<uint64_t>(&task_pl.tensors[i]);
+        }
+        for (int32_t i = 0; i < task_pl.scalar_count; i++) {
+            out.args[n++] = task_pl.scalars[i];
         }
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -22,7 +22,7 @@
 #include <stddef.h>
 
 // Type headers needed by orchestration
-#include "pto_types.h"          // PTOParam, make_input_param, make_output_param, etc.
+#include "pto_types.h"          // PTOParam, PTOTensorEntry, PTOParamType
 #include "tensor.h"             // Tensor, make_tensor, make_tensor_external
 #include "pto_submit_types.h"   // MixedKernels, INVALID_KERNEL_ID, subtask slots
 
@@ -43,7 +43,7 @@ typedef struct PTO2Runtime PTO2Runtime;
  */
 typedef struct PTO2RuntimeOps {
     void (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                        PTOParam* params, int32_t num_params);
+                        const PTOParam& params);
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
     void (*orchestration_done)(PTO2Runtime* rt);
@@ -73,28 +73,28 @@ struct PTO2Runtime {
 // =============================================================================
 
 static inline void pto2_rt_submit_task(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                                        PTOParam* params, int32_t num_params) {
-    rt->ops->submit_task(rt, mixed_kernels, params, num_params);
+                                        const PTOParam& params) {
+    rt->ops->submit_task(rt, mixed_kernels, params);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
 static inline void pto2_rt_submit_aic_task(PTO2Runtime* rt, int32_t kernel_id,
-                                            PTOParam* params, int32_t num_params) {
+                                            const PTOParam& params) {
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
-    rt->ops->submit_task(rt, mk, params, num_params);
+    rt->ops->submit_task(rt, mk, params);
 }
 
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
 static inline void pto2_rt_submit_aiv_task(PTO2Runtime* rt, int32_t kernel_id,
-                                            PTOParam* params, int32_t num_params) {
+                                            const PTOParam& params) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
-    rt->ops->submit_task(rt, mk, params, num_params);
+    rt->ops->submit_task(rt, mk, params);
 }
 
 static inline void pto2_rt_scope_begin(PTO2Runtime* rt) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -332,7 +332,7 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
 // Task Submission
 // =============================================================================
 void pto2_submit_mixed_task(
-    PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, PTOParam* params, int32_t num_params) {
+    PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const PTOParam& params) {
     // Fast path after fatal error — all subsequent submits are no-ops
     if (orch->fatal) { return; }
 
@@ -341,7 +341,6 @@ void pto2_submit_mixed_task(
     // === Validate submit inputs ===
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
     always_assert(active_mask != 0 && "MixedKernels must have at least one active slot");
-    always_assert((params != nullptr || num_params == 0) && "params must not be null when num_params > 0");
 
     // Normalize single-AIV tasks: if only aiv1 is set, move it to the aiv0 slot.
     // This guarantees the dispatch path can always use PTO2SubtaskSlot::AIV0 for
@@ -419,6 +418,21 @@ void pto2_submit_mixed_task(
     PTO2TaskDescriptor& task = task_ring.get_task_by_slot(slot);
     PTO2TaskPayload* payload = &orch->sm_handle->task_payloads[ring_id][slot];
 
+    // Early write-prefetch payload GM cache lines to issue RFO in background.
+    // ~130 lines of computation (output_size, lookup, insert) follow before
+    // param_copy writes, giving ample time for prefetch to complete.
+    for (int32_t i = 0; i < params.tensor_count; i++) {
+        __builtin_prefetch(&payload->tensors[i], 1, 0);
+        __builtin_prefetch(reinterpret_cast<char*>(&payload->tensors[i]) + 64, 1, 0);
+    }
+    for (int32_t j = 0; j < params.scalar_count; j += 8) {
+        __builtin_prefetch(&payload->scalars[j], 1, 0);
+    }
+    // Metadata area: tensor_count, scalar_count, fanin_slot_states[], fanin_actual_count
+    __builtin_prefetch(&payload->tensor_count, 1, 0);
+    __builtin_prefetch(&payload->fanin_slot_states[0], 1, 0);
+    __builtin_prefetch(&payload->fanin_slot_states[8], 1, 0);
+
     // Initialize mixed-task descriptor
     task.mixed_task_id = mixed_task_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)]  = normalized.aic_kernel_id;
@@ -451,37 +465,18 @@ void pto2_submit_mixed_task(
 
     // Register this task in its owning scope
 
+    // Temporary storage for fanin (cached slot state pointers, avoids repeated ring/slot lookups)
+    PTO2TaskSlotState* fanin_states[PTO2_MAX_INPUTS];
+    int32_t fanin_count = 0;
 
     CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, local_id);
 
-    // Temporary storage for fanin (64-bit task_ids for multi-ring)
-    PTO2TaskId fanin_temp[PTO2_MAX_INPUTS];
-    int32_t fanin_count = 0;
-
-    payload->param_count = num_params;
-    for (int i = 0; i < num_params; i++) {
-        payload->is_tensor[i] = params[i].type != PTOParamType::SCALAR;
-        if (payload->is_tensor[i]) {
-            payload->tensors[i].copy(*params[i].tensor);
-        } else {
-            payload->scalar_value[i] = params[i].scalar_value;
-        }
-    }
-
-    CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS, local_id);
-#if PTO2_ORCH_PROFILING
-    g_orch_params_atomic_count += 2;  // fanout_lock.store + fanout_count.store
-#endif
-
-    // Temporary storage for collecting output sizes
+    // === Calculate output size + heap alloc (read from params only, no GM access) ===
     int32_t total_output_size = 0;
-    for (int i = 0; i < num_params; i++) {
-        if (params[i].type != PTOParamType::OUTPUT) {
-            continue;
-        }
-        // Only allocate from ring buffer when caller did not provide an address
-        if (payload->tensors[i].buffer.addr == 0) {
-            total_output_size += PTO2_ALIGN_UP(payload->tensors[i].buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
+    for (int i = 0; i < params.tensor_count; i++) {
+        if (params.tensor_types[i] == PTOParamType::OUTPUT
+            && params.tensors[i]->buffer.addr == 0) {
+            total_output_size += PTO2_ALIGN_UP(params.tensors[i]->buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
         }
     }
 
@@ -497,27 +492,30 @@ void pto2_submit_mixed_task(
     }
 #endif
 
-    // === STEP 2: First pass - set output addr and process tensor ===
+    // === Lookup inputs + assign output addrs (all from params, no GM) ===
     int32_t offset = 0;
-    for (int i = 0; i < num_params; i++) {
-        PTOParamType ptype = params[i].type;
+    for (int i = 0; i < params.tensor_count; i++) {
+        PTOParamType ptype = params.tensor_types[i];
 
         switch (ptype) {
             case PTOParamType::INOUT:
             case PTOParamType::INPUT: {
-                // Look up producer via TensorMap
+                // Look up producer via TensorMap (reads from cached stack tensor)
                 PTO2LookupResult lookup_result;
-                orch->tensor_map.lookup(payload->tensors[i], lookup_result);
+                orch->tensor_map.lookup(*params.tensors[i], lookup_result);
 
                 for (int r = 0; r < lookup_result.count; r++) {
                     PTO2TensorMapEntry& entry = *lookup_result.entries[r].entry;
                     auto overlap_status = lookup_result.entries[r].overlap_status;
                     // Check if this producer is already in fanin list (avoid duplicates)
-                        PTO2TaskId producer_task_id = entry.producer_task_id;
-                        bool already_added = false;
-                        for (int j = 0; j < fanin_count; j++) {
-                            if (fanin_temp[j] == producer_task_id) {
-                                already_added = true;
+                    int32_t prod_ring = static_cast<int32_t>(pto2_task_id_ring(entry.producer_task_id));
+                    int32_t prod_local = static_cast<int32_t>(pto2_task_id_local(entry.producer_task_id));
+                    PTO2TaskSlotState* prod_state =
+                        &sched->ring_sched_states[prod_ring].get_slot_state_by_task_id(prod_local);
+                    bool already_added = false;
+                    for (int j = 0; j < fanin_count; j++) {
+                        if (fanin_states[j] == prod_state) {
+                            already_added = true;
                             break;
                         }
                     }
@@ -525,7 +523,7 @@ void pto2_submit_mixed_task(
                     if (!already_added) {
                         // Add to fanin list (this task depends on producer)
                         if (fanin_count < PTO2_MAX_INPUTS) {
-                            fanin_temp[fanin_count++] = producer_task_id;
+                            fanin_states[fanin_count++] = prod_state;
                         }
                     }
                     if (ptype == PTOParamType::INOUT && overlap_status == OverlapStatus::COVERED) {
@@ -542,33 +540,59 @@ void pto2_submit_mixed_task(
             }
 
             case PTOParamType::OUTPUT: {
-                auto& tensor = payload->tensors[i];
+                Tensor& tensor = *params.tensors[i];
                 if (tensor.buffer.addr == 0) {
                     uint64_t alloc_addr = reinterpret_cast<uint64_t>((char*)task.packed_buffer_base + offset);
                     tensor.buffer.addr = alloc_addr;
-                    // Write back allocated address to caller's original Tensor
-                    params[i].tensor->buffer.addr = alloc_addr;
                     offset += PTO2_ALIGN_UP(tensor.buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
                 }
                 break;
             }
-            default:
-                break;
         }
     }
 
     CYCLE_COUNT_LAP_RECORD(g_orch_lookup_cycle, AicpuPhaseId::ORCH_LOOKUP, local_id);
 
-    // === STEP 4: Second pass - register outputs in TensorMap ===
-    for (int i = 0; i < num_params; i++) {
-        PTOParamType ptype = params[i].type;
+    // === Register outputs/inouts in TensorMap (must be separate from lookup) ===
+    for (int i = 0; i < params.tensor_count; i++) {
+        PTOParamType ptype = params.tensor_types[i];
         if (ptype == PTOParamType::OUTPUT || ptype == PTOParamType::INOUT) {
-            // Register in TensorMap: this tensor is produced by mixed_task_id
-            orch->tensor_map.insert(payload->tensors[i], mixed_task_id, ptype == PTOParamType::OUTPUT);
+            orch->tensor_map.insert(*params.tensors[i], mixed_task_id, ptype == PTOParamType::OUTPUT);
         }
     }
 
     CYCLE_COUNT_LAP_RECORD(g_orch_insert_cycle, AicpuPhaseId::ORCH_INSERT, local_id);
+
+
+    // Prefetch producer slot_states and cur_slot_state (written at init but likely
+    // evicted by lookup/insert/heap). param_copy below provides hide time.
+    if (sched) {
+        auto& rs = sched->ring_sched_states[ring_id];
+        __builtin_prefetch(&rs.get_slot_state_by_slot(slot), 1, 0);
+        for (int i = 0; i < fanin_count; i++) {
+            __builtin_prefetch(fanin_states[i], 1, 0);
+        }
+    }
+
+    payload->tensor_count = params.tensor_count;
+    payload->scalar_count = params.scalar_count;
+    // === Copy tensors + scalars to GM payload ===
+    // dst cache lines already prefetched after slot allocation (early prefetch).
+    auto dst_tensors = payload->tensors;
+    auto src_tensors = params.tensors;
+    for (int32_t i = 0; i < params.tensor_count; i++) {
+        dst_tensors[i] = *src_tensors[i];
+    }
+    auto dst_scalars = payload->scalars;
+    auto src_scalars = params.scalars;
+    for (int32_t i = 0; i < params.scalar_count; i++) {
+        dst_scalars[i] = src_scalars[i];
+    }
+
+    CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS, local_id);
+#if PTO2_ORCH_PROFILING
+    g_orch_params_atomic_count += 2;  // fanout_lock.store + fanout_count.store
+#endif
 
     // === STEP 5: Finalize fanin list ===
     // First build the fanin list
@@ -592,18 +616,10 @@ void pto2_submit_mixed_task(
         cur_slot_state.fanin_count = fanin_count + 1;  // +1 redundance for not being ready too early
         payload->fanin_actual_count = fanin_count;
         for (int i = 0; i < fanin_count; i++) {
-            int32_t prod_ring = static_cast<int32_t>(pto2_task_id_ring(fanin_temp[i]));
-            int32_t prod_local = static_cast<int32_t>(pto2_task_id_local(fanin_temp[i]));
-            payload->fanin_slot_states[i] =
-                &sched->ring_sched_states[prod_ring].get_slot_state_by_task_id(prod_local);
+            payload->fanin_slot_states[i] = fanin_states[i];
         }
         for (int i = 0; i < fanin_count; i++) {
-            PTO2TaskId producer_task_id = fanin_temp[i];
-            int32_t prod_ring = static_cast<int32_t>(pto2_task_id_ring(producer_task_id));
-            int32_t prod_local = static_cast<int32_t>(pto2_task_id_local(producer_task_id));
-            // Add this task to producer's fanout list (with spinlock)
-            PTO2TaskSlotState& producer_slot_state =
-                sched->ring_sched_states[prod_ring].get_slot_state_by_task_id(prod_local);
+            PTO2TaskSlotState& producer_slot_state = *fanin_states[i];
             orch->dep_pool_cur_entries[ring_id]->slot_state = &cur_slot_state;
             orch->dep_pool_cur_entries[ring_id]->next = producer_slot_state.fanout_head;
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -180,15 +180,12 @@ void pto2_scope_end(PTO2OrchestratorState* orch);
  * 6. Initializes task state in scheduler
  *
  * @param orch        Orchestrator state
- * @param kernel_id   InCore function ID
- * @param worker_type Target worker type (CUBE, VECTOR, AI_CPU, ACCELERATOR)
- * @param params      Array of task parameters
- * @param num_params  Number of parameters
+ * @param mixed_kernels  Kernel IDs for AIC/AIV0/AIV1 slots
+ * @param params      Aggregated tensor and scalar parameters
  */
 void pto2_submit_mixed_task(PTO2OrchestratorState* orch,
     const MixedKernels& mixed_kernels,
-    PTOParam* params,
-    int32_t num_params);
+    const PTOParam& params);
 
 // =============================================================================
 // Flow Control

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -27,9 +27,9 @@ void pto2_set_orch_thread_idx(int idx) {
 // =============================================================================
 
 static void submit_task_impl(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                             PTOParam* params, int32_t num_params) {
+                             const PTOParam& params) {
     pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels,
-                           params, num_params);
+                           params);
 }
 
 void pto2_rt_scope_begin(PTO2Runtime* rt) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -60,7 +60,7 @@ typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
     void (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                        PTOParam* params, int32_t num_params);
+                        const PTOParam& params);
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
     void (*orchestration_done)(PTO2Runtime* rt);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -21,7 +21,6 @@
 
 #include "pto_types.h"
 #include "pto_submit_types.h"
-#include "pto2_dispatch_payload.h"
 
 // =============================================================================
 // Profiling Configuration
@@ -90,7 +89,8 @@
 #define PTO2_TENSORMAP_NUM_BUCKETS 65536    // Power of 2 for fast hash
 
 // Task parameters
-#define PTO2_MAX_PARAMS           128     // Maximum parameters per task (tensors + scalars)
+#define PTO2_MAX_TENSOR_PARAMS    16      // Maximum tensor parameters per task
+#define PTO2_MAX_SCALAR_PARAMS    128     // Maximum scalar parameters per task
 #define PTO2_MAX_OUTPUTS          16      // Maximum outputs per task
 #define PTO2_MAX_INPUTS           16      // Maximum inputs per task
 #define PTO2_MAX_INOUTS           8       // Maximum in-out params per task
@@ -362,15 +362,14 @@ struct PTO2TaskDescriptor {
 /**
  * Task payload data (cold path - only accessed during orchestration and dispatch)
  *
- * Separated from PTO2TaskDescriptor to keep the descriptor cache-friendly
- * for the scheduler's hot completion path (~80 bytes vs ~2912 bytes).
+ * Tensors and scalars are stored in separate compact arrays.
+ * Dispatch order: tensor args first, then scalar args.
  */
 struct PTO2TaskPayload {
-    PTO2DispatchPayload dispatch;  // function_bin_addr + args[], built in-place at dispatch time
-    Tensor tensors[PTO2_MAX_PARAMS];
-    uint64_t scalar_value[PTO2_MAX_PARAMS];
-    bool is_tensor[PTO2_MAX_PARAMS];
-    int param_count{0};
+    Tensor tensors[PTO2_MAX_TENSOR_PARAMS];
+    uint64_t scalars[PTO2_MAX_SCALAR_PARAMS];
+    int32_t tensor_count{0};
+    int32_t scalar_count{0};
     PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS]; // Producer slot states (cold path, used by on_task_release)
     int32_t fanin_actual_count{0};             // Actual fanin count (without the +1 redundance)
     int32_t dep_pool_mark{0};                  // Dep pool top after this task's submission (for reclamation)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -222,6 +222,10 @@ struct PTO2TensorMap {
 #endif
 
         while (cur_entry != nullptr) {
+            // Prefetch next entry to hide pointer-chasing latency.
+            // entry_valid() + is_overlap() computation provides hide time.
+            PTO2TensorMapEntry* next_entry = cur_entry->next_in_bucket;
+            if (next_entry) __builtin_prefetch(next_entry, 0, 0);
 #if PTO2_TENSORMAP_PROFILING
             chain_len++;
 #endif
@@ -229,7 +233,7 @@ struct PTO2TensorMap {
             // rings can be interleaved, so a stale entry from one ring does NOT
             // imply subsequent entries from other rings are also stale)
             if (!entry_valid(*cur_entry)) {
-                cur_entry = cur_entry->next_in_bucket;
+                cur_entry = next_entry;
                 continue;
             }
 
@@ -250,7 +254,7 @@ struct PTO2TensorMap {
             }
 
             // Move to next entry
-            cur_entry = cur_entry->next_in_bucket;
+            cur_entry = next_entry;
         }
 #if PTO2_TENSORMAP_PROFILING
         g_lookup_chain_total += chain_len;
@@ -271,17 +275,26 @@ struct PTO2TensorMap {
 #if PTO2_TENSORMAP_PROFILING
         g_insert_count++;
 #endif
+        // Prefetch bucket head and task_entry_head early; new_entry() + field
+        // initialization below provides hide time for these RFOs.
+        uint32_t bucket_index = hash(tensor.buffer.addr);
+        __builtin_prefetch(&buckets[bucket_index], 1, 0);
+        auto ring_id = producer_task_id.ring();
+        auto local_id = producer_task_id.local();
+        int32_t task_slot = local_id & (task_window_sizes[ring_id] - 1);
+        __builtin_prefetch(&task_entry_heads[ring_id][task_slot], 1, 0);
+
         // Allocate entry from ring buffer pool
         PTO2TensorMapEntry* entry = new_entry();
 
         // Initialize new entry
-        entry->tensor.copy(tensor);
+        entry->tensor = tensor;
         entry->producer_task_id = producer_task_id;
         entry->with_alloc = with_alloc;
 
         // Insert at head of hash bucket (maintains task_id descending order)
-        entry->bucket_index = hash(tensor.buffer.addr);
-        entry->next_in_bucket = buckets[entry->bucket_index];
+        entry->bucket_index = bucket_index;
+        entry->next_in_bucket = buckets[bucket_index];
         // Update old head's prev pointer
         if (entry->next_in_bucket != nullptr) {
             entry->next_in_bucket->prev_in_bucket = entry;
@@ -290,9 +303,6 @@ struct PTO2TensorMap {
         entry->prev_in_bucket = nullptr;  // New head has no predecessor
 
         // Link to task's entry list (for cleanup), indexed by ring and local slot
-        int32_t ring_id = static_cast<int32_t>(pto2_task_id_ring(producer_task_id));
-        int32_t local_id = static_cast<int32_t>(pto2_task_id_local(producer_task_id));
-        int32_t task_slot = local_id & (task_window_sizes[ring_id] - 1);
         entry->next_in_task = task_entry_heads[ring_id][task_slot];
         entry->prev_in_task = nullptr;  // New head has no predecessor
         // Update old head's prev pointer

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -2,8 +2,7 @@
  * Orchestration Build Graph Types - Data structures for orchestration runtime extensions
  *
  * Standalone header defining orchestration-specific types for:
- * - PTOParam: Parameter descriptor for pto_submit_task API
- * - PTOWorkerType: Worker types for heterogeneous scheduling
+ * - PTOParam: Aggregated parameter container for pto_submit_task API
  *
  * Tensor descriptor types (Tensor, PTOBufferHandle, PTOOverlapStrategy) are
  * defined in tensor.h.
@@ -16,6 +15,8 @@
 #define ORCH_BUILD_GRAPH_PTO_TYPES_H
 
 #include <stdint.h>
+#include <assert.h>
+#include <string.h>
 
 #include "tensor.h"
 
@@ -30,62 +31,112 @@ enum class PTOParamType : int32_t {
     INPUT = 0,   // Read-only input buffer
     OUTPUT = 1,  // Write-only output buffer (NULL addr: runtime allocates; non-NULL: use as-is)
     INOUT = 2,   // Read-then-write: consumer of prior producer + modifier for downstream
-    SCALAR = 3   // Raw scalar value (no buffer, no dependency tracking)
 };
 
 /**
- * Parameter Descriptor for pto_submit_task
+ * Aggregated parameter container for pto_submit_task
  *
- * Holds a pointer to the caller's Tensor (reference semantics). The runtime
- * copies the Tensor into the task descriptor for scheduler access, and
- * writes allocated OUTPUT addresses back through the pointer.
+ * Tensor pointers and types are stored in separate parallel arrays for
+ * efficient bulk copy: the runtime can memcpy the pointer array and type
+ * array independently, avoiding per-element branching.
+ * Tensors are dispatched first in kernel args, followed by scalars.
  *
  * Example:
- *   Tensor td_a = make_tensor_external(dev_a, size);
- *   Tensor td_c = make_tensor(size);
- *   PTOParam params[] = {
- *       make_input_param(td_a),
- *       make_output_param(td_c),
- *   };
- *   pto2_rt_submit_task(rt, func_id, worker_type, params, 2);
+ *   Tensor td_a = make_tensor_external(dev_a, shapes, 2);
+ *   Tensor td_c = make_tensor(shapes, 2);
+ *   PTOParam params;
+ *   params.add_input(td_a);
+ *   params.add_output(td_c);
+ *   params.add_scalar(some_value);
+ *   pto2_rt_submit_aic_task(rt, kernel_id, params);
  *   // td_c.buffer.addr is already updated via pointer write-back
  */
 struct PTOParam {
-    PTOParamType type;         // PTOParamType::INPUT, PTOParamType::OUTPUT, or PTOParamType::SCALAR
-    Tensor* tensor{nullptr};   // Pointer to caller's Tensor (reference semantics)
-    uint64_t scalar_value{0};  // Raw value for PTOParamType::SCALAR (e.g., encoded float, int size)
+    static constexpr int32_t MAX_TENSORS = 32;
+    static constexpr int32_t MAX_SCALARS = 128;
+
+    Tensor* tensors[MAX_TENSORS];
+    PTOParamType tensor_types[MAX_TENSORS];
+    uint64_t scalars[MAX_SCALARS];
+    int32_t tensor_count{0};
+    int32_t scalar_count{0};
+
+    void reset() {
+        tensor_count = 0;
+        scalar_count = 0;
+    }
+
+    bool check_add_tensor_valid() const {
+        assert(scalar_count == 0 && "scalar must add after all tensor added");
+        return true;
+    }
+
+    void add_input(Tensor& t) {
+        if (!check_add_tensor_valid()) {
+            return;
+        }
+        assert(t.buffer.addr != 0 && "INPUT param must have a non-NULL buffer address");
+        assert(tensor_count < MAX_TENSORS && "Too many tensor params");
+        tensors[tensor_count] = &t;
+        tensor_types[tensor_count] = PTOParamType::INPUT;
+        tensor_count++;
+    }
+
+    void add_output(Tensor& t) {
+        if (!check_add_tensor_valid()) {
+            return;
+        }
+        assert(tensor_count < MAX_TENSORS && "Too many tensor params");
+        tensors[tensor_count] = &t;
+        tensor_types[tensor_count] = PTOParamType::OUTPUT;
+        tensor_count++;
+    }
+
+    void add_inout(Tensor& t) {
+        if (!check_add_tensor_valid()) {
+            return;
+        }
+        assert(t.buffer.addr != 0 && "INOUT param must have a non-NULL buffer address");
+        assert(tensor_count < MAX_TENSORS && "Too many tensor params");
+        tensors[tensor_count] = &t;
+        tensor_types[tensor_count] = PTOParamType::INOUT;
+        tensor_count++;
+    }
+
+    void add_scalar(uint64_t v) {
+        assert(scalar_count < MAX_SCALARS && "Too many scalar params");
+        scalars[scalar_count++] = v;
+    }
+
+    void add_scalars(const uint64_t* values, int count) {
+        assert(scalar_count + count <= MAX_SCALARS && "Too many scalar params");
+        memcpy(&scalars[scalar_count], values, count * sizeof(uint64_t));
+        scalar_count += count;
+    }
+
+    /**
+     * Widen int32 values to uint64 directly into the scalars array.
+     * Avoids an intermediate uint64_t buffer when source data is int32.
+     */
+    void add_scalars_i32(const int32_t* values, int count) {
+        assert(scalar_count + count <= MAX_SCALARS && "Too many scalar params");
+        uint64_t* dst = &scalars[scalar_count];
+        for (int i = 0; i < count; i++) {
+            dst[i] = static_cast<uint64_t>(static_cast<uint32_t>(values[i]));
+        }
+        scalar_count += count;
+    }
+
+    /**
+     * Copy scalars from another PTOParam's scalar array.
+     * Useful when multiple tasks share the same scalar data (e.g., block indices).
+     */
+    void copy_scalars_from(const PTOParam& src, int src_offset, int count) {
+        assert(src_offset + count <= src.scalar_count && "Source scalar range out of bounds");
+        assert(scalar_count + count <= MAX_SCALARS && "Too many scalar params");
+        memcpy(&scalars[scalar_count], &src.scalars[src_offset], count * sizeof(uint64_t));
+        scalar_count += count;
+    }
 };
-
-// =============================================================================
-// Factory Helpers
-// =============================================================================
-
-static inline PTOParam make_scalar_param(uint64_t value) {
-    PTOParam p;
-    p.type = PTOParamType::SCALAR;
-    p.scalar_value = value;
-    return p;
-}
-
-static inline PTOParam make_input_param(Tensor& tensor) {
-    PTOParam p;
-    p.type = PTOParamType::INPUT;
-    p.tensor = &tensor;
-    return p;
-}
-
-static inline PTOParam make_output_param(Tensor& tensor) {
-    PTOParam p;
-    p.type = PTOParamType::OUTPUT;
-    p.tensor = &tensor;
-    return p;
-}
-
-static inline PTOParam make_inout_param(Tensor& tensor) {
-    PTOParam p;
-    p.type = PTOParamType::INOUT;
-    p.tensor = &tensor;
-    return p;
-}
 
 #endif  // ORCH_BUILD_GRAPH_PTO_TYPES_H

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -117,12 +117,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
             Tensor B_view = ext_B.view(matmul_group_shapes, view_offsets);
             Tensor C_view = ext_C.view(matmul_group_shapes, view_offsets);
 
-            PTOParam params_matmul[] = {
-                make_input_param(A_view),
-                make_input_param(B_view),
-                make_output_param(C_view),
-            };
-            pto2_rt_submit_aic_task(rt, FUNC_MATMUL, params_matmul, 3);
+            PTOParam params_matmul;
+            params_matmul.add_input(A_view);
+            params_matmul.add_input(B_view);
+            params_matmul.add_output(C_view);
+            pto2_rt_submit_aic_task(rt, FUNC_MATMUL, params_matmul);
             total_matmul++;
         }
 
@@ -138,12 +137,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
             Tensor Y_view = ext_Y.view(add_group_shapes, view_offsets);
             Tensor Z_view = ext_Z.view(add_group_shapes, view_offsets);
 
-            PTOParam params_add[] = {
-                make_input_param(X_view),
-                make_input_param(Y_view),
-                make_output_param(Z_view),
-            };
-            pto2_rt_submit_aiv_task(rt, FUNC_ADD, params_add, 3);
+            PTOParam params_add;
+            params_add.add_input(X_view);
+            params_add.add_input(Y_view);
+            params_add.add_output(Z_view);
+            pto2_rt_submit_aiv_task(rt, FUNC_ADD, params_add);
             total_add++;
         }
     }

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -130,12 +130,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                 Tensor li_batch = make_tensor(scalar_acc_shapes, 1, DataType::FLOAT32);
                 Tensor mi_batch = make_tensor(scalar_acc_shapes, 1, DataType::FLOAT32);
 
-                PTOParam params_hub[] = {
-                    make_output_param(oi_batch),
-                    make_output_param(li_batch),
-                    make_output_param(mi_batch),
-                };
-                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_hub, 3);
+                PTOParam params_hub;
+                params_hub.add_output(oi_batch);
+                params_hub.add_output(li_batch);
+                params_hub.add_output(mi_batch);
+                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_hub);
 
                 for (uint64_t bn = 0; bn < max_bn; bn++) {
                     PTO2_SCOPE_GUARD(rt);
@@ -150,63 +149,59 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                     Tensor lij_b = make_tensor(vec_shapes, 1, DataType::FLOAT32);
                     Tensor oi_new_b = make_tensor(oi_new_shapes, 2, DataType::FLOAT32);
 
-                    PTOParam params_qk[] = {
-                        make_input_param(query),
-                        make_input_param(key_cache),
-                        make_output_param(sij_b),
-                        make_scalar_param(bt_addr),
-                        make_scalar_param(chunk_bc),
-                        make_scalar_param(bn),
-                        make_scalar_param(q_offset),
-                        make_scalar_param(block_num),
-                        make_scalar_param(num_heads),
-                        make_scalar_param(batch_start),
-                    };
-                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk, 10);
+                    PTOParam params_qk;
+                    params_qk.add_input(query);
+                    params_qk.add_input(key_cache);
+                    params_qk.add_output(sij_b);
+                    params_qk.add_scalar(bt_addr);
+                    params_qk.add_scalar(chunk_bc);
+                    params_qk.add_scalar(bn);
+                    params_qk.add_scalar(q_offset);
+                    params_qk.add_scalar(block_num);
+                    params_qk.add_scalar(num_heads);
+                    params_qk.add_scalar(batch_start);
+                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk);
 
-                    PTOParam params_sf[] = {
-                        make_input_param(sij_b),
-                        make_output_param(pij_b),
-                        make_output_param(mij_b),
-                        make_output_param(lij_b),
-                        make_scalar_param(float_to_u64(scale_value)),
-                        make_scalar_param(cl_addr),
-                        make_scalar_param(chunk_bc),
-                        make_scalar_param(bn),
-                        make_scalar_param(batch_start),
-                    };
-                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf, 9);
+                    PTOParam params_sf;
+                    params_sf.add_input(sij_b);
+                    params_sf.add_output(pij_b);
+                    params_sf.add_output(mij_b);
+                    params_sf.add_output(lij_b);
+                    params_sf.add_scalar(float_to_u64(scale_value));
+                    params_sf.add_scalar(cl_addr);
+                    params_sf.add_scalar(chunk_bc);
+                    params_sf.add_scalar(bn);
+                    params_sf.add_scalar(batch_start);
+                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf);
 
-                    PTOParam params_pv[] = {
-                        make_input_param(pij_b),
-                        make_input_param(value_cache),
-                        make_output_param(oi_new_b),
-                        make_scalar_param(bt_addr),
-                        make_scalar_param(chunk_bc),
-                        make_scalar_param(bn),
-                        make_scalar_param(block_num),
-                        make_scalar_param(batch_start),
-                    };
-                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv, 8);
+                    PTOParam params_pv;
+                    params_pv.add_input(pij_b);
+                    params_pv.add_input(value_cache);
+                    params_pv.add_output(oi_new_b);
+                    params_pv.add_scalar(bt_addr);
+                    params_pv.add_scalar(chunk_bc);
+                    params_pv.add_scalar(bn);
+                    params_pv.add_scalar(block_num);
+                    params_pv.add_scalar(batch_start);
+                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv);
 
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn == max_bn - 1) ? 1 : 0;
-                    PTOParam params_up[] = {
-                        make_input_param(mij_b),
-                        make_input_param(lij_b),
-                        make_input_param(oi_new_b),
-                        make_inout_param(mi_batch),
-                        make_inout_param(li_batch),
-                        make_output_param(oi_batch),
-                        make_output_param(out),
-                        make_scalar_param(is_first),
-                        make_scalar_param(is_last),
-                        make_scalar_param(chunk_bc),
-                        make_scalar_param(q_offset),
-                        make_scalar_param(num_heads),
-                        make_scalar_param(batch_start),
-                    };
-                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up, 13);
+                    PTOParam params_up;
+                    params_up.add_input(mij_b);
+                    params_up.add_input(lij_b);
+                    params_up.add_input(oi_new_b);
+                    params_up.add_inout(mi_batch);
+                    params_up.add_inout(li_batch);
+                    params_up.add_output(oi_batch);
+                    params_up.add_output(out);
+                    params_up.add_scalar(is_first);
+                    params_up.add_scalar(is_last);
+                    params_up.add_scalar(chunk_bc);
+                    params_up.add_scalar(q_offset);
+                    params_up.add_scalar(num_heads);
+                    params_up.add_scalar(batch_start);
+                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up);
                 }
             }
         }

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -119,23 +119,19 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count) {
             Tensor B_view = ext_B.view(group_shapes, b_view_offsets);
             Tensor P = make_tensor(group_shapes, 1, DataType::FLOAT32);
 
-            PTOParam params_gemm[] = {
-                make_input_param(A_view),
-                make_input_param(B_view),
-                make_output_param(P),
-                make_input_param(ext_config),
-            };
-            pto2_rt_submit_aic_task(rt, FUNC_GEMM_TILE,
-                                params_gemm, 4);
+            PTOParam params_gemm;
+            params_gemm.add_input(A_view);
+            params_gemm.add_input(B_view);
+            params_gemm.add_output(P);
+            params_gemm.add_input(ext_config);
+            pto2_rt_submit_aic_task(rt, FUNC_GEMM_TILE, params_gemm);
             total_gemm++;
 
-            PTOParam params_add[] = {
-                make_inout_param(C_view),
-                make_input_param(P),
-                make_input_param(ext_config),
-            };
-            pto2_rt_submit_aiv_task(rt, FUNC_TILE_ADD,
-                                params_add, 3);
+            PTOParam params_add;
+            params_add.add_inout(C_view);
+            params_add.add_input(P);
+            params_add.add_input(ext_config);
+            pto2_rt_submit_aiv_task(rt, FUNC_TILE_ADD, params_add);
             total_add++;
         }
     }

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -113,15 +113,15 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[1]);
+    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[3]);
     union {
         uint64_t u;
         float f;
     } scale_conv;
-    scale_conv.u = static_cast<uint64_t>(args[1]);
+    scale_conv.u = static_cast<uint64_t>(args[4]);
     float scale_value = scale_conv.f;
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[4]);
     uint64_t q_tile_size = static_cast<uint64_t>(sij->shapes[0]);
 
     if (q_tile_size == 16) {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -161,13 +161,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                 prof_view_count += 2;
                 CYCLE_COUNT_LAP(prof_tensor_view);
 
-                PTOParam params_inplace[] = {
-                    make_output_param(oi),
-                    make_output_param(li_update),
-                    make_output_param(mi_update),
-                };
+                PTOParam params_inplace;
+                params_inplace.add_output(oi);
+                params_inplace.add_output(li_update);
+                params_inplace.add_output(mi_update);
                 CYCLE_COUNT_LAP(prof_param_setup);
-                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_inplace, 3);
+                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_inplace);
                 prof_submit_count++;
                 CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -191,13 +190,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     prof_make_count += 2;
                     CYCLE_COUNT_LAP(prof_make_tensor);
 
-                    PTOParam params_qk[] = {
-                        make_input_param(qi),
-                        make_input_param(kj),
-                        make_output_param(sij),
-                    };
+                    PTOParam params_qk;
+                    params_qk.add_input(qi);
+                    params_qk.add_input(kj);
+                    params_qk.add_output(sij);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk, 3);
+                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -212,15 +210,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     prof_make_count += 2;
                     CYCLE_COUNT_LAP(prof_make_tensor);
 
-                    PTOParam params_sf[] = {
-                        make_input_param(sij_valid),
-                        make_scalar_param(float_to_u64(scale_value)),
-                        make_output_param(pij_f16),
-                        make_output_param(mi),
-                        make_output_param(li),
-                    };
+                    PTOParam params_sf;
+                    params_sf.add_input(sij_valid);
+                    params_sf.add_output(pij_f16);
+                    params_sf.add_output(mi);
+                    params_sf.add_output(li);
+                    params_sf.add_scalar(float_to_u64(scale_value));
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf, 5);
+                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -229,13 +226,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     prof_make_count += 1;
                     CYCLE_COUNT_LAP(prof_make_tensor);
 
-                    PTOParam params_pv[] = {
-                        make_input_param(pij_f16),
-                        make_input_param(vj),
-                        make_output_param(oi_tmp),
-                    };
+                    PTOParam params_pv;
+                    params_pv.add_input(pij_f16);
+                    params_pv.add_input(vj);
+                    params_pv.add_output(oi_tmp);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv, 3);
+                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -243,19 +239,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
                     CYCLE_COUNT_LAP(prof_param_extract);
 
-                    PTOParam params_up[] = {
-                        make_input_param(mi),
-                        make_input_param(li),
-                        make_input_param(oi_tmp),
-                        make_inout_param(mi_update),
-                        make_inout_param(li_update),
-                        make_inout_param(oi),
-                        make_output_param(out_view),
-                        make_scalar_param(is_first),
-                        make_scalar_param(is_last),
-                    };
+                    PTOParam params_up;
+                    params_up.add_input(mi);
+                    params_up.add_input(li);
+                    params_up.add_input(oi_tmp);
+                    params_up.add_inout(mi_update);
+                    params_up.add_inout(li_update);
+                    params_up.add_inout(oi);
+                    params_up.add_output(out_view);
+                    params_up.add_scalar(is_first);
+                    params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up, 9);
+                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
                 }

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -200,15 +200,15 @@ static __aicore__ void softmax_prepare_n_impl(
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ TensorData* sij_buf = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* pij_buf = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* mij = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    __gm__ TensorData* lij = reinterpret_cast<__gm__ TensorData*>(args[3]);
     union {
         uint64_t u;
         float f;
     } scale_conv;
-    scale_conv.u = static_cast<uint64_t>(args[1]);
+    scale_conv.u = static_cast<uint64_t>(args[4]);
     float scale_value = scale_conv.f;
-    __gm__ TensorData* pij_buf = reinterpret_cast<__gm__ TensorData*>(args[2]);
-    __gm__ TensorData* mij = reinterpret_cast<__gm__ TensorData*>(args[3]);
-    __gm__ TensorData* lij = reinterpret_cast<__gm__ TensorData*>(args[4]);
     uint64_t n_blocks = static_cast<uint64_t>(args[5]);
     uint64_t valid_len_last = static_cast<uint64_t>(args[6]);
 

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
@@ -41,5 +41,6 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
+    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -127,9 +127,26 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     Tensor out = make_tensor_external(host_out, out_shapes, 2, DataType::FLOAT32);
     CYCLE_COUNT_LAP(prof_ext_tensor);
 
+    // Prefetch first batch's block table data into cache (4 cache lines = 256 bytes)
+    for (int cl = 0; cl < N_UNROLL * (int)sizeof(int); cl += 64) {
+        __builtin_prefetch(reinterpret_cast<char*>(host_block_table) + cl, 0, 3);
+    }
+    __builtin_prefetch(&host_context_lens[0], 0, 3);
+
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
         uint64_t cur_seq = host_context_lens[b_idx];
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
+        // Pre-compute block table base pointer for this batch
+        int* bt_base = host_block_table + b_idx * block_num;
+
+        // Prefetch next batch's block table + context_lens while processing current batch
+        if (b_idx + 1 < batch) {
+            int* bt_next = host_block_table + (b_idx + 1) * block_num;
+            for (int cl = 0; cl < N_UNROLL * (int)sizeof(int); cl += 64) {
+                __builtin_prefetch(reinterpret_cast<char*>(bt_next) + cl, 0, 3);
+            }
+            __builtin_prefetch(&host_context_lens[b_idx + 1], 0, 3);
+        }
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             PTO2_SCOPE(rt) {
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
@@ -153,29 +170,27 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                 prof_view_count += 2;
                 CYCLE_COUNT_LAP(prof_tensor_view);
 
-                PTOParam params_inplace[] = {
-                    make_output_param(oi),
-                    make_output_param(li_update),
-                    make_output_param(mi_update),
-                };
+                PTOParam params_inplace;
+                params_inplace.add_output(oi);
+                params_inplace.add_output(li_update);
+                params_inplace.add_output(mi_update);
                 CYCLE_COUNT_LAP(prof_param_setup);
-                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_inplace, 3);
+                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_inplace);
                 prof_submit_count++;
                 CYCLE_COUNT_LAP(prof_submit_task);
+
+                // Reusable PTOParam objects — reset() before each use avoids
+                // repeated stack-frame construction in the inner loop.
+                // params_qk must persist until params_pv.copy_scalars_from().
+                PTOParam params_qk, params_sf, params_pv, params_up;
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
                     uint64_t n_blocks = std::min((uint64_t)N_UNROLL, bn_this_batch - bn);
 
-                    // Prepare block indices for this group
-                    uint64_t block_indices[N_UNROLL] = {};
-                    for (uint64_t i = 0; i < n_blocks; i++) {
-                        block_indices[i] = host_block_table[b_idx * block_num + bn + i];
-                    }
-                    CYCLE_COUNT_LAP(prof_param_extract);
-
                     // Valid length for last block in this group
                     uint64_t last_block_seq_start = (bn + n_blocks - 1) * block_size;
                     uint64_t valid_len_last = std::min(block_size, cur_seq - last_block_seq_start);
+                    CYCLE_COUNT_LAP(prof_param_extract);
 
                     // === Task 1: Batched QK matmul ===
                     uint32_t sij_buf_shapes[2] = {(uint32_t)q_tile, (uint32_t)(n_blocks * block_size)};
@@ -183,15 +198,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     prof_make_count += 1;
                     CYCLE_COUNT_LAP(prof_make_tensor);
 
-                    PTOParam params_qk[4 + N_UNROLL];
-                    params_qk[0] = make_input_param(qi);
-                    params_qk[1] = make_input_param(key_cache);
-                    params_qk[2] = make_output_param(sij_buf);
-                    params_qk[3] = make_scalar_param(n_blocks);
-                    for (int i = 0; i < N_UNROLL; i++)
-                        params_qk[4 + i] = make_scalar_param(block_indices[i]);
+                    params_qk.reset();
+                    params_qk.add_input(qi);
+                    params_qk.add_input(key_cache);
+                    params_qk.add_output(sij_buf);
+                    params_qk.add_scalar(n_blocks);
+                    params_qk.add_scalars_i32(bt_base + bn, N_UNROLL);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk, 4 + N_UNROLL);
+                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -203,17 +217,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     prof_make_count += 3;
                     CYCLE_COUNT_LAP(prof_make_tensor);
 
-                    PTOParam params_sf[] = {
-                        make_input_param(sij_buf),
-                        make_scalar_param(float_to_u64(scale_value)),
-                        make_output_param(pij_buf),
-                        make_output_param(mi),
-                        make_output_param(li),
-                        make_scalar_param(n_blocks),
-                        make_scalar_param(valid_len_last),
-                    };
+                    params_sf.reset();
+                    params_sf.add_input(sij_buf);
+                    params_sf.add_output(pij_buf);
+                    params_sf.add_output(mi);
+                    params_sf.add_output(li);
+                    params_sf.add_scalar(float_to_u64(scale_value));
+                    params_sf.add_scalar(n_blocks);
+                    params_sf.add_scalar(valid_len_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf, 7);
+                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -223,15 +236,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     prof_make_count += 1;
                     CYCLE_COUNT_LAP(prof_make_tensor);
 
-                    PTOParam params_pv[4 + N_UNROLL];
-                    params_pv[0] = make_input_param(pij_buf);
-                    params_pv[1] = make_input_param(value_cache);
-                    params_pv[2] = make_output_param(oi_new);
-                    params_pv[3] = make_scalar_param(n_blocks);
-                    for (int i = 0; i < N_UNROLL; i++)
-                        params_pv[4 + i] = make_scalar_param(block_indices[i]);
+                    params_pv.reset();
+                    params_pv.add_input(pij_buf);
+                    params_pv.add_input(value_cache);
+                    params_pv.add_output(oi_new);
+                    params_pv.add_scalar(n_blocks);
+                    params_pv.copy_scalars_from(params_qk, 1, N_UNROLL);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv, 4 + N_UNROLL);
+                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -240,19 +252,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     uint64_t is_last = (bn + n_blocks >= bn_this_batch) ? 1 : 0;
                     CYCLE_COUNT_LAP(prof_param_extract);
 
-                    PTOParam params_up[] = {
-                        make_input_param(mi),
-                        make_input_param(li),
-                        make_input_param(oi_new),
-                        make_inout_param(mi_update),
-                        make_inout_param(li_update),
-                        make_inout_param(oi),
-                        make_output_param(out_view),
-                        make_scalar_param(is_first),
-                        make_scalar_param(is_last),
-                    };
+                    params_up.reset();
+                    params_up.add_input(mi);
+                    params_up.add_input(li);
+                    params_up.add_input(oi_new);
+                    params_up.add_inout(mi_update);
+                    params_up.add_inout(li_update);
+                    params_up.add_inout(oi);
+                    params_up.add_output(out_view);
+                    params_up.add_scalar(is_first);
+                    params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up, 9);
+                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
                 }


### PR DESCRIPTION
PTOParam restructured from array-of-structs to struct-of-arrays with separate tensors/scalars arrays and add_input/add_output/add_inout/add_scalar methods. API signatures changed from (PTOParam*, int32_t) to (const PTOParam&). Dispatch order: tensors first, then scalars.

Added __builtin_prefetch in pto2_submit_mixed_task for GM cache line optimization: early write-prefetch of payload after slot allocation, and producer slot_states prefetch after tensormap insert.