### PR TITLE
Fix: use RAII scope guards for error-path resource cleanup

### DIFF
--- a/src/a2a3/platform/include/host/raii_scope_guard.h
+++ b/src/a2a3/platform/include/host/raii_scope_guard.h
@@ -1,0 +1,46 @@
+#ifndef PLATFORM_RAII_SCOPE_GUARD_H_
+#define PLATFORM_RAII_SCOPE_GUARD_H_
+
+#include <utility>
+
+/**
+ * RAII guard that runs a cleanup function on scope exit.
+ *
+ * The destructor invokes the stored callable unless dismiss() has been called,
+ * allowing error paths to clean up automatically while success paths retain resources.
+ *
+ * Usage:
+ *   auto guard = RAIIScopeGuard([&]() { allocator.free(ptr); });
+ *   // ... do work that might fail ...
+ *   guard.dismiss();  // success — keep the resource
+ */
+template <typename F>
+class RAIIScopeGuard {
+public:
+    explicit RAIIScopeGuard(F fn)
+        : fn_(std::move(fn)), active_(true) {}
+
+    ~RAIIScopeGuard() {
+        if (active_) {
+            fn_();
+        }
+    }
+
+    RAIIScopeGuard(RAIIScopeGuard&& other) noexcept
+        : fn_(std::move(other.fn_)), active_(other.active_) {
+        other.active_ = false;
+    }
+
+    RAIIScopeGuard(const RAIIScopeGuard&) = delete;
+    RAIIScopeGuard& operator=(const RAIIScopeGuard&) = delete;
+
+    void dismiss() noexcept {
+        active_ = false;
+    }
+
+private:
+    F fn_;
+    bool active_;
+};
+
+#endif  // PLATFORM_RAII_SCOPE_GUARD_H_

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -12,6 +12,7 @@
 // Include HAL constants from CANN (header only, library loaded dynamically)
 #include "ascend_hal.h"
 #include "host/host_regs.h"  // Register address retrieval
+#include "host/raii_scope_guard.h"
 
 // =============================================================================
 // Lazy-loaded HAL (ascend_hal) for profiling host-register only
@@ -47,6 +48,7 @@ HalHostUnregisterFn get_halHostUnregister() {
     }
     return reinterpret_cast<HalHostUnregisterFn>(dlsym(g_hal_handle, "halHostUnregister"));
 }
+
 }  // namespace
 
 // =============================================================================
@@ -379,6 +381,19 @@ int DeviceRunner::run(Runtime& runtime,
     }
     LOG_DEBUG("");
 
+    // Scope guards for cleanup on all exit paths
+    auto regs_cleanup = RAIIScopeGuard([this]() {
+        if (kernel_args_.args.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            kernel_args_.args.regs = 0;
+        }
+    });
+
+    auto runtime_args_cleanup = RAIIScopeGuard([this]() {
+        kernel_args_.finalize_runtime_args();
+    });
+
+
     // Initialize performance profiling if enabled
     if (runtime.enable_profiling) {
         rc = init_performance_profiling(runtime, num_aicore, device_id);
@@ -389,6 +404,13 @@ int DeviceRunner::run(Runtime& runtime,
         // Start memory management thread
         perf_collector_.start_memory_manager();
     }
+
+    auto perf_cleanup = RAIIScopeGuard([this]() {
+        bool was_initialized = perf_collector_.is_initialized();
+        if (was_initialized) {
+            perf_collector_.stop_memory_manager();
+        }
+    });
 
     std::cout << "\n=== Initialize runtime args ===" << '\n';
     // Initialize runtime args
@@ -403,11 +425,6 @@ int DeviceRunner::run(Runtime& runtime,
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServerInit", 1);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (init) failed: %d", rc);
-        if (kernel_args_.args.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
-            kernel_args_.args.regs = 0;
-        }
-        kernel_args_.finalize_runtime_args();
         return rc;
     }
 
@@ -416,11 +433,6 @@ int DeviceRunner::run(Runtime& runtime,
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
-        if (kernel_args_.args.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
-            kernel_args_.args.regs = 0;
-        }
-        kernel_args_.finalize_runtime_args();
         return rc;
     }
 
@@ -429,56 +441,37 @@ int DeviceRunner::run(Runtime& runtime,
     rc = launch_aicore_kernel(stream_aicore_, kernel_args_.args.runtime_args);
     if (rc != 0) {
         LOG_ERROR("launch_aicore_kernel failed: %d", rc);
-        if (kernel_args_.args.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
-            kernel_args_.args.regs = 0;
-        }
-        kernel_args_.finalize_runtime_args();
         return rc;
     }
 
-    // Poll and collect performance data in a separate collector thread
-    std::thread collector_thread;
-    if (runtime.enable_profiling) {
-        collector_thread = std::thread([this, &runtime]() {
-            poll_and_collect_performance_data(runtime.get_task_count());
+    {
+        // Poll and collect performance data in a separate collector thread
+        std::thread collector_thread;
+        if (runtime.enable_profiling) {
+            collector_thread = std::thread([this, &runtime]() {
+                poll_and_collect_performance_data(runtime.get_task_count());
+            });
+        }
+        auto thread_guard = RAIIScopeGuard([&]() {
+            if (runtime.enable_profiling && collector_thread.joinable()) {
+                collector_thread.join();
+            }
         });
-    }
 
-    std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
-    // Synchronize streams
-    rc = rtStreamSynchronize(stream_aicpu_);
-    if (rc != 0) {
-        LOG_ERROR("rtStreamSynchronize (AICPU) failed: %d", rc);
-        if (runtime.enable_profiling && collector_thread.joinable()) {
-            collector_thread.join();
+        std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
+        // Synchronize streams
+        rc = rtStreamSynchronize(stream_aicpu_);
+        if (rc != 0) {
+            LOG_ERROR("rtStreamSynchronize (AICPU) failed: %d", rc);
+            return rc;
         }
-        if (kernel_args_.args.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
-            kernel_args_.args.regs = 0;
-        }
-        kernel_args_.finalize_runtime_args();
-        return rc;
-    }
 
-    std::cout << "\n=== rtStreamSynchronize stream_aicore_===" << '\n';
-    rc = rtStreamSynchronize(stream_aicore_);
-    if (rc != 0) {
-        LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
-        if (runtime.enable_profiling && collector_thread.joinable()) {
-            collector_thread.join();
+        std::cout << "\n=== rtStreamSynchronize stream_aicore_===" << '\n';
+        rc = rtStreamSynchronize(stream_aicore_);
+        if (rc != 0) {
+            LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
+            return rc;
         }
-        if (kernel_args_.args.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
-            kernel_args_.args.regs = 0;
-        }
-        kernel_args_.finalize_runtime_args();
-        return rc;
-    }
-
-    // Wait for collector thread to finish
-    if (runtime.enable_profiling && collector_thread.joinable()) {
-        collector_thread.join();
     }
 
     // Stop memory management, drain remaining buffers, collect phase data, export
@@ -491,13 +484,6 @@ int DeviceRunner::run(Runtime& runtime,
 
     // Print handshake results (reads from device memory, must be before free)
     print_handshake_results();
-
-    // Free per-run resources
-    if (kernel_args_.args.regs != 0) {
-        mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
-        kernel_args_.args.regs = 0;
-    }
-    kernel_args_.finalize_runtime_args();
 
     return 0;
 }

--- a/src/a2a3/platform/onboard/host/host_regs.cpp
+++ b/src/a2a3/platform/onboard/host/host_regs.cpp
@@ -164,6 +164,7 @@ int init_aicore_register_addresses(
     int ret = rtMemcpy(reg_ptr, regs_size, host_regs.data(), regs_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (ret != 0) {
         LOG_ERROR("Failed to copy register addresses to device (rc=%d)", ret);
+        allocator.free(reg_ptr);
         return -1;
     }
 

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -91,6 +91,11 @@ int init_runtime(RuntimeHandle runtime,
         LOG_DEBUG("init_runtime_impl returned: %d", result);
 
         if (result != 0) {
+            // Clear SM pointer so validate_runtime_impl skips reading
+            // the uninitialized shared memory header (garbage graph_output_ptr
+            // could cause copy_from_device to access an invalid address).
+            r->set_pto2_gm_sm_ptr(nullptr);
+            validate_runtime_impl(r);
             r->~Runtime();
         }
 

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -16,6 +16,7 @@
 
 #include "device_runner.h"
 #include "aicpu/platform_aicpu_affinity.h"
+#include "host/raii_scope_guard.h"
 
 // Function pointer types for dynamically loaded executors
 typedef int (*aicpu_execute_func_t)(Runtime* runtime);
@@ -241,6 +242,13 @@ int DeviceRunner::run(Runtime& runtime,
         perf_collector_.start_memory_manager();
     }
 
+    auto perf_cleanup = RAIIScopeGuard([this]() {
+        bool was_initialized = perf_collector_.is_initialized();
+        if (was_initialized) {
+            perf_collector_.stop_memory_manager();
+        }
+    });
+
     // Allocate simulated register blocks for all AICore cores
     size_t total_reg_size = num_aicore * SIM_REG_BLOCK_SIZE;
     void* reg_blocks = mem_alloc_.alloc(total_reg_size);
@@ -249,6 +257,10 @@ int DeviceRunner::run(Runtime& runtime,
         return -1;
     }
     std::memset(reg_blocks, 0, total_reg_size);
+
+    auto reg_blocks_cleanup = RAIIScopeGuard([this, reg_blocks]() {
+        mem_alloc_.free(reg_blocks);
+    });
 
     // Build array of per-core register base addresses
     size_t regs_array_size = num_aicore * sizeof(uint64_t);
@@ -262,6 +274,13 @@ int DeviceRunner::run(Runtime& runtime,
             static_cast<uint8_t*>(reg_blocks) + i * SIM_REG_BLOCK_SIZE);
     }
     kernel_args_.regs = reinterpret_cast<uint64_t>(regs_array);
+
+    auto regs_array_cleanup = RAIIScopeGuard([this]() {
+        if (kernel_args_.regs != 0) {
+            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.regs));
+            kernel_args_.regs = 0;
+        }
+    });
 
     LOG_INFO("Allocated simulated registers: %d cores x 0x%x bytes", num_aicore, SIM_REG_BLOCK_SIZE);
 

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -91,6 +91,11 @@ int init_runtime(RuntimeHandle runtime,
                                kernel_sizes, kernel_count);
 
         if (result != 0) {
+            // Clear SM pointer so validate_runtime_impl skips reading
+            // the uninitialized shared memory header (garbage graph_output_ptr
+            // could cause copy_from_device to access an invalid address).
+            r->set_pto2_gm_sm_ptr(nullptr);
+            validate_runtime_impl(r);
             r->~Runtime();
         }
 


### PR DESCRIPTION
- Add RAIIScopeGuard template to automate cleanup on scope exit
- Replace duplicated manual cleanup in onboard device_runner with
  guards for regs, runtime_args, perf_collector, and collector thread
- Add cleanup guards in sim device_runner for reg_blocks, regs_array,
  and perf_collector
- Fix reg_ptr leak in host_regs on rtMemcpy failure
- Null SM pointer before validate on init failure to prevent reading
  garbage graph_output_ptr in both platform variants