### PR TITLE
Default perf-runtime-device skill to tensormap_and_ringbuffer runtime

### DIFF
--- a/.claude/commands/perf-runtime-device.md
+++ b/.claude/commands/perf-runtime-device.md
@@ -1,8 +1,10 @@
-Benchmark the hardware performance of all examples under `tests/device_tests/a2a3/$ARGUMENTS/`.
+Benchmark the hardware performance of all examples under `tests/device_tests/a2a3/<runtime>/`.
+
+If `$ARGUMENTS` is provided, use it as the runtime name. Otherwise, default to `tensormap_and_ringbuffer`.
 
 Reference `tools/benchmark_rounds.sh` for the full implementation pattern (device log resolution, timing parsing, reporting format).
 
-1. Validate `$ARGUMENTS` is one of: `host_build_graph`, `aicpu_build_graph`, `tensormap_and_ringbuffer`. If not, list valid runtimes and stop
+1. Validate the runtime is one of: `host_build_graph`, `aicpu_build_graph`, `tensormap_and_ringbuffer`. If not, list valid runtimes and stop
 2. Check `command -v npu-smi` — if not found, tell the user this requires hardware and stop
 3. Run `npu-smi info`, find the lowest-ID idle device (HBM-Usage = 0). If none, stop
 4. Enumerate all subdirectories under `tests/device_tests/a2a3/$ARGUMENTS/` that contain both `kernels/kernel_config.py` and `golden.py`


### PR DESCRIPTION
## Summary

Default `perf-runtime-device` skill to `tensormap_and_ringbuffer` when no runtime argument is provided.

## Motivation

`perf-example-device` already hardcodes `tensormap_and_ringbuffer` as its target runtime. However, `perf-runtime-device` required `$ARGUMENTS` to be explicitly set, making the two skills inconsistent. Since `tensormap_and_ringbuffer` is the most commonly benchmarked runtime, defaulting to it reduces friction and aligns behavior across the perf skills.

## Changes

- Make `$ARGUMENTS` optional in `perf-runtime-device.md`; default to `tensormap_and_ringbuffer` when omitted
- Update path description from `$ARGUMENTS` to `<runtime>` placeholder to reflect the optional semantics