### PR TITLE
Feat: scalar data dependency via GetTensorData/SetTensorData and add_inout with initial value

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -1,0 +1,127 @@
+# Scalar Data Access — get/set_tensor_data Design
+
+## 1. Overview
+
+During task graph construction, orchestration sometimes needs to read InCore kernel results (for control-flow decisions) or write initial values into tensors. `get_tensor_data` / `set_tensor_data` provide **blocking** cross-layer data access, allowing orchestration to safely read and write tensor data.
+
+**Core design principle**: Reuse the existing TensorMap dependency tracking mechanism — no new synchronization infrastructure.
+
+## 2. API
+
+```cpp
+// Blocking read: returns raw uint64_t bit pattern at the given indices
+uint64_t get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
+
+// Blocking write: stores value at the given indices
+void set_tensor_data(Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value);
+```
+
+Both call into the runtime through the ops table — orchestration .so needs no runtime symbol linkage.
+
+## 3. Blocking Interface Design
+
+### 3.1 get_tensor_data Flow
+
+```
+addr null-check → TensorMap lookup → spin-wait producer COMPLETED → compute flat offset → memcpy read
+```
+
+- **addr null-check**: `buffer.addr == 0` means unallocated — log error, return 0
+- **TensorMap lookup**: find producer task by `buffer.addr`
+- **spin-wait**: wait until producer `task_state >= PTO2_TASK_COMPLETED`
+- **No producer** (`lookup_result.count == 0`): skip waiting, read immediately
+
+### 3.2 set_tensor_data Flow
+
+```
+addr null-check → TensorMap lookup → spin-wait producer COMPLETED → spin-wait consumers done → memcpy write
+```
+
+One extra step versus get_tensor_data: wait for all consumers to finish (`fanout_refcount >= fanout_count - 1`, excluding the scope reference).
+
+### 3.3 Timeout
+
+- Uses cycle counter (`get_sys_cnt_aicpu()`), checked every 1024 spins
+- Threshold: `PTO2_TENSOR_DATA_TIMEOUT_CYCLES` (~10 s at 1.5 GHz)
+- On timeout: sets `orch.fatal = true`, preventing further task submission
+
+## 4. add_output with Initial Value
+
+```cpp
+params.add_output(tensor, initial_value);  // tensor must have addr == 0
+```
+
+**Mechanism**:
+1. `add_output` sets `has_initial_value = true` and `initial_value` on the Tensor struct
+2. During orchestrator submit, after HeapRing allocation, the flag is checked
+3. Fill strategy:
+   - Small buffer (< 64 B): element-by-element memcpy directly into dst
+   - Large buffer (≥ 64 B): fill the first 64 bytes as a template block, then bulk-memcpy in 64 B chunks; partial tail copy for remainder
+4. Flag cleared after consumption (`has_initial_value = false`)
+
+**Constraint**: `addr != 0` triggers an error — use `add_inout()` for already-allocated tensors.
+
+## 5. Scalar Dependencies via 1-Element Tensors
+
+Traditional scalars (`PTOParam::add_scalar`) are one-way inputs with no TensorMap tracking. For cross-task scalar values, use a 1-element tensor as the carrier:
+
+```cpp
+uint32_t shapes[1] = {1};
+Tensor scalar_tensor = make_tensor(shapes, 1, DataType::FLOAT32);
+
+// Submit with initial value
+PTOParam params;
+params.add_output(scalar_tensor, float_to_u64(77.0f));
+pto2_rt_submit_aiv_task(FUNC_NOOP, params);
+
+// Orchestration-side blocking read (waits for kernel completion)
+uint32_t idx[1] = {0};
+uint64_t raw = get_tensor_data(scalar_tensor, 1, idx);
+```
+
+**Advantage**: Fully reuses existing TensorMap (producer tracking, fanin/fanout dependencies) — no new infrastructure needed.
+
+## 6. Data Hazard Analysis
+
+Three actors:
+- **Kernel**: InCore task submitted via add_input/add_output/add_inout (asynchronous execution)
+- **Orch Read**: orchestration calls `get_tensor_data` (blocking read)
+- **Orch Write**: orchestration calls `set_tensor_data` (blocking write)
+
+### Hazard Matrix (earlier operation → later operation)
+
+| # | Earlier Op | Later Op | Hazard | Guarantee | Safe? |
+|---|------------|----------|--------|-----------|-------|
+| 1 | Kernel write (OUTPUT) | Orch Read | RAW | spin-wait producer COMPLETED | Yes |
+| 2 | Kernel write (OUTPUT) | Orch Write | WAW | spin-wait producer COMPLETED | Yes |
+| 3 | Kernel read (INPUT) | Orch Write | WAR | spin-wait fanout_refcount | **Needs INOUT** |
+| 4 | Kernel read-write (INOUT) | Orch Read | RAW | spin-wait producer COMPLETED | Yes |
+| 5 | Kernel read-write (INOUT) | Orch Write | WAW+WAR | spin-wait producer + consumers | Yes |
+| 6 | Orch Write | Kernel read (INPUT) | RAW | blocking completes before next submit | Yes |
+| 7 | Orch Write | Kernel write (OUTPUT) | WAW | same — serial guarantee | Yes |
+| 8 | Orch Read | Kernel write (OUTPUT) | WAR | same — serial guarantee | Yes |
+| 9–12 | Orch ↔ Orch | — | — | same-thread serial execution | Yes |
+
+### Key Design Points
+
+**Scenario #3 is the only case requiring special attention**:
+
+TensorMap tracks only producers (OUTPUT/INOUT), not pure INPUT consumers. If a tensor is only registered via `add_input()`, TensorMap has no producer entry for it. `set_tensor_data`'s `wait_for_tensor_ready()` sees `lookup_result.count == 0` and returns immediately — but the kernel may still be reading → **WAR data race**.
+
+**Solution**: For tensors that may later be written via `set_tensor_data`, use `add_inout()` instead of `add_input()`. INOUT registers a producer entry in TensorMap, enabling `set_tensor_data` to track all consumers through `fanout_refcount`.
+
+**Scenarios #6–8 serial guarantee**:
+
+get/set_tensor_data are blocking calls, and orchestration is single-threaded serial submission. After a blocking operation completes, subsequent code (including task submissions) executes strictly afterward.
+
+## 7. External Tensor Behavior
+
+`make_tensor_external()` creates tensors with a pre-set `buffer.addr` (pointing to host-allocated device memory).
+
+| Scenario | Behavior |
+|----------|----------|
+| External tensor never submitted as OUTPUT/INOUT | No TensorMap entry — get/set execute immediately |
+| External tensor previously submitted as OUTPUT/INOUT | TensorMap has producer entry — get/set spin-wait |
+| External tensor submitted as INPUT, then set_tensor_data | **WAR risk** — must use INOUT instead (same as scenario #3) |
+
+**Key rule**: If an external tensor will later be written via `set_tensor_data`, all prior kernel accesses must use `add_inout()`, not `add_input()`.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -125,6 +125,14 @@ typedef struct PTO2RuntimeOps {
     void (*log_info)(const char* func, const char* fmt, ...);
     void (*log_debug)(const char* func, const char* fmt, ...);
     void (*log_always)(const char* func, const char* fmt, ...);
+
+    // Cross-layer data access (orchestration reads/writes tensor values via runtime)
+    // Placed after logging to avoid shifting hot-path field offsets.
+    uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
+                                uint32_t ndims, const uint32_t indices[]);
+    void (*set_tensor_data)(PTO2Runtime* rt, Tensor& tensor,
+                            uint32_t ndims, const uint32_t indices[],
+                            uint64_t value);
 } PTO2RuntimeOps;
 
 /**
@@ -201,6 +209,54 @@ static inline bool pto2_rt_is_fatal() {
 #define LOG_INFO(fmt, ...)  pto2_current_runtime()->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
 #define LOG_DEBUG(fmt, ...) pto2_current_runtime()->ops->log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
 #define LOG_ALWAYS(fmt, ...) pto2_current_runtime()->ops->log_always(__FUNCTION__, fmt, ##__VA_ARGS__)
+
+// =============================================================================
+// Cross-Layer Data Access
+// =============================================================================
+
+/**
+ * Read a value from a tensor at the given multi-dimensional indices.
+ *
+ * If the tensor has a producer in TensorMap, spin-waits until the producer
+ * task completes before reading. External tensors (make_tensor_external)
+ * are read immediately without waiting.
+ *
+ * Returns the raw bits as uint64_t; caller reinterprets via bit_cast.
+ */
+static inline uint64_t get_tensor_data(const Tensor& tensor,
+                                       uint32_t ndims, const uint32_t indices[]) {
+    PTO2Runtime* rt = pto2_current_runtime();
+    return rt->ops->get_tensor_data(rt, tensor, ndims, indices);
+}
+
+/**
+ * Write a value to a tensor at the given multi-dimensional indices.
+ *
+ * If the tensor has a producer in TensorMap, spin-waits until the producer
+ * and all its consumers complete before writing (WAW + WAR safety).
+ * External tensors (make_tensor_external) with no TensorMap entry are
+ * written immediately without waiting.
+ *
+ * Limitation: TensorMap only tracks producers (OUTPUT/INOUT), not consumers
+ * that used the tensor as INPUT. If a kernel reads this tensor as INPUT
+ * (not INOUT) and the tensor has no TensorMap producer entry, set_tensor_data
+ * cannot detect the reader and may cause a data race.
+ *
+ * To ensure WAR safety for all access patterns, use add_inout() instead of
+ * add_input() for kernel parameters that may later be written via
+ * set_tensor_data. INOUT creates a TensorMap entry that enables automatic
+ * consumer tracking via fanout_refcount.
+ *
+ * The tensor must already have an allocated buffer (addr != 0).
+ * For make_tensor() outputs, call this only after the tensor has been
+ * submitted as OUTPUT at least once (so HeapRing allocation has occurred).
+ */
+static inline void set_tensor_data(Tensor& tensor,
+                                   uint32_t ndims, const uint32_t indices[],
+                                   uint64_t value) {
+    PTO2Runtime* rt = pto2_current_runtime();
+    rt->ops->set_tensor_data(rt, tensor, ndims, indices, value);
+}
 
 // =============================================================================
 // C++ Scope Guards and Macros

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -462,6 +462,23 @@ void pto2_submit_mixed_task(
                     uint64_t alloc_addr = reinterpret_cast<uint64_t>((char*)alloc_result.packed_base + offset);
                     tensor.buffer.addr = alloc_addr;
                     offset += PTO2_ALIGN_UP(tensor.buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
+                    // Cache line 1 is hot (just wrote buffer.addr at offset 0).
+                    // has_initial_value sits on the same cache line (offset 39) — zero-cost check.
+                    if (tensor.has_initial_value) {
+                        uint64_t elem_size = get_element_size(tensor.dtype);
+                        tensor.has_initial_value = false;
+                        uint64_t total = tensor.buffer.size;
+                        char* dst = reinterpret_cast<char*>(alloc_addr);
+                        constexpr uint64_t BLK = 64;
+                        uint64_t blk = (total < BLK) ? total : BLK;
+                        for (uint64_t b = 0; b < blk; b += elem_size)
+                            memcpy(dst + b, &tensor.initial_value, elem_size);
+                        uint64_t off = blk;
+                        for (; off + blk <= total; off += blk)
+                            memcpy(dst + off, dst, blk);
+                        if (off < total)
+                            memcpy(dst + off, dst, total - off);
+                    }
                 }
                 break;
             }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -11,6 +11,12 @@
 #include <string.h>
 #include <stdio.h>
 #include "common/unified_log.h"
+#include "aicpu/device_time.h"
+
+// Weak fallback for HOST .so builds (never called, but satisfies linker).
+// The AICPU build links the strong symbol from platform/.../device_time.cpp.
+// Hidden visibility prevents HOST .so from polluting global symbol table.
+__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
 
 // =============================================================================
 // Thread-local orchestrator index for multi-orchestrator dispatch
@@ -48,6 +54,108 @@ static bool is_fatal_impl(PTO2Runtime* rt) {
     return rt->orchestrators[pto2_current_orch_idx].fatal;
 }
 
+// Wait for TensorMap producers of this tensor to be safe for data access.
+// For reads: wait until producer COMPLETED (done writing).
+// For writes: also wait until all consumers done reading
+//   (fanout_refcount >= fanout_count - 1, excluding scope reference).
+// Uses cycle-based timeout (checked every 1024 spins).
+// Returns false on timeout (sets orch.fatal).
+static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor,
+                                  bool wait_for_consumers, const char* caller) {
+    PTO2OrchestratorState& orch = rt->orchestrators[pto2_current_orch_idx];
+    PTO2LookupResult lookup_result;
+    orch.tensor_map.lookup(tensor, lookup_result);
+
+    for (int r = 0; r < lookup_result.count; r++) {
+        PTO2TensorMapEntry& entry = *lookup_result.entries[r].entry;
+        PTO2TaskId producer_id = entry.producer_task_id;
+        uint8_t ring_id = producer_id.ring();
+        int32_t local_id = producer_id.local();
+        PTO2TaskSlotState& slot =
+            rt->scheduler.ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
+
+        // Wait for producer to complete (WAW safety)
+        uint64_t t0 = get_sys_cnt_aicpu();
+        int32_t spin_count = 0;
+        while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
+            SPIN_WAIT_HINT();
+            if ((++spin_count & 1023) == 0 &&
+                get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+                orch.fatal = true;
+                unified_log_error(caller,
+                    "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
+                    (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id);
+                return false;
+            }
+        }
+
+        // For writes: also wait for all consumers to finish reading (WAR safety).
+        // fanout_count includes 1 scope reference that won't release until scope_end,
+        // so wait until fanout_refcount >= fanout_count - 1.
+        if (wait_for_consumers) {
+            t0 = get_sys_cnt_aicpu();
+            spin_count = 0;
+            while (slot.fanout_refcount.load(std::memory_order_acquire)
+                   < slot.fanout_count - 1) {
+                SPIN_WAIT_HINT();
+                if ((++spin_count & 1023) == 0 &&
+                    get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+                    orch.fatal = true;
+                    unified_log_error(caller,
+                        "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
+                        (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id);
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
+                              uint32_t ndims, const uint32_t indices[]) {
+    if (tensor.buffer.addr == 0) {
+        unified_log_error(__FUNCTION__,
+            "get_tensor_data: buffer not allocated (addr=0). "
+            "make_tensor() tensors must be submitted as OUTPUT first.");
+        return 0;
+    }
+
+    if (!wait_for_tensor_ready(rt, tensor, false, __FUNCTION__)) {
+        return 0;
+    }
+
+    uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
+    uint64_t elem_size = get_element_size(tensor.dtype);
+    const void* ptr = reinterpret_cast<const void*>(
+        tensor.buffer.addr + flat_offset * elem_size);
+    uint64_t result = 0;
+    memcpy(&result, ptr, elem_size);
+    return result;
+}
+
+void pto2_set_tensor_data(PTO2Runtime* rt, Tensor& tensor,
+                          uint32_t ndims, const uint32_t indices[],
+                          uint64_t value) {
+    if (tensor.buffer.addr == 0) {
+        unified_log_error(__FUNCTION__,
+            "set_tensor_data: buffer not allocated (addr=0). "
+            "make_tensor() tensors must be submitted as OUTPUT first.");
+        return;
+    }
+
+    // Wait for producer + all consumers before writing (WAW + WAR safety)
+    if (!wait_for_tensor_ready(rt, tensor, true, __FUNCTION__)) {
+        return;
+    }
+
+    uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
+    uint64_t elem_size = get_element_size(tensor.dtype);
+    void* ptr = reinterpret_cast<void*>(
+        tensor.buffer.addr + flat_offset * elem_size);
+    memcpy(ptr, &value, elem_size);
+}
+
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task          = submit_task_impl,
     .scope_begin          = pto2_rt_scope_begin,
@@ -59,6 +167,8 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .log_info             = unified_log_info,
     .log_debug            = unified_log_debug,
     .log_always           = unified_log_always,
+    .get_tensor_data      = pto2_get_tensor_data,
+    .set_tensor_data      = pto2_set_tensor_data,
 };
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -72,6 +72,14 @@ struct PTO2RuntimeOps {
     void (*log_info)(const char* func, const char* fmt, ...);
     void (*log_debug)(const char* func, const char* fmt, ...);
     void (*log_always)(const char* func, const char* fmt, ...);
+
+    // Cross-layer data access (orchestration reads/writes tensor values via runtime)
+    // Placed after logging to avoid shifting hot-path field offsets.
+    uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
+                                uint32_t ndims, const uint32_t indices[]);
+    void (*set_tensor_data)(PTO2Runtime* rt, Tensor& tensor,
+                            uint32_t ndims, const uint32_t indices[],
+                            uint64_t value);
 };
 
 /**
@@ -187,6 +195,21 @@ void pto2_rt_scope_end(PTO2Runtime* rt);
  * Signals that no more tasks will be submitted.
  */
 void pto2_rt_orchestration_done(PTO2Runtime* rt);
+
+/**
+ * Cross-layer data access: read a tensor value by waiting for its producer.
+ */
+uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
+                              uint32_t ndims, const uint32_t indices[]);
+
+/**
+ * Cross-layer data access: write a value to a tensor at given indices.
+ * Waits for producer completion (WAW) and all consumers (WAR) via TensorMap.
+ * See set_tensor_data in pto_orchestration_api.h for full documentation.
+ */
+void pto2_set_tensor_data(PTO2Runtime* rt, Tensor& tensor,
+                          uint32_t ndims, const uint32_t indices[],
+                          uint64_t value);
 
 /**
  * Slim config struct exported by orchestration .so via aicpu_orchestration_config().

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -106,6 +106,10 @@
 #define PTO2_TENSORMAP_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
 #define PTO2_DEP_POOL_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
 
+// get_tensor_data/set_tensor_data spin wait timeout in cycles.
+// ~10s on hardware (1.5 GHz counter), ~10s on simulation (chrono-based).
+constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES = 15 * 1000 * 1000 * 1000ULL;
+
 // =============================================================================
 // Multi-Ring task_id Encoding
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -126,6 +126,32 @@ struct PTOParam {
         tensor_count++;
     }
 
+    /**
+     * Add an OUTPUT tensor with initial value.
+     *
+     * Registers as OUTPUT so the runtime allocates from HeapRing, then
+     * writes initial_value to the allocated buffer. The initial value is
+     * stored on the Tensor itself (has_initial_value flag on cache line 1,
+     * value on cache line 2) and consumed during HeapRing allocation in
+     * the submit path.
+     *
+     * The tensor must not have been allocated yet (addr must be 0).
+     * For already-allocated tensors, use add_inout() instead.
+     */
+    void add_output(Tensor& t, uint64_t initial_value) {
+        if (!check_add_tensor_valid()) { return; }
+        if (t.buffer.addr != 0) {
+            set_error("add_output with initial_value requires unallocated tensor (addr==0). "
+                      "Use add_inout() for already-allocated tensors");
+            return;
+        }
+        tensors[tensor_count] = &t;
+        t.has_initial_value = true;
+        t.initial_value = initial_value;
+        tensor_types[tensor_count] = PTOParamType::OUTPUT;
+        tensor_count++;
+    }
+
     void add_scalar(uint64_t v) {
         if (scalar_count >= PTO2_MAX_SCALAR_PARAMS) {
             set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS)");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -66,12 +66,14 @@ struct alignas(64) Tensor {
     bool is_all_offset_zero;                       // True when all offsets[] are zero (skip offset read/write)
     bool is_raw_eq_shapes;                         // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
     bool manual_dep;                               // True when dependency is managed manually (skip tensormap lookup/insert)
+    bool has_initial_value{false};                 // True when initial_value should be written after HeapRing allocation
     uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
     uint32_t __padding__;
 
     // === Cache line 2 (64B) — warm path ===
     uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
     uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
+    uint64_t initial_value;                        // Pending initial value (valid when has_initial_value)
 
     Tensor() = default;
     Tensor(const Tensor&) = default;
@@ -181,6 +183,22 @@ struct alignas(64) Tensor {
             }
         }
         is_all_offset_zero = all_zero;
+    }
+
+    /// Compute 1D flat element offset from multi-dimensional indices.
+    /// Uses Horner's method (forward traversal, no stride variable).
+    uint64_t compute_flat_offset(const uint32_t indices[], uint32_t in_ndims) const {
+        if (in_ndims == 0) return 0;
+        const uint32_t* rs = get_raw_shapes();
+        uint64_t offset = 0;
+        if (is_all_offset_zero) {
+            for (uint32_t d = 0; d < in_ndims; d++)
+                offset = offset * rs[d] + indices[d];
+        } else {
+            for (uint32_t d = 0; d < in_ndims; d++)
+                offset = offset * rs[d] + indices[d] + offsets[d];
+        }
+        return offset;
     }
 
     // --- Operations ---

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/golden.py
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/golden.py
@@ -1,0 +1,70 @@
+"""
+Golden script for scalar data dependency test.
+
+Tests GetTensorData, SetTensorData, and add_inout with initial value.
+
+Computation:
+  c = a + b (kernel, internal tensor)
+  check[0] = GetTensorData(c, {0})     = a[0]+b[0] = 2.0+0.0 = 2.0
+  check[1] = GetTensorData(c, {100})   = a[100]+b[100] = 2.0+100.0 = 102.0
+  scalar initialized to 77.0 via add_output(scalar, float_to_u64(77.0f))
+  check[2] = GetTensorData(scalar, {0}) = 77.0
+  second noop with add_inout(scalar), value preserved
+  check[3] = GetTensorData(scalar, {0}) = 77.0
+  check[4] = orchestration arithmetic: 2.0 + 77.0 = 79.0
+  SetTensorData(scalar, {0}, 42.0), then GetTensorData round-trip
+  check[5] = GetTensorData(scalar, {0}) = 42.0
+  Orch SetTensorData(d, {0}, 10.0) → kernel_add(d, a) → e[0] = 12.0
+  check[6] = GetTensorData(e, {0}) = 12.0
+  WAW+WAR: kernel reads c as INPUT, then SetTensorData(c, 88.0) auto-waits
+  check[7] = GetTensorData(c, {0}) = 88.0
+  External WAR: noop(ext_b as INOUT) → SetTensorData(ext_b, 55.0) auto-waits
+  check[8] = GetTensorData(ext_b, {0}) = 55.0 (ext_b[0] restored to 0.0 after)
+  result = a + b (kernel, external output)
+
+Args layout: [a, b, result, check]
+"""
+
+import torch
+
+__outputs__ = ["result", "check"]
+
+RTOL = 1e-5
+ATOL = 1e-5
+
+
+def generate_inputs(params: dict) -> list:
+    SIZE = 128 * 128  # 16384 -- matches kernel_add 128x128 tile
+
+    a = torch.full((SIZE,), 2.0, dtype=torch.float32)
+    b = torch.arange(SIZE, dtype=torch.float32)
+    result = torch.zeros(SIZE, dtype=torch.float32)
+    check = torch.zeros(10, dtype=torch.float32)
+
+    return [
+        ("a", a),
+        ("b", b),
+        ("result", result),
+        ("check", check),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    a = torch.as_tensor(tensors["a"])
+    b = torch.as_tensor(tensors["b"])
+
+    # result = a + b (computed by kernel_add)
+    tensors["result"][:] = a + b
+
+    # check values written by orchestration via SetTensorData
+    check = torch.as_tensor(tensors["check"])
+    check[0] = 2.0    # GetTensorData(c, {0}): c = a + b, c[0] = 2.0+0.0
+    check[1] = 102.0  # GetTensorData(c, {100}): c[100] = 2.0+100.0
+    check[2] = 77.0   # add_inout initial value (first use, OUTPUT path)
+    check[3] = 77.0   # add_inout second use (INOUT path, value preserved)
+    check[4] = 79.0   # orchestration arithmetic: 2.0 + 77.0
+    check[5] = 42.0   # Orch set→get round-trip: SetTensorData then GetTensorData
+    check[6] = 12.0   # Orch→AICore RAW: SetTensorData(d,10.0) + kernel_add(d,a) → 10.0+2.0
+    check[7] = 88.0   # WAW+WAR: kernel reads c, SetTensorData(c,88.0) auto-waits for consumer
+    check[8] = 55.0   # External WAR: noop(ext_b INOUT) → SetTensorData(ext_b,55.0) auto-waits
+    # check[9] remains 0.0 (sentinel)

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_add.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_add.cpp
@@ -1,0 +1,79 @@
+/**
+ * Element-wise Tensor Addition Kernel
+ *
+ * Implements: out[i] = src0[i] + src1[i]
+ *
+ * This kernel performs element-wise addition of two tensors. It's compiled
+ * separately as a standalone kernel and linked with the dispatcher using
+ * function pointers, demonstrating the separation pattern used in production
+ * systems where kernel binaries are loaded dynamically.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+/**
+ * Element-wise addition kernel implementation
+ *
+ * Unified signature: all arguments passed via int64_t array
+ * @param args  Argument array:
+ *              args[0] = src0 pointer (first input tensor)
+ *              args[1] = src1 pointer (second input tensor)
+ *              args[2] = out pointer (output tensor)
+ *              args[3] = size (number of elements)
+ */
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+    // Unpack arguments (Tensor* pointers from runtime)
+    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
+    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    // Configuration: float, 128, 128, 128, 128
+    constexpr int kTRows_ = 128;
+    constexpr int kTCols_ = 128;
+    constexpr int vRows = 128;
+    constexpr int vCols = 128;
+
+    using DynShapeDim5 = Shape<1, 1, 1, vRows, vCols>;
+    using DynStridDim5 = Stride<1, 1, 1, kTCols_, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
+
+    TileData src0Tile(vRows, vCols);
+    TileData src1Tile(vRows, vCols);
+    TileData dstTile(vRows, vCols);
+    TASSIGN(src0Tile, 0x0);
+    TASSIGN(src1Tile, 0x10000);
+    TASSIGN(dstTile, 0x20000);
+
+    GlobalData src0Global(src0);
+    GlobalData src1Global(src1);
+    GlobalData dstGlobal(out);
+
+    TLOAD(src0Tile, src0Global);
+    TLOAD(src1Tile, src1Global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(dstTile, src0Tile, src1Tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, dstTile);
+    
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+}

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_noop.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_noop.cpp
@@ -1,0 +1,25 @@
+/**
+ * No-op Kernel
+ *
+ * Empty kernel used to trigger runtime allocation for tensors passed
+ * as OUTPUT/INOUT via add_inout(). The runtime allocates HeapRing memory
+ * and writes initial values before dispatching this task; the kernel
+ * itself does not read or modify any data.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    (void)args;
+}

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/kernel_config.py
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/kernel_config.py
@@ -1,0 +1,29 @@
+"""
+Kernel configuration for scalar data dependency test (tensormap_and_ringbuffer).
+
+Tests GetTensorData, SetTensorData, and add_inout with initial value.
+
+Kernels:
+  func_id=0: kernel_add (AIV) - element-wise tensor addition (128x128)
+  func_id=1: kernel_noop (AIV) - empty kernel for allocation trigger
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "scalar_data_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {"func_id": 0, "source": str(_KERNELS_ROOT / "aiv" / "kernel_add.cpp"), "core_type": "aiv"},
+    {"func_id": 1, "source": str(_KERNELS_ROOT / "aiv" / "kernel_noop.cpp"), "core_type": "aiv"},
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 3,
+}

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
@@ -1,0 +1,301 @@
+/**
+ * Scalar Data Dependency Test Orchestration
+ *
+ * End-to-end test for get_tensor_data, set_tensor_data, and add_inout
+ * with initial value support.
+ *
+ * Flow:
+ *   1. c = a + b           (kernel_add, internal tensor)
+ *   2. get_tensor_data(c, {0})   → check[0] = 2.0
+ *   3. get_tensor_data(c, {100}) → check[1] = 102.0
+ *   4. scalar_tensor = make_tensor({1}), add_output(scalar_tensor, 77.0f), submit noop
+ *   5. get_tensor_data(scalar_tensor, {0}) → check[2] = 77.0
+ *   6. add_inout(scalar_tensor) (INOUT path), submit noop
+ *   7. get_tensor_data(scalar_tensor, {0}) → check[3] = 77.0
+ *   8. check[4] = 2.0 + 77.0 = 79.0  (orchestration arithmetic)
+ *   9. set_tensor_data(scalar_tensor, {0}, 42.0), get_tensor_data → check[5] = 42.0
+ *  10. Orch set_tensor_data(d, {0}, 10.0) → kernel_add(d, a) → check[6] = 12.0
+ *  11. WAW+WAR: kernel_add reads c → set_tensor_data(c, 88.0) auto-waits → check[7] = 88.0
+ *  12. External WAR with INOUT: noop(ext_b as INOUT) → set_tensor_data(ext_b) → check[8] = 55.0
+ *  13. result = a + b      (kernel_add, external output, ext_b[0] restored)
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_ADD  0
+#define FUNC_NOOP 1
+
+static uint64_t float_to_u64(float f) {
+    union {
+        float f32;
+        uint64_t u64;
+    } conv;
+    conv.u64 = 0;
+    conv.f32 = f;
+    return conv.u64;
+}
+
+static float u64_to_float(uint64_t u) {
+    union {
+        uint64_t u64;
+        float f32;
+    } conv;
+    conv.u64 = u;
+    return conv.f32;
+}
+
+extern "C" {
+
+__attribute__((visibility("default")))
+PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 4,  // a, b, result, check
+    };
+}
+
+__attribute__((visibility("default")))
+void aicpu_orchestration_entry(TaskArg* orch_args,
+                               int orch_thread_num,
+                               int orch_thread_index) {
+    (void)orch_thread_num;
+    (void)orch_thread_index;
+
+    // External tensors from golden.py
+    Tensor ext_a      = from_task_arg(orch_args[0]);
+    Tensor ext_b      = from_task_arg(orch_args[1]);
+    Tensor ext_result  = from_task_arg(orch_args[2]);
+    Tensor ext_check   = from_task_arg(orch_args[3]);
+
+    uint32_t SIZE = orch_args[0].tensor.shapes[0];
+    LOG_INFO("scalar_data_test: SIZE=%u, check_size=%u",
+             SIZE, orch_args[3].tensor.shapes[0]);
+
+    // =========================================================
+    // Step 1: c = a + b (internal tensor, kernel_add)
+    // =========================================================
+    uint32_t inter_shapes[1] = {SIZE};
+    Tensor c = make_tensor(inter_shapes, 1, DataType::FLOAT32);
+
+    {
+        PTOParam params;
+        params.add_input(ext_a);
+        params.add_input(ext_b);
+        params.add_output(c);
+        pto2_rt_submit_aiv_task(FUNC_ADD, params);
+    }
+
+    // =========================================================
+    // Step 2: get_tensor_data(c, {0}) → check[0]
+    //   Tests TensorMap lookup + spin-wait for kernel completion
+    // =========================================================
+    uint32_t idx[1] = {0};
+    uint64_t c0_raw = get_tensor_data(c, 1, idx);
+    float c0_val = u64_to_float(c0_raw);
+    LOG_INFO("get_tensor_data(c, {0}) = %f (expected 2.0)", (double)c0_val);
+
+    uint32_t check_idx[1] = {0};
+    set_tensor_data(ext_check, 1, check_idx, c0_raw);
+
+    // =========================================================
+    // Step 3: get_tensor_data(c, {100}) → check[1]
+    //   Tests flat offset calculation for non-zero index
+    // =========================================================
+    idx[0] = 100;
+    uint64_t c100_raw = get_tensor_data(c, 1, idx);
+    LOG_INFO("get_tensor_data(c, {100}) = %f (expected 102.0)",
+             (double)u64_to_float(c100_raw));
+
+    check_idx[0] = 1;
+    set_tensor_data(ext_check, 1, check_idx, c100_raw);
+
+    // =========================================================
+    // Step 4: add_inout with initial value (first use → OUTPUT path)
+    //   Runtime allocates HeapRing buffer, writes 77.0 to element [0]
+    // =========================================================
+    uint32_t scalar_shapes[1] = {1};
+    Tensor scalar_tensor = make_tensor(scalar_shapes, 1, DataType::FLOAT32);
+
+    {
+        PTOParam params;
+        params.add_output(scalar_tensor, float_to_u64(77.0f));
+        pto2_rt_submit_aiv_task(FUNC_NOOP, params);
+    }
+
+    // =========================================================
+    // Step 5: get_tensor_data(scalar_tensor, {0}) → check[2]
+    //   Verifies initial value was written correctly
+    // =========================================================
+    idx[0] = 0;
+    uint64_t s0_raw = get_tensor_data(scalar_tensor, 1, idx);
+    float s0_val = u64_to_float(s0_raw);
+    LOG_INFO("get_tensor_data(scalar_tensor, {0}) after init = %f (expected 77.0)",
+             (double)s0_val);
+
+    check_idx[0] = 2;
+    set_tensor_data(ext_check, 1, check_idx, s0_raw);
+
+    // =========================================================
+    // Step 6: add_inout(scalar_tensor) second use → INOUT path
+    //   addr != 0, so registered as INOUT (no reallocation)
+    // =========================================================
+    {
+        PTOParam params;
+        params.add_inout(scalar_tensor);
+        pto2_rt_submit_aiv_task(FUNC_NOOP, params);
+    }
+
+    // =========================================================
+    // Step 7: get_tensor_data(scalar_tensor, {0}) → check[3]
+    //   Value should be preserved (noop kernel didn't modify it)
+    // =========================================================
+    uint64_t s1_raw = get_tensor_data(scalar_tensor, 1, idx);
+    LOG_INFO("get_tensor_data(scalar_tensor, {0}) after 2nd noop = %f (expected 77.0)",
+             (double)u64_to_float(s1_raw));
+
+    check_idx[0] = 3;
+    set_tensor_data(ext_check, 1, check_idx, s1_raw);
+
+    // =========================================================
+    // Step 8: set_tensor_data with orchestration-computed value → check[4]
+    //   Tests set_tensor_data write + orchestration arithmetic
+    // =========================================================
+    float combined = c0_val + s0_val;  // 2.0 + 77.0 = 79.0
+    LOG_INFO("Orchestration arithmetic: %f + %f = %f",
+             (double)c0_val, (double)s0_val, (double)combined);
+
+    check_idx[0] = 4;
+    set_tensor_data(ext_check, 1, check_idx, float_to_u64(combined));
+
+    // =========================================================
+    // Step 9: Orch set→get round-trip on internal tensor
+    //   Validates that set_tensor_data writes are visible to get_tensor_data
+    //   on the same tensor. Uses scalar_tensor (currently 77.0), overwrites to 42.0.
+    // =========================================================
+    set_tensor_data(scalar_tensor, 1, idx, float_to_u64(42.0f));
+    uint64_t rw_raw = get_tensor_data(scalar_tensor, 1, idx);
+    float rw_val = u64_to_float(rw_raw);
+    LOG_INFO("set_tensor_data→get_tensor_data round-trip = %f (expected 42.0)",
+             (double)rw_val);
+
+    check_idx[0] = 5;
+    set_tensor_data(ext_check, 1, check_idx, rw_raw);
+
+    // =========================================================
+    // Step 10: Orch→AICore RAW (set_tensor_data → kernel reads)
+    //   Orchestration writes d[0]=10.0 via set_tensor_data, then
+    //   kernel_add reads d as input: e[0] = d[0] + a[0] = 12.0
+    // =========================================================
+    Tensor d = make_tensor(inter_shapes, 1, DataType::FLOAT32);
+    {
+        PTOParam params;
+        params.add_output(d);
+        pto2_rt_submit_aiv_task(FUNC_NOOP, params);
+    }
+
+    idx[0] = 0;
+    set_tensor_data(d, 1, idx, float_to_u64(10.0f));
+
+    Tensor e = make_tensor(inter_shapes, 1, DataType::FLOAT32);
+    {
+        PTOParam params;
+        params.add_input(d);
+        params.add_input(ext_a);
+        params.add_output(e);
+        pto2_rt_submit_aiv_task(FUNC_ADD, params);
+    }
+
+    uint64_t e0_raw = get_tensor_data(e, 1, idx);
+    LOG_INFO("Orch→AICore RAW: e[0] = %f (expected 12.0)",
+             (double)u64_to_float(e0_raw));
+
+    check_idx[0] = 6;
+    set_tensor_data(ext_check, 1, check_idx, e0_raw);
+
+    // =========================================================
+    // Step 11: WAW + WAR on internal tensor
+    //   c was written by Step 1 (kernel_add, TensorMap has producer entry).
+    //   Submit a new kernel that reads c as INPUT (creates consumer dep).
+    //   Then set_tensor_data(c) — no manual get_tensor_data sync.
+    //   set_tensor_data internally waits for:
+    //     - WAW: producer (Step 1) COMPLETED
+    //     - WAR: consumer (this kernel) done (fanout_refcount check)
+    //
+    //   NOTE on external tensors: ext_a was read by Step 1 as INPUT,
+    //   but TensorMap has no producer entry for ext_a (only consumers).
+    //   set_tensor_data(ext_a) would NOT detect the reader — data race.
+    //   To ensure WAR safety on external tensors, use add_inout()
+    //   instead of add_input() so TensorMap tracks the access chain.
+    // =========================================================
+    {
+        // Submit kernel that reads c as INPUT (creates fanout on c's producer)
+        Tensor f = make_tensor(inter_shapes, 1, DataType::FLOAT32);
+        PTOParam params;
+        params.add_input(c);
+        params.add_input(ext_b);
+        params.add_output(f);
+        pto2_rt_submit_aiv_task(FUNC_ADD, params);
+    }
+
+    // set_tensor_data auto-waits for producer + consumer before writing
+    idx[0] = 0;
+    set_tensor_data(c, 1, idx, float_to_u64(88.0f));
+    uint64_t waw_raw = get_tensor_data(c, 1, idx);
+    LOG_INFO("WAW+WAR: set_tensor_data(c, 88.0) after consumer = %f (expected 88.0)",
+             (double)u64_to_float(waw_raw));
+
+    check_idx[0] = 7;
+    set_tensor_data(ext_check, 1, check_idx, waw_raw);
+
+    // =========================================================
+    // Step 12: External tensor WAR — must use INOUT, not INPUT
+    //
+    //   For external tensors, using add_input() does NOT create a
+    //   TensorMap entry. set_tensor_data would then write immediately
+    //   without waiting for the reader kernel — a WAR data race.
+    //
+    //   Using add_inout() creates a TensorMap entry, enabling
+    //   set_tensor_data to detect the producer via TensorMap lookup
+    //   and wait for fanout_refcount (all consumers done).
+    //
+    //   Here we submit noop with ext_b as INOUT (noop doesn't modify
+    //   data), then set_tensor_data overwrites ext_b[0] = 55.0.
+    //   set_tensor_data auto-waits for the noop to complete.
+    // =========================================================
+    {
+        PTOParam params;
+        params.add_inout(ext_b);   // INOUT: creates TensorMap entry (not INPUT!)
+        pto2_rt_submit_aiv_task(FUNC_NOOP, params);
+    }
+
+    idx[0] = 0;
+    set_tensor_data(ext_b, 1, idx, float_to_u64(55.0f));
+    uint64_t ext_war_raw = get_tensor_data(ext_b, 1, idx);
+    LOG_INFO("External WAR (INOUT): set_tensor_data(ext_b, 55.0) = %f (expected 55.0)",
+             (double)u64_to_float(ext_war_raw));
+
+    check_idx[0] = 8;
+    set_tensor_data(ext_check, 1, check_idx, ext_war_raw);
+
+    // Restore ext_b[0] for final result comparison
+    set_tensor_data(ext_b, 1, idx, float_to_u64(0.0f));
+
+    // =========================================================
+    // Step 13: result = a + b (external output, kernel_add)
+    // =========================================================
+    {
+        PTOParam params;
+        params.add_input(ext_a);
+        params.add_input(ext_b);
+        params.add_output(ext_result);
+        pto2_rt_submit_aiv_task(FUNC_ADD, params);
+    }
+
+    LOG_INFO("scalar_data_test: orchestration complete");
+}
+
+}  // extern "C"


### PR DESCRIPTION
## Summary
- Enable orchestration code to read/write individual tensor elements for control-flow patterns (e.g. online softmax running_max)
- Add `GetTensorData`: TensorMap lookup + spin-wait for producer completion, returns raw element value
- Add `SetTensorData`: direct memory write at multi-dimensional indices from orchestration
- Add `PTOParam::add_inout(Tensor&, uint64_t)`: auto-allocate on first use (OUTPUT path) with initial value, subsequent uses go through INOUT path
- Add `PTO2_GET_TENSOR_DATA_TIMEOUT` (100M iterations) for GetTensorData spin-wait, sized for simulation where 13+ threads compete for CPU time
- Add end-to-end device test `scalar_data_test` covering all three features

## Key Changes
- `pto_orchestration_api.h`: Public API for `GetTensorData` and `SetTensorData` inline wrappers + TLS bridge declarations
- `pto_types.h`: New `add_inout(Tensor&, uint64_t)` overload with `initial_values[]` / `has_initial_value[]` fields in PTOParam
- `pto_runtime2.cpp`: `pto2_get_tensor_data()` implementation with TensorMap lookup + spin-wait
- `pto_orchestrator.cpp`: Step 4.5 — write initial values after HeapRing allocation, before TensorMap registration
- `orchestration/common.cpp`: TLS-bound `GetTensorData` function pointer bridge (avoids PTO2RuntimeOps struct change)
- `aicpu_executor.cpp`: dlsym + bind `pto2_framework_bind_get_tensor_data` from orchestration SO
- `pto_runtime2_types.h`: New `PTO2_GET_TENSOR_DATA_TIMEOUT` constant (100M) for simulation environments
- `tests/device_tests/.../scalar_data_test/`: New device test with kernel_add + kernel_noop, verifying 5 check values

## Testing
- Test verifies: GetTensorData from kernel output (index 0 and 100), add_inout initial value (100.0), INOUT persistence, SetTensorData with computed value (105.0)