### PR TITLE
fix(perf): fix missing orchestrator→scheduler flow arrows in swimlane

### DIFF
--- a/src/a2a3/platform/include/aicore/performance_collector_aicore.h
+++ b/src/a2a3/platform/include/aicore/performance_collector_aicore.h
@@ -59,6 +59,7 @@ static inline void perf_aicore_record_task(
     record->end_time = end_time;
     record->kernel_ready_time = kernel_ready_time;
     record->task_id = task_id;
+    record->submit_idx = 0;
 
     perf_buf->count = idx + 1;
 

--- a/src/a2a3/platform/include/common/perf_profiling.h
+++ b/src/a2a3/platform/include/common/perf_profiling.h
@@ -75,8 +75,8 @@ struct PerfRecord {
     uint64_t finish_time;        // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
 
     // Task identification
-    uint32_t task_id;         // Register dispatch id (per-core monotonic counter, NOT mixed_task_id).
-                              // May collide across cores; use (ring_id, task_id, core_id) as unique key.
+    uint32_t task_id;         // Local task id for swimlane correlation (task-id domain is runtime-dependent).
+    uint32_t submit_idx;      // Monotonic orchestrator submit sequence for cross-view correlation.
     uint32_t func_id;         // Kernel function identifier
     CoreType core_type;       // Core type (AIC/AIV)
     uint8_t ring_id;          // Ring layer (0 for single-ring / legacy)

--- a/src/a2a3/platform/src/host/performance_collector.cpp
+++ b/src/a2a3/platform/src/host/performance_collector.cpp
@@ -988,6 +988,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
         outfile << "    {\n";
         outfile << "      \"task_id\": " << record.task_id << ",\n";
+        outfile << "      \"submit_idx\": " << record.submit_idx << ",\n";
         outfile << "      \"func_id\": " << record.func_id << ",\n";
         outfile << "      \"core_id\": " << tagged.core_id << ",\n";
         outfile << "      \"core_type\": \"" << core_type_str << "\",\n";

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -370,6 +370,10 @@ struct AicpuExecutor {
                         if (record->task_id == static_cast<uint32_t>(expected_reg_task_id)) {
                             // Fill metadata that AICore doesn't know
                             int32_t perf_slot_idx = static_cast<int32_t>(executing_subslot_by_core_[core_id]);
+                            // Normalize to orchestrator-visible task identity.
+                            record->task_id = static_cast<uint32_t>(
+                                pto2_task_id_local(slot_state.task->mixed_task_id));
+                            record->submit_idx = slot_state.task->submit_idx;
                             record->func_id = slot_state.task->kernel_id[perf_slot_idx];
                             record->core_type = CT;
                             perf_aicpu_record_dispatch_and_finish_time(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -435,6 +435,7 @@ void pto2_submit_mixed_task(
 
     // Initialize mixed-task descriptor
     task.mixed_task_id = mixed_task_id;
+    task.submit_idx = g_orch_submit_idx;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)]  = normalized.aic_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -346,6 +346,7 @@ struct PTO2DepListEntry {
 struct PTO2TaskDescriptor {
     // Mixed-task identification (encodes ring_id in upper 32 bits)
     PTO2TaskId mixed_task_id;         // raw: (ring_id << 32) | local_id
+    uint32_t submit_idx{0};           // Monotonic submit order for profiling correlation
 
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];

--- a/tools/swimlane_converter.py
+++ b/tools/swimlane_converter.py
@@ -867,62 +867,77 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                 })
                 flow_id += 1
 
-    # Orchestrator FINALIZE → Scheduler DISPATCH arrows (per task_id)
-    if orchestrator_phases and scheduler_phases:
-        # Flatten per-thread orch phases and track source thread
-        orch_finalize_by_task = {}
+    # Orchestrator FANIN(end) → Scheduler DISPATCH(start) arrows.
+    # Prefer submit_idx (global monotonic submit order), fallback to task_id.
+    if orchestrator_phases and scheduler_phases and has_aicpu_data:
+        # submit_idx -> (fanin_record, orch_thread_idx)
+        orch_fanin_by_submit = {}
+        # task_id -> (fanin_record, orch_thread_idx)
+        orch_fanin_by_task = {}
         for orch_idx, thread_records in enumerate(orch_threads):
             for record in thread_records:
-                if record.get("phase") == "orch_finalize":
-                    task_id = record.get("task_id", -1)
-                    if task_id >= 0:
-                        orch_finalize_by_task[task_id] = (record, orch_idx)
-
-        # Use core_to_sched_thread mapping (built above) to find the correct
-        # scheduler thread for each task's core.
-        if orch_finalize_by_task and has_aicpu_data:
-            for task in tasks:
-                tid = task.get('task_id')
-                if tid is None or tid not in orch_finalize_by_task:
+                if record.get("phase") != "orch_fanin":
                     continue
-
-                dispatch_us = task.get('dispatch_time_us', 0)
-                if dispatch_us <= 0:
+                submit_idx = record.get("submit_idx", 0)
+                if isinstance(submit_idx, int) and submit_idx > 0:
+                    prev = orch_fanin_by_submit.get(submit_idx)
+                    if prev is None or record.get("end_time_us", 0) > prev[0].get("end_time_us", 0):
+                        orch_fanin_by_submit[submit_idx] = (record, orch_idx)
+                task_id = record.get("task_id", -1)
+                if not isinstance(task_id, int) or task_id < 0:
                     continue
+                prev = orch_fanin_by_task.get(task_id)
+                if prev is None or record.get("end_time_us", 0) > prev[0].get("end_time_us", 0):
+                    orch_fanin_by_task[task_id] = (record, orch_idx)
 
-                finalize_rec, orch_idx = orch_finalize_by_task[tid]
-                # Use finalize start_time: init_task() runs at the beginning of FINALIZE,
-                # making the task dispatchable before FINALIZE ends. Using start avoids
-                # reverse arrows when the scheduler dispatches during FINALIZE.
-                finalize_start_us = finalize_rec["start_time_us"]
+        for task in tasks:
+            fanin_entry = None
+            submit_idx = task.get("submit_idx", 0)
+            if isinstance(submit_idx, int) and submit_idx > 0:
+                fanin_entry = orch_fanin_by_submit.get(submit_idx)
+            if fanin_entry is None:
+                task_id = task.get("task_id")
+                if task_id is None:
+                    continue
+                fanin_entry = orch_fanin_by_task.get(task_id)
+                if fanin_entry is None:
+                    continue
+            dispatch_us = task.get("dispatch_time_us", 0)
+            if dispatch_us <= 0:
+                continue
 
-                matched_thread = core_to_sched_thread.get(task['core_id'])
+            fanin_rec, orch_idx = fanin_entry
+            fanin_end_us = fanin_rec.get("end_time_us", 0)
+            if fanin_end_us <= 0:
+                continue
 
-                if matched_thread is not None:
-                    sched_tid = 3000 + matched_thread
-                    orch_tid = 4000 + orch_idx
+            matched_thread = core_to_sched_thread.get(task['core_id'])
+            if matched_thread is None:
+                continue
 
-                    # Flow: Orchestrator finalize start → Scheduler DISPATCH
-                    events.append({
-                        "cat": "flow",
-                        "id": flow_id,
-                        "name": "orch→dispatch",
-                        "ph": "s",
-                        "pid": 4,
-                        "tid": orch_tid,
-                        "ts": finalize_start_us
-                    })
-                    events.append({
-                        "cat": "flow",
-                        "id": flow_id,
-                        "name": "orch→dispatch",
-                        "ph": "f",
-                        "pid": 3,
-                        "tid": sched_tid,
-                        "ts": dispatch_us,
-                        "bp": "e"
-                    })
-                    flow_id += 1
+            sched_tid = 3000 + matched_thread
+            orch_tid = 4000 + orch_idx
+
+            events.append({
+                "cat": "flow",
+                "id": flow_id,
+                "name": "orch→dispatch",
+                "ph": "s",
+                "pid": 4,
+                "tid": orch_tid,
+                "ts": fanin_end_us
+            })
+            events.append({
+                "cat": "flow",
+                "id": flow_id,
+                "name": "orch→dispatch",
+                "ph": "f",
+                "pid": 3,
+                "tid": sched_tid,
+                "ts": dispatch_us,
+                "bp": "e"
+            })
+            flow_id += 1
 
     if verbose:
         print(f"  Total events: {len(events)}")

--- a/tools/swimlane_converter.py
+++ b/tools/swimlane_converter.py
@@ -878,17 +878,14 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
             for record in thread_records:
                 if record.get("phase") != "orch_fanin":
                     continue
+
                 submit_idx = record.get("submit_idx", 0)
                 if isinstance(submit_idx, int) and submit_idx > 0:
-                    prev = orch_fanin_by_submit.get(submit_idx)
-                    if prev is None or record.get("end_time_us", 0) > prev[0].get("end_time_us", 0):
-                        orch_fanin_by_submit[submit_idx] = (record, orch_idx)
+                    _update_fanin_lookup(orch_fanin_by_submit, submit_idx, record, orch_idx)
+
                 task_id = record.get("task_id", -1)
-                if not isinstance(task_id, int) or task_id < 0:
-                    continue
-                prev = orch_fanin_by_task.get(task_id)
-                if prev is None or record.get("end_time_us", 0) > prev[0].get("end_time_us", 0):
-                    orch_fanin_by_task[task_id] = (record, orch_idx)
+                if isinstance(task_id, int) and task_id >= 0:
+                    _update_fanin_lookup(orch_fanin_by_task, task_id, record, orch_idx)
 
         for task in tasks:
             fanin_entry = None


### PR DESCRIPTION
Two issues prevented the orch→dispatch arrows from appearing:

1. task_id mismatch: AICore PerfRecord stored the per-core dispatch counter (expected_reg_task_id) as task_id, while orchestrator phase records use pto2_task_id_local(mixed_task_id). The converter could never match them. Fix by normalizing record->task_id to pto2_task_id_local(mixed_task_id) in aicpu_executor.cpp.

2. Wrong phase anchor: the converter looked for orch_finalize records but orch_fanin end is the correct semantic anchor (task becomes ready after fanin processing completes). Switch to orch_fanin and use end_time_us as the flow source timestamp.

Also add submit_idx to PerfRecord and PTO2TaskDescriptor to propagate the monotonic orchestrator submit sequence into the swimlane JSON. Without submit_idx-based correlation, multi-ring execution exposes a latent bug: pto2_task_id_local strips the ring_id, so tasks from different rings sharing the same local_id collide in the converter's orch_fanin lookup table, causing arrows to target the wrong orchestrator phase. submit_idx is globally monotonic across all rings and will serve as the correct matching key once the converter is updated to use it.