### PR TITLE
Add: a5 bgemm example using TPUSH/TPOP

### DIFF
--- a/tests/device_tests/a5/tensormap_and_ringbuffer/bgemm/golden.py
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/bgemm/golden.py
@@ -1,0 +1,64 @@
+"""
+Golden test specification for BGEMM (tensormap_and_ringbuffer Runtime).
+
+Computation: C = A @ B (tiled matrix multiplication)
+Configuration: 4x4x4 grid, 64x64 tiles
+
+Args layout: [A, B, C]  — shape/dtype/size in TaskArg metadata
+"""
+
+import torch
+
+__outputs__ = ["C"]
+RTOL = 1e-3
+ATOL = 1e-3
+
+TILE_M = 64
+TILE_K = 64
+TILE_N = 64
+
+GRID_M = 4
+GRID_K = 4
+GRID_N = 4
+BATCH = 2
+
+M = TILE_M * GRID_M
+K = TILE_K * GRID_K
+N = TILE_N * GRID_N
+
+
+def generate_inputs(params: dict) -> list:
+    """Generate input tensors with tile-first memory layout."""
+    A = torch.randn(BATCH, GRID_M, GRID_K, TILE_M, TILE_K, dtype=torch.float32) * 0.01
+    B = torch.randn(BATCH, GRID_K, GRID_N, TILE_K, TILE_N, dtype=torch.float32) * 0.01
+    C = torch.zeros(BATCH, GRID_M, GRID_N, TILE_M, TILE_N, dtype=torch.float32)
+
+    A_flat = A.flatten()
+    B_flat = B.flatten()
+    C_flat = C.flatten()
+
+    return [
+        ("A", A_flat),
+        ("B", B_flat),
+        ("C", C_flat),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    """Compute golden result: C[m,n] = sum(k) A[m,k] @ B[k,n]."""
+    A = torch.as_tensor(tensors["A"]).reshape(BATCH, GRID_M, GRID_K, TILE_M, TILE_K)
+    B = torch.as_tensor(tensors["B"]).reshape(BATCH, GRID_K, GRID_N, TILE_K, TILE_N)
+    C = torch.as_tensor(tensors["C"]).reshape(BATCH, GRID_M, GRID_N, TILE_M, TILE_N)
+
+    C[:] = 0.0
+
+    for batch in range(BATCH):
+        for m_idx in range(GRID_M):
+            for n_idx in range(GRID_N):
+                for k_idx in range(GRID_K):
+                    C[batch, m_idx, n_idx] += torch.matmul(
+                        A[batch, m_idx, k_idx],
+                        B[batch, k_idx, n_idx]
+                    )
+
+    tensors["C"][:] = C.flatten()

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/bgemm/kernels/kernel_config.py
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/bgemm/kernels/kernel_config.py
@@ -1,0 +1,36 @@
+"""
+Kernel configuration for BGEMM (tensormap_and_ringbuffer Runtime).
+
+Cube core (AIC) for matrix multiplication, Vector core (AIV) for accumulation.
+Uses TPUSH/TPOP for cube-to-vector data transfer (bypasses GM).
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "bgemm_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "GEMM",
+        "source": str(_KERNELS_ROOT / "mix" / "kernel_bgemm.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "ADD",
+        "source": str(_KERNELS_ROOT / "mix" / "kernel_bgemm.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 3,
+}

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/bgemm/kernels/mix/kernel_bgemm.cpp
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/bgemm/kernels/mix/kernel_bgemm.cpp
@@ -1,0 +1,301 @@
+/**
+ * Tile-based BGEMM Kernel — Combined Cube + Vector (TPUSH/TPOP)
+ *
+ * Computes one tile iteration: P = A[m,k] @ B[k,n], then C[m,n] += P
+ *
+ * Single source compiled twice:
+ *   - AIC (Cube):   __DAV_CUBE__ defined → TLOAD, TMATMUL, TPUSH
+ *   - AIV (Vector):  __DAV_VEC__ defined → TPOP, TADD, TSTORE
+ *
+ * Intermediate result P is transferred via VEC_FIFO (TPUSH/TPOP),
+ * bypassing GM. The accumulator C is still read/written via GM.
+ *
+ * Simulation fallback (__CPU_SIM):
+ *   Uses separate AIC/AIV tasks with GM intermediary (no TPUSH/TPOP).
+ *   AIC args: [A, B, P_output]    AIV args: [C_inout, P_input]
+ *
+ * Hardware args (MixedKernels):
+ *   args[0] = input_a  (INPUT)
+ *   args[1] = input_b  (INPUT)
+ *   args[2] = C_tile   (INOUT: read + write accumulator)
+ */
+
+ #include <cstdint>
+ #include <pto/pto-inst.hpp>
+ #ifndef __CPU_SIM
+ #include <pto/common/fifo.hpp>
+ #endif
+ 
+ #include "tensor.h"
+ 
+ using namespace pto;
+ 
+ #ifndef __gm__
+ #define __gm__
+ #endif
+ 
+ #ifndef __aicore__
+ #define __aicore__ [aicore]
+ #endif
+ 
+ #ifdef __DAV_CUBE__
+ constexpr bool DAV_CUBE = true;
+ #else
+ constexpr bool DAV_CUBE = false;
+ #endif
+ 
+ #ifdef __DAV_VEC__
+ constexpr bool DAV_VEC = true;
+ #else
+ constexpr bool DAV_VEC = false;
+ #endif
+ 
+ // Tile dimensions (must match golden.py)
+ constexpr int TILE = 64;
+ constexpr int M = TILE;
+ constexpr int K = TILE;
+ constexpr int N = TILE;
+ 
+ // =============================================================================
+ // Simulation: separate AIC/AIV tasks with GM intermediate (no TPUSH/TPOP)
+ // =============================================================================
+ #ifdef __CPU_SIM
+ 
+ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+     // AIC path: args = [A (input), B (input), P (output)]
+     if constexpr (DAV_CUBE) {
+         __gm__ Tensor* input_a_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+         __gm__ Tensor* input_b_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
+         __gm__ Tensor* output_tensor  = reinterpret_cast<__gm__ Tensor*>(args[2]);
+ 
+         __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
+         __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
+         __gm__ float* output  = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr)  + output_tensor->start_offset;
+ 
+         using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, M, K>,
+             pto::Stride<M * K, M * K, M * K, K, 1>>;
+         using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, K, N>,
+             pto::Stride<K * N, K * N, K * N, N, 1>>;
+         using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, M, N>,
+             pto::Stride<M * N, M * N, M * N, N, 1>>;
+ 
+         GlobalDataA src0Global(input_a);
+         GlobalDataB src1Global(input_b);
+         GlobalDataC dstGlobal(output);
+ 
+         using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+         using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
+         using LeftTile = TileLeft<float, M, K, M, K>;
+         using RightTile = TileRight<float, K, N, K, N>;
+         using AccTile = TileAcc<float, M, N, M, N>;
+ 
+         TileMatA aMatTile;
+         TileMatB bMatTile;
+         TASSIGN(aMatTile, 0x0);
+         TASSIGN(bMatTile, 0x20000);
+ 
+         LeftTile aTile;
+         RightTile bTile;
+         AccTile cTile;
+         TASSIGN(aTile, 0x0);
+         TASSIGN(bTile, 0x0);
+         TASSIGN(cTile, 0x0);
+ 
+         TLOAD(aMatTile, src0Global);
+         TLOAD(bMatTile, src1Global);
+ 
+         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+ 
+         TMOV(aTile, aMatTile);
+         TMOV(bTile, bMatTile);
+ 
+         set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+         wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+ 
+         TMATMUL(cTile, aTile, bTile);
+ 
+         set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+         wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+ 
+         TSTORE(dstGlobal, cTile);
+ 
+         set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+         wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+     }
+ 
+     // AIV path: args = [C (inout), P (input)]
+     if constexpr (DAV_VEC) {
+         __gm__ Tensor* c_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+         __gm__ Tensor* p_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
+ 
+         __gm__ float* c_ptr = reinterpret_cast<__gm__ float*>(c_tensor->buffer.addr) + c_tensor->start_offset;
+         __gm__ float* p_ptr = reinterpret_cast<__gm__ float*>(p_tensor->buffer.addr) + p_tensor->start_offset;
+ 
+         using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
+         using DynStridDim5 = pto::Stride<1, 1, 1, TILE, 1>;
+         using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+         using TileData = Tile<TileType::Vec, float, TILE, TILE, BLayout::RowMajor, -1, -1>;
+ 
+         TileData cTile(TILE, TILE);
+         TileData pTile(TILE, TILE);
+         TileData outTile(TILE, TILE);
+         TASSIGN(cTile, 0x0);
+         TASSIGN(pTile, 0x10000);
+         TASSIGN(outTile, 0x20000);
+ 
+         GlobalData cGlobal(c_ptr);
+         GlobalData pGlobal(p_ptr);
+         GlobalData outGlobal(c_ptr);  // write back to same C location
+ 
+         TLOAD(cTile, cGlobal);
+         TLOAD(pTile, pGlobal);
+         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+         TADD(outTile, cTile, pTile);
+         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+         TSTORE(outGlobal, outTile);
+ 
+         set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+         wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+     }
+ }
+ 
+ // =============================================================================
+ // Hardware: MixedKernels with TPUSH/TPOP via VEC_FIFO
+ // =============================================================================
+ #else  // !__CPU_SIM
+ 
+ #define VEC_CORES 2
+ constexpr int VEC_M = M / VEC_CORES;  // each vector sub-core handles half the rows
+ 
+ // TPUSH/TPOP pipe configuration
+ constexpr uint16_t PP_FLAG_ID = 0;
+ constexpr uint8_t PP_FIFO_DEPTH = 2;
+ 
+ // Cube accumulator (full M×N tile in L0C)
+ using AccTileT = TileAcc<float, M, N, M, N>;
+ // Vector consumer tile (half tile: VEC_M×N in UB, split across 2 vector sub-cores)
+ using VecFifoTileT = Tile<TileType::Vec, float, VEC_M, N, BLayout::RowMajor, VEC_M, N>;
+ 
+ // Cube→Vector pipe via on-chip VEC_FIFO (bypasses global memory)
+ using PipeT = TPipe<PP_FLAG_ID, Direction::DIR_C2V, sizeof(float) * VEC_M * N, PP_FIFO_DEPTH>;
+ 
+ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+     __gm__ Tensor* input_a_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+     __gm__ Tensor* input_b_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
+     __gm__ Tensor* c_tensor       = reinterpret_cast<__gm__ Tensor*>(args[2]);
+ 
+     // Pipe and FIFO tile are declared in common scope (both sides reference the type)
+     VecFifoTileT vecFifoTile;
+     PipeT mPipe((__gm__ void *)(uint64_t)0x0, (uint32_t)0x0, (uint32_t)0x0);
+ 
+     // =========================================================================
+     // Cube side: TLOAD A,B → TMATMUL → TPUSH result to vector via VEC_FIFO
+     // =========================================================================
+     if constexpr (DAV_CUBE) {
+         __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr)
+                                 + input_a_tensor->start_offset;
+         __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr)
+                                 + input_b_tensor->start_offset;
+ 
+         using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, M, K>,
+             pto::Stride<M * K, M * K, M * K, K, 1>>;
+         using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, K, N>,
+             pto::Stride<K * N, K * N, K * N, N, 1>>;
+ 
+         GlobalDataA src0Global(input_a);
+         GlobalDataB src1Global(input_b);
+ 
+         using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+         using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
+         using LeftTile = TileLeft<float, M, K, M, K>;
+         using RightTile = TileRight<float, K, N, K, N>;
+ 
+         TileMatA aMatTile;
+         TileMatB bMatTile;
+         TASSIGN(aMatTile, 0x0);
+         TASSIGN(bMatTile, 0x20000);
+ 
+         LeftTile aTile;
+         RightTile bTile;
+         AccTileT accTile;
+         TASSIGN(aTile, 0x0);
+         TASSIGN(bTile, 0x0);
+         TASSIGN(accTile, 0x0);
+ 
+         // Load A and B from GM to L1
+         TLOAD(aMatTile, src0Global);
+         TLOAD(bMatTile, src1Global);
+ 
+         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+ 
+         // Move from L1 to L0A/L0B
+         TMOV(aTile, aMatTile);
+         TMOV(bTile, bMatTile);
+ 
+         set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+         wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+ 
+         // Matrix multiply
+         TMATMUL(accTile, aTile, bTile);
+ 
+         set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+         wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+ 
+         // Push result directly to vector core's UB (replaces TSTORE to GM)
+         TPUSH<PipeT, AccTileT, TileSplitAxis::TILE_UP_DOWN>(mPipe, accTile);
+     }
+ 
+     // =========================================================================
+     // Vector side: TPOP result from cube → TLOAD C from GM → TADD → TSTORE
+     // =========================================================================
+     if constexpr (DAV_VEC) {
+         uint32_t subBlockIdx = get_subblockid();
+ 
+         __gm__ float* c_ptr = reinterpret_cast<__gm__ float*>(c_tensor->buffer.addr)
+                               + c_tensor->start_offset;
+         // Each vector sub-core handles its half: sub-core 0 → rows [0, VEC_M),
+         //                                       sub-core 1 → rows [VEC_M, M)
+         __gm__ float* c_sub = c_ptr + static_cast<size_t>(subBlockIdx) * VEC_M * N;
+ 
+         using GlobalC = GlobalTensor<float, Shape<1, 1, 1, VEC_M, N>,
+             pto::Stride<VEC_M * N, VEC_M * N, VEC_M * N, N, 1>>;
+ 
+         GlobalC cGlobal(c_sub);
+         GlobalC outGlobal(c_sub);  // write back to same location
+ 
+         using VecTile = Tile<TileType::Vec, float, VEC_M, N, BLayout::RowMajor, VEC_M, N>;
+ 
+         VecTile cTile;
+         VecTile outTile;
+         // Place after FIFO buffer: FIFO uses [0x0, FIFO_DEPTH * VEC_M * N * 4)
+         // = [0x0, 2 * 32 * 64 * 4) = [0x0, 0x4000)
+         TASSIGN(cTile, 0x4000);
+         TASSIGN(outTile, 0x6000);
+ 
+         // Pop matmul result from cube via VEC_FIFO (replaces TLOAD from GM)
+         TPOP<PipeT, VecFifoTileT, TileSplitAxis::TILE_UP_DOWN>(mPipe, vecFifoTile);
+ 
+         // Load current C tile from GM
+         TLOAD(cTile, cGlobal);
+ 
+         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+ 
+         // Accumulate: C += P
+         TADD(outTile, cTile, vecFifoTile);
+         TFREE<PipeT, TileSplitAxis::TILE_UP_DOWN>(mPipe);
+ 
+         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+ 
+         // Store result back to GM
+         TSTORE(outGlobal, outTile);
+     }
+ }
+ 
+ #endif  // __CPU_SIM
+ 

--- a/tests/device_tests/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/device_tests/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -1,0 +1,118 @@
+/**
+ * BGEMM Orchestration Function (tensormap_and_ringbuffer Runtime)
+ *
+ * Builds the task graph for tiled matrix multiplication: C = A @ B
+ *
+ * Configuration:
+ *   - Tile size: 64 x 64
+ *   - Grid: 4 x 4 x 4 (GRID_M x GRID_K x GRID_N)
+ *   - Batch: 2
+ *
+ * Memory layout (tile-first, 5D flattened):
+ *   A: [BATCH, GRID_M, GRID_K, TILE, TILE]
+ *   B: [BATCH, GRID_K, GRID_N, TILE, TILE]
+ *   C: [BATCH, GRID_M, GRID_N, TILE, TILE]
+ *
+ * Task graph per output tile C[batch, m, n]:
+ *   for k in [0, GRID_K):
+ *     P = A[m,k] @ B[k,n]    (matmul on Cube core, func_id=0)
+ *     C[m,n] = C[m,n] + P    (accumulate on Vector core, func_id=1)
+ *
+ * Each iteration submits a MixedKernels task (AIC + AIV0 + AIV1).
+ * Intermediate result P flows via TPUSH/TPOP (VEC_FIFO), bypassing GM.
+ * Dependencies are automatic via TensorMap overlap detection.
+ *
+ * Args layout: [A, B, C]  — shape/dtype/size in TaskArg metadata
+ */
+
+ #include <stddef.h>
+ #include <stdint.h>
+ 
+ #include "pto_orchestration_api.h"
+ 
+ #define FUNC_GEMM_TILE 0
+ #define FUNC_TILE_ADD  1
+ 
+ // Grid and tile constants
+ static constexpr int TILE = 64;
+ static constexpr int GRID_M = 4;
+ static constexpr int GRID_K = 4;
+ static constexpr int GRID_N = 4;
+ static constexpr int BATCH = 2;
+ 
+ static constexpr uint32_t TILE_ELEMS = TILE * TILE;           // 4096 elements
+ 
+ extern "C" {
+ 
+ __attribute__((visibility("default")))
+ PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+     (void)orch_args;
+     return PTO2OrchestrationConfig{
+         .expected_arg_count = 3,
+     };
+ }
+ 
+ __attribute__((visibility("default")))
+ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+     (void)orch_thread_num;
+     (void)orch_thread_index;
+ 
+     // 1D external tensors for the full A, B, C arrays
+     Tensor ext_A = from_task_arg(orch_args[0]);
+     Tensor ext_B = from_task_arg(orch_args[1]);
+     Tensor ext_C = from_task_arg(orch_args[2]);
+ 
+     LOG_INFO(rt, "[bgemm_orch] Grid: %dx%dx%d, Batch: %d, Tile: %d",
+                   GRID_M, GRID_K, GRID_N, BATCH, TILE);
+ 
+     uint32_t tile_shapes[1] = {TILE_ELEMS};
+ 
+     for (int batch = 0; batch < BATCH; batch++) {
+         for (int m_idx = 0; m_idx < GRID_M; m_idx++) {
+             for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
+                 PTO2_SCOPE(rt) {
+                     uint32_t c_elem_offset =
+                         ((uint32_t)batch * GRID_M * GRID_N +
+                          (uint32_t)m_idx * GRID_N +
+                          (uint32_t)n_idx) * TILE_ELEMS;
+                     uint32_t c_view_offsets[1] = {c_elem_offset};
+                     Tensor C_view = ext_C.view(tile_shapes, c_view_offsets);
+ 
+                     for (int k_idx = 0; k_idx < GRID_K; k_idx++) {
+                         uint32_t a_elem_offset =
+                             ((uint32_t)batch * GRID_M * GRID_K +
+                              (uint32_t)m_idx * GRID_K +
+                              (uint32_t)k_idx) * TILE_ELEMS;
+                         uint32_t b_elem_offset =
+                             ((uint32_t)batch * GRID_K * GRID_N +
+                              (uint32_t)k_idx * GRID_N +
+                              (uint32_t)n_idx) * TILE_ELEMS;
+ 
+                         uint32_t a_view_offsets[1] = {a_elem_offset};
+                         Tensor A_view = ext_A.view(tile_shapes, a_view_offsets);
+                         uint32_t b_view_offsets[1] = {b_elem_offset};
+                         Tensor B_view = ext_B.view(tile_shapes, b_view_offsets);
+ 
+                         // P = A[m,k] @ B[k,n], then C[m,n] += P
+                         PTOParam params;
+                         params.add_input(A_view);
+                         params.add_input(B_view);
+                         params.add_inout(C_view);
+ 
+                         MixedKernels mk;
+                         mk.aic_kernel_id  = FUNC_GEMM_TILE;
+                         mk.aiv0_kernel_id = FUNC_TILE_ADD;
+                         mk.aiv1_kernel_id = FUNC_TILE_ADD;
+                         pto2_rt_submit_task(rt, mk, params);
+                     }
+                 }
+             }
+         }
+     }
+ 
+     LOG_INFO(rt, "[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each",
+                   BATCH, GRID_M, GRID_N, GRID_K);
+ }
+ 
+ }  // extern "C"
+ 


### PR DESCRIPTION
Add: a5 bgemm example using TPUSH/TPOP

Standard BGEMM example for a5 tensormap_and_ringbuffer runtime.
Uses MixedKernels with TPUSH/TPOP for cube-to-vector data transfer,
bypassing GM for the intermediate matmul result.