### PR TITLE
Optimize paged attention kernel pipeline and eliminate GM round-trips

### DIFF
--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -77,12 +77,13 @@ static __aicore__ void qk_matmul_batch_impl(
         GlobalOut sijGlobal(sij_addr);
 
         TLOAD(aMatTile, qiGlobal);
-        TLOAD(bMatTile, kjGlobal);
-
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
-        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        TLOAD(bMatTile, kjGlobal);
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
 
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
         TMOV(aTile, aMatTile);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
         TMOV(bTile, bMatTile);
 
         set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -8,11 +8,11 @@
 //   Case1: (16, 128) -- q_tile=16, head_dim=128
 //   Case2: (64, 128) -- q_tile=64, head_dim=128
 //
-// Scalar layout strategy (unchanged from unbatched version):
+// Scalar layout strategy:
 //   M scalar floats stored contiguously in GM can be loaded as either:
 //   - ND (kScalarRows, kScalarCols) RowMajor for element-wise ops
 //   - DN (kAlignedRows, 1) ColMajor for row-broadcast ops
-//   Conversion between layouts uses GM round-trip: ND TSTORE -> DN TLOAD.
+//   Conversion between layouts uses TRESHAPE (UB-internal, zero GM access).
 
 #include <cstdint>
 #include <pto/pto-inst.hpp>
@@ -60,7 +60,6 @@ static __aicore__ void online_update_batch_impl(
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
     using GlobalScalarND =
         GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
     using TileScalarND =
@@ -69,7 +68,6 @@ static __aicore__ void online_update_batch_impl(
 
     constexpr int kDataBytes = M * N * sizeof(float);
     constexpr int kScalarNDBytes = kScalarRows * kScalarCols * sizeof(float);
-    constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
 
     TileDataMxN oiNewTile;
     TileDataMxN oiTile;
@@ -89,9 +87,6 @@ static __aicore__ void online_update_batch_impl(
     TASSIGN(alphaND, 2 * kDataBytes + 5 * kScalarNDBytes);
     TASSIGN(betaND, 2 * kDataBytes + 6 * kScalarNDBytes);
     TASSIGN(tmpND, 2 * kDataBytes + 7 * kScalarNDBytes);
-    TASSIGN(alphaDN, 2 * kDataBytes + 8 * kScalarNDBytes);
-    TASSIGN(betaDN, 2 * kDataBytes + 8 * kScalarNDBytes + kScalarDNBytes);
-    TASSIGN(liDN, 2 * kDataBytes + 8 * kScalarNDBytes + 2 * kScalarDNBytes);
 
     for (uint64_t b = 0; b < batch_count; b++) {
         __gm__ float* mij_ptr = mij_base + b * M;
@@ -111,10 +106,6 @@ static __aicore__ void online_update_batch_impl(
         GlobalScalarND miGlobalND(mi_ptr);
         GlobalScalarND liGlobalND(li_ptr);
 
-        GlobalScalarDN mijGlobalDN(mij_ptr);
-        GlobalScalarDN lijGlobalDN(lij_ptr);
-        GlobalScalarDN liGlobalDN(li_ptr);
-
         if (is_first) {
             TLOAD(oiNewTile, oiNewGlobal);
             TLOAD(mijND, mijGlobalND);
@@ -129,11 +120,9 @@ static __aicore__ void online_update_batch_impl(
             TSTORE(oiGlobal, oiNewTile);
 
             if (is_last) {
-                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-                TLOAD(liDN, liGlobalDN);
-                set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-                wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+                TRESHAPE(liDN, lijND);
+                set_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
+                wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
                 TROWEXPANDDIV(oiNewTile, oiNewTile, liDN);
                 set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
                 wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
@@ -165,22 +154,16 @@ static __aicore__ void online_update_batch_impl(
             pipe_barrier(PIPE_V);
             TADD(liND, liND, tmpND);
 
+            TRESHAPE(alphaDN, alphaND);
+            TRESHAPE(betaDN, betaND);
+            if (is_last) {
+                TRESHAPE(liDN, liND);
+            }
+
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             TSTORE(miGlobalND, miNewND);
             TSTORE(liGlobalND, liND);
-            TSTORE(mijGlobalND, alphaND);
-            TSTORE(lijGlobalND, betaND);
-
-            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            TLOAD(alphaDN, mijGlobalDN);
-            TLOAD(betaDN, lijGlobalDN);
-            if (is_last) {
-                TLOAD(liDN, liGlobalDN);
-            }
-            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
 
             TROWEXPANDMUL(oiTile, oiTile, alphaDN);
             TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -134,16 +134,21 @@ static __aicore__ void softmax_prepare_batch_impl(
         TROWEXPANDSUB(pijTile, sijTile, maxTile);
         pipe_barrier(PIPE_V);
         TEXP(pijTile, pijTile);
+        pipe_barrier(PIPE_V);
         // Truncate pij to bf16 first, then compute lij from truncated values (matches golden)
         TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
-        TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
-        TROWSUM(sumTile, pijTile, tmpTile);
-
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        pipe_barrier(PIPE_V);
+        TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
+        pipe_barrier(PIPE_V);
+        TROWSUM(sumTile, pijTile, tmpTile);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(mijGlobal, maxTile);
-        TSTORE(lijGlobal, sumTile);
         TSTORE(pijGlobal, pijBf16Tile);
+        TSTORE(mijGlobal, maxTile);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+        TSTORE(lijGlobal, sumTile);
 
         if (b + 1 < batch_count) {
             pipe_barrier(PIPE_ALL);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -137,17 +137,16 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
                 pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_hub);
 
                 for (uint64_t bn = 0; bn < max_bn; bn++) {
-                    PTO2_SCOPE_GUARD(rt);
+                    PTO2_SCOPE(rt) {
+                        uint32_t sij_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)block_size};
+                        uint32_t vec_shapes[1] = {(uint32_t)(chunk_bc * q_tile)};
+                        uint32_t oi_new_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)head_dim};
 
-                    uint32_t sij_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)block_size};
-                    uint32_t vec_shapes[1] = {(uint32_t)(chunk_bc * q_tile)};
-                    uint32_t oi_new_shapes[2] = {(uint32_t)(chunk_bc * q_tile), (uint32_t)head_dim};
-
-                    Tensor sij_b = make_tensor(sij_shapes, 2, DataType::FLOAT32);
-                    Tensor pij_b = make_tensor(sij_shapes, 2, data_type);
-                    Tensor mij_b = make_tensor(vec_shapes, 1, DataType::FLOAT32);
-                    Tensor lij_b = make_tensor(vec_shapes, 1, DataType::FLOAT32);
-                    Tensor oi_new_b = make_tensor(oi_new_shapes, 2, DataType::FLOAT32);
+                        Tensor sij_b = make_tensor(sij_shapes, 2, DataType::FLOAT32);
+                        Tensor pij_b = make_tensor(sij_shapes, 2, data_type);
+                        Tensor mij_b = make_tensor(vec_shapes, 1, DataType::FLOAT32);
+                        Tensor lij_b = make_tensor(vec_shapes, 1, DataType::FLOAT32);
+                        Tensor oi_new_b = make_tensor(oi_new_shapes, 2, DataType::FLOAT32);
 
                     PTOParam params_qk;
                     params_qk.add_input(query);
@@ -213,4 +212,5 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, i
              (unsigned long)num_chunks, (unsigned long)IN_CORE_BATCH);
 }
 
+}
 }  // extern "C"

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -59,15 +59,17 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
 
-    // Load pij and vj to L1
+    // Load pij and vj to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, pijGlobal);
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
     TLOAD(bMatTile, vjGlobal);
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
 
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
-
-    // Move to L0A/L0B
     TMOV(aTile, aMatTile);
+    // Move B to L0B after B load completes
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
     TMOV(bTile, bMatTile);
 
     set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -60,15 +60,17 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
 
-    // // Load A and B to L1
+    // Load A and B to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, qiGlobal);
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
     TLOAD(bMatTile, kjGlobal);
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
 
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
-
-    // Move from L1 to L0A/L0B
     TMOV(aTile, aMatTile);
+    // Move B to L0B after B load completes
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
     TMOV(bTile, bMatTile);
 
     set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -4,11 +4,11 @@
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
 //
-// Scalar layout strategy:
-//   M scalar floats stored contiguously in GM can be loaded as either:
-//   - ND (kScalarRows, kScalarCols) RowMajor for element-wise ops (TMAX, TSUB, TEXP, TMUL, TADD)
-//   - DN (kAlignedRows, 1) ColMajor for row-broadcast ops (TROWEXPANDMUL, TROWEXPANDDIV)
-//   Conversion between layouts uses GM round-trip: ND TSTORE → DN TLOAD.
+// Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
+//   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
+//   For element-wise ops (TMAX, TSUB, TEXP, etc.), TRESHAPE to RowMajor (1, M).
+//   After arithmetic, TRESHAPE back to ColMajor (M, 1) for row-broadcast ops.
+//   This eliminates the GM round-trip (TSTORE ND → TLOAD DN) used in the original.
 
 #include <cstdint>
 #include <pto/pto-inst.hpp>
@@ -43,11 +43,6 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
     __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
 
-    // Scalar tile dimensions for RowMajor layout:
-    // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
-    // kScalarRows = M / 8 (M=16 → 2 rows, M=64 → 8 rows)
-    constexpr int kScalarCols = 32 / sizeof(float);
-    constexpr int kScalarRows = M / kScalarCols;
     // Aligned rows for ColMajor DN tiles (32-byte alignment)
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -56,12 +51,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     // Data (M, N) RowMajor
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
 
-    // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
+    // Scalar DN: M contiguous floats as (kAlignedRows, 1) ColMajor for TROWEXPAND ops and loading
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+
+    // Scalar ND: for storing mi_new and li_new back to GM
+    constexpr int kScalarCols = 32 / sizeof(float);
+    constexpr int kScalarRows = M / kScalarCols;
     using GlobalScalarND =
         GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
-
-    // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -69,64 +66,69 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     GlobalDataMxN oiGlobal(oi_ptr + oi->start_offset);
     GlobalDataMxN dstGlobal(dst_ptr + dst->start_offset);
 
-    // ND globals for scalar element-wise operations
-    GlobalScalarND mijGlobalND(mij_ptr + mij->start_offset);
-    GlobalScalarND lijGlobalND(lij_ptr + lij->start_offset);
-    GlobalScalarND miGlobalND(mi_ptr + mi->start_offset);
-    GlobalScalarND liGlobalND(li_ptr + li->start_offset);
-
-    // DN globals aliased to same GM for ColMajor reload (used after ND TSTORE)
+    // DN globals for loading scalars as ColMajor
     GlobalScalarDN mijGlobalDN(mij_ptr + mij->start_offset);
     GlobalScalarDN lijGlobalDN(lij_ptr + lij->start_offset);
+    GlobalScalarDN miGlobalDN(mi_ptr + mi->start_offset);
     GlobalScalarDN liGlobalDN(li_ptr + li->start_offset);
+
+    // ND globals for storing scalar results
+    GlobalScalarND miGlobalND(mi_ptr + mi->start_offset);
+    GlobalScalarND liGlobalND(li_ptr + li->start_offset);
 
     // --- Tile types ---
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+
+    // RowMajor (1, M) tiles for element-wise arithmetic via TRESHAPE
+    using TileScalarRow = Tile<TileType::Vec, float, 1, M, BLayout::RowMajor, 1, M>;
+
+    // ND tile for storing back to GM
     using TileScalarND =
         Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
-    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     // --- UB memory layout ---
 
     constexpr int kDataBytes = M * N * sizeof(float);
-    constexpr int kScalarNDBytes = kScalarRows * kScalarCols * sizeof(float);
     constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
 
     // Data tiles
     TileDataMxN oiNewTile;
     TileDataMxN oiTile;
 
-    // Scalar ND tiles for element-wise arithmetic
-    TileScalarND mijND, lijND, miND, liND;
-    TileScalarND miNewND, alphaND, betaND, tmpND;
+    // Scalar DN tiles loaded from GM (ColMajor)
+    TileScalarDN mijDN, lijDN, miDN, liDN;
 
-    // Scalar DN tiles for TROWEXPAND operations
-    TileScalarDN alphaDN, betaDN, liDN;
+    // Temporary DN tiles for results
+    TileScalarDN miNewDN, alphaDN, betaDN, liNewDN, tmpDN;
 
     TASSIGN(oiNewTile, 0);
     TASSIGN(oiTile, kDataBytes);
-    TASSIGN(mijND, 2 * kDataBytes);
-    TASSIGN(lijND, 2 * kDataBytes + kScalarNDBytes);
-    TASSIGN(miND, 2 * kDataBytes + 2 * kScalarNDBytes);
-    TASSIGN(liND, 2 * kDataBytes + 3 * kScalarNDBytes);
-    TASSIGN(miNewND, 2 * kDataBytes + 4 * kScalarNDBytes);
-    TASSIGN(alphaND, 2 * kDataBytes + 5 * kScalarNDBytes);
-    TASSIGN(betaND, 2 * kDataBytes + 6 * kScalarNDBytes);
-    TASSIGN(tmpND, 2 * kDataBytes + 7 * kScalarNDBytes);
-    TASSIGN(alphaDN, 2 * kDataBytes + 8 * kScalarNDBytes);
-    TASSIGN(betaDN, 2 * kDataBytes + 8 * kScalarNDBytes + kScalarDNBytes);
-    TASSIGN(liDN, 2 * kDataBytes + 8 * kScalarNDBytes + 2 * kScalarDNBytes);
+    TASSIGN(mijDN, 2 * kDataBytes);
+    TASSIGN(lijDN, 2 * kDataBytes + kScalarDNBytes);
+    TASSIGN(miDN, 2 * kDataBytes + 2 * kScalarDNBytes);
+    TASSIGN(liDN, 2 * kDataBytes + 3 * kScalarDNBytes);
+    TASSIGN(miNewDN, 2 * kDataBytes + 4 * kScalarDNBytes);
+    TASSIGN(alphaDN, 2 * kDataBytes + 5 * kScalarDNBytes);
+    TASSIGN(betaDN, 2 * kDataBytes + 6 * kScalarDNBytes);
+    TASSIGN(liNewDN, 2 * kDataBytes + 7 * kScalarDNBytes);
+    TASSIGN(tmpDN, 2 * kDataBytes + 8 * kScalarDNBytes);
 
     if (is_first) {
         // --- First block: copy inputs to accumulators ---
         TLOAD(oiNewTile, oiNewGlobal);
-        TLOAD(mijND, mijGlobalND);
-        TLOAD(lijND, lijGlobalND);
+        TLOAD(mijDN, mijGlobalDN);
+        TLOAD(lijDN, lijGlobalDN);
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-        // Passthrough to MTE3 (no V compute needed)
+        // Store mi = mij, li = lij, oi = oi_new
+        // Alias ND tiles to the same UB as DN tiles for storing as ND format
+        TileScalarND mijND, lijND;
+        TASSIGN(mijND, 2 * kDataBytes);           // alias same UB as mijDN
+        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
+
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         TSTORE(miGlobalND, mijND);    // mi = mij
@@ -135,13 +137,10 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
 
         if (is_last) {
             // Single block: normalize dst = oi_new / lij
-            // lij stored to li buffer in ND format; reload as DN for TROWEXPANDDIV
-            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            TLOAD(liDN, liGlobalDN);
-            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-            TROWEXPANDDIV(oiNewTile, oiNewTile, liDN);
+            // lijDN already in ColMajor DN format, use directly for TROWEXPANDDIV
+            set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+            TROWEXPANDDIV(oiNewTile, oiNewTile, lijDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             TSTORE(dstGlobal, oiNewTile);
@@ -149,73 +148,79 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     } else {
         // --- Subsequent blocks: accumulate ---
 
-        // Phase 1: Load all inputs
+        // Load all inputs
         TLOAD(oiNewTile, oiNewGlobal);
         TLOAD(oiTile, oiGlobal);
-        TLOAD(mijND, mijGlobalND);
-        TLOAD(lijND, lijGlobalND);
-        TLOAD(miND, miGlobalND);
-        TLOAD(liND, liGlobalND);
+        TLOAD(mijDN, mijGlobalDN);
+        TLOAD(lijDN, lijGlobalDN);
+        TLOAD(miDN, miGlobalDN);
+        TLOAD(liDN, liGlobalDN);
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-        // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
-        // pipe_barrier(PIPE_V) required between each dependent vector operation
-        // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);  // mi_new = max(mi, mij)
-        pipe_barrier(PIPE_V);
-        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
-        pipe_barrier(PIPE_V);
-        TEXP(alphaND, alphaND);  // alpha = exp(mi - mi_new)
-        pipe_barrier(PIPE_V);
-        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
-        pipe_barrier(PIPE_V);
-        TEXP(betaND, betaND);  // beta = exp(mij - mi_new)
-        pipe_barrier(PIPE_V);
-        TMUL(liND, alphaND, liND);  // li = alpha * li
-        pipe_barrier(PIPE_V);
-        TMUL(tmpND, betaND, lijND);  // tmp = beta * lij
-        pipe_barrier(PIPE_V);
-        TADD(liND, liND, tmpND);  // li = alpha * li + beta * lij (= li_new)
+        // TRESHAPE: ColMajor(M,1) → RowMajor(1,M) for element-wise arithmetic
+        TileScalarRow miRow, mijRow, liRow, lijRow;
+        TRESHAPE(miRow, miDN);
+        TRESHAPE(mijRow, mijDN);
+        TRESHAPE(liRow, liDN);
+        TRESHAPE(lijRow, lijDN);
 
-        // Phase 3: Store scalar results to GM (ND format)
-        // mi_new → mi accumulator, li_new → li accumulator
-        // alpha → mij buffer (reuse), beta → lij buffer (reuse)
-        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, miNewND);   // persist mi_new
-        TSTORE(liGlobalND, liND);      // persist li_new
-        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
-        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
+        // Scalar arithmetic in RowMajor (1, M) layout
+        TileScalarRow miNewRow, alphaRow, betaRow, liNewRow, tmpRow;
+        TASSIGN(miNewRow, 2 * kDataBytes + 4 * kScalarDNBytes);
+        TASSIGN(alphaRow, 2 * kDataBytes + 5 * kScalarDNBytes);
+        TASSIGN(betaRow, 2 * kDataBytes + 6 * kScalarDNBytes);
+        TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
+        TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
-        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
-        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
-        if (is_last) {
-            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
-        }
-        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        pipe_barrier(PIPE_V);
+        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        pipe_barrier(PIPE_V);
+        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        pipe_barrier(PIPE_V);
+        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        pipe_barrier(PIPE_V);
+        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        pipe_barrier(PIPE_V);
+        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        pipe_barrier(PIPE_V);
+        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        pipe_barrier(PIPE_V);
+        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
 
-        // Phase 5: Scale data tiles using row-broadcast multiply
+        // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
+        TRESHAPE(alphaDN, alphaRow);
+        TRESHAPE(betaDN, betaRow);
+
+        // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+
+        // Store mi_new and li_new to GM (ND format)
+        // Alias ND tiles to the same UB locations as miNewRow and liNewRow
+        TileScalarND miNewND, liNewND;
+        TASSIGN(miNewND, 2 * kDataBytes + 4 * kScalarDNBytes);
+        TASSIGN(liNewND, 2 * kDataBytes + 7 * kScalarDNBytes);
 
         if (is_last) {
-            // Phase 6: Normalize and output
+            // Normalize and output: dst = oi / li_new
+            TRESHAPE(liNewDN, liNewRow);
             pipe_barrier(PIPE_V);
-            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
-            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TROWEXPANDDIV(oiTile, oiTile, liNewDN);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(miGlobalND, miNewND);   // persist mi_new
+            TSTORE(liGlobalND, liNewND);   // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
-            // Phase 6: Store updated accumulators
-            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            // Store updated accumulators
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(miGlobalND, miNewND);   // persist mi_new
+            TSTORE(liGlobalND, liNewND);   // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -99,16 +99,26 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     TROWEXPANDSUB(pijTile, sijTile, maxTile);
     pipe_barrier(PIPE_V);
     TEXP(pijTile, pijTile);
-    // Truncate pij to bf16 first, then compute lij from truncated values (matches golden)
+    // Truncate pij to bf16 first
+    pipe_barrier(PIPE_V);
     TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
-    TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
-    TROWSUM(sumTile, pijTile, tmpTile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);        // pij bf16 ready, can store early
 
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    // Continue computing: bf16 → f32 and rowsum while pij store proceeds in parallel
+    pipe_barrier(PIPE_V);
+    TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
+    pipe_barrier(PIPE_V);
+    TROWSUM(sumTile, pijTile, tmpTile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);        // sum ready
+
+    // Store pij (overlaps with TCVT + TROWSUM above)
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-    TSTORE(mijGlobal, maxTile);
-    TSTORE(lijGlobal, sumTile);
     TSTORE(pijGlobal, pijBf16Tile);
+
+    // Store max and sum
+    TSTORE(mijGlobal, maxTile);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+    TSTORE(lijGlobal, sumTile);
 
     set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -8,6 +8,10 @@
 // Per-block vj addresses: value_cache base + block_indices lookup
 // Single output: oi_new (M, N) fp32 = sum of P_i @ V_i across all blocks
 //
+// Optimizations:
+//   - Double-buffered L1 tiles (ping/pong for A and B)
+//   - TLOAD(next pij+vj) overlaps with TMATMUL_ACC(current) via MTE2/PIPE_M parallelism
+//
 // Supports two tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
@@ -51,10 +55,13 @@ static __aicore__ void pv_matmul_n_impl(
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
     using AccTile = TileAcc<float, M, N, M, N>;
 
-    TileMatA aMatTile;
-    TileMatB bMatTile;
-    TASSIGN(aMatTile, 0x0);
-    TASSIGN(bMatTile, 0x20000);
+    // Double-buffered L1 tiles (ping/pong)
+    TileMatA aMatTile_ping, aMatTile_pong;
+    TileMatB bMatTile_ping, bMatTile_pong;
+    TASSIGN(aMatTile_ping, 0x0);
+    TASSIGN(aMatTile_pong, 0x10000);
+    TASSIGN(bMatTile_ping, 0x20000);
+    TASSIGN(bMatTile_pong, 0x30000);
 
     LeftTile aTile;
     RightTile bTile;
@@ -65,18 +72,28 @@ static __aicore__ void pv_matmul_n_impl(
 
     GlobalOut oiGlobal(oi_base);
 
+    // Pre-load first iteration's tiles into ping buffers
+    GlobalA pijGlobal_0(pij_base);
+    GlobalB vjGlobal_0(val_base + block_indices[0] * K * N);
+    TLOAD(aMatTile_ping, pijGlobal_0);
+    TLOAD(bMatTile_ping, vjGlobal_0);
+
     for (uint64_t i = 0; i < n_blocks; i++) {
-        GlobalA pijGlobal(pij_base + i * M * K);
-        GlobalB vjGlobal(val_base + block_indices[i] * K * N);
+        // Select current buffers based on iteration parity
+        TileMatA& curA = (i % 2 == 0) ? aMatTile_ping : aMatTile_pong;
+        TileMatB& curB = (i % 2 == 0) ? bMatTile_ping : bMatTile_pong;
 
-        TLOAD(aMatTile, pijGlobal);
-        TLOAD(bMatTile, vjGlobal);
-
+        // Wait for current TLOAD to complete
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
 
-        TMOV(aTile, aMatTile);
-        TMOV(bTile, bMatTile);
+        // Wait for previous matmul to complete (L0A/L0B safe to overwrite)
+        if (i > 0) {
+            wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
+        }
+
+        TMOV(aTile, curA);
+        TMOV(bTile, curB);
 
         set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
         wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
@@ -87,8 +104,17 @@ static __aicore__ void pv_matmul_n_impl(
             TMATMUL_ACC(cTile, cTile, aTile, bTile);
         }
 
-        set_flag(PIPE_M, PIPE_MTE2, EVENT_ID0);
-        wait_flag(PIPE_M, PIPE_MTE2, EVENT_ID0);
+        // Prefetch next iteration's data (MTE2 overlaps with matmul completion)
+        if (i + 1 < n_blocks) {
+            // Signal matmul completion for next iteration's TMOV guard
+            set_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
+            TileMatA& nxtA = (i % 2 == 0) ? aMatTile_pong : aMatTile_ping;
+            TileMatB& nxtB = (i % 2 == 0) ? bMatTile_pong : bMatTile_ping;
+            GlobalA pijGlobal_next(pij_base + (i + 1) * M * K);
+            GlobalB vjGlobal_next(val_base + block_indices[i + 1] * K * N);
+            TLOAD(nxtA, pijGlobal_next);
+            TLOAD(nxtB, vjGlobal_next);
+        }
     }
 
     set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -7,6 +7,9 @@
 // Output layout: n_blocks contiguous (M, N) tiles stacked vertically.
 // Block i occupies sij[i*M : (i+1)*M, 0:N].
 //
+// Optimizations:
+//   - qi TLOAD hoisted before the loop (constant across all iterations)
+//
 // Supports two tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
@@ -61,17 +64,21 @@ static __aicore__ void qk_matmul_n_impl(
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
 
+    // Hoist qi TLOAD before the loop (qi is constant across all blocks)
+    GlobalA qiGlobal(qi_base);
+    TLOAD(aMatTile, qiGlobal);
+
     for (uint64_t i = 0; i < n_blocks; i++) {
-        GlobalA qiGlobal(qi_base);
         GlobalB kjGlobal(key_base + block_indices[i] * N * K);
         GlobalOut sijGlobal(sij_base + i * M * N);
 
-        TLOAD(aMatTile, qiGlobal);
+        // Load only B each iteration (qi already in L1 from hoist)
         TLOAD(bMatTile, kjGlobal);
 
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
 
+        // TMOV qi from L1→L0A (re-copy since TMATMUL consumed L0A) and kj from L1→L0B
         TMOV(aTile, aMatTile);
         TMOV(bTile, bMatTile);
 

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -4,11 +4,11 @@
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
 //
-// Scalar layout strategy:
-//   M scalar floats stored contiguously in GM can be loaded as either:
-//   - ND (kScalarRows, kScalarCols) RowMajor for element-wise ops (TMAX, TSUB, TEXP, TMUL, TADD)
-//   - DN (kAlignedRows, 1) ColMajor for row-broadcast ops (TROWEXPANDMUL, TROWEXPANDDIV)
-//   Conversion between layouts uses GM round-trip: ND TSTORE → DN TLOAD.
+// Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
+//   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
+//   For element-wise ops (TMAX, TSUB, TEXP, etc.), TRESHAPE to RowMajor (1, M).
+//   After arithmetic, TRESHAPE back to ColMajor (M, 1) for row-broadcast ops.
+//   This eliminates the GM round-trip (TSTORE ND → TLOAD DN) used in the original.
 
 #include <cstdint>
 #include <pto/pto-inst.hpp>
@@ -43,11 +43,6 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
     __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
     __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
 
-    // Scalar tile dimensions for RowMajor layout:
-    // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
-    // kScalarRows = M / 8 (M=16 → 2 rows, M=64 → 8 rows)
-    constexpr int kScalarCols = 32 / sizeof(float);
-    constexpr int kScalarRows = M / kScalarCols;
     // Aligned rows for ColMajor DN tiles (32-byte alignment)
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -56,12 +51,14 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
     // Data (M, N) RowMajor
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
 
-    // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
+    // Scalar DN: M contiguous floats as (kAlignedRows, 1) ColMajor for TROWEXPAND ops and loading
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
+
+    // Scalar ND: for storing mi_new and li_new back to GM
+    constexpr int kScalarCols = 32 / sizeof(float);
+    constexpr int kScalarRows = M / kScalarCols;
     using GlobalScalarND =
         GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
-
-    // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -69,64 +66,69 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
     GlobalDataMxN oiGlobal(oi_ptr + oi->start_offset);
     GlobalDataMxN dstGlobal(dst_ptr + dst->start_offset);
 
-    // ND globals for scalar element-wise operations
-    GlobalScalarND mijGlobalND(mij_ptr + mij->start_offset);
-    GlobalScalarND lijGlobalND(lij_ptr + lij->start_offset);
-    GlobalScalarND miGlobalND(mi_ptr + mi->start_offset);
-    GlobalScalarND liGlobalND(li_ptr + li->start_offset);
-
-    // DN globals aliased to same GM for ColMajor reload (used after ND TSTORE)
+    // DN globals for loading scalars as ColMajor
     GlobalScalarDN mijGlobalDN(mij_ptr + mij->start_offset);
     GlobalScalarDN lijGlobalDN(lij_ptr + lij->start_offset);
+    GlobalScalarDN miGlobalDN(mi_ptr + mi->start_offset);
     GlobalScalarDN liGlobalDN(li_ptr + li->start_offset);
+
+    // ND globals for storing scalar results
+    GlobalScalarND miGlobalND(mi_ptr + mi->start_offset);
+    GlobalScalarND liGlobalND(li_ptr + li->start_offset);
 
     // --- Tile types ---
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+
+    // RowMajor (1, M) tiles for element-wise arithmetic via TRESHAPE
+    using TileScalarRow = Tile<TileType::Vec, float, 1, M, BLayout::RowMajor, 1, M>;
+
+    // ND tile for storing back to GM
     using TileScalarND =
         Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
-    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     // --- UB memory layout ---
 
     constexpr int kDataBytes = M * N * sizeof(float);
-    constexpr int kScalarNDBytes = kScalarRows * kScalarCols * sizeof(float);
     constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
 
     // Data tiles
     TileDataMxN oiNewTile;
     TileDataMxN oiTile;
 
-    // Scalar ND tiles for element-wise arithmetic
-    TileScalarND mijND, lijND, miND, liND;
-    TileScalarND miNewND, alphaND, betaND, tmpND;
+    // Scalar DN tiles loaded from GM (ColMajor)
+    TileScalarDN mijDN, lijDN, miDN, liDN;
 
-    // Scalar DN tiles for TROWEXPAND operations
-    TileScalarDN alphaDN, betaDN, liDN;
+    // Temporary DN tiles for results
+    TileScalarDN miNewDN, alphaDN, betaDN, liNewDN, tmpDN;
 
     TASSIGN(oiNewTile, 0);
     TASSIGN(oiTile, kDataBytes);
-    TASSIGN(mijND, 2 * kDataBytes);
-    TASSIGN(lijND, 2 * kDataBytes + kScalarNDBytes);
-    TASSIGN(miND, 2 * kDataBytes + 2 * kScalarNDBytes);
-    TASSIGN(liND, 2 * kDataBytes + 3 * kScalarNDBytes);
-    TASSIGN(miNewND, 2 * kDataBytes + 4 * kScalarNDBytes);
-    TASSIGN(alphaND, 2 * kDataBytes + 5 * kScalarNDBytes);
-    TASSIGN(betaND, 2 * kDataBytes + 6 * kScalarNDBytes);
-    TASSIGN(tmpND, 2 * kDataBytes + 7 * kScalarNDBytes);
-    TASSIGN(alphaDN, 2 * kDataBytes + 8 * kScalarNDBytes);
-    TASSIGN(betaDN, 2 * kDataBytes + 8 * kScalarNDBytes + kScalarDNBytes);
-    TASSIGN(liDN, 2 * kDataBytes + 8 * kScalarNDBytes + 2 * kScalarDNBytes);
+    TASSIGN(mijDN, 2 * kDataBytes);
+    TASSIGN(lijDN, 2 * kDataBytes + kScalarDNBytes);
+    TASSIGN(miDN, 2 * kDataBytes + 2 * kScalarDNBytes);
+    TASSIGN(liDN, 2 * kDataBytes + 3 * kScalarDNBytes);
+    TASSIGN(miNewDN, 2 * kDataBytes + 4 * kScalarDNBytes);
+    TASSIGN(alphaDN, 2 * kDataBytes + 5 * kScalarDNBytes);
+    TASSIGN(betaDN, 2 * kDataBytes + 6 * kScalarDNBytes);
+    TASSIGN(liNewDN, 2 * kDataBytes + 7 * kScalarDNBytes);
+    TASSIGN(tmpDN, 2 * kDataBytes + 8 * kScalarDNBytes);
 
     if (is_first) {
         // --- First block: copy inputs to accumulators ---
         TLOAD(oiNewTile, oiNewGlobal);
-        TLOAD(mijND, mijGlobalND);
-        TLOAD(lijND, lijGlobalND);
+        TLOAD(mijDN, mijGlobalDN);
+        TLOAD(lijDN, lijGlobalDN);
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-        // Passthrough to MTE3 (no V compute needed)
+        // Store mi = mij, li = lij, oi = oi_new
+        // Alias ND tiles to same UB as DN tiles for ND-format store
+        TileScalarND mijND, lijND;
+        TASSIGN(mijND, 2 * kDataBytes);                    // alias same UB as mijDN
+        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);   // alias same UB as lijDN
+
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         TSTORE(miGlobalND, mijND);    // mi = mij
@@ -135,13 +137,10 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
 
         if (is_last) {
             // Single block: normalize dst = oi_new / lij
-            // lij stored to li buffer in ND format; reload as DN for TROWEXPANDDIV
-            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            TLOAD(liDN, liGlobalDN);
-            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-            TROWEXPANDDIV(oiNewTile, oiNewTile, liDN);
+            // lijDN already in ColMajor DN format, use directly for TROWEXPANDDIV
+            set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+            TROWEXPANDDIV(oiNewTile, oiNewTile, lijDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             TSTORE(dstGlobal, oiNewTile);
@@ -149,73 +148,79 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
     } else {
         // --- Subsequent blocks: accumulate ---
 
-        // Phase 1: Load all inputs
+        // Load all inputs as DN (ColMajor)
         TLOAD(oiNewTile, oiNewGlobal);
         TLOAD(oiTile, oiGlobal);
-        TLOAD(mijND, mijGlobalND);
-        TLOAD(lijND, lijGlobalND);
-        TLOAD(miND, miGlobalND);
-        TLOAD(liND, liGlobalND);
+        TLOAD(mijDN, mijGlobalDN);
+        TLOAD(lijDN, lijGlobalDN);
+        TLOAD(miDN, miGlobalDN);
+        TLOAD(liDN, liGlobalDN);
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-        // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
-        // pipe_barrier(PIPE_V) required between each dependent vector operation
-        // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);  // mi_new = max(mi, mij)
-        pipe_barrier(PIPE_V);
-        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
-        pipe_barrier(PIPE_V);
-        TEXP(alphaND, alphaND);  // alpha = exp(mi - mi_new)
-        pipe_barrier(PIPE_V);
-        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
-        pipe_barrier(PIPE_V);
-        TEXP(betaND, betaND);  // beta = exp(mij - mi_new)
-        pipe_barrier(PIPE_V);
-        TMUL(liND, alphaND, liND);  // li = alpha * li
-        pipe_barrier(PIPE_V);
-        TMUL(tmpND, betaND, lijND);  // tmp = beta * lij
-        pipe_barrier(PIPE_V);
-        TADD(liND, liND, tmpND);  // li = alpha * li + beta * lij (= li_new)
+        // TRESHAPE: ColMajor(M,1) → RowMajor(1,M) for element-wise arithmetic
+        TileScalarRow miRow, mijRow, liRow, lijRow;
+        TRESHAPE(miRow, miDN);
+        TRESHAPE(mijRow, mijDN);
+        TRESHAPE(liRow, liDN);
+        TRESHAPE(lijRow, lijDN);
 
-        // Phase 3: Store scalar results to GM (ND format)
-        // mi_new → mi accumulator, li_new → li accumulator
-        // alpha → mij buffer (reuse), beta → lij buffer (reuse)
-        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, miNewND);   // persist mi_new
-        TSTORE(liGlobalND, liND);      // persist li_new
-        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
-        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
+        // Scalar arithmetic in RowMajor (1, M) layout
+        TileScalarRow miNewRow, alphaRow, betaRow, liNewRow, tmpRow;
+        TASSIGN(miNewRow, 2 * kDataBytes + 4 * kScalarDNBytes);
+        TASSIGN(alphaRow, 2 * kDataBytes + 5 * kScalarDNBytes);
+        TASSIGN(betaRow, 2 * kDataBytes + 6 * kScalarDNBytes);
+        TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
+        TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
-        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
-        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
-        if (is_last) {
-            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
-        }
-        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        pipe_barrier(PIPE_V);
+        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        pipe_barrier(PIPE_V);
+        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        pipe_barrier(PIPE_V);
+        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        pipe_barrier(PIPE_V);
+        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        pipe_barrier(PIPE_V);
+        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        pipe_barrier(PIPE_V);
+        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        pipe_barrier(PIPE_V);
+        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
 
-        // Phase 5: Scale data tiles using row-broadcast multiply
+        // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
+        TRESHAPE(alphaDN, alphaRow);
+        TRESHAPE(betaDN, betaRow);
+
+        // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+
+        // Store mi_new and li_new to GM (ND format)
+        // Alias ND tiles to the same UB locations as miNewRow and liNewRow
+        TileScalarND miNewND, liNewND;
+        TASSIGN(miNewND, 2 * kDataBytes + 4 * kScalarDNBytes);
+        TASSIGN(liNewND, 2 * kDataBytes + 7 * kScalarDNBytes);
 
         if (is_last) {
-            // Phase 6: Normalize and output
+            // Normalize and output: dst = oi / li_new
+            TRESHAPE(liNewDN, liNewRow);
             pipe_barrier(PIPE_V);
-            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
-            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TROWEXPANDDIV(oiTile, oiTile, liNewDN);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(miGlobalND, miNewND);   // persist mi_new
+            TSTORE(liGlobalND, liNewND);   // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
-            // Phase 6: Store updated accumulators
-            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            // Store updated accumulators
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(miGlobalND, miNewND);   // persist mi_new
+            TSTORE(liGlobalND, liNewND);   // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -7,8 +7,11 @@
 //
 // Pass 1: Iterate over n_blocks tiles, apply scale, mask last block,
 //         find global m = max over all blocks of rowmax(S_i * scale)
+//         Uses TRESHAPE for DN↔Row conversion to keep globalMax in UB
+//         (eliminates 63 × 4 GM round-trip operations).
 // Pass 2: Iterate again, compute P_i = exp(S_i * scale - m) -> bf16,
 //         accumulate l = sum over all blocks of rowsum(P_i)
+//         Uses double-buffered sij tiles to overlap TLOAD with computation.
 //
 // Two-pass ensures all P_i tiles share the same scale (global max),
 // enabling direct TMATMUL_ACC accumulation in the PV kernel.
@@ -61,110 +64,128 @@ static __aicore__ void softmax_prepare_n_impl(
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
     using TileScalarND =
         Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
+    // RowMajor (1, M) tile for element-wise arithmetic via TRESHAPE
+    using TileScalarRow = Tile<TileType::Vec, float, 1, M, BLayout::RowMajor, 1, M>;
 
-    // --- UB memory layout ---
+    // --- UB memory layout (double-buffered sij) ---
     constexpr int kDataBytes = M * N * sizeof(float);
     constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
-    constexpr int kScalarNDBytes = kScalarRows * kScalarCols * sizeof(float);
 
-    TileVecMxN sijTile;
-    TileSijPad sijPadTile;
+    // Double-buffered sij tiles
+    TileVecMxN sijTile_A;
+    TileSijPad sijPadTile_A;
+    TileVecMxN sijTile_B;
+    TileSijPad sijPadTile_B;
     TileVecMxN pijTile;
     TileVecMxN tmpTile;
     TileVecMxN sumAccTile;
     TileScalarDN localMaxDN;
     TileScalarDN globalMaxDN;
-    TileScalarND maxND_a;
-    TileScalarND maxND_b;
     TileScalarDN sumDN;
     TileVecMxN_bf16 pijBf16Tile;
 
-    TASSIGN(sijTile, 0x0);
-    TASSIGN(sijPadTile, 0x0);
-    TASSIGN(pijTile, kDataBytes);
-    TASSIGN(tmpTile, 2 * kDataBytes);
-    TASSIGN(sumAccTile, 3 * kDataBytes);
-    int scalarBase = 4 * kDataBytes;
-    TASSIGN(localMaxDN, scalarBase);
-    TASSIGN(globalMaxDN, scalarBase + kScalarDNBytes);
-    TASSIGN(maxND_a, scalarBase + 2 * kScalarDNBytes);
-    TASSIGN(maxND_b, scalarBase + 2 * kScalarDNBytes + kScalarNDBytes);
-    TASSIGN(sumDN, scalarBase + 2 * kScalarDNBytes + 2 * kScalarNDBytes);
-    TASSIGN(pijBf16Tile, scalarBase + 2 * kScalarDNBytes + 2 * kScalarNDBytes + kScalarDNBytes);
+    // TRESHAPE aliases (same UB address as their DN counterparts)
+    TileScalarRow localMaxRow;
+    TileScalarRow globalMaxRow;
 
-    // GM scratch aliases (mij/lij output buffers double as scratch)
+    // ND alias for storing globalMax to GM
+    TileScalarND globalMaxND;
+
+    TASSIGN(sijTile_A, 0x0);
+    TASSIGN(sijPadTile_A, 0x0);
+    TASSIGN(sijTile_B, kDataBytes);
+    TASSIGN(sijPadTile_B, kDataBytes);
+    TASSIGN(pijTile, 2 * kDataBytes);
+    TASSIGN(tmpTile, 3 * kDataBytes);
+    TASSIGN(sumAccTile, 4 * kDataBytes);
+    int scalarBase = 5 * kDataBytes;
+    TASSIGN(localMaxDN, scalarBase);
+    TASSIGN(localMaxRow, scalarBase);                     // alias: same UB as localMaxDN
+    TASSIGN(globalMaxDN, scalarBase + kScalarDNBytes);
+    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);    // alias: same UB as globalMaxDN
+    TASSIGN(sumDN, scalarBase + 2 * kScalarDNBytes);
+    TASSIGN(pijBf16Tile, scalarBase + 3 * kScalarDNBytes);
+
+    // GM aliases (mij/lij output buffers)
     GlobalScalarND mijGlobalND(mij_addr);
-    GlobalScalarDN mijGlobalDN(mij_addr);
-    GlobalScalarND lijGlobalND(lij_addr);
     GlobalScalarDN lijGlobalDN(lij_addr);
 
-    // ======== Pass 1: Find global row max ========
+    // ======== Pass 1: Find global row max via TRESHAPE (no GM round-trip) ========
     for (uint64_t i = 0; i < n_blocks; i++) {
         GlobalDataMxN sijGlobal(sij_base + i * M * N);
-        TLOAD(sijTile, sijGlobal);
+        TLOAD(sijTile_A, sijGlobal);
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
         if (i == n_blocks - 1 && valid_len_last < static_cast<uint64_t>(N)) {
             TileSijDyn sijDynTile(static_cast<size_t>(valid_len_last));
             TASSIGN(sijDynTile, 0x0);
-            TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+            TFILLPAD_INPLACE(sijPadTile_A, sijDynTile);
         }
 
-        TMULS(sijTile, sijTile, scale_value);
+        TMULS(sijTile_A, sijTile_A, scale_value);
         pipe_barrier(PIPE_V);
-        TROWMAX(localMaxDN, sijTile, tmpTile);
+        TROWMAX(localMaxDN, sijTile_A, tmpTile);
 
+        // TRESHAPE: ColMajor(M,1) → RowMajor(1,M) for element-wise TMAX
+        TRESHAPE(localMaxRow, localMaxDN);
         if (i == 0) {
-            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(mijGlobalDN, localMaxDN);
+            pipe_barrier(PIPE_V);
+            TMAX(globalMaxRow, localMaxRow, localMaxRow);
         } else {
-            // Store local max to lij buffer (scratch) as DN, reload as ND for TMAX
-            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(lijGlobalDN, localMaxDN);
-
-            // Reload both as ND for TMAX
-            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            TLOAD(maxND_a, mijGlobalND);
-            TLOAD(maxND_b, lijGlobalND);
-
-            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            TMAX(maxND_a, maxND_a, maxND_b);
-
-            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(mijGlobalND, maxND_a);
+            pipe_barrier(PIPE_V);
+            TMAX(globalMaxRow, globalMaxRow, localMaxRow);
         }
     }
 
-    // ======== Pass 2: Compute softmax with global max ========
+    // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for Pass 2's TROWEXPANDSUB
+    TRESHAPE(globalMaxDN, globalMaxRow);
+
+    // Store final global max to mij for online_update to consume
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(mijGlobalND, globalMaxND);
+
+    // ======== Pass 2: Compute softmax with double-buffered sij ========
+    // globalMaxDN is already in UB from TRESHAPE — no reload needed.
+    // Sync MTE3→MTE2 to ensure the mij TSTORE completed before first sij TLOAD.
     set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
     wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-    TLOAD(globalMaxDN, mijGlobalDN);
-    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    // Pre-load first sij tile into buffer A
+    GlobalDataMxN sijGlobal_0(sij_base);
+    TLOAD(sijTile_A, sijGlobal_0);
 
     for (uint64_t i = 0; i < n_blocks; i++) {
-        GlobalDataMxN sijGlobal(sij_base + i * M * N);
         GlobalDataMxN_bf16 pijGlobal(pij_base + i * M * N);
 
-        TLOAD(sijTile, sijGlobal);
+        // Wait for current tile's TLOAD to complete
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
+        // TFILLPAD on current buffer if last block with partial valid length
         if (i == n_blocks - 1 && valid_len_last < static_cast<uint64_t>(N)) {
-            TileSijDyn sijDynTile(static_cast<size_t>(valid_len_last));
-            TASSIGN(sijDynTile, 0x0);
-            TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+            TileSijDyn curSijDyn(static_cast<size_t>(valid_len_last));
+            if (i % 2 == 0) {
+                TASSIGN(curSijDyn, 0x0);
+                TFILLPAD_INPLACE(sijPadTile_A, curSijDyn);
+            } else {
+                TASSIGN(curSijDyn, static_cast<int>(kDataBytes));
+                TFILLPAD_INPLACE(sijPadTile_B, curSijDyn);
+            }
         }
 
-        TMULS(sijTile, sijTile, scale_value);
-        pipe_barrier(PIPE_V);
-        TROWEXPANDSUB(pijTile, sijTile, globalMaxDN);
+        // Compute on current buffer (select A or B based on iteration parity)
+        if (i % 2 == 0) {
+            TMULS(sijTile_A, sijTile_A, scale_value);
+            pipe_barrier(PIPE_V);
+            TROWEXPANDSUB(pijTile, sijTile_A, globalMaxDN);
+        } else {
+            TMULS(sijTile_B, sijTile_B, scale_value);
+            pipe_barrier(PIPE_V);
+            TROWEXPANDSUB(pijTile, sijTile_B, globalMaxDN);
+        }
         pipe_barrier(PIPE_V);
         TEXP(pijTile, pijTile);
         TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
@@ -176,13 +197,21 @@ static __aicore__ void softmax_prepare_n_impl(
             TADD(sumAccTile, sumAccTile, pijTile);
         }
 
+        // Store pij (must complete before next iteration's TCVT overwrites pijBf16Tile)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         TSTORE(pijGlobal, pijBf16Tile);
 
+        // Prefetch next sij into alternate buffer (after TSTORE to avoid UB race)
         if (i + 1 < n_blocks) {
             set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
             wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            GlobalDataMxN sijGlobal_next(sij_base + (i + 1) * M * N);
+            if (i % 2 == 0) {
+                TLOAD(sijTile_B, sijGlobal_next);
+            } else {
+                TLOAD(sijTile_A, sijGlobal_next);
+            }
         }
     }
 
@@ -190,9 +219,7 @@ static __aicore__ void softmax_prepare_n_impl(
     pipe_barrier(PIPE_V);
     TROWSUM(sumDN, sumAccTile, tmpTile);
 
-    // Store mij (global max) and lij (total sum)
-    // mij already contains the correct global max from Pass 1.
-    // Reload and store as DN to ensure consistent format for online_update.
+    // Store lij (total sum). mij already stored after Pass 1.
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(lijGlobalDN, sumDN);


### PR DESCRIPTION
## Summary

- **Eliminate GM round-trips in online_update via TRESHAPE**: Replace the
  costly `TSTORE ND → TLOAD DN` global-memory round-trip pattern with
  UB-internal `TRESHAPE` for scalar layout conversion between RowMajor
  and ColMajor. Primary scalar tiles are now loaded as DN ColMajor and
  reshaped to RowMajor(1, M) for element-wise arithmetic, then reshaped
  back for TROWEXPAND ops — all without touching GM.

- **Improve MTE2→MTE1 pipeline overlap in AIC matmul kernels**: Split
  the single shared `set_flag`/`wait_flag` pair for dual TLOADs (A and B
  matrices) into two separate event IDs (EVENT_ID0/EVENT_ID1). This
  allows `TMOV` of matrix A into L0A to proceed as soon as A's load
  completes, overlapping with B's ongoing MTE2 transfer.

- **Fix RAW hazards and improve store overlap in softmax_prepare**: Insert
  `pipe_barrier(PIPE_V)` between dependent vector operations (TEXP→TCVT,
  TCVT→TROWSUM) to resolve read-after-write hazards. Use separate event
  IDs to overlap `TSTORE` of pij (bf16) with subsequent TCVT and TROWSUM
  computation.

- **Add double-buffering in paged_attention_unroll pv_matmul**: Introduce
  ping-pong tile buffers to prefetch next iteration's A/B matrices during
  the current matmul, hiding MTE2 load latency behind computation.

- **Migrate batch orchestrator to PTO2_SCOPE block syntax**: Replace
  `PTO2_SCOPE_GUARD` with `PTO2_SCOPE(rt) { ... }` in the batch paged
  attention orchestrator inner loop.

## Changed files

| Directory | Kernel | Change |
|-----------|--------|--------|
| `paged_attention/` | `aic_qk_matmul`, `aic_pv_matmul` | Dual-event MTE2→MTE1 overlap |
| `paged_attention/` | `aiv_online_update` | TRESHAPE replaces GM round-trip |
| `paged_attention/` | `aiv_softmax_prepare` | RAW barrier + store overlap |
| `paged_attention_unroll/` | `aic_qk_matmul` | Dual-event MTE2→MTE1 overlap |
| `paged_attention_unroll/` | `aic_pv_matmul` | Ping-pong double buffering |
| `paged_attention_unroll/` | `aiv_online_update` | TRESHAPE replaces GM round-trip |
| `paged_attention_unroll/` | `aiv_softmax_prepare` | RAW barrier + store overlap |
| `batch_paged_attention/` | `aic_qk_matmul` | Dual-event MTE2→MTE1 overlap |
| `batch_paged_attention/` | `aiv_online_update` | TRESHAPE replaces GM round-trip |
| `batch_paged_attention/` | `aiv_softmax_prepare` | RAW barrier + store overlap |
| `batch_paged_attention/` | `paged_attention_orch` | PTO2_SCOPE_GUARD → PTO2_SCOPE |