### PR TITLE
sync(a5): align runtime with a2a3 and add paged_attention_unroll test

### DIFF
--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -46,7 +46,7 @@ constexpr int PLATFORM_MAX_AICPU_THREADS = 7;
  * Can be larger than PLATFORM_MAX_AICPU_THREADS to allow threads to be dropped
  * from scheduling while still participating in affinity (e.g. 6 launch, 4 active).
  */
-constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 6;
+constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 7;
 
 // =============================================================================
 // Derived Platform Limits

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -304,11 +304,10 @@ int DeviceRunner::run(Runtime& runtime,
     }
 
     // Validate even core distribution for initial scheduler threads
-    // All-orchestrator mode (scheduler_thread_num == 0): cores assigned post-transition
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
-            LOG_ERROR("block_dim (%d) must be evenly divisible by scheduler_thread_num (%d)",
-                      block_dim, scheduler_thread_num);
+            LOG_ERROR("block_dim (%d) not evenly divisible by scheduler_thread_num (%d)",
+                     block_dim, scheduler_thread_num);
             return -1;
         }
     } else {
@@ -413,9 +412,8 @@ int DeviceRunner::run(Runtime& runtime,
     }
 
     std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServer===" << '\n';
-    // Launch AICPU main kernel
-    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer",
-                             PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
+    // Launch AICPU main kernel (over-launch for affinity gate)
+    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
         if (kernel_args_.args.regs != 0) {
@@ -741,7 +739,6 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
 
-    // Define free callback (a5: use MemoryAllocator)
     auto free_cb = [](void* dev_ptr, void* user_data) -> int {
         auto* allocator = static_cast<MemoryAllocator*>(user_data);
         return allocator->free(dev_ptr);

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -81,10 +81,10 @@ struct CoreInfo {
 };
 
 struct CoreTypeTracker {
-    int32_t idle[MAX_CORES_PER_THREAD];
-    int32_t running[MAX_CORES_PER_THREAD];
     int32_t idle_count;
     int32_t running_count;
+    int32_t idle[MAX_CORES_PER_THREAD];
+    int32_t running[MAX_CORES_PER_THREAD];
 
     void move_idle_to_running(int32_t idx) {
         running[running_count++] = idle[idx];
@@ -113,7 +113,6 @@ struct CoreStateTracker {
     CoreTypeTracker by_type[2];  // indexed by static_cast<int32_t>(CoreType)
     Cluster clusters[MAX_AIC_PER_THREAD];
     int32_t cluster_count;
-    bool core_idle[MAX_CORES_PER_THREAD];
 
     CoreTypeTracker& aic() { return by_type[0]; }
     CoreTypeTracker& aiv() { return by_type[1]; }
@@ -121,7 +120,7 @@ struct CoreStateTracker {
     template<CoreType CT>
     CoreTypeTracker& get() { return by_type[static_cast<int32_t>(CT)]; }
 
-    int32_t find_cluster_for_shape(PTO2ResourceShape shape) {
+    int32_t find_cluster_for_shape(PTO2ResourceShape shape, bool* core_idle) {
         for (int32_t i = 0; i < cluster_count; i++) {
             Cluster& c = clusters[i];
             switch (shape) {
@@ -151,6 +150,7 @@ struct CoreStateTracker {
 struct AicpuExecutor {
     int32_t orch_thread_num_;
     int32_t sched_thread_num_;
+    bool orch_to_sched_{false};
 
     // ===== Thread management state =====
     std::atomic<int32_t> thread_idx_{0};
@@ -193,8 +193,9 @@ struct AicpuExecutor {
     // Track executing register task_id per core (AICPU_TASK_INVALID = idle).
     // NOTE: this is NOT the mixed_task_id; it is the per-core dispatch id used by the
     // register protocol (derived from dispatch_seq_by_core_ and masked by TASK_ID_MASK).
-    int32_t executing_reg_task_ids_[MAX_AICPU_THREADS][MAX_CORES_PER_THREAD];
+    int32_t executing_reg_task_ids_[MAX_CORES_PER_THREAD];
     CoreStateTracker trackers_[MAX_AICPU_THREADS];
+    bool core_idle_[MAX_CORES_PER_THREAD];
 
     // ===== Task queue state (managed by scheduler ready queues) =====
 
@@ -202,8 +203,9 @@ struct AicpuExecutor {
     std::atomic<int32_t> completed_tasks_{0};
     int32_t total_tasks_{0};
     std::atomic<int32_t> finished_count_{0};
-    // Device orchestration: set by Thread 3 when graph is built; workers wait for it
-    bool orchestrator_done_{false};
+    // Device orchestration: set by last orchestrator when graph is built; schedulers poll it.
+    // volatile prevents the compiler from hoisting the load out of spin loops.
+    volatile bool orchestrator_done_{false};
     std::atomic<bool> pto2_init_done_{false};
     std::atomic<bool> runtime_init_ready_{false};
     std::atomic<bool> pto2_init_complete_{false};  // init block finished; others wait for this
@@ -268,9 +270,7 @@ struct AicpuExecutor {
     template <CoreType CT>
     void check_running_cores_for_completion(int32_t thread_idx,
         CoreTypeTracker& ct,
-        bool* core_idle,
         Handshake* hank,
-        int32_t* executing_reg_task_ids,
         int32_t& completed_this_turn,
         int32_t& cur_thread_completed,
         bool& made_progress,
@@ -294,11 +294,14 @@ struct AicpuExecutor {
         uint64_t& sched_complete_perf_cycle
 #endif
     ) {
+#if !PTO2_PROFILING
+        (void)hank;
+#endif
         for (int32_t i = ct.running_count - 1; i >= 0; i--) {
             int32_t core_id = ct.running[i];
             uint64_t reg_addr = core_id_to_reg_addr_[core_id];
 
-            int32_t expected_reg_task_id = executing_reg_task_ids[core_id];
+            int32_t expected_reg_task_id = executing_reg_task_ids_[core_id];
             uint64_t reg_val = read_reg(reg_addr, RegId::COND);
             int32_t reg_task_id = EXTRACT_TASK_ID(reg_val);
             int32_t reg_state = EXTRACT_TASK_STATE(reg_val);
@@ -313,7 +316,7 @@ struct AicpuExecutor {
 #endif
 
             if (done) {
-                executing_reg_task_ids[core_id] = AICPU_TASK_INVALID;
+                executing_reg_task_ids_[core_id] = AICPU_TASK_INVALID;
                 PTO2SubtaskSlot subslot = executing_subslot_by_core_[core_id];
                 PTO2TaskSlotState& slot_state = *executing_slot_state_by_core_[core_id];
 
@@ -354,7 +357,7 @@ struct AicpuExecutor {
                     }
                 }
                 ct.move_running_to_idle(i);
-                core_idle[core_id] = true;
+                core_idle_[core_id] = true;
 #if PTO2_PROFILING
                 if (profiling_enabled) {
 #if PTO2_SCHED_PROFILING
@@ -492,14 +495,21 @@ struct AicpuExecutor {
         return slot_state;
     }
 
-    void dispatch_subtask_to_core(
-        Runtime* runtime, CoreStateTracker& tracker, int32_t* executing_reg_task_ids,
-        int32_t core_id, CoreType core_type, PTO2TaskSlotState& slot_state,
+    void dispatch_subtask_to_core(Runtime* runtime,
+        CoreStateTracker& tracker,
+        int32_t core_id,
+        CoreType core_type,
+        PTO2TaskSlotState& slot_state,
         PTO2SubtaskSlot subslot
 #if PTO2_PROFILING
-        , bool profiling_enabled, int32_t thread_idx
+        ,
+        bool profiling_enabled,
+        int32_t thread_idx
 #endif
     ) {
+#if !PTO2_PROFILING
+        (void)runtime;
+#endif
         PTO2DispatchPayload& payload = s_pto2_payload_per_core[core_id];
         PTO2TaskDescriptor& task = *slot_state.task;
         int32_t slot_idx = static_cast<int32_t>(subslot);
@@ -535,8 +545,8 @@ struct AicpuExecutor {
         CoreTypeTracker& ct = tracker.by_type[static_cast<int32_t>(core_type)];
         int32_t idle_idx = ct.find_idle_index(core_id);
         ct.move_idle_to_running(idle_idx);
-        tracker.core_idle[core_id] = false;
-        executing_reg_task_ids[core_id] = reg_task_id;
+        core_idle_[core_id] = false;
+        executing_reg_task_ids_[core_id] = reg_task_id;
     }
 };
 
@@ -645,16 +655,17 @@ void AicpuExecutor::assign_cores_to_threads() {
     DEV_INFO("Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)",
              cluster_count, divisor, aic_count_, aiv_count_);
 
+    memset(core_idle_, true, sizeof(core_idle_));
+    for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
+        executing_reg_task_ids_[i] = AICPU_TASK_INVALID;
+    }
     for (int32_t i = 0; i < thread_num_; i++) {
-        for (int32_t j = 0; j < MAX_CORES_PER_THREAD; j++) {
-            executing_reg_task_ids_[i][j] = AICPU_TASK_INVALID;
-        }
+        
         trackers_[i].aic().running_count = 0;
         trackers_[i].aiv().running_count = 0;
         trackers_[i].aic().idle_count = 0;
         trackers_[i].aiv().idle_count = 0;
         trackers_[i].cluster_count = 0;
-        memset(trackers_[i].core_idle, 0, sizeof(trackers_[i].core_idle));
         core_count_per_thread_[i] = 0;
     }
 
@@ -679,14 +690,11 @@ void AicpuExecutor::assign_cores_to_threads() {
 
         core_assignments_[t][idx++] = aic_wid;
         tracker.aic().idle[tracker.aic().idle_count++] = aic_wid;
-        tracker.core_idle[aic_wid] = true;
 
         core_assignments_[t][idx++] = aiv0_wid;
         core_assignments_[t][idx++] = aiv1_wid;
         tracker.aiv().idle[tracker.aiv().idle_count++] = aiv0_wid;
         tracker.aiv().idle[tracker.aiv().idle_count++] = aiv1_wid;
-        tracker.core_idle[aiv0_wid] = true;
-        tracker.core_idle[aiv1_wid] = true;
 
         DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)",
                  t, ci, aic_wid, aiv0_wid, aiv1_wid);
@@ -712,31 +720,17 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
              thread_num_, aic_count_, aiv_count_);
 
     // Collect running/idle state from all threads before reassignment
-    int32_t running_cores[128];
-    int32_t running_task_ids[128];
-    int32_t running_count = 0;
-
-    bool was_idle[MAX_CORES_PER_THREAD];
-    memset(was_idle, 0, sizeof(was_idle));
+    bool running_cores[MAX_CORES_PER_THREAD];
+    memset(running_cores, 0, sizeof(running_cores));
 
     for (int32_t i = 0; i < thread_num_; i++) {
         for (int32_t j = 0; j < trackers_[i].aic().running_count; j++) {
             int32_t core_id = trackers_[i].aic().running[j];
-            running_cores[running_count] = core_id;
-            running_task_ids[running_count] = executing_reg_task_ids_[i][core_id];
-            running_count++;
-        }
-        for (int32_t j = 0; j < trackers_[i].aic().idle_count; j++) {
-            was_idle[trackers_[i].aic().idle[j]] = true;
+            running_cores[core_id] = true;
         }
         for (int32_t j = 0; j < trackers_[i].aiv().running_count; j++) {
             int32_t core_id = trackers_[i].aiv().running[j];
-            running_cores[running_count] = core_id;
-            running_task_ids[running_count] = executing_reg_task_ids_[i][core_id];
-            running_count++;
-        }
-        for (int32_t j = 0; j < trackers_[i].aiv().idle_count; j++) {
-            was_idle[trackers_[i].aiv().idle[j]] = true;
+            running_cores[core_id] = true;
         }
     }
 
@@ -748,28 +742,18 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
         trackers_[i].aiv().running_count = 0;
         trackers_[i].aiv().idle_count = 0;
         trackers_[i].cluster_count = 0;
-        memset(trackers_[i].core_idle, 0, sizeof(trackers_[i].core_idle));
-        for (int32_t j = 0; j < MAX_CORES_PER_THREAD; j++) {
-            executing_reg_task_ids_[i][j] = AICPU_TASK_INVALID;
-        }
     }
 
     // Restore a single core's running/idle state into its new thread's tracker
-    auto reassign_core = [&](int32_t worker_id, CoreTypeTracker& type_tracker,
-                             CoreStateTracker& tracker, int32_t thread_idx) {
-        core_assignments_[thread_idx][core_count_per_thread_[thread_idx]++] = worker_id;
-        for (int32_t j = 0; j < running_count; j++) {
-            if (running_cores[j] == worker_id) {
+    auto reassign_core =
+        [&](int32_t worker_id, CoreTypeTracker& type_tracker, int32_t thread_idx) {
+            core_assignments_[thread_idx][core_count_per_thread_[thread_idx]++] = worker_id;
+            if (running_cores[worker_id]) {
                 type_tracker.running[type_tracker.running_count++] = worker_id;
-                executing_reg_task_ids_[thread_idx][worker_id] = running_task_ids[j];
-                return;
+            } else {
+                type_tracker.idle[type_tracker.idle_count++] = worker_id;
             }
-        }
-        if (was_idle[worker_id]) {
-            type_tracker.idle[type_tracker.idle_count++] = worker_id;
-            tracker.core_idle[worker_id] = true;
-        }
-    };
+        };
 
     // Assign whole clusters round-robin across all threads
     for (int32_t ci = 0; ci < aic_count_; ci++) {
@@ -782,9 +766,9 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
 
         tracker.clusters[tracker.cluster_count++] = {aic_wid, {aiv0_wid, aiv1_wid}};
 
-        reassign_core(aic_wid, tracker.aic(), tracker, t);
-        reassign_core(aiv0_wid, tracker.aiv(), tracker, t);
-        reassign_core(aiv1_wid, tracker.aiv(), tracker, t);
+        reassign_core(aic_wid, tracker.aic(), t);
+        reassign_core(aiv0_wid, tracker.aiv(), t);
+        reassign_core(aiv1_wid, tracker.aiv(), t);
     }
 
     // Log final distribution for verification
@@ -817,7 +801,16 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
     thread_num_ = runtime->sche_cpu_num;
     orch_thread_num_ = runtime->orch_thread_num;
     sched_thread_num_ = thread_num_ - orch_thread_num_;
+    orch_to_sched_ = runtime->orch_to_sched;
     if (thread_num_ == 0) thread_num_ = 1;
+
+    if (!orch_to_sched_ && sched_thread_num_ == 0) {
+        DEV_ERROR(
+            "no scheduler and orch not trans to schedulers when finished, maybe you need set env PTO2_ORCH_TO_SCHED=1 "
+            "or scale down orch number.");
+        init_failed_.store(true, std::memory_order_release);
+        return -1;
+    }
 
     if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
         DEV_ERROR("Invalid thread_num: %d", thread_num_);
@@ -908,7 +901,6 @@ int32_t AicpuExecutor::shutdown_aicore(Runtime* runtime, int32_t thread_idx, con
 
 int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx) {
     int32_t &core_num = core_count_per_thread_[thread_idx];
-    int32_t* executing_reg_task_ids = executing_reg_task_ids_[thread_idx];
     CoreStateTracker& tracker = trackers_[thread_idx];
     DEV_INFO("Thread %d: resolve_and_dispatch_pto2 entry", thread_idx);
 
@@ -999,6 +991,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
     bool cores_released = false;
 
+#if PTO2_PROFILING
+    // Benchmark: scheduler lifetime start timestamp (independent of enable_profiling)
+    DEV_ALWAYS("Thread %d: sched_start=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+#endif
+
     while (true) {
         bool made_progress = false;
 #if PTO2_PROFILING
@@ -1034,7 +1031,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         }
 
         // Check for core transition request (execute once per thread)
-        if (!cores_released && transition_requested_.load(std::memory_order_acquire)) {
+        if (!cores_released && orch_to_sched_ && transition_requested_.load(std::memory_order_acquire)) {
             if (!reassigned_.load(std::memory_order_acquire)) {
                 wait_reassign_.fetch_add(1, std::memory_order_release);
                 while (!reassigned_.load(std::memory_order_acquire)) {
@@ -1067,7 +1064,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         if (tracker.aic().running_count > 0) {
             try_completed = true;
             check_running_cores_for_completion<CoreType::AIC>(
-                thread_idx, tracker.aic(), tracker.core_idle, hank, executing_reg_task_ids,
+                thread_idx, tracker.aic(), hank,
                 completed_this_turn, cur_thread_completed, made_progress,
                 deferred_release_slot_states, deferred_release_count,
                 local_bufs
@@ -1086,7 +1083,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         if (tracker.aiv().running_count > 0) {
             try_completed = true;
             check_running_cores_for_completion<CoreType::AIV>(
-                thread_idx, tracker.aiv(), tracker.core_idle, hank, executing_reg_task_ids,
+                thread_idx, tracker.aiv(), hank,
                 completed_this_turn, cur_thread_completed, made_progress,
                 deferred_release_slot_states, deferred_release_count,
                 local_bufs
@@ -1142,7 +1139,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             while (local_bufs[bi].count > 0) {
                 PTO2TaskSlotState* slot_state = local_bufs[bi].pop();
                 PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state->active_mask);
-                int32_t ci = tracker.find_cluster_for_shape(shape);
+                int32_t ci = tracker.find_cluster_for_shape(shape, core_idle_);
 
                 if (ci >= 0) {
                     try_pushed = true;
@@ -1153,7 +1150,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     ResourceCount rc = shape_resource_count(shape);
 
                     if (rc.aic) {
-                        dispatch_subtask_to_core(runtime, tracker, executing_reg_task_ids,
+                        dispatch_subtask_to_core(runtime, tracker,
                             c.aic_core_id, CoreType::AIC, *slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                             , profiling_enabled, thread_idx
@@ -1161,8 +1158,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         );
                     }
                     if (rc.aiv >= 1) {
-                        int32_t aiv0 = tracker.core_idle[c.aiv_core_ids[0]] ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
-                        dispatch_subtask_to_core(runtime, tracker, executing_reg_task_ids,
+                        int32_t aiv0 = core_idle_[c.aiv_core_ids[0]] ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
+                        dispatch_subtask_to_core(runtime, tracker,
                             aiv0, CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                             , profiling_enabled, thread_idx
@@ -1170,7 +1167,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         );
                     }
                     if (rc.aiv >= 2) {
-                        dispatch_subtask_to_core(runtime, tracker, executing_reg_task_ids,
+                        dispatch_subtask_to_core(runtime, tracker,
                             c.aiv_core_ids[1], CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
                             , profiling_enabled, thread_idx
@@ -1213,7 +1210,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             if (rt->scheduler.ready_queues[static_cast<int32_t>(shape)].size() == 0) continue;
 
             while (true) {
-                int32_t ci = tracker.find_cluster_for_shape(shape);
+                int32_t ci = tracker.find_cluster_for_shape(shape, core_idle_);
                 if (ci < 0) break;
 
                 PTO2TaskSlotState* slot_state = pop_ready_task(shape, thread_idx
@@ -1235,7 +1232,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 ResourceCount rc = shape_resource_count(shape);
 
                 if (rc.aic) {
-                    dispatch_subtask_to_core(runtime, tracker, executing_reg_task_ids,
+                    dispatch_subtask_to_core(runtime, tracker,
                         c.aic_core_id, CoreType::AIC, *slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                         , profiling_enabled, thread_idx
@@ -1243,9 +1240,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     );
                 }
                 if (rc.aiv >= 1) {
-                    int32_t aiv_id = tracker.core_idle[c.aiv_core_ids[0]]
+                    int32_t aiv_id = core_idle_[c.aiv_core_ids[0]]
                         ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
-                    dispatch_subtask_to_core(runtime, tracker, executing_reg_task_ids,
+                    dispatch_subtask_to_core(runtime, tracker,
                         aiv_id, CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                         , profiling_enabled, thread_idx
@@ -1253,7 +1250,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     );
                 }
                 if (rc.aiv >= 2) {
-                    dispatch_subtask_to_core(runtime, tracker, executing_reg_task_ids,
+                    dispatch_subtask_to_core(runtime, tracker,
                         c.aiv_core_ids[1], CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
                         , profiling_enabled, thread_idx
@@ -1283,8 +1280,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 _t0_phase = _t1;
                 phase_dispatch_count = 0;
             }
-#endif
         }
+#endif
+
+#if !PTO2_PROFILING
+        (void)try_completed;
+        (void)try_pushed;
+#endif
 
         if (made_progress) {
             idle_iterations = 0;
@@ -1367,7 +1369,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 // Dump AIC running cores
                 for (int32_t ci = 0; ci < tracker.aic().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
                     int32_t cid = tracker.aic().running[ci];
-                    int32_t sw_tid = executing_reg_task_ids[cid];
+                    int32_t sw_tid = executing_reg_task_ids_[cid];
                     int32_t hw_kernel = -1;
                     if (sw_tid >= 0 && executing_slot_state_by_core_[cid]) {
                         int32_t diag_slot = static_cast<int32_t>(executing_subslot_by_core_[cid]);
@@ -1382,7 +1384,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 // Dump AIV running cores
                 for (int32_t ci = 0; ci < tracker.aiv().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
                     int32_t cid = tracker.aiv().running[ci];
-                    int32_t sw_tid = executing_reg_task_ids[cid];
+                    int32_t sw_tid = executing_reg_task_ids_[cid];
                     int32_t hw_kernel = -1;
                     if (sw_tid >= 0 && executing_slot_state_by_core_[cid]) {
                         int32_t diag_slot = static_cast<int32_t>(executing_subslot_by_core_[cid]);
@@ -1398,13 +1400,18 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 for (int32_t cli = 0; cli < tracker.cluster_count && cli < STALL_DUMP_CORE_MAX; cli++) {
                     Cluster& cl = tracker.clusters[cli];
                     DEV_ALWAYS("    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)",
-                               cli, cl.aic_core_id, tracker.core_idle[cl.aic_core_id] ? "idle" : "busy",
-                               cl.aiv_core_ids[0], tracker.core_idle[cl.aiv_core_ids[0]] ? "idle" : "busy",
-                               cl.aiv_core_ids[1], tracker.core_idle[cl.aiv_core_ids[1]] ? "idle" : "busy");
+                               cli, cl.aic_core_id, core_idle_[cl.aic_core_id] ? "idle" : "busy",
+                               cl.aiv_core_ids[0], core_idle_[cl.aiv_core_ids[0]] ? "idle" : "busy",
+                               cl.aiv_core_ids[1], core_idle_[cl.aiv_core_ids[1]] ? "idle" : "busy");
                 }
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
                 DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+#if PTO2_PROFILING
+                // Benchmark: scheduler lifetime end timestamp on timeout path
+                DEV_ALWAYS("Thread %d: sched_end(timeout)=%llu",
+                           thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+#endif
                 return -1;
             } else {
                 SPIN_WAIT_HINT();
@@ -1556,8 +1563,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
 int32_t AicpuExecutor::run(Runtime* runtime) {
     int32_t thread_idx = thread_idx_++;
+    DEV_INFO("Thread %d: Start", thread_idx);
 
-    DEV_ALWAYS("Thread %d: Start", thread_idx);
 
     // Orchestrator check
     if (thread_idx >= sched_thread_num_) {
@@ -1763,17 +1770,17 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             }
 #endif
 
-            // Call orchestration function wrapped in an outer scope
-            DEV_ALWAYS("Thread %d: Calling aicpu_orchestration_entry from SO (orch_idx=%d/(0~%d))",
-                       thread_idx, orch_idx, orch_thread_num_ - 1);
 #if PTO2_PROFILING
-            DEV_ALWAYS("Thread=%d orch_start=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
             uint64_t orch_cycle_start = get_sys_cnt_aicpu();
+            DEV_ALWAYS("Thread %d: orch_start=%llu orch_idx=%d/(0~%d)", thread_idx, (unsigned long long)orch_cycle_start, orch_idx, orch_thread_num_ - 1);
 #endif
             PTO2_SCOPE(rt) { orch_func_(rt, orch_args_cached_, orch_arg_count_cached_, orch_thread_num_, orch_idx); }
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
-            DEV_ALWAYS("Thread %d: aicpu_orchestration_entry returned, cost %.3fus (orch_idx=%d)",
+            // Function-level timing: measures only orch_func_ execution time.
+            // This differs from `orch_end`, which marks stage-level end right before
+            // requesting core transition (includes additional post-orchestration work).
+            DEV_ALWAYS("Thread %d: aicpu_orchestration_entry returned, orch_func_cost=%.3fus (orch_idx=%d)",
                 thread_idx, cycles_to_us(orch_cycle_end - orch_cycle_start), orch_idx);
 #endif
 
@@ -1911,17 +1918,22 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     }
                 }
 
+#if PTO2_ORCH_PROFILING
+                uint64_t reassign_cycle_start = get_sys_cnt_aicpu();
+#endif
+
                 // Skip core transition on fatal error — cores already shut down above
                 if (completed_.load(std::memory_order_acquire)) {
                     // Signal transition to unblock scheduler threads waiting at core transition
                     transition_requested_.store(true, std::memory_order_release);
                     reassigned_.store(true, std::memory_order_release);
-                } else {
+                } else if (orch_to_sched_) {
                     // Compute new core assignments for all threads and initialize donated slots
                     DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
 #if PTO2_PROFILING
-                    // Benchmark: record orchestrator end timestamp before waiting for schedulers
-                    DEV_ALWAYS("BENCHMARK: thread=%d end=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+                    // Stage-level end: orchestrator phase finishes before requesting transition.
+                    DEV_ALWAYS("Thread %d: orch_stage_end=%llu, requesting core transition", thread_idx,
+                               (unsigned long long)get_sys_cnt_aicpu());
 #endif
                     transition_requested_.store(true, std::memory_order_release);
 
@@ -1940,25 +1952,38 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                         reassigned_.store(true, std::memory_order_release);
                     }
                 }
+
+#if PTO2_ORCH_PROFILING
+                uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
+                DEV_ALWAYS("Thread %d: reassign, cost %.3fus (orch_idx=%d)",
+                    thread_idx,
+                    cycles_to_us(reassign_cycle_end - reassign_cycle_start),
+                    orch_idx);
+#endif
             } else {
                 // Non-last orchestrator: wait for last orchestrator to finish setup
-                while (!transition_requested_.load(std::memory_order_acquire)) {
-                    SPIN_WAIT_HINT();
-                }
-                while (!reassigned_.load(std::memory_order_acquire)) {
-                    if (completed_.load(std::memory_order_acquire)) {
-                        break;
+                if (orch_to_sched_) {
+                    while (!transition_requested_.load(std::memory_order_acquire)) {
+                        SPIN_WAIT_HINT();
                     }
-                    SPIN_WAIT_HINT();
+                    while (!reassigned_.load(std::memory_order_acquire)) {
+                        if (completed_.load(std::memory_order_acquire)) {
+                            break;
+                        }
+                        SPIN_WAIT_HINT();
+                    }
                 }
             }
         }
+#if PTO2_PROFILING
+        DEV_ALWAYS("Thread %d: orch_end=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+#endif
         DEV_INFO("Thread %d: Orchestrator completed (orch_idx=%d)", thread_idx, orch_idx);
     }
 
-    // Scheduler thread
-    if (!completed_.load(std::memory_order_acquire)) {
-        DEV_ALWAYS("Thread %d: Starting PTO2 dispatch", thread_idx);
+    // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
+    if (!completed_.load(std::memory_order_acquire) &&
+        (thread_idx < sched_thread_num_ || orch_to_sched_)) {
         // Device orchestration: wait for primary orchestrator to initialize SM header
         if (!runtime->get_orch_built_on_host()) {
             while (!runtime_init_ready_.load(std::memory_order_acquire)) {
@@ -1976,14 +2001,11 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     {
         const int32_t* shutdown_cores = core_assignments_[thread_idx];
         int32_t shutdown_count = core_count_per_thread_[thread_idx];
+        if (shutdown_count > 0) {
 #if PTO2_PROFILING
-        // Benchmark: record scheduler end timestamp before shutdown cleanup
-        if (shutdown_count > 0) {
-            DEV_ALWAYS("Thread=%d end=%llu",
+            DEV_ALWAYS("Thread %d: sched_end=%llu",
                        thread_idx, (unsigned long long)get_sys_cnt_aicpu());
-        }
 #endif
-        if (shutdown_count > 0) {
             auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
             if (rc != 0) {
                 return rc;
@@ -2003,7 +2025,6 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             dlclose(orch_so_handle_);
             unlink(orch_so_path_);
         }
-        DEV_ALWAYS("Thread %d: Last thread, marking executor finished", thread_idx);
     }
 
     return 0;
@@ -2049,11 +2070,7 @@ void AicpuExecutor::deinit(Runtime* runtime) {
     // Reset register-related state
     for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
         core_id_to_reg_addr_[i] = 0;
-    }
-    for (int32_t i = 0; i < thread_num_; i++) {
-        for (int32_t j = 0; j < MAX_CORES_PER_THREAD; j++) {
-            executing_reg_task_ids_[i][j] = AICPU_TASK_INVALID;
-        }
+        executing_reg_task_ids_[i] = AICPU_TASK_INVALID;
     }
     regs_ = 0;
 
@@ -2121,7 +2138,7 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
         uint64_t reg_val = read_reg(reg_addr, RegId::COND);
         int32_t reg_task_id = EXTRACT_TASK_ID(reg_val);
         int32_t reg_state = EXTRACT_TASK_STATE(reg_val);
-        int32_t task_id = executing_reg_task_ids_[thread_idx][core_id];
+        int32_t task_id = executing_reg_task_ids_[core_id];
 
         if (reg_state != TASK_FIN_STATE || task_id >= 0) {
             busy_cores++;

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -41,43 +41,97 @@ Each sub-level macro requires `PTO2_PROFILING=1`:
 
 **What's compiled:**
 - Debug/diagnostic logs (always present)
-- Progress tracking
-- Stall detection
-- Deadlock/livelock detection
+- Progress tracking (`PTO2 progress: completed=...`)
+- Stall detection and dump (triggered only after `MAX_IDLE_ITERATIONS` idle loops)
+- Deadlock/livelock detection (`diagnose_stuck_state`, called on stall)
 
 **What's NOT compiled:**
-- All profiling counters
-- All profiling logs
-- Performance data collection
+- All `CYCLE_COUNT_*` timing counters (`sched_*_cycle`, orchestrator cost counters)
+- Scheduler/Orchestrator profiling summary logs guarded by `#if PTO2_PROFILING`
+- Performance data collection paths (`enable_profiling` runtime flag becomes ineffective because profiling code is not compiled)
 
-**Log output:** 11 DEV_ALWAYS logs (debug/diagnostic only)
+**Log output (normal run, no stall):**
+- No `sched_start/sched_end` timestamps
+- No `orch_start/orch_stage_end/orch_end` timestamps
+- No `Scheduler summary: total_time=...`
+- No orchestration function cost log (`aicpu_orchestration_entry returned, ...us`)
+- `PTO2 progress: completed=... total=...` may appear (thread 0 only, at task completion milestones)
+
 
 ---
 
 ### Level 1: Basic Profiling (PTO2_PROFILING=1)
 
 **What's compiled:**
-- All profiling counters (cycles, task counts, loop counts)
-- Basic profiling summaries
-- Scheduler summary output
-- Orchestration completion time
+- Base timing counters for scheduler loop (`sched_complete/dispatch/idle/scan`)
+- Per-thread orchestration timing (`orch_start`, `orch_func_cost`)
+- Stage-level orchestration end timestamp (`orch_stage_end`, printed by last orch thread only, marks the moment all orch threads have finished and core transition is about to be requested; only when `orch_to_sched_` is true)
+- Per-thread orchestration end timestamp (`orch_end`, printed by each orch thread after all post-orchestration work completes)
+- Scheduler summary output (`total_time`, `loops`, `tasks_scheduled`)
+- Scheduler lifetime timestamps (`sched_start`, `sched_end`)
 
 **What's NOT compiled:**
 - Detailed phase breakdowns
 - TensorMap statistics
 
-**Log output:** 13 DEV_ALWAYS logs
-- 11 debug/diagnostic logs (always present)
-- 2 basic profiling summaries:
-  - Orchestration completion time
-  - Total submitted tasks
+**Log output (additional lines vs Level 0, per normal run):**
+- `Thread %d: sched_start=%llu` — each sched thread, at scheduler loop start
+- `Thread %d: orch_start=%llu orch_idx=%d/(0~%d)` — each orch thread, before `orch_func_` call
+- `Thread %d: aicpu_orchestration_entry returned, orch_func_cost=%.3fus (orch_idx=%d)` — each orch thread, after `orch_func_` returns
+- `PTO2 total submitted tasks = %d, already executed %d tasks` — last orch thread only (×1)
+- `Thread %d: orch_stage_end=%llu` — last orch thread only (×1), only when `orch_to_sched_=true`
+- `Thread %d: orch_end=%llu` — each orch thread, after orchestration fully complete
+- `Thread %d: Scheduler summary: total_time=%.3fus, loops=%llu, tasks_scheduled=%d` — each sched thread
+- `Thread %d: sched_end=%llu` — each sched thread, before `shutdown_aicore` (normal path)
+- `Thread %d: sched_end(timeout)=%llu` — timeout path only (replaces `sched_end`)
 
-**Scheduler output:**
+**DEV_ALWAYS count (normal run):**
+- `orch_to_sched_=false` (default): `N_sched*2 + N_orch*2 + 1` (sched_start + orch_start + orch_func_cost + orch_end + PTO2_total + Scheduler_summary + sched_end)
+- `orch_to_sched_=true` (`PTO2_ORCH_TO_SCHED=1`): adds 1 (`orch_stage_end`)
+
+> See the table at the end for concrete counts based on the `paged_attention` example.
+
+**Example log output — `orch_to_sched_=false`** (from `paged_attention`, device 10):
 ```
-Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
+Thread 0: sched_start=48214752948200
+Thread 1: sched_start=48214752948235
+Thread 3: orch_start=48214752948316 orch_idx=1/(0~1)
+Thread 2: orch_start=48214752948321 orch_idx=0/(0~1)
+Thread 2: aicpu_orchestration_entry returned, orch_func_cost=193.700us (orch_idx=0)
+Thread 2: orch_end=48214752959379
+Thread 3: aicpu_orchestration_entry returned, orch_func_cost=218.640us (orch_idx=1)
+PTO2 total submitted tasks = 13, already executed 13 tasks
+Thread 3: orch_end=48214752961505
+Thread 1: Scheduler summary: total_time=159.560us, loops=3782, tasks_scheduled=6
+Thread 1: sched_end=48214752962379
+Thread 0: Scheduler summary: total_time=183.180us, loops=4611, tasks_scheduled=7
+Thread 0: sched_end=48214752963571
 ```
 
-**Note:** Scheduler summary always prints when `PTO2_PROFILING=1`, regardless of `enable_profiling` flag.
+**Example log output — `orch_to_sched_=true`** (`PTO2_ORCH_TO_SCHED=1`, from `paged_attention`, device 11):
+```
+Thread 0: sched_start=48236915043911
+Thread 1: sched_start=48236915043947
+Thread 3: orch_start=48236915044001 orch_idx=1/(0~1)
+Thread 2: orch_start=48236915044003 orch_idx=0/(0~1)
+Thread 2: aicpu_orchestration_entry returned, orch_func_cost=226.820us (orch_idx=0)
+Thread 3: aicpu_orchestration_entry returned, orch_func_cost=250.960us (orch_idx=1)
+PTO2 total submitted tasks = 13, already executed 13 tasks
+Thread 3: orch_stage_end=48236915058307
+Thread 0: Scheduler summary: total_time=187.920us, loops=4561, tasks_scheduled=4
+Thread 0: sched_end=48236915059191
+Thread 3: orch_end=48236915058781
+Thread 2: orch_end=48236915058782
+Thread 1: Scheduler summary: total_time=168.620us, loops=3880, tasks_scheduled=9
+Thread 1: sched_end=48236915061881
+```
+
+> With `orch_to_sched_=true`, orch threads transition to schedulers after orchestration. They print `orch_end` but do NOT print `Scheduler summary` or `sched_end` (they have no cores assigned at shutdown time).
+
+**Note:**
+- All logs above are controlled by compile-time macro `PTO2_PROFILING`, not by `enable_profiling`.
+- `enable_profiling` only controls shared-memory data collection / swimlane export.
+- Enable `orch_to_sched_` via environment variable: `PTO2_ORCH_TO_SCHED=1`.
 
 ---
 
@@ -257,13 +311,15 @@ add_definitions(-DPTO2_ORCH_PROFILING=1)
 
 ## Log Output Summary
 
-| Level | Macro Settings | DEV_ALWAYS Count | Description |
-|-------|---------------|------------------|-------------|
-| 0 | `PTO2_PROFILING=0` | 11 | Debug/diagnostic only |
-| 1 | `PTO2_PROFILING=1` | 13 | Basic summaries |
-| 2 | `+PTO2_SCHED_PROFILING=1` | 18 | Scheduler detailed |
-| 3 | `+PTO2_ORCH_PROFILING=1` | 30 | Orchestrator detailed |
-| 4 | `+PTO2_TENSORMAP_PROFILING=1` | 34 | TensorMap stats |
+> Example: `paged_attention` on Ascend hardware, 2 sched threads + 2 orch threads, normal run (no stall/timeout).
+
+| Level | Macro Settings | DEV_ALWAYS Count (`orch_to_sched_=false`) | DEV_ALWAYS Count (`orch_to_sched_=true`) | Description |
+|-------|---------------|------------------------------------------|------------------------------------------|-------------|
+| 0 | `PTO2_PROFILING=0` | 0 | 0 | No timing output |
+| 1 | `PTO2_PROFILING=1` | 13 | 14 | Timing timestamps + scheduler summary |
+| 2 | `+PTO2_SCHED_PROFILING=1` | — | — | Scheduler detailed phase breakdown |
+| 3 | `+PTO2_ORCH_PROFILING=1` | — | — | Orchestrator detailed phase breakdown |
+| 4 | `+PTO2_TENSORMAP_PROFILING=1` | — | — | TensorMap lookup stats |
 
 ---
 
@@ -287,10 +343,10 @@ add_definitions(-DPTO2_ORCH_PROFILING=1)
 
 ### Code Locations
 
-- Macro definitions: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h`
-- Scheduler profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp` (lines 770-835)
-- Orchestrator profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp` (lines 1035-1105)
-- TensorMap profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h`
+- Macro definitions: `src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h`
+- Scheduler profiling: `src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp` (lines 770-835)
+- Orchestrator profiling: `src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp` (lines 1035-1105)
+- TensorMap profiling: `src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h`
 
 ---
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -261,6 +261,15 @@ extern "C" int init_runtime_impl(Runtime *runtime,
         LOG_INFO("Ready queue shards: %d", runtime->ready_queue_shards);
     }
 
+    // Read orchestrator-to-scheduler transition flag from environment
+    {
+        const char* env_val = std::getenv("PTO2_ORCH_TO_SCHED");
+        if (env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T')) {
+            runtime->orch_to_sched = true;
+        }
+        LOG_INFO("Orchestrator-to-scheduler transition: %s", runtime->orch_to_sched ? "enabled" : "disabled");
+    }
+
     // Read ring buffer size overrides from environment
     {
         runtime->pto2_task_window_size  = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -27,6 +27,7 @@ Runtime::Runtime() {
     pto2_task_window_size = 0;
     pto2_heap_size = 0;
     pto2_dep_pool_size = 0;
+    orch_to_sched = false;
 
     // Initialize tensor pairs
     tensor_pair_count = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -31,7 +31,7 @@
 // =============================================================================
 
 #define RUNTIME_MAX_ARGS 128
-#define RUNTIME_MAX_WORKER 72  // 24 AIC + 48 AIV cores
+#define RUNTIME_MAX_WORKER 108  // 36 AIC + 72 AIV cores
 #define RUNTIME_MAX_TENSOR_PAIRS 64
 #define RUNTIME_MAX_FUNC_ID 32
 #define RUNTIME_MAX_ORCH_SO_SIZE (4 * 1024 * 1024)  // 1MB max for orchestration SO
@@ -158,6 +158,12 @@ public:
 
     // Profiling support
     bool enable_profiling;    // Enable profiling flag
+
+    // Orchestrator-to-scheduler transition control
+    // When true, orchestrator threads convert to scheduler threads after orchestration completes.
+    // When false (default), orchestrator threads exit after orchestration without dispatching tasks.
+    // Controlled via PTO2_ORCH_TO_SCHED environment variable.
+    bool orch_to_sched;
     uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
 
 private:

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
@@ -1,0 +1,55 @@
+"""Paged Attention Unroll Golden - tensormap_and_ringbuffer test (production scale, bfloat16)."""
+
+from paged_attention_golden import (
+    generate_inputs as _generate_inputs,
+    compute_golden,
+    run_golden_test,
+)
+
+__outputs__ = ["out"]
+
+RTOL = 1e-3
+ATOL = 1e-3
+
+ALL_CASES = {
+    "Case1": {
+        "batch": 256,
+        "num_heads": 16,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 128,
+        "context_len": 8192,
+        "max_model_len": 32768,
+        "dtype": "bfloat16",
+    },
+    "Case2": {
+        "batch": 64,
+        "num_heads": 64,
+        "kv_head_num": 1,
+        "head_dim": 128,
+        "block_size": 64,
+        "context_len": 8192,
+        "max_model_len": 32768,
+        "dtype": "bfloat16",
+    },
+    "Case3": {
+        "batch": 64,
+        "num_heads": 64,
+        "kv_head_num": 1,
+        "head_dim": 256,
+        "block_size": 64,
+        "context_len": 8192,
+        "max_model_len": 32768,
+        "dtype": "bfloat16",
+    },
+}
+
+DEFAULT_CASE = "Case1"
+
+
+def generate_inputs(params: dict) -> list:
+    return _generate_inputs(params, return_all_sizes=False)
+
+
+if __name__ == "__main__":
+    run_golden_test(ALL_CASES, DEFAULT_CASE, generate_inputs, label="Paged Attention Unroll")

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_hub.cpp
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_hub.cpp
@@ -1,0 +1,18 @@
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+constexpr int M = 16;
+constexpr int K = 16;
+constexpr int N = 16;
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -1,0 +1,152 @@
+// SplitK PV Matmul Kernel: Accumulated P @ V across n_blocks
+//
+// Processes n_blocks blocks using SplitK accumulation pattern:
+//   Block 0: TMATMUL(C, A, B)       — initialize accumulator
+//   Block i: TMATMUL_ACC(C, C, A, B) — accumulate into same C
+//
+// Per-block pij addresses: contiguous slices of pij_buf (n_blocks * M * K)
+// Per-block vj addresses: value_cache base + block_indices lookup
+// Single output: oi_new (M, N) fp32 = sum of P_i @ V_i across all blocks
+//
+// Optimizations:
+//   - Double-buffered L1 tiles (ping/pong for A and B via MTE2)
+//   - Double-buffered L0 tiles (ping/pong for L0A and L0B via MTE1)
+//   - TLOAD(next) overlaps with TMATMUL(current) via MTE2/M-pipe parallelism
+//   - Canonical 3-stage pipeline: TLOAD(MTE2) → TMOV(MTE1) → TMATMUL(M)
+//   - Reverse-dependency events ensure buffer safety across iterations
+//
+// Supports two tile configurations via runtime dispatch:
+//   Case1: (16, 128) @ (128, 128) -> (16, 128)
+//   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//
+// pij is bfloat16 (from softmax_prepare TCVT).
+// vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int K, int N>
+static __aicore__ void pv_matmul_n_impl(
+    __gm__ bfloat16_t* pij_base,
+    __gm__ bfloat16_t* val_base,
+    __gm__ float* oi_base,
+    uint64_t n_blocks,
+    __gm__ int32_t* block_table) {
+
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
+
+    using TileMatA = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
+
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile = TileRight<bfloat16_t, K, N, K, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
+
+    // L1 memory layout: double-buffered A and B tiles (tightly packed)
+    constexpr int kATileBytes = M * K * static_cast<int>(sizeof(bfloat16_t));
+    constexpr int kBTileBytes = K * N * static_cast<int>(sizeof(bfloat16_t));
+
+    TileMatA aMatTile[2];
+    TileMatB bMatTile[2];
+    TASSIGN(aMatTile[0], 0x0);
+    TASSIGN(aMatTile[1], kATileBytes);
+    TASSIGN(bMatTile[0], 2 * kATileBytes);
+    TASSIGN(bMatTile[1], 2 * kATileBytes + kBTileBytes);
+
+    // L0 memory layout: double-buffered L0A and L0B, single accumulator L0C
+    LeftTile aTile[2];
+    RightTile bTile[2];
+    AccTile cTile;
+    TASSIGN(aTile[0], 0x0);
+    TASSIGN(aTile[1], kATileBytes);
+    TASSIGN(bTile[0], 0x0);
+    TASSIGN(bTile[1], kBTileBytes);
+    TASSIGN(cTile, 0x0);
+
+    GlobalOut oiGlobal(oi_base);
+
+    // Seed reverse-dependency flags: all ping/pong buffers initially free
+    //   PIPE_MTE1 → PIPE_MTE2: L1 buffer [0/1] safe for TLOAD to overwrite
+    //   PIPE_M    → PIPE_MTE1: L0 buffer [0/1] safe for TMOV to overwrite
+    set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
+    set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID1);
+    set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+    set_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
+
+    for (uint64_t i = 0; i < n_blocks; i++) {
+        int cur = static_cast<int>(i % 2);
+        GlobalA pijGlobal(pij_base + i * M * K);
+        GlobalB vjGlobal(val_base + block_table[i] * K * N);
+
+        // Stage 1: TLOAD (MTE2: GM → L1[cur])
+        // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
+        wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
+        TLOAD(aMatTile[cur], pijGlobal);
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);   // forward: A in L1 ready
+        TLOAD(bMatTile[cur], vjGlobal);
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);   // forward: B in L1 ready
+
+        // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
+        // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
+        wait_flag(PIPE_M, PIPE_MTE1, (event_t)cur);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: wait A loaded
+        TMOV(aTile[cur], aMatTile[cur]);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
+        TMOV(bTile[cur], bMatTile[cur]);
+        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur); // reverse: release L1[cur]
+
+        // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
+        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);   // forward: L0[cur] ready
+        wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
+        if (i == 0) {
+            TMATMUL(cTile, aTile[cur], bTile[cur]);
+        } else {
+            TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
+        }
+        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);   // reverse: release L0[cur]
+    }
+
+    // Drain outstanding reverse-dependency flags
+    wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID1);
+    wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    TSTORE(oiGlobal, cTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* pij_buf = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* value_cache = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* oi_new = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    uint64_t n_blocks = static_cast<uint64_t>(args[3]);
+    __gm__ int32_t* block_table = reinterpret_cast<__gm__ int32_t*>(args[4]);
+
+    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_buf->buffer.addr) + pij_buf->start_offset;
+    __gm__ bfloat16_t* val_base = reinterpret_cast<__gm__ bfloat16_t*>(value_cache->buffer.addr);
+    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr) + oi_new->start_offset;
+
+    uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
+
+    if (q_tile_size == 16) {
+        pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, block_table);
+    } else {
+        pv_matmul_n_impl<64, 64, 128>(pij_base, val_base, oi_base, n_blocks, block_table);
+    }
+}

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -1,0 +1,117 @@
+// Multi-block QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N) for each block
+//
+// Processes n_blocks blocks in a single kernel invocation.
+// Per-block kj addresses computed from key_cache base + block_indices lookup.
+// qi is shared across all blocks (same query head against different key blocks).
+//
+// Output layout: n_blocks contiguous (M, N) tiles stacked vertically.
+// Block i occupies sij[i*M : (i+1)*M, 0:N].
+//
+// Optimizations:
+//   - qi TLOAD hoisted before the loop (constant across all iterations)
+//
+// Supports two tile configurations via runtime dispatch:
+//   Case1: (16, 128) @ (128, 128).T -> (16, 128)
+//   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//
+// Template: M=q_tile, K=head_dim, N=block_size
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int K, int N>
+static __aicore__ void qk_matmul_n_impl(
+    __gm__ bfloat16_t* qi_base,
+    __gm__ bfloat16_t* key_base,
+    __gm__ float* sij_base,
+    uint64_t n_blocks,
+    __gm__ int32_t* block_table) {
+
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
+
+    using TileMatA = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
+
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile = TileRight<bfloat16_t, K, N, K, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    // Hoist qi TLOAD before the loop (qi is constant across all blocks)
+    GlobalA qiGlobal(qi_base);
+    TLOAD(aMatTile, qiGlobal);
+
+    for (uint64_t i = 0; i < n_blocks; i++) {
+        GlobalB kjGlobal(key_base + block_table[i] * N * K);
+        GlobalOut sijGlobal(sij_base + i * M * N);
+
+        // Load only B each iteration (qi already in L1 from hoist)
+        TLOAD(bMatTile, kjGlobal);
+
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+        // TMOV qi from L1→L0A (re-copy since TMATMUL consumed L0A) and kj from L1→L0B
+        TMOV(aTile, aMatTile);
+        TMOV(bTile, bMatTile);
+
+        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+        TMATMUL(cTile, aTile, bTile);
+
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+        TSTORE(sijGlobal, cTile);
+
+        if (i + 1 < n_blocks) {
+            pipe_barrier(PIPE_ALL);
+        }
+    }
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* qi = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* key_cache = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* sij_buf = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    uint64_t n_blocks = static_cast<uint64_t>(args[3]);
+    __gm__ int32_t* block_table = reinterpret_cast<__gm__ int32_t*>(args[4]);
+
+    __gm__ bfloat16_t* qi_base = reinterpret_cast<__gm__ bfloat16_t*>(qi->buffer.addr) + qi->start_offset;
+    __gm__ bfloat16_t* key_base = reinterpret_cast<__gm__ bfloat16_t*>(key_cache->buffer.addr);
+    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_buf->buffer.addr) + sij_buf->start_offset;
+
+    uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
+
+    if (q_tile_size == 16) {
+        qk_matmul_n_impl<16, 128, 128>(qi_base, key_base, sij_base, n_blocks, block_table);
+    } else {
+        qk_matmul_n_impl<64, 128, 64>(qi_base, key_base, sij_base, n_blocks, block_table);
+    }
+}

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_hub.cpp
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_hub.cpp
@@ -1,0 +1,18 @@
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+constexpr int M = 16;
+constexpr int K = 16;
+constexpr int N = 16;
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -1,0 +1,249 @@
+// Online Softmax Update + Normalize Kernel (AIV)
+//
+// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+//   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
+//   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//
+// Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
+//   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
+//   For element-wise ops (TMAX, TSUB, TEXP, etc.), TRESHAPE to RowMajor (1, M).
+//   After arithmetic, TRESHAPE back to ColMajor (M, 1) for row-broadcast ops.
+//   This eliminates the GM round-trip (TSTORE ND → TLOAD DN) used in the original.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int N>
+static __aicore__ void online_update_impl(__gm__ TensorData* mij,
+    __gm__ TensorData* lij,
+    __gm__ TensorData* oi_new,
+    __gm__ TensorData* mi,
+    __gm__ TensorData* li,
+    __gm__ TensorData* oi,
+    uint64_t is_first,
+    uint64_t is_last,
+    __gm__ TensorData* dst) {
+    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
+    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
+    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
+    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
+    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
+    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
+    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+
+    // Aligned rows for ColMajor DN tiles (32-byte alignment)
+    constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+
+    // --- GlobalTensor types ---
+
+    // Data (M, N) RowMajor
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<1, 1, 1, N, 1>>;
+
+    // Scalar DN: M contiguous floats as (kAlignedRows, 1) ColMajor for TROWEXPAND ops and loading
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, pto::Stride<1, 1, 1, 1, 1>, Layout::DN>;
+
+    // Scalar ND: for storing mi_new and li_new back to GM
+    constexpr int kScalarCols = 32 / sizeof(float);
+    constexpr int kScalarRows = M / kScalarCols;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, pto::Stride<1, 1, 1, kScalarCols, 1>>;
+
+    // --- GlobalTensor instances ---
+
+    GlobalDataMxN oiNewGlobal(oi_new_ptr + oi_new->start_offset);
+    GlobalDataMxN oiGlobal(oi_ptr + oi->start_offset);
+    GlobalDataMxN dstGlobal(dst_ptr + dst->start_offset);
+
+    // DN globals for loading scalars as ColMajor
+    GlobalScalarDN mijGlobalDN(mij_ptr + mij->start_offset);
+    GlobalScalarDN lijGlobalDN(lij_ptr + lij->start_offset);
+    GlobalScalarDN miGlobalDN(mi_ptr + mi->start_offset);
+    GlobalScalarDN liGlobalDN(li_ptr + li->start_offset);
+
+    // ND globals for storing scalar results
+    GlobalScalarND miGlobalND(mi_ptr + mi->start_offset);
+    GlobalScalarND liGlobalND(li_ptr + li->start_offset);
+
+    // --- Tile types ---
+
+    using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+
+    // RowMajor (1, M) tiles for element-wise arithmetic via TRESHAPE
+    using TileScalarRow = Tile<TileType::Vec, float, 1, M, BLayout::RowMajor, 1, M>;
+
+    // ND tile for storing back to GM
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
+
+    // --- UB memory layout ---
+
+    constexpr int kDataBytes = M * N * sizeof(float);
+    constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
+
+    // Data tiles
+    TileDataMxN oiNewTile;
+    TileDataMxN oiTile;
+
+    // Scalar DN tiles loaded from GM (ColMajor)
+    TileScalarDN mijDN, lijDN, miDN, liDN;
+
+    // Temporary DN tiles for results
+    TileScalarDN miNewDN, alphaDN, betaDN, liNewDN, tmpDN;
+
+    TASSIGN(oiNewTile, 0);
+    TASSIGN(oiTile, kDataBytes);
+    TASSIGN(mijDN, 2 * kDataBytes);
+    TASSIGN(lijDN, 2 * kDataBytes + kScalarDNBytes);
+    TASSIGN(miDN, 2 * kDataBytes + 2 * kScalarDNBytes);
+    TASSIGN(liDN, 2 * kDataBytes + 3 * kScalarDNBytes);
+    TASSIGN(miNewDN, 2 * kDataBytes + 4 * kScalarDNBytes);
+    TASSIGN(alphaDN, 2 * kDataBytes + 5 * kScalarDNBytes);
+    TASSIGN(betaDN, 2 * kDataBytes + 6 * kScalarDNBytes);
+    TASSIGN(liNewDN, 2 * kDataBytes + 7 * kScalarDNBytes);
+    TASSIGN(tmpDN, 2 * kDataBytes + 8 * kScalarDNBytes);
+
+    if (is_first) {
+        // --- First block: copy inputs to accumulators ---
+        TLOAD(oiNewTile, oiNewGlobal);
+        TLOAD(mijDN, mijGlobalDN);
+        TLOAD(lijDN, lijGlobalDN);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // Store mi = mij, li = lij, oi = oi_new
+        // Alias ND tiles to same UB as DN tiles for ND-format store
+        TileScalarND mijND, lijND;
+        TASSIGN(mijND, 2 * kDataBytes);                    // alias same UB as mijDN
+        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);   // alias same UB as lijDN
+
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
+
+        if (is_last) {
+            // Single block: normalize dst = oi_new / lij
+            // lijDN already in ColMajor DN format, use directly for TROWEXPANDDIV
+            set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+            TROWEXPANDDIV(oiNewTile, oiNewTile, lijDN);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+            TSTORE(dstGlobal, oiNewTile);
+        }
+    } else {
+        // --- Subsequent blocks: accumulate ---
+
+        // Load all inputs as DN (ColMajor)
+        TLOAD(oiNewTile, oiNewGlobal);
+        TLOAD(oiTile, oiGlobal);
+        TLOAD(mijDN, mijGlobalDN);
+        TLOAD(lijDN, lijGlobalDN);
+        TLOAD(miDN, miGlobalDN);
+        TLOAD(liDN, liGlobalDN);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // TRESHAPE: ColMajor(M,1) → RowMajor(1,M) for element-wise arithmetic
+        TileScalarRow miRow, mijRow, liRow, lijRow;
+        TRESHAPE(miRow, miDN);
+        TRESHAPE(mijRow, mijDN);
+        TRESHAPE(liRow, liDN);
+        TRESHAPE(lijRow, lijDN);
+
+        // Scalar arithmetic in RowMajor (1, M) layout
+        TileScalarRow miNewRow, alphaRow, betaRow, liNewRow, tmpRow;
+        TASSIGN(miNewRow, 2 * kDataBytes + 4 * kScalarDNBytes);
+        TASSIGN(alphaRow, 2 * kDataBytes + 5 * kScalarDNBytes);
+        TASSIGN(betaRow, 2 * kDataBytes + 6 * kScalarDNBytes);
+        TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
+        TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
+
+        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        
+        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        
+        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        
+        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        
+        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        
+        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        
+        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        
+        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+
+        // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
+        
+        TRESHAPE(alphaDN, alphaRow);
+        TRESHAPE(betaDN, betaRow);
+
+        // Scale data tiles using row-broadcast multiply
+        TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
+        
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        
+        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+
+        // Store mi_new and li_new to GM (ND format)
+        // Alias ND tiles to the same UB locations as miNewRow and liNewRow
+        TileScalarND miNewND, liNewND;
+        TASSIGN(miNewND, 2 * kDataBytes + 4 * kScalarDNBytes);
+        TASSIGN(liNewND, 2 * kDataBytes + 7 * kScalarDNBytes);
+
+        if (is_last) {
+            // Normalize and output: dst = oi / li_new
+            TRESHAPE(liNewDN, liNewRow);
+            
+            TROWEXPANDDIV(oiTile, oiTile, liNewDN);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(miGlobalND, miNewND);   // persist mi_new
+            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(dstGlobal, oiTile);
+        } else {
+            // Store updated accumulators
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(miGlobalND, miNewND);   // persist mi_new
+            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(oiGlobal, oiTile);
+        }
+    }
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* mij = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* lij = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* oi_new = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    __gm__ TensorData* mi = reinterpret_cast<__gm__ TensorData*>(args[3]);
+    __gm__ TensorData* li = reinterpret_cast<__gm__ TensorData*>(args[4]);
+    __gm__ TensorData* oi = reinterpret_cast<__gm__ TensorData*>(args[5]);
+    __gm__ TensorData* dst = reinterpret_cast<__gm__ TensorData*>(args[6]);
+    uint64_t is_first = static_cast<uint64_t>(args[7]);
+    uint64_t is_last = static_cast<uint64_t>(args[8]);
+    uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);
+    // args[10] = head_dim (128)
+
+    if (q_tile_size == 16) {
+        online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else {
+        online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    }
+}

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,0 +1,260 @@
+// Two-Pass Softmax Kernel (AIV) for n_blocks tiles
+//
+// Input:  sij_buf (n_blocks * M, N) fp32 — QK results stacked vertically
+// Output: pij_buf (n_blocks * M, N) bf16 — attention weights per block
+//         mij (M,) fp32 — global row max across all blocks
+//         lij (M,) fp32 — total row sum across all blocks
+//
+// Pass 1: Iterate over n_blocks tiles, apply scale, mask last block,
+//         find global m = max over all blocks of rowmax(S_i * scale)
+//         Uses TRESHAPE for DN↔Row conversion to keep globalMax in UB
+//         (eliminates 63 × 4 GM round-trip operations).
+// Pass 2: Iterate again, compute P_i = exp(S_i * scale - m) -> bf16,
+//         accumulate l = sum over all blocks of rowsum(P_i)
+//         Uses double-buffered sij tiles to overlap TLOAD with computation.
+//
+// Two-pass ensures all P_i tiles share the same scale (global max),
+// enabling direct TMATMUL_ACC accumulation in the PV kernel.
+//
+// Supports two tile configurations via runtime dispatch:
+//   Case1: M=16, N=128 (q_tile=16, block_size=128)
+//   Case2: M=64, N=64  (q_tile=64, block_size=64)
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int M, int N>
+static __aicore__ void softmax_prepare_n_impl(
+    __gm__ float* sij_base,
+    float scale_value,
+    __gm__ bfloat16_t* pij_base,
+    __gm__ float* mij_addr,
+    __gm__ float* lij_addr,
+    uint64_t n_blocks,
+    uint64_t valid_len_last) {
+
+    constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+    constexpr int kScalarCols = 32 / sizeof(float);
+    constexpr int kScalarRows = M / kScalarCols;
+
+    // --- GlobalTensor types ---
+    using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<1, 1, 1, N, 1>>;
+    using GlobalDataMxN_bf16 = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, N>, pto::Stride<1, 1, 1, N, 1>>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, pto::Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, pto::Stride<1, 1, 1, kScalarCols, 1>>;
+
+    // --- Tile types ---
+    using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N, SLayout::NoneBox, 512, PadValue::Min>;
+    using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
+    using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
+    // RowMajor (1, M) tile for element-wise arithmetic via TRESHAPE
+    using TileScalarRow = Tile<TileType::Vec, float, 1, M, BLayout::RowMajor, 1, M>;
+
+    // --- UB memory layout (double-buffered sij) ---
+    constexpr int kDataBytes = M * N * sizeof(float);
+    constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
+
+    // Double-buffered sij tiles
+    TileVecMxN sijTile_A;
+    TileSijPad sijPadTile_A;
+    TileVecMxN sijTile_B;
+    TileSijPad sijPadTile_B;
+    TileVecMxN pijTile;
+    TileVecMxN tmpTile;
+    TileVecMxN sumAccTile;
+    TileScalarDN localMaxDN;
+    TileScalarDN globalMaxDN;
+    TileScalarDN sumDN;
+    TileVecMxN_bf16 pijBf16Tile;
+
+    // TRESHAPE aliases (same UB address as their DN counterparts)
+    TileScalarRow localMaxRow;
+    TileScalarRow globalMaxRow;
+
+    // ND alias for storing globalMax to GM
+    TileScalarND globalMaxND;
+
+    TASSIGN(sijTile_A, 0x0);
+    TASSIGN(sijPadTile_A, 0x0);
+    TASSIGN(sijTile_B, kDataBytes);
+    TASSIGN(sijPadTile_B, kDataBytes);
+    TASSIGN(pijTile, 2 * kDataBytes);
+    TASSIGN(tmpTile, 3 * kDataBytes);
+    TASSIGN(sumAccTile, 4 * kDataBytes);
+    int scalarBase = 5 * kDataBytes;
+    TASSIGN(localMaxDN, scalarBase);
+    TASSIGN(localMaxRow, scalarBase);                     // alias: same UB as localMaxDN
+    TASSIGN(globalMaxDN, scalarBase + kScalarDNBytes);
+    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);    // alias: same UB as globalMaxDN
+    TASSIGN(sumDN, scalarBase + 2 * kScalarDNBytes);
+    TASSIGN(pijBf16Tile, scalarBase + 3 * kScalarDNBytes);
+
+    // GM aliases (mij/lij output buffers)
+    GlobalScalarND mijGlobalND(mij_addr);
+    GlobalScalarDN lijGlobalDN(lij_addr);
+
+    // ======== Pass 1: Find global row max via TRESHAPE (no GM round-trip) ========
+    for (uint64_t i = 0; i < n_blocks; i++) {
+        GlobalDataMxN sijGlobal(sij_base + i * M * N);
+        TLOAD(sijTile_A, sijGlobal);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        if (i == n_blocks - 1 && valid_len_last < static_cast<uint64_t>(N)) {
+            TileSijDyn sijDynTile(static_cast<size_t>(valid_len_last));
+            TASSIGN(sijDynTile, 0x0);
+            TFILLPAD_INPLACE(sijPadTile_A, sijDynTile);
+            
+        }
+
+        TMULS(sijTile_A, sijTile_A, scale_value);
+        
+        TROWMAX(localMaxDN, sijTile_A, tmpTile);
+        
+
+        // TRESHAPE: ColMajor(M,1) → RowMajor(1,M) for element-wise TMAX
+        TRESHAPE(localMaxRow, localMaxDN);
+        if (i == 0) {
+            TMAX(globalMaxRow, localMaxRow, localMaxRow);
+        } else {
+            TMAX(globalMaxRow, globalMaxRow, localMaxRow);
+        }
+        
+    }
+
+    // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for Pass 2's TROWEXPANDSUB
+    TRESHAPE(globalMaxDN, globalMaxRow);
+
+    // Store final global max to mij for online_update to consume
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(mijGlobalND, globalMaxND);
+
+    // ======== Pass 2: Compute softmax with double-buffered sij ========
+    // globalMaxDN is already in UB from TRESHAPE — no reload needed.
+    // Sync MTE3→MTE2 to ensure the mij TSTORE completed before first sij TLOAD.
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+
+    // Pre-load first sij tile into buffer A
+    GlobalDataMxN sijGlobal_0(sij_base);
+    TLOAD(sijTile_A, sijGlobal_0);
+
+    for (uint64_t i = 0; i < n_blocks; i++) {
+        GlobalDataMxN_bf16 pijGlobal(pij_base + i * M * N);
+
+        // Wait for current tile's TLOAD to complete
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // TFILLPAD on current buffer if last block with partial valid length
+        if (i == n_blocks - 1 && valid_len_last < static_cast<uint64_t>(N)) {
+            TileSijDyn curSijDyn(static_cast<size_t>(valid_len_last));
+            if (i % 2 == 0) {
+                TASSIGN(curSijDyn, 0x0);
+                TFILLPAD_INPLACE(sijPadTile_A, curSijDyn);
+            } else {
+                TASSIGN(curSijDyn, static_cast<int>(kDataBytes));
+                TFILLPAD_INPLACE(sijPadTile_B, curSijDyn);
+            }
+            
+        }
+
+        // Compute on current buffer (select A or B based on iteration parity)
+        if (i % 2 == 0) {
+            TMULS(sijTile_A, sijTile_A, scale_value);
+            
+            TROWEXPANDSUB(pijTile, sijTile_A, globalMaxDN);
+        } else {
+            TMULS(sijTile_B, sijTile_B, scale_value);
+            
+            TROWEXPANDSUB(pijTile, sijTile_B, globalMaxDN);
+        }
+        
+        TEXP(pijTile, pijTile);
+        
+        TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
+        
+        TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
+
+        
+        if (i == 0) {
+            TMULS(sumAccTile, pijTile, 1.0f);
+        } else {
+            TADD(sumAccTile, sumAccTile, pijTile);
+        }
+
+        // Store pij (must complete before next iteration's TCVT overwrites pijBf16Tile)
+        
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(pijGlobal, pijBf16Tile);
+
+        // Prefetch next sij into alternate buffer (after TSTORE to avoid UB race)
+        if (i + 1 < n_blocks) {
+            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            GlobalDataMxN sijGlobal_next(sij_base + (i + 1) * M * N);
+            if (i % 2 == 0) {
+                TLOAD(sijTile_B, sijGlobal_next);
+            } else {
+                TLOAD(sijTile_A, sijGlobal_next);
+            }
+        }
+    }
+
+    // Compute final row sum from accumulated pij values
+    
+    TROWSUM(sumDN, sumAccTile, tmpTile);
+
+    // Store lij (total sum). mij already stored after Pass 1.
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(lijGlobalDN, sumDN);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ TensorData* sij_buf = reinterpret_cast<__gm__ TensorData*>(args[0]);
+    __gm__ TensorData* pij_buf = reinterpret_cast<__gm__ TensorData*>(args[1]);
+    __gm__ TensorData* mij = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    __gm__ TensorData* lij = reinterpret_cast<__gm__ TensorData*>(args[3]);
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
+    scale_conv.u = static_cast<uint64_t>(args[4]);
+    float scale_value = scale_conv.f;
+    uint64_t n_blocks = static_cast<uint64_t>(args[5]);
+    uint64_t valid_len_last = static_cast<uint64_t>(args[6]);
+
+    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_buf->buffer.addr) + sij_buf->start_offset;
+    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_buf->buffer.addr) + pij_buf->start_offset;
+    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr) + mij->start_offset;
+    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr) + lij->start_offset;
+
+    uint64_t q_tile_size = static_cast<uint64_t>(sij_buf->shapes[0]);
+
+    if (q_tile_size == 16) {
+        softmax_prepare_n_impl<16, 128>(sij_base, scale_value, pij_base, mij_addr, lij_addr, n_blocks, valid_len_last);
+    } else {
+        softmax_prepare_n_impl<64, 64>(sij_base, scale_value, pij_base, mij_addr, lij_addr, n_blocks, valid_len_last);
+    }
+}

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
@@ -1,0 +1,46 @@
+"""
+Paged Attention Kernel and Orchestration Configuration
+
+Defines the kernels and orchestration function for paged attention
+with AIC/AIV subgraph splitting:
+
+AIC Kernels (Matrix Multiplication):
+  - aic_qk_matmul: Q @ K^T computation
+  - aic_pv_matmul: P @ V computation
+
+AIV Kernels (Vector Operations):
+  - aiv_softmax_prepare: scale, rowmax, exp, rowsum
+  - aiv_online_update: online softmax accumulation + fused normalization
+
+Note: aiv_normalize has been merged into aiv_online_update for efficiency.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+# Orchestration config
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "paged_attention_orch.cpp"),
+    "function_name": "build_paged_attention_graph",
+}
+
+# Kernel configs (aiv_normalize removed - merged into aiv_online_update)
+KERNELS = [
+    # AIC kernels (matrix multiplication using Cube unit)
+    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
+    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),       "core_type": "aic"},
+    # AIV kernels (vector operations)
+    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
+    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
+    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),       "core_type": "aiv"},
+]
+
+# Runtime configuration
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "orch_thread_num": 1,
+    "block_dim": 36,
+}

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -1,0 +1,338 @@
+/**
+ * Paged Attention Orchestration Function V2 - N_UNROLL=8, 4 Tasks Per Group
+ *
+ * Batches up to N_UNROLL blocks per group. Each group submits exactly 4 tasks:
+ *   1. QK matmul:  qi @ K^T for n_blocks → sij_buf (q_tile, n_blocks * block_size)
+ *   2. Softmax:    two-pass over sij_buf → pij_buf, mi, li
+ *   3. PV matmul:  SplitK accumulated P @ V → oi_new (q_tile, head_dim)
+ *   4. Update:     online softmax accumulation with group-level mi, li, oi_new
+ *
+ * Memory Layout:
+ *   Query: (batch * num_heads, head_dim) bf16
+ *   Key:   (total_blocks, block_size, head_dim) bf16 (stored as K^T for QK)
+ *   Value: (total_blocks, block_size, head_dim) bf16
+ */
+
+#include <cstdint>
+#include <cstring>
+
+#include "pto_orchestration_api.h"
+
+#define N_UNROLL 64
+
+#define FUNC_QK_MATMUL 0
+#define FUNC_SOFTMAX_PREPARE 1
+#define FUNC_PV_MATMUL 2
+#define FUNC_ONLINE_UPDATE 3
+#define FUNC_AIC_HUB 4
+#define FUNC_AIV_HUB 5
+
+constexpr uint64_t PLATFORM_PROF_SYS_CNT_FREQ = 50000000;  // 50 MHz
+
+inline double cycles_to_us(uint64_t cycles) {
+    return (static_cast<double>(cycles) / PLATFORM_PROF_SYS_CNT_FREQ) * 1000000.0;
+};
+
+inline uint64_t get_sys_cnt_aicpu() {
+    uint64_t ticks;
+    asm volatile("mrs %0, cntvct_el0" : "=r"(ticks));
+    return ticks;
+}
+
+#ifdef ENABLE_PROFILING
+#define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
+#define CYCLE_COUNT_LAP(acc)       \
+    do {                           \
+        _t1 = get_sys_cnt_aicpu(); \
+        acc += (_t1 - _t0);        \
+        _t0 = _t1;                 \
+    } while (0)
+#else
+#define CYCLE_COUNT_START() (void)0
+#define CYCLE_COUNT_LAP(acc) (void)0
+#endif
+
+// Helper to encode float as uint64_t for scalar params
+static uint64_t float_to_u64(float f) {
+    union {
+        float f32;
+        uint64_t u64;
+    } conv;
+    conv.u64 = 0;  // Clear upper bits
+    conv.f32 = f;
+    return conv.u64;
+}
+
+extern "C" {
+/**
+ * Orchestration config — the executor reads these values to set up
+ * shared memory and runtime before calling aicpu_orchestration_entry.
+ */
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
+    uint64_t* args, int arg_count) {
+    (void)args;
+    (void)arg_count;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 10,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtime* rt, uint64_t* args, int arg_count, int orch_thread_num, int orch_thread_index) {
+    (void)orch_thread_num;
+    (void)orch_thread_index;
+#ifdef ENABLE_PROFILING
+    uint64_t prof_param_extract = 0;
+    uint64_t prof_ext_tensor    = 0;
+    uint64_t prof_make_tensor   = 0;
+    uint64_t prof_tensor_view   = 0;
+    uint64_t prof_param_setup   = 0;
+    uint64_t prof_submit_task   = 0;
+    uint64_t prof_scope_and_loop = 0;
+    int      prof_submit_count  = 0;
+    int      prof_make_count    = 0;
+    int      prof_view_count    = 0;
+#endif
+
+    CYCLE_COUNT_START();
+
+    // Extract device pointers (first 7)
+    void* host_query = reinterpret_cast<void*>(args[0]);
+    void* host_key_cache = reinterpret_cast<void*>(args[1]);
+    void* host_value_cache = reinterpret_cast<void*>(args[2]);
+    int* host_block_table = reinterpret_cast<int*>(args[3]);
+    int* host_context_lens = reinterpret_cast<int*>(args[4]);
+    void* host_out = reinterpret_cast<void*>(args[5]);
+    int64_t* host_config = reinterpret_cast<int64_t*>(args[6]);
+
+    // Extract sizes (next 3)
+    size_t query_size = static_cast<size_t>(args[7]);
+    size_t key_cache_size = static_cast<size_t>(args[8]);
+    size_t value_cache_size = static_cast<size_t>(args[9]);
+
+    // Extract config parameters
+    uint64_t batch = static_cast<uint64_t>(static_cast<int>(host_config[0]));
+    uint64_t num_heads = static_cast<uint64_t>(static_cast<int>(host_config[1]));
+    int kv_head_num = static_cast<int>(host_config[2]);
+    uint64_t head_dim = static_cast<uint64_t>(static_cast<int>(host_config[3]));
+    uint64_t block_size = static_cast<uint64_t>(static_cast<int>(host_config[4]));
+    uint64_t block_num = static_cast<uint64_t>(static_cast<int>(host_config[5]));
+    union {
+        uint32_t u;
+        float f;
+    } scale_conv;
+    scale_conv.u = static_cast<uint32_t>(host_config[6]);
+    float scale_value = scale_conv.f;
+    uint64_t q_head_num = num_heads;
+    uint64_t q_tile = std::min(num_heads, 128UL);
+    uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;
+    DataType data_type = DataType::BFLOAT16;
+    CYCLE_COUNT_LAP(prof_param_extract);
+
+    uint32_t query_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
+    uint32_t key_cache_shapes[2] = {(uint32_t)(batch * block_num * block_size), (uint32_t)head_dim};
+    uint32_t value_cache_shapes[2] = {(uint32_t)(batch * block_num * block_size), (uint32_t)head_dim};
+    uint32_t out_shapes[2] = {(uint32_t)(batch * num_heads), (uint32_t)head_dim};
+    Tensor query = make_tensor_external(host_query, query_shapes, 2, data_type, false);
+    Tensor key_cache = make_tensor_external(host_key_cache, key_cache_shapes, 2, data_type, false);
+    Tensor value_cache = make_tensor_external(host_value_cache, value_cache_shapes, 2, data_type, false);
+    Tensor out = make_tensor_external(host_out, out_shapes, 2, DataType::FLOAT32);
+
+#ifdef ENABLE_PROFILING
+    CYCLE_COUNT_LAP(prof_ext_tensor);
+#endif
+
+    // Prefetch first batch's block table data into cache (4 cache lines = 256 bytes)
+    for (int cl = 0; cl < N_UNROLL * (int)sizeof(int); cl += 64) {
+        __builtin_prefetch(reinterpret_cast<char*>(host_block_table) + cl, 0, 3);
+    }
+    __builtin_prefetch(&host_context_lens[0], 0, 3);
+
+    for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
+        uint64_t cur_seq = host_context_lens[b_idx];
+        uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
+        // Pre-compute block table base pointer for this batch
+        int* bt_base = host_block_table + b_idx * block_num;
+
+        // Prefetch next batch's block table + context_lens while processing current batch
+        if (b_idx + 1 < batch) {
+            int* bt_next = host_block_table + (b_idx + 1) * block_num;
+            for (int cl = 0; cl < N_UNROLL * (int)sizeof(int); cl += 64) {
+                __builtin_prefetch(reinterpret_cast<char*>(bt_next) + cl, 0, 3);
+            }
+            __builtin_prefetch(&host_context_lens[b_idx + 1], 0, 3);
+        }
+        for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
+            CYCLE_COUNT_LAP(prof_scope_and_loop);
+            PTO2_SCOPE(rt) {
+                uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
+
+                uint32_t oi_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t li_shapes[1] = {(uint32_t)q_tile};
+                uint32_t mi_shapes[1] = {(uint32_t)q_tile};
+                Tensor oi = make_tensor(oi_shapes, 2, DataType::FLOAT32);
+                Tensor li_update = make_tensor(li_shapes, 1, DataType::FLOAT32, false);
+                Tensor mi_update = make_tensor(mi_shapes, 1, DataType::FLOAT32, false);
+#ifdef ENABLE_PROFILING
+                prof_make_count += 3;
+                CYCLE_COUNT_LAP(prof_make_tensor);
+#endif
+
+                uint32_t qi_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t qi_offsets[2] = {(uint32_t)cur_offset, 0};
+                Tensor qi = query.view(qi_shapes, qi_offsets);
+                uint32_t out_view_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                uint32_t out_view_offsets[2] = {(uint32_t)cur_offset, 0};
+                Tensor out_view = out.view(out_view_shapes, out_view_offsets);
+#ifdef ENABLE_PROFILING
+                prof_view_count += 2;
+                CYCLE_COUNT_LAP(prof_tensor_view);
+#endif
+                PTOParam params_inplace;
+                params_inplace.add_output(oi);
+                params_inplace.add_output(li_update);
+                params_inplace.add_output(mi_update);
+                CYCLE_COUNT_LAP(prof_param_setup);
+                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_inplace);
+#ifdef ENABLE_PROFILING
+                prof_submit_count++;
+                CYCLE_COUNT_LAP(prof_submit_task);
+#endif
+
+                // Reusable PTOParam objects — reset() before each use avoids
+                // repeated stack-frame construction in the inner loop.
+                PTOParam params_qk, params_sf, params_pv, params_up;
+
+                for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
+                    uint64_t n_blocks = std::min((uint64_t)N_UNROLL, bn_this_batch - bn);
+
+                    // Valid length for last block in this group
+                    uint64_t last_block_seq_start = (bn + n_blocks - 1) * block_size;
+                    uint64_t valid_len_last = std::min(block_size, cur_seq - last_block_seq_start);
+                    CYCLE_COUNT_LAP(prof_param_extract);
+
+                    // === Task 1: Batched QK matmul ===
+                    uint32_t sij_buf_shapes[2] = {(uint32_t)q_tile, (uint32_t)(n_blocks * block_size)};
+                    Tensor sij_buf = make_tensor(sij_buf_shapes, 2, DataType::FLOAT32);
+#ifdef ENABLE_PROFILING
+                    prof_make_count += 1;
+                    CYCLE_COUNT_LAP(prof_make_tensor);
+#endif
+
+                    params_qk.reset();
+                    params_qk.add_input(qi);
+                    params_qk.add_input(key_cache);
+                    params_qk.add_output(sij_buf);
+                    params_qk.add_scalar(n_blocks);
+                    params_qk.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
+                    CYCLE_COUNT_LAP(prof_param_setup);
+                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk);
+#ifdef ENABLE_PROFILING
+                    prof_submit_count++;
+                    CYCLE_COUNT_LAP(prof_submit_task);
+#endif
+
+                    // === Task 2: Two-pass softmax over all blocks in group ===
+                    uint32_t pij_buf_shapes[2] = {(uint32_t)q_tile, (uint32_t)(n_blocks * block_size)};
+                    Tensor pij_buf = make_tensor(pij_buf_shapes, 2, data_type);
+                    Tensor mi = make_tensor(mi_shapes, 1, DataType::FLOAT32);
+                    Tensor li = make_tensor(li_shapes, 1, DataType::FLOAT32);
+#ifdef ENABLE_PROFILING
+                    prof_make_count += 3;
+                    CYCLE_COUNT_LAP(prof_make_tensor);
+#endif
+
+                    params_sf.reset();
+                    params_sf.add_input(sij_buf);
+                    params_sf.add_output(pij_buf);
+                    params_sf.add_output(mi);
+                    params_sf.add_output(li);
+                    params_sf.add_scalar(float_to_u64(scale_value));
+                    params_sf.add_scalar(n_blocks);
+                    params_sf.add_scalar(valid_len_last);
+                    CYCLE_COUNT_LAP(prof_param_setup);
+                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf);
+#ifdef ENABLE_PROFILING
+                    prof_submit_count++;
+                    CYCLE_COUNT_LAP(prof_submit_task);
+#endif
+
+                    // === Task 3: SplitK PV matmul (accumulated P @ V) ===
+                    uint32_t oi_new_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
+                    Tensor oi_new = make_tensor(oi_new_shapes, 2, DataType::FLOAT32);
+#ifdef ENABLE_PROFILING
+                    prof_make_count += 1;
+                    CYCLE_COUNT_LAP(prof_make_tensor);
+#endif
+
+                    params_pv.reset();
+                    params_pv.add_input(pij_buf);
+                    params_pv.add_input(value_cache);
+                    params_pv.add_output(oi_new);
+                    params_pv.add_scalar(n_blocks);
+                    params_pv.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
+                    CYCLE_COUNT_LAP(prof_param_setup);
+                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv);
+#ifdef ENABLE_PROFILING
+                    prof_submit_count++;
+                    CYCLE_COUNT_LAP(prof_submit_task);
+#endif
+
+                    // === Task 4: Online update (per-group) ===
+                    uint64_t is_first = (bn == 0) ? 1 : 0;
+                    uint64_t is_last = (bn + n_blocks >= bn_this_batch) ? 1 : 0;
+
+                    params_up.reset();
+                    params_up.add_input(mi);
+                    params_up.add_input(li);
+                    params_up.add_input(oi_new);
+                    params_up.add_inout(mi_update);
+                    params_up.add_inout(li_update);
+                    params_up.add_inout(oi);
+                    params_up.add_output(out_view);
+                    params_up.add_scalar(is_first);
+                    params_up.add_scalar(is_last);
+                    CYCLE_COUNT_LAP(prof_param_setup);
+                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up);
+#ifdef ENABLE_PROFILING
+                    prof_submit_count++;
+                    CYCLE_COUNT_LAP(prof_submit_task);
+#endif
+                }
+            }
+            CYCLE_COUNT_LAP(prof_scope_and_loop);
+        }
+    }
+    CYCLE_COUNT_LAP(prof_scope_and_loop);
+
+#ifdef ENABLE_PROFILING
+    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor +
+                     prof_tensor_view + prof_param_setup + prof_submit_task +
+                     prof_scope_and_loop;
+    LOG_ALWAYS(rt, "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
+        prof_submit_count, prof_make_count, prof_view_count, cycles_to_us(total));
+    if (total > 0) {
+        LOG_ALWAYS(rt, "  param_extract    : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_param_extract), prof_param_extract * 100.0 / total);
+        LOG_ALWAYS(rt, "  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
+        LOG_ALWAYS(rt, "  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_make_count, cycles_to_us(prof_make_tensor), prof_make_tensor * 100.0 / total,
+            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
+        LOG_ALWAYS(rt, "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_view_count, cycles_to_us(prof_tensor_view), prof_tensor_view * 100.0 / total,
+            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
+        LOG_ALWAYS(rt, "  param_setup      : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
+        LOG_ALWAYS(rt, "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_submit_count, cycles_to_us(prof_submit_task), prof_submit_task * 100.0 / total,
+            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
+        LOG_ALWAYS(rt, "  scope_and_loop   : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_scope_and_loop), prof_scope_and_loop * 100.0 / total);
+    }
+#endif
+
+#undef CYCLE_COUNT_START
+#undef CYCLE_COUNT_LAP
+}
+
+}  // extern "C"


### PR DESCRIPTION
Sync platform and tensormap_and_ringbuffer runtime changes from a2a3:
- Bump PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH to 7 for affinity gate
- Increase RUNTIME_MAX_WORKER to 108 (36 AIC + 72 AIV)
- Flatten executing_reg_task_ids to single-dimension array
- Add orch_to_sched flag for orchestrator-to-scheduler transition
- Refactor check_running_cores_for_completion signature
- Update profiling_levels.md documentation

Add paged_attention_unroll device test for a5 with AIC/AIV kernels (qk_matmul, pv_matmul, softmax_prepare, online_update) and orchestration.