### PR TITLE
Refactor: compress PTO2ResourceShape from 5 states to 3 (AIC/AIV/MIX)

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -201,18 +201,12 @@ public:
 
     BitStates get_valid_cluster_offset_states(PTO2ResourceShape shape) const {
         switch (shape) {
-            case PTO2ResourceShape::AIC_ONLY:
+            case PTO2ResourceShape::AIC:
                 return core_states_ & aic_mask_;
-            case PTO2ResourceShape::AIV_X1:
-                return (((core_states_ & aiv_mask_) >> 1) | ((core_states_ & aiv_mask_) >> 2)) & aic_mask_;
-            case PTO2ResourceShape::AIV_X2:
-                return (((core_states_ & aiv_mask_) >> 1) & ((core_states_ & aiv_mask_) >> 2)) & aic_mask_;
-            case PTO2ResourceShape::AIC_AIV_X1:
-                return (((core_states_ & aiv_mask_) >> 1) | ((core_states_ & aiv_mask_) >> 2)) & core_states_ &
-                       aic_mask_;
-            case PTO2ResourceShape::AIC_AIV_X2:
-                return (((core_states_ & aiv_mask_) >> 1) & ((core_states_ & aiv_mask_) >> 2)) & core_states_ &
-                       aic_mask_;
+            case PTO2ResourceShape::AIV:
+                return ((core_states_ >> 1) | (core_states_ >> 2)) & aic_mask_;
+            case PTO2ResourceShape::MIX:
+                return (core_states_ >> 1) & (core_states_ >> 2) & core_states_ & aic_mask_;
         }
         return BitStates(0ULL);
     }
@@ -476,29 +470,14 @@ struct AicpuExecutor {
 
     static const char* shape_name(PTO2ResourceShape shape) {
         switch (shape) {
-        case PTO2ResourceShape::AIC_ONLY:   return "AIC_ONLY";
-        case PTO2ResourceShape::AIV_X1:     return "AIV_X1";
-        case PTO2ResourceShape::AIV_X2:     return "AIV_X2";
-        case PTO2ResourceShape::AIC_AIV_X1: return "AIC_AIV_X1";
-        case PTO2ResourceShape::AIC_AIV_X2: return "AIC_AIV_X2";
+            case PTO2ResourceShape::AIC:
+                return "AIC";
+            case PTO2ResourceShape::AIV:
+                return "AIV";
+            case PTO2ResourceShape::MIX:
+                return "MIX";
         }
         return "UNKNOWN";
-    }
-
-    struct ResourceCount {
-        int32_t aic;
-        int32_t aiv;
-    };
-
-    static constexpr ResourceCount shape_resource_count(PTO2ResourceShape shape) {
-        constexpr ResourceCount kTable[PTO2_NUM_RESOURCE_SHAPES] = {
-            {1, 0},  // AIC_ONLY    = 0
-            {0, 1},  // AIV_X1      = 1
-            {0, 2},  // AIV_X2      = 2
-            {1, 1},  // AIC_AIV_X1  = 3
-            {1, 2},  // AIC_AIV_X2  = 4
-        };
-        return kTable[static_cast<int>(shape)];
     }
 
     /**
@@ -510,19 +489,15 @@ struct AicpuExecutor {
     static const PTO2ResourceShape* get_dispatch_order(int32_t thread_idx) {
         // Even threads: AIC-first fallback after widest
         static constexpr PTO2ResourceShape kEvenOrder[PTO2_NUM_RESOURCE_SHAPES] = {
-            PTO2ResourceShape::AIC_AIV_X2,
-            PTO2ResourceShape::AIC_AIV_X1,
-            PTO2ResourceShape::AIC_ONLY,
-            PTO2ResourceShape::AIV_X2,
-            PTO2ResourceShape::AIV_X1,
+            PTO2ResourceShape::MIX,
+            PTO2ResourceShape::AIC,
+            PTO2ResourceShape::AIV,
         };
         // Odd threads: AIV-first fallback after widest
         static constexpr PTO2ResourceShape kOddOrder[PTO2_NUM_RESOURCE_SHAPES] = {
-            PTO2ResourceShape::AIC_AIV_X2,
-            PTO2ResourceShape::AIV_X2,
-            PTO2ResourceShape::AIC_AIV_X1,
-            PTO2ResourceShape::AIV_X1,
-            PTO2ResourceShape::AIC_ONLY,
+            PTO2ResourceShape::MIX,
+            PTO2ResourceShape::AIV,
+            PTO2ResourceShape::AIC,
         };
         return (thread_idx % 2 == 0) ? kEvenOrder : kOddOrder;
     }
@@ -1214,31 +1189,73 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     uint64_t t_setup_start = get_sys_cnt_aicpu();
 #endif
                     auto current_valid_cluster_offset = valid_cluster_states.pop_first();
-                    ResourceCount rc = shape_resource_count(shape);
-
-                    if (rc.aic) {
+                    if (shape == PTO2ResourceShape::MIX) {
+                        // Full-cluster scheduling: dispatch only to cores indicated by active_mask.
+                        // Unused cores in the cluster remain idle for single-core tasks.
+                        uint8_t mask = slot_state->active_mask;
+                        if (mask & PTO2_SUBTASK_MASK_AIC) {
+                            auto core_offset = tracker.get_aic_core_offset(current_valid_cluster_offset);
+                            dispatch_subtask_to_core(runtime,
+                                thread_idx,
+                                core_offset,
+                                *slot_state,
+                                PTO2SubtaskSlot::AIC
+#if PTO2_PROFILING
+                                ,
+                                profiling_enabled
+#endif
+                            );
+                        }
+                        if (mask & PTO2_SUBTASK_MASK_AIV0) {
+                            auto core_offset = tracker.get_aiv0_core_offset(current_valid_cluster_offset);
+                            dispatch_subtask_to_core(runtime,
+                                thread_idx,
+                                core_offset,
+                                *slot_state,
+                                PTO2SubtaskSlot::AIV0
+#if PTO2_PROFILING
+                                ,
+                                profiling_enabled
+#endif
+                            );
+                        }
+                        if (mask & PTO2_SUBTASK_MASK_AIV1) {
+                            auto core_offset = tracker.get_aiv1_core_offset(current_valid_cluster_offset);
+                            dispatch_subtask_to_core(runtime,
+                                thread_idx,
+                                core_offset,
+                                *slot_state,
+                                PTO2SubtaskSlot::AIV1
+#if PTO2_PROFILING
+                                ,
+                                profiling_enabled
+#endif
+                            );
+                        }
+                    } else if (shape == PTO2ResourceShape::AIC) {
                         auto core_offset = tracker.get_aic_core_offset(current_valid_cluster_offset);
-                        dispatch_subtask_to_core(runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIC
+                        dispatch_subtask_to_core(runtime,
+                            thread_idx,
+                            core_offset,
+                            *slot_state,
+                            PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
-                            , profiling_enabled
+                            ,
+                            profiling_enabled
 #endif
                         );
-                    }
-                    if (rc.aiv >= 1) {
+                    } else {  // shape == PTO2ResourceShape::AIV
                         auto core_offset = tracker.is_aiv0_core_idle(current_valid_cluster_offset)
-                                           ? tracker.get_aiv0_core_offset(current_valid_cluster_offset)
-                                           : tracker.get_aiv1_core_offset(current_valid_cluster_offset);
-                        dispatch_subtask_to_core(runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV0
+                                               ? tracker.get_aiv0_core_offset(current_valid_cluster_offset)
+                                               : tracker.get_aiv1_core_offset(current_valid_cluster_offset);
+                        dispatch_subtask_to_core(runtime,
+                            thread_idx,
+                            core_offset,
+                            *slot_state,
+                            PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
-                            , profiling_enabled
-#endif
-                        );
-                    }
-                    if (rc.aiv >= 2) {
-                        auto core_offset = tracker.get_aiv1_core_offset(current_valid_cluster_offset);
-                        dispatch_subtask_to_core(runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV1
-#if PTO2_PROFILING
-                            , profiling_enabled
+                            ,
+                            profiling_enabled
 #endif
                         );
                     }
@@ -2141,16 +2158,13 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
     DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)",
              completed, total, total > 0 ? completed * 100.0 / total : 0.0);
 
-    uint64_t aic_ready = 0, aiv_ready = 0, aiv_x2_ready = 0, mixed_x1_ready = 0, mixed_x2_ready = 0;
+    uint64_t aic_ready = 0, aiv_ready = 0, mix_ready = 0;
     if (rt) {
-        aic_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC_ONLY)].size();
-        aiv_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIV_X1)].size();
-        aiv_x2_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIV_X2)].size();
-        mixed_x1_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC_AIV_X1)].size();
-        mixed_x2_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC_AIV_X2)].size();
+        aic_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC)].size();
+        aiv_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIV)].size();
+        mix_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::MIX)].size();
     }
-    DEV_ALWAYS("Ready Queues: AIC=%lu, AIV=%lu, AIV_X2=%lu, AIC_AIV_X1=%lu, AIC_AIV_X2=%lu",
-               aic_ready, aiv_ready, aiv_x2_ready, mixed_x1_ready, mixed_x2_ready);
+    DEV_ALWAYS("Ready Queues: AIC=%lu, AIV=%lu, MIX=%lu", aic_ready, aiv_ready, mix_ready);
 
     int32_t busy_cores = 0;
     int32_t idle_cores = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -275,13 +275,16 @@ void pto2_submit_mixed_task(
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
     always_assert(active_mask != 0 && "MixedKernels must have at least one active slot");
 
-    // Normalize single-AIV tasks: if only aiv1 is set, move it to the aiv0 slot.
-    // This guarantees the dispatch path can always use PTO2SubtaskSlot::AIV0 for
-    // AIV_X1 and AIC_AIV_X1 shapes without inspecting active_mask.
+    // Normalize single-AIV tasks: if only aiv1 is set (no aic, no aiv0), move
+    // it to the aiv0 slot.  This guarantees the dispatch path can always use
+    // PTO2SubtaskSlot::AIV0 for single-AIV shapes without inspecting active_mask.
+    // Mixed tasks (AIC+AIV) keep their original AIV identity so the correct
+    // hardware channel (AIV0→AIC vs AIV1→AIC) is used at dispatch time.
     MixedKernels normalized = mixed_kernels;
+    bool has_aic  = (active_mask & PTO2_SUBTASK_MASK_AIC) != 0;
     bool has_aiv0 = (active_mask & PTO2_SUBTASK_MASK_AIV0) != 0;
     bool has_aiv1 = (active_mask & PTO2_SUBTASK_MASK_AIV1) != 0;
-    if (has_aiv1 && !has_aiv0) {
+    if (!has_aic && has_aiv1 && !has_aiv0) {
         normalized.aiv0_kernel_id = normalized.aiv1_kernel_id;
         normalized.aiv1_kernel_id = INVALID_KERNEL_ID;
         active_mask = pto2_mixed_kernels_to_active_mask(normalized);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -209,7 +209,7 @@ void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
 void pto2_scheduler_print_queues(PTO2SchedulerState* sched) {
     LOG_INFO("=== Ready Queues ===");
 
-    const char* shape_names[] = {"AIC_ONLY", "AIV_X1", "AIV_X2", "AIC_AIV_X1", "AIC_AIV_X2"};
+    const char* shape_names[] = {"AIC", "AIV", "MIX"};
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         LOG_INFO("  %s: count=%" PRIu64, shape_names[i],

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -53,34 +53,30 @@ struct MixedKernels {
 };
 
 /**
- * Resource shape — classifies a MixedKernels into one of 5 queue buckets.
+ * Resource shape — classifies a MixedKernels into one of 3 scheduling buckets.
+ *
+ * Multi-subtask tasks (2+ active slots) are all scheduled as MIX, which
+ * requires a fully-idle cluster (1 AIC + 2 AIV).  The actual cores used
+ * are determined at dispatch time by active_mask — unused cores in the
+ * cluster remain idle and available for single-core tasks.
  */
 enum class PTO2ResourceShape : uint8_t {
-    AIC_ONLY    = 0,   // AIC only
-    AIV_X1      = 1,   // One AIV slot
-    AIV_X2      = 2,   // Both AIV slots
-    AIC_AIV_X1  = 3,   // AIC + one AIV
-    AIC_AIV_X2  = 4,   // AIC + both AIV
+    AIC = 0,   // Single AIC
+    AIV = 1,   // Single AIV
+    MIX = 2,   // Full cluster (dispatch uses active_mask)
 };
 
-inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 5;
+inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 3;
 
 /**
  * Derive resource shape from active_mask.
  * Caller must ensure active_mask is valid (at least one bit set).
  */
 static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
-    bool has_aic = (active_mask & PTO2_SUBTASK_MASK_AIC) != 0;
-    int aiv_count = ((active_mask & PTO2_SUBTASK_MASK_AIV0) != 0)
-                  + ((active_mask & PTO2_SUBTASK_MASK_AIV1) != 0);
-
-    if (has_aic) {
-        if (aiv_count == 0) return PTO2ResourceShape::AIC_ONLY;
-        if (aiv_count == 1) return PTO2ResourceShape::AIC_AIV_X1;
-        return PTO2ResourceShape::AIC_AIV_X2;
-    }
-    if (aiv_count == 1) return PTO2ResourceShape::AIV_X1;
-    return PTO2ResourceShape::AIV_X2;
+    int bit_count = __builtin_popcount(active_mask);
+    if (bit_count >= 2) return PTO2ResourceShape::MIX;
+    if (active_mask & PTO2_SUBTASK_MASK_AIC) return PTO2ResourceShape::AIC;
+    return PTO2ResourceShape::AIV;
 }
 
 /**


### PR DESCRIPTION
- Replace AIC_ONLY/AIV_X1/AIV_X2/AIC_AIV_X1/AIC_AIV_X2 with AIC/AIV/MIX
- Multi-subtask tasks (2+ active slots) schedule as MIX, requiring a fully-idle cluster; dispatch uses active_mask to occupy only needed cores, leaving unused cores available for single-core tasks
- Preserve AIV0/AIV1 identity in mixed tasks (no longer normalize AIC+AIV1 to AIC+AIV0) so the correct hardware channel is used
- Simplify ready queues, dispatch order, and CoreTracker matching from 5 to 3 resource shapes