### PR TITLE
Refactor: unify task slot and heap allocation into PTO2TaskAllocator

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1816,27 +1816,20 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             // Print orchestrator profiling data
 #if PTO2_ORCH_PROFILING
             PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
-            uint64_t total = p.sync_cycle + p.alloc_cycle + p.params_cycle + p.lookup_cycle + p.heap_cycle +
+            uint64_t total = p.sync_cycle + p.alloc_cycle + p.params_cycle + p.lookup_cycle +
                              p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
             DEV_ALWAYS("Thread %d: === Orchestrator Profiling: %lld tasks, total=%.3fus ===",
                 thread_idx,
                 (long long)p.submit_count,
                 cycles_to_us(total));
-            DEV_ALWAYS("Thread %d:   task_ring_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
+            DEV_ALWAYS("Thread %d:   task+heap_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
                 thread_idx,
                 cycles_to_us(p.alloc_cycle),
                 p.alloc_cycle * 100.0 / total,
                 cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle),
                 cycles_to_us(p.alloc_wait_cycle),
                 (unsigned long long)p.alloc_atomic_count);
-            DEV_ALWAYS("Thread %d:   heap_alloc     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-                thread_idx,
-                cycles_to_us(p.heap_cycle),
-                p.heap_cycle * 100.0 / total,
-                cycles_to_us(p.heap_cycle - p.heap_wait_cycle),
-                cycles_to_us(p.heap_wait_cycle),
-                (unsigned long long)p.heap_atomic_count);
             DEV_ALWAYS("Thread %d:   sync_tensormap : %.3fus (%.1f%%)",
                 thread_idx,
                 cycles_to_us(p.sync_cycle),
@@ -1889,7 +1882,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 orch_summary.alloc_cycle = p.alloc_cycle;
                 orch_summary.params_cycle = p.params_cycle;
                 orch_summary.lookup_cycle = p.lookup_cycle;
-                orch_summary.heap_cycle = p.heap_cycle;
+                orch_summary.heap_cycle = 0;  // Now included in alloc_cycle
                 orch_summary.insert_cycle = p.insert_cycle;
                 orch_summary.fanin_cycle = p.fanin_cycle;
                 orch_summary.scope_end_cycle = p.scope_end_cycle;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -46,21 +46,18 @@ __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
     AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 // Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
-static uint64_t g_orch_alloc_cycle = 0;      // task ring alloc
+static uint64_t g_orch_alloc_cycle = 0;      // unified task+heap alloc
 static uint64_t g_orch_params_cycle = 0;     // param copy
 static uint64_t g_orch_lookup_cycle = 0;     // tensormap lookup + dep building
-static uint64_t g_orch_heap_cycle = 0;       // heap alloc + output assign
 static uint64_t g_orch_insert_cycle = 0;     // tensormap insert
 static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
 static uint64_t g_orch_scope_end_cycle = 0;  // scope_end overhead
 static int64_t  g_orch_submit_count = 0;
 static uint32_t g_orch_submit_idx = 0;
 uint64_t g_orch_alloc_wait_cycle = 0;
-uint64_t g_orch_heap_wait_cycle = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
 uint64_t g_orch_alloc_atomic_count = 0;
 uint64_t g_orch_params_atomic_count = 0;
-uint64_t g_orch_heap_atomic_count = 0;
 uint64_t g_orch_fanin_atomic_count = 0;
 uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
@@ -115,21 +112,17 @@ bool pto2_orchestrator_init(
 
     // Initialize per-ring resources
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        // Each ring gets its own heap region
         void* ring_heap_base = (char*)gm_heap + r * heap_size;
         auto &fc = sm_handle->header->rings[r].fc;
 
-        // Initialize heap ring buffer
-        pto2_heap_ring_init(&orch->rings[r].heap_ring, ring_heap_base, heap_size, &fc.heap_tail, &fc.heap_top);
-        orch->rings[r].heap_ring.error_code_ptr = &sm_handle->header->orch_error_code;
-
-        // Initialize task ring buffer
-        pto2_task_ring_init(&orch->rings[r].task_ring,
+        // Initialize unified task allocator
+        orch->rings[r].task_allocator.init(
             sm_handle->task_descriptors[r],
             sm_handle->header->rings[r].task_window_size,
+            &fc.current_task_index,
             &fc.last_task_alive,
-            &fc.current_task_index);
-        orch->rings[r].task_ring.error_code_ptr = &sm_handle->header->orch_error_code;
+            ring_heap_base, heap_size,
+            &sm_handle->header->orch_error_code);
 
         // Allocate and initialize dependency list pool (per-ring)
         PTO2DepListEntry* dep_entries = (PTO2DepListEntry*)calloc(dep_pool_capacity, sizeof(PTO2DepListEntry));
@@ -274,7 +267,7 @@ void pto2_submit_mixed_task(
 
     // Determine which ring this task belongs to
     uint8_t ring_id = orch->current_ring_id();
-    auto& task_ring = orch->rings[ring_id].task_ring;
+    auto& allocator = orch->rings[ring_id].task_allocator;
     PTO2SchedulerState* sched = orch->scheduler;
     PTO2RingFlowControl &fc = orch->sm_handle->header->rings[ring_id].fc;
 
@@ -302,29 +295,25 @@ void pto2_submit_mixed_task(
     // If scope task count >= window_size, no slots can ever be reclaimed → deadlock.
     {
         int32_t scope_task_count = orch->scope_tasks_size - orch->scope_begins[orch->scope_stack_top];
-        if (scope_task_count >= task_ring.window_size - 1) {
-            int32_t total_submitted = task_ring.current_index_ptr->load(std::memory_order_acquire);
-            int32_t last_alive = task_ring.last_alive_ptr->load(std::memory_order_acquire);
-            int32_t active_count = total_submitted - last_alive;
+        if (scope_task_count >= allocator.window_size() - 1) {
+            int32_t active_count = allocator.active_count();
 
             LOG_ERROR("========================================");
             LOG_ERROR("FATAL: Scope Deadlock Detected! (ring %d)", ring_id);
             LOG_ERROR("========================================");
             LOG_ERROR("Tasks in current scope (%d) >= task_window_size (%d).",
-                      scope_task_count, task_ring.window_size);
+                      scope_task_count, allocator.window_size());
             LOG_ERROR("  scope_depth:        %d", orch->scope_stack_top + 1);
             LOG_ERROR("  ring_id:            %d", ring_id);
             LOG_ERROR("  scope_task_count:   %d", scope_task_count);
-            LOG_ERROR("  total_submitted:    %d", total_submitted);
-            LOG_ERROR("  last_task_alive:    %d", last_alive);
-            LOG_ERROR("  active_tasks:       %d / %d", active_count, task_ring.window_size);
+            LOG_ERROR("  active_tasks:       %d / %d", active_count, allocator.window_size());
             LOG_ERROR("Root Cause:");
             LOG_ERROR("  Tasks within a scope hold a fanout_count reference that is only");
             LOG_ERROR("  released at scope_end. When scope task count >= window_size,");
             LOG_ERROR("  no slots can be reclaimed -> deadlock.");
             LOG_ERROR("Solution:");
             LOG_ERROR("  1. Reduce tasks per scope (use batching/unroll)");
-            LOG_ERROR("  2. Increase task window (current: %d)", task_ring.window_size);
+            LOG_ERROR("  2. Increase task window (current: %d)", allocator.window_size());
             LOG_ERROR("     Compile-time: PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");
             LOG_ERROR("     Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2>");
             LOG_ERROR("  3. Split work across multiple scopes");
@@ -336,17 +325,30 @@ void pto2_submit_mixed_task(
         }
     }
 
-    // === STEP 1: Allocate task slot from Task Ring (blocks until available) ===
-    int32_t local_id = task_ring.pto2_task_ring_alloc();
-    if (local_id < 0) { orch->fatal = true; return; }
-    int32_t slot = task_ring.get_task_slot(local_id);
+    // === Calculate output size (read from params only, no GM access) ===
+    bool needs_alloc[PTO2_MAX_TENSOR_PARAMS] = {};
+    int32_t total_output_size = 0;
+    for (int i = 0; i < params.tensor_count; i++) {
+        if (params.tensor_types[i] == PTOParamType::OUTPUT
+            && params.tensors[i]->buffer.addr == 0) {
+            needs_alloc[i] = true;
+            total_output_size += PTO2_ALIGN_UP(params.tensors[i]->buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
+        }
+    }
+
+    // === STEP 1: Unified alloc — task slot + packed output buffer (blocks until available) ===
+    PTO2TaskAllocResult alloc_result = allocator.alloc(total_output_size);
+    if (alloc_result.failed()) { orch->fatal = true; return; }
+
+    int32_t local_id = alloc_result.task_id;
+    int32_t slot = alloc_result.slot;
     PTO2TaskId task_id = pto2_make_task_id(ring_id, static_cast<uint32_t>(local_id));
 
-    PTO2TaskDescriptor& task = task_ring.get_task_by_slot(slot);
+    PTO2TaskDescriptor& task = allocator.task_by_slot(slot);
     PTO2TaskPayload* payload = &orch->sm_handle->task_payloads[ring_id][slot];
 
     // Early write-prefetch payload GM cache lines to issue RFO in background.
-    // ~130 lines of computation (output_size, lookup, insert) follow before
+    // ~130 lines of computation (lookup, insert) follow before
     // param_copy writes, giving ample time for prefetch to complete.
     // Use locality=3 (PSTL1KEEP) so prefetched CLs survive lookup/insert eviction.
     for (int32_t i = 0; i < params.tensor_count; i++) {
@@ -381,40 +383,20 @@ void pto2_submit_mixed_task(
         scope_tasks_push(orch, nullptr);
     }
 
-    // Register this task in its owning scope
-
     // Temporary storage for fanin (cached slot state pointers, avoids repeated ring/slot lookups)
     PTO2TaskSlotState* fanin_states[PTO2_MAX_INPUTS];
     int32_t fanin_count = 0;
 
     CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, task_id.raw);
 
-    // === STEP 2: Calculate output size + heap alloc (read from params only, no GM access) ===
-    bool needs_alloc[PTO2_MAX_TENSOR_PARAMS] = {};
-    int32_t total_output_size = 0;
-    for (int i = 0; i < params.tensor_count; i++) {
-        if (params.tensor_types[i] == PTOParamType::OUTPUT
-            && params.tensors[i]->buffer.addr == 0) {
-            needs_alloc[i] = true;
-            total_output_size += PTO2_ALIGN_UP(params.tensors[i]->buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
-        }
-    }
-
-    void* local_packed_base = nullptr;
-    void* local_packed_end = nullptr;
+#if PTO2_PROFILING
     if (total_output_size > 0) {
-        local_packed_base = orch->pto2_alloc_packed_buffer(total_output_size);
-        if (!local_packed_base) { orch->fatal = true; return; }
-        local_packed_end = (char*)local_packed_base + total_output_size;
-    }
-    CYCLE_COUNT_LAP_RECORD(g_orch_heap_cycle, AicpuPhaseId::ORCH_HEAP, task_id.raw);
-#if PTO2_ORCH_PROFILING
-    if (total_output_size > 0) {
-        g_orch_heap_atomic_count += 1;  // heap_top.store in pto2_alloc_packed_buffer
+        orch->buffers_allocated++;
+        orch->bytes_allocated += total_output_size;
     }
 #endif
 
-    // === STEP 3: Sync TensorMap validity and optional cleanup ===
+    // === STEP 2: Sync TensorMap validity and optional cleanup ===
     // Read current last_task_alive from shared memory for this ring
     int32_t sm_last_task_alive = fc.last_task_alive.load(std::memory_order_acquire);
 
@@ -426,7 +408,7 @@ void pto2_submit_mixed_task(
 
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, task_id.raw);
 
-    // === STEP 4: Lookup inputs + assign output addrs (all from params, no GM) ===
+    // === STEP 3: Lookup inputs + assign output addrs (all from params, no GM) ===
     int32_t offset = 0;
     for (int i = 0; i < params.tensor_count; i++) {
         PTOParamType ptype = params.tensor_types[i];
@@ -477,7 +459,7 @@ void pto2_submit_mixed_task(
             case PTOParamType::OUTPUT: {
                 Tensor& tensor = *params.tensors[i];
                 if (tensor.buffer.addr == 0) {
-                    uint64_t alloc_addr = reinterpret_cast<uint64_t>((char*)local_packed_base + offset);
+                    uint64_t alloc_addr = reinterpret_cast<uint64_t>((char*)alloc_result.packed_base + offset);
                     tensor.buffer.addr = alloc_addr;
                     offset += PTO2_ALIGN_UP(tensor.buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
                 }
@@ -488,7 +470,7 @@ void pto2_submit_mixed_task(
 
     CYCLE_COUNT_LAP_RECORD(g_orch_lookup_cycle, AicpuPhaseId::ORCH_LOOKUP, task_id.raw);
 
-    // === STEP 5: Register outputs/inouts in TensorMap (must be separate from lookup) ===
+    // === STEP 4: Register outputs/inouts in TensorMap (must be separate from lookup) ===
     for (int i = 0; i < params.tensor_count; i++) {
         PTOParamType ptype = params.tensor_types[i];
         if (ptype == PTOParamType::OUTPUT || ptype == PTOParamType::INOUT) {
@@ -500,7 +482,7 @@ void pto2_submit_mixed_task(
 
     CYCLE_COUNT_LAP_RECORD(g_orch_insert_cycle, AicpuPhaseId::ORCH_INSERT, task_id.raw);
 
-    // === STEP 6: Batch-write to GM (single cache line burst) ===
+    // === STEP 5: Batch-write to GM (single cache line burst) ===
     // Deferred from allocation phase to avoid scattered GM writes that get
     // evicted by TensorMap lookup/insert cache pressure.
     __builtin_prefetch(&task, 1, 1);
@@ -508,8 +490,8 @@ void pto2_submit_mixed_task(
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)]  = normalized.aic_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;
-    task.packed_buffer_base = local_packed_base;
-    task.packed_buffer_end = local_packed_end;
+    task.packed_buffer_base = alloc_result.packed_base;
+    task.packed_buffer_end = alloc_result.packed_end;
 
     // Prefetch producer slot_states and cur_slot_state (written at init but likely
     // evicted by lookup/insert/heap). param_copy below provides hide time.
@@ -528,7 +510,7 @@ void pto2_submit_mixed_task(
     g_orch_params_atomic_count += 2;  // fanout_lock.store + fanout_count.store
 #endif
 
-    // === STEP 7: Finalize fanin list ===
+    // === STEP 6: Finalize fanin list ===
     // First build the fanin list
     if (sched) {
         auto& rs = sched->ring_sched_states[ring_id];
@@ -605,7 +587,7 @@ void pto2_submit_mixed_task(
 
 void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        int32_t total_tasks = orch->rings[r].task_ring.current_index_ptr->load(std::memory_order_acquire);
+        int32_t total_tasks = orch->rings[r].task_allocator.active_count();
         if (total_tasks > 0) {
             LOG_INFO("=== [Orchestrator] ring %d: total_tasks=%d ===", r, total_tasks);
         }
@@ -634,12 +616,12 @@ void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
 #endif
     LOG_INFO("Current scope depth: %d", orch->scope_stack_top + 1);
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        int32_t active = pto2_task_ring_active_count(&orch->rings[r].task_ring);
+        int32_t active = orch->rings[r].task_allocator.active_count();
         if (active > 0) {
             LOG_INFO("Ring %d task active:  %d", r, active);
             LOG_INFO("Ring %d heap used:    %" PRIu64 " / %" PRIu64, r,
-                     orch->rings[r].heap_ring.top_ptr->load(std::memory_order_relaxed),
-                     orch->rings[r].heap_ring.size);
+                     orch->rings[r].task_allocator.heap_top(),
+                     orch->rings[r].task_allocator.heap_capacity());
             LOG_INFO("Ring %d dep pool:     %d / %d", r,
                      orch->rings[r].dep_pool.used(),
                      orch->rings[r].dep_pool.capacity);
@@ -669,33 +651,28 @@ PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     d.alloc_cycle = g_orch_alloc_cycle;
     d.params_cycle = g_orch_params_cycle;
     d.lookup_cycle = g_orch_lookup_cycle;
-    d.heap_cycle = g_orch_heap_cycle;
     d.insert_cycle = g_orch_insert_cycle;
     d.fanin_cycle = g_orch_fanin_cycle;
     d.scope_end_cycle = g_orch_scope_end_cycle;
     d.submit_count = g_orch_submit_count;
     d.alloc_wait_cycle = g_orch_alloc_wait_cycle;
-    d.heap_wait_cycle = g_orch_heap_wait_cycle;
     d.fanin_wait_cycle = g_orch_fanin_wait_cycle;
     d.alloc_atomic_count = g_orch_alloc_atomic_count;
     d.params_atomic_count = g_orch_params_atomic_count;
-    d.heap_atomic_count = g_orch_heap_atomic_count;
     d.fanin_atomic_count = g_orch_fanin_atomic_count;
     d.finalize_atomic_count = g_orch_finalize_atomic_count;
     d.scope_end_atomic_count = g_orch_scope_end_atomic_count;
 
     // Reset
     g_orch_sync_cycle = g_orch_alloc_cycle = g_orch_params_cycle = 0;
-    g_orch_lookup_cycle = g_orch_heap_cycle = g_orch_insert_cycle = 0;
+    g_orch_lookup_cycle = g_orch_insert_cycle = 0;
     g_orch_fanin_cycle = g_orch_scope_end_cycle = 0;
     g_orch_submit_count = 0;
     g_orch_submit_idx = 0;
     g_orch_alloc_wait_cycle = 0;
-    g_orch_heap_wait_cycle = 0;
     g_orch_fanin_wait_cycle = 0;
     g_orch_alloc_atomic_count = 0;
     g_orch_params_atomic_count = 0;
-    g_orch_heap_atomic_count = 0;
     g_orch_fanin_atomic_count = 0;
     g_orch_finalize_atomic_count = 0;
     g_orch_scope_end_atomic_count = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -91,24 +91,6 @@ struct PTO2OrchestratorState {
         return depth < PTO2_MAX_RING_DEPTH ? static_cast<uint8_t>(depth) : PTO2_MAX_RING_DEPTH - 1;
     }
 
-    /**
-     * Allocate packed output buffer from current ring's heap
-     */
-    void* pto2_alloc_packed_buffer(int32_t total_size) {
-        if (total_size <= 0) {
-            return NULL;
-        }
-
-        uint8_t rid = current_ring_id();
-        void* buffer = rings[rid].heap_ring.pto2_heap_ring_alloc(total_size);
-
-#if PTO2_PROFILING
-        buffers_allocated++;
-        bytes_allocated += total_size;
-#endif
-
-        return buffer;
-    }
 };
 
 // =============================================================================
@@ -169,12 +151,11 @@ void pto2_scope_end(PTO2OrchestratorState* orch);
  * Submit a task with InCore function and parameters
  *
  * This is the main API for building the task graph:
- * 1. Allocates task slot from TaskRing (blocks until available)
- * 2. Allocates packed output buffer from HeapRing (blocks until available)
- * 3. Looks up inputs in TensorMap to find dependencies
- * 4. Updates producer's fanout_count/list (with spinlock)
- * 5. Registers outputs in TensorMap
- * 6. Initializes task state in scheduler
+ * 1. Allocates task slot + packed output buffer via TaskAllocator (blocks until available)
+ * 2. Looks up inputs in TensorMap to find dependencies
+ * 3. Updates producer's fanout_count/list (with spinlock)
+ * 4. Registers outputs in TensorMap
+ * 5. Initializes task state in scheduler
  *
  * @param orch        Orchestrator state
  * @param mixed_kernels  Kernel IDs for AIC/AIV0/AIV1 slots
@@ -216,22 +197,19 @@ void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch);
 #if PTO2_ORCH_PROFILING
 struct PTO2OrchProfilingData {
     uint64_t sync_cycle;
-    uint64_t alloc_cycle;
+    uint64_t alloc_cycle;           // Combined task slot + heap allocation
     uint64_t params_cycle;
     uint64_t lookup_cycle;
-    uint64_t heap_cycle;
     uint64_t insert_cycle;
     uint64_t fanin_cycle;
     uint64_t scope_end_cycle;
     int64_t  submit_count;
     // Wait time tracking for blocking phases
-    uint64_t alloc_wait_cycle;      // Cycles spent waiting in task_ring_alloc
-    uint64_t heap_wait_cycle;       // Cycles spent waiting in heap_ring_alloc
+    uint64_t alloc_wait_cycle;      // Cycles spent waiting in unified alloc
     uint64_t fanin_wait_cycle;      // Cycles spent waiting in fanout_lock
     // Atomic operation counts per phase
     uint64_t alloc_atomic_count;
     uint64_t params_atomic_count;
-    uint64_t heap_atomic_count;
     uint64_t fanin_atomic_count;
     uint64_t finalize_atomic_count;
     uint64_t scope_end_atomic_count;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -1,8 +1,8 @@
 /**
  * PTO Runtime2 - Ring Buffer Implementation
  *
- * Implements HeapRing, TaskRing, and DepListPool ring buffers
- * for zero-overhead memory management.
+ * Implements DepListPool ring buffer for zero-overhead dependency management.
+ * TaskAllocator methods are defined inline in pto_ring_buffer.h.
  *
  * Based on: docs/RUNTIME_LOGIC.md
  */
@@ -13,32 +13,6 @@
 #include <stdlib.h>  // for exit()
 #include "common/unified_log.h"
 #include "pto_scheduler.h"
-
-// =============================================================================
-// Heap Ring Buffer Implementation
-// =============================================================================
-
-void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
-                          std::atomic<uint64_t>* tail_ptr,
-                          std::atomic<uint64_t>* top_ptr) {
-    ring->base = base;
-    ring->size = size;
-    ring->top_ptr = top_ptr;
-    ring->tail_ptr = tail_ptr;
-}
-
-// =============================================================================
-// Task Ring Buffer Implementation
-// =============================================================================
-
-void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
-                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr,
-                          std::atomic<int32_t>* current_index_ptr) {
-    ring->descriptors = descriptors;
-    ring->window_size = window_size;
-    ring->current_index_ptr = current_index_ptr;
-    ring->last_alive_ptr = last_alive_ptr;
-}
 
 // =============================================================================
 // Dependency List Pool Implementation

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -1,21 +1,14 @@
 /**
  * PTO Runtime2 - Ring Buffer Data Structures
- * 
+ *
  * Implements ring buffer designs for zero-overhead memory management:
- * 
- * 1. HeapRing - Output buffer allocation from GM Heap
- *    - O(1) bump allocation
- *    - Wrap-around at end, skip to beginning if buffer doesn't fit
- *    - Implicit reclamation via heap_tail advancement
- *    - Back-pressure: stalls when no space available
- * 
- * 2. TaskRing - Task slot allocation
- *    - Fixed window size (TASK_WINDOW_SIZE)
- *    - Wrap-around modulo window size
- *    - Implicit reclamation via last_task_alive advancement
- *    - Back-pressure: stalls when window is full
- * 
- * 3. DepListPool - Dependency list entry allocation
+ *
+ * 1. TaskAllocator - Unified task slot + output buffer allocation
+ *    - Combines task ring (slot allocation) and heap ring (output buffer allocation)
+ *    - Single spin-wait loop with unified back-pressure and deadlock detection
+ *    - O(1) bump allocation for both task slots and heap buffers
+ *
+ * 2. DepListPool - Dependency list entry allocation
  *    - Ring buffer for linked list entries
  *    - O(1) prepend operation
  *    - Implicit reclamation with task ring
@@ -41,414 +34,325 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 
 // Block notification interval (in spin counts)
 #define PTO2_BLOCK_NOTIFY_INTERVAL  10000
-// Heap ring spin limit - after this, report deadlock and exit
-#define PTO2_HEAP_SPIN_LIMIT        100000
-
-// Flow control spin limit - if exceeded, likely deadlock due to scope/fanout_count
-#define PTO2_FLOW_CONTROL_SPIN_LIMIT  100000
+// Alloc spin limit - after this, report deadlock and exit
+#define PTO2_ALLOC_SPIN_LIMIT       100000
 
 // Dep pool spin limit - if exceeded, dep pool capacity too small for workload
 #define PTO2_DEP_POOL_SPIN_LIMIT      100000
 
 // =============================================================================
-// Heap Ring Buffer
+// Task Allocator (unified task slot + heap buffer allocation)
 // =============================================================================
 
 /**
- * Heap ring buffer structure
- * 
- * Allocates output buffers from a contiguous GM Heap.
- * Wrap-around design with implicit reclamation.
+ * Result of a unified task allocation.
  */
-struct PTO2HeapRing {
-    void*    base;        // GM_Heap_Base pointer
-    uint64_t size;        // GM_Heap_Size (total heap size in bytes)
-    std::atomic<uint64_t>* top_ptr;  // Allocation pointer (shared atomic in SM header)
+struct PTO2TaskAllocResult {
+    int32_t task_id;      // Absolute task ID (not wrapped), -1 on failure
+    int32_t slot;         // task_id & (window_size - 1)
+    void* packed_base;    // Heap allocation result (nullptr if output_size == 0)
+    void* packed_end;     // packed_base + aligned output_size
 
-    // Reference to shared memory tail (for back-pressure)
-    std::atomic<uint64_t>* tail_ptr;  // Points to header->heap_tail
+    bool failed() const { return task_id < 0; }
+};
 
-    // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
-    std::atomic<int32_t>* error_code_ptr = nullptr;
+/**
+ * Unified task slot + heap buffer allocator.
+ *
+ * Since task and heap are always allocated together and the orchestrator is
+ * single-threaded, both pointers (task index, heap top) are tracked locally
+ * and published to shared memory via plain store — no fetch_add or CAS needed.
+ *
+ * The alloc() method checks both resources BEFORE committing to either,
+ * eliminating the need for rollback on partial failure.
+ */
+class PTO2TaskAllocator {
+public:
+    /**
+     * Initialize the allocator with task ring and heap ring resources.
+     */
+    void init(PTO2TaskDescriptor* descriptors, int32_t window_size,
+              std::atomic<int32_t>* current_index_ptr,
+              std::atomic<int32_t>* last_alive_ptr,
+              void* heap_base, uint64_t heap_size,
+              std::atomic<int32_t>* error_code_ptr) {
+        descriptors_ = descriptors;
+        window_size_ = window_size;
+        window_mask_ = window_size - 1;
+        current_index_ptr_ = current_index_ptr;
+        last_alive_ptr_ = last_alive_ptr;
+        heap_base_ = heap_base;
+        heap_size_ = heap_size;
+        error_code_ptr_ = error_code_ptr;
+        local_task_id_ = current_index_ptr->load(std::memory_order_relaxed);
+        heap_top_ = 0;
+        heap_tail_ = 0;
+        last_alive_seen_ = 0;
+    }
 
     /**
-     * Allocate memory from heap ring
+     * Allocate a task slot and its associated output buffer in one call.
      *
-     * O(1) bump allocation with wrap-around.
-     * May STALL (spin-wait) if insufficient space (back-pressure).
-     * Never splits a buffer across the wrap-around boundary.
+     * Both task index and heap top are maintained as local counters and
+     * published to shared memory only on success. Since the orchestrator is
+     * single-threaded, no CAS or fetch_add is needed — just check-then-commit.
      *
-     * @param size  Requested size in bytes
-     * @return Pointer to allocated memory, or nullptr on fatal error
+     * @param output_size  Total packed output size in bytes (0 = no heap needed)
+     * @return Allocation result; check failed() for errors
      */
-    void* pto2_heap_ring_alloc(uint64_t size) {
-        // Align size for DMA efficiency
-        size = PTO2_ALIGN_UP(size, PTO2_ALIGN_SIZE);
+    PTO2TaskAllocResult alloc(int32_t output_size) {
+        uint64_t aligned_size = output_size > 0
+            ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
 
-        // Spin-wait if insufficient space (back-pressure from Scheduler)
         int spin_count = 0;
-        uint64_t prev_tail = tail_ptr->load(std::memory_order_acquire);
-#if PTO2_SPIN_VERBOSE_LOGGING
-        bool notified = false;
-#endif
+        int32_t prev_last_alive = last_alive_ptr_->load(std::memory_order_acquire);
+        int32_t last_alive = prev_last_alive;
+        update_heap_tail(last_alive);
+        bool blocked_on_heap = false;
 #if PTO2_ORCH_PROFILING
         uint64_t wait_start = 0;
         bool waiting = false;
 #endif
-
-        while (1) {
-            void* ptr = pto2_heap_ring_try_alloc(size);
-            if (ptr != NULL) {
-#if PTO2_SPIN_VERBOSE_LOGGING
-                if (notified) {
-                    LOG_INFO("[HeapRing] Unblocked after %d spins", spin_count);
-                }
-#endif
-#if PTO2_ORCH_PROFILING
-                if (waiting) {
-                    extern uint64_t g_orch_heap_wait_cycle;
-                    g_orch_heap_wait_cycle += (get_sys_cnt_aicpu() - wait_start);
-                }
-                {
-                    extern uint64_t g_orch_heap_atomic_count;
-                    g_orch_heap_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
-                }
-#endif
-                return ptr;
-            }
-
-            // No space available, spin-wait
-            spin_count++;
-#if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
-#endif
-
-            // Progress detection: reset spin counter if heap_tail advances
-            uint64_t cur_tail = tail_ptr->load(std::memory_order_acquire);
-            if (cur_tail != prev_tail) {
-#if PTO2_SPIN_VERBOSE_LOGGING
-                LOG_INFO("[HeapRing] Progress: tail %" PRIu64 " -> %" PRIu64 " (reset spin_count=%d)",
-                         prev_tail, cur_tail, spin_count);
-#endif
-                spin_count = 0;
-                prev_tail = cur_tail;
-            }
-
-#if PTO2_SPIN_VERBOSE_LOGGING
-            // Periodic block notification
-            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 && spin_count < PTO2_HEAP_SPIN_LIMIT) {
-                uint64_t top = top_ptr->load(std::memory_order_acquire);
-                LOG_WARN("[HeapRing] BLOCKED: requesting %" PRIu64 " bytes"
-                     ", top=%" PRIu64 ", tail=%" PRIu64 ", spins=%d",
-                     size, top, cur_tail, spin_count);
-                notified = true;
-            }
-#endif
-
-            if (spin_count >= PTO2_HEAP_SPIN_LIMIT) {
-                uint64_t top = top_ptr->load(std::memory_order_acquire);
-                LOG_ERROR("========================================");
-                LOG_ERROR("FATAL: Heap Ring Deadlock Detected!");
-                LOG_ERROR("========================================");
-                LOG_ERROR("Orchestrator blocked waiting for heap space after %d spins (no tail progress).", spin_count);
-                LOG_ERROR("  - Requested:     %" PRIu64 " bytes", size);
-                LOG_ERROR("  - Heap top:      %" PRIu64, top);
-                LOG_ERROR("  - Heap tail:     %" PRIu64 " (stuck here)", cur_tail);
-                LOG_ERROR("  - Heap size:     %" PRIu64, this->size);
-                LOG_ERROR("  - Available:     %" PRIu64 " bytes", pto2_heap_ring_available());
-                LOG_ERROR("Diagnosis:");
-                LOG_ERROR("  heap_tail is not advancing, which means last_task_alive");
-                LOG_ERROR("  is stuck. Check TaskRing diagnostics for root cause.");
-                LOG_ERROR("Solution: Increase heap size or investigate task stall.");
-                LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
-                LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %lu)",
-                          (unsigned long)(this->size * 2));
-                LOG_ERROR("========================================");
-                if (error_code_ptr) {
-                    error_code_ptr->store(PTO2_ERROR_HEAP_RING_DEADLOCK, std::memory_order_release);
-                }
-                return nullptr;
-            }
-
-            SPIN_WAIT_HINT();
-        }
-    }
-
-    /**
-     * Try to allocate memory without stalling (thread-safe via CAS)
-     *
-     * @param size  Requested size in bytes
-     * @return Pointer to allocated memory, or NULL if no space
-     */
-    void* pto2_heap_ring_try_alloc(uint64_t alloc_size) {
-        // Align size for DMA efficiency
-        alloc_size = PTO2_ALIGN_UP(alloc_size, PTO2_ALIGN_SIZE);
 
         while (true) {
-            uint64_t top = top_ptr->load(std::memory_order_acquire);
-            // Read latest tail from shared memory (Scheduler updates this)
-            uint64_t tail = tail_ptr->load(std::memory_order_acquire);
-            uint64_t new_top;
-            void* result;
-
-            if (top >= tail) {
-                // Case 1: top is at or ahead of tail (normal case)
-                uint64_t space_at_end = size - top;
-
-                if (space_at_end >= alloc_size) {
-                    new_top = top + alloc_size;
-                    result = (char*)base + top;
-                } else if (tail > alloc_size) {
-                    // Wrap to beginning
-                    new_top = alloc_size;
-                    result = base;
-                } else {
-                    return NULL;
+            // Check both resources; commit only if both available
+            if (local_task_id_ - last_alive  + 1 < window_size_) {
+                void* heap_ptr = try_bump_heap(aligned_size);
+                if (heap_ptr) {
+                    int32_t task_id = commit_task();
+#if PTO2_ORCH_PROFILING
+                    record_wait(spin_count, wait_start, waiting);
+#endif
+                    return {task_id, task_id & window_mask_,
+                            heap_ptr, static_cast<char*>(heap_ptr) + aligned_size};
                 }
+                blocked_on_heap = true;
             } else {
-                // Case 2: top has wrapped, tail is ahead
-                uint64_t gap = tail - top;
-                if (gap >= alloc_size) {
-                    new_top = top + alloc_size;
-                    result = (char*)base + top;
-                } else {
-                    return NULL;
-                }
+                blocked_on_heap = false;
             }
 
-            if (top_ptr->compare_exchange_weak(top, new_top,
-                    std::memory_order_acq_rel, std::memory_order_acquire)) {
-                return result;
-            }
-            // CAS failed, retry with updated top
-        }
-    }
-
-    /**
-     * Get available space in heap ring
-     */
-    uint64_t pto2_heap_ring_available() {
-        uint64_t top = top_ptr->load(std::memory_order_acquire);
-        uint64_t tail = tail_ptr->load(std::memory_order_acquire);
-
-        if (top >= tail) {
-            uint64_t at_end = size - top;
-            uint64_t at_begin = tail;
-            return at_end > at_begin ? at_end : at_begin;
-        } else {
-            return tail - top;
-        }
-    }
-};
-
-/**
- * Initialize heap ring buffer
- * 
- * @param ring      Heap ring to initialize
- * @param base      Base address of heap memory
- * @param size      Total heap size in bytes
- * @param tail_ptr  Pointer to shared memory heap_tail
- */
-void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
-                          std::atomic<uint64_t>* tail_ptr,
-                          std::atomic<uint64_t>* top_ptr);
-
-// =============================================================================
-// Task Ring Buffer
-// =============================================================================
-
-/**
- * Task ring buffer structure
- * 
- * Fixed-size sliding window for task management.
- * Provides back-pressure when window is full.
- */
-struct PTO2TaskRing {
-    PTO2TaskDescriptor* descriptors;  // Task descriptor array (from shared memory)
-    int32_t window_size;              // Window size (power of 2)
-    std::atomic<int32_t>* current_index_ptr;  // Shared atomic in SM header
-
-    // Reference to shared memory last_task_alive (for back-pressure)
-    std::atomic<int32_t>* last_alive_ptr;  // Points to header->last_task_alive
-
-    // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
-    std::atomic<int32_t>* error_code_ptr = nullptr;
-
-    /**
-     * Allocate a task slot from task ring
-     *
-     * May STALL (spin-wait) if window is full (back-pressure).
-     * Initializes the task descriptor to default values.
-     *
-     * @return Allocated task ID (absolute, not wrapped)
-     */
-    int32_t pto2_task_ring_alloc() {
-        // Spin-wait if window is full (back-pressure from Scheduler)
-        int spin_count = 0;
-        int32_t prev_last_alive = last_alive_ptr->load(std::memory_order_acquire);
-#if PTO2_SPIN_VERBOSE_LOGGING
-        bool notified = false;
-#endif
-#if PTO2_ORCH_PROFILING
-        uint64_t wait_start = 0;
-        bool waiting = false;
-#endif
-
-        while (1) {
-            int32_t task_id = pto2_task_ring_try_alloc();
-            if (task_id >= 0) {
-#if PTO2_SPIN_VERBOSE_LOGGING
-                if (notified) {
-                    LOG_INFO("[TaskRing] Unblocked after %d spins, task_id=%d", spin_count, task_id);
-                }
-#endif
-#if PTO2_ORCH_PROFILING
-                if (waiting) {
-                    extern uint64_t g_orch_alloc_wait_cycle;
-                    g_orch_alloc_wait_cycle += (get_sys_cnt_aicpu() - wait_start);
-                }
-                {
-                    extern uint64_t g_orch_alloc_atomic_count;
-                    g_orch_alloc_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
-                }
-#endif
-                return task_id;
-            }
-
-            // Window is full, spin-wait (with yield to prevent CPU starvation)
+            // Spin: wait for scheduler to advance last_task_alive
             spin_count++;
 #if PTO2_ORCH_PROFILING
             if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
 #endif
-
-            // Progress detection: reset spin counter if last_task_alive advances
-            int32_t cur_last_alive = last_alive_ptr->load(std::memory_order_acquire);
-            if (cur_last_alive > prev_last_alive) {
-#if PTO2_SPIN_VERBOSE_LOGGING
-                LOG_INFO("[TaskRing] Progress: last_alive %d -> %d (reset spin_count=%d)",
-                         prev_last_alive, cur_last_alive, spin_count);
-#endif
+            last_alive = last_alive_ptr_->load(std::memory_order_acquire);
+            update_heap_tail(last_alive);
+            if (last_alive > prev_last_alive) {
                 spin_count = 0;
-                prev_last_alive = cur_last_alive;
-            }
-
+                prev_last_alive = last_alive;
+            } else {
 #if PTO2_SPIN_VERBOSE_LOGGING
-            // Periodic block notification
-            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 && spin_count < PTO2_FLOW_CONTROL_SPIN_LIMIT) {
-                int32_t current = current_index_ptr->load(std::memory_order_acquire);
-                int32_t active_count = current - cur_last_alive;
-                LOG_WARN("[TaskRing] BLOCKED (Flow Control): current=%d, last_alive=%d, "
-                     "active=%d/%d (%.1f%%), spins=%d",
-                     current, cur_last_alive, active_count, window_size,
-                     100.0 * active_count / window_size, spin_count);
-                notified = true;
-            }
-#endif
-
-            // Deadlock: no progress after SPIN_LIMIT spins
-            if (spin_count >= PTO2_FLOW_CONTROL_SPIN_LIMIT) {
-                int32_t current = current_index_ptr->load(std::memory_order_acquire);
-                int32_t active_count = current - cur_last_alive;
-
-                LOG_ERROR("========================================");
-                LOG_ERROR("FATAL: Flow Control Deadlock Detected!");
-                LOG_ERROR("========================================");
-                LOG_ERROR("Task Ring is FULL and no progress after %d spins.", spin_count);
-                LOG_ERROR("  - Current task index:  %d", current);
-                LOG_ERROR("  - Last task alive:     %d (stuck here)", cur_last_alive);
-                LOG_ERROR("  - Active tasks:        %d / %d", active_count, window_size);
-                LOG_ERROR("  - Window utilization:  %.1f%%", 100.0 * active_count / window_size);
-                LOG_ERROR("Diagnosis:");
-                LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d",
-                          cur_last_alive, cur_last_alive);
-                LOG_ERROR("  cannot transition to CONSUMED. Possible causes:");
-                LOG_ERROR("  1. Task %d still executing (subtasks not complete)", cur_last_alive);
-                LOG_ERROR("  2. Task %d fanout not fully released (downstream not done)", cur_last_alive);
-                LOG_ERROR("  3. Scope reference not released (scope_end not called)");
-                LOG_ERROR("  4. Orchestrator blocked here -> can't call scope_end -> circular wait");
-                LOG_ERROR("Solution:");
-                LOG_ERROR("  Increase task window size (current: %d, recommended: %d)", window_size, active_count * 2);
-                LOG_ERROR("  Compile-time: PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");
-                LOG_ERROR("  Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2> (e.g. %d)", active_count * 2);
-                LOG_ERROR("========================================");
-                if (error_code_ptr) {
-                    error_code_ptr->store(PTO2_ERROR_FLOW_CONTROL_DEADLOCK, std::memory_order_release);
+                if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0) {
+                    LOG_WARN("[TaskAllocator] BLOCKED: tasks=%d/%d, heap=%" PRIu64 "/%" PRIu64 ", on=%s, spins=%d",
+                        local_task_id_ - last_alive,
+                        window_size_,
+                        heap_top_,
+                        heap_size_,
+                        blocked_on_heap ? "heap" : "task",
+                        spin_count);
                 }
-                return -1;
+#endif
+                if (spin_count >= PTO2_ALLOC_SPIN_LIMIT) {
+                    report_deadlock(output_size, blocked_on_heap);
+                    return {-1, -1, nullptr, nullptr};
+                }
             }
-
             SPIN_WAIT_HINT();
         }
     }
 
-    /**
-     * Try to allocate task slot without stalling (thread-safe via fetch_add)
-     *
-     * @return Task ID, or -1 if window is full
-     */
-    int32_t pto2_task_ring_try_alloc() {
-        // Optimistically allocate a task ID
-        int32_t task_id = current_index_ptr->fetch_add(1, std::memory_order_acq_rel);
-        int32_t last_alive = last_alive_ptr->load(std::memory_order_acquire);
-        int32_t active_count = task_id - last_alive;
+    // =========================================================================
+    // Task descriptor accessors
+    // =========================================================================
 
-        // Check if there's room (leave at least 1 slot empty)
-        if (active_count < window_size - 1) {
-            return task_id;
-        }
-
-        // Window is full — roll back the optimistic increment
-        current_index_ptr->fetch_sub(1, std::memory_order_release);
-        return -1;
+    PTO2TaskDescriptor& task(int32_t task_id) const {
+        return descriptors_[task_id & window_mask_];
     }
 
-    int32_t get_task_slot(int32_t task_id) const { return task_id & (window_size - 1); }
+    PTO2TaskDescriptor& task_by_slot(int32_t slot) const {
+        return descriptors_[slot];
+    }
+
+    // =========================================================================
+    // State queries
+    // =========================================================================
+
+    int32_t active_count() const {
+        int32_t last_alive = last_alive_ptr_->load(std::memory_order_acquire);
+        return local_task_id_ - last_alive;
+    }
+
+    int32_t window_size() const { return window_size_; }
+
+    uint64_t heap_available() const {
+        uint64_t tail = heap_tail_;
+        if (heap_top_ >= tail) {
+            uint64_t at_end = heap_size_ - heap_top_;
+            uint64_t at_begin = tail;
+            return at_end > at_begin ? at_end : at_begin;
+        }
+        return tail - heap_top_;
+    }
+
+    uint64_t heap_top() const { return heap_top_; }
+    uint64_t heap_capacity() const { return heap_size_; }
+
+private:
+    // --- Task Ring ---
+    PTO2TaskDescriptor* descriptors_ = nullptr;
+    int32_t window_size_ = 0;
+    int32_t window_mask_ = 0;
+    std::atomic<int32_t>* current_index_ptr_ = nullptr;
+    std::atomic<int32_t>* last_alive_ptr_ = nullptr;
+
+    // --- Heap ---
+    void*    heap_base_ = nullptr;
+    uint64_t heap_size_ = 0;
+
+    // --- Local state (single-writer, no atomics needed) ---
+    int32_t  local_task_id_ = 0;      // Next task ID to allocate
+    uint64_t heap_top_ = 0;     // Current heap allocation pointer
+    uint64_t heap_tail_ = 0;    // Heap reclamation pointer (derived from consumed tasks)
+    int32_t  last_alive_seen_ = 0;    // last_task_alive at last heap_tail derivation
+
+    // --- Shared ---
+    std::atomic<int32_t>* error_code_ptr_ = nullptr;
+
+    // =========================================================================
+    // Internal helpers
+    // =========================================================================
 
     /**
-    * Get task descriptor by ID
-    */
-    PTO2TaskDescriptor& get_task(int32_t task_id) { return descriptors[task_id & (window_size - 1)]; }
+     * Commit a task slot: bump local counter and publish to shared memory.
+     * Must only be called after space check has passed.
+     */
+    int32_t commit_task() {
+        int32_t task_id = local_task_id_++;
+        current_index_ptr_->store(local_task_id_, std::memory_order_release);
+        return task_id;
+    }
 
     /**
-    * Get task descriptor by task slot
-    */
-    PTO2TaskDescriptor& get_task_by_slot(int32_t task_slot) { return descriptors[task_slot]; }
+     * Derive heap_tail_ from the last consumed task's packed_buffer_end.
+     *
+     * Every task has a valid packed_buffer_end (equal to packed_buffer_base
+     * for zero-size allocations), so the last consumed task always determines
+     * the correct heap_tail — no backward scan needed.
+     */
+    void update_heap_tail(int32_t last_alive) {
+        if (last_alive <= last_alive_seen_) return;
+        last_alive_seen_ = last_alive;
+
+        PTO2TaskDescriptor& desc = descriptors_[(last_alive - 1) & window_mask_];
+        heap_tail_ = static_cast<uint64_t>(
+            static_cast<char*>(desc.packed_buffer_end) - static_cast<char*>(heap_base_));
+    }
+
+    /**
+     * Bump the heap pointer for the given allocation size.
+     * Returns the allocated pointer, or nullptr if insufficient space.
+     * When alloc_size == 0, returns current position without advancing.
+     */
+    void* try_bump_heap(uint64_t alloc_size) {
+        uint64_t top = heap_top_;
+        if (alloc_size == 0) {
+            return static_cast<char*>(heap_base_) + top;
+        }
+        uint64_t tail = heap_tail_;
+        void* result;
+
+        if (top >= tail) {
+            uint64_t space_at_end = heap_size_ - top;
+            if (space_at_end >= alloc_size) {
+                result = static_cast<char*>(heap_base_) + top;
+                heap_top_ = top + alloc_size;
+            } else if (tail > alloc_size) {
+                result = heap_base_;
+                heap_top_ = alloc_size;
+            } else {
+                return nullptr;
+            }
+        } else {
+            if (tail - top >= alloc_size) {
+                result = static_cast<char*>(heap_base_) + top;
+                heap_top_ = top + alloc_size;
+            } else {
+                return nullptr;
+            }
+        }
+
+        return result;
+    }
+
+#if PTO2_ORCH_PROFILING
+    void record_wait(int spin_count, uint64_t wait_start, bool waiting) {
+        if (waiting) {
+            extern uint64_t g_orch_alloc_wait_cycle;
+            g_orch_alloc_wait_cycle += (get_sys_cnt_aicpu() - wait_start);
+        }
+        {
+            extern uint64_t g_orch_alloc_atomic_count;
+            g_orch_alloc_atomic_count += spin_count + 1;
+        }
+    }
+#endif
+
+    /**
+     * Report deadlock with targeted diagnostics.
+     */
+    void report_deadlock(int32_t requested_output_size, bool heap_blocked) {
+        int32_t last_alive = last_alive_ptr_->load(std::memory_order_acquire);
+        int32_t active_tasks = local_task_id_ - last_alive;
+        uint64_t htail = heap_tail_;
+
+        LOG_ERROR("========================================");
+        if (heap_blocked) {
+            LOG_ERROR("FATAL: Task Allocator Deadlock - Heap Exhausted!");
+        } else {
+            LOG_ERROR("FATAL: Task Allocator Deadlock - Task Ring Full!");
+        }
+        LOG_ERROR("========================================");
+        LOG_ERROR("No progress after %d spins.", PTO2_ALLOC_SPIN_LIMIT);
+        LOG_ERROR("  Task ring:  current=%d, last_alive=%d, active=%d/%d (%.1f%%)",
+                  local_task_id_, last_alive, active_tasks, window_size_,
+                  100.0 * active_tasks / window_size_);
+        LOG_ERROR("  Heap ring:  top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64
+                  ", available=%" PRIu64,
+                  heap_top_, htail, heap_size_, heap_available());
+        if (heap_blocked) {
+            LOG_ERROR("  Requested:  %d bytes", requested_output_size);
+        }
+        LOG_ERROR("Diagnosis:");
+        LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d",
+                  last_alive, last_alive);
+        LOG_ERROR("  cannot transition to CONSUMED. Possible causes:");
+        LOG_ERROR("  1. Task %d still executing (subtasks not complete)", last_alive);
+        LOG_ERROR("  2. Task %d fanout not fully released (downstream not done)", last_alive);
+        LOG_ERROR("  3. Scope reference not released (scope_end not called)");
+        LOG_ERROR("  4. Orchestrator blocked here -> can't call scope_end -> circular wait");
+        LOG_ERROR("Solution:");
+        if (heap_blocked) {
+            LOG_ERROR("  Increase heap size (current: %" PRIu64 ", recommended: %" PRIu64 ")",
+                      heap_size_, heap_size_ * 2);
+            LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
+            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %" PRIu64 ")",
+                      heap_size_ * 2);
+        } else {
+            LOG_ERROR("  Increase task window size (current: %d, recommended: %d)",
+                      window_size_, active_tasks * 2);
+            LOG_ERROR("  Compile-time: PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");
+            LOG_ERROR("  Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2> (e.g. %d)",
+                      active_tasks * 2);
+        }
+        LOG_ERROR("========================================");
+        if (error_code_ptr_) {
+            int32_t code = heap_blocked ? PTO2_ERROR_HEAP_RING_DEADLOCK
+                                        : PTO2_ERROR_FLOW_CONTROL_DEADLOCK;
+            error_code_ptr_->store(code, std::memory_order_release);
+        }
+    }
 };
-
-/**
- * Initialize task ring buffer
- * 
- * @param ring            Task ring to initialize
- * @param descriptors     Task descriptor array from shared memory
- * @param window_size     Window size (must be power of 2)
- * @param last_alive_ptr  Pointer to shared memory last_task_alive
- */
-void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
-                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr,
-                          std::atomic<int32_t>* current_index_ptr);
-
-/**
- * Get number of active tasks in window
- */
-static inline int32_t pto2_task_ring_active_count(PTO2TaskRing* ring) {
-    int32_t last_alive = ring->last_alive_ptr->load(std::memory_order_acquire);
-    return ring->current_index_ptr->load(std::memory_order_acquire) - last_alive;
-}
-
-/**
- * Check if task ring has space for more tasks
- */
-static inline bool pto2_task_ring_has_space(PTO2TaskRing* ring) {
-    int32_t active = pto2_task_ring_active_count(ring);
-    return active < ring->window_size - 1;
-}
-
-/**
- * Get task descriptor by ID
- */
-static inline PTO2TaskDescriptor* pto2_task_ring_get(PTO2TaskRing* ring, int32_t task_id) {
-    return &ring->descriptors[task_id & (ring->window_size - 1)];
-}
 
 // =============================================================================
 // Dependency List Pool
@@ -593,13 +497,12 @@ struct PTO2DepListPool {
 // =============================================================================
 
 /**
- * Groups a HeapRing, TaskRing, and DepPool into one per-depth unit.
+ * Groups a TaskAllocator and DepPool into one per-depth unit.
  * PTO2_MAX_RING_DEPTH instances provide independent reclamation per scope depth.
  */
 struct PTO2RingSet {
-    PTO2HeapRing    heap_ring;
-    PTO2TaskRing    task_ring;
-    PTO2DepListPool dep_pool;
+    PTO2TaskAllocator task_allocator;
+    PTO2DepListPool   dep_pool;
 };
 
 #endif // PTO_RING_BUFFER_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -119,7 +119,7 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, rt->gm_heap, heap_size)) {
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
         pto2_orchestrator_destroy(&rt->orchestrators[0]);
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
@@ -167,7 +167,7 @@ PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, rt->gm_heap, heap_size)) {
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
         for (int i = 0; i < orch_count; i++) {
             pto2_orchestrator_destroy(&rt->orchestrators[i]);
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -103,15 +103,11 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
 // =============================================================================
 
 bool PTO2SchedulerState::RingSchedState::init(
-    PTO2SharedMemoryHandle* sm_handle, int32_t ring_id,
-    void* gm_heap_base, uint64_t per_ring_heap_size) {
+    PTO2SharedMemoryHandle* sm_handle, int32_t ring_id) {
     task_descriptors = sm_handle->task_descriptors[ring_id];
-    heap_base = (char*)gm_heap_base + ring_id * per_ring_heap_size;
     task_window_size = sm_handle->header->rings[ring_id].task_window_size;
     task_window_mask = static_cast<int32_t>(task_window_size - 1);
     last_task_alive = 0;
-    last_heap_consumed = 0;
-    heap_tail = 0;
     slot_states = nullptr;
     advance_lock.store(0, std::memory_order_relaxed);
 
@@ -147,8 +143,7 @@ void PTO2SchedulerState::RingSchedState::destroy() {
 }
 
 bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle,
-                          void* gm_heap_base, uint64_t per_ring_heap_size) {
+                          PTO2SharedMemoryHandle* sm_handle) {
     sched->sm_handle = sm_handle;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -157,7 +152,7 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
 
     // Initialize per-ring state
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (!sched->ring_sched_states[r].init(sm_handle, r, gm_heap_base, per_ring_heap_size)) {
+        if (!sched->ring_sched_states[r].init(sm_handle, r)) {
             for (int j = 0; j < r; j++) {
                 sched->ring_sched_states[j].destroy();
             }
@@ -199,11 +194,9 @@ void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
 void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
     LOG_INFO("=== Scheduler Statistics ===");
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (sched->ring_sched_states[r].last_task_alive > 0 ||
-            sched->ring_sched_states[r].heap_tail > 0) {
+        if (sched->ring_sched_states[r].last_task_alive > 0) {
             LOG_INFO("Ring %d:", r);
             LOG_INFO("  last_task_alive: %d", sched->ring_sched_states[r].last_task_alive);
-            LOG_INFO("  heap_tail:       %" PRIu64, sched->ring_sched_states[r].heap_tail);
         }
     }
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -414,16 +414,12 @@ struct PTO2SchedulerState {
         PTO2TaskDescriptor* task_descriptors;
         PTO2TaskSlotState* slot_states;
         int32_t last_task_alive;
-        int32_t last_heap_consumed;
-        uint64_t heap_tail;
-        void* heap_base;
         int32_t task_window_mask;
         uint64_t task_window_size;
-        // Try-lock used to advance this ring's pointers (CONSUMED scanning + heap tail update).
+        // Try-lock used to advance this ring's last_task_alive pointer.
         std::atomic<int32_t> advance_lock;
 
-        bool init(PTO2SharedMemoryHandle* sm_handle, int32_t ring_id,
-                  void* gm_heap_base, uint64_t per_ring_heap_size);
+        bool init(PTO2SharedMemoryHandle* sm_handle, int32_t ring_id);
         void destroy();
 
         PTO2TaskSlotState& get_slot_state_by_task_id(int32_t local_id) {
@@ -435,7 +431,6 @@ struct PTO2SchedulerState {
 
         void sync_to_sm(PTO2SharedMemoryRingHeader& ring) {
             ring.fc.last_task_alive.store(last_task_alive, std::memory_order_release);
-            ring.fc.heap_tail.store(heap_tail, std::memory_order_release);
         }
 
         void advance_ring_pointers(PTO2SharedMemoryRingHeader& ring) {
@@ -447,15 +442,6 @@ struct PTO2SchedulerState {
                     break;
                 }
                 last_task_alive++;
-            }
-
-            if (last_task_alive > 0) {
-                int32_t last_consumed_id = last_task_alive - 1;
-                PTO2TaskSlotState& slot_state = get_slot_state_by_task_id(last_consumed_id);
-                PTO2TaskDescriptor& task = *slot_state.task;
-                if (task.packed_buffer_end != NULL) {
-                    heap_tail = (uint64_t)((char*)task.packed_buffer_end - (char*)heap_base);
-                }
             }
 
             sync_to_sm(ring);
@@ -777,8 +763,7 @@ struct PTO2SchedulerState {
 // =============================================================================
 
 bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle,
-                          void* gm_heap_base, uint64_t per_ring_heap_size);
+                          PTO2SharedMemoryHandle* sm_handle);
 void pto2_scheduler_destroy(PTO2SchedulerState* sched);
 
 // =============================================================================


### PR DESCRIPTION
- Merge separate PTO2TaskRing + PTO2HeapRing into a single PTO2TaskAllocator that returns both task slot and packed output buffer in one alloc() call
- Eliminate separate heap spin-wait loop, reducing atomic contention on the submit hot path
- Remove heap-specific profiling counters (now folded into alloc phase)
- Simplify orchestrator submit from 7 steps to 6