### PR TITLE
Perf: encode ring_id in task_id and fix AICore cache flush ordering

### DIFF
--- a/src/a2a3/platform/include/aicore/performance_collector_aicore.h
+++ b/src/a2a3/platform/include/aicore/performance_collector_aicore.h
@@ -27,11 +27,12 @@
  * Writes performance metrics to the provided buffer. Buffer management
  * and status tracking are handled by AICPU.
  *
- * AICore records task_id and timestamps only. AICPU fills func_id and
- * core_type at completion time from TaskDescriptor.
+ * AICore writes PerfRecord.task_id as the register dispatch token (low 32 bits, zero-extended).
+ * For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), AICPU overwrites
+ * with the full (ring_id << 32) | local_id encoding after handshake match.
  *
  * @param perf_buf Performance buffer pointer
- * @param task_id Task ID
+ * @param task_id Register dispatch id (DATA_MAIN_BASE), stored in task_id low 32 bits
  * @param start_time Start timestamp
  * @param end_time End timestamp
  * @param kernel_ready_time Kernel ready timestamp
@@ -58,13 +59,13 @@ static inline void perf_aicore_record_task(
     record->start_time = start_time;
     record->end_time = end_time;
     record->kernel_ready_time = kernel_ready_time;
-    record->task_id = task_id;
+    record->task_id = static_cast<uint64_t>(task_id);
 
     perf_buf->count = idx + 1;
 
     // Flush cache to make data visible
-    dcci(&perf_buf->count, SINGLE_CACHE_LINE, CACHELINE_OUT);
     dcci(record, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+    dsb((mem_dsb_t)0);
 }
 
 #endif  // PLATFORM_AICORE_PERFORMANCE_COLLECTOR_AICORE_H_

--- a/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
@@ -101,12 +101,14 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
  * @param start_time Phase start timestamp
  * @param end_time Phase end timestamp
  * @param loop_iter Current loop iteration number
- * @param tasks_processed Number of tasks processed in this phase
+ * @param tasks_processed Number of tasks processed in this batch (scheduler phases), or
+ *                        full PTO2 task_id encoding (ring_id << 32) | local_id (orchestrator
+ *                        phases in multi-ring runtimes: tensormap_and_ringbuffer, aicpu_build_graph)
  */
 void perf_aicpu_record_phase(int thread_idx,
                               AicpuPhaseId phase_id,
                               uint64_t start_time, uint64_t end_time,
-                              uint32_t loop_iter, uint32_t tasks_processed);
+                              uint32_t loop_iter, uint64_t tasks_processed);
 
 /**
  * Write orchestrator cumulative summary
@@ -138,11 +140,13 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx);
  * @param start_time Phase start timestamp
  * @param end_time Phase end timestamp
  * @param submit_idx Task submission index (acts as loop_iter)
- * @param task_id Task ID (stored in tasks_processed field for task tracking)
+ * @param task_id Task identifier. For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), this is the full PTO2 encoding:
+ *               (ring_id << 32) | local_id, enabling cross-view correlation between orchestrator
+ *               and scheduler swimlanes.
  */
 void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
                                    uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx, uint32_t task_id);
+                                   uint32_t submit_idx, uint64_t task_id);
 
 /**
  * Write core-to-thread assignment mapping to shared memory

--- a/src/a2a3/platform/include/common/perf_profiling.h
+++ b/src/a2a3/platform/include/common/perf_profiling.h
@@ -74,16 +74,17 @@ struct PerfRecord {
     uint64_t dispatch_time;      // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
     uint64_t finish_time;        // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
 
-    // Task identification
-    uint32_t task_id;         // Register dispatch id (per-core monotonic counter, NOT mixed_task_id).
-                              // May collide across cores; use (ring_id, task_id, core_id) as unique key.
+    // AICore writes the register dispatch token (low 32 bits only) zero-extended into task_id.
+    // For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), AICPU overwrites
+    // with the full PTO2 encoding (ring_id << 32) | local_id after FIN/perf row match.
+    // For host_build_graph, task_id stays as the plain integer task index (ring_id = 0).
+    uint64_t task_id;
     uint32_t func_id;         // Kernel function identifier
     CoreType core_type;       // Core type (AIC/AIV)
-    uint8_t ring_id;          // Ring layer (0 for single-ring / legacy)
 
     // Dependency relationship (fanout only)
-    int32_t fanout[RUNTIME_MAX_FANOUT];  // Successor task ID array
-    int32_t fanout_count;                 // Number of successor tasks
+    uint64_t fanout[RUNTIME_MAX_FANOUT];  // Successor task task_id array
+    int32_t fanout_count;                  // Number of successor tasks
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(PerfRecord) % 64 == 0,
@@ -262,8 +263,11 @@ struct AicpuPhaseRecord {
     uint64_t end_time;         // Phase end timestamp
     uint32_t loop_iter;        // Loop iteration number
     AicpuPhaseId phase_id;     // Phase type
-    uint32_t tasks_processed;  // Tasks processed in this phase
-    uint32_t padding;          // Alignment padding
+    union {
+        uint64_t task_id;   // Multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph):
+                            // full PTO2 encoding (ring_id << 32) | local_id for cross-view correlation.
+        uint64_t tasks_processed; // Scheduler phases: number of tasks processed in this batch
+    };
 };
 
 /**

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -31,6 +31,15 @@
 // Use variadic macro to support both 2-arg and 3-arg calls.
 #define dcci(...) std::atomic_thread_fence(std::memory_order_seq_cst)
 
+// dsb / mem_dsb_t — CANN provides these on real AICore; perf_collector uses them after dcci flush.
+// Simulation: full fence (same strength as dcci above) so AICPU ordering matches hardware intent.
+typedef int mem_dsb_t;
+#define dsb(_kind)                                                                               \
+    do {                                                                                         \
+        (void)(_kind);                                                                           \
+        std::atomic_thread_fence(std::memory_order_seq_cst);                                    \
+    } while (0)
+
 // Cache coherency constants (no-op in simulation)
 #define ENTIRE_DATA_CACHE 0
 #define SINGLE_CACHE_LINE 0

--- a/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -39,11 +39,11 @@ static __thread int s_orch_thread_idx = -1;
  * @return 0 on success, -1 if queue full
  */
 static int enqueue_ready_buffer(PerfDataHeader* header,
-                                 int thread_idx,
-                                 uint32_t core_index,
-                                 uint64_t buffer_ptr,
-                                 uint32_t buffer_seq,
-                                 uint32_t is_phase) {
+    int thread_idx,
+    uint32_t core_index,
+    uint64_t buffer_ptr,
+    uint32_t buffer_seq,
+    uint32_t is_phase) {
     uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
     uint32_t current_tail = header->queue_tails[thread_idx];
     uint32_t current_head = header->queue_heads[thread_idx];
@@ -144,15 +144,15 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
     runtime->complete_perf_records(full_buf);
 
     LOG_INFO("Thread %d: Core %d buffer is full (count=%u)",
-             thread_idx, core_id, full_buf->count);
+         thread_idx, core_id, full_buf->count);
 
     // Enqueue to ReadyQueue
     uint32_t seq = state->current_buf_seq;
     int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
-                                   state->current_buf_ptr, seq, 0);
+        state->current_buf_ptr, seq, 0);
     if (rc != 0) {
         LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
-                 thread_idx, core_id);
+             thread_idx, core_id);
         // Revert: discard data and keep writing
         full_buf->count = 0;
         wmb();
@@ -180,12 +180,12 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
         h->perf_records_addr = new_buf_ptr;
         wmb();
 
-        LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)",
-                 thread_idx, core_id, new_buf_ptr);
+        LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", 
+            thread_idx, core_id, new_buf_ptr);
     } else {
         // No free buffer available, stop profiling
-        LOG_WARN("Thread %d: Core %d no free buffer available, stopping profiling",
-                 thread_idx, core_id);
+        LOG_WARN("Thread %d: Core %d no free buffer available, stopping profiling", 
+            thread_idx, core_id);
         state->current_buf_ptr = 0;
         Handshake* h = &runtime->workers[core_id];
         h->perf_records_addr = 0;
@@ -193,10 +193,10 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
     }
 }
 
-void perf_aicpu_flush_buffers(Runtime* runtime,
-                               int thread_idx,
-                               const int* cur_thread_cores,
-                               int core_num) {
+void perf_aicpu_flush_buffers(Runtime* runtime, 
+    int thread_idx, 
+    const int* cur_thread_cores, 
+    int core_num) {
     if (!runtime->enable_profiling) {
         return;
     }
@@ -233,23 +233,23 @@ void perf_aicpu_flush_buffers(Runtime* runtime,
 
         uint32_t seq = state->current_buf_seq;
         int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
-                                       buf_ptr, seq, 0);
+            buf_ptr, seq, 0);
         if (rc == 0) {
             LOG_INFO("Thread %d: Core %d flushed buffer with %u records",
-                     thread_idx, core_id, buf->count);
+                thread_idx, core_id, buf->count);
             flushed_count++;
             state->current_buf_ptr = 0;
             wmb();
         } else {
             LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
-                     thread_idx, core_id);
+                thread_idx, core_id);
         }
     }
 
     wmb();
 
-    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed",
-             thread_idx, flushed_count);
+    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", 
+        thread_idx, flushed_count);
 }
 
 void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
@@ -326,7 +326,7 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
     wmb();
 
     LOG_INFO("Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread",
-             num_sched_threads, num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD);
+        num_sched_threads, num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD);
 }
 
 /**
@@ -344,15 +344,15 @@ static void switch_phase_buffer(int thread_idx) {
     if (full_buf == nullptr) return;
 
     LOG_INFO("Thread %d: phase buffer is full (count=%u)",
-             thread_idx, full_buf->count);
+        thread_idx, full_buf->count);
 
     // Enqueue to ReadyQueue
     uint32_t seq = state->current_buf_seq;
     int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-                                   state->current_buf_ptr, seq, 1);
+        state->current_buf_ptr, seq, 1);
     if (rc != 0) {
         LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data",
-                 thread_idx);
+            thread_idx);
         full_buf->count = 0;
         wmb();
         return;
@@ -379,7 +379,7 @@ static void switch_phase_buffer(int thread_idx) {
     } else {
         // No free buffer available, drop subsequent records
         LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up",
-                 thread_idx);
+            thread_idx);
         s_current_phase_buf[thread_idx] = nullptr;
         state->current_buf_ptr = 0;
         wmb();
@@ -388,8 +388,8 @@ static void switch_phase_buffer(int thread_idx) {
 
 void perf_aicpu_record_phase(int thread_idx,
     AicpuPhaseId phase_id,
-                              uint64_t start_time, uint64_t end_time,
-                              uint32_t loop_iter, uint32_t tasks_processed) {
+    uint64_t start_time, uint64_t end_time,
+    uint32_t loop_iter, uint64_t tasks_processed) {
     if (s_phase_header == nullptr) {
         return;
     }
@@ -440,8 +440,7 @@ void perf_aicpu_record_phase(int thread_idx,
     record->end_time = end_time;
     record->loop_iter = loop_iter;
     record->phase_id = phase_id;
-    record->tasks_processed = tasks_processed;
-    record->padding = 0;
+    record->task_id = tasks_processed;
 
     buf->count = idx + 1;
 }
@@ -460,17 +459,17 @@ void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src) {
     wmb();
 
     LOG_INFO("Orchestrator summary written: %lld tasks, %.3fus",
-             (long long)src->submit_count,
-             cycles_to_us(src->end_time - src->start_time));
+        (long long)src->submit_count,
+        cycles_to_us(src->end_time - src->start_time));
 }
 
-void perf_aicpu_set_orch_thread_idx(int thread_idx) {
-    s_orch_thread_idx = thread_idx;
+void perf_aicpu_set_orch_thread_idx(int thread_idx) { 
+    s_orch_thread_idx = thread_idx; 
 }
 
 void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
-                                   uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx, uint32_t task_id) {
+    uint64_t start_time, uint64_t end_time,
+    uint32_t submit_idx, uint64_t task_id) {
     if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
     perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
 }
@@ -497,25 +496,25 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
 
     uint32_t seq = state->current_buf_seq;
     int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-                                   buf_ptr, seq, 1);
+        buf_ptr, seq, 1);
     if (rc == 0) {
         LOG_INFO("Thread %d: flushed phase buffer with %u records",
-                 thread_idx, buf->count);
+            thread_idx, buf->count);
         state->current_buf_ptr = 0;
         s_current_phase_buf[thread_idx] = nullptr;
         wmb();
     } else {
         LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!",
-                 thread_idx);
+            thread_idx);
     }
 
     wmb();
 }
 
 void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
-                                        const int* core_counts,
-                                        int num_threads,
-                                        int total_cores) {
+    const int* core_counts,
+    int num_threads,
+    int total_cores) {
     if (s_phase_header == nullptr) {
         return;
     }

--- a/src/a2a3/platform/src/host/performance_collector.cpp
+++ b/src/a2a3/platform/src/host/performance_collector.cpp
@@ -916,7 +916,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         }
     }
 
-    // Sort by task_id
+    // Sort by canonical task_id (64-bit PTO2 raw)
     std::sort(tagged_records.begin(), tagged_records.end(),
               [](const TaggedRecord& a, const TaggedRecord& b) {
                   return a.record->task_id < b.record->task_id;
@@ -930,7 +930,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         }
         if (tagged.record->dispatch_time < base_time_cycles && tagged.record->dispatch_time > 0) {
             base_time_cycles = tagged.record->dispatch_time;
-            LOG_WARN("Timestamp violation: dispatch_time (%lu) < base_time (%lu) for task %u, using dispatch_time as new base_time",
+            LOG_WARN("Timestamp violation: dispatch_time (%lu) < base_time (%lu) for task (task_id=%lu), using dispatch_time as new base_time",
                         tagged.record->dispatch_time, base_time_cycles, tagged.record->task_id);
         }
     }
@@ -991,7 +991,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         outfile << "      \"func_id\": " << record.func_id << ",\n";
         outfile << "      \"core_id\": " << tagged.core_id << ",\n";
         outfile << "      \"core_type\": \"" << core_type_str << "\",\n";
-        outfile << "      \"ring_id\": " << static_cast<int>(record.ring_id) << ",\n";
+        outfile << "      \"ring_id\": " << static_cast<int>(record.task_id >> 32) << ",\n";
         outfile << "      \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us << ",\n";
         outfile << "      \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us << ",\n";
         outfile << "      \"duration_us\": " << std::fixed << std::setprecision(3) << duration_us << ",\n";
@@ -1113,7 +1113,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                             << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                             << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
                             << ", \"submit_idx\": " << pr.loop_iter
-                            << ", \"task_id\": " << static_cast<int32_t>(pr.tasks_processed)
+                            << ", \"task_id\": " << pr.task_id
                             << "}";
                     first = false;
                 }

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -191,7 +191,7 @@ struct AicpuExecutor {
     uint64_t regs_{0};
 
     // Track executing register task_id per core (AICPU_TASK_INVALID = idle).
-    // NOTE: this is NOT the mixed_task_id; it is the per-core dispatch id used by the
+    // NOTE: this is NOT the task_id; it is the per-core dispatch id used by the
     // register protocol (derived from dispatch_seq_by_core_ and masked by TASK_ID_MASK).
     int32_t executing_reg_task_ids_[MAX_CORES_PER_THREAD];
     CoreStateTracker trackers_[MAX_AICPU_THREADS];
@@ -249,7 +249,7 @@ struct AicpuExecutor {
         Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank);
 
     // Build slim PTO2DispatchPayload: only function_bin_addr + args.
-    // Metadata (mixed_task_id, subslot, kernel_id, core_type) stays in TaskDescriptor.
+    // Metadata (task_id, subslot, kernel_id, core_type) stays in TaskDescriptor.
     // Dispatch order: tensor args first, then scalar args.
     void build_pto2_payload(PTO2DispatchPayload& out,
         int32_t kernel_id,
@@ -366,7 +366,8 @@ struct AicpuExecutor {
                     uint32_t count = perf_buf->count;
                     if (count > 0) {
                         PerfRecord* record = &perf_buf->records[count - 1];
-                        if (record->task_id == static_cast<uint32_t>(expected_reg_task_id)) {
+                        if (static_cast<uint32_t>(record->task_id) ==
+                            static_cast<uint32_t>(expected_reg_task_id)) {
                             // Fill metadata that AICore doesn't know
                             int32_t perf_slot_idx = static_cast<int32_t>(executing_subslot_by_core_[core_id]);
                             record->func_id = slot_state.task->kernel_id[perf_slot_idx];
@@ -375,7 +376,7 @@ struct AicpuExecutor {
                                 record, dispatch_timestamps_[core_id], finish_ts);
 
                             // Fill ring_id from slot state
-                            record->ring_id = slot_state.ring_id;
+                            record->task_id = slot_state.task->task_id.raw;
 
                             // Fill fanout from slot_state's dependency linked list.
                             // No lock: head-insert guarantees existing nodes' next pointers
@@ -383,8 +384,8 @@ struct AicpuExecutor {
                             record->fanout_count = 0;
                             PTO2DepListEntry* cur = slot_state.fanout_head;
                             while (cur != nullptr && record->fanout_count < RUNTIME_MAX_FANOUT) {
-                                record->fanout[record->fanout_count++] = static_cast<int32_t>(
-                                    pto2_task_id_local(cur->slot_state->task->mixed_task_id));
+                                const PTO2TaskId succ = cur->slot_state->task->task_id;
+                                record->fanout[record->fanout_count++] = succ.raw;
                                 cur = cur->next;
                             }
                         }
@@ -520,18 +521,16 @@ struct AicpuExecutor {
         }
 #endif
         // Per-core monotonic counter for register protocol uniqueness.
-        // mixed_task_id encodes (ring_id << 32 | local_id); truncation to
-        // uint32 loses ring_id, so tasks from different rings with the same
-        // local_id would write identical DATA_MAIN_BASE values. The AICore
-        // uses last_reg_val to detect new dispatches and would skip the
-        // duplicate, while the stale COND register from the previous task
-        // (same local_id) would cause a false-positive completion.
+        // PTO2 task_id encodes (ring_id << 32 | local_id); truncation to uint32 loses ring_id,
+        // so tasks from different rings with the same local_id would write identical DATA_MAIN_BASE
+        // values. The AICore uses last_reg_val to detect new dispatches and would skip the
+        // duplicate, while the stale COND register from the previous task (same local_id) would
+        // cause a false-positive completion.
         dispatch_seq_by_core_[core_id]++;
         uint32_t reg_task_id = dispatch_seq_by_core_[core_id] & TASK_ID_MASK;
-        // Skip reserved sentinel values
-        while (reg_task_id == AICORE_IDLE_TASK_ID ||
-            (reg_task_id + 1) == AICORE_EXIT_SIGNAL) {
-            dispatch_seq_by_core_[core_id]++;
+        // Skip reserved sentinel range [AICORE_EXIT_SIGNAL, 0x7FFFFFFF]: jump directly to 0.
+        if (reg_task_id >= AICORE_EXIT_SIGNAL) {
+            dispatch_seq_by_core_[core_id] += (TASK_ID_MASK - reg_task_id + 1);
             reg_task_id = dispatch_seq_by_core_[core_id] & TASK_ID_MASK;
         }
         write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE, static_cast<uint64_t>(reg_task_id));
@@ -1175,7 +1174,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     DEV_DEBUG("Thread %d: Dispatching %s task %lld to cluster %d (local)",
                         thread_idx,
                         shape_name(shape),
-                        (long long)pto2_task_id_raw(slot_state->task->mixed_task_id),
+                        (long long)slot_state->task->task_id.raw,
                         ci);
                 } else {
                     overflow_ptrs[overflow_count++] = slot_state;
@@ -1253,7 +1252,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 DEV_DEBUG("Thread %d: Dispatching %s task %lld to cluster %d",
                     thread_idx,
                     shape_name(shape),
-                    (long long)pto2_task_id_raw(slot_state->task->mixed_task_id),
+                    (long long)slot_state->task->task_id.raw,
                     ci);
             }
         }
@@ -1331,13 +1330,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                             cnt_ready++;
                             if (cnt_ready <= STALL_DUMP_READY_MAX) {
                                 DEV_ALWAYS("  STUCK-READY  ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
-                                            r, (long long)pto2_task_id_raw(slot_state.task->mixed_task_id), kid, rc, fi, (int32_t)st);
+                                            r, (long long)slot_state.task->task_id.raw, kid, rc, fi, (int32_t)st);
                             }
                         } else {
                             cnt_waiting++;
                             if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
                                 DEV_ALWAYS("  STUCK-WAIT   ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
-                                            r, (long long)pto2_task_id_raw(slot_state.task->mixed_task_id), kid, rc, fi, (int32_t)st);
+                                            r, (long long)slot_state.task->task_id.raw, kid, rc, fi, (int32_t)st);
                             }
                         }
                     }

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.cpp
@@ -33,7 +33,7 @@
 // Weak fallback for builds that don't link device_time.cpp (e.g. host).
 __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
 __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
+    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 static uint64_t g_orch_alloc_cycle = 0;
 static uint64_t g_orch_params_cycle = 0;
 static uint64_t g_orch_heap_cycle = 0;
@@ -63,7 +63,7 @@ uint64_t g_orch_scope_end_atomic_count = 0;
 #include "aicpu/performance_collector_aicpu.h"
 __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
 __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
+    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 static uint32_t g_orch_submit_idx = 0;
 #define CYCLE_COUNT_START()                                                           \
     bool _prof_active = orch->enable_profiling;                                       \
@@ -305,7 +305,7 @@ PTO2TaskId pto2_submit_mixed_task(
     int32_t local_id = task_ring.pto2_task_ring_alloc();
     if (local_id < 0) { orch->fatal = true; return invalid_id; }
     int32_t slot = task_ring.get_task_slot(local_id);
-    PTO2TaskId mixed_task_id = pto2_make_task_id(ring_id, static_cast<uint32_t>(local_id));
+    PTO2TaskId task_id = pto2_make_task_id(ring_id, static_cast<uint32_t>(local_id));
 
     PTO2TaskDescriptor& task = task_ring.get_task_by_slot(slot);
     PTO2TaskPayload* payload = &orch->sm_handle->task_payloads[ring_id][slot];
@@ -388,7 +388,7 @@ PTO2TaskId pto2_submit_mixed_task(
 
     // === STEP 3: Write task descriptor and payload ===
     __builtin_prefetch(&task, 1, 1);
-    task.mixed_task_id = mixed_task_id;
+    task.task_id = task_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)]  = normalized.aic_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;
@@ -415,7 +415,7 @@ PTO2TaskId pto2_submit_mixed_task(
     g_orch_submit_idx++;
 #endif
 
-    return mixed_task_id;
+    return task_id;
 }
 
 // =============================================================================

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2_types.h
@@ -206,7 +206,7 @@ struct PTO2DepListEntry {
  */
 struct PTO2TaskDescriptor {
     // Mixed-task identification (encodes ring_id in upper 32 bits)
-    PTO2TaskId mixed_task_id;         // raw: (ring_id << 32) | local_id
+    PTO2TaskId task_id;         // raw: (ring_id << 32) | local_id
 
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
@@ -184,10 +184,10 @@ void Runtime::complete_perf_records(PerfBuffer* perf_buf) {
 
     for (uint32_t i = 0; i < count; i++) {
         PerfRecord* record = &perf_buf->records[i];
-        int32_t task_id = record->task_id;
+        uint32_t local_id = static_cast<uint32_t>(record->task_id & 0xFFFFFFFFu);
 
         // Get slot state for fanout traversal
-        int32_t slot = task_id & window_mask;
+        int32_t slot = static_cast<int32_t>(local_id) & window_mask;
         PTO2TaskSlotState& ss = slot_states[slot];
 
         // Fill fanout information by traversing the linked list
@@ -195,16 +195,8 @@ void Runtime::complete_perf_records(PerfBuffer* perf_buf) {
         PTO2DepListEntry* cur = ss.fanout_head;
 
         while (cur != nullptr && record->fanout_count < RUNTIME_MAX_FANOUT) {
-            // PerfRecord.fanout stores 32-bit legacy task IDs. Our multi-ring task ID
-            // encodes ring_id in the upper 32 bits, so only the legacy single-ring
-            // case (ring_id==0) is representable here.
-            uint64_t mixed = pto2_task_id_raw(cur->slot_state->task->mixed_task_id);
-            if ((mixed >> 32) != 0) {
-                // Skip: cannot represent (ring_id, local_id) in a 32-bit fanout slot.
-                cur = cur->next;
-                continue;
-            }
-            record->fanout[record->fanout_count++] = static_cast<int32_t>(mixed & 0xFFFFFFFFu);
+            const PTO2TaskId succ = cur->slot_state->task->task_id;
+            record->fanout[record->fanout_count++] = succ.raw;
             cur = cur->next;
         }
     }

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -632,11 +632,13 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     uint32_t count = perf_buf->count;
                     if (count > 0) {
                         PerfRecord* record = &perf_buf->records[count - 1];
-                        if (record->task_id == static_cast<uint32_t>(completed_task_id)) {
+                        if (static_cast<uint32_t>(record->task_id) ==
+                            static_cast<uint32_t>(completed_task_id)) {
                             record->func_id = runtime.tasks[completed_task_id].func_id;
                             record->core_type = h->core_type;
                             perf_aicpu_record_dispatch_and_finish_time(
                                 record, dispatch_timestamps_[core_id], finish_ts);
+                            record->task_id = static_cast<uint64_t>(completed_task_id);
                         }
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
@@ -769,11 +771,13 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     uint32_t count = perf_buf->count;
                     if (count > 0) {
                         PerfRecord* record = &perf_buf->records[count - 1];
-                        if (record->task_id == static_cast<uint32_t>(completed_task_id)) {
+                        if (static_cast<uint32_t>(record->task_id) ==
+                            static_cast<uint32_t>(completed_task_id)) {
                             record->func_id = runtime.tasks[completed_task_id].func_id;
                             record->core_type = h->core_type;
                             perf_aicpu_record_dispatch_and_finish_time(
                                 record, dispatch_timestamps_[core_id], finish_ts);
+                            record->task_id = static_cast<uint64_t>(completed_task_id);
                         }
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -228,7 +228,7 @@ void Runtime::complete_perf_records(PerfBuffer* perf_buf) {
 
     for (uint32_t i = 0; i < count; i++) {
         PerfRecord* record = &perf_buf->records[i];
-        uint32_t task_id = record->task_id;
+        int task_id = static_cast<int>(record->task_id & 0xFFFFFFFFu);
 
         // Query Task by task_id (O(1) array indexing)
         Task* task = get_task(task_id);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -437,25 +437,19 @@ struct AicpuExecutor {
                     uint32_t count = perf_buf->count;
                     if (count > 0) {
                         PerfRecord* record = &perf_buf->records[count - 1];
-                        if (record->task_id == static_cast<uint32_t>(expected_reg_task_id)) {
+                        if (static_cast<uint32_t>(record->task_id) == static_cast<uint32_t>(expected_reg_task_id)) {
                             // Fill metadata that AICore doesn't know
                             int32_t perf_slot_idx = static_cast<int32_t>(core_exec_state.executing_subslot);
                             record->func_id = slot_state.task->kernel_id[perf_slot_idx];
                             record->core_type = CT;
                             perf_aicpu_record_dispatch_and_finish_time(
                                 record, core_exec_state.dispatch_timestamp, finish_ts);
-
-                            // Fill ring_id from slot state
-                            record->ring_id = slot_state.ring_id;
-
-                            // Fill fanout from slot_state's dependency linked list.
-                            // No lock: head-insert guarantees existing nodes' next pointers
-                            // are stable, so this snapshot is consistent (best-effort).
+                            record->task_id = slot_state.task->task_id.raw;
                             record->fanout_count = 0;
                             PTO2DepListEntry* cur = slot_state.fanout_head;
                             while (cur != nullptr && record->fanout_count < RUNTIME_MAX_FANOUT) {
-                                record->fanout[record->fanout_count++] = static_cast<int32_t>(
-                                    cur->slot_state->task->mixed_task_id.local());
+                                const PTO2TaskId succ = cur->slot_state->task->task_id;
+                                record->fanout[record->fanout_count++] = succ.raw;
                                 cur = cur->next;
                             }
                         }
@@ -598,13 +592,13 @@ struct AicpuExecutor {
             core_exec_state.dispatch_count++;
         }
 #endif
-        // Per-core monotonic counter for register protocol uniqueness.
-        // mixed_task_id encodes (ring_id << 32 | local_id); truncation to
-        // uint32 loses ring_id, so tasks from different rings with the same
-        // local_id would write identical DATA_MAIN_BASE values. The AICore
-        // uses last_reg_val to detect new dispatches and would skip the
-        // duplicate, while the stale COND register from the previous task
-        // (same local_id) would cause a false-positive completion.
+        // Per-core monotonic counter for register protocol uniqueness (32-bit).
+        // PTO2 task_id encodes (ring_id << 32 | local_id); truncation to uint32 loses ring_id,
+        // so tasks from different rings with the same local_id would write identical DATA_MAIN_BASE
+        // values. The AICore uses last_reg_val to detect new dispatches and would skip the
+        // duplicate, while the stale COND register from the previous task (same local_id) would
+        // cause a false-positive completion.
+        // PerfRecord.task_id: register token (low 32) until AICPU overwrites with full (ring_id << 32 | local_id).
         core_exec_state.dispatch_seq++;
         uint32_t reg_task_id = core_exec_state.dispatch_seq & TASK_ID_MASK;
         // Skip reserved sentinel range [AICORE_EXIT_SIGNAL, 0x7FFFFFFF]
@@ -1256,7 +1250,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     DEV_DEBUG("Thread %d: Dispatching %s task %lld to cluster_offset %d",
                         thread_idx,
                         shape_name(shape),
-                        (long long)slot_state->task->mixed_task_id.raw,
+                        (long long)slot_state->task->task_id.raw,
                         current_valid_cluster_offset);
                 }
 
@@ -1359,13 +1353,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                             cnt_ready++;
                             if (cnt_ready <= STALL_DUMP_READY_MAX) {
                                 DEV_ALWAYS("  STUCK-READY  ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
-                                            r, (long long)slot_state.task->mixed_task_id.raw, kid, rc, fi, (int32_t)st);
+                                            r, (long long)slot_state.task->task_id.raw, kid, rc, fi, (int32_t)st);
                             }
                         } else {
                             cnt_waiting++;
                             if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
                                 DEV_ALWAYS("  STUCK-WAIT   ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
-                                            r, (long long)slot_state.task->mixed_task_id.raw, kid, rc, fi, (int32_t)st);
+                                            r, (long long)slot_state.task->task_id.raw, kid, rc, fi, (int32_t)st);
                             }
                         }
                     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -24,7 +24,7 @@ Inner-scope tasks can now be reclaimed independently without waiting for outer-s
 Task IDs are widened from 32-bit to 64-bit to carry the ring identity:
 
 ```
-mixed_task_id.raw = (ring_id << 32) | local_id
+task_id.raw = (ring_id << 32) | local_id
 ```
 
 `PTO2TaskId` exposes direct accessors in `pto_runtime2_types.h`:
@@ -40,7 +40,7 @@ Type changes:
 
 | Field | Before | After |
 |-------|--------|-------|
-| `PTO2TaskDescriptor.mixed_task_id` | `int32_t` | `PTO2TaskId` |
+| `PTO2TaskDescriptor.task_id` | `int32_t` | `PTO2TaskId` |
 | `PTO2TensorMapEntry.producer_task_id` | `int32_t` | `PTO2TaskId` |
 | `PTO2TaskSlotState.ring_id` | N/A | `uint8_t` (new, denormalized for fast access) |
 
@@ -187,7 +187,7 @@ Note: dep entries from ring N's pool may appear in ring M's fanout lists. Reclam
 
 ## 6. AICPU Register Protocol Fix
 
-The AICore dispatch protocol uses 32-bit registers. With multi-ring, `mixed_task_id` truncation to 32-bit loses the `ring_id`, causing collisions:
+The AICore dispatch protocol uses 32-bit registers. With multi-ring, `task_id` truncation to 32-bit loses the `ring_id`, causing collisions:
 
 ```
 Ring 0, local_id=0  →  DATA_MAIN_BASE = 0 + 1 = 1
@@ -196,7 +196,7 @@ Ring 1, local_id=0  →  DATA_MAIN_BASE = 0 + 1 = 1  (collision!)
 
 AICore uses `last_reg_val` to detect new dispatches — identical values cause skipped tasks and false completions from stale COND registers.
 
-**Fix**: Per-core monotonic dispatch counter `s_dispatch_seq[core_id]` replaces `mixed_task_id` in register writes, guaranteeing unique `DATA_MAIN_BASE` values per core regardless of ring origin.
+**Fix**: Per-core monotonic dispatch counter `s_dispatch_seq[core_id]` replaces `task_id` in register writes, guaranteeing unique `DATA_MAIN_BASE` values per core regardless of ring origin.
 
 ## 7. Configuration
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -325,7 +325,7 @@ When `pto2_submit_task` processes parameters:
 
 | Field | Description |
 |-------|-------------|
-| `mixed_task_id` | Canonical mixed-task ID (64-bit: `ring_id << 32 | local_id`). See [MULTI_RING.md §3](MULTI_RING.md). |
+| `task_id` | Canonical mixed-task ID (64-bit: `ring_id << 32 | local_id`). See [MULTI_RING.md §3](MULTI_RING.md). |
 | `kernel_id[3]` | Per-slot kernel IDs: `[AIC, AIV0, AIV1]`; `INVALID_KERNEL_ID` = inactive |
 | `active_mask` | Bitmask of active subtask slots: `bit0=AIC`, `bit1=AIV0`, `bit2=AIV1` |
 | `subtask_done_mask` | Atomic bitmask; each subtask sets its done bit on completion |
@@ -446,11 +446,11 @@ Each scheduler thread runs a tight loop with two main phases:
 
 **Phase 1 — Completion Handling**:
 - Poll register `COND` on each managed core
-- When `TASK_FIN_STATE` detected: record completion timestamps, call `on_subtask_complete(mixed_task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, trigger `on_mixed_task_complete(mixed_task_id)` which marks `task_state[slot] = COMPLETED`, acquires fanout lock, traverses fanout list (incrementing consumers' `fanin_refcount`), marks `task_state[slot] = CONSUMED`, and advances `last_task_alive` watermark
+- When `TASK_FIN_STATE` detected: record completion timestamps, call `on_subtask_complete(task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, trigger `on_mixed_task_complete(task_id)` which marks `task_state[slot] = COMPLETED`, acquires fanout lock, traverses fanout list (incrementing consumers' `fanin_refcount`), marks `task_state[slot] = CONSUMED`, and advances `last_task_alive` watermark
 
 **Phase 2 — Dispatch**:
 - For each idle core: pop a task from the matching shape-based ready queue (lock-free MPMC Vyukov queue, one per resource shape)
-- Build `PTO2DispatchPayload` from `TaskDescriptor` with `mixed_task_id`, `subslot`, `kernel_id`, and `core_type`
+- Build `PTO2DispatchPayload` from `TaskDescriptor` with `task_id`, `subslot`, `kernel_id`, and `core_type`
 - Write task pointer to `Handshake.task`, signal AICore via register `DATA_MAIN_BASE`
 
 After these phases, the scheduler updates profiling headers and checks for termination (all tasks completed and orchestrator done).
@@ -498,7 +498,7 @@ Each AICore worker has a `Handshake` struct in shared memory:
 
 Instead of polling `Handshake.task_status`, the production protocol uses hardware registers.
 
-> **Multi-ring note**: `mixed_task_id` is 64-bit but registers are 32-bit. A per-core monotonic dispatch counter (`s_dispatch_seq`) replaces `mixed_task_id` in register writes to prevent collisions. See [MULTI_RING.md §6](MULTI_RING.md).
+> **Multi-ring note**: `task_id` is 64-bit but registers are 32-bit. A per-core monotonic dispatch counter (`s_dispatch_seq`) replaces `task_id` in register writes to prevent collisions. See [MULTI_RING.md §6](MULTI_RING.md).
 
 | Register | Direction | Usage |
 |----------|-----------|-------|
@@ -518,7 +518,7 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 
 | Field | Description |
 |-------|-------------|
-| `mixed_task_id` | Mixed-task identifier (for completion aggregation) |
+| `task_id` | Mixed-task identifier (for completion aggregation) |
 | `subslot` | Which subtask slot this dispatch represents (`AIC`, `AIV0`, or `AIV1`) |
 | `kernel_id` | Function ID for this subtask slot |
 | `core_type` | AIC or AIV |

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -89,7 +89,7 @@ Rules:
 
 `PTO2TaskDescriptor` (hot path) carries mixed-task identity/state:
 
-1. `mixed_task_id`
+1. `task_id`
 2. `active_mask`
 3. `subtask_done_mask`
 4. `kernel_id[3]` for `(AIC, AIV0, AIV1)`
@@ -128,8 +128,8 @@ Queueing key is normalized resource shape (not raw slot label).
 
 1. Fanin release/readiness remains dependency-correct and graph-level.
 2. Two-stage completion:
-   - `on_subtask_complete(mixed_task_id, subslot)`
-   - `on_mixed_task_complete(mixed_task_id)` only when `subtask_done_mask == active_mask`
+   - `on_subtask_complete(task_id, subslot)`
+   - `on_mixed_task_complete(task_id)` only when `subtask_done_mask == active_mask`
 3. Downstream release is triggered once per mixed task completion, not once per subslot.
 
 ## 9. Executor Ownership and Numbering

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -110,7 +110,7 @@ The scheduler loop runs four phases each iteration. Each phase's time is accumul
 
 | Phase | What it does | Inline stats |
 |-------|-------------|-------------|
-| **complete** | Polls handshake on each managed core; when a core completes, calls `on_subtask_complete(mixed_task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, triggers `on_mixed_task_complete` which traverses fanout list (notify consumers) and fanin list (release producers) | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
+| **complete** | Polls handshake on each managed core; when a core completes, calls `on_subtask_complete(task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, triggers `on_mixed_task_complete` which traverses fanout list (notify consumers) and fanin list (release producers) | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
 | **scan** | Updates the perf profiling header with latest scheduler state | — |
 | **dispatch** | For each idle core, pops a task from the shape-based ready queue via `get_ready_task(shape)`, builds the dispatch payload, and writes the task to the core's handshake register | `pop`: `hit` = successful pops (task dispatched), `miss` = empty queue pops, `hit_rate` = hit/(hit+miss) |
 | **idle** | Scheduler loop iteration where no progress was made (no completions, no dispatches) | — |

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -43,7 +43,7 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // The strong symbol from the AICPU build wins when profiling is available.
 // Also hidden to prevent HOST .so from polluting the global symbol table.
 __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
+    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 // Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // task ring alloc
@@ -78,7 +78,7 @@ uint64_t g_orch_scope_end_atomic_count = 0;
 #include "aicpu/performance_collector_aicpu.h"
 __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
 __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
+    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 // submit_idx needed for swimlane task_id tagging (no cycle accumulation at this level)
 static uint32_t g_orch_submit_idx = 0;
 #define CYCLE_COUNT_START()                                                           \
@@ -340,7 +340,7 @@ void pto2_submit_mixed_task(
     int32_t local_id = task_ring.pto2_task_ring_alloc();
     if (local_id < 0) { orch->fatal = true; return; }
     int32_t slot = task_ring.get_task_slot(local_id);
-    PTO2TaskId mixed_task_id = pto2_make_task_id(ring_id, static_cast<uint32_t>(local_id));
+    PTO2TaskId task_id = pto2_make_task_id(ring_id, static_cast<uint32_t>(local_id));
 
     PTO2TaskDescriptor& task = task_ring.get_task_by_slot(slot);
     PTO2TaskPayload* payload = &orch->sm_handle->task_payloads[ring_id][slot];
@@ -387,7 +387,7 @@ void pto2_submit_mixed_task(
     PTO2TaskSlotState* fanin_states[PTO2_MAX_INPUTS];
     int32_t fanin_count = 0;
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, local_id);
+    CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, task_id.raw);
 
     // === STEP 2: Calculate output size + heap alloc (read from params only, no GM access) ===
     bool needs_alloc[PTO2_MAX_TENSOR_PARAMS] = {};
@@ -407,7 +407,7 @@ void pto2_submit_mixed_task(
         if (!local_packed_base) { orch->fatal = true; return; }
         local_packed_end = (char*)local_packed_base + total_output_size;
     }
-    CYCLE_COUNT_LAP_RECORD(g_orch_heap_cycle, AicpuPhaseId::ORCH_HEAP, local_id);
+    CYCLE_COUNT_LAP_RECORD(g_orch_heap_cycle, AicpuPhaseId::ORCH_HEAP, task_id.raw);
 #if PTO2_ORCH_PROFILING
     if (total_output_size > 0) {
         g_orch_heap_atomic_count += 1;  // heap_top.store in pto2_alloc_packed_buffer
@@ -424,7 +424,7 @@ void pto2_submit_mixed_task(
         orch->rings[ring_id].dep_pool.reclaim(*sched, ring_id, sm_last_task_alive);
     }
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, local_id);
+    CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, task_id.raw);
 
     // === STEP 4: Lookup inputs + assign output addrs (all from params, no GM) ===
     int32_t offset = 0;
@@ -486,25 +486,25 @@ void pto2_submit_mixed_task(
         }
     }
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_lookup_cycle, AicpuPhaseId::ORCH_LOOKUP, local_id);
+    CYCLE_COUNT_LAP_RECORD(g_orch_lookup_cycle, AicpuPhaseId::ORCH_LOOKUP, task_id.raw);
 
     // === STEP 5: Register outputs/inouts in TensorMap (must be separate from lookup) ===
     for (int i = 0; i < params.tensor_count; i++) {
         PTOParamType ptype = params.tensor_types[i];
         if (ptype == PTOParamType::OUTPUT || ptype == PTOParamType::INOUT) {
             if (!params.tensors[i]->manual_dep) {
-                orch->tensor_map.insert(*params.tensors[i], mixed_task_id, needs_alloc[i]);
+                orch->tensor_map.insert(*params.tensors[i], task_id, needs_alloc[i]);
             }
         }
     }
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_insert_cycle, AicpuPhaseId::ORCH_INSERT, local_id);
+    CYCLE_COUNT_LAP_RECORD(g_orch_insert_cycle, AicpuPhaseId::ORCH_INSERT, task_id.raw);
 
     // === STEP 6: Batch-write to GM (single cache line burst) ===
     // Deferred from allocation phase to avoid scattered GM writes that get
     // evicted by TensorMap lookup/insert cache pressure.
     __builtin_prefetch(&task, 1, 1);
-    task.mixed_task_id = mixed_task_id;
+    task.task_id = task_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)]  = normalized.aic_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;
@@ -523,7 +523,7 @@ void pto2_submit_mixed_task(
 
     payload->init(params);
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS, local_id);
+    CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS, task_id.raw);
 #if PTO2_ORCH_PROFILING
     g_orch_params_atomic_count += 2;  // fanout_lock.store + fanout_count.store
 #endif
@@ -588,7 +588,7 @@ void pto2_submit_mixed_task(
 #endif
     }
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_fanin_cycle, AicpuPhaseId::ORCH_FANIN, local_id);
+    CYCLE_COUNT_LAP_RECORD(g_orch_fanin_cycle, AicpuPhaseId::ORCH_FANIN, task_id.raw);
 
 #if PTO2_PROFILING
     orch->tasks_submitted++;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -329,7 +329,7 @@ struct PTO2DepListEntry {
  */
 struct PTO2TaskDescriptor {
     // Mixed-task identification (encodes ring_id in upper 32 bits)
-    PTO2TaskId mixed_task_id;         // raw: (ring_id << 32) | local_id
+    PTO2TaskId task_id;         // raw: (ring_id << 32) | local_id
 
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -184,10 +184,10 @@ void Runtime::complete_perf_records(PerfBuffer* perf_buf) {
 
     for (uint32_t i = 0; i < count; i++) {
         PerfRecord* record = &perf_buf->records[i];
-        int32_t task_id = record->task_id;
+        uint32_t local_id = static_cast<uint32_t>(record->task_id & 0xFFFFFFFFu);
 
         // Get slot state for fanout traversal
-        int32_t slot = task_id & window_mask;
+        int32_t slot = static_cast<int32_t>(local_id) & window_mask;
         PTO2TaskSlotState& ss = slot_states[slot];
 
         // Fill fanout information by traversing the linked list
@@ -195,16 +195,8 @@ void Runtime::complete_perf_records(PerfBuffer* perf_buf) {
         PTO2DepListEntry* cur = ss.fanout_head;
 
         while (cur != nullptr && record->fanout_count < RUNTIME_MAX_FANOUT) {
-            // PerfRecord.fanout stores 32-bit legacy task IDs. Our multi-ring task ID
-            // encodes ring_id in the upper 32 bits, so only the legacy single-ring
-            // case (ring_id==0) is representable here.
-            PTO2TaskId mixed_task_id = cur->slot_state->task->mixed_task_id;
-            if (mixed_task_id.ring() != 0) {
-                // Skip: cannot represent (ring_id, local_id) in a 32-bit fanout slot.
-                cur = cur->next;
-                continue;
-            }
-            record->fanout[record->fanout_count++] = static_cast<int32_t>(mixed_task_id.local());
+            const PTO2TaskId succ = cur->slot_state->task->task_id;
+            record->fanout[record->fanout_count++] = succ.raw;
             cur = cur->next;
         }
     }

--- a/tools/swimlane_converter.py
+++ b/tools/swimlane_converter.py
@@ -31,6 +31,29 @@ except ImportError:
     from tools.sched_overhead_analysis import parse_scheduler_threads, run_analysis as run_sched_overhead_analysis
 
 
+def format_task_display(task_id):
+    """Format PTO2 task_id for human-readable labels.
+
+    Layout: 64-bit raw = (ring_id << 32) | local_id (same as runtime PTO2TaskId).
+
+    Returns:
+        ``r{ring}t{local}`` when ring != 0 (e.g. r2t100), else ``t{local}`` for single-ring (ring 0).
+
+    For invalid or non-numeric values, returns str(task_id).
+    """
+    try:
+        tid = int(task_id)
+    except (TypeError, ValueError):
+        return str(task_id)
+    if tid < 0:
+        tid &= (1 << 64) - 1
+    ring = (tid >> 32) & 0xFF
+    local = tid & 0xFFFFFFFF
+    if ring == 0:
+        return f"t{local}"
+    return f"r{ring}t{local}"
+
+
 def read_perf_data(filepath):
     """Read performance data from JSON file.
 
@@ -418,22 +441,21 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
         ts = task['start_time_us']
         dur = task['duration_us']
 
-        # Build fanout hint string
-        fanout_str = "[" + ", ".join(str(x) for x in task['fanout']) + "]"
+        # Build fanout hint string (packed ids → rXtY / tY for readability)
+        fanout_str = "[" + ", ".join(format_task_display(x) for x in task['fanout']) + "]"
 
         # Get function name if available
         func_id = task['func_id']
+        tdisp = format_task_display(task['task_id'])
         if func_id_to_name and str(func_id) in func_id_to_name:
             func_name = func_id_to_name[str(func_id)]
-            # New format: FuncName(task_id)
-            task_name = f"{func_name}({task['task_id']})"
+            task_name = f"{func_name}({tdisp})"
         else:
-            # Fallback format: Func_{func_id}(task_id)
-            task_name = f"Func_{func_id}({task['task_id']})"
+            task_name = f"Func_{func_id}({tdisp})"
 
         events.append({
             "args": {
-                "event-hint": f"Task:{task['task_id']}, FuncId:{func_id}, CoreId:{task['core_id']}",
+                "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
                 "fanout-hint": fanout_str,
                 "duration-us": dur,
                 "kernel-ready-time-us": task['kernel_ready_time_us'],
@@ -466,15 +488,16 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
             # Get function name if available
             func_id = task['func_id']
+            tdisp = format_task_display(task['task_id'])
             if func_id_to_name and str(func_id) in func_id_to_name:
                 func_name = func_id_to_name[str(func_id)]
-                task_name = f"{func_name}({task['task_id']})"
+                task_name = f"{func_name}({tdisp})"
             else:
-                task_name = f"Func_{func_id}({task['task_id']})"
+                task_name = f"Func_{func_id}({tdisp})"
 
             events.append({
                 "args": {
-                    "event-hint": f"Task:{task['task_id']}, FuncId:{func_id}, CoreId:{task['core_id']}",
+                    "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
                     "dispatch-time-us": dispatch_us,
                     "finish-time-us": finish_us,
                     "aicpu-duration-us": aicpu_dur,
@@ -502,7 +525,10 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
         for succ_task_id in task['fanout']:
             if succ_task_id not in task_map:
                 if verbose:
-                    print(f"Warning: Task {task['task_id']} references non-existent successor {succ_task_id}")
+                    print(
+                        f"Warning: Task {format_task_display(task['task_id'])} (raw {task['task_id']}) "
+                        f"references non-existent successor {format_task_display(succ_task_id)} (raw {succ_task_id})"
+                    )
                 continue
 
             succ_task = task_map[succ_task_id]
@@ -678,9 +704,9 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                 # Strip "orch_" prefix for display name
                 display_name = phase.replace("orch_", "") if phase.startswith("orch_") else phase
 
-                # Show task_id in name for task-specific phases
+                # Show packed task_id as rXtY / tY for task-specific phases
                 if task_id >= 0:
-                    label = f"{display_name}(t{task_id})"
+                    label = f"{display_name}({format_task_display(task_id)})"
                 else:
                     label = f"{display_name}({submit_idx})"
 
@@ -867,34 +893,31 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                 })
                 flow_id += 1
 
-    # Orchestrator FINALIZE → Scheduler DISPATCH arrows (per task_id)
+    # Orchestrator → scheduler dispatch: anchor at orch_fanin end (not orch_finalize.start).
+    # Fanin completion ⇒ dependencies satisfied ⇒ task becomes dispatchable; tie flow to dispatch_time_us.
     if orchestrator_phases and scheduler_phases:
-        # Flatten per-thread orch phases and track source thread
-        orch_finalize_by_task = {}
+        orch_fanin_by_task = {}
         for orch_idx, thread_records in enumerate(orch_threads):
             for record in thread_records:
-                if record.get("phase") == "orch_finalize":
+                if record.get("phase") == "orch_fanin":
                     task_id = record.get("task_id", -1)
                     if task_id >= 0:
-                        orch_finalize_by_task[task_id] = (record, orch_idx)
+                        orch_fanin_by_task[task_id] = (record, orch_idx)
 
         # Use core_to_sched_thread mapping (built above) to find the correct
         # scheduler thread for each task's core.
-        if orch_finalize_by_task and has_aicpu_data:
+        if orch_fanin_by_task and has_aicpu_data:
             for task in tasks:
                 tid = task.get('task_id')
-                if tid is None or tid not in orch_finalize_by_task:
+                if tid is None or tid not in orch_fanin_by_task:
                     continue
 
                 dispatch_us = task.get('dispatch_time_us', 0)
                 if dispatch_us <= 0:
                     continue
 
-                finalize_rec, orch_idx = orch_finalize_by_task[tid]
-                # Use finalize start_time: init_task() runs at the beginning of FINALIZE,
-                # making the task dispatchable before FINALIZE ends. Using start avoids
-                # reverse arrows when the scheduler dispatches during FINALIZE.
-                finalize_start_us = finalize_rec["start_time_us"]
+                fanin_rec, orch_idx = orch_fanin_by_task[tid]
+                fanin_end_us = fanin_rec["end_time_us"]
 
                 matched_thread = core_to_sched_thread.get(task['core_id'])
 
@@ -902,20 +925,20 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     sched_tid = 3000 + matched_thread
                     orch_tid = 4000 + orch_idx
 
-                    # Flow: Orchestrator finalize start → Scheduler DISPATCH
+                    # Flow: fanin end → dispatch (dependencies ready → scheduler issues dispatch)
                     events.append({
                         "cat": "flow",
                         "id": flow_id,
-                        "name": "orch→dispatch",
+                        "name": "fanin→dispatch",
                         "ph": "s",
                         "pid": 4,
                         "tid": orch_tid,
-                        "ts": finalize_start_us
+                        "ts": fanin_end_us
                     })
                     events.append({
                         "cat": "flow",
                         "id": flow_id,
-                        "name": "orch→dispatch",
+                        "name": "fanin→dispatch",
                         "ph": "f",
                         "pid": 3,
                         "tid": sched_tid,


### PR DESCRIPTION
PerfRecord.task_id was uint32 and could only represent local task
indices, making it impossible to distinguish tasks across rings in
multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph).

- Widen PerfRecord.task_id uint32 → uint64; encode as (ring_id << 32)
  | local_id; remove now-redundant ring_id field
- Widen PerfRecord.fanout[] int32 → uint64 to store full 64-bit
  successor task_ids across rings
- Merge AicpuPhaseRecord.tasks_processed/padding into union
  { task_id; tasks_processed } for orchestrator cross-view correlation
- AICPU executors overwrite task_id with full PTO2 encoding after
  handshake match; host_build_graph sets task_id to plain integer index
- Rename PTO2TaskDescriptor.mixed_task_id → task_id; pass task_id.raw
  to orchestrator perf phases (replacing local_id)
- Update host perf export to derive ring_id from task_id >> 32
- Add format_task_display() in swimlane_converter.py for r{ring}t{local}
  human-readable labels in Chrome trace output
- AICore perf flush: replace dcci(count) + dcci(record) with
  dcci(record) + dsb(0) to ensure record visibility before count update