### PR TITLE
Support: unify profiling log format and add missing timestamps

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -294,6 +294,9 @@ struct AicpuExecutor {
         uint64_t& sched_complete_perf_cycle
 #endif
     ) {
+#if !PTO2_PROFILING
+        (void)hank;
+#endif
         for (int32_t i = ct.running_count - 1; i >= 0; i--) {
             int32_t core_id = ct.running[i];
             uint64_t reg_addr = core_id_to_reg_addr_[core_id];
@@ -504,6 +507,9 @@ struct AicpuExecutor {
         int32_t thread_idx
 #endif
     ) {
+#if !PTO2_PROFILING
+        (void)runtime;
+#endif
         PTO2DispatchPayload& payload = s_pto2_payload_per_core[core_id];
         PTO2TaskDescriptor& task = *slot_state.task;
         int32_t slot_idx = static_cast<int32_t>(subslot);
@@ -986,6 +992,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
     bool cores_released = false;
 
+#if PTO2_PROFILING
+    // Benchmark: scheduler lifetime start timestamp (independent of enable_profiling)
+    DEV_ALWAYS("Thread %d: sched_start=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+#endif
+
     while (true) {
         bool made_progress = false;
 #if PTO2_PROFILING
@@ -1270,8 +1281,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 _t0_phase = _t1;
                 phase_dispatch_count = 0;
             }
-#endif
         }
+#endif
+
+#if !PTO2_PROFILING
+        (void)try_completed;
+        (void)try_pushed;
+#endif
 
         if (made_progress) {
             idle_iterations = 0;
@@ -1392,6 +1408,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
                 DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+#if PTO2_PROFILING
+                // Benchmark: scheduler lifetime end timestamp on timeout path
+                DEV_ALWAYS("Thread %d: sched_end(timeout)=%llu",
+                           thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+#endif
                 return -1;
             } else {
                 SPIN_WAIT_HINT();
@@ -1543,8 +1564,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
 int32_t AicpuExecutor::run(Runtime* runtime) {
     int32_t thread_idx = thread_idx_++;
+    DEV_INFO("Thread %d: Start", thread_idx);
 
-    DEV_ALWAYS("Thread %d: Start", thread_idx);
 
     // Orchestrator check
     if (thread_idx >= sched_thread_num_) {
@@ -1750,17 +1771,17 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             }
 #endif
 
-            // Call orchestration function wrapped in an outer scope
-            DEV_ALWAYS("Thread %d: Calling aicpu_orchestration_entry from SO (orch_idx=%d/(0~%d))",
-                       thread_idx, orch_idx, orch_thread_num_ - 1);
 #if PTO2_PROFILING
-            DEV_ALWAYS("Thread=%d orch_start=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
             uint64_t orch_cycle_start = get_sys_cnt_aicpu();
+            DEV_ALWAYS("Thread %d: orch_start=%llu orch_idx=%d/(0~%d)", thread_idx, (unsigned long long)orch_cycle_start, orch_idx, orch_thread_num_ - 1);
 #endif
             PTO2_SCOPE(rt) { orch_func_(rt, orch_args_cached_, orch_arg_count_cached_, orch_thread_num_, orch_idx); }
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
-            DEV_ALWAYS("Thread %d: aicpu_orchestration_entry returned, cost %.3fus (orch_idx=%d)",
+            // Function-level timing: measures only orch_func_ execution time.
+            // This differs from `orch_end`, which marks stage-level end right before
+            // requesting core transition (includes additional post-orchestration work).
+            DEV_ALWAYS("Thread %d: aicpu_orchestration_entry returned, orch_func_cost=%.3fus (orch_idx=%d)",
                 thread_idx, cycles_to_us(orch_cycle_end - orch_cycle_start), orch_idx);
 #endif
 
@@ -1911,8 +1932,9 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     // Compute new core assignments for all threads and initialize donated slots
                     DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
 #if PTO2_PROFILING
-                    // Benchmark: record orchestrator end timestamp before waiting for schedulers
-                    DEV_ALWAYS("BENCHMARK: thread=%d end=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+                    // Stage-level end: orchestrator phase finishes before requesting transition.
+                    DEV_ALWAYS("Thread %d: orch_stage_end=%llu, requesting core transition", thread_idx,
+                               (unsigned long long)get_sys_cnt_aicpu());
 #endif
                     transition_requested_.store(true, std::memory_order_release);
 
@@ -1954,13 +1976,15 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 }
             }
         }
+#if PTO2_PROFILING
+        DEV_ALWAYS("Thread %d: orch_end=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+#endif
         DEV_INFO("Thread %d: Orchestrator completed (orch_idx=%d)", thread_idx, orch_idx);
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
     if (!completed_.load(std::memory_order_acquire) &&
         (thread_idx < sched_thread_num_ || orch_to_sched_)) {
-        DEV_ALWAYS("Thread %d: Starting PTO2 dispatch", thread_idx);
         // Device orchestration: wait for primary orchestrator to initialize SM header
         if (!runtime->get_orch_built_on_host()) {
             while (!runtime_init_ready_.load(std::memory_order_acquire)) {
@@ -1978,14 +2002,11 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     {
         const int32_t* shutdown_cores = core_assignments_[thread_idx];
         int32_t shutdown_count = core_count_per_thread_[thread_idx];
+        if (shutdown_count > 0) {
 #if PTO2_PROFILING
-        // Benchmark: record scheduler end timestamp before shutdown cleanup
-        if (shutdown_count > 0) {
-            DEV_ALWAYS("Thread=%d end=%llu",
+            DEV_ALWAYS("Thread %d: sched_end=%llu",
                        thread_idx, (unsigned long long)get_sys_cnt_aicpu());
-        }
 #endif
-        if (shutdown_count > 0) {
             auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
             if (rc != 0) {
                 return rc;
@@ -2005,7 +2026,6 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             dlclose(orch_so_handle_);
             unlink(orch_so_path_);
         }
-        DEV_ALWAYS("Thread %d: Last thread, marking executor finished", thread_idx);
     }
 
     return 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -41,43 +41,97 @@ Each sub-level macro requires `PTO2_PROFILING=1`:
 
 **What's compiled:**
 - Debug/diagnostic logs (always present)
-- Progress tracking
-- Stall detection
-- Deadlock/livelock detection
+- Progress tracking (`PTO2 progress: completed=...`)
+- Stall detection and dump (triggered only after `MAX_IDLE_ITERATIONS` idle loops)
+- Deadlock/livelock detection (`diagnose_stuck_state`, called on stall)
 
 **What's NOT compiled:**
-- All profiling counters
-- All profiling logs
-- Performance data collection
+- All `CYCLE_COUNT_*` timing counters (`sched_*_cycle`, orchestrator cost counters)
+- Scheduler/Orchestrator profiling summary logs guarded by `#if PTO2_PROFILING`
+- Performance data collection paths (`enable_profiling` runtime flag becomes ineffective because profiling code is not compiled)
 
-**Log output:** 11 DEV_ALWAYS logs (debug/diagnostic only)
+**Log output (normal run, no stall):**
+- No `sched_start/sched_end` timestamps
+- No `orch_start/orch_stage_end/orch_end` timestamps
+- No `Scheduler summary: total_time=...`
+- No orchestration function cost log (`aicpu_orchestration_entry returned, ...us`)
+- `PTO2 progress: completed=... total=...` may appear (thread 0 only, at task completion milestones)
+
 
 ---
 
 ### Level 1: Basic Profiling (PTO2_PROFILING=1)
 
 **What's compiled:**
-- All profiling counters (cycles, task counts, loop counts)
-- Basic profiling summaries
-- Scheduler summary output
-- Orchestration completion time
+- Base timing counters for scheduler loop (`sched_complete/dispatch/idle/scan`)
+- Per-thread orchestration timing (`orch_start`, `orch_func_cost`)
+- Stage-level orchestration end timestamp (`orch_stage_end`, printed by last orch thread only, marks the moment all orch threads have finished and core transition is about to be requested; only when `orch_to_sched_` is true)
+- Per-thread orchestration end timestamp (`orch_end`, printed by each orch thread after all post-orchestration work completes)
+- Scheduler summary output (`total_time`, `loops`, `tasks_scheduled`)
+- Scheduler lifetime timestamps (`sched_start`, `sched_end`)
 
 **What's NOT compiled:**
 - Detailed phase breakdowns
 - TensorMap statistics
 
-**Log output:** 13 DEV_ALWAYS logs
-- 11 debug/diagnostic logs (always present)
-- 2 basic profiling summaries:
-  - Orchestration completion time
-  - Total submitted tasks
+**Log output (additional lines vs Level 0, per normal run):**
+- `Thread %d: sched_start=%llu` — each sched thread, at scheduler loop start
+- `Thread %d: orch_start=%llu orch_idx=%d/(0~%d)` — each orch thread, before `orch_func_` call
+- `Thread %d: aicpu_orchestration_entry returned, orch_func_cost=%.3fus (orch_idx=%d)` — each orch thread, after `orch_func_` returns
+- `PTO2 total submitted tasks = %d, already executed %d tasks` — last orch thread only (×1)
+- `Thread %d: orch_stage_end=%llu` — last orch thread only (×1), only when `orch_to_sched_=true`
+- `Thread %d: orch_end=%llu` — each orch thread, after orchestration fully complete
+- `Thread %d: Scheduler summary: total_time=%.3fus, loops=%llu, tasks_scheduled=%d` — each sched thread
+- `Thread %d: sched_end=%llu` — each sched thread, before `shutdown_aicore` (normal path)
+- `Thread %d: sched_end(timeout)=%llu` — timeout path only (replaces `sched_end`)
 
-**Scheduler output:**
+**DEV_ALWAYS count (normal run):**
+- `orch_to_sched_=false` (default): `N_sched*2 + N_orch*2 + 1` (sched_start + orch_start + orch_func_cost + orch_end + PTO2_total + Scheduler_summary + sched_end)
+- `orch_to_sched_=true` (`PTO2_ORCH_TO_SCHED=1`): adds 1 (`orch_stage_end`)
+
+> See the table at the end for concrete counts based on the `paged_attention` example.
+
+**Example log output — `orch_to_sched_=false`** (from `paged_attention`, device 10):
 ```
-Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
+Thread 0: sched_start=48214752948200
+Thread 1: sched_start=48214752948235
+Thread 3: orch_start=48214752948316 orch_idx=1/(0~1)
+Thread 2: orch_start=48214752948321 orch_idx=0/(0~1)
+Thread 2: aicpu_orchestration_entry returned, orch_func_cost=193.700us (orch_idx=0)
+Thread 2: orch_end=48214752959379
+Thread 3: aicpu_orchestration_entry returned, orch_func_cost=218.640us (orch_idx=1)
+PTO2 total submitted tasks = 13, already executed 13 tasks
+Thread 3: orch_end=48214752961505
+Thread 1: Scheduler summary: total_time=159.560us, loops=3782, tasks_scheduled=6
+Thread 1: sched_end=48214752962379
+Thread 0: Scheduler summary: total_time=183.180us, loops=4611, tasks_scheduled=7
+Thread 0: sched_end=48214752963571
 ```
 
-**Note:** Scheduler summary always prints when `PTO2_PROFILING=1`, regardless of `enable_profiling` flag.
+**Example log output — `orch_to_sched_=true`** (`PTO2_ORCH_TO_SCHED=1`, from `paged_attention`, device 11):
+```
+Thread 0: sched_start=48236915043911
+Thread 1: sched_start=48236915043947
+Thread 3: orch_start=48236915044001 orch_idx=1/(0~1)
+Thread 2: orch_start=48236915044003 orch_idx=0/(0~1)
+Thread 2: aicpu_orchestration_entry returned, orch_func_cost=226.820us (orch_idx=0)
+Thread 3: aicpu_orchestration_entry returned, orch_func_cost=250.960us (orch_idx=1)
+PTO2 total submitted tasks = 13, already executed 13 tasks
+Thread 3: orch_stage_end=48236915058307
+Thread 0: Scheduler summary: total_time=187.920us, loops=4561, tasks_scheduled=4
+Thread 0: sched_end=48236915059191
+Thread 3: orch_end=48236915058781
+Thread 2: orch_end=48236915058782
+Thread 1: Scheduler summary: total_time=168.620us, loops=3880, tasks_scheduled=9
+Thread 1: sched_end=48236915061881
+```
+
+> With `orch_to_sched_=true`, orch threads transition to schedulers after orchestration. They print `orch_end` but do NOT print `Scheduler summary` or `sched_end` (they have no cores assigned at shutdown time).
+
+**Note:**
+- All logs above are controlled by compile-time macro `PTO2_PROFILING`, not by `enable_profiling`.
+- `enable_profiling` only controls shared-memory data collection / swimlane export.
+- Enable `orch_to_sched_` via environment variable: `PTO2_ORCH_TO_SCHED=1`.
 
 ---
 
@@ -257,13 +311,15 @@ add_definitions(-DPTO2_ORCH_PROFILING=1)
 
 ## Log Output Summary
 
-| Level | Macro Settings | DEV_ALWAYS Count | Description |
-|-------|---------------|------------------|-------------|
-| 0 | `PTO2_PROFILING=0` | 11 | Debug/diagnostic only |
-| 1 | `PTO2_PROFILING=1` | 13 | Basic summaries |
-| 2 | `+PTO2_SCHED_PROFILING=1` | 18 | Scheduler detailed |
-| 3 | `+PTO2_ORCH_PROFILING=1` | 30 | Orchestrator detailed |
-| 4 | `+PTO2_TENSORMAP_PROFILING=1` | 34 | TensorMap stats |
+> Example: `paged_attention` on Ascend hardware, 2 sched threads + 2 orch threads, normal run (no stall/timeout).
+
+| Level | Macro Settings | DEV_ALWAYS Count (`orch_to_sched_=false`) | DEV_ALWAYS Count (`orch_to_sched_=true`) | Description |
+|-------|---------------|------------------------------------------|------------------------------------------|-------------|
+| 0 | `PTO2_PROFILING=0` | 0 | 0 | No timing output |
+| 1 | `PTO2_PROFILING=1` | 13 | 14 | Timing timestamps + scheduler summary |
+| 2 | `+PTO2_SCHED_PROFILING=1` | — | — | Scheduler detailed phase breakdown |
+| 3 | `+PTO2_ORCH_PROFILING=1` | — | — | Orchestrator detailed phase breakdown |
+| 4 | `+PTO2_TENSORMAP_PROFILING=1` | — | — | TensorMap lookup stats |
 
 ---
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -270,11 +270,12 @@ flowchart TD
 
 ### 功能概述
 
-`benchmark_rounds.sh` 遍历 `EXAMPLES` 数组中配置的测试用例（位于 `tests/device_tests/tensormap_and_ringbuffer/` 下），依次调用 `run_example.py` 运行每个 example，然后从生成的 device log 中提取 `orch_start` / `end` 时间戳计算每轮 elapsed 时间。
+`benchmark_rounds.sh` 遍历 `EXAMPLES` 数组中配置的测试用例（位于 `tests/device_tests/tensormap_and_ringbuffer/` 下），依次调用 `run_example.py` 运行每个 example，然后从生成的 device log 中提取 `orch_start` / `orch_end` / `sched_end` 时间戳计算每轮 elapsed 时间。
 
 当前预配置的 examples：
 - `alternating_matmul_add`
 - `benchmark_bgemm`
+- `paged_attention_unroll`
 - `batch_paged_attention`
 - `paged_attention`
 
@@ -472,7 +473,7 @@ python3 tools/perf_to_mermaid.py -k ./kernels/kernel_config.py
 ### benchmark_rounds.sh 无 timing 数据
 - 确保运行时启用了 profiling（`PTO2_PROFILING` 环境变量）
 - 检查 device log 目录是否可访问
-- 确认 log 中包含 `orch_start` / `end` 时间戳行
+- 确认 log 中包含 `orch_start` / `orch_end` / `sched_end` 时间戳行（需要 `PTO2_PROFILING=1`）
 
 ### Mermaid 图在 GitHub 上不显示
 - 确保文件是 `.md` 扩展名

--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -120,7 +120,7 @@ parse_timing() {
     local log_file="$1"
 
     local timing
-    timing=$(grep -E 'Thread=[0-9]+ (orch_start|end)=' "$log_file" || true)
+    timing=$(grep -E 'Thread [0-9]+: (orch_start|orch_end|sched_end|orch_stage_end)=' "$log_file" || true)
 
     if [[ -z "$timing" ]]; then
         echo "  (no benchmark timing data — was PTO2_PROFILING enabled?)"
@@ -136,7 +136,7 @@ parse_timing() {
     }
     BEGIN { round = 0; min_start = 0; max_end = 0; count = 0 }
     /orch_start=/ {
-        match($0, /Thread=([0-9]+)/, tm)
+        match($0, /Thread ([0-9]+):/, tm)
         tid = tm[1] + 0
         if (tid in seen) {
             flush_round()

--- a/tools/perf_to_mermaid.py
+++ b/tools/perf_to_mermaid.py
@@ -208,7 +208,7 @@ def main():
     parser.add_argument('--style', choices=['detailed', 'compact'], default='detailed',
                         help='节点信息密度：detailed（详细，包含核心和时间）或 compact（紧凑，仅函数名）')
     parser.add_argument('--direction', choices=['TD', 'LR'], default='TD',
-                        help='流程图方向：TD（从上到下）或 LR（从左到右，默认）')
+                        help='流程图方向：TD（从上到下，默认）或 LR（从左到右）')
     parser.add_argument('-v', '--verbose', action='store_true', help='详细输出')
 
     args = parser.parse_args()


### PR DESCRIPTION
- Standardize all profiling logs to `Thread %d: key=value` format
  (was inconsistent mix of `Thread=N end=`, `Thread N: ...`, etc.)
- Add sched_start timestamp at scheduler loop entry
- Add orch_end timestamp after all post-orchestration work completes
- Add sched_end(timeout) on the timeout exit path
- Fix unused-variable warnings in non-profiling builds ((void) casts)
- Demote non-profiling DEV_ALWAYS to DEV_INFO (thread start, dispatch)
- Update benchmark_rounds.sh grep pattern to match new log format
- Update profiling_levels.md with accurate log examples and line counts
- Add paged_attention_unroll to tools/README.md and fix timing keywords
- Fix perf_to_mermaid.py --direction help text (TD is default, not LR)
