### PR TITLE
fix(paged_attention_unroll): fix Case2 precision error with canonical double-buffering

### DIFF
--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -9,8 +9,11 @@
 // Single output: oi_new (M, N) fp32 = sum of P_i @ V_i across all blocks
 //
 // Optimizations:
-//   - Double-buffered L1 tiles (ping/pong for A and B)
-//   - TLOAD(next pij+vj) overlaps with TMATMUL_ACC(current) via MTE2/PIPE_M parallelism
+//   - Double-buffered L1 tiles (ping/pong for A and B via MTE2)
+//   - Double-buffered L0 tiles (ping/pong for L0A and L0B via MTE1)
+//   - TLOAD(next) overlaps with TMATMUL(current) via MTE2/M-pipe parallelism
+//   - Canonical 3-stage pipeline: TLOAD(MTE2) → TMOV(MTE1) → TMATMUL(M)
+//   - Reverse-dependency events ensure buffer safety across iterations
 //
 // Supports two tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
@@ -53,67 +56,75 @@ static __aicore__ void pv_matmul_n_impl(
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
     using AccTile = TileAcc<float, M, N, M, N>;
 
-    // Double-buffered L1 tiles (ping/pong)
-    TileMatA aMatTile_ping, aMatTile_pong;
-    TileMatB bMatTile_ping, bMatTile_pong;
-    TASSIGN(aMatTile_ping, 0x0);
-    TASSIGN(aMatTile_pong, 0x10000);
-    TASSIGN(bMatTile_ping, 0x20000);
-    TASSIGN(bMatTile_pong, 0x30000);
+    // L1 memory layout: double-buffered A and B tiles (tightly packed)
+    constexpr int kATileBytes = M * K * static_cast<int>(sizeof(bfloat16_t));
+    constexpr int kBTileBytes = K * N * static_cast<int>(sizeof(bfloat16_t));
 
-    LeftTile aTile;
-    RightTile bTile;
+    TileMatA aMatTile[2];
+    TileMatB bMatTile[2];
+    TASSIGN(aMatTile[0], 0x0);
+    TASSIGN(aMatTile[1], kATileBytes);
+    TASSIGN(bMatTile[0], 2 * kATileBytes);
+    TASSIGN(bMatTile[1], 2 * kATileBytes + kBTileBytes);
+
+    // L0 memory layout: double-buffered L0A and L0B, single accumulator L0C
+    LeftTile aTile[2];
+    RightTile bTile[2];
     AccTile cTile;
-    TASSIGN(aTile, 0x0);
-    TASSIGN(bTile, 0x0);
+    TASSIGN(aTile[0], 0x0);
+    TASSIGN(aTile[1], kATileBytes);
+    TASSIGN(bTile[0], 0x0);
+    TASSIGN(bTile[1], kBTileBytes);
     TASSIGN(cTile, 0x0);
 
     GlobalOut oiGlobal(oi_base);
 
-    // Pre-load first iteration's tiles into ping buffers
-    GlobalA pijGlobal_0(pij_base);
-    GlobalB vjGlobal_0(val_base + block_table[0] * K * N);
-    TLOAD(aMatTile_ping, pijGlobal_0);
-    TLOAD(bMatTile_ping, vjGlobal_0);
+    // Seed reverse-dependency flags: all ping/pong buffers initially free
+    //   PIPE_MTE1 → PIPE_MTE2: L1 buffer [0/1] safe for TLOAD to overwrite
+    //   PIPE_M    → PIPE_MTE1: L0 buffer [0/1] safe for TMOV to overwrite
+    set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
+    set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID1);
+    set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+    set_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
 
     for (uint64_t i = 0; i < n_blocks; i++) {
-        // Select current buffers based on iteration parity
-        TileMatA& curA = (i % 2 == 0) ? aMatTile_ping : aMatTile_pong;
-        TileMatB& curB = (i % 2 == 0) ? bMatTile_ping : bMatTile_pong;
+        int cur = static_cast<int>(i % 2);
+        GlobalA pijGlobal(pij_base + i * M * K);
+        GlobalB vjGlobal(val_base + block_table[i] * K * N);
 
-        // Wait for current TLOAD to complete
-        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
-        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        // Stage 1: TLOAD (MTE2: GM → L1[cur])
+        // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
+        wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
+        TLOAD(aMatTile[cur], pijGlobal);
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);   // forward: A in L1 ready
+        TLOAD(bMatTile[cur], vjGlobal);
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);   // forward: B in L1 ready
 
-        // Wait for previous matmul to complete (L0A/L0B safe to overwrite)
-        if (i > 0) {
-            wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
-        }
+        // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
+        // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
+        wait_flag(PIPE_M, PIPE_MTE1, (event_t)cur);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: wait A loaded
+        TMOV(aTile[cur], aMatTile[cur]);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
+        TMOV(bTile[cur], bMatTile[cur]);
+        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur); // reverse: release L1[cur]
 
-        TMOV(aTile, curA);
-        TMOV(bTile, curB);
-
-        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
-        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
-
+        // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
+        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);   // forward: L0[cur] ready
+        wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
         if (i == 0) {
-            TMATMUL(cTile, aTile, bTile);
+            TMATMUL(cTile, aTile[cur], bTile[cur]);
         } else {
-            TMATMUL_ACC(cTile, cTile, aTile, bTile);
+            TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
         }
-
-        // Prefetch next iteration's data (MTE2 overlaps with matmul completion)
-        if (i + 1 < n_blocks) {
-            // Signal matmul completion for next iteration's TMOV guard
-            set_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
-            TileMatA& nxtA = (i % 2 == 0) ? aMatTile_pong : aMatTile_ping;
-            TileMatB& nxtB = (i % 2 == 0) ? bMatTile_pong : bMatTile_ping;
-            GlobalA pijGlobal_next(pij_base + (i + 1) * M * K);
-            GlobalB vjGlobal_next(val_base + block_table[i + 1] * K * N);
-            TLOAD(nxtA, pijGlobal_next);
-            TLOAD(nxtB, vjGlobal_next);
-        }
+        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);   // reverse: release L0[cur]
     }
+
+    // Drain outstanding reverse-dependency flags
+    wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID1);
+    wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
 
     set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -190,11 +190,13 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
+        pipe_barrier(PIPE_V);
         TRESHAPE(alphaDN, alphaRow);
         TRESHAPE(betaDN, betaRow);
 
         // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
+        pipe_barrier(PIPE_V);
         TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
         pipe_barrier(PIPE_V);
         TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -122,21 +122,22 @@ static __aicore__ void softmax_prepare_n_impl(
             TileSijDyn sijDynTile(static_cast<size_t>(valid_len_last));
             TASSIGN(sijDynTile, 0x0);
             TFILLPAD_INPLACE(sijPadTile_A, sijDynTile);
+            pipe_barrier(PIPE_V);
         }
 
         TMULS(sijTile_A, sijTile_A, scale_value);
         pipe_barrier(PIPE_V);
         TROWMAX(localMaxDN, sijTile_A, tmpTile);
+        pipe_barrier(PIPE_V);
 
         // TRESHAPE: ColMajor(M,1) → RowMajor(1,M) for element-wise TMAX
         TRESHAPE(localMaxRow, localMaxDN);
         if (i == 0) {
-            pipe_barrier(PIPE_V);
             TMAX(globalMaxRow, localMaxRow, localMaxRow);
         } else {
-            pipe_barrier(PIPE_V);
             TMAX(globalMaxRow, globalMaxRow, localMaxRow);
         }
+        pipe_barrier(PIPE_V);
     }
 
     // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for Pass 2's TROWEXPANDSUB
@@ -174,6 +175,7 @@ static __aicore__ void softmax_prepare_n_impl(
                 TASSIGN(curSijDyn, static_cast<int>(kDataBytes));
                 TFILLPAD_INPLACE(sijPadTile_B, curSijDyn);
             }
+            pipe_barrier(PIPE_V);
         }
 
         // Compute on current buffer (select A or B based on iteration parity)
@@ -188,9 +190,12 @@ static __aicore__ void softmax_prepare_n_impl(
         }
         pipe_barrier(PIPE_V);
         TEXP(pijTile, pijTile);
+        pipe_barrier(PIPE_V);
         TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
+        pipe_barrier(PIPE_V);
         TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
 
+        pipe_barrier(PIPE_V);
         if (i == 0) {
             TMULS(sumAccTile, pijTile, 1.0f);
         } else {
@@ -198,6 +203,7 @@ static __aicore__ void softmax_prepare_n_impl(
         }
 
         // Store pij (must complete before next iteration's TCVT overwrites pijBf16Tile)
+        pipe_barrier(PIPE_V);
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         TSTORE(pijGlobal, pijBf16Tile);


### PR DESCRIPTION
## Summary

Fix Case2 precision error in `paged_attention_unroll` by rewriting the
PV matmul with canonical 3-stage double-buffered pipeline synchronization,
and adding missing vector pipe barriers in the AIV kernels.

## Problem

Case2 (M=64, K=64, N=128) fails precision verification intermittently
while Case1 (M=16, K=128, N=128) always passes. Case2's larger M makes
M-pipe execution longer, exposing pipeline hazards masked by Case1.

## Root Cause

### AIC: aic_pv_matmul.cpp

Three synchronization defects in the double-buffered pipeline:

| Defect | Description |
|--------|-------------|
| Single-buffered L0 | One L0A/L0B address — TMOV overwrites L0 while M-pipe still reads previous TMATMUL_ACC |
| Missing L1 reverse dep | TLOAD into L1[next] without waiting for MTE1 to finish reading that buffer |
| Fragile event IDs | EVENT_ID0/1 overloaded across dependency types without per-buffer tracking |

### AIV: aiv_softmax_prepare.cpp, aiv_online_update.cpp

Missing `pipe_barrier(PIPE_V)` between dependent vector operations
(TFILLPAD_INPLACE, TROWMAX, TRESHAPE, TROWEXPANDMUL, TEXP, TCVT),
allowing V-pipe reordering to produce stale results on larger tiles.

## Fix

**aic_pv_matmul.cpp** — Canonical 3-stage pipeline: TLOAD(MTE2) → TMOV(MTE1) → TMATMUL(M)
- Double-buffer both L1 and L0 with ping/pong indexed by `i % 2`
- Per-buffer reverse-dependency events: MTE1→MTE2 (L1) and M→MTE1 (L0)
- Per-operand forward events: EVENT_ID0 for A, EVENT_ID1 for B
- Seed all reverse flags before loop, drain after

**aiv_softmax_prepare.cpp** — Add 6 `pipe_barrier(PIPE_V)` between
dependent vector instructions.

**aiv_online_update.cpp** — Add 2 `pipe_barrier(PIPE_V)` between
TRESHAPE and TROWEXPANDMUL sequences.
