### PR TITLE
Eliminate AIV_HUB init task in paged_attention_unroll orchestration

### DIFF
--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -170,15 +170,6 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                 prof_view_count += 2;
                 CYCLE_COUNT_LAP(prof_tensor_view);
 
-                PTOParam params_inplace;
-                params_inplace.add_output(oi);
-                params_inplace.add_output(li_update);
-                params_inplace.add_output(mi_update);
-                CYCLE_COUNT_LAP(prof_param_setup);
-                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_inplace);
-                prof_submit_count++;
-                CYCLE_COUNT_LAP(prof_submit_task);
-
                 // Reusable PTOParam objects — reset() before each use avoids
                 // repeated stack-frame construction in the inner loop.
                 // params_qk must persist until params_pv.copy_scalars_from().
@@ -256,9 +247,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
                     params_up.add_input(mi);
                     params_up.add_input(li);
                     params_up.add_input(oi_new);
-                    params_up.add_inout(mi_update);
-                    params_up.add_inout(li_update);
-                    params_up.add_inout(oi);
+                    if (is_first) {
+                        params_up.add_output(mi_update);
+                        params_up.add_output(li_update);
+                        params_up.add_output(oi);
+                    } else {
+                        params_up.add_inout(mi_update);
+                        params_up.add_inout(li_update);
+                        params_up.add_inout(oi);
+                    }
                     params_up.add_output(out_view);
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);


### PR DESCRIPTION
## Summary

- Remove the standalone `FUNC_AIV_HUB` task that was submitted solely
  to zero-initialize the online-update accumulators (`oi`, `mi_update`,
  `li_update`) before the paged-attention inner loop.
- Change the first-iteration buffer semantics in `FUNC_ONLINE_UPDATE`:
  use `add_output` (write-only) when `is_first == true` so the kernel
  initializes the accumulators itself; keep `add_inout` (read-write)
  for subsequent iterations.
- Net effect: one fewer AIV task submission per query-head group,
  reducing AICPU scheduling overhead and shortening the critical path.

## Motivation

The `AIV_HUB` initialization task was a separate kernel launch whose
only purpose was to prepare accumulator buffers before the first online-
update iteration. Since the online-update kernel already receives the
`is_first` flag and can distinguish the initial write from incremental
updates, the initialization can be folded into the first iteration by
switching the buffer direction from `inout` to `output`. This avoids
the extra task submission, parameter setup, and synchronization cost.