### PR TITLE
Refactor: move heap allocation from Orchestrator to Scheduler dispatch

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -934,6 +934,75 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
     return 0;
 }
 
+// =============================================================================
+// Deferred Heap Allocation + Virtual Address Resolution
+// =============================================================================
+// Called at dispatch time (Scheduler thread) for each ready task, before any
+// subtask is sent to AICore.
+//
+// Phase 1 — OUTPUT allocation:
+//   If the task has outputs requiring heap memory (total_output_size > 0),
+//   try_alloc from the per-ring HeapRing.  On success, patch each OUTPUT
+//   tensor's virtual address to the physical address and record the mapping
+//   in vaddr_to_paddr[] so consumers can resolve their copies later.
+//   Returns false on heap exhaustion — the caller re-enqueues the task and
+//   processes completions to free heap space (non-blocking back-pressure).
+//
+// Phase 2 — INPUT/INOUT virtual address translation:
+//   Consumer payloads retain virtual addresses (payload->init() copies by value).
+//   Translate each remaining virtual address to a physical address via the
+//   mapping table written by the producer's Phase 1.
+
+static bool try_alloc_and_patch(PTO2TaskSlotState& slot_state) {
+    PTO2TaskDescriptor& task = *slot_state.task;
+    PTO2TaskPayload* payload = slot_state.payload;
+    auto& sched = rt->scheduler;
+
+    // === Phase 1: Allocate physical memory for OUTPUT tensors ===
+    if (task.total_output_size > 0 && task.packed_buffer_base == nullptr) {
+        // All orchestrators share the same heap ring pointers for each ring_id.
+        auto& heap = rt->orchestrators[0].rings[slot_state.ring_id].heap_ring;
+        void* buf = heap.pto2_heap_ring_try_alloc(static_cast<uint64_t>(task.total_output_size));
+        if (!buf) return false;  // Heap full — caller re-enqueues task
+
+        task.packed_buffer_base = buf;
+        task.packed_buffer_end = (char*)buf + task.total_output_size;
+
+        // Patch OUTPUT tensors and write virtual→physical mapping
+        uint16_t alloc_mask = payload->output_alloc_mask;
+        int32_t offset = 0;
+        for (int i = 0; i < payload->tensor_count; i++) {
+            if (alloc_mask & (1u << i)) {
+                uint64_t vaddr = payload->tensors[i].buffer.addr;
+                uint64_t paddr = reinterpret_cast<uint64_t>((char*)buf + offset);
+                payload->tensors[i].buffer.addr = paddr;
+
+                // Write mapping table entry
+                int32_t idx = static_cast<int32_t>(vaddr & PTO2_VIRTUAL_ADDR_SEQ_MASK)
+                            & sched.vaddr_map_mask;
+                sched.vaddr_to_paddr[idx] = paddr;
+
+                offset += PTO2_ALIGN_UP(payload->tensors[i].buffer.size,
+                                         PTO2_PACKED_OUTPUT_ALIGN);
+            }
+        }
+    }
+
+    // === Phase 2: Translate INPUT/INOUT virtual addresses via mapping table ===
+    for (int i = 0; i < payload->tensor_count; i++) {
+        uint64_t addr = payload->tensors[i].buffer.addr;
+        if (pto2_is_virtual_addr(addr)) {
+            int32_t idx = static_cast<int32_t>(addr & PTO2_VIRTUAL_ADDR_SEQ_MASK)
+                        & sched.vaddr_map_mask;
+            uint64_t paddr = sched.vaddr_to_paddr[idx];
+            always_assert(paddr != 0 && "Virtual address has no physical mapping in vaddr_to_paddr table");
+            payload->tensors[i].buffer.addr = paddr;
+        }
+    }
+
+    return true;
+}
+
 /**
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
@@ -1184,6 +1253,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #endif
 
         bool try_pushed = false;
+        bool heap_full = false;
         const PTO2ResourceShape* dispatch_order = get_dispatch_order(thread_idx);
         for (int32_t si = 0; si < PTO2_NUM_RESOURCE_SHAPES; si++) {
             PTO2ResourceShape shape = dispatch_order[si];
@@ -1213,6 +1283,19 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
                 for (int bi = 0; bi < got; bi++) {
                     PTO2TaskSlotState* slot_state = batch[bi];
+
+                    // Deferred heap allocation + virtual address resolution.
+                    // Must succeed before dispatching any subtask to AICore.
+                    if (!try_alloc_and_patch(*slot_state)) {
+                        // Heap full — re-enqueue this and remaining tasks,
+                        // then break to process completions (which free heap).
+                        for (int ri = bi; ri < got; ri++) {
+                            rt->scheduler.ready_queues[static_cast<int32_t>(shape)].push(batch[ri]);
+                        }
+                        heap_full = true;
+                        break;
+                    }
+
                     try_pushed = true;
 #if PTO2_PROFILING
                     phase_dispatch_count++;
@@ -1259,12 +1342,14 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         (long long)slot_state->task->mixed_task_id.raw,
                         current_valid_cluster_offset);
                 }
+                if (heap_full) break;
 
                 // lazy update valid_cluster_states
                 if (!valid_cluster_states.has_value()) {
                     valid_cluster_states = tracker.get_valid_cluster_offset_states(shape);
                 }
             }
+            if (heap_full) break;
         }
 
         // requeue in global ready queue
@@ -1821,7 +1906,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             // Print orchestrator profiling data
 #if PTO2_ORCH_PROFILING
             PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
-            uint64_t total = p.sync_cycle + p.alloc_cycle + p.params_cycle + p.lookup_cycle + p.heap_cycle +
+            uint64_t total = p.sync_cycle + p.alloc_cycle + p.params_cycle + p.lookup_cycle +
                              p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
             DEV_ALWAYS("Thread %d: === Orchestrator Profiling: %lld tasks, total=%.3fus ===",
@@ -1835,13 +1920,6 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle),
                 cycles_to_us(p.alloc_wait_cycle),
                 (unsigned long long)p.alloc_atomic_count);
-            DEV_ALWAYS("Thread %d:   heap_alloc     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-                thread_idx,
-                cycles_to_us(p.heap_cycle),
-                p.heap_cycle * 100.0 / total,
-                cycles_to_us(p.heap_cycle - p.heap_wait_cycle),
-                cycles_to_us(p.heap_wait_cycle),
-                (unsigned long long)p.heap_atomic_count);
             DEV_ALWAYS("Thread %d:   sync_tensormap : %.3fus (%.1f%%)",
                 thread_idx,
                 cycles_to_us(p.sync_cycle),
@@ -1894,7 +1972,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 orch_summary.alloc_cycle = p.alloc_cycle;
                 orch_summary.params_cycle = p.params_cycle;
                 orch_summary.lookup_cycle = p.lookup_cycle;
-                orch_summary.heap_cycle = p.heap_cycle;
+                orch_summary.heap_cycle = 0;  // Heap allocation moved to Scheduler
                 orch_summary.insert_cycle = p.insert_cycle;
                 orch_summary.fanin_cycle = p.fanin_cycle;
                 orch_summary.scope_end_cycle = p.scope_end_cycle;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -49,18 +49,15 @@ static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // task ring alloc
 static uint64_t g_orch_params_cycle = 0;     // param copy
 static uint64_t g_orch_lookup_cycle = 0;     // tensormap lookup + dep building
-static uint64_t g_orch_heap_cycle = 0;       // heap alloc + output assign
 static uint64_t g_orch_insert_cycle = 0;     // tensormap insert
 static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
 static uint64_t g_orch_scope_end_cycle = 0;  // scope_end overhead
 static int64_t  g_orch_submit_count = 0;
 static uint32_t g_orch_submit_idx = 0;
 uint64_t g_orch_alloc_wait_cycle = 0;
-uint64_t g_orch_heap_wait_cycle = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
 uint64_t g_orch_alloc_atomic_count = 0;
 uint64_t g_orch_params_atomic_count = 0;
-uint64_t g_orch_heap_atomic_count = 0;
 uint64_t g_orch_fanin_atomic_count = 0;
 uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
@@ -389,30 +386,19 @@ void pto2_submit_mixed_task(
 
     CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, local_id);
 
-    // === STEP 2: Calculate output size + heap alloc (read from params only, no GM access) ===
-    bool needs_alloc[PTO2_MAX_TENSOR_PARAMS] = {};
+    // === STEP 2: Calculate output size + assign virtual addresses ===
+    // Physical heap allocation is deferred to Scheduler dispatch time.
+    // Here we only compute total_output_size and output_alloc_mask metadata,
+    // and assign virtual addresses to OUTPUT tensors for TensorMap hashing.
     int32_t total_output_size = 0;
+    uint16_t output_alloc_mask = 0;
     for (int i = 0; i < params.tensor_count; i++) {
         if (params.tensor_types[i] == PTOParamType::OUTPUT
             && params.tensors[i]->buffer.addr == 0) {
-            needs_alloc[i] = true;
+            output_alloc_mask |= (1u << i);
             total_output_size += PTO2_ALIGN_UP(params.tensors[i]->buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
         }
     }
-
-    void* local_packed_base = nullptr;
-    void* local_packed_end = nullptr;
-    if (total_output_size > 0) {
-        local_packed_base = orch->pto2_alloc_packed_buffer(total_output_size);
-        if (!local_packed_base) { orch->fatal = true; return; }
-        local_packed_end = (char*)local_packed_base + total_output_size;
-    }
-    CYCLE_COUNT_LAP_RECORD(g_orch_heap_cycle, AicpuPhaseId::ORCH_HEAP, local_id);
-#if PTO2_ORCH_PROFILING
-    if (total_output_size > 0) {
-        g_orch_heap_atomic_count += 1;  // heap_top.store in pto2_alloc_packed_buffer
-    }
-#endif
 
     // === STEP 3: Sync TensorMap validity and optional cleanup ===
     // Read current last_task_alive from shared memory for this ring
@@ -426,8 +412,7 @@ void pto2_submit_mixed_task(
 
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, local_id);
 
-    // === STEP 4: Lookup inputs + assign output addrs (all from params, no GM) ===
-    int32_t offset = 0;
+    // === STEP 4: Lookup inputs + assign virtual output addrs ===
     for (int i = 0; i < params.tensor_count; i++) {
         PTOParamType ptype = params.tensor_types[i];
 
@@ -477,9 +462,9 @@ void pto2_submit_mixed_task(
             case PTOParamType::OUTPUT: {
                 Tensor& tensor = *params.tensors[i];
                 if (tensor.buffer.addr == 0) {
-                    uint64_t alloc_addr = reinterpret_cast<uint64_t>((char*)local_packed_base + offset);
-                    tensor.buffer.addr = alloc_addr;
-                    offset += PTO2_ALIGN_UP(tensor.buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
+                    // Assign virtual address for TensorMap hashing.
+                    // Physical allocation deferred to Scheduler dispatch.
+                    tensor.buffer.addr = PTO2_VIRTUAL_ADDR_FLAG | orch->next_vaddr_seq++;
                 }
                 break;
             }
@@ -493,7 +478,8 @@ void pto2_submit_mixed_task(
         PTOParamType ptype = params.tensor_types[i];
         if (ptype == PTOParamType::OUTPUT || ptype == PTOParamType::INOUT) {
             if (!params.tensors[i]->manual_dep) {
-                orch->tensor_map.insert(*params.tensors[i], mixed_task_id, needs_alloc[i]);
+                orch->tensor_map.insert(*params.tensors[i], mixed_task_id,
+                                        (output_alloc_mask & (1u << i)) != 0);
             }
         }
     }
@@ -508,8 +494,9 @@ void pto2_submit_mixed_task(
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)]  = normalized.aic_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;
-    task.packed_buffer_base = local_packed_base;
-    task.packed_buffer_end = local_packed_end;
+    task.packed_buffer_base = nullptr;  // Set by Scheduler at dispatch
+    task.packed_buffer_end = nullptr;   // Set by Scheduler at dispatch
+    task.total_output_size = total_output_size;
 
     // Prefetch producer slot_states and cur_slot_state (written at init but likely
     // evicted by lookup/insert/heap). param_copy below provides hide time.
@@ -522,6 +509,7 @@ void pto2_submit_mixed_task(
     }
 
     payload->init(params);
+    payload->output_alloc_mask = output_alloc_mask;
 
     CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS, local_id);
 #if PTO2_ORCH_PROFILING
@@ -669,33 +657,28 @@ PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     d.alloc_cycle = g_orch_alloc_cycle;
     d.params_cycle = g_orch_params_cycle;
     d.lookup_cycle = g_orch_lookup_cycle;
-    d.heap_cycle = g_orch_heap_cycle;
     d.insert_cycle = g_orch_insert_cycle;
     d.fanin_cycle = g_orch_fanin_cycle;
     d.scope_end_cycle = g_orch_scope_end_cycle;
     d.submit_count = g_orch_submit_count;
     d.alloc_wait_cycle = g_orch_alloc_wait_cycle;
-    d.heap_wait_cycle = g_orch_heap_wait_cycle;
     d.fanin_wait_cycle = g_orch_fanin_wait_cycle;
     d.alloc_atomic_count = g_orch_alloc_atomic_count;
     d.params_atomic_count = g_orch_params_atomic_count;
-    d.heap_atomic_count = g_orch_heap_atomic_count;
     d.fanin_atomic_count = g_orch_fanin_atomic_count;
     d.finalize_atomic_count = g_orch_finalize_atomic_count;
     d.scope_end_atomic_count = g_orch_scope_end_atomic_count;
 
     // Reset
     g_orch_sync_cycle = g_orch_alloc_cycle = g_orch_params_cycle = 0;
-    g_orch_lookup_cycle = g_orch_heap_cycle = g_orch_insert_cycle = 0;
+    g_orch_lookup_cycle = g_orch_insert_cycle = 0;
     g_orch_fanin_cycle = g_orch_scope_end_cycle = 0;
     g_orch_submit_count = 0;
     g_orch_submit_idx = 0;
     g_orch_alloc_wait_cycle = 0;
-    g_orch_heap_wait_cycle = 0;
     g_orch_fanin_wait_cycle = 0;
     g_orch_alloc_atomic_count = 0;
     g_orch_params_atomic_count = 0;
-    g_orch_heap_atomic_count = 0;
     g_orch_fanin_atomic_count = 0;
     g_orch_finalize_atomic_count = 0;
     g_orch_scope_end_atomic_count = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -69,6 +69,12 @@ struct PTO2OrchestratorState {
     void* gm_heap_base;    // Base address of GM heap
     uint64_t gm_heap_size;   // Total size of GM heap (all rings)
 
+    // === VIRTUAL ADDRESS SEQUENCE ===
+    // Monotonically increasing counter for assigning virtual addresses to
+    // OUTPUT tensors. Used as TensorMap hash key; physical allocation is
+    // deferred to Scheduler dispatch time.
+    uint64_t next_vaddr_seq{1};
+
     // === FATAL ERROR ===
     // Fatal error flag (single-thread access by orchestrator, no atomic needed)
     // Cross-thread notification uses shared memory orch_error_code (atomic)
@@ -89,25 +95,6 @@ struct PTO2OrchestratorState {
         int32_t depth = scope_stack_top;
         if (depth < 0) depth = 0;
         return depth < PTO2_MAX_RING_DEPTH ? static_cast<uint8_t>(depth) : PTO2_MAX_RING_DEPTH - 1;
-    }
-
-    /**
-     * Allocate packed output buffer from current ring's heap
-     */
-    void* pto2_alloc_packed_buffer(int32_t total_size) {
-        if (total_size <= 0) {
-            return NULL;
-        }
-
-        uint8_t rid = current_ring_id();
-        void* buffer = rings[rid].heap_ring.pto2_heap_ring_alloc(total_size);
-
-#if PTO2_PROFILING
-        buffers_allocated++;
-        bytes_allocated += total_size;
-#endif
-
-        return buffer;
     }
 };
 
@@ -219,19 +206,16 @@ struct PTO2OrchProfilingData {
     uint64_t alloc_cycle;
     uint64_t params_cycle;
     uint64_t lookup_cycle;
-    uint64_t heap_cycle;
     uint64_t insert_cycle;
     uint64_t fanin_cycle;
     uint64_t scope_end_cycle;
     int64_t  submit_count;
     // Wait time tracking for blocking phases
     uint64_t alloc_wait_cycle;      // Cycles spent waiting in task_ring_alloc
-    uint64_t heap_wait_cycle;       // Cycles spent waiting in heap_ring_alloc
     uint64_t fanin_wait_cycle;      // Cycles spent waiting in fanout_lock
     // Atomic operation counts per phase
     uint64_t alloc_atomic_count;
     uint64_t params_atomic_count;
-    uint64_t heap_atomic_count;
     uint64_t fanin_atomic_count;
     uint64_t finalize_atomic_count;
     uint64_t scope_end_atomic_count;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -91,10 +91,6 @@ struct PTO2HeapRing {
 #if PTO2_SPIN_VERBOSE_LOGGING
         bool notified = false;
 #endif
-#if PTO2_ORCH_PROFILING
-        uint64_t wait_start = 0;
-        bool waiting = false;
-#endif
 
         while (1) {
             void* ptr = pto2_heap_ring_try_alloc(size);
@@ -104,24 +100,11 @@ struct PTO2HeapRing {
                     LOG_INFO("[HeapRing] Unblocked after %d spins", spin_count);
                 }
 #endif
-#if PTO2_ORCH_PROFILING
-                if (waiting) {
-                    extern uint64_t g_orch_heap_wait_cycle;
-                    g_orch_heap_wait_cycle += (get_sys_cnt_aicpu() - wait_start);
-                }
-                {
-                    extern uint64_t g_orch_heap_atomic_count;
-                    g_orch_heap_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
-                }
-#endif
                 return ptr;
             }
 
             // No space available, spin-wait
             spin_count++;
-#if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
-#endif
 
             // Progress detection: reset spin counter if heap_tail advances
             uint64_t cur_tail = tail_ptr->load(std::memory_order_acquire);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -107,6 +107,23 @@
 #define PTO2_DEP_POOL_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
 
 // =============================================================================
+// Virtual Address for Deferred Heap Allocation
+// =============================================================================
+// OUTPUT tensors from make_tensor() get a virtual address (buffer identity)
+// at submit time for TensorMap dependency discovery. Physical allocation
+// is deferred to Scheduler dispatch time.
+//
+// Encoding: top 16 bits = 0xFFFF (flag), low 48 bits = monotonic sequence.
+// Real GM addresses on Ascend never have 0xFFFF in top 16 bits.
+
+static constexpr uint64_t PTO2_VIRTUAL_ADDR_FLAG = 0xFFFF'0000'0000'0000ULL;
+static constexpr uint64_t PTO2_VIRTUAL_ADDR_SEQ_MASK = ~PTO2_VIRTUAL_ADDR_FLAG;
+
+static inline bool pto2_is_virtual_addr(uint64_t addr) {
+    return (addr & PTO2_VIRTUAL_ADDR_FLAG) == PTO2_VIRTUAL_ADDR_FLAG;
+}
+
+// =============================================================================
 // Multi-Ring task_id Encoding
 // =============================================================================
 
@@ -334,7 +351,13 @@ struct PTO2TaskDescriptor {
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];
 
+    // Total output size in bytes needing heap allocation (0 = no alloc needed).
+    // Set by Orchestrator, read by Scheduler at dispatch.
+    // Fits in the 4B natural padding after kernel_id[3] — sizeof unchanged.
+    int32_t total_output_size;
+
     // Packed output buffer (all outputs packed into single contiguous buffer)
+    // Set by Scheduler at dispatch, read during heap reclamation.
     void*    packed_buffer_base;  // Start of packed buffer in GM Heap
     void*    packed_buffer_end;   // End of packed buffer (for heap reclamation)
 };
@@ -359,7 +382,8 @@ struct PTO2TaskPayload {
     int32_t tensor_count{0};
     int32_t scalar_count{0};
     int32_t fanin_actual_count{0};             // Actual fanin count (without the +1 redundance)
-    int32_t _reserved{0};                      // Reserved (dep_pool_mark moved to SlotState for local access)
+    uint16_t output_alloc_mask{0};             // Bit i set = tensors[i] is OUTPUT needing heap alloc
+    uint16_t _reserved2{0};                    // Reserved for alignment
     PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS]; // Producer slot states (used by on_task_release)
     // === Tensors (2048B) — alignas(64) Tensor forces alignment ===
     Tensor tensors[PTO2_MAX_TENSOR_PARAMS];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -179,6 +179,38 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
         }
     }
 
+    // Initialize virtual address → physical address mapping table.
+    // Size = next_power_of_2(sum_of_all_ring_windows × PTO2_MAX_OUTPUTS).
+    // task_ring back-pressure guarantees at most window_size live tasks per ring,
+    // each with at most PTO2_MAX_OUTPUTS outputs, so the table cannot overflow.
+    {
+        int64_t total_window = 0;
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            total_window += sm_handle->header->rings[r].task_window_size;
+        }
+        int64_t required = total_window * PTO2_MAX_OUTPUTS;
+        sched->vaddr_map_size = 1;
+        while (sched->vaddr_map_size < required) {
+            sched->vaddr_map_size <<= 1;
+        }
+        sched->vaddr_map_mask = sched->vaddr_map_size - 1;
+        sched->vaddr_to_paddr = new (std::nothrow) uint64_t[sched->vaddr_map_size]();
+        if (!sched->vaddr_to_paddr) {
+            for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+                pto2_ready_queue_destroy(&sched->ready_queues[i]);
+            }
+            for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                sched->ring_sched_states[r].destroy();
+            }
+            return false;
+        }
+        LOG_INFO("vaddr mapping table: size=%d entries (%zu KB), "
+                 "total_window=%" PRId64 ", max_outputs=%d",
+                 sched->vaddr_map_size,
+                 (size_t)sched->vaddr_map_size * sizeof(uint64_t) / 1024,
+                 total_window, PTO2_MAX_OUTPUTS);
+    }
+
     return true;
 }
 
@@ -190,6 +222,9 @@ void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         pto2_ready_queue_destroy(&sched->ready_queues[i]);
     }
+
+    delete[] sched->vaddr_to_paddr;
+    sched->vaddr_to_paddr = nullptr;
 }
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -465,6 +465,35 @@ struct PTO2SchedulerState {
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
+    // =========================================================================
+    // Virtual Address → Physical Address Mapping Table
+    // =========================================================================
+    // Resolves virtual address "residue" in consumer payloads at dispatch time.
+    // payload->init() copies tensors by value, so consumer payloads retain the
+    // virtual address assigned at submit time even after the producer payload
+    // is patched to a physical address.
+    //
+    // Table sizing:
+    //   max_live_vaddrs = sum_of_all_ring_window_sizes × PTO2_MAX_OUTPUTS
+    //   Default: (16384 × 4) × 16 = 1,048,576
+    //   Rounded up to next power of 2 for fast index masking (& instead of %).
+    //
+    // Safety: task_ring back-pressure caps live tasks at window_size per ring,
+    //   each with at most PTO2_MAX_OUTPUTS outputs, so the table cannot overflow.
+    //   Producer slots are held alive by fanout_refcount until all consumers
+    //   complete, so entries are never overwritten before being consumed.
+    //   A runtime INTERNAL_CHECK guards against mapping misses.
+    //
+    // Lifecycle: implicit ring-buffer — entries are overwritten when the
+    //   sequence wraps. No explicit free needed.
+    //
+    // Thread safety: producer dispatch writes → fanin_refcount.fetch_add(acq_rel)
+    //   → ready queue push/pop (acquire) → consumer dispatch reads.
+    //   The happens-before chain guarantees visibility across threads.
+    uint64_t* vaddr_to_paddr{nullptr};  // Dynamically allocated at init, freed at destroy
+    int32_t   vaddr_map_size{0};        // Table capacity (power of 2)
+    int32_t   vaddr_map_mask{0};        // = vaddr_map_size - 1 (for fast index)
+
     // Statistics
 #if PTO2_SCHED_PROFILING
     std::atomic<int64_t> tasks_completed;


### PR DESCRIPTION
## Summary
- Move physical heap allocation from submit time (Orchestrator thread) to dispatch time (Scheduler threads)
- Orchestrator assigns virtual addresses to OUTPUT tensors; Scheduler resolves them to physical addresses at dispatch via `try_alloc_and_patch()`
- Introduces a `vaddr_to_paddr` mapping table for O(1) consumer address resolution
- Replaces blocking heap spin-wait with non-blocking back-pressure (re-enqueue on heap exhaustion)

## Key Changes
- `pto_runtime2_types.h`: Add virtual address constants (`PTO2_VIRTUAL_ADDR_FLAG`), `total_output_size` field in TaskDescriptor (using natural padding), `output_alloc_mask` in TaskPayload (reusing reserved bytes)
- `pto_orchestrator.h/cpp`: Replace heap allocation with virtual address assignment; add `next_vaddr_seq` counter; remove `g_orch_heap_*` profiling counters
- `pto_scheduler.h/cpp`: Add `vaddr_to_paddr` mapping table (power-of-2 sized, dynamically allocated at init)
- `pto_ring_buffer.h`: Remove orphaned profiling code from unused blocking `pto2_heap_ring_alloc()`
- `aicpu_executor.cpp`: Add `try_alloc_and_patch()` — Phase 1 allocates heap + patches OUTPUTs + writes mapping; Phase 2 translates INPUT virtual addresses via table lookup. Integrated into dispatch loop with `heap_full` back-pressure break-out

## Performance
Benchmarked on Ascend hardware (device 6, 100 rounds trimmed mean):

| Example | Base (us) | HEAD (us) | Elapsed Δ | Orch Δ |
|---|---|---|---|---|
| alternating_matmul_add | 953.2 | 914.4 | -4.1% | -4.1% |
| benchmark_bgemm | 692.1 | 673.0 | -2.8% | -3.0% |
| paged_attention_unroll (Case1) | 1336.9 | 1317.2 | -1.5% | **-14.6%** |
| paged_attention_unroll (Case2) | 655.5 | 631.8 | -3.6% | **-16.7%** |
| batch_paged_attention | 3689.4 | 3470.6 | **-5.9%** | **-7.5%** |