### PR TITLE
Add: pre-commit config with formatting-only hooks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,3 +23,6 @@ BinPackArguments: false
 
 # 访问修饰符(public/private/protected)的缩进偏移，-4表示与class对齐
 AccessModifierOffset: -4
+
+# Ascend headers have implicit order dependencies — do not reorder includes
+SortIncludes: Never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ concurrency:
 
 jobs:
   # ---------- Python unit tests (no hardware) ----------
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files
+
   ut-py:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+repos:
+
+    # Basic checks
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.6.0
+      hooks:
+        - id: check-added-large-files
+        - id: check-yaml
+        - id: end-of-file-fixer
+        - id: trailing-whitespace
+
+    # C++ formatting
+    - repo: https://github.com/pre-commit/mirrors-clang-format
+      rev: v18.1.8
+      hooks:
+        - id: clang-format
+          types_or: [c++, c]
+          exclude: ^(3rdparty/)
+
+    # Python formatting
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.9.10
+      hooks:
+        - id: ruff-format
+          types_or: [python, pyi]
+          exclude: ^(examples/)

--- a/examples/a2a3/aicpu_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/a2a3/aicpu_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -36,13 +36,10 @@ AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
 }
 
 static __aicore__ void gemm_tile_impl(
-    __gm__ Tensor* input_a_tensor,
-    __gm__ Tensor* input_b_tensor,
-    __gm__ Tensor* output_tensor) {
-
+    __gm__ Tensor* input_a_tensor, __gm__ Tensor* input_b_tensor, __gm__ Tensor* output_tensor) {
     __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
     __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
-    __gm__ float* output  = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr)  + output_tensor->start_offset;
+    __gm__ float* output = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr) + output_tensor->start_offset;
 
     constexpr int TILE = 64;
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
@@ -50,12 +47,12 @@ static __aicore__ void gemm_tile_impl(
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);
@@ -106,7 +103,7 @@ static __aicore__ void gemm_tile_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* input_a = reinterpret_cast<__gm__ Tensor*>(args[0]);
     __gm__ Tensor* input_b = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* output  = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ Tensor* output = reinterpret_cast<__gm__ Tensor*>(args[2]);
 
     gemm_tile_impl(input_a, input_b, output);
 }

--- a/examples/a2a3/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -31,7 +31,7 @@
 #include "pto_orchestration_api.h"
 
 #define FUNC_GEMM_TILE 0
-#define FUNC_TILE_ADD  1
+#define FUNC_TILE_ADD 1
 
 static constexpr int TILE = 64;
 static constexpr int GRID_M = 4;
@@ -44,16 +44,15 @@ static constexpr uint64_t TILE_BYTES = TILE_ELEMS * sizeof(float);
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 
@@ -61,8 +60,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
     Tensor ext_B = from_task_arg(orch_args[1]);
     Tensor ext_C = from_task_arg(orch_args[2]);
 
-    LOG_INFO(rt, "[bgemm_orch] Grid: %dx%dx%d, Batch: %d, Tile: %d",
-                  GRID_M, GRID_K, GRID_N, BATCH, TILE);
+    LOG_INFO(rt, "[bgemm_orch] Grid: %dx%dx%d, Batch: %d, Tile: %d", GRID_M, GRID_K, GRID_N, BATCH, TILE);
 
     uint32_t tile_shapes[1] = {TILE_ELEMS};
 
@@ -71,9 +69,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
             for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
                 PTO2_SCOPE(rt) {
                     uint32_t c_elem_offset =
-                        ((uint32_t)batch * GRID_M * GRID_N +
-                         (uint32_t)m_idx * GRID_N +
-                         (uint32_t)n_idx) * TILE_ELEMS;
+                        ((uint32_t)batch * GRID_M * GRID_N + (uint32_t)m_idx * GRID_N + (uint32_t)n_idx) * TILE_ELEMS;
                     uint32_t c_view_offsets[1] = {c_elem_offset};
                     Tensor C_view = ext_C.view(tile_shapes, c_view_offsets);
 
@@ -82,13 +78,11 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
 
                     for (int k_idx = 0; k_idx < GRID_K; k_idx++) {
                         uint32_t a_elem_offset =
-                            ((uint32_t)batch * GRID_M * GRID_K +
-                             (uint32_t)m_idx * GRID_K +
-                             (uint32_t)k_idx) * TILE_ELEMS;
+                            ((uint32_t)batch * GRID_M * GRID_K + (uint32_t)m_idx * GRID_K + (uint32_t)k_idx) *
+                            TILE_ELEMS;
                         uint32_t b_elem_offset =
-                            ((uint32_t)batch * GRID_K * GRID_N +
-                             (uint32_t)k_idx * GRID_N +
-                             (uint32_t)n_idx) * TILE_ELEMS;
+                            ((uint32_t)batch * GRID_K * GRID_N + (uint32_t)k_idx * GRID_N + (uint32_t)n_idx) *
+                            TILE_ELEMS;
 
                         uint32_t a_view_offsets[1] = {a_elem_offset};
                         Tensor A_view = ext_A.view(tile_shapes, a_view_offsets);
@@ -124,8 +118,12 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
         }
     }
 
-    LOG_INFO(rt, "[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each",
-                  BATCH, GRID_M, GRID_N, GRID_K);
+    LOG_INFO(rt,
+        "[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each",
+        BATCH,
+        GRID_M,
+        GRID_N,
+        GRID_K);
 }
 
 }  // extern "C"

--- a/examples/a2a3/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
+++ b/examples/a2a3/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
@@ -29,16 +29,15 @@ static uint64_t float_to_u64(float f) {
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 

--- a/examples/a2a3/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/a2a3/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -39,12 +39,12 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);

--- a/examples/a2a3/host_build_graph/matmul/kernels/aic/kernel_matmul.cpp
+++ b/examples/a2a3/host_build_graph/matmul/kernels/aic/kernel_matmul.cpp
@@ -49,11 +49,14 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     __gm__ float* out = reinterpret_cast<__gm__ float*>(args[2]);
 
     // Global tensor types
-    using GlobalDataSrc0 = GlobalTensor<half, Shape<1, 1, 1, validM, validK>,
+    using GlobalDataSrc0 = GlobalTensor<half,
+        Shape<1, 1, 1, validM, validK>,
         Stride<validM * validK, validM * validK, validM * validK, validK, 1>>;
-    using GlobalDataSrc1 = GlobalTensor<half, Shape<1, 1, 1, validK, validN>,
+    using GlobalDataSrc1 = GlobalTensor<half,
+        Shape<1, 1, 1, validK, validN>,
         Stride<validK * validN, validK * validN, validK * validN, validN, 1>>;
-    using GlobalDataOut = GlobalTensor<float, Shape<1, 1, 1, validM, validN>,
+    using GlobalDataOut = GlobalTensor<float,
+        Shape<1, 1, 1, validM, validN>,
         Stride<validM * validN, validM * validN, validM * validN, validN, 1>>;
 
     GlobalDataSrc0 src0Global(src0);

--- a/examples/a2a3/host_build_graph/matmul/kernels/orchestration/matmul_orch.cpp
+++ b/examples/a2a3/host_build_graph/matmul/kernels/orchestration/matmul_orch.cpp
@@ -34,14 +34,14 @@ int build_matmul_graph(Runtime* runtime, const TaskArg* orch_args, int arg_count
     }
 
     // Extract host pointers and sizes from TaskArg metadata
-    void* host_a  = orch_args[0].data<void>();
+    void* host_a = orch_args[0].data<void>();
     void* host_w1 = orch_args[1].data<void>();
     void* host_w2 = orch_args[2].data<void>();
-    void* host_f  = orch_args[3].data<void>();
-    size_t size_a  = orch_args[0].nbytes();
+    void* host_f = orch_args[3].data<void>();
+    size_t size_a = orch_args[0].nbytes();
     size_t size_w1 = orch_args[1].nbytes();
     size_t size_w2 = orch_args[2].nbytes();
-    size_t size_f  = orch_args[3].nbytes();
+    size_t size_f = orch_args[3].nbytes();
     uint32_t SIZE = orch_args[0].tensor.shapes[0];
 
     std::cout << "\n=== build_matmul_graph: Creating Task Runtime ===" << '\n';
@@ -93,8 +93,8 @@ int build_matmul_graph(Runtime* runtime, const TaskArg* orch_args, int arg_count
     // Allocate intermediate tensors (b, c, d)
     // dev_b is half precision (output of log_sqrt kernel, input to matmul)
     // dev_c, dev_d are float precision (output of matmul kernels)
-    size_t BYTES_HALF = SIZE * sizeof(uint16_t);   // half = 2 bytes
-    size_t BYTES_FLOAT = SIZE * sizeof(float);     // float = 4 bytes
+    size_t BYTES_HALF = SIZE * sizeof(uint16_t);                 // half = 2 bytes
+    size_t BYTES_FLOAT = SIZE * sizeof(float);                   // float = 4 bytes
     void* dev_b = runtime->host_api.device_malloc(BYTES_HALF);   // sqrt(log(A)) - half output
     void* dev_c = runtime->host_api.device_malloc(BYTES_FLOAT);  // B @ W1 - float output
     void* dev_d = runtime->host_api.device_malloc(BYTES_FLOAT);  // B @ W2 - float output
@@ -111,13 +111,14 @@ int build_matmul_graph(Runtime* runtime, const TaskArg* orch_args, int arg_count
         return -1;
     }
 
-    std::cout << "Allocated intermediate tensors: B (" << BYTES_HALF << " bytes, half), C (" << BYTES_FLOAT << " bytes, float), D (" << BYTES_FLOAT << " bytes, float)\n";
+    std::cout << "Allocated intermediate tensors: B (" << BYTES_HALF << " bytes, half), C (" << BYTES_FLOAT
+              << " bytes, float), D (" << BYTES_FLOAT << " bytes, float)\n";
 
     // Task 0: B = sqrt(log(A)) (func_id=0: kernel_log_sqrt, AIV)
     uint64_t args_t0[3];
     args_t0[0] = reinterpret_cast<uint64_t>(dev_a);  // src
     args_t0[1] = reinterpret_cast<uint64_t>(dev_b);  // out
-    args_t0[2] = SIZE;                                // size
+    args_t0[2] = SIZE;                               // size
     int t0 = runtime->add_task(args_t0, 3, 0, CoreType::AIV);
 
     // Task 1: C = B @ W1 (func_id=1: kernel_matmul, AIC)
@@ -125,7 +126,7 @@ int build_matmul_graph(Runtime* runtime, const TaskArg* orch_args, int arg_count
     args_t1[0] = reinterpret_cast<uint64_t>(dev_b);   // src0 (left matrix)
     args_t1[1] = reinterpret_cast<uint64_t>(dev_w1);  // src1 (right matrix)
     args_t1[2] = reinterpret_cast<uint64_t>(dev_c);   // out
-    args_t1[3] = SIZE;                                 // size
+    args_t1[3] = SIZE;                                // size
     int t1 = runtime->add_task(args_t1, 4, 1, CoreType::AIC);
 
     // Task 2: D = B @ W2 (func_id=1: kernel_matmul, AIC)
@@ -133,7 +134,7 @@ int build_matmul_graph(Runtime* runtime, const TaskArg* orch_args, int arg_count
     args_t2[0] = reinterpret_cast<uint64_t>(dev_b);   // src0 (left matrix)
     args_t2[1] = reinterpret_cast<uint64_t>(dev_w2);  // src1 (right matrix)
     args_t2[2] = reinterpret_cast<uint64_t>(dev_d);   // out
-    args_t2[3] = SIZE;                                 // size
+    args_t2[3] = SIZE;                                // size
     int t2 = runtime->add_task(args_t2, 4, 1, CoreType::AIC);
 
     // Task 3: F = exp(C + D) (func_id=2: kernel_add_exp, AIV)
@@ -141,7 +142,7 @@ int build_matmul_graph(Runtime* runtime, const TaskArg* orch_args, int arg_count
     args_t3[0] = reinterpret_cast<uint64_t>(dev_c);  // src0
     args_t3[1] = reinterpret_cast<uint64_t>(dev_d);  // src1
     args_t3[2] = reinterpret_cast<uint64_t>(dev_f);  // out
-    args_t3[3] = SIZE;                                // size
+    args_t3[3] = SIZE;                               // size
     int t3 = runtime->add_task(args_t3, 4, 2, CoreType::AIV);
 
     // Add dependencies (diamond: t0→t1→t3, t0→t2→t3)

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -19,21 +19,20 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw)
-{
+static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw) {
     constexpr int M = 16, K = 16, N = 16;
 
     __gm__ half* pij = reinterpret_cast<__gm__ half*>(pij_raw);
-    __gm__ half* vj  = reinterpret_cast<__gm__ half*>(vj_raw);
-    __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ half* vj = reinterpret_cast<__gm__ half*>(vj_raw);
+    __gm__ float* oi = reinterpret_cast<__gm__ float*>(oi_raw);
 
     // pij (M, K) fp16, vj (K, N) fp16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
-    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, N, 1>>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   pijGlobal(pij);
-    GlobalB   vjGlobal(vj);
+    GlobalA pijGlobal(pij);
+    GlobalB vjGlobal(vj);
     GlobalOut oiGlobal(oi);
 
     // L1 Mat tiles: standard ND pattern for both A and B
@@ -41,18 +40,18 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<half, M, K, M, K>;
+    using LeftTile = TileLeft<half, M, K, M, K>;
     using RightTile = TileRight<half, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -80,10 +79,9 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     TSTORE(oiGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* pij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* vj     = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* vj = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
 
     pv_matmul_impl(pij, vj, oi_new);

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -19,22 +19,21 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw)
-{
+static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw) {
     constexpr int M = 16, K = 16, N = 16;
 
-    __gm__ half* qi  = reinterpret_cast<__gm__ half*>(qi_raw);
-    __gm__ half* kj  = reinterpret_cast<__gm__ half*>(kj_raw);
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+    __gm__ half* qi = reinterpret_cast<__gm__ half*>(qi_raw);
+    __gm__ half* kj = reinterpret_cast<__gm__ half*>(kj_raw);
+    __gm__ float* sij = reinterpret_cast<__gm__ float*>(sij_raw);
 
     // qi (M, K) fp16 in ND (row-major) layout
-    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   qiGlobal(qi);
-    GlobalB   kjGlobal(kj);
+    GlobalA qiGlobal(qi);
+    GlobalB kjGlobal(kj);
     GlobalOut sijGlobal(sij);
 
     // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
@@ -42,18 +41,18 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<half, M, K, M, K>;
+    using LeftTile = TileLeft<half, M, K, M, K>;
     using RightTile = TileRight<half, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -81,10 +80,9 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     TSTORE(sijGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* qi  = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* kj  = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ uint8_t* qi = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* kj = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
 
     qk_matmul_impl(qi, kj, sij);

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -21,20 +21,24 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_t* lij_raw,
-                               __gm__ uint8_t* oi_new_raw, __gm__ uint8_t* mi_raw,
-                               __gm__ uint8_t* li_raw, __gm__ uint8_t* oi_raw,
-                               int is_first, int is_last, __gm__ uint8_t* dst_raw)
-{
+static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw,
+    __gm__ uint8_t* lij_raw,
+    __gm__ uint8_t* oi_new_raw,
+    __gm__ uint8_t* mi_raw,
+    __gm__ uint8_t* li_raw,
+    __gm__ uint8_t* oi_raw,
+    int is_first,
+    int is_last,
+    __gm__ uint8_t* dst_raw) {
     constexpr int M = 16, N = 16;
 
-    __gm__ float* mij_ptr    = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float* lij_ptr    = reinterpret_cast<__gm__ float*>(lij_raw);
+    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij_raw);
+    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij_raw);
     __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new_raw);
-    __gm__ float* mi_ptr     = reinterpret_cast<__gm__ float*>(mi_raw);
-    __gm__ float* li_ptr     = reinterpret_cast<__gm__ float*>(li_raw);
-    __gm__ float* oi_ptr     = reinterpret_cast<__gm__ float*>(oi_raw);
-    __gm__ float* dst_ptr    = reinterpret_cast<__gm__ float*>(dst_raw);
+    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi_raw);
+    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li_raw);
+    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst_raw);
 
     // Scalar tile dimensions for RowMajor layout:
     // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
@@ -50,12 +54,11 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
 
     // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
-    using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
-                                        Stride<1, 1, 1, kScalarCols, 1>>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
 
     // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
-                                        Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -77,8 +80,8 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     // --- Tile types ---
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
-    using TileScalarND = Tile<TileType::Vec, float, kScalarRows, kScalarCols,
-                              BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     // --- UB memory layout ---
@@ -123,9 +126,9 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Passthrough to MTE3 (no V compute needed)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, mijND);     // mi = mij
-        TSTORE(liGlobalND, lijND);     // li = lij
-        TSTORE(oiGlobal, oiNewTile);   // oi = oi_new
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
 
         if (is_last) {
             // Single block: normalize dst = oi_new / lij
@@ -156,53 +159,53 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
         // pipe_barrier(PIPE_V) required between each dependent vector operation
         // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
+        TMAX(miNewND, miND, mijND);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
+        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
+        TEXP(alphaND, alphaND);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
+        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
+        TEXP(betaND, betaND);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(liND, alphaND, liND);           // li = alpha * li
+        TMUL(liND, alphaND, liND);  // li = alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
+        TMUL(tmpND, betaND, lijND);  // tmp = beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
+        TADD(liND, liND, tmpND);  // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
         // mi_new -> mi accumulator, li_new -> li accumulator
         // alpha -> mij buffer (reuse), beta -> lij buffer (reuse)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, miNewND);         // persist mi_new
-        TSTORE(liGlobalND, liND);            // persist li_new
-        TSTORE(mijGlobalND, alphaND);        // temp: alpha to mij buffer
-        TSTORE(lijGlobalND, betaND);         // temp: beta to lij buffer
+        TSTORE(miGlobalND, miNewND);   // persist mi_new
+        TSTORE(liGlobalND, liND);      // persist li_new
+        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
 
         // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        TLOAD(alphaDN, mijGlobalDN);         // alpha from mij buffer as DN
-        TLOAD(betaDN, lijGlobalDN);          // beta from lij buffer as DN
+        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
         if (is_last) {
-            TLOAD(liDN, liGlobalDN);         // li_new from li buffer as DN
+            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
         }
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
 
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
             pipe_barrier(PIPE_V);
-            TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
+            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             TSTORE(dstGlobal, oiTile);
@@ -216,15 +219,15 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* mij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* lij    = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+    __gm__ uint8_t* mij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mi     = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* li     = reinterpret_cast<__gm__ uint8_t*>(args[4]);
-    __gm__ uint8_t* oi     = reinterpret_cast<__gm__ uint8_t*>(args[5]);
-    int is_first  = static_cast<int>(args[6]);
-    int is_last   = static_cast<int>(args[7]);
-    __gm__ uint8_t* dst    = reinterpret_cast<__gm__ uint8_t*>(args[8]);
+    __gm__ uint8_t* mi = reinterpret_cast<__gm__ uint8_t*>(args[3]);
+    __gm__ uint8_t* li = reinterpret_cast<__gm__ uint8_t*>(args[4]);
+    __gm__ uint8_t* oi = reinterpret_cast<__gm__ uint8_t*>(args[5]);
+    int is_first = static_cast<int>(args[6]);
+    int is_last = static_cast<int>(args[7]);
+    __gm__ uint8_t* dst = reinterpret_cast<__gm__ uint8_t*>(args[8]);
 
     online_update_impl(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
 }

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -21,14 +21,15 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
-                                 __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
-                                 __gm__ uint8_t* lij_raw)
-{
+static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw,
+    float scale_value,
+    __gm__ uint8_t* pij_raw,
+    __gm__ uint8_t* mij_raw,
+    __gm__ uint8_t* lij_raw) {
     constexpr int M = 16, N = 16;
 
     __gm__ float* sij = reinterpret_cast<__gm__ float*>(sij_raw);
-    __gm__ half*  pij = reinterpret_cast<__gm__ half*>(pij_raw);
+    __gm__ half* pij = reinterpret_cast<__gm__ half*>(pij_raw);
     __gm__ float* mij = reinterpret_cast<__gm__ float*>(mij_raw);
     __gm__ float* lij = reinterpret_cast<__gm__ float*>(lij_raw);
 
@@ -83,7 +84,10 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    union { uint64_t u; float f; } scale_conv;
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[1]);
     float scale_value = scale_conv.f;
     __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[2]);

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -19,10 +19,10 @@
 #include <algorithm>
 #include <cstring>
 
-#define FUNC_QK_MATMUL       0
+#define FUNC_QK_MATMUL 0
 #define FUNC_SOFTMAX_PREPARE 1
-#define FUNC_PV_MATMUL       2
-#define FUNC_ONLINE_UPDATE   3
+#define FUNC_PV_MATMUL 2
+#define FUNC_ONLINE_UPDATE 3
 
 extern "C" {
 
@@ -33,27 +33,27 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     }
 
     // Extract host pointers from TaskArg tensor metadata
-    void* host_query       = orch_args[0].data<void>();
-    void* host_key_cache   = orch_args[1].data<void>();
+    void* host_query = orch_args[0].data<void>();
+    void* host_key_cache = orch_args[1].data<void>();
     void* host_value_cache = orch_args[2].data<void>();
-    int*  host_block_table = orch_args[3].data<int>();
-    int*  host_context_lens = orch_args[4].data<int>();
-    void* host_out         = orch_args[5].data<void>();
+    int* host_block_table = orch_args[3].data<int>();
+    int* host_context_lens = orch_args[4].data<int>();
+    void* host_out = orch_args[5].data<void>();
 
     // Extract sizes from TaskArg metadata
-    size_t query_size       = orch_args[0].nbytes();
-    size_t key_cache_size   = orch_args[1].nbytes();
+    size_t query_size = orch_args[0].nbytes();
+    size_t key_cache_size = orch_args[1].nbytes();
     size_t value_cache_size = orch_args[2].nbytes();
-    size_t out_size         = orch_args[5].nbytes();
+    size_t out_size = orch_args[5].nbytes();
 
     // Read dimensions from tensor shapes (uint32_t — matches TaskArg::tensor.shapes type)
     // query: (batch, num_heads, head_dim)
-    uint32_t batch       = orch_args[0].tensor.shapes[0];
-    uint32_t num_heads   = orch_args[0].tensor.shapes[1];
-    uint32_t head_dim    = orch_args[0].tensor.shapes[2];
+    uint32_t batch = orch_args[0].tensor.shapes[0];
+    uint32_t num_heads = orch_args[0].tensor.shapes[1];
+    uint32_t head_dim = orch_args[0].tensor.shapes[2];
 
     // key_cache: (total_blocks, block_size, kv_head_num, head_dim)
-    uint32_t block_size  = orch_args[1].tensor.shapes[1];
+    uint32_t block_size = orch_args[1].tensor.shapes[1];
     uint32_t kv_head_num = orch_args[1].tensor.shapes[2];
 
     // block_table: (batch, max_num_blocks_per_req)
@@ -66,8 +66,8 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     uint32_t num_head_tiles = (num_heads + q_tile_size - 1) / q_tile_size;
 
     std::cout << "\n=== build_paged_attention_graph ===" << '\n';
-    std::cout << "batch=" << batch << ", num_heads=" << num_heads
-              << ", kv_head_num=" << kv_head_num << ", head_dim=" << head_dim << '\n';
+    std::cout << "batch=" << batch << ", num_heads=" << num_heads << ", kv_head_num=" << kv_head_num
+              << ", head_dim=" << head_dim << '\n';
     std::cout << "block_size=" << block_size << ", max_num_blocks=" << max_num_blocks << '\n';
     std::cout << "q_tile_size=" << q_tile_size << ", num_head_tiles=" << num_head_tiles << '\n';
 
@@ -88,25 +88,25 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     runtime->record_tensor_pair(host_out, dev_out, out_size);
 
     // Buffer sizes depend on q_tile_size and block_size
-    size_t sij_size    = static_cast<size_t>(q_tile_size) * block_size * sizeof(float);
-    size_t pij_size    = static_cast<size_t>(q_tile_size) * block_size * sizeof(uint16_t);
-    size_t mij_size    = static_cast<size_t>(q_tile_size) * sizeof(float);
-    size_t lij_size    = mij_size;
+    size_t sij_size = static_cast<size_t>(q_tile_size) * block_size * sizeof(float);
+    size_t pij_size = static_cast<size_t>(q_tile_size) * block_size * sizeof(uint16_t);
+    size_t mij_size = static_cast<size_t>(q_tile_size) * sizeof(float);
+    size_t lij_size = mij_size;
     size_t oi_new_size = static_cast<size_t>(q_tile_size) * head_dim * sizeof(float);
 
     // Per-batch-per-block intermediate buffers
     uint32_t total_buffers = batch * max_num_blocks;
-    void** dev_sij_arr    = new void*[total_buffers];
-    void** dev_pij_arr    = new void*[total_buffers];
-    void** dev_mij_arr    = new void*[total_buffers];
-    void** dev_lij_arr    = new void*[total_buffers];
+    void** dev_sij_arr = new void*[total_buffers];
+    void** dev_pij_arr = new void*[total_buffers];
+    void** dev_mij_arr = new void*[total_buffers];
+    void** dev_lij_arr = new void*[total_buffers];
     void** dev_oi_new_arr = new void*[total_buffers];
 
     for (uint32_t i = 0; i < total_buffers; i++) {
-        dev_sij_arr[i]    = runtime->host_api.device_malloc(sij_size);
-        dev_pij_arr[i]    = runtime->host_api.device_malloc(pij_size);
-        dev_mij_arr[i]    = runtime->host_api.device_malloc(mij_size);
-        dev_lij_arr[i]    = runtime->host_api.device_malloc(lij_size);
+        dev_sij_arr[i] = runtime->host_api.device_malloc(sij_size);
+        dev_pij_arr[i] = runtime->host_api.device_malloc(pij_size);
+        dev_mij_arr[i] = runtime->host_api.device_malloc(mij_size);
+        dev_lij_arr[i] = runtime->host_api.device_malloc(lij_size);
         dev_oi_new_arr[i] = runtime->host_api.device_malloc(oi_new_size);
     }
 
@@ -140,12 +140,12 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
             // Query: (batch, q_head_num, head_dim) fp16
             // qi points to heads [cur_offset .. cur_offset+q_tile_size) for batch b_idx
-            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query)
-                + static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
+            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query) +
+                              static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
 
             // Output: (batch * q_head_num, head_dim) float32
-            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out)
-                + static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
+            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out) +
+                               static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
 
             // GQA: which kv_head this head tile maps to
             uint32_t kv_head_idx = cur_offset / (num_heads / kv_head_num);
@@ -162,56 +162,50 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
                 int cur_block_idx = host_block_table[b_idx * max_num_blocks + bn];
 
                 // Key: (total_blocks, block_size, kv_head_num, head_dim) fp16
-                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache)
-                    + (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx)
-                      * head_dim * sizeof(uint16_t);
+                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache) +
+                                  (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
+                                      head_dim * sizeof(uint16_t);
 
                 // Value: (total_blocks, block_size, kv_head_num, head_dim) fp16
-                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache)
-                    + (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx)
-                      * head_dim * sizeof(uint16_t);
+                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache) +
+                                  (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
+                                      head_dim * sizeof(uint16_t);
 
                 uint32_t buf_idx = b_idx * max_num_blocks + bn;
-                void* dev_sij    = dev_sij_arr[buf_idx];
-                void* dev_pij    = dev_pij_arr[buf_idx];
-                void* dev_mij    = dev_mij_arr[buf_idx];
-                void* dev_lij    = dev_lij_arr[buf_idx];
+                void* dev_sij = dev_sij_arr[buf_idx];
+                void* dev_pij = dev_pij_arr[buf_idx];
+                void* dev_mij = dev_mij_arr[buf_idx];
+                void* dev_lij = dev_lij_arr[buf_idx];
                 void* dev_oi_new = dev_oi_new_arr[buf_idx];
 
                 // QK: qi(M, K) @ kj.T(K, N) -> sij(M, N)
-                uint64_t qk_args[6] = {
-                    reinterpret_cast<uint64_t>(qi_ptr),
+                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),
                     reinterpret_cast<uint64_t>(kj_ptr),
                     reinterpret_cast<uint64_t>(dev_sij),
                     static_cast<uint64_t>(q_tile_size),
                     static_cast<uint64_t>(head_dim),
-                    static_cast<uint64_t>(block_size)
-                };
+                    static_cast<uint64_t>(block_size)};
                 int t_qk = runtime->add_task(qk_args, 6, FUNC_QK_MATMUL, CoreType::AIC);
                 total_tasks++;
 
                 // SF: scale, rowmax, exp, rowsum -> pij, mij, lij
-                uint64_t sf_args[7] = {
-                    reinterpret_cast<uint64_t>(dev_sij),
+                uint64_t sf_args[7] = {reinterpret_cast<uint64_t>(dev_sij),
                     scale_value_bits,
                     reinterpret_cast<uint64_t>(dev_pij),
                     reinterpret_cast<uint64_t>(dev_mij),
                     reinterpret_cast<uint64_t>(dev_lij),
                     static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size)
-                };
+                    static_cast<uint64_t>(block_size)};
                 int t_sf = runtime->add_task(sf_args, 7, FUNC_SOFTMAX_PREPARE, CoreType::AIV);
                 total_tasks++;
 
                 // PV: pij(M, K') @ vj(K', N') -> oi_new(M, N')
-                uint64_t pv_args[6] = {
-                    reinterpret_cast<uint64_t>(dev_pij),
+                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),
                     reinterpret_cast<uint64_t>(vj_ptr),
                     reinterpret_cast<uint64_t>(dev_oi_new),
                     static_cast<uint64_t>(q_tile_size),
                     static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(head_dim)
-                };
+                    static_cast<uint64_t>(head_dim)};
                 int t_pv = runtime->add_task(pv_args, 6, FUNC_PV_MATMUL, CoreType::AIC);
                 total_tasks++;
 
@@ -220,10 +214,9 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
                 // Online Update: serialized across blocks (each depends on previous)
                 int is_first = (bn == 0) ? 1 : 0;
-                int is_last  = (bn == bn_this_batch - 1) ? 1 : 0;
+                int is_last = (bn == bn_this_batch - 1) ? 1 : 0;
 
-                uint64_t up_args[11] = {
-                    reinterpret_cast<uint64_t>(dev_mij),
+                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),
                     reinterpret_cast<uint64_t>(dev_lij),
                     reinterpret_cast<uint64_t>(dev_oi_new),
                     reinterpret_cast<uint64_t>(dev_mi),
@@ -233,8 +226,7 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
                     static_cast<uint64_t>(is_last),
                     reinterpret_cast<uint64_t>(out_ptr),
                     static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim)
-                };
+                    static_cast<uint64_t>(head_dim)};
                 int t_up = runtime->add_task(up_args, 11, FUNC_ONLINE_UPDATE, CoreType::AIV);
                 total_tasks++;
 
@@ -261,5 +253,4 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
     return 0;
 }
-
 }

--- a/examples/a2a3/host_build_graph/vector_example/kernels/orchestration/example_orch.cpp
+++ b/examples/a2a3/host_build_graph/vector_example/kernels/orchestration/example_orch.cpp
@@ -99,25 +99,25 @@ int build_example_graph(Runtime* runtime, const TaskArg* orch_args, int arg_coun
     args_t0[0] = reinterpret_cast<uint64_t>(dev_a);  // src0
     args_t0[1] = reinterpret_cast<uint64_t>(dev_b);  // src1
     args_t0[2] = reinterpret_cast<uint64_t>(dev_c);  // out
-    args_t0[3] = SIZE;                                // size
+    args_t0[3] = SIZE;                               // size
     int t0 = runtime->add_task(args_t0, 4, 0, CoreType::AIV);
 
     // Task 1: d = c + 1 (func_id=1: kernel_add_scalar, AIV)
     uint64_t args_t1[4];
     args_t1[0] = reinterpret_cast<uint64_t>(dev_c);  // src
     scalar_converter.f32 = 1.0f;
-    args_t1[1] = scalar_converter.u64;                // scalar=1.0
+    args_t1[1] = scalar_converter.u64;               // scalar=1.0
     args_t1[2] = reinterpret_cast<uint64_t>(dev_d);  // out
-    args_t1[3] = SIZE;                                // size
+    args_t1[3] = SIZE;                               // size
     int t1 = runtime->add_task(args_t1, 4, 1, CoreType::AIV);
 
     // Task 2: e = c + 2 (func_id=1: kernel_add_scalar, AIV)
     uint64_t args_t2[4];
     args_t2[0] = reinterpret_cast<uint64_t>(dev_c);  // src
     scalar_converter.f32 = 2.0f;
-    args_t2[1] = scalar_converter.u64;                // scalar=2.0
+    args_t2[1] = scalar_converter.u64;               // scalar=2.0
     args_t2[2] = reinterpret_cast<uint64_t>(dev_e);  // out
-    args_t2[3] = SIZE;                                // size
+    args_t2[3] = SIZE;                               // size
     int t2 = runtime->add_task(args_t2, 4, 1, CoreType::AIV);
 
     // Task 3: f = d * e (func_id=2: kernel_mul, AIV)
@@ -125,7 +125,7 @@ int build_example_graph(Runtime* runtime, const TaskArg* orch_args, int arg_coun
     args_t3[0] = reinterpret_cast<uint64_t>(dev_d);  // src0
     args_t3[1] = reinterpret_cast<uint64_t>(dev_e);  // src1
     args_t3[2] = reinterpret_cast<uint64_t>(dev_f);  // out
-    args_t3[3] = SIZE;                                // size
+    args_t3[3] = SIZE;                               // size
     int t3 = runtime->add_task(args_t3, 4, 2, CoreType::AIV);
 
     // Add dependencies

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -21,8 +21,7 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_batch_impl(
-    __gm__ Tensor* pij_batch,
+static __aicore__ void pv_matmul_batch_impl(__gm__ Tensor* pij_batch,
     __gm__ Tensor* value_cache,
     __gm__ Tensor* oi_new_batch,
     uint64_t block_table_ptr,
@@ -30,7 +29,6 @@ static __aicore__ void pv_matmul_batch_impl(
     uint64_t block_idx,
     uint64_t block_num,
     uint64_t batch_start) {
-
     __gm__ half* pij_base = reinterpret_cast<__gm__ half*>(pij_batch->buffer.addr);
     __gm__ half* val_base = reinterpret_cast<__gm__ half*>(value_cache->buffer.addr);
     __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new_batch->buffer.addr);
@@ -106,6 +104,5 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t batch_start = static_cast<uint64_t>(args[7]);
 
     pv_matmul_batch_impl<16, 16, 16>(
-        pij_batch, value_cache, oi_new_batch,
-        block_table_ptr, batch_count, block_idx, block_num, batch_start);
+        pij_batch, value_cache, oi_new_batch, block_table_ptr, batch_count, block_idx, block_num, batch_start);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -21,8 +21,7 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_batch_impl(
-    __gm__ Tensor* query,
+static __aicore__ void qk_matmul_batch_impl(__gm__ Tensor* query,
     __gm__ Tensor* key_cache,
     __gm__ Tensor* sij_batch,
     uint64_t block_table_ptr,
@@ -32,7 +31,6 @@ static __aicore__ void qk_matmul_batch_impl(
     uint64_t block_num,
     uint64_t num_heads,
     uint64_t batch_start) {
-
     __gm__ half* query_base = reinterpret_cast<__gm__ half*>(query->buffer.addr);
     __gm__ half* key_base = reinterpret_cast<__gm__ half*>(key_cache->buffer.addr);
     __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_batch->buffer.addr);
@@ -109,8 +107,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t num_heads = static_cast<uint64_t>(args[8]);
     uint64_t batch_start = static_cast<uint64_t>(args[9]);
 
-    qk_matmul_batch_impl<16, 16, 16>(
-        query, key_cache, sij_batch,
-        block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
+    qk_matmul_batch_impl<16, 16, 16>(query,
+        key_cache,
+        sij_batch,
+        block_table_ptr,
+        batch_count,
+        block_idx,
+        q_offset,
+        block_num,
+        num_heads,
         batch_start);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -26,8 +26,7 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_batch_impl(
-    __gm__ Tensor* mij_batch,
+static __aicore__ void online_update_batch_impl(__gm__ Tensor* mij_batch,
     __gm__ Tensor* lij_batch,
     __gm__ Tensor* oi_new_batch,
     __gm__ Tensor* mi_batch,
@@ -40,7 +39,6 @@ static __aicore__ void online_update_batch_impl(
     uint64_t q_offset,
     uint64_t num_heads,
     uint64_t batch_start) {
-
     __gm__ float* mij_base = reinterpret_cast<__gm__ float*>(mij_batch->buffer.addr);
     __gm__ float* lij_base = reinterpret_cast<__gm__ float*>(lij_batch->buffer.addr);
     __gm__ float* oi_new_base = reinterpret_cast<__gm__ float*>(oi_new_batch->buffer.addr);
@@ -217,8 +215,17 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t num_heads = static_cast<uint64_t>(args[11]);
     uint64_t batch_start = static_cast<uint64_t>(args[12]);
 
-    online_update_batch_impl<16, 16>(
-        mij_batch, lij_batch, oi_new_batch,
-        mi_batch, li_batch, oi_batch, out,
-        is_first, is_last, batch_count, q_offset, num_heads, batch_start);
+    online_update_batch_impl<16, 16>(mij_batch,
+        lij_batch,
+        oi_new_batch,
+        mi_batch,
+        li_batch,
+        oi_batch,
+        out,
+        is_first,
+        is_last,
+        batch_count,
+        q_offset,
+        num_heads,
+        batch_start);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -25,8 +25,7 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_batch_impl(
-    __gm__ Tensor* sij_batch,
+static __aicore__ void softmax_prepare_batch_impl(__gm__ Tensor* sij_batch,
     __gm__ Tensor* pij_batch,
     __gm__ Tensor* mij_batch,
     __gm__ Tensor* lij_batch,
@@ -35,7 +34,6 @@ static __aicore__ void softmax_prepare_batch_impl(
     uint64_t batch_count,
     uint64_t block_idx,
     uint64_t batch_start) {
-
     __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_batch->buffer.addr);
     __gm__ half* pij_base = reinterpret_cast<__gm__ half*>(pij_batch->buffer.addr);
     __gm__ float* mij_base = reinterpret_cast<__gm__ float*>(mij_batch->buffer.addr);
@@ -151,7 +149,10 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* pij_batch = reinterpret_cast<__gm__ Tensor*>(args[1]);
     __gm__ Tensor* mij_batch = reinterpret_cast<__gm__ Tensor*>(args[2]);
     __gm__ Tensor* lij_batch = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    union { uint64_t u; float f; } scale_conv;
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[4]);
     float scale_value = scale_conv.f;
     uint64_t context_lens_ptr = static_cast<uint64_t>(args[5]);
@@ -160,6 +161,5 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t batch_start = static_cast<uint64_t>(args[8]);
 
     softmax_prepare_batch_impl<16, 16>(
-        sij_batch, pij_batch, mij_batch, lij_batch,
-        scale_value, context_lens_ptr, batch_count, block_idx, batch_start);
+        sij_batch, pij_batch, mij_batch, lij_batch, scale_value, context_lens_ptr, batch_count, block_idx, batch_start);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -25,24 +25,23 @@
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     // Read dimensions from TaskArg tensor metadata
-    uint64_t batch     = orch_args[0].tensor.shapes[0];
+    uint64_t batch = orch_args[0].tensor.shapes[0];
     uint64_t num_heads = orch_args[0].tensor.shapes[1];
-    uint64_t head_dim  = orch_args[0].tensor.shapes[2];
+    uint64_t head_dim = orch_args[0].tensor.shapes[2];
     DataType data_type = orch_args[0].tensor.dtype;
 
     uint64_t block_size = orch_args[1].tensor.shapes[1];
-    uint64_t block_num  = orch_args[3].tensor.shapes[1];
+    uint64_t block_num = orch_args[3].tensor.shapes[1];
 
     uint64_t scale_value = orch_args[6].scalar;
 
@@ -50,10 +49,9 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
     uint64_t q_loop = (num_heads + q_tile - 1) / q_tile;
     uint64_t elem_size = get_element_size(data_type);
 
-    LOG_INFO("batch_paged_attention: batch=%lu, num_heads=%lu",
-             (unsigned long)batch, (unsigned long)num_heads);
+    LOG_INFO("batch_paged_attention: batch=%lu, num_heads=%lu", (unsigned long)batch, (unsigned long)num_heads);
 
-    int* host_block_table  = orch_args[3].data<int>();
+    int* host_block_table = orch_args[3].data<int>();
     int* host_context_lens = orch_args[4].data<int>();
 
     uint64_t max_bn = 0;
@@ -65,9 +63,9 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
 
     // Reshape tensors for kernel consumption (2D flattened)
     void* query_ptr = orch_args[0].data<void>();
-    void* kc_ptr    = orch_args[1].data<void>();
-    void* vc_ptr    = orch_args[2].data<void>();
-    void* out_ptr   = orch_args[5].data<void>();
+    void* kc_ptr = orch_args[1].data<void>();
+    void* vc_ptr = orch_args[2].data<void>();
+    void* out_ptr = orch_args[5].data<void>();
 
     uint64_t total_blocks_count = orch_args[1].tensor.shapes[0];
     uint64_t kv_total_rows = total_blocks_count * block_size;
@@ -179,9 +177,11 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
     }
 
     LOG_INFO("batch_paged_attention: %lu tasks (batch=%lu, max_bn=%lu, chunks=%lu, IN_CORE_BATCH=%lu)",
-             (unsigned long)(num_chunks * (1 + max_bn * 4)),
-             (unsigned long)batch, (unsigned long)max_bn,
-             (unsigned long)num_chunks, (unsigned long)IN_CORE_BATCH);
+        (unsigned long)(num_chunks * (1 + max_bn * 4)),
+        (unsigned long)batch,
+        (unsigned long)max_bn,
+        (unsigned long)num_chunks,
+        (unsigned long)IN_CORE_BATCH);
 }
 
 }  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -36,13 +36,10 @@ AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
 }
 
 static __aicore__ void gemm_tile_impl(
-    __gm__ Tensor* input_a_tensor,
-    __gm__ Tensor* input_b_tensor,
-    __gm__ Tensor* output_tensor) {
-
+    __gm__ Tensor* input_a_tensor, __gm__ Tensor* input_b_tensor, __gm__ Tensor* output_tensor) {
     __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
     __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
-    __gm__ float* output  = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr)  + output_tensor->start_offset;
+    __gm__ float* output = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr) + output_tensor->start_offset;
 
     constexpr int TILE = 64;
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
@@ -50,12 +47,12 @@ static __aicore__ void gemm_tile_impl(
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);
@@ -106,7 +103,7 @@ static __aicore__ void gemm_tile_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* input_a = reinterpret_cast<__gm__ Tensor*>(args[0]);
     __gm__ Tensor* input_b = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* output  = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ Tensor* output = reinterpret_cast<__gm__ Tensor*>(args[2]);
 
     gemm_tile_impl(input_a, input_b, output);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -29,7 +29,7 @@
 #include "pto_orchestration_api.h"
 
 #define FUNC_GEMM_TILE 0
-#define FUNC_TILE_ADD  1
+#define FUNC_TILE_ADD 1
 
 // Grid and tile constants
 static constexpr int TILE = 64;
@@ -38,20 +38,19 @@ static constexpr int GRID_K = 4;
 static constexpr int GRID_N = 4;
 static constexpr int BATCH = 2;
 
-static constexpr uint32_t TILE_ELEMS = TILE * TILE;           // 4096 elements
+static constexpr uint32_t TILE_ELEMS = TILE * TILE;  // 4096 elements
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 
@@ -60,8 +59,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
     Tensor ext_B = from_task_arg(orch_args[1]);
     Tensor ext_C = from_task_arg(orch_args[2]);
 
-    LOG_INFO("[bgemm_orch] Grid: %dx%dx%d, Batch: %d, Tile: %d",
-                  GRID_M, GRID_K, GRID_N, BATCH, TILE);
+    LOG_INFO("[bgemm_orch] Grid: %dx%dx%d, Batch: %d, Tile: %d", GRID_M, GRID_K, GRID_N, BATCH, TILE);
 
     uint32_t tile_shapes[1] = {TILE_ELEMS};
 
@@ -70,21 +68,17 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
             for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
                 PTO2_SCOPE() {
                     uint32_t c_elem_offset =
-                        ((uint32_t)batch * GRID_M * GRID_N +
-                         (uint32_t)m_idx * GRID_N +
-                         (uint32_t)n_idx) * TILE_ELEMS;
+                        ((uint32_t)batch * GRID_M * GRID_N + (uint32_t)m_idx * GRID_N + (uint32_t)n_idx) * TILE_ELEMS;
                     uint32_t c_view_offsets[1] = {c_elem_offset};
                     Tensor C_view = ext_C.view(tile_shapes, c_view_offsets);
 
                     for (int k_idx = 0; k_idx < GRID_K; k_idx++) {
                         uint32_t a_elem_offset =
-                            ((uint32_t)batch * GRID_M * GRID_K +
-                             (uint32_t)m_idx * GRID_K +
-                             (uint32_t)k_idx) * TILE_ELEMS;
+                            ((uint32_t)batch * GRID_M * GRID_K + (uint32_t)m_idx * GRID_K + (uint32_t)k_idx) *
+                            TILE_ELEMS;
                         uint32_t b_elem_offset =
-                            ((uint32_t)batch * GRID_K * GRID_N +
-                             (uint32_t)k_idx * GRID_N +
-                             (uint32_t)n_idx) * TILE_ELEMS;
+                            ((uint32_t)batch * GRID_K * GRID_N + (uint32_t)k_idx * GRID_N + (uint32_t)n_idx) *
+                            TILE_ELEMS;
 
                         uint32_t a_view_offsets[1] = {a_elem_offset};
                         Tensor A_view = ext_A.view(tile_shapes, a_view_offsets);
@@ -98,14 +92,14 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
                         params_gemm.add_input(B_view);
                         params_gemm.add_output(P);
                         pto2_rt_submit_aic_task(FUNC_GEMM_TILE,
-                                           params_gemm); // gemm
+                            params_gemm);  // gemm
 
                         // C[m,n] += P
                         PTOParam params_add;
                         params_add.add_inout(C_view);
                         params_add.add_input(P);
                         pto2_rt_submit_aiv_task(FUNC_TILE_ADD,
-                                           params_add); // add
+                            params_add);  // add
                     }
                 }
             }
@@ -113,7 +107,10 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
     }
 
     LOG_INFO("[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each",
-                  BATCH, GRID_M, GRID_N, GRID_K);
+        BATCH,
+        GRID_M,
+        GRID_N,
+        GRID_K);
 }
 
 }  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
@@ -41,21 +41,20 @@ static __aicore__ inline int get_num_tiles(__gm__ Tensor* tensor, uint64_t tile_
 }
 
 template <int TILE>
-static __aicore__ void matmul_impl(
-    __gm__ float* input_a,
-    __gm__ float* input_b,
-    __gm__ float* output) {
-
+static __aicore__ void matmul_impl(__gm__ float* input_a, __gm__ float* input_b, __gm__ float* output) {
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
     constexpr int M = CeilAlign<int>(TILE, 16);
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+    using GlobalDataA = GlobalTensor<float,
+        Shape<1, 1, 1, TILE, TILE>,
         pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+    using GlobalDataB = GlobalTensor<float,
+        Shape<1, 1, 1, TILE, TILE>,
         pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
+    using GlobalDataC = GlobalTensor<float,
+        Shape<1, 1, 1, TILE, TILE>,
         pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
@@ -107,7 +106,7 @@ static __aicore__ void matmul_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* input_a = reinterpret_cast<__gm__ Tensor*>(args[0]);
     __gm__ Tensor* input_b = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* output  = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ Tensor* output = reinterpret_cast<__gm__ Tensor*>(args[2]);
 
     constexpr uint64_t TILE_ELEMS = 128 * 128;
     int num_tiles = get_num_tiles(input_a, TILE_ELEMS);

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
@@ -34,11 +34,7 @@ static __aicore__ inline int get_num_tiles(__gm__ Tensor* tensor, uint64_t tile_
 }
 
 template <int ROWS, int COLS>
-static __aicore__ void add_impl(
-    __gm__ float* src0,
-    __gm__ float* src1,
-    __gm__ float* out) {
-
+static __aicore__ void add_impl(__gm__ float* src0, __gm__ float* src1, __gm__ float* out) {
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
@@ -28,11 +28,7 @@ using namespace pto;
 #endif
 
 template <int ROWS, int COLS>
-static __aicore__ void add_impl(
-    __gm__ float* src0,
-    __gm__ float* src1,
-    __gm__ float* out) {
-
+static __aicore__ void add_impl(__gm__ float* src0, __gm__ float* src1, __gm__ float* out) {
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
@@ -35,11 +35,7 @@ static __aicore__ inline int get_num_tiles(__gm__ Tensor* tensor, uint64_t tile_
 }
 
 template <int ROWS, int COLS>
-static __aicore__ void mul_impl(
-    __gm__ float* src0,
-    __gm__ float* src1,
-    __gm__ float* out) {
-
+static __aicore__ void mul_impl(__gm__ float* src0, __gm__ float* src1, __gm__ float* out) {
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
@@ -28,11 +28,7 @@ using namespace pto;
 #endif
 
 template <int ROWS, int COLS>
-static __aicore__ void mul_impl(
-    __gm__ float* src0,
-    __gm__ float* src1,
-    __gm__ float* out) {
-
+static __aicore__ void mul_impl(__gm__ float* src0, __gm__ float* src1, __gm__ float* out) {
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -19,27 +19,26 @@
 #include "pto_orchestration_api.h"
 
 // Mixed-task kernels (args offset matches param position in mixed param list)
-#define FUNC_MATMUL         0   // AIC: reads args[0..2]
-#define FUNC_ADD            1   // AIV0 in mixed: reads args[3..5]
-#define FUNC_MUL            2   // AIV1 in mixed: reads args[6..8]
+#define FUNC_MATMUL 0  // AIC: reads args[0..2]
+#define FUNC_ADD 1     // AIV0 in mixed: reads args[3..5]
+#define FUNC_MUL 2     // AIV1 in mixed: reads args[6..8]
 // Standalone kernels (read args[0..2] or args[3..5])
-#define FUNC_ADD_STANDALONE 3   // AIV: reads args[0..2]
-#define FUNC_MUL_STANDALONE 4   // AIV1 in AIV_X2: reads args[3..5]
+#define FUNC_ADD_STANDALONE 3  // AIV: reads args[0..2]
+#define FUNC_MUL_STANDALONE 4  // AIV1 in AIV_X2: reads args[3..5]
 
 static constexpr uint32_t TILE_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 15,
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -29,11 +29,8 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
-    float scale_value,
-    __gm__ Tensor* pij,
-    __gm__ Tensor* mij,
-    __gm__ Tensor* lij) {
+static __aicore__ void softmax_prepare_impl(
+    __gm__ Tensor* sij, float scale_value, __gm__ Tensor* pij, __gm__ Tensor* mij, __gm__ Tensor* lij) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
     __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
     __gm__ half* pij_addr = reinterpret_cast<__gm__ half*>(pij->buffer.addr);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -27,25 +27,24 @@
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     // Read dimensions from TaskArg tensor metadata
     // query: shape=[batch, num_heads, head_dim]
-    uint64_t batch     = orch_args[0].tensor.shapes[0];
+    uint64_t batch = orch_args[0].tensor.shapes[0];
     uint64_t num_heads = orch_args[0].tensor.shapes[1];
-    uint64_t head_dim  = orch_args[0].tensor.shapes[2];
+    uint64_t head_dim = orch_args[0].tensor.shapes[2];
     DataType data_type = orch_args[0].tensor.dtype;
 
     // key_cache: shape=[total_blocks, block_size, kv_head_num, head_dim]
-    uint64_t block_size  = orch_args[1].tensor.shapes[1];
+    uint64_t block_size = orch_args[1].tensor.shapes[1];
 
     // block_table: shape=[batch, max_num_blocks_per_req]
     uint64_t block_num = orch_args[3].tensor.shapes[1];
@@ -63,14 +62,17 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
     uint64_t b_end = batch * (orch_thread_index + 1) / orch_thread_num;
 
     LOG_INFO("orch_idx=%d/%d batch=%lu b_range=[%lu,%lu)",
-             orch_thread_index, orch_thread_num,
-             (unsigned long)batch, (unsigned long)b_start, (unsigned long)b_end);
+        orch_thread_index,
+        orch_thread_num,
+        (unsigned long)batch,
+        (unsigned long)b_start,
+        (unsigned long)b_end);
 
     // Reshape tensors for kernel consumption (2D flattened)
     void* query_ptr = orch_args[0].data<void>();
-    void* kc_ptr    = orch_args[1].data<void>();
-    void* vc_ptr    = orch_args[2].data<void>();
-    void* out_ptr   = orch_args[5].data<void>();
+    void* kc_ptr = orch_args[1].data<void>();
+    void* vc_ptr = orch_args[2].data<void>();
+    void* out_ptr = orch_args[5].data<void>();
 
     // Compute kv_total_rows from key_cache tensor metadata
     uint64_t total_blocks_count = orch_args[1].tensor.shapes[0];
@@ -89,7 +91,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
     LOG_DEBUG("value_cache=%s", value_cache.dump().c_str());
     LOG_DEBUG("out=%s", out.dump().c_str());
 
-    int* host_block_table  = orch_args[3].data<int>();
+    int* host_block_table = orch_args[3].data<int>();
     int* host_context_lens = orch_args[4].data<int>();
 
     for (uint64_t b_idx = b_start; b_idx < b_end; b_idx++) {
@@ -116,11 +118,12 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
                 params_inplace.add_output(oi);
                 params_inplace.add_output(li_update);
                 params_inplace.add_output(mi_update);
-                pto2_rt_submit_aiv_task(FUNC_AIV_HUB, params_inplace); // create_inplace
+                pto2_rt_submit_aiv_task(FUNC_AIV_HUB, params_inplace);  // create_inplace
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
                     uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
-                    uint64_t valid_len = block_size < (cur_seq - bn * block_size) ? block_size : (cur_seq - bn * block_size);
+                    uint64_t valid_len =
+                        block_size < (cur_seq - bn * block_size) ? block_size : (cur_seq - bn * block_size);
                     uint32_t kv_shapes[2] = {(uint32_t)block_size, (uint32_t)head_dim};
                     uint32_t kv_offsets[2] = {(uint32_t)(cur_block_idx * block_size), 0};
                     Tensor kj = key_cache.view(kv_shapes, kv_offsets);
@@ -134,7 +137,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
                     params_qk.add_input(qi);
                     params_qk.add_input(kj);
                     params_qk.add_output(sij);
-                    pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk); // c1
+                    pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);  // c1
 
                     uint32_t sij_valid_shapes[2] = {(uint32_t)q_tile, (uint32_t)valid_len};
                     uint32_t sij_valid_offsets[2] = {0, 0};
@@ -147,7 +150,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
                     params_sf.add_output(mi);
                     params_sf.add_output(li);
                     params_sf.add_scalar(scale_value);
-                    pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf); // v1
+                    pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);  // v1
 
                     uint32_t oi_tmp_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
                     Tensor oi_tmp = make_tensor(oi_tmp_shapes, 2, DataType::FLOAT32);
@@ -156,7 +159,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(oi_tmp);
-                    pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv); // c2
+                    pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);  // c2
 
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
@@ -171,15 +174,17 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
                     params_up.add_output(out_view);
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
-                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up); // v2
+                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);  // v2
                 }
             }
         }
     }
 
     LOG_INFO("orch_idx=%d: tasks submitted for batch=[%lu,%lu), num_heads=%lu",
-                  orch_thread_index, (unsigned long)b_start, (unsigned long)b_end,
-                  (unsigned long)num_heads);
+        orch_thread_index,
+        (unsigned long)b_start,
+        (unsigned long)b_end,
+        (unsigned long)num_heads);
 }
 
 }  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp
@@ -73,7 +73,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    
+
     set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -75,7 +75,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    
+
     set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_mul.cpp
@@ -73,7 +73,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    
+
     set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -40,8 +40,7 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
@@ -53,8 +52,8 @@ PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
  * The executor wraps this call in PTO2_SCOPE, so we are already inside
  * the outer scope on entry.
  */
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 
@@ -74,7 +73,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
     params_t0.add_output(c);
-    pto2_rt_submit_aiv_task(0, params_t0); // kernel_add
+    pto2_rt_submit_aiv_task(0, params_t0);  // kernel_add
 
     // Inner scope: owns t1, t2, t3, t4; intermediates d, e, g release on scope end.
     // c flows in from outer scope (outer-scope tensors are visible to inner scopes).
@@ -89,7 +88,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
         params_t1.add_output(d);
         params_t1.add_scalar(float_to_u64(1.0f));
         params_t1.add_scalar((uint64_t)3);
-        pto2_rt_submit_aiv_task(1, params_t1); // kernel_add_scalar
+        pto2_rt_submit_aiv_task(1, params_t1);  // kernel_add_scalar
 
         // t2: e = c + 2 (kernel_id=1, kernel_add_scalar)
         PTOParam params_t2;
@@ -97,7 +96,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
         params_t2.add_output(e);
         params_t2.add_scalar(float_to_u64(2.0f));
         params_t2.add_scalar((uint64_t)3);
-        pto2_rt_submit_aiv_task(1, params_t2); // kernel_add_scalar
+        pto2_rt_submit_aiv_task(1, params_t2);  // kernel_add_scalar
 
         // t3: g = d * e (kernel_id=2, kernel_mul)
         PTOParam params_t3;
@@ -105,14 +104,14 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
         params_t3.add_input(e);
         params_t3.add_output(g);
         params_t3.add_scalar((uint64_t)3);
-        pto2_rt_submit_aiv_task(2, params_t3); // kernel_mul
+        pto2_rt_submit_aiv_task(2, params_t3);  // kernel_mul
 
         // t4: f = g + c (kernel_id=0, kernel_add)
         PTOParam params_t4;
         params_t4.add_input(g);
         params_t4.add_input(c);
         params_t4.add_output(ext_f);
-        pto2_rt_submit_aiv_task(0, params_t4); // kernel_add
+        pto2_rt_submit_aiv_task(0, params_t4);  // kernel_add
     }  // inner scope ends: releases d, e, g
 }
 

--- a/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -19,21 +19,20 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw)
-{
+static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw) {
     constexpr int M = 16, K = 16, N = 16;
 
     __gm__ half* pij = reinterpret_cast<__gm__ half*>(pij_raw);
-    __gm__ half* vj  = reinterpret_cast<__gm__ half*>(vj_raw);
-    __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ half* vj = reinterpret_cast<__gm__ half*>(vj_raw);
+    __gm__ float* oi = reinterpret_cast<__gm__ float*>(oi_raw);
 
     // pij (M, K) fp16, vj (K, N) fp16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, pto::Stride<M*K, M*K, M*K, K, 1>>;
-    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, pto::Stride<K*N, K*N, K*N, N, 1>>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   pijGlobal(pij);
-    GlobalB   vjGlobal(vj);
+    GlobalA pijGlobal(pij);
+    GlobalB vjGlobal(vj);
     GlobalOut oiGlobal(oi);
 
     // L1 Mat tiles: standard ND pattern for both A and B
@@ -41,18 +40,18 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<half, M, K, M, K>;
+    using LeftTile = TileLeft<half, M, K, M, K>;
     using RightTile = TileRight<half, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -80,10 +79,9 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     TSTORE(oiGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* pij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* vj     = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* vj = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
 
     pv_matmul_impl(pij, vj, oi_new);

--- a/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -19,22 +19,21 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw)
-{
+static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw) {
     constexpr int M = 16, K = 16, N = 16;
 
-    __gm__ half* qi  = reinterpret_cast<__gm__ half*>(qi_raw);
-    __gm__ half* kj  = reinterpret_cast<__gm__ half*>(kj_raw);
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+    __gm__ half* qi = reinterpret_cast<__gm__ half*>(qi_raw);
+    __gm__ half* kj = reinterpret_cast<__gm__ half*>(kj_raw);
+    __gm__ float* sij = reinterpret_cast<__gm__ float*>(sij_raw);
 
     // qi (M, K) fp16 in ND (row-major) layout
-    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, pto::Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, pto::Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   qiGlobal(qi);
-    GlobalB   kjGlobal(kj);
+    GlobalA qiGlobal(qi);
+    GlobalB kjGlobal(kj);
     GlobalOut sijGlobal(sij);
 
     // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
@@ -42,18 +41,18 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<half, M, K, M, K>;
+    using LeftTile = TileLeft<half, M, K, M, K>;
     using RightTile = TileRight<half, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -81,10 +80,9 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     TSTORE(sijGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* qi  = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* kj  = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ uint8_t* qi = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* kj = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
 
     qk_matmul_impl(qi, kj, sij);

--- a/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -21,20 +21,24 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_t* lij_raw,
-                               __gm__ uint8_t* oi_new_raw, __gm__ uint8_t* mi_raw,
-                               __gm__ uint8_t* li_raw, __gm__ uint8_t* oi_raw,
-                               int is_first, int is_last, __gm__ uint8_t* dst_raw)
-{
+static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw,
+    __gm__ uint8_t* lij_raw,
+    __gm__ uint8_t* oi_new_raw,
+    __gm__ uint8_t* mi_raw,
+    __gm__ uint8_t* li_raw,
+    __gm__ uint8_t* oi_raw,
+    int is_first,
+    int is_last,
+    __gm__ uint8_t* dst_raw) {
     constexpr int M = 16, N = 16;
 
-    __gm__ float* mij_ptr    = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float* lij_ptr    = reinterpret_cast<__gm__ float*>(lij_raw);
+    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij_raw);
+    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij_raw);
     __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new_raw);
-    __gm__ float* mi_ptr     = reinterpret_cast<__gm__ float*>(mi_raw);
-    __gm__ float* li_ptr     = reinterpret_cast<__gm__ float*>(li_raw);
-    __gm__ float* oi_ptr     = reinterpret_cast<__gm__ float*>(oi_raw);
-    __gm__ float* dst_ptr    = reinterpret_cast<__gm__ float*>(dst_raw);
+    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi_raw);
+    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li_raw);
+    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst_raw);
 
     // Scalar tile dimensions for RowMajor layout:
     // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
@@ -50,12 +54,11 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<1, 1, 1, N, 1>>;
 
     // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
-    using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
-                                        pto::Stride<1, 1, 1, kScalarCols, 1>>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, pto::Stride<1, 1, 1, kScalarCols, 1>>;
 
     // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
-                                        pto::Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, pto::Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -77,8 +80,8 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     // --- Tile types ---
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
-    using TileScalarND = Tile<TileType::Vec, float, kScalarRows, kScalarCols,
-                              BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     // --- UB memory layout ---
@@ -123,9 +126,9 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Passthrough to MTE3 (no V compute needed)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, mijND);     // mi = mij
-        TSTORE(liGlobalND, lijND);     // li = lij
-        TSTORE(oiGlobal, oiNewTile);   // oi = oi_new
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
 
         if (is_last) {
             // Single block: normalize dst = oi_new / lij
@@ -155,44 +158,44 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
 
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
         // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
-        TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
-        TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
-        TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
-        TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
-        TMUL(liND, alphaND, liND);           // li = alpha * li
-        TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
-        TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
+        TMAX(miNewND, miND, mijND);    // mi_new = max(mi, mij)
+        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
+        TEXP(alphaND, alphaND);        // alpha = exp(mi - mi_new)
+        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
+        TEXP(betaND, betaND);          // beta = exp(mij - mi_new)
+        TMUL(liND, alphaND, liND);     // li = alpha * li
+        TMUL(tmpND, betaND, lijND);    // tmp = beta * lij
+        TADD(liND, liND, tmpND);       // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
         // mi_new -> mi accumulator, li_new -> li accumulator
         // alpha -> mij buffer (reuse), beta -> lij buffer (reuse)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, miNewND);         // persist mi_new
-        TSTORE(liGlobalND, liND);            // persist li_new
-        TSTORE(mijGlobalND, alphaND);        // temp: alpha to mij buffer
-        TSTORE(lijGlobalND, betaND);         // temp: beta to lij buffer
+        TSTORE(miGlobalND, miNewND);   // persist mi_new
+        TSTORE(liGlobalND, liND);      // persist li_new
+        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
 
         // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        TLOAD(alphaDN, mijGlobalDN);         // alpha from mij buffer as DN
-        TLOAD(betaDN, lijGlobalDN);          // beta from lij buffer as DN
+        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
         if (is_last) {
-            TLOAD(liDN, liGlobalDN);         // li_new from li buffer as DN
+            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
         }
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
 
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
-        TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
+        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
-            TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
+            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             TSTORE(dstGlobal, oiTile);
@@ -206,15 +209,15 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* mij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* lij    = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+    __gm__ uint8_t* mij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mi     = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* li     = reinterpret_cast<__gm__ uint8_t*>(args[4]);
-    __gm__ uint8_t* oi     = reinterpret_cast<__gm__ uint8_t*>(args[5]);
-    int is_first  = static_cast<int>(args[6]);
-    int is_last   = static_cast<int>(args[7]);
-    __gm__ uint8_t* dst    = reinterpret_cast<__gm__ uint8_t*>(args[8]);
+    __gm__ uint8_t* mi = reinterpret_cast<__gm__ uint8_t*>(args[3]);
+    __gm__ uint8_t* li = reinterpret_cast<__gm__ uint8_t*>(args[4]);
+    __gm__ uint8_t* oi = reinterpret_cast<__gm__ uint8_t*>(args[5]);
+    int is_first = static_cast<int>(args[6]);
+    int is_last = static_cast<int>(args[7]);
+    __gm__ uint8_t* dst = reinterpret_cast<__gm__ uint8_t*>(args[8]);
 
     online_update_impl(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
 }

--- a/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -21,14 +21,15 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
-                                 __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
-                                 __gm__ uint8_t* lij_raw)
-{
+static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw,
+    float scale_value,
+    __gm__ uint8_t* pij_raw,
+    __gm__ uint8_t* mij_raw,
+    __gm__ uint8_t* lij_raw) {
     constexpr int M = 16, N = 16;
 
     __gm__ float* sij = reinterpret_cast<__gm__ float*>(sij_raw);
-    __gm__ half*  pij = reinterpret_cast<__gm__ half*>(pij_raw);
+    __gm__ half* pij = reinterpret_cast<__gm__ half*>(pij_raw);
     __gm__ float* mij = reinterpret_cast<__gm__ float*>(mij_raw);
     __gm__ float* lij = reinterpret_cast<__gm__ float*>(lij_raw);
 
@@ -83,7 +84,10 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    union { uint64_t u; float f; } scale_conv;
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[1]);
     float scale_value = scale_conv.f;
     __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[2]);

--- a/examples/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -19,10 +19,10 @@
 #include <algorithm>
 #include <cstring>
 
-#define FUNC_QK_MATMUL       0
+#define FUNC_QK_MATMUL 0
 #define FUNC_SOFTMAX_PREPARE 1
-#define FUNC_PV_MATMUL       2
-#define FUNC_ONLINE_UPDATE   3
+#define FUNC_PV_MATMUL 2
+#define FUNC_ONLINE_UPDATE 3
 
 extern "C" {
 
@@ -33,27 +33,27 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     }
 
     // Extract host pointers from TaskArg tensor metadata
-    void* host_query       = orch_args[0].data<void>();
-    void* host_key_cache   = orch_args[1].data<void>();
+    void* host_query = orch_args[0].data<void>();
+    void* host_key_cache = orch_args[1].data<void>();
     void* host_value_cache = orch_args[2].data<void>();
-    int*  host_block_table = orch_args[3].data<int>();
-    int*  host_context_lens = orch_args[4].data<int>();
-    void* host_out         = orch_args[5].data<void>();
+    int* host_block_table = orch_args[3].data<int>();
+    int* host_context_lens = orch_args[4].data<int>();
+    void* host_out = orch_args[5].data<void>();
 
     // Extract sizes from TaskArg metadata
-    size_t query_size       = orch_args[0].nbytes();
-    size_t key_cache_size   = orch_args[1].nbytes();
+    size_t query_size = orch_args[0].nbytes();
+    size_t key_cache_size = orch_args[1].nbytes();
     size_t value_cache_size = orch_args[2].nbytes();
-    size_t out_size         = orch_args[5].nbytes();
+    size_t out_size = orch_args[5].nbytes();
 
     // Read dimensions from tensor shapes (uint32_t — matches TaskArg::tensor.shapes type)
     // query: (batch, num_heads, head_dim)
-    uint32_t batch       = orch_args[0].tensor.shapes[0];
-    uint32_t num_heads   = orch_args[0].tensor.shapes[1];
-    uint32_t head_dim    = orch_args[0].tensor.shapes[2];
+    uint32_t batch = orch_args[0].tensor.shapes[0];
+    uint32_t num_heads = orch_args[0].tensor.shapes[1];
+    uint32_t head_dim = orch_args[0].tensor.shapes[2];
 
     // key_cache: (total_blocks, block_size, kv_head_num, head_dim)
-    uint32_t block_size  = orch_args[1].tensor.shapes[1];
+    uint32_t block_size = orch_args[1].tensor.shapes[1];
     uint32_t kv_head_num = orch_args[1].tensor.shapes[2];
 
     // block_table: (batch, max_num_blocks_per_req)
@@ -66,8 +66,8 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     uint32_t num_head_tiles = (num_heads + q_tile_size - 1) / q_tile_size;
 
     std::cout << "\n=== build_paged_attention_graph ===" << '\n';
-    std::cout << "batch=" << batch << ", num_heads=" << num_heads
-              << ", kv_head_num=" << kv_head_num << ", head_dim=" << head_dim << '\n';
+    std::cout << "batch=" << batch << ", num_heads=" << num_heads << ", kv_head_num=" << kv_head_num
+              << ", head_dim=" << head_dim << '\n';
     std::cout << "block_size=" << block_size << ", max_num_blocks=" << max_num_blocks << '\n';
     std::cout << "q_tile_size=" << q_tile_size << ", num_head_tiles=" << num_head_tiles << '\n';
 
@@ -88,25 +88,25 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     runtime->record_tensor_pair(host_out, dev_out, out_size);
 
     // Buffer sizes depend on q_tile_size and block_size
-    size_t sij_size    = static_cast<size_t>(q_tile_size) * block_size * sizeof(float);
-    size_t pij_size    = static_cast<size_t>(q_tile_size) * block_size * sizeof(uint16_t);
-    size_t mij_size    = static_cast<size_t>(q_tile_size) * sizeof(float);
-    size_t lij_size    = mij_size;
+    size_t sij_size = static_cast<size_t>(q_tile_size) * block_size * sizeof(float);
+    size_t pij_size = static_cast<size_t>(q_tile_size) * block_size * sizeof(uint16_t);
+    size_t mij_size = static_cast<size_t>(q_tile_size) * sizeof(float);
+    size_t lij_size = mij_size;
     size_t oi_new_size = static_cast<size_t>(q_tile_size) * head_dim * sizeof(float);
 
     // Per-batch-per-block intermediate buffers
     uint32_t total_buffers = batch * max_num_blocks;
-    void** dev_sij_arr    = new void*[total_buffers];
-    void** dev_pij_arr    = new void*[total_buffers];
-    void** dev_mij_arr    = new void*[total_buffers];
-    void** dev_lij_arr    = new void*[total_buffers];
+    void** dev_sij_arr = new void*[total_buffers];
+    void** dev_pij_arr = new void*[total_buffers];
+    void** dev_mij_arr = new void*[total_buffers];
+    void** dev_lij_arr = new void*[total_buffers];
     void** dev_oi_new_arr = new void*[total_buffers];
 
     for (uint32_t i = 0; i < total_buffers; i++) {
-        dev_sij_arr[i]    = runtime->host_api.device_malloc(sij_size);
-        dev_pij_arr[i]    = runtime->host_api.device_malloc(pij_size);
-        dev_mij_arr[i]    = runtime->host_api.device_malloc(mij_size);
-        dev_lij_arr[i]    = runtime->host_api.device_malloc(lij_size);
+        dev_sij_arr[i] = runtime->host_api.device_malloc(sij_size);
+        dev_pij_arr[i] = runtime->host_api.device_malloc(pij_size);
+        dev_mij_arr[i] = runtime->host_api.device_malloc(mij_size);
+        dev_lij_arr[i] = runtime->host_api.device_malloc(lij_size);
         dev_oi_new_arr[i] = runtime->host_api.device_malloc(oi_new_size);
     }
 
@@ -140,12 +140,12 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
             // Query: (batch, q_head_num, head_dim) fp16
             // qi points to heads [cur_offset .. cur_offset+q_tile_size) for batch b_idx
-            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query)
-                + static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
+            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query) +
+                              static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
 
             // Output: (batch * q_head_num, head_dim) float32
-            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out)
-                + static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
+            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out) +
+                               static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
 
             // GQA: which kv_head this head tile maps to
             uint32_t kv_head_idx = cur_offset / (num_heads / kv_head_num);
@@ -162,56 +162,50 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
                 int cur_block_idx = host_block_table[b_idx * max_num_blocks + bn];
 
                 // Key: (total_blocks, block_size, kv_head_num, head_dim) fp16
-                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache)
-                    + (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx)
-                      * head_dim * sizeof(uint16_t);
+                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache) +
+                                  (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
+                                      head_dim * sizeof(uint16_t);
 
                 // Value: (total_blocks, block_size, kv_head_num, head_dim) fp16
-                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache)
-                    + (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx)
-                      * head_dim * sizeof(uint16_t);
+                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache) +
+                                  (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
+                                      head_dim * sizeof(uint16_t);
 
                 uint32_t buf_idx = b_idx * max_num_blocks + bn;
-                void* dev_sij    = dev_sij_arr[buf_idx];
-                void* dev_pij    = dev_pij_arr[buf_idx];
-                void* dev_mij    = dev_mij_arr[buf_idx];
-                void* dev_lij    = dev_lij_arr[buf_idx];
+                void* dev_sij = dev_sij_arr[buf_idx];
+                void* dev_pij = dev_pij_arr[buf_idx];
+                void* dev_mij = dev_mij_arr[buf_idx];
+                void* dev_lij = dev_lij_arr[buf_idx];
                 void* dev_oi_new = dev_oi_new_arr[buf_idx];
 
                 // QK: qi(M, K) @ kj.T(K, N) -> sij(M, N)
-                uint64_t qk_args[6] = {
-                    reinterpret_cast<uint64_t>(qi_ptr),
+                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),
                     reinterpret_cast<uint64_t>(kj_ptr),
                     reinterpret_cast<uint64_t>(dev_sij),
                     static_cast<uint64_t>(q_tile_size),
                     static_cast<uint64_t>(head_dim),
-                    static_cast<uint64_t>(block_size)
-                };
+                    static_cast<uint64_t>(block_size)};
                 int t_qk = runtime->add_task(qk_args, 6, FUNC_QK_MATMUL, CoreType::AIC);
                 total_tasks++;
 
                 // SF: scale, rowmax, exp, rowsum -> pij, mij, lij
-                uint64_t sf_args[7] = {
-                    reinterpret_cast<uint64_t>(dev_sij),
+                uint64_t sf_args[7] = {reinterpret_cast<uint64_t>(dev_sij),
                     scale_value_bits,
                     reinterpret_cast<uint64_t>(dev_pij),
                     reinterpret_cast<uint64_t>(dev_mij),
                     reinterpret_cast<uint64_t>(dev_lij),
                     static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size)
-                };
+                    static_cast<uint64_t>(block_size)};
                 int t_sf = runtime->add_task(sf_args, 7, FUNC_SOFTMAX_PREPARE, CoreType::AIV);
                 total_tasks++;
 
                 // PV: pij(M, K') @ vj(K', N') -> oi_new(M, N')
-                uint64_t pv_args[6] = {
-                    reinterpret_cast<uint64_t>(dev_pij),
+                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),
                     reinterpret_cast<uint64_t>(vj_ptr),
                     reinterpret_cast<uint64_t>(dev_oi_new),
                     static_cast<uint64_t>(q_tile_size),
                     static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(head_dim)
-                };
+                    static_cast<uint64_t>(head_dim)};
                 int t_pv = runtime->add_task(pv_args, 6, FUNC_PV_MATMUL, CoreType::AIC);
                 total_tasks++;
 
@@ -220,10 +214,9 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
                 // Online Update: serialized across blocks (each depends on previous)
                 int is_first = (bn == 0) ? 1 : 0;
-                int is_last  = (bn == bn_this_batch - 1) ? 1 : 0;
+                int is_last = (bn == bn_this_batch - 1) ? 1 : 0;
 
-                uint64_t up_args[11] = {
-                    reinterpret_cast<uint64_t>(dev_mij),
+                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),
                     reinterpret_cast<uint64_t>(dev_lij),
                     reinterpret_cast<uint64_t>(dev_oi_new),
                     reinterpret_cast<uint64_t>(dev_mi),
@@ -233,8 +226,7 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
                     static_cast<uint64_t>(is_last),
                     reinterpret_cast<uint64_t>(out_ptr),
                     static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim)
-                };
+                    static_cast<uint64_t>(head_dim)};
                 int t_up = runtime->add_task(up_args, 11, FUNC_ONLINE_UPDATE, CoreType::AIV);
                 total_tasks++;
 
@@ -261,5 +253,4 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
     return 0;
 }
-
 }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -159,14 +159,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
 
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
         // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);  // mi_new = max(mi, mij)
+        TMAX(miNewND, miND, mijND);    // mi_new = max(mi, mij)
         TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
-        TEXP(alphaND, alphaND);  // alpha = exp(mi - mi_new)
+        TEXP(alphaND, alphaND);        // alpha = exp(mi - mi_new)
         TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
-        TEXP(betaND, betaND);  // beta = exp(mij - mi_new)
-        TMUL(liND, alphaND, liND);  // li = alpha * li
-        TMUL(tmpND, betaND, lijND);  // tmp = beta * lij
-        TADD(liND, liND, tmpND);  // li = alpha * li + beta * lij (= li_new)
+        TEXP(betaND, betaND);          // beta = exp(mij - mi_new)
+        TMUL(liND, alphaND, liND);     // li = alpha * li
+        TMUL(tmpND, betaND, lijND);    // tmp = beta * lij
+        TADD(liND, liND, tmpND);       // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
         // mi_new -> mi accumulator, li_new -> li accumulator
@@ -192,7 +192,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
         TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
-        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -29,11 +29,8 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
-    float scale_value,
-    __gm__ Tensor* pij,
-    __gm__ Tensor* mij,
-    __gm__ Tensor* lij) {
+static __aicore__ void softmax_prepare_impl(
+    __gm__ Tensor* sij, float scale_value, __gm__ Tensor* pij, __gm__ Tensor* mij, __gm__ Tensor* lij) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
     __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
     __gm__ half* pij_addr = reinterpret_cast<__gm__ half*>(pij->buffer.addr);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -27,25 +27,24 @@
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     // Read dimensions from TaskArg tensor metadata
     // query: shape=[batch, num_heads, head_dim]
-    uint64_t batch     = orch_args[0].tensor.shapes[0];
+    uint64_t batch = orch_args[0].tensor.shapes[0];
     uint64_t num_heads = orch_args[0].tensor.shapes[1];
-    uint64_t head_dim  = orch_args[0].tensor.shapes[2];
+    uint64_t head_dim = orch_args[0].tensor.shapes[2];
     DataType data_type = orch_args[0].tensor.dtype;
 
     // key_cache: shape=[total_blocks, block_size, kv_head_num, head_dim]
-    uint64_t block_size  = orch_args[1].tensor.shapes[1];
+    uint64_t block_size = orch_args[1].tensor.shapes[1];
 
     // block_table: shape=[batch, max_num_blocks_per_req]
     uint64_t block_num = orch_args[3].tensor.shapes[1];
@@ -62,15 +61,19 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
     uint64_t b_start = batch * orch_thread_index / orch_thread_num;
     uint64_t b_end = batch * (orch_thread_index + 1) / orch_thread_num;
 
-    LOG_INFO(rt, "orch_idx=%d/%d batch=%lu b_range=[%lu,%lu)",
-             orch_thread_index, orch_thread_num,
-             (unsigned long)batch, (unsigned long)b_start, (unsigned long)b_end);
+    LOG_INFO(rt,
+        "orch_idx=%d/%d batch=%lu b_range=[%lu,%lu)",
+        orch_thread_index,
+        orch_thread_num,
+        (unsigned long)batch,
+        (unsigned long)b_start,
+        (unsigned long)b_end);
 
     // Reshape tensors for kernel consumption (2D flattened)
     void* query_ptr = orch_args[0].data<void>();
-    void* kc_ptr    = orch_args[1].data<void>();
-    void* vc_ptr    = orch_args[2].data<void>();
-    void* out_ptr   = orch_args[5].data<void>();
+    void* kc_ptr = orch_args[1].data<void>();
+    void* vc_ptr = orch_args[2].data<void>();
+    void* out_ptr = orch_args[5].data<void>();
 
     // Compute kv_total_rows from key_cache tensor metadata
     uint64_t total_blocks_count = orch_args[1].tensor.shapes[0];
@@ -89,7 +92,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
     LOG_DEBUG(rt, "value_cache=%s", value_cache.dump().c_str());
     LOG_DEBUG(rt, "out=%s", out.dump().c_str());
 
-    int* host_block_table  = orch_args[3].data<int>();
+    int* host_block_table = orch_args[3].data<int>();
     int* host_context_lens = orch_args[4].data<int>();
 
     for (uint64_t b_idx = b_start; b_idx < b_end; b_idx++) {
@@ -116,11 +119,12 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
                 params_inplace.add_output(oi);
                 params_inplace.add_output(li_update);
                 params_inplace.add_output(mi_update);
-                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_inplace); // create_inplace
+                pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, params_inplace);  // create_inplace
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
                     uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
-                    uint64_t valid_len = block_size < (cur_seq - bn * block_size) ? block_size : (cur_seq - bn * block_size);
+                    uint64_t valid_len =
+                        block_size < (cur_seq - bn * block_size) ? block_size : (cur_seq - bn * block_size);
                     uint32_t kv_shapes[2] = {(uint32_t)block_size, (uint32_t)head_dim};
                     uint32_t kv_offsets[2] = {(uint32_t)(cur_block_idx * block_size), 0};
                     Tensor kj = key_cache.view(kv_shapes, kv_offsets);
@@ -134,7 +138,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
                     params_qk.add_input(qi);
                     params_qk.add_input(kj);
                     params_qk.add_output(sij);
-                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk); // c1
+                    pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, params_qk);  // c1
 
                     uint32_t sij_valid_shapes[2] = {(uint32_t)q_tile, (uint32_t)valid_len};
                     uint32_t sij_valid_offsets[2] = {0, 0};
@@ -147,7 +151,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
                     params_sf.add_output(mi);
                     params_sf.add_output(li);
                     params_sf.add_scalar(scale_value);
-                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf); // v1
+                    pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, params_sf);  // v1
 
                     uint32_t oi_tmp_shapes[2] = {(uint32_t)q_tile, (uint32_t)head_dim};
                     Tensor oi_tmp = make_tensor(oi_tmp_shapes, 2, DataType::FLOAT32);
@@ -156,7 +160,7 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(oi_tmp);
-                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv); // c2
+                    pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, params_pv);  // c2
 
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
@@ -171,15 +175,18 @@ void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thr
                     params_up.add_output(out_view);
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
-                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up); // v2
+                    pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, params_up);  // v2
                 }
             }
         }
     }
 
-    LOG_INFO(rt, "orch_idx=%d: tasks submitted for batch=[%lu,%lu), num_heads=%lu",
-                  orch_thread_index, (unsigned long)b_start, (unsigned long)b_end,
-                  (unsigned long)num_heads);
+    LOG_INFO(rt,
+        "orch_idx=%d: tasks submitted for batch=[%lu,%lu), num_heads=%lu",
+        orch_thread_index,
+        (unsigned long)b_start,
+        (unsigned long)b_end,
+        (unsigned long)num_heads);
 }
 
 }  // extern "C"

--- a/examples/scripts/run_example.py
+++ b/examples/scripts/run_example.py
@@ -213,7 +213,7 @@ Golden.py interface:
         log_level_str = "error"
     else:
         log_level_str = "info"
-    
+
     # Setup logging before any other operations
     level_map = {
         'error': logging.ERROR,
@@ -222,14 +222,14 @@ Golden.py interface:
         'debug': logging.DEBUG,
     }
     log_level = level_map.get(log_level_str.lower(), logging.INFO)
-    
+
     # Configure Python logging
     logging.basicConfig(
         level=log_level,
         format='[%(levelname)s] %(message)s',
         force=True
     )
-    
+
     # Set environment variable for C++ side
     os.environ['PTO_LOG_LEVEL'] = log_level_str
 

--- a/golden/paged_attention_golden.py
+++ b/golden/paged_attention_golden.py
@@ -36,7 +36,9 @@ def generate_inputs(params: dict) -> list:
     context_lens_list = params.get("context_lens_list")
     dtype = getattr(torch, params.get("dtype", "bfloat16"))
 
-    assert context_len >= 1, "context_len must be >= 1 to avoid division by zero in attention"
+    assert context_len >= 1, (
+        "context_len must be >= 1 to avoid division by zero in attention"
+    )
 
     max_num_blocks_per_req = max_model_len // block_size
     scale_value = 1.0
@@ -45,7 +47,9 @@ def generate_inputs(params: dict) -> list:
     if context_lens_list is not None:
         seq_vals = list(context_lens_list)
         if len(seq_vals) < batch:
-            seq_vals = (seq_vals * ((batch + len(seq_vals) - 1) // len(seq_vals)))[:batch]
+            seq_vals = (seq_vals * ((batch + len(seq_vals) - 1) // len(seq_vals)))[
+                :batch
+            ]
         elif len(seq_vals) > batch:
             seq_vals = seq_vals[:batch]
         context_lens = torch.tensor(seq_vals, dtype=torch.int32)
@@ -64,18 +68,29 @@ def generate_inputs(params: dict) -> list:
     )
 
     query = torch.empty(batch, num_heads, head_dim).uniform_(-0.5, 0.5).to(dtype)
-    key_cache = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-0.5, 0.5).to(dtype)
-    value_cache = torch.empty(total_blocks, block_size, kv_head_num, head_dim).uniform_(-1, 1).to(dtype)
+    key_cache = (
+        torch.empty(total_blocks, block_size, kv_head_num, head_dim)
+        .uniform_(-0.5, 0.5)
+        .to(dtype)
+    )
+    value_cache = (
+        torch.empty(total_blocks, block_size, kv_head_num, head_dim)
+        .uniform_(-1, 1)
+        .to(dtype)
+    )
     out = torch.zeros(batch, num_heads, head_dim, dtype=torch.float32)
 
     return [
-        ("query", query),                              # [batch, num_heads, head_dim]
-        ("key_cache", key_cache),                      # [total_blocks, block_size, kv_head_num, head_dim]
-        ("value_cache", value_cache),                  # [total_blocks, block_size, kv_head_num, head_dim]
-        ("block_table", block_table),                  # [batch, max_num_blocks_per_req]
-        ("context_lens", context_lens),                # [batch]
-        ("out", out),                                  # [batch, num_heads, head_dim]
-        ("scale", ctypes.c_float(scale_value)),        # scalar
+        ("query", query),  # [batch, num_heads, head_dim]
+        ("key_cache", key_cache),  # [total_blocks, block_size, kv_head_num, head_dim]
+        (
+            "value_cache",
+            value_cache,
+        ),  # [total_blocks, block_size, kv_head_num, head_dim]
+        ("block_table", block_table),  # [batch, max_num_blocks_per_req]
+        ("context_lens", context_lens),  # [batch]
+        ("out", out),  # [batch, num_heads, head_dim]
+        ("scale", ctypes.c_float(scale_value)),  # scalar
     ]
 
 
@@ -123,14 +138,16 @@ def paged_attention(
 
     for q_offset in range(0, num_heads_dim, q_tile):
         q_tile_size = min(q_tile, num_heads_dim - q_offset)
-        qi = query[:, q_offset:q_offset + q_tile_size, :].to(torch.float32)
+        qi = query[:, q_offset : q_offset + q_tile_size, :].to(torch.float32)
 
         oi = None
         li = None
         mi = None
 
         for bn in range(max_bn):
-            valid_lens = torch.clamp(context_lens - bn * block_size, min=0, max=block_size)
+            valid_lens = torch.clamp(
+                context_lens - bn * block_size, min=0, max=block_size
+            )
             active_mask = valid_lens > 0
 
             if not active_mask.any():
@@ -146,10 +163,10 @@ def paged_attention(
             pos = torch.arange(block_size, device=sij.device).unsqueeze(0)
             valid_mask = pos < valid_lens.unsqueeze(1)
             valid_mask = valid_mask.unsqueeze(1)
-            sij = sij.masked_fill(~valid_mask, float('-inf'))
+            sij = sij.masked_fill(~valid_mask, float("-inf"))
 
             batch_mask = active_mask.view(-1, 1, 1)
-            sij = sij.masked_fill(~batch_mask, float('-inf'))
+            sij = sij.masked_fill(~batch_mask, float("-inf"))
 
             mij = sij.max(dim=-1, keepdim=True)[0]
             mij = mij.clamp(min=-1e30)
@@ -173,7 +190,7 @@ def paged_attention(
                 oi = alpha * oi + beta * oi_new
                 mi = mi_new
 
-        out[:, q_offset:q_offset + q_tile_size, :] = oi / li
+        out[:, q_offset : q_offset + q_tile_size, :] = oi / li
 
     return out
 
@@ -209,27 +226,40 @@ def compute_golden(tensors: dict, params: dict) -> None:
     tensors["out"][:] = out
 
 
-def run_golden_test(all_cases: dict, default_case: str, generate_inputs_fn, label: str = "Paged Attention"):
+def run_golden_test(
+    all_cases: dict,
+    default_case: str,
+    generate_inputs_fn,
+    label: str = "Paged Attention",
+):
     """Run golden test for __main__ blocks."""
     params = {"name": default_case, **all_cases[default_case]}
     result = generate_inputs_fn(params)
-    tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
+    tensors = {
+        name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)
+    }
     compute_golden(tensors, params)
 
     print(f"=== {label} Golden Test ({params['name']}) ===")
-    print(f"batch={params['batch']}, num_heads={params['num_heads']}, head_dim={params['head_dim']}")
+    print(
+        f"batch={params['batch']}, num_heads={params['num_heads']}, head_dim={params['head_dim']}"
+    )
     print(f"kv_head_num={params['kv_head_num']}, block_size={params['block_size']}")
-    if params.get('context_lens_list'):
-        ctx_list = params['context_lens_list']
-        print(f"context_lens (variable): {ctx_list[:8]}{'...' if len(ctx_list) > 8 else ''}")
+    if params.get("context_lens_list"):
+        ctx_list = params["context_lens_list"]
+        print(
+            f"context_lens (variable): {ctx_list[:8]}{'...' if len(ctx_list) > 8 else ''}"
+        )
     else:
         print(f"context_len={params['context_len']}")
 
-    max_num_blocks = params['max_model_len'] // params['block_size']
-    q_tile = min(params['num_heads'], 128)
+    max_num_blocks = params["max_model_len"] // params["block_size"]
+    q_tile = min(params["num_heads"], 128)
     print(f"max_num_blocks_per_req={max_num_blocks}, q_tile_size={q_tile}")
 
-    out = tensors["out"].reshape(params["batch"] * params["num_heads"], params["head_dim"])
+    out = tensors["out"].reshape(
+        params["batch"] * params["num_heads"], params["head_dim"]
+    )
     print(f"Output shape: {out.shape}")
     print(f"Output range: [{out.min():.4f}, {out.max():.4f}]")
     print(f"Output mean: {out.mean():.4f}")

--- a/python/bindings.py
+++ b/python/bindings.py
@@ -33,7 +33,6 @@ Usage:
     runtime.finalize()
 """
 
-
 from ctypes import (
     CDLL,
     POINTER,
@@ -99,9 +98,9 @@ from toolchain import ToolchainType
 # Runtime Library Loader
 # ============================================================================
 
+
 class RuntimeLibraryLoader:
     """Loads and manages the PTO runtime C API library."""
-
 
     def __init__(self, lib_path: Union[str, Path]):
         """
@@ -133,30 +132,30 @@ class RuntimeLibraryLoader:
 
         # init_runtime - placement new + register kernels + load SO + build runtime with orchestration
         self.lib.init_runtime.argtypes = [
-            c_void_p,               # runtime
-            POINTER(c_uint8),       # orch_so_binary
-            c_size_t,               # orch_so_size
-            c_char_p,               # orch_func_name
-            POINTER(TaskArgC),      # orch_args
-            c_int,                  # orch_args_count
-            POINTER(c_int),         # kernel_func_ids (array of func_ids)
+            c_void_p,  # runtime
+            POINTER(c_uint8),  # orch_so_binary
+            c_size_t,  # orch_so_size
+            c_char_p,  # orch_func_name
+            POINTER(TaskArgC),  # orch_args
+            c_int,  # orch_args_count
+            POINTER(c_int),  # kernel_func_ids (array of func_ids)
             POINTER(POINTER(c_uint8)),  # kernel_binaries (array of binary pointers)
-            POINTER(c_size_t),      # kernel_sizes (array of sizes)
-            c_int,                  # kernel_count
+            POINTER(c_size_t),  # kernel_sizes (array of sizes)
+            c_int,  # kernel_count
         ]
         self.lib.init_runtime.restype = c_int
 
         # launch_runtime - device init + execute runtime
         self.lib.launch_runtime.argtypes = [
-            c_void_p,           # runtime
-            c_int,              # aicpu_thread_num
-            c_int,              # block_dim
-            c_int,              # device_id
-            POINTER(c_uint8),   # aicpu_binary
-            c_size_t,           # aicpu_size
-            POINTER(c_uint8),   # aicore_binary
-            c_size_t,           # aicore_size
-            c_int,              # orch_thread_num
+            c_void_p,  # runtime
+            c_int,  # aicpu_thread_num
+            c_int,  # block_dim
+            c_int,  # device_id
+            POINTER(c_uint8),  # aicpu_binary
+            c_size_t,  # aicpu_size
+            POINTER(c_uint8),  # aicore_binary
+            c_size_t,  # aicore_size
+            c_int,  # orch_thread_num
         ]
         self.lib.launch_runtime.restype = c_int
 
@@ -208,6 +207,7 @@ class RuntimeLibraryLoader:
 # Python Wrapper Classes
 # ============================================================================
 
+
 class Runtime:
     """
 
@@ -216,7 +216,6 @@ class Runtime:
     Python wrapper around the C Runtime API.
     User allocates memory via ctypes buffer, C++ uses placement new.
     """
-
 
     def __init__(self, lib: CDLL):
         """
@@ -273,7 +272,11 @@ class Runtime:
         from _task_interface import TaskArgArray as _NbTaskArgArray
 
         if isinstance(orch_args, _NbTaskArgArray):
-            orch_args_array = cast(orch_args.ctypes_ptr(), POINTER(TaskArgC)) if orch_args_count > 0 else None
+            orch_args_array = (
+                cast(orch_args.ctypes_ptr(), POINTER(TaskArgC))
+                if orch_args_count > 0
+                else None
+            )
             # Prevent GC of the nanobind array while the ctypes pointer is live
             self._nb_args_ref = orch_args
         elif orch_args_count > 0:
@@ -313,7 +316,7 @@ class Runtime:
             self._handle,
             orch_so_array,
             len(orch_so_binary),
-            orch_func_name.encode('utf-8'),
+            orch_func_name.encode("utf-8"),
             orch_args_array,
             orch_args_count,
             func_ids_array,
@@ -478,7 +481,9 @@ def copy_from_device(host_ptr: int, dev_ptr: int, size: int) -> None:
     if _lib is None:
         raise RuntimeError("Runtime not loaded. Call bind_host_binary() first.")
 
-    rc = _lib.copy_from_device(ctypes.c_void_p(host_ptr), ctypes.c_void_p(dev_ptr), size)
+    rc = _lib.copy_from_device(
+        ctypes.c_void_p(host_ptr), ctypes.c_void_p(dev_ptr), size
+    )
     if rc != 0:
         raise RuntimeError(f"copy_from_device failed: {rc}")
 
@@ -539,6 +544,7 @@ def launch_runtime(
 # Compile Strategy Functions
 # ============================================================================
 
+
 def get_incore_compiler() -> ToolchainType:
     """
     Get the toolchain for incore kernel compilation.
@@ -583,6 +589,7 @@ def get_orchestration_compiler() -> ToolchainType:
 # Public API
 # ============================================================================
 
+
 def bind_host_binary(lib_path: Union[str, Path, bytes]) -> type:
     """
 
@@ -624,7 +631,7 @@ def bind_host_binary(lib_path: Union[str, Path, bytes]) -> type:
 
     # If bytes are provided, write to temporary file
     if isinstance(lib_path, bytes):
-        with tempfile.NamedTemporaryFile(delete=False, suffix='.so') as f:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".so") as f:
             f.write(lib_path)
             lib_path = f.name
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -30,119 +30,123 @@ NB_MODULE(_task_interface, m) {
 
     // --- DataType enum ---
     nb::enum_<DataType>(m, "DataType")
-        .value("FLOAT32",  DataType::FLOAT32)
-        .value("FLOAT16",  DataType::FLOAT16)
-        .value("INT32",    DataType::INT32)
-        .value("INT16",    DataType::INT16)
-        .value("INT8",     DataType::INT8)
-        .value("UINT8",    DataType::UINT8)
+        .value("FLOAT32", DataType::FLOAT32)
+        .value("FLOAT16", DataType::FLOAT16)
+        .value("INT32", DataType::INT32)
+        .value("INT16", DataType::INT16)
+        .value("INT8", DataType::INT8)
+        .value("UINT8", DataType::UINT8)
         .value("BFLOAT16", DataType::BFLOAT16)
-        .value("INT64",    DataType::INT64)
-        .value("UINT64",   DataType::UINT64);
+        .value("INT64", DataType::INT64)
+        .value("UINT64", DataType::UINT64);
 
     // --- TaskArgKind enum ---
-    nb::enum_<TaskArgKind>(m, "TaskArgKind")
-        .value("TENSOR", TaskArgKind::TENSOR)
-        .value("SCALAR", TaskArgKind::SCALAR);
+    nb::enum_<TaskArgKind>(m, "TaskArgKind").value("TENSOR", TaskArgKind::TENSOR).value("SCALAR", TaskArgKind::SCALAR);
 
     // --- Constants ---
     m.attr("TASK_ARG_MAX_DIMS") = TASK_ARG_MAX_DIMS;
 
     // --- Free functions ---
-    m.def("get_element_size", &get_element_size,
-          nb::arg("dtype"),
-          "Return the byte size of a single element of the given DataType.");
+    m.def("get_element_size",
+        &get_element_size,
+        nb::arg("dtype"),
+        "Return the byte size of a single element of the given DataType.");
 
-    m.def("get_dtype_name",
-          [](DataType dt) -> std::string { return get_dtype_name(dt); },
-          nb::arg("dtype"),
-          "Return the string name of a DataType.");
+    m.def(
+        "get_dtype_name",
+        [](DataType dt) -> std::string { return get_dtype_name(dt); },
+        nb::arg("dtype"),
+        "Return the string name of a DataType.");
 
     // --- TaskArg ---
     nb::class_<TaskArg>(m, "TaskArg")
         .def(nb::init<>())
 
         // kind
-        .def_prop_rw("kind",
-            [](const TaskArg& self) { return self.kind; },
-            [](TaskArg& self, TaskArgKind k) { self.kind = k; })
+        .def_prop_rw(
+            "kind", [](const TaskArg& self) { return self.kind; }, [](TaskArg& self, TaskArgKind k) { self.kind = k; })
 
         // scalar (union field)
-        .def_prop_rw("scalar",
+        .def_prop_rw(
+            "scalar",
             [](const TaskArg& self) -> uint64_t { return self.scalar; },
             [](TaskArg& self, uint64_t v) { self.scalar = v; })
 
         // tensor.data
-        .def_prop_rw("tensor_data",
+        .def_prop_rw(
+            "tensor_data",
             [](const TaskArg& self) -> uint64_t { return self.tensor.data; },
             [](TaskArg& self, uint64_t v) { self.tensor.data = v; })
 
         // tensor.shapes — getter returns tuple[:ndims], setter writes + updates ndims
-        .def_prop_rw("tensor_shapes",
+        .def_prop_rw(
+            "tensor_shapes",
             [](const TaskArg& self) -> nb::tuple {
                 uint32_t n = self.tensor.ndims;
                 if (n > TASK_ARG_MAX_DIMS) n = TASK_ARG_MAX_DIMS;
                 nb::list lst;
-                for (uint32_t i = 0; i < n; ++i)
-                    lst.append(self.tensor.shapes[i]);
+                for (uint32_t i = 0; i < n; ++i) lst.append(self.tensor.shapes[i]);
                 return nb::tuple(lst);
             },
             [](TaskArg& self, nb::tuple t) {
                 size_t n = nb::len(t);
                 if (n > TASK_ARG_MAX_DIMS)
                     throw std::invalid_argument(
-                        "shapes tuple length exceeds TASK_ARG_MAX_DIMS ("
-                        + std::to_string(TASK_ARG_MAX_DIMS) + ")");
-                for (size_t i = 0; i < n; ++i)
-                    self.tensor.shapes[i] = nb::cast<uint32_t>(t[i]);
+                        "shapes tuple length exceeds TASK_ARG_MAX_DIMS (" + std::to_string(TASK_ARG_MAX_DIMS) + ")");
+                for (size_t i = 0; i < n; ++i) self.tensor.shapes[i] = nb::cast<uint32_t>(t[i]);
                 self.tensor.ndims = static_cast<uint32_t>(n);
             })
 
         // tensor.ndims
-        .def_prop_rw("tensor_ndims",
+        .def_prop_rw(
+            "tensor_ndims",
             [](const TaskArg& self) -> uint32_t { return self.tensor.ndims; },
             [](TaskArg& self, uint32_t v) { self.tensor.ndims = v; })
 
         // tensor.dtype
-        .def_prop_rw("tensor_dtype",
+        .def_prop_rw(
+            "tensor_dtype",
             [](const TaskArg& self) -> DataType { return self.tensor.dtype; },
             [](TaskArg& self, DataType dt) { self.tensor.dtype = dt; })
 
         // set_tensor_shape(dim, val)
-        .def("set_tensor_shape",
+        .def(
+            "set_tensor_shape",
             [](TaskArg& self, uint32_t dim, uint32_t val) {
-                if (dim >= TASK_ARG_MAX_DIMS)
-                    throw std::out_of_range("dim >= TASK_ARG_MAX_DIMS");
+                if (dim >= TASK_ARG_MAX_DIMS) throw std::out_of_range("dim >= TASK_ARG_MAX_DIMS");
                 self.tensor.shapes[dim] = val;
             },
-            nb::arg("dim"), nb::arg("val"))
+            nb::arg("dim"),
+            nb::arg("val"))
 
         // nbytes()
-        .def("nbytes",
+        .def(
+            "nbytes",
             [](const TaskArg& self) -> uint64_t { return self.nbytes(); },
             "Compute total bytes for this tensor (product of shapes * element_size).")
 
         // Static factory: make_tensor
-        .def_static("make_tensor",
+        .def_static(
+            "make_tensor",
             [](uint64_t data, nb::tuple shapes, DataType dtype) -> TaskArg {
                 size_t n = nb::len(shapes);
-                if (n > TASK_ARG_MAX_DIMS)
-                    throw std::invalid_argument(
-                        "shapes length exceeds TASK_ARG_MAX_DIMS");
+                if (n > TASK_ARG_MAX_DIMS) throw std::invalid_argument("shapes length exceeds TASK_ARG_MAX_DIMS");
                 TaskArg arg{};
                 arg.kind = TaskArgKind::TENSOR;
                 arg.tensor.data = data;
                 arg.tensor.dtype = dtype;
                 arg.tensor.ndims = static_cast<uint32_t>(n);
-                for (size_t i = 0; i < n; ++i)
-                    arg.tensor.shapes[i] = nb::cast<uint32_t>(shapes[i]);
+                for (size_t i = 0; i < n; ++i) arg.tensor.shapes[i] = nb::cast<uint32_t>(shapes[i]);
                 return arg;
             },
-            nb::arg("data"), nb::arg("shapes"), nb::arg("dtype"),
+            nb::arg("data"),
+            nb::arg("shapes"),
+            nb::arg("dtype"),
             "Create a TENSOR TaskArg from a data pointer, shape tuple, and dtype.")
 
         // Static factory: make_scalar
-        .def_static("make_scalar",
+        .def_static(
+            "make_scalar",
             [](uint64_t value) -> TaskArg {
                 TaskArg arg{};
                 arg.kind = TaskArgKind::SCALAR;
@@ -153,34 +157,28 @@ NB_MODULE(_task_interface, m) {
             "Create a SCALAR TaskArg with the given uint64 value.")
 
         // __repr__
-        .def("__repr__",
-            [](const TaskArg& self) -> std::string {
-                std::ostringstream os;
-                if (self.kind == TaskArgKind::TENSOR) {
-                    os << "TaskArg(TENSOR, data=0x"
-                       << std::hex << self.tensor.data << std::dec
-                       << ", shapes=(";
-                    for (uint32_t i = 0; i < self.tensor.ndims; ++i) {
-                        if (i) os << ", ";
-                        os << self.tensor.shapes[i];
-                    }
-                    os << "), dtype=" << get_dtype_name(self.tensor.dtype)
-                       << ")";
-                } else {
-                    os << "TaskArg(SCALAR, value=" << self.scalar << ")";
+        .def("__repr__", [](const TaskArg& self) -> std::string {
+            std::ostringstream os;
+            if (self.kind == TaskArgKind::TENSOR) {
+                os << "TaskArg(TENSOR, data=0x" << std::hex << self.tensor.data << std::dec << ", shapes=(";
+                for (uint32_t i = 0; i < self.tensor.ndims; ++i) {
+                    if (i) os << ", ";
+                    os << self.tensor.shapes[i];
                 }
-                return os.str();
-            });
+                os << "), dtype=" << get_dtype_name(self.tensor.dtype) << ")";
+            } else {
+                os << "TaskArg(SCALAR, value=" << self.scalar << ")";
+            }
+            return os.str();
+        });
 
     // --- TaskArgArray ---
     nb::class_<TaskArgArray>(m, "TaskArgArray")
         .def(nb::init<>())
 
-        .def("append", &TaskArgArray::append, nb::arg("arg"),
-             "Append a TaskArg to the array.")
+        .def("append", &TaskArgArray::append, nb::arg("arg"), "Append a TaskArg to the array.")
 
-        .def("clear", &TaskArgArray::clear,
-             "Remove all elements.")
+        .def("clear", &TaskArgArray::clear, "Remove all elements.")
 
         .def("__len__", &TaskArgArray::size)
 
@@ -190,7 +188,8 @@ NB_MODULE(_task_interface, m) {
             nb::rv_policy::reference_internal,
             "Return a reference to the TaskArg at the given index.")
 
-        .def("ctypes_ptr", &TaskArgArray::data_ptr,
-             "Return the raw memory address of the contiguous TaskArg array "
-             "(for passing to ctypes CDLL calls).");
+        .def("ctypes_ptr",
+            &TaskArgArray::data_ptr,
+            "Return the raw memory address of the contiguous TaskArg array "
+            "(for passing to ctypes CDLL calls).");
 }

--- a/python/elf_parser.py
+++ b/python/elf_parser.py
@@ -15,9 +15,9 @@ logger = logging.getLogger(__name__)
 
 # ELF Magic Numbers
 ELFMAG0 = 0x7F
-ELFMAG1 = ord('E')
-ELFMAG2 = ord('L')
-ELFMAG3 = ord('F')
+ELFMAG1 = ord("E")
+ELFMAG2 = ord("L")
+ELFMAG3 = ord("F")
 
 # Mach-O Magic Numbers
 MH_MAGIC_64 = 0xFEEDFACF
@@ -48,7 +48,7 @@ def extract_text_section(obj_input: Union[str, Path, bytes]) -> bytes:
         path = Path(obj_input)
         if not path.exists():
             raise FileNotFoundError(f"Object file not found: {obj_input}")
-        with open(obj_input, 'rb') as f:
+        with open(obj_input, "rb") as f:
             obj_data = f.read()
         source_name = str(obj_input)
 
@@ -56,12 +56,16 @@ def extract_text_section(obj_input: Union[str, Path, bytes]) -> bytes:
         raise ValueError(f"Data too small to be a valid object file: {source_name}")
 
     # Detect format by magic number
-    magic32 = struct.unpack('<I', obj_data[:4])[0]
+    magic32 = struct.unpack("<I", obj_data[:4])[0]
     if magic32 == MH_MAGIC_64:
         return _extract_text_macho64(obj_data, source_name)
 
-    if (obj_data[0] == ELFMAG0 and obj_data[1] == ELFMAG1 and
-        obj_data[2] == ELFMAG2 and obj_data[3] == ELFMAG3):
+    if (
+        obj_data[0] == ELFMAG0
+        and obj_data[1] == ELFMAG1
+        and obj_data[2] == ELFMAG2
+        and obj_data[3] == ELFMAG3
+    ):
         return _extract_text_elf64(obj_data, source_name)
 
     raise ValueError(f"Not a valid ELF or Mach-O file: {source_name}")
@@ -73,29 +77,39 @@ def _extract_text_elf64(elf_data: bytes, source_name: str) -> bytes:
         raise ValueError(f"Data too small to be a valid ELF: {source_name}")
 
     # Extract section header table info from ELF header
-    e_shoff = struct.unpack('<Q', elf_data[40:48])[0]
-    e_shnum = struct.unpack('<H', elf_data[60:62])[0]
-    e_shstrndx = struct.unpack('<H', elf_data[62:64])[0]
+    e_shoff = struct.unpack("<Q", elf_data[40:48])[0]
+    e_shnum = struct.unpack("<H", elf_data[60:62])[0]
+    e_shstrndx = struct.unpack("<H", elf_data[62:64])[0]
 
     # Get string table section header
     shstr_offset = e_shoff + e_shstrndx * 64
-    shstr_sh_offset = struct.unpack('<Q', elf_data[shstr_offset+24:shstr_offset+32])[0]
-    shstr_sh_size = struct.unpack('<Q', elf_data[shstr_offset+32:shstr_offset+40])[0]
+    shstr_sh_offset = struct.unpack(
+        "<Q", elf_data[shstr_offset + 24 : shstr_offset + 32]
+    )[0]
+    shstr_sh_size = struct.unpack(
+        "<Q", elf_data[shstr_offset + 32 : shstr_offset + 40]
+    )[0]
 
     # Extract string table
-    strtab = elf_data[shstr_sh_offset:shstr_sh_offset+shstr_sh_size]
+    strtab = elf_data[shstr_sh_offset : shstr_sh_offset + shstr_sh_size]
 
     # Find .text section
     for i in range(e_shnum):
         section_offset = e_shoff + i * 64
-        sh_name = struct.unpack('<I', elf_data[section_offset:section_offset+4])[0]
-        sh_offset = struct.unpack('<Q', elf_data[section_offset+24:section_offset+32])[0]
-        sh_size = struct.unpack('<Q', elf_data[section_offset+32:section_offset+40])[0]
+        sh_name = struct.unpack("<I", elf_data[section_offset : section_offset + 4])[0]
+        sh_offset = struct.unpack(
+            "<Q", elf_data[section_offset + 24 : section_offset + 32]
+        )[0]
+        sh_size = struct.unpack(
+            "<Q", elf_data[section_offset + 32 : section_offset + 40]
+        )[0]
 
         section_name = _extract_cstring(strtab, sh_name)
-        if section_name == '.text':
-            text_data = elf_data[sh_offset:sh_offset+sh_size]
-            logger.debug(f"Loaded .text section from {source_name} (size: {sh_size} bytes)")
+        if section_name == ".text":
+            text_data = elf_data[sh_offset : sh_offset + sh_size]
+            logger.debug(
+                f"Loaded .text section from {source_name} (size: {sh_size} bytes)"
+            )
             return text_data
 
     raise ValueError(f".text section not found in: {source_name}")
@@ -108,21 +122,21 @@ def _extract_text_macho64(data: bytes, source_name: str) -> bytes:
     if len(data) < 32:
         raise ValueError(f"Data too small to be a valid Mach-O: {source_name}")
 
-    ncmds = struct.unpack('<I', data[16:20])[0]
+    ncmds = struct.unpack("<I", data[16:20])[0]
 
     # Walk load commands starting at offset 32
     offset = 32
     for _ in range(ncmds):
         if offset + 8 > len(data):
             break
-        cmd = struct.unpack('<I', data[offset:offset+4])[0]
-        cmdsize = struct.unpack('<I', data[offset+4:offset+8])[0]
+        cmd = struct.unpack("<I", data[offset : offset + 4])[0]
+        cmdsize = struct.unpack("<I", data[offset + 4 : offset + 8])[0]
 
         if cmd == LC_SEGMENT_64:
             # segment_command_64: cmd(4) + cmdsize(4) + segname(16) + vmaddr(8)
             #   + vmsize(8) + fileoff(8) + filesize(8) + maxprot(4) + initprot(4)
             #   + nsects(4) + flags(4) = 72 bytes header
-            nsects = struct.unpack('<I', data[offset+64:offset+68])[0]
+            nsects = struct.unpack("<I", data[offset + 64 : offset + 68])[0]
 
             # Sections start at offset+72, each section_64 is 80 bytes:
             # sectname(16) + segname(16) + addr(8) + size(8) + offset(4) + align(4)
@@ -130,12 +144,18 @@ def _extract_text_macho64(data: bytes, source_name: str) -> bytes:
             sect_base = offset + 72
             for s in range(nsects):
                 sect_off = sect_base + s * 80
-                sectname = data[sect_off:sect_off+16].split(b'\x00')[0].decode('ascii')
-                if sectname == '__text':
-                    s_size = struct.unpack('<Q', data[sect_off+40:sect_off+48])[0]
-                    s_offset = struct.unpack('<I', data[sect_off+48:sect_off+52])[0]
-                    text_data = data[s_offset:s_offset+s_size]
-                    logger.debug(f"Loaded __text section from {source_name} (size: {s_size} bytes)")
+                sectname = (
+                    data[sect_off : sect_off + 16].split(b"\x00")[0].decode("ascii")
+                )
+                if sectname == "__text":
+                    s_size = struct.unpack("<Q", data[sect_off + 40 : sect_off + 48])[0]
+                    s_offset = struct.unpack("<I", data[sect_off + 48 : sect_off + 52])[
+                        0
+                    ]
+                    text_data = data[s_offset : s_offset + s_size]
+                    logger.debug(
+                        f"Loaded __text section from {source_name} (size: {s_size} bytes)"
+                    )
                     return text_data
 
         offset += cmdsize
@@ -154,7 +174,7 @@ def _extract_cstring(data: bytes, offset: int) -> str:
     Returns:
         Decoded string
     """
-    end = data.find(b'\x00', offset)
+    end = data.find(b"\x00", offset)
     if end == -1:
         end = len(data)
-    return data[offset:end].decode('ascii', errors='ignore')
+    return data[offset:end].decode("ascii", errors="ignore")

--- a/python/env_manager.py
+++ b/python/env_manager.py
@@ -16,8 +16,6 @@ def ensure(name: str) -> str:
         return cached
     value = os.environ.get(name)
     if not value:
-        raise EnvironmentError(
-            f"Environment variable '{name}' is not set."
-        )
+        raise EnvironmentError(f"Environment variable '{name}' is not set.")
     _cache[name] = value
     return value

--- a/python/kernel_compiler.py
+++ b/python/kernel_compiler.py
@@ -10,7 +10,12 @@ from typing import List, Optional, Tuple
 
 from bindings import get_incore_compiler, get_orchestration_compiler
 from toolchain import (
-    Toolchain, ToolchainType, CCECToolchain, Gxx15Toolchain, GxxToolchain, Aarch64GxxToolchain,
+    Toolchain,
+    ToolchainType,
+    CCECToolchain,
+    Gxx15Toolchain,
+    GxxToolchain,
+    Aarch64GxxToolchain,
 )
 import env_manager
 
@@ -104,11 +109,15 @@ class KernelCompiler:
         else:
             arch = "a2a3"
 
-        runtime_dir = str(self.project_root / "src" / arch / "runtime" / runtime_name / "runtime")
+        runtime_dir = str(
+            self.project_root / "src" / arch / "runtime" / runtime_name / "runtime"
+        )
         common_dir = str(self.project_root / "src" / "common" / "task_interface")
         return [runtime_dir, common_dir] + self.get_platform_include_dirs()
 
-    def _get_orchestration_config(self, runtime_name: str) -> Tuple[List[str], List[str]]:
+    def _get_orchestration_config(
+        self, runtime_name: str
+    ) -> Tuple[List[str], List[str]]:
         """
         Load the optional "orchestration" section from a runtime's build_config.py.
 
@@ -130,7 +139,14 @@ class KernelCompiler:
         else:
             arch = "a2a3"
 
-        config_path = self.project_root / "src" / arch / "runtime" / runtime_name / "build_config.py"
+        config_path = (
+            self.project_root
+            / "src"
+            / arch
+            / "runtime"
+            / runtime_name
+            / "build_config.py"
+        )
         if not config_path.is_file():
             return [], []
 
@@ -146,8 +162,7 @@ class KernelCompiler:
         config_dir = config_path.parent
 
         include_dirs = [
-            str((config_dir / p).resolve())
-            for p in orch_cfg.get("include_dirs", [])
+            str((config_dir / p).resolve()) for p in orch_cfg.get("include_dirs", [])
         ]
 
         source_files = []
@@ -161,13 +176,10 @@ class KernelCompiler:
         return include_dirs, source_files
 
     def _run_subprocess(
-        self,
-        cmd: List[str],
-        label: str,
-        error_hint: str = "Compiler not found"
+        self, cmd: List[str], label: str, error_hint: str = "Compiler not found"
     ) -> subprocess.CompletedProcess:
         """Run a subprocess command with standardized logging and error handling."""
-        logger.debug(f"[{label}] Command: {' '.join(cmd)}")        
+        logger.debug(f"[{label}] Command: {' '.join(cmd)}")
         try:
             result = subprocess.run(cmd, capture_output=True, text=True)
 
@@ -217,12 +229,14 @@ class KernelCompiler:
                 f"Compilation succeeded but output file not found: {output_path}"
             )
 
-        with open(output_path, 'rb') as f:
+        with open(output_path, "rb") as f:
             binary_data = f.read()
 
         if delete_output:
             os.remove(output_path)
-        logger.info(f"[{label}] Compilation {output_path} successful: {len(binary_data)} bytes")
+        logger.info(
+            f"[{label}] Compilation {output_path} successful: {len(binary_data)} bytes"
+        )
         return binary_data
 
     def _get_toolchain(self, strategy_fn, fallback_map: dict) -> ToolchainType:
@@ -248,13 +262,17 @@ class KernelCompiler:
             return fallback_map[self.platform]
 
     @staticmethod
-    def _make_temp_path(prefix: str, suffix: str, build_dir: Optional[str]=None) -> str:
+    def _make_temp_path(
+        prefix: str, suffix: str, build_dir: Optional[str] = None
+    ) -> str:
         """Create a unique temporary file path in /tmp via mkstemp.
 
         The file is created atomically to avoid races, then immediately
         closed so the caller can overwrite it with compiler output.
         """
-        fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=build_dir or "/tmp")
+        fd, path = tempfile.mkstemp(
+            prefix=prefix, suffix=suffix, dir=build_dir or "/tmp"
+        )
         os.close(fd)
         return path
 
@@ -292,8 +310,8 @@ class KernelCompiler:
                 "a2a3": ToolchainType.CCEC,
                 "a2a3sim": ToolchainType.HOST_GXX_15,
                 "a5": ToolchainType.CCEC,  # Phase 1: A5 uses same as A2A3
-                "a5sim": ToolchainType.HOST_GXX_15  # Phase 1: A5sim uses same as A2A3sim
-            }
+                "a5sim": ToolchainType.HOST_GXX_15,  # Phase 1: A5sim uses same as A2A3sim
+            },
         )
 
         # Dispatch based on toolchain
@@ -320,7 +338,8 @@ class KernelCompiler:
         output_path = self._make_temp_path(
             prefix=f"{os.path.basename(source_path)}.incore_",
             suffix=".o",
-            build_dir=build_dir)
+            build_dir=build_dir,
+        )
 
         # Build command from toolchain
         cmd = [self.ccec.cxx_path] + self.ccec.get_compile_flags(core_type=core_type)
@@ -338,7 +357,9 @@ class KernelCompiler:
         logger.debug(f"  Command: {' '.join(cmd)}")
 
         return self._compile_to_bytes(
-            cmd, output_path, "Incore",
+            cmd,
+            output_path,
+            "Incore",
             error_hint=f"ccec compiler not found at {self.ccec.cxx_path}",
             delete_output=build_dir is None,
         )
@@ -386,16 +407,21 @@ class KernelCompiler:
                 "a2a3": ToolchainType.AARCH64_GXX,
                 "a2a3sim": ToolchainType.HOST_GXX,
                 "a5": ToolchainType.AARCH64_GXX,  # Phase 1: A5 uses same as A2A3
-                "a5sim": ToolchainType.HOST_GXX  # Phase 1: A5sim uses same as A2A3sim
-            }
+                "a5sim": ToolchainType.HOST_GXX,  # Phase 1: A5sim uses same as A2A3sim
+            },
         )
-        toolchain = self.aarch64 if toolchain_type == ToolchainType.AARCH64_GXX else self.host_gxx
+        toolchain = (
+            self.aarch64
+            if toolchain_type == ToolchainType.AARCH64_GXX
+            else self.host_gxx
+        )
 
         # HOST_GXX: simulation build (host execution)
         # AARCH64_GXX: cross-compilation for supported runtimes
         #   Note: orchestration uses ops table via pto_orchestration_api.h (no extra runtime sources needed)
         return self._compile_orchestration_shared_lib(
-            source_path, toolchain,
+            source_path,
+            toolchain,
             extra_include_dirs=include_dirs,
             extra_sources=orch_sources or None,
             build_dir=build_dir,
@@ -430,7 +456,8 @@ class KernelCompiler:
         output_path = self._make_temp_path(
             prefix=f"{os.path.basename(source_path)}.orch_",
             suffix=".so",
-            build_dir=build_dir)
+            build_dir=build_dir,
+        )
 
         cmd = [toolchain.cxx_path] + toolchain.get_compile_flags()
 
@@ -459,7 +486,9 @@ class KernelCompiler:
         logger.debug(f"  Command: {' '.join(cmd)}")
 
         return self._compile_to_bytes(
-            cmd, output_path, "Orchestration",
+            cmd,
+            output_path,
+            "Orchestration",
             error_hint=f"{toolchain.cxx_path} not found. Please install it.",
             delete_output=build_dir is None,
         )
@@ -495,7 +524,8 @@ class KernelCompiler:
         output_path = self._make_temp_path(
             prefix=f"{os.path.basename(source_path)}.sim_",
             suffix=ext,
-            build_dir=build_dir)
+            build_dir=build_dir,
+        )
 
         # Build command from toolchain
         cmd = [self.gxx15.cxx_path] + self.gxx15.get_compile_flags()
@@ -518,7 +548,9 @@ class KernelCompiler:
         logger.debug(f"  Command: {' '.join(cmd)}")
 
         return self._compile_to_bytes(
-            cmd, output_path, "SimKernel",
+            cmd,
+            output_path,
+            "SimKernel",
             error_hint=f"{self.gxx15.cxx_path} not found. Please install g++-15.",
             delete_output=build_dir is None,
         )

--- a/python/runtime_builder.py
+++ b/python/runtime_builder.py
@@ -99,24 +99,50 @@ class RuntimeBuilder:
 
         # Prepare configs for all three targets
         aicore_cfg = build_config["aicore"]
-        aicore_include_dirs = [str((config_dir / p).resolve()) for p in aicore_cfg["include_dirs"]]
-        aicore_source_dirs = [str((config_dir / p).resolve()) for p in aicore_cfg["source_dirs"]]
+        aicore_include_dirs = [
+            str((config_dir / p).resolve()) for p in aicore_cfg["include_dirs"]
+        ]
+        aicore_source_dirs = [
+            str((config_dir / p).resolve()) for p in aicore_cfg["source_dirs"]
+        ]
 
         aicpu_cfg = build_config["aicpu"]
-        aicpu_include_dirs = [str((config_dir / p).resolve()) for p in aicpu_cfg["include_dirs"]]
-        aicpu_source_dirs = [str((config_dir / p).resolve()) for p in aicpu_cfg["source_dirs"]]
+        aicpu_include_dirs = [
+            str((config_dir / p).resolve()) for p in aicpu_cfg["include_dirs"]
+        ]
+        aicpu_source_dirs = [
+            str((config_dir / p).resolve()) for p in aicpu_cfg["source_dirs"]
+        ]
 
         host_cfg = build_config["host"]
-        host_include_dirs = [str((config_dir / p).resolve()) for p in host_cfg["include_dirs"]]
-        host_source_dirs = [str((config_dir / p).resolve()) for p in host_cfg["source_dirs"]]
+        host_include_dirs = [
+            str((config_dir / p).resolve()) for p in host_cfg["include_dirs"]
+        ]
+        host_source_dirs = [
+            str((config_dir / p).resolve()) for p in host_cfg["source_dirs"]
+        ]
 
         # Compile all three targets in parallel
         logger.info("Compiling AICore, AICPU, Host in parallel...")
 
         with ThreadPoolExecutor(max_workers=3) as executor:
-            fut_aicore = executor.submit(compiler.compile, "aicore", aicore_include_dirs, aicore_source_dirs, build_dir)
-            fut_aicpu = executor.submit(compiler.compile, "aicpu", aicpu_include_dirs, aicpu_source_dirs, build_dir)
-            fut_host = executor.submit(compiler.compile, "host", host_include_dirs, host_source_dirs, build_dir)
+            fut_aicore = executor.submit(
+                compiler.compile,
+                "aicore",
+                aicore_include_dirs,
+                aicore_source_dirs,
+                build_dir,
+            )
+            fut_aicpu = executor.submit(
+                compiler.compile,
+                "aicpu",
+                aicpu_include_dirs,
+                aicpu_source_dirs,
+                build_dir,
+            )
+            fut_host = executor.submit(
+                compiler.compile, "host", host_include_dirs, host_source_dirs, build_dir
+            )
 
             aicore_binary = fut_aicore.result()
             aicpu_binary = fut_aicpu.result()

--- a/python/runtime_compiler.py
+++ b/python/runtime_compiler.py
@@ -28,7 +28,9 @@ class BuildTarget:
     def get_binary_name(self) -> str:
         return self._binary_name
 
-    def gen_cmake_args(self, include_dirs: List[str], source_dirs: List[str]) -> List[str]:
+    def gen_cmake_args(
+        self, include_dirs: List[str], source_dirs: List[str]
+    ) -> List[str]:
         """Generate CMake arguments list from toolchain args + custom directories."""
         inc = ";".join(os.path.abspath(d) for d in include_dirs)
         src = ";".join(os.path.abspath(d) for d in source_dirs)
@@ -56,6 +58,7 @@ class RuntimeCompiler:
 
     Use get_instance() to get a cached instance per platform.
     """
+
     _instances = {}
 
     @classmethod
@@ -71,20 +74,24 @@ class RuntimeCompiler:
 
         # Map platform name to architecture path
         if platform == "a2a3":
-            self.platform_dir = self.project_root / "src" / "a2a3" / "platform" / "onboard"
+            self.platform_dir = (
+                self.project_root / "src" / "a2a3" / "platform" / "onboard"
+            )
         elif platform == "a2a3sim":
             self.platform_dir = self.project_root / "src" / "a2a3" / "platform" / "sim"
         elif platform == "a5":
-            self.platform_dir = self.project_root / "src" / "a5" / "platform" / "onboard"
+            self.platform_dir = (
+                self.project_root / "src" / "a5" / "platform" / "onboard"
+            )
         elif platform == "a5sim":
             self.platform_dir = self.project_root / "src" / "a5" / "platform" / "sim"
         else:
-            raise ValueError(f"Unknown platform: {platform}. Supported: a2a3, a2a3sim, a5, a5sim")
+            raise ValueError(
+                f"Unknown platform: {platform}. Supported: a2a3, a2a3sim, a5, a5sim"
+            )
 
         if not self.platform_dir.is_dir():
-            raise ValueError(
-                f"Platform '{platform}' not found at {self.platform_dir}"
-            )
+            raise ValueError(f"Platform '{platform}' not found at {self.platform_dir}")
 
         if platform == "a2a3":
             self._init_a2a3()
@@ -95,7 +102,9 @@ class RuntimeCompiler:
         elif platform == "a5sim":
             self._init_a5sim()
         else:
-            raise ValueError(f"Unknown platform: {platform}. Supported: a2a3, a2a3sim, a5, a5sim")
+            raise ValueError(
+                f"Unknown platform: {platform}. Supported: a2a3, a2a3sim, a5, a5sim"
+            )
 
     def _init_a2a3(self):
         """Initialize toolchains for real a2a3 hardware."""
@@ -181,20 +190,20 @@ class RuntimeCompiler:
 
     def _ensure_host_compilers(self):
         if not self._find_executable("gcc"):
-            raise FileNotFoundError("Host C compiler not found: gcc. Please install gcc.")
+            raise FileNotFoundError(
+                "Host C compiler not found: gcc. Please install gcc."
+            )
         if not self._find_executable("g++"):
-            raise FileNotFoundError("Host C++ compiler not found: g++. Please install g++.")
+            raise FileNotFoundError(
+                "Host C++ compiler not found: g++. Please install g++."
+            )
 
     @staticmethod
     def _find_executable(name: str) -> bool:
         """Check if an executable exists (either as absolute path or in PATH)."""
         if os.path.isfile(name) and os.access(name, os.X_OK):
             return True
-        result = subprocess.run(
-            ["which", name],
-            capture_output=True,
-            timeout=1
-        )
+        result = subprocess.run(["which", name], capture_output=True, timeout=1)
         return result.returncode == 0
 
     def compile(
@@ -246,11 +255,16 @@ class RuntimeCompiler:
                 platform=platform,
                 build_dir=build_dir,
             )
+
         if build_dir is None:
-            with tempfile.TemporaryDirectory(prefix=f"{platform.lower()}_build_", dir="/tmp") as build_dir:
+            with tempfile.TemporaryDirectory(
+                prefix=f"{platform.lower()}_build_", dir="/tmp"
+            ) as build_dir:
                 return _build(build_dir)
         else:
-            platform_build_dir = Path(os.path.realpath(build_dir)) / f"{platform.lower()}"
+            platform_build_dir = (
+                Path(os.path.realpath(build_dir)) / f"{platform.lower()}"
+            )
             os.makedirs(platform_build_dir, exist_ok=True)
             return _build(platform_build_dir)
 
@@ -338,4 +352,3 @@ class RuntimeCompiler:
             binary_data = f.read()
 
         return binary_data
-

--- a/python/task_interface.py
+++ b/python/task_interface.py
@@ -41,15 +41,16 @@ def _ensure_torch_map():
     if _TORCH_DTYPE_MAP is not None:
         return
     import torch
+
     _TORCH_DTYPE_MAP = {
-        torch.float32:  DataType.FLOAT32,
-        torch.float16:  DataType.FLOAT16,
-        torch.int32:    DataType.INT32,
-        torch.int16:    DataType.INT16,
-        torch.int8:     DataType.INT8,
-        torch.uint8:    DataType.UINT8,
+        torch.float32: DataType.FLOAT32,
+        torch.float16: DataType.FLOAT16,
+        torch.int32: DataType.INT32,
+        torch.int16: DataType.INT16,
+        torch.int8: DataType.INT8,
+        torch.uint8: DataType.UINT8,
         torch.bfloat16: DataType.BFLOAT16,
-        torch.int64:    DataType.INT64,
+        torch.int64: DataType.INT64,
     }
 
 
@@ -84,6 +85,7 @@ def make_scalar_arg(value) -> TaskArg:
     bit-cast to uint64.
     """
     import ctypes as _ct
+
     if isinstance(value, _ct._SimpleCData):
         if isinstance(value, (_ct.c_float, _ct.c_double)):
             uint_type = _ct.c_uint32 if isinstance(value, _ct.c_float) else _ct.c_uint64

--- a/python/toolchain.py
+++ b/python/toolchain.py
@@ -1,4 +1,3 @@
-
 import os
 from enum import IntEnum
 from typing import List, Optional
@@ -8,10 +7,11 @@ import env_manager
 # Must match compile_strategy.h
 class ToolchainType(IntEnum):
     """Toolchain types matching the C enum in compile_strategy.h."""
-    CCEC = 0           # ccec (Ascend AICore compiler)
-    HOST_GXX_15 = 1    # g++-15 (host, simulation kernels)
-    HOST_GXX = 2       # g++ (host, orchestration .so)
-    AARCH64_GXX = 3    # aarch64-target-linux-gnu-g++ (cross-compile)
+
+    CCEC = 0  # ccec (Ascend AICore compiler)
+    HOST_GXX_15 = 1  # g++-15 (host, simulation kernels)
+    HOST_GXX = 2  # g++ (host, orchestration .so)
+    AARCH64_GXX = 3  # aarch64-target-linux-gnu-g++ (cross-compile)
 
 
 class Toolchain:
@@ -53,13 +53,9 @@ class CCECToolchain(Toolchain):
         self.linker_path = os.path.join(self.ascend_home_path, "bin", "ld.lld")
 
         if not os.path.isfile(self.cxx_path):
-            raise FileNotFoundError(
-                f"ccec compiler not found: {self.cxx_path}"
-            )
+            raise FileNotFoundError(f"ccec compiler not found: {self.cxx_path}")
         if not os.path.isfile(self.linker_path):
-            raise FileNotFoundError(
-                f"ccec linker not found: {self.linker_path}"
-            )
+            raise FileNotFoundError(f"ccec linker not found: {self.linker_path}")
 
     def get_compile_flags(self, core_type: str = "aiv", **kwargs) -> List[str]:
         # A5 uses dav-c310 architecture, A2A3 uses dav-c220
@@ -68,18 +64,30 @@ class CCECToolchain(Toolchain):
         elif self.platform in ("a2a3", "a2a3sim"):
             arch = "dav-c220-vec" if core_type == "aiv" else "dav-c220-cube"
         else:
-            raise ValueError(f"Unknown platform: {self.platform}. Supported: a2a3, a2a3sim, a5, a5sim")
+            raise ValueError(
+                f"Unknown platform: {self.platform}. Supported: a2a3, a2a3sim, a5, a5sim"
+            )
 
         return [
-            "-c", "-O3", "-g", "-x", "cce",
-            "-Wall", "-std=c++17",
+            "-c",
+            "-O3",
+            "-g",
+            "-x",
+            "cce",
+            "-Wall",
+            "-std=c++17",
             "--cce-aicore-only",
             f"--cce-aicore-arch={arch}",
-            "-mllvm", "-cce-aicore-stack-size=0x8000",
-            "-mllvm", "-cce-aicore-function-stack-size=0x8000",
-            "-mllvm", "-cce-aicore-record-overflow=false",
-            "-mllvm", "-cce-aicore-addr-transform",
-            "-mllvm", "-cce-aicore-dcci-insert-for-scalar=false",
+            "-mllvm",
+            "-cce-aicore-stack-size=0x8000",
+            "-mllvm",
+            "-cce-aicore-function-stack-size=0x8000",
+            "-mllvm",
+            "-cce-aicore-record-overflow=false",
+            "-mllvm",
+            "-cce-aicore-addr-transform",
+            "-mllvm",
+            "-cce-aicore-dcci-insert-for-scalar=false",
             "-DMEMORY_BASE",
         ]
 
@@ -99,7 +107,9 @@ class Gxx15Toolchain(Toolchain):
 
     def get_compile_flags(self, core_type: str = "", **kwargs) -> List[str]:
         flags = [
-            "-shared", "-O2", "-fPIC",
+            "-shared",
+            "-O2",
+            "-fPIC",
             "-std=c++23",
             "-fpermissive",
             "-Wno-macro-redefined",
@@ -156,21 +166,23 @@ class Aarch64GxxToolchain(Toolchain):
     def __init__(self):
         super().__init__()
         self.cxx_path = os.path.join(
-            self.ascend_home_path, "tools", "hcc", "bin",
+            self.ascend_home_path,
+            "tools",
+            "hcc",
+            "bin",
             "aarch64-target-linux-gnu-g++",
         )
         self.cc_path = os.path.join(
-            self.ascend_home_path, "tools", "hcc", "bin",
+            self.ascend_home_path,
+            "tools",
+            "hcc",
+            "bin",
             "aarch64-target-linux-gnu-gcc",
         )
         if not os.path.isfile(self.cc_path):
-            raise FileNotFoundError(
-                f"aarch64 C compiler not found: {self.cc_path}"
-            )
+            raise FileNotFoundError(f"aarch64 C compiler not found: {self.cc_path}")
         if not os.path.isfile(self.cxx_path):
-            raise FileNotFoundError(
-                f"aarch64 C++ compiler not found: {self.cxx_path}"
-            )
+            raise FileNotFoundError(f"aarch64 C++ compiler not found: {self.cxx_path}")
 
     def get_compile_flags(self, **kwargs) -> List[str]:
         return ["-shared", "-fPIC", "-O3", "-g", "-std=c++17"]

--- a/src/a2a3/platform/include/aicore/performance_collector_aicore.h
+++ b/src/a2a3/platform/include/aicore/performance_collector_aicore.h
@@ -36,13 +36,8 @@
  * @param start_time Start timestamp
  * @param end_time End timestamp
  */
-__aicore__ __attribute__((always_inline))
-static inline void perf_aicore_record_task(
-    __gm__ PerfBuffer* perf_buf,
-    uint32_t task_id,
-    uint64_t start_time,
-    uint64_t end_time) {
-
+__aicore__ __attribute__((always_inline)) static inline void perf_aicore_record_task(
+    __gm__ PerfBuffer* perf_buf, uint32_t task_id, uint64_t start_time, uint64_t end_time) {
     // Read current buffer count (AICPU owns the count, AICore reads only)
     dcci(&perf_buf->count, SINGLE_CACHE_LINE);
     uint32_t idx = perf_buf->count;

--- a/src/a2a3/platform/include/aicpu/device_log.h
+++ b/src/a2a3/platform/include/aicpu/device_log.h
@@ -57,41 +57,41 @@ void dev_log_always(const char* func, const char* fmt, ...);
 // High-Level Logging Macros (Platform-Independent Layer)
 // =============================================================================
 
-#define D_DEV_LOGD(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_debug()) { \
+#define D_DEV_LOGD(MODE_NAME, fmt, ...)                      \
+    do {                                                     \
+        if (is_log_enable_debug()) {                         \
             dev_log_debug(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                    \
+    } while (0)
 
-#define D_DEV_LOGI(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_info()) { \
+#define D_DEV_LOGI(MODE_NAME, fmt, ...)                     \
+    do {                                                    \
+        if (is_log_enable_info()) {                         \
             dev_log_info(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                   \
+    } while (0)
 
-#define D_DEV_LOGW(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_warn()) { \
+#define D_DEV_LOGW(MODE_NAME, fmt, ...)                     \
+    do {                                                    \
+        if (is_log_enable_warn()) {                         \
             dev_log_warn(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                   \
+    } while (0)
 
-#define D_DEV_LOGE(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_error()) { \
+#define D_DEV_LOGE(MODE_NAME, fmt, ...)                      \
+    do {                                                     \
+        if (is_log_enable_error()) {                         \
             dev_log_error(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                    \
+    } while (0)
 
 // =============================================================================
 // Convenience Macros
 // =============================================================================
 
 #define DEV_DEBUG(fmt, args...) D_DEV_LOGD(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_INFO(fmt, args...)  D_DEV_LOGI(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_WARN(fmt, args...)  D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
+#define DEV_INFO(fmt, args...) D_DEV_LOGI(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
+#define DEV_WARN(fmt, args...) D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
 #define DEV_ERROR(fmt, args...) D_DEV_LOGE(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
 #define DEV_ALWAYS(fmt, args...) dev_log_always(__FUNCTION__, fmt, ##args)
 
@@ -110,32 +110,32 @@ void dev_log_always(const char* func, const char* fmt, ...);
 // Conditional Check Macros
 // =============================================================================
 
-#define DEV_CHECK_COND_RETURN_VOID(cond, fmt, ...)          \
-    do {                                                    \
-        if (!(cond)) {                                      \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return;                                         \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_COND_RETURN_VOID(cond, fmt, ...) \
+    do {                                           \
+        if (!(cond)) {                             \
+            DEV_ERROR(fmt, ##__VA_ARGS__);         \
+            DEV_ASSERT(0);                         \
+            return;                                \
+        }                                          \
+    } while (0)
 
-#define DEV_CHECK_COND_RETURN(cond, retval, fmt, ...)       \
-    do {                                                    \
-        if (!(cond)) {                                      \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return (retval);                                \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_COND_RETURN(cond, retval, fmt, ...) \
+    do {                                              \
+        if (!(cond)) {                                \
+            DEV_ERROR(fmt, ##__VA_ARGS__);            \
+            DEV_ASSERT(0);                            \
+            return (retval);                          \
+        }                                             \
+    } while (0)
 
-#define DEV_CHECK_POINTER_NULL_RETURN_VOID(ptr, fmt, ...)   \
-    do {                                                    \
-        if ((ptr) == nullptr) {                             \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return;                                         \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_POINTER_NULL_RETURN_VOID(ptr, fmt, ...) \
+    do {                                                  \
+        if ((ptr) == nullptr) {                           \
+            DEV_ERROR(fmt, ##__VA_ARGS__);                \
+            DEV_ASSERT(0);                                \
+            return;                                       \
+        }                                                 \
+    } while (0)
 
 // =============================================================================
 // Helper Functions
@@ -143,8 +143,8 @@ void dev_log_always(const char* func, const char* fmt, ...);
 
 // Check if log level is enabled (inline for efficiency)
 inline bool is_log_enable_debug() { return g_is_log_enable_debug; }
-inline bool is_log_enable_info()  { return g_is_log_enable_info; }
-inline bool is_log_enable_warn()  { return g_is_log_enable_warn; }
+inline bool is_log_enable_info() { return g_is_log_enable_info; }
+inline bool is_log_enable_warn() { return g_is_log_enable_warn; }
 inline bool is_log_enable_error() { return g_is_log_enable_error; }
 
 // Initialize log switch (platform-specific implementation)

--- a/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
@@ -46,14 +46,14 @@ void perf_aicpu_init_profiling(Runtime* runtime);
  * @param fanout_count          Number of entries in fanout array (0 if none)
  */
 int perf_aicpu_complete_record(PerfBuffer* perf_buf,
-                                uint32_t expected_reg_task_id,
-                                uint64_t task_id,
-                                uint32_t func_id,
-                                CoreType core_type,
-                                uint64_t dispatch_time,
-                                uint64_t finish_time,
-                                const uint64_t* fanout,
-                                int32_t fanout_count);
+    uint32_t expected_reg_task_id,
+    uint64_t task_id,
+    uint32_t func_id,
+    CoreType core_type,
+    uint64_t dispatch_time,
+    uint64_t finish_time,
+    const uint64_t* fanout,
+    int32_t fanout_count);
 
 /**
  * Switch performance buffer when current buffer is full
@@ -76,10 +76,7 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx);
  * @param cur_thread_cores Array of core IDs managed by this thread
  * @param core_num Number of cores managed by this thread
  */
-void perf_aicpu_flush_buffers(Runtime* runtime,
-                               int thread_idx,
-                               const int* cur_thread_cores,
-                               int core_num);
+void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num);
 
 /**
  * Update total task count in performance header
@@ -120,9 +117,11 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
  *                        phases in multi-ring runtimes: tensormap_and_ringbuffer, aicpu_build_graph)
  */
 void perf_aicpu_record_phase(int thread_idx,
-                              AicpuPhaseId phase_id,
-                              uint64_t start_time, uint64_t end_time,
-                              uint32_t loop_iter, uint64_t tasks_processed);
+    AicpuPhaseId phase_id,
+    uint64_t start_time,
+    uint64_t end_time,
+    uint32_t loop_iter,
+    uint64_t tasks_processed);
 
 /**
  * Write orchestrator cumulative summary
@@ -154,13 +153,12 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx);
  * @param start_time Phase start timestamp
  * @param end_time Phase end timestamp
  * @param submit_idx Task submission index (acts as loop_iter)
- * @param task_id Task identifier. For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), this is the full PTO2 encoding:
- *               (ring_id << 32) | local_id, enabling cross-view correlation between orchestrator
- *               and scheduler swimlanes.
+ * @param task_id Task identifier. For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), this is the
+ * full PTO2 encoding: (ring_id << 32) | local_id, enabling cross-view correlation between orchestrator and scheduler
+ * swimlanes.
  */
-void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
-                                   uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx, uint64_t task_id);
+void perf_aicpu_record_orch_phase(
+    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id);
 
 /**
  * Write core-to-thread assignment mapping to shared memory
@@ -174,9 +172,9 @@ void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
  * @param total_cores Total number of cores
  */
 void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
-                                        const int* core_counts,
-                                        int num_threads,
-                                        int total_cores);
+    const int* core_counts,
+    int num_threads,
+    int total_cores);
 
 /**
  * Flush remaining phase records for a thread

--- a/src/a2a3/platform/include/common/compile_strategy.h
+++ b/src/a2a3/platform/include/common/compile_strategy.h
@@ -16,10 +16,10 @@
 #define COMPILE_STRATEGY_H
 
 typedef enum {
-    TOOLCHAIN_CCEC = 0,          // ccec (Ascend AICore compiler)
-    TOOLCHAIN_HOST_GXX_15 = 1,   // g++-15 (host, simulation kernels)
-    TOOLCHAIN_HOST_GXX = 2,      // g++ (host, orchestration .so)
-    TOOLCHAIN_AARCH64_GXX = 3,   // aarch64-target-linux-gnu-g++ (cross-compile)
+    TOOLCHAIN_CCEC = 0,         // ccec (Ascend AICore compiler)
+    TOOLCHAIN_HOST_GXX_15 = 1,  // g++-15 (host, simulation kernels)
+    TOOLCHAIN_HOST_GXX = 2,     // g++ (host, orchestration .so)
+    TOOLCHAIN_AARCH64_GXX = 3,  // aarch64-target-linux-gnu-g++ (cross-compile)
 } ToolchainType;
 
 #endif /* COMPILE_STRATEGY_H */

--- a/src/a2a3/platform/include/common/core_type.h
+++ b/src/a2a3/platform/include/common/core_type.h
@@ -53,9 +53,12 @@ inline CoreType core_type_from_string(const char* type_str) {
  */
 inline const char* core_type_to_string(CoreType core_type) {
     switch (core_type) {
-        case CoreType::AIC: return "AIC";
-        case CoreType::AIV: return "AIV";
-        default: return "UNKNOWN";
+        case CoreType::AIC:
+            return "AIC";
+        case CoreType::AIV:
+            return "AIV";
+        default:
+            return "UNKNOWN";
     }
 }
 

--- a/src/a2a3/platform/include/common/memory_barrier.h
+++ b/src/a2a3/platform/include/common/memory_barrier.h
@@ -21,24 +21,24 @@
 // =============================================================================
 
 #ifdef __aarch64__
-    /**
-     * Read memory barrier (ARM64)
-     * Ensures all loads before this point complete before any loads after.
-     */
-    #define rmb() __asm__ __volatile__("dsb ld" ::: "memory")
+/**
+ * Read memory barrier (ARM64)
+ * Ensures all loads before this point complete before any loads after.
+ */
+#define rmb() __asm__ __volatile__("dsb ld" ::: "memory")
 
-    /**
-     * Write memory barrier (ARM64)
-     * Ensures all stores before this point complete before any stores after.
-     */
-    #define wmb() __asm__ __volatile__("dsb st" ::: "memory")
+/**
+ * Write memory barrier (ARM64)
+ * Ensures all stores before this point complete before any stores after.
+ */
+#define wmb() __asm__ __volatile__("dsb st" ::: "memory")
 #else
-    /**
-     * Compiler barrier (fallback for non-ARM64 platforms)
-     * Prevents compiler reordering but does not emit hardware barriers.
-     */
-    #define rmb() __asm__ __volatile__("" ::: "memory")
-    #define wmb() __asm__ __volatile__("" ::: "memory")
+/**
+ * Compiler barrier (fallback for non-ARM64 platforms)
+ * Prevents compiler reordering but does not emit hardware barriers.
+ */
+#define rmb() __asm__ __volatile__("" ::: "memory")
+#define wmb() __asm__ __volatile__("" ::: "memory")
 #endif
 
 #endif  // PLATFORM_COMMON_MEMORY_BARRIER_H_

--- a/src/a2a3/platform/include/common/perf_profiling.h
+++ b/src/a2a3/platform/include/common/perf_profiling.h
@@ -63,29 +63,28 @@
  */
 struct PerfRecord {
     // Timing information (device clock timestamps)
-    uint64_t start_time;         // Task start timestamp (get_sys_cnt)
-    uint64_t end_time;           // Task end timestamp
-    uint64_t duration;           // Execution duration (end - start)
+    uint64_t start_time;  // Task start timestamp (get_sys_cnt)
+    uint64_t end_time;    // Task end timestamp
+    uint64_t duration;    // Execution duration (end - start)
 
     // AICPU-side timestamps (written by AICPU, not AICore)
-    uint64_t dispatch_time;      // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
-    uint64_t finish_time;        // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
+    uint64_t dispatch_time;  // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
+    uint64_t finish_time;    // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
 
     // AICore writes the register dispatch token (low 32 bits only) zero-extended into task_id.
     // For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), AICPU overwrites
     // with the full PTO2 encoding (ring_id << 32) | local_id after FIN/perf row match.
     // For host_build_graph, task_id stays as the plain integer task index (ring_id = 0).
     uint64_t task_id;
-    uint32_t func_id;         // Kernel function identifier
-    CoreType core_type;       // Core type (AIC/AIV)
+    uint32_t func_id;    // Kernel function identifier
+    CoreType core_type;  // Core type (AIC/AIV)
 
     // Dependency relationship (fanout only)
     uint64_t fanout[RUNTIME_MAX_FANOUT];  // Successor task task_id array
-    int32_t fanout_count;                  // Number of successor tasks
+    int32_t fanout_count;                 // Number of successor tasks
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfRecord) % 64 == 0,
-              "PerfRecord must be 64-byte aligned for optimal cache performance");
+static_assert(sizeof(PerfRecord) % 64 == 0, "PerfRecord must be 64-byte aligned for optimal cache performance");
 
 // =============================================================================
 // PerfBuffer - Fixed-Size Record Buffer
@@ -99,7 +98,7 @@ static_assert(sizeof(PerfRecord) % 64 == 0,
  */
 struct PerfBuffer {
     PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Record array
-    volatile uint32_t count;                         // Current record count
+    volatile uint32_t count;                        // Current record count
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -123,13 +122,12 @@ struct PerfBuffer {
  */
 struct PerfFreeQueue {
     volatile uint64_t buffer_ptrs[PLATFORM_PROF_SLOT_COUNT];  // Free buffer addresses
-    volatile uint32_t head;  // Consumer read position (Device increments)
-    volatile uint32_t tail;  // Producer write position (Host increments)
-    uint32_t pad[13];        // Pad to 128 bytes (aligned to cache line)
+    volatile uint32_t head;                                   // Consumer read position (Device increments)
+    volatile uint32_t tail;                                   // Producer write position (Host increments)
+    uint32_t pad[13];                                         // Pad to 128 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfFreeQueue) == 128,
-              "PerfFreeQueue must be 128 bytes for cache alignment");
+static_assert(sizeof(PerfFreeQueue) == 128, "PerfFreeQueue must be 128 bytes for cache alignment");
 
 // =============================================================================
 // PerfBufferState - Per-Core/Thread Buffer State (Unified for PerfRecord and Phase)
@@ -154,14 +152,13 @@ static_assert(sizeof(PerfFreeQueue) == 128,
  * - current_buf_seq: Device writes (monotonic counter)
  */
 struct PerfBufferState {
-    PerfFreeQueue free_queue;            // SPSC queue of free buffer addresses
-    volatile uint64_t current_buf_ptr;   // Current active buffer (0 = none)
-    volatile uint32_t current_buf_seq;   // Sequence number for ordering
-    uint32_t pad[13];                    // Pad to 192 bytes (aligned to cache line)
+    PerfFreeQueue free_queue;           // SPSC queue of free buffer addresses
+    volatile uint64_t current_buf_ptr;  // Current active buffer (0 = none)
+    volatile uint32_t current_buf_seq;  // Sequence number for ordering
+    uint32_t pad[13];                   // Pad to 192 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfBufferState) == 192,
-              "PerfBufferState must be 192 bytes for cache alignment");
+static_assert(sizeof(PerfBufferState) == 192, "PerfBufferState must be 192 bytes for cache alignment");
 
 // Type alias for semantic clarity in Phase profiling context
 using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
@@ -181,11 +178,11 @@ using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
  * - Phase entry:      core_index = thread_idx, is_phase = 1
  */
 struct ReadyQueueEntry {
-    uint32_t core_index;      // Core index (0 ~ num_cores-1), or thread_idx for phase entries
-    uint32_t is_phase;        // 0 = PerfRecord, 1 = Phase
-    uint64_t buffer_ptr;      // Device pointer to the full buffer
-    uint32_t buffer_seq;      // Sequence number for ordering
-    uint32_t pad;             // Alignment padding
+    uint32_t core_index;  // Core index (0 ~ num_cores-1), or thread_idx for phase entries
+    uint32_t is_phase;    // 0 = PerfRecord, 1 = Phase
+    uint64_t buffer_ptr;  // Device pointer to the full buffer
+    uint32_t buffer_seq;  // Sequence number for ordering
+    uint32_t pad;         // Alignment padding
 } __attribute__((aligned(32)));
 
 // =============================================================================
@@ -216,8 +213,8 @@ struct PerfDataHeader {
     volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // Producer write positions (AICPU modifies)
 
     // Metadata (Host initializes, Device read-only)
-    uint32_t num_cores;                              // Actual number of cores launched
-    volatile uint32_t total_tasks;                   // Total tasks (AICPU writes after orchestration)
+    uint32_t num_cores;             // Actual number of cores launched
+    volatile uint32_t total_tasks;  // Total tasks (AICPU writes after orchestration)
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -232,21 +229,21 @@ struct PerfDataHeader {
  */
 enum class AicpuPhaseId : uint32_t {
     // Scheduler phases (0-3)
-    SCHED_COMPLETE    = 0,  // Process completed tasks (fanout traversal)
-    SCHED_DISPATCH    = 1,  // Dispatch ready tasks to idle cores
-    SCHED_SCAN        = 2,  // Incremental scan for root tasks
-    SCHED_IDLE_WAIT   = 3,  // Idle/spinning (no progress)
+    SCHED_COMPLETE = 0,     // Process completed tasks (fanout traversal)
+    SCHED_DISPATCH = 1,     // Dispatch ready tasks to idle cores
+    SCHED_SCAN = 2,         // Incremental scan for root tasks
+    SCHED_IDLE_WAIT = 3,    // Idle/spinning (no progress)
     SCHED_PHASE_COUNT = 4,  // Sentinel: number of scheduler phases
     // Orchestrator phases (16-24)
-    ORCH_SYNC      = 16,  // tensormap sync
-    ORCH_ALLOC     = 17,  // task_ring_alloc
-    ORCH_PARAMS    = 18,  // param copy
-    ORCH_LOOKUP    = 19,  // tensormap lookup + dep
-    ORCH_HEAP      = 20,  // heap alloc
-    ORCH_INSERT    = 21,  // tensormap insert
-    ORCH_FANIN     = 22,  // fanin + early-ready
-    ORCH_FINALIZE  = 23,  // scheduler init + SM
-    ORCH_SCOPE_END = 24   // scope_end
+    ORCH_SYNC = 16,      // tensormap sync
+    ORCH_ALLOC = 17,     // task_ring_alloc
+    ORCH_PARAMS = 18,    // param copy
+    ORCH_LOOKUP = 19,    // tensormap lookup + dep
+    ORCH_HEAP = 20,      // heap alloc
+    ORCH_INSERT = 21,    // tensormap insert
+    ORCH_FANIN = 22,     // fanin + early-ready
+    ORCH_FINALIZE = 23,  // scheduler init + SM
+    ORCH_SCOPE_END = 24  // scope_end
 };
 
 /**
@@ -256,14 +253,14 @@ enum class AicpuPhaseId : uint32_t {
  * No thread_id field: identity is derived from array index (position = identity).
  */
 struct AicpuPhaseRecord {
-    uint64_t start_time;       // Phase start timestamp
-    uint64_t end_time;         // Phase end timestamp
-    uint32_t loop_iter;        // Loop iteration number
-    AicpuPhaseId phase_id;     // Phase type
+    uint64_t start_time;    // Phase start timestamp
+    uint64_t end_time;      // Phase end timestamp
+    uint32_t loop_iter;     // Loop iteration number
+    AicpuPhaseId phase_id;  // Phase type
     union {
-        uint64_t task_id;   // Multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph):
-                            // full PTO2 encoding (ring_id << 32) | local_id for cross-view correlation.
-        uint64_t tasks_processed; // Scheduler phases: number of tasks processed in this batch
+        uint64_t task_id;          // Multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph):
+                                   // full PTO2 encoding (ring_id << 32) | local_id for cross-view correlation.
+        uint64_t tasks_processed;  // Scheduler phases: number of tasks processed in this batch
     };
 };
 
@@ -284,12 +281,12 @@ struct AicpuOrchSummary {
     uint64_t insert_cycle;     // tensormap_insert phase
     uint64_t fanin_cycle;      // fanin+ready phase
     uint64_t scope_end_cycle;  // scope_end phase
-    int64_t  submit_count;     // Total tasks submitted
+    int64_t submit_count;      // Total tasks submitted
     uint32_t magic;            // Validation magic (AICPU_PHASE_MAGIC)
     uint32_t padding;          // Alignment padding
 } __attribute__((aligned(64)));
 
-constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"
+constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;        // "ACPH"
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per thread
 
 /**
@@ -310,12 +307,12 @@ struct PhaseBuffer {
  * Contains metadata and per-thread tracking.
  */
 struct AicpuPhaseHeader {
-    uint32_t magic;                  // Validation magic (AICPU_PHASE_MAGIC)
-    uint32_t num_sched_threads;      // Number of scheduler threads
-    uint32_t records_per_thread;     // Max records per PhaseBuffer
-    uint32_t num_cores;              // Total number of cores with valid assignments
+    uint32_t magic;                             // Validation magic (AICPU_PHASE_MAGIC)
+    uint32_t num_sched_threads;                 // Number of scheduler threads
+    uint32_t records_per_thread;                // Max records per PhaseBuffer
+    uint32_t num_cores;                         // Total number of cores with valid assignments
     int8_t core_to_thread[PLATFORM_MAX_CORES];  // core_id → scheduler thread index (-1 = unassigned)
-    AicpuOrchSummary orch_summary;   // Orchestrator cumulative data
+    AicpuOrchSummary orch_summary;              // Orchestrator cumulative data
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -345,9 +342,7 @@ inline size_t calc_perf_data_size(int num_cores) {
  * @param base_ptr Shared memory base address (device_ptr or host_ptr)
  * @return PerfDataHeader pointer
  */
-inline PerfDataHeader* get_perf_header(void* base_ptr) {
-    return (PerfDataHeader*)base_ptr;
-}
+inline PerfDataHeader* get_perf_header(void* base_ptr) { return (PerfDataHeader*)base_ptr; }
 
 /**
  * Get PerfBufferState array start address
@@ -378,9 +373,7 @@ inline PerfBufferState* get_perf_buffer_state(void* base_ptr, int core_index) {
  * @return Total bytes needed for header + all buffer states
  */
 inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threads) {
-    return calc_perf_data_size(num_cores)
-         + sizeof(AicpuPhaseHeader)
-         + num_sched_threads * sizeof(PhaseBufferState);
+    return calc_perf_data_size(num_cores) + sizeof(AicpuPhaseHeader) + num_sched_threads * sizeof(PhaseBufferState);
 }
 
 /**

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -60,14 +60,11 @@ constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 6;
  * - MAX_AIC_PER_THREAD = MAX_BLOCKDIM * AIC_CORES_PER_BLOCKDIM = 24 * 1 = 24
  * - MAX_AIV_PER_THREAD = MAX_BLOCKDIM * AIV_CORES_PER_BLOCKDIM = 24 * 2 = 48
  */
-constexpr int PLATFORM_MAX_AIC_PER_THREAD =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_AIC_CORES_PER_BLOCKDIM;  // 24
+constexpr int PLATFORM_MAX_AIC_PER_THREAD = PLATFORM_MAX_BLOCKDIM * PLATFORM_AIC_CORES_PER_BLOCKDIM;  // 24
 
-constexpr int PLATFORM_MAX_AIV_PER_THREAD =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_AIV_CORES_PER_BLOCKDIM;  // 48
+constexpr int PLATFORM_MAX_AIV_PER_THREAD = PLATFORM_MAX_BLOCKDIM * PLATFORM_AIV_CORES_PER_BLOCKDIM;  // 48
 
-constexpr int PLATFORM_MAX_CORES_PER_THREAD =
-    PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD;  // 72
+constexpr int PLATFORM_MAX_CORES_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD;  // 72
 
 // =============================================================================
 // Performance Profiling Configuration
@@ -77,8 +74,7 @@ constexpr int PLATFORM_MAX_CORES_PER_THREAD =
  * Maximum number of cores that can be profiled simultaneously
  * Calculated as: MAX_BLOCKDIM * CORES_PER_BLOCKDIM = 24 * 3 = 72
  */
-constexpr int PLATFORM_MAX_CORES =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 72
+constexpr int PLATFORM_MAX_CORES = PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 72
 
 /**
  * Performance buffer capacity per buffer
@@ -103,8 +99,7 @@ constexpr int PLATFORM_PROF_SLOT_COUNT = 8;
  *   Phase:      PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT
  */
 constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
-    PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT
-    + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT;  // 608
+    PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT;  // 608
 
 /**
  * System counter frequency (get_sys_cnt)
@@ -159,9 +154,12 @@ enum class RegId : uint32_t {
  */
 constexpr uint32_t reg_offset(RegId reg) {
     switch (reg) {
-        case RegId::DATA_MAIN_BASE:  return REG_SPR_DATA_MAIN_BASE_OFFSET;
-        case RegId::COND:            return REG_SPR_COND_OFFSET;
-        case RegId::FAST_PATH_ENABLE: return REG_SPR_FAST_PATH_ENABLE_OFFSET;
+        case RegId::DATA_MAIN_BASE:
+            return REG_SPR_DATA_MAIN_BASE_OFFSET;
+        case RegId::COND:
+            return REG_SPR_COND_OFFSET;
+        case RegId::FAST_PATH_ENABLE:
+            return REG_SPR_FAST_PATH_ENABLE_OFFSET;
     }
     return 0;  // unreachable: all RegId cases handled above
 }
@@ -197,26 +195,26 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = 25;
  * State: ACK (0) = task received, FIN (1) = task completed
  */
 
-#define TASK_ID_MASK       0x7FFFFFFFU
-#define TASK_STATE_MASK    0x80000000U
+#define TASK_ID_MASK 0x7FFFFFFFU
+#define TASK_STATE_MASK 0x80000000U
 
-#define TASK_ACK_STATE     0
-#define TASK_FIN_STATE     1
+#define TASK_ACK_STATE 0
+#define TASK_FIN_STATE 1
 
-#define EXTRACT_TASK_ID(regval)    ((int)((regval) & TASK_ID_MASK))
+#define EXTRACT_TASK_ID(regval) ((int)((regval) & TASK_ID_MASK))
 #define EXTRACT_TASK_STATE(regval) ((int)(((regval) & TASK_STATE_MASK) >> 31))
-#define MAKE_ACK_VALUE(task_id)    ((uint64_t)((task_id) & TASK_ID_MASK))
-#define MAKE_FIN_VALUE(task_id)    ((uint64_t)(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
+#define MAKE_ACK_VALUE(task_id) ((uint64_t)((task_id) & TASK_ID_MASK))
+#define MAKE_FIN_VALUE(task_id) ((uint64_t)(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
 
 // These values are RESERVED and must never be used as real task IDs.
 // Valid task IDs: 0 to 0x7FFFFFEF (2147483631)
-#define AICORE_IDLE_TASK_ID        0x7FFFFFFFU
-#define AICORE_IDLE_VALUE          MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
+#define AICORE_IDLE_TASK_ID 0x7FFFFFFFU
+#define AICORE_IDLE_VALUE MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
 
-#define AICORE_EXIT_TASK_ID        0x7FFFFFFEU
-#define AICORE_EXITED_VALUE        MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
+#define AICORE_EXIT_TASK_ID 0x7FFFFFFEU
+#define AICORE_EXITED_VALUE MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
 
-#define AICPU_IDLE_TASK_ID         0x7FFFFFFDU
+#define AICPU_IDLE_TASK_ID 0x7FFFFFFDU
 
 // =============================================================================
 // Task State Constants

--- a/src/a2a3/platform/include/common/unified_log.h
+++ b/src/a2a3/platform/include/common/unified_log.h
@@ -32,10 +32,9 @@ void unified_log_always(const char* func, const char* fmt, ...);
 
 // Convenience macros (automatically capture function name)
 #define LOG_ERROR(fmt, ...) unified_log_error(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
-#define LOG_WARN(fmt, ...)  unified_log_warn(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
-#define LOG_INFO(fmt, ...)  unified_log_info(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) unified_log_warn(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...) unified_log_info(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 #define LOG_DEBUG(fmt, ...) unified_log_debug(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 #define LOG_ALWAYS(fmt, ...) unified_log_always(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 
 #endif  // PLATFORM_UNIFIED_LOG_H_
-

--- a/src/a2a3/platform/include/host/function_cache.h
+++ b/src/a2a3/platform/include/host/function_cache.h
@@ -85,9 +85,7 @@ struct CoreFunctionBinCache {
      * Get pointer to binary data region
      * @return Pointer to start of binary data
      */
-    uint8_t* get_binary_data() {
-        return reinterpret_cast<uint8_t*>(get_offsets()) + num_kernels * sizeof(uint64_t);
-    }
+    uint8_t* get_binary_data() { return reinterpret_cast<uint8_t*>(get_offsets()) + num_kernels * sizeof(uint64_t); }
 
     /**
      * Get CoreFunctionBin by index

--- a/src/a2a3/platform/include/host/host_regs.h
+++ b/src/a2a3/platform/include/host/host_regs.h
@@ -32,9 +32,6 @@ constexpr uint8_t PLATFORM_AICORE_MAP_BUFF_LEN = 2;
  * @param allocator Memory allocator for device memory
  * @return 0 on success, negative on failure
  */
-int init_aicore_register_addresses(
-    uint64_t* runtime_regs_ptr,
-    uint64_t device_id,
-    MemoryAllocator& allocator);
+int init_aicore_register_addresses(uint64_t* runtime_regs_ptr, uint64_t device_id, MemoryAllocator& allocator);
 
 #endif  // PLATFORM_HOST_HOST_REGS_H_

--- a/src/a2a3/platform/include/host/performance_collector.h
+++ b/src/a2a3/platform/include/host/performance_collector.h
@@ -46,8 +46,7 @@ using PerfAllocCallback = void* (*)(size_t size, void* user_data);
  * @param[out] host_ptr Host-mapped pointer
  * @return 0 on success, error code on failure
  */
-using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id,
-                                      void* user_data, void** host_ptr);
+using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id, void* user_data, void** host_ptr);
 
 /**
  * Memory unregister callback
@@ -82,18 +81,18 @@ enum class ProfBufferType { PERF_RECORD, PHASE };
  */
 struct ReadyBufferInfo {
     ProfBufferType type;
-    uint32_t index;           // core_index (PERF_RECORD) or thread_idx (PHASE)
-    uint32_t slot_idx;        // Reserved (unused in free queue design)
-    void* dev_buffer_ptr;     // Device address of the full buffer
-    void* host_buffer_ptr;    // Host-mapped address (sim: same as dev)
-    uint32_t buffer_seq;      // Sequence number for ordering
+    uint32_t index;         // core_index (PERF_RECORD) or thread_idx (PHASE)
+    uint32_t slot_idx;      // Reserved (unused in free queue design)
+    void* dev_buffer_ptr;   // Device address of the full buffer
+    void* host_buffer_ptr;  // Host-mapped address (sim: same as dev)
+    uint32_t buffer_seq;    // Sequence number for ordering
 };
 
 /**
  * Notification that a buffer has been copied and can be freed
  */
 struct CopyDoneInfo {
-    void* dev_buffer_ptr;     // Device buffer to free
+    void* dev_buffer_ptr;  // Device buffer to free
 };
 
 /**
@@ -130,9 +129,14 @@ public:
      * @param user_data User context for callbacks
      * @param device_id Device ID for registration
      */
-    void start(void* shared_mem_host, int num_cores, int num_phase_threads,
-               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-               PerfFreeCallback free_cb, void* user_data, int device_id);
+    void start(void* shared_mem_host,
+        int num_cores,
+        int num_phase_threads,
+        PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb,
+        void* user_data,
+        int device_id);
 
     /**
      * Stop the memory management thread
@@ -213,8 +217,7 @@ private:
     void register_mapping(void* dev_ptr, void* host_ptr);
 
     // Process one ReadyQueue entry
-    void process_ready_entry(PerfDataHeader* header, int thread_idx,
-                              const ReadyQueueEntry& entry);
+    void process_ready_entry(PerfDataHeader* header, int thread_idx, const ReadyQueueEntry& entry);
 };
 
 // =============================================================================
@@ -257,12 +260,12 @@ public:
      * @return 0 on success, error code on failure
      */
     int initialize(Runtime& runtime,
-                   int num_aicore,
-                   int device_id,
-                   PerfAllocCallback alloc_cb,
-                   PerfRegisterCallback register_cb,
-                   PerfFreeCallback free_cb,
-                   void* user_data);
+        int num_aicore,
+        int device_id,
+        PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb,
+        void* user_data);
 
     /**
      * Start the memory management thread
@@ -305,9 +308,7 @@ public:
      * @param user_data User-provided context pointer
      * @return 0 on success, error code on failure
      */
-    int finalize(PerfUnregisterCallback unregister_cb,
-                 PerfFreeCallback free_cb,
-                 void* user_data);
+    int finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data);
 
     /**
      * Check if collector is initialized

--- a/src/a2a3/platform/include/host/pto_runtime_c_api.h
+++ b/src/a2a3/platform/include/host/pto_runtime_c_api.h
@@ -82,15 +82,15 @@ size_t get_runtime_size(void);
  * @return 0 on success, -1 on failure
  */
 int init_runtime(RuntimeHandle runtime,
-                const uint8_t* orch_so_binary,
-                size_t orch_so_size,
-                const char* orch_func_name,
-                const struct TaskArg* orch_args,
-                int orch_args_count,
-                const int* kernel_func_ids,
-                const uint8_t* const* kernel_binaries,
-                const size_t* kernel_sizes,
-                int kernel_count);
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const struct TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count);
 
 /* ===========================================================================
  * Device Memory API (for use by orchestration functions)
@@ -203,11 +203,7 @@ int set_device(int device_id);
  * @param dev_ptr   Device memory pointer
  * @param size      Size of tensor in bytes
  */
-void record_tensor_pair(RuntimeHandle runtime,
-                       void* host_ptr,
-                       void* dev_ptr,
-                       size_t size);
-
+void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size);
 
 /**
  * Enable or disable performance profiling for swimlane visualization.

--- a/src/a2a3/platform/include/host/raii_scope_guard.h
+++ b/src/a2a3/platform/include/host/raii_scope_guard.h
@@ -17,8 +17,7 @@
 template <typename F>
 class RAIIScopeGuard {
 public:
-    explicit RAIIScopeGuard(F fn)
-        : fn_(std::move(fn)), active_(true) {}
+    explicit RAIIScopeGuard(F fn) : fn_(std::move(fn)), active_(true) {}
 
     ~RAIIScopeGuard() {
         if (active_) {
@@ -26,17 +25,14 @@ public:
         }
     }
 
-    RAIIScopeGuard(RAIIScopeGuard&& other) noexcept
-        : fn_(std::move(other.fn_)), active_(other.active_) {
+    RAIIScopeGuard(RAIIScopeGuard&& other) noexcept : fn_(std::move(other.fn_)), active_(other.active_) {
         other.active_ = false;
     }
 
     RAIIScopeGuard(const RAIIScopeGuard&) = delete;
     RAIIScopeGuard& operator=(const RAIIScopeGuard&) = delete;
 
-    void dismiss() noexcept {
-        active_ = false;
-    }
+    void dismiss() noexcept { active_ = false; }
 
 private:
     F fn_;

--- a/src/a2a3/platform/onboard/aicore/inner_kernel.h
+++ b/src/a2a3/platform/onboard/aicore/inner_kernel.h
@@ -70,9 +70,7 @@ __aicore__ inline void write_reg(RegId reg, uint64_t value) {
  *
  * @return Physical core ID (masked to 12 bits)
  */
-__aicore__ inline uint32_t get_physical_core_id() {
-    return static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK;
-}
+__aicore__ inline uint32_t get_physical_core_id() { return static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK; }
 
 // =============================================================================
 // System Counter
@@ -83,8 +81,6 @@ __aicore__ inline uint32_t get_physical_core_id() {
  *
  * @return Hardware counter value (ticks)
  */
-__aicore__ __attribute__((always_inline)) inline uint64_t get_sys_cnt_aicore() {
-    return get_sys_cnt();
-}
+__aicore__ __attribute__((always_inline)) inline uint64_t get_sys_cnt_aicore() { return get_sys_cnt(); }
 
 #endif  // PLATFORM_A2A3_AICORE_INNER_KERNEL_H_

--- a/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
@@ -74,4 +74,3 @@ target_link_directories(aicpu_kernel
 
 # Output name
 set_target_properties(aicpu_kernel PROPERTIES OUTPUT_NAME aicpu_kernel)
-

--- a/src/a2a3/platform/onboard/aicpu/cache_ops.cpp
+++ b/src/a2a3/platform/onboard/aicpu/cache_ops.cpp
@@ -9,9 +9,9 @@ void cache_invalidate_range(const void* addr, size_t size) {
     }
     const size_t kCacheLineSize = 64;
     uintptr_t start = (uintptr_t)addr & ~(kCacheLineSize - 1);
-    uintptr_t end   = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    uintptr_t end = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
     for (uintptr_t p = start; p < end; p += kCacheLineSize) {
-        __asm__ __volatile__("dc civac, %0" :: "r"(p) : "memory");
+        __asm__ __volatile__("dc civac, %0" ::"r"(p) : "memory");
     }
     __asm__ __volatile__("dsb sy" ::: "memory");
     __asm__ __volatile__("isb" ::: "memory");

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -72,8 +72,7 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_platform_regs(k_args->regs);
 
     // Affinity gate: drop excess threads before entering runtime
-    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num,
-                                      PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
+    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
         LOG_INFO("Thread dropped by cluster affinity");
         return 0;
     }

--- a/src/a2a3/platform/onboard/aicpu/platform_aicpu_affinity.cpp
+++ b/src/a2a3/platform/onboard/aicpu/platform_aicpu_affinity.cpp
@@ -21,9 +21,7 @@ static std::atomic<int32_t> s_gate_ready{0};
 static int32_t s_thread_cpu[MAX_GATE_THREADS];
 static bool s_thread_survive[MAX_GATE_THREADS];
 
-static inline int32_t popcount64(uint64_t v) {
-    return __builtin_popcountll(static_cast<unsigned long long>(v));
-}
+static inline int32_t popcount64(uint64_t v) { return __builtin_popcountll(static_cast<unsigned long long>(v)); }
 
 bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched) {
     if (logical_count >= total_launched) {
@@ -60,8 +58,7 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
 
     // CAS winner does cluster classification
     int32_t expected = 0;
-    if (s_gate_init.compare_exchange_strong(expected, 1,
-            std::memory_order_acq_rel, std::memory_order_acquire)) {
+    if (s_gate_init.compare_exchange_strong(expected, 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
         // Initialize survive flags
         for (int32_t i = 0; i < total_launched; ++i) {
             s_thread_survive[i] = false;
@@ -88,7 +85,11 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
         int32_t minor_cnt = clusters[minor_id].count;
 
         LOG_INFO("AICPU affinity gate: major=%d(cnt=%d) minor=%d(cnt=%d) logical=%d",
-                 major_id, major_cnt, minor_id, minor_cnt, logical_count);
+            major_id,
+            major_cnt,
+            minor_id,
+            minor_cnt,
+            logical_count);
 
         if (major_cnt == logical_count && minor_cnt == (total_launched - logical_count)) {
             // Expected topology: major cluster threads survive
@@ -97,9 +98,11 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
             }
         } else {
             // Unexpected topology: fall back to first logical_count threads
-            LOG_WARN("AICPU affinity gate: unexpected topology (major=%d minor=%d), "
-                     "falling back to index-based cutoff",
-                     major_cnt, minor_cnt);
+            LOG_WARN(
+                "AICPU affinity gate: unexpected topology (major=%d minor=%d), "
+                "falling back to index-based cutoff",
+                major_cnt,
+                minor_cnt);
             for (int32_t i = 0; i < logical_count && i < total_launched; ++i) {
                 s_thread_survive[i] = true;
             }

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -281,18 +281,15 @@ int DeviceRunner::run(Runtime& runtime,
     const std::vector<uint8_t>& aicpu_so_binary,
     const std::vector<uint8_t>& aicore_kernel_binary,
     int launch_aicpu_num) {
-
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]",
-                      launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
+        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
         return -1;
     }
 
     // Validate block_dim
     if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
-        LOG_ERROR("block_dim (%d) must be in range [1, %d]",
-                      block_dim, PLATFORM_MAX_BLOCKDIM);
+        LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
         return -1;
     }
 
@@ -300,26 +297,28 @@ int DeviceRunner::run(Runtime& runtime,
     int scheduler_thread_num = launch_aicpu_num - runtime.orch_thread_num;
 
     if (runtime.orch_thread_num > launch_aicpu_num) {
-        LOG_ERROR("orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)",
-                  runtime.orch_thread_num, launch_aicpu_num);
+        LOG_ERROR(
+            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num);
         return -1;
     }
 
     // Validate even core distribution for initial scheduler threads
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
-            LOG_ERROR("block_dim (%d) not evenly divisible by scheduler_thread_num (%d)",
-                     block_dim, scheduler_thread_num);
+            LOG_ERROR(
+                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num);
             return -1;
         }
     } else {
-        LOG_INFO("All %d threads are orchestrators, cores will be assigned after orchestration completes",
-                 launch_aicpu_num);
+        LOG_INFO(
+            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num);
         // Post-transition: all threads become schedulers
         if (block_dim % launch_aicpu_num != 0) {
-            LOG_WARN("block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
-                     "some threads will have different core counts after transition",
-                     block_dim, launch_aicpu_num);
+            LOG_WARN(
+                "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
+                "some threads will have different core counts after transition",
+                block_dim,
+                launch_aicpu_num);
         }
     }
 
@@ -336,8 +335,7 @@ int DeviceRunner::run(Runtime& runtime,
     int num_aicore = block_dim * cores_per_blockdim_;
     // Initialize handshake buffers in runtime
     if (num_aicore > RUNTIME_MAX_WORKER) {
-        LOG_ERROR("block_dim (%d) exceeds RUNTIME_MAX_WORKER (%d)",
-                      block_dim, RUNTIME_MAX_WORKER);
+        LOG_ERROR("block_dim (%d) exceeds RUNTIME_MAX_WORKER (%d)", block_dim, RUNTIME_MAX_WORKER);
         return -1;
     }
 
@@ -363,7 +361,7 @@ int DeviceRunner::run(Runtime& runtime,
         runtime.workers[i].task_status = 0;
         // Set core type: first 1/3 are AIC, remaining 2/3 are AIV
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
-        runtime.workers[i].perf_records_addr = (uint64_t)nullptr;
+        runtime.workers[i].perf_records_addr = (uint64_t) nullptr;
         runtime.workers[i].perf_buffer_status = 0;
     }
 
@@ -375,8 +373,7 @@ int DeviceRunner::run(Runtime& runtime,
         if (task != nullptr) {
             uint64_t addr = runtime.get_function_bin_addr(task->func_id);
             task->function_bin_addr = addr;
-            LOG_DEBUG("Task %d (func_id=%d) -> function_bin_addr=0x%lx",
-                          i, task->func_id, addr);
+            LOG_DEBUG("Task %d (func_id=%d) -> function_bin_addr=0x%lx", i, task->func_id, addr);
         }
     }
     LOG_DEBUG("");
@@ -389,10 +386,7 @@ int DeviceRunner::run(Runtime& runtime,
         }
     });
 
-    auto runtime_args_cleanup = RAIIScopeGuard([this]() {
-        kernel_args_.finalize_runtime_args();
-    });
-
+    auto runtime_args_cleanup = RAIIScopeGuard([this]() { kernel_args_.finalize_runtime_args(); });
 
     // Initialize performance profiling if enabled
     if (runtime.enable_profiling) {
@@ -430,7 +424,8 @@ int DeviceRunner::run(Runtime& runtime,
 
     std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServer===" << '\n';
     // Launch AICPU main kernel (over-launch for affinity gate)
-    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
+    rc = launch_aicpu_kernel(
+        stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
         return rc;
@@ -448,9 +443,8 @@ int DeviceRunner::run(Runtime& runtime,
         // Poll and collect performance data in a separate collector thread
         std::thread collector_thread;
         if (runtime.enable_profiling) {
-            collector_thread = std::thread([this, &runtime]() {
-                poll_and_collect_performance_data(runtime.get_task_count());
-            });
+            collector_thread =
+                std::thread([this, &runtime]() { poll_and_collect_performance_data(runtime.get_task_count()); });
         }
         auto thread_guard = RAIIScopeGuard([&]() {
             if (runtime.enable_profiling && collector_thread.joinable()) {
@@ -501,8 +495,11 @@ void DeviceRunner::print_handshake_results() {
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
         LOG_DEBUG("  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d",
-                      i, workers[i].aicore_done, workers[i].aicpu_ready,
-                      workers[i].control, workers[i].task);
+            i,
+            workers[i].aicore_done,
+            workers[i].aicpu_ready,
+            workers[i].control,
+            workers[i].task);
     }
 }
 
@@ -519,8 +516,7 @@ int DeviceRunner::finalize() {
 
     // Kernel binaries should have been removed by validate_runtime_impl()
     if (!func_id_to_addr_.empty()) {
-        LOG_ERROR("finalize() called with %zu kernel binaries still cached (memory leak)",
-                  func_id_to_addr_.size());
+        LOG_ERROR("finalize() called with %zu kernel binaries still cached (memory leak)", func_id_to_addr_.size());
         // Cleanup leaked binaries to prevent memory leaks
         for (const auto& pair : func_id_to_addr_) {
             void* gm_addr = reinterpret_cast<void*>(pair.second);
@@ -710,8 +706,7 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
     };
 
     // Define registration callback (a2a3: use halHostRegister for shared memory)
-    auto register_cb = [](void* dev_ptr, size_t size, int device_id,
-                          void* user_data, void** host_ptr) -> int {
+    auto register_cb = [](void* dev_ptr, size_t size, int device_id, void* user_data, void** host_ptr) -> int {
         (void)user_data;  // Not needed for registration
         if (load_hal_if_needed() != 0) {
             LOG_ERROR("Failed to load ascend_hal for profiling: %s", dlerror());
@@ -730,8 +725,7 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
         return allocator->free(dev_ptr);
     };
 
-    return perf_collector_.initialize(runtime, num_aicore, device_id,
-                                       alloc_cb, register_cb, free_cb, &mem_alloc_);
+    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
@@ -741,4 +735,3 @@ void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
 int DeviceRunner::export_swimlane_json(const std::string& output_path) {
     return perf_collector_.export_swimlane_json(output_path);
 }
-

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -350,7 +350,7 @@ private:
     DeviceArgs device_args_;
 
     // Kernel binary management
-    bool binaries_loaded_{false};            // true after AICPU SO loaded
+    bool binaries_loaded_{false};              // true after AICPU SO loaded
     std::map<int, uint64_t> func_id_to_addr_;  // func_id -> function_bin_addr (device GM)
 
     // Performance profiling
@@ -370,9 +370,8 @@ private:
      * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int ensure_device_initialized(int device_id,
-                                const std::vector<uint8_t>& aicpu_so_binary,
-                                const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_device_initialized(
+        int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
 
     /**
      * Load AICPU SO and initialize device args
@@ -385,7 +384,8 @@ private:
      * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_binaries_loaded(
+        const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
 
     /**
      * Initialize performance profiling shared memory

--- a/src/a2a3/platform/onboard/host/host_regs.cpp
+++ b/src/a2a3/platform/onboard/host/host_regs.cpp
@@ -46,8 +46,8 @@ static bool get_pg_mask(uint64_t& valid, int64_t device_id) {
 /**
  * Retrieve AICore register base addresses via HAL API
  */
-static int get_aicore_reg_info(std::vector<int64_t>& aic, std::vector<int64_t>& aiv,
-                           const int& addr_type, int64_t device_id) {
+static int get_aicore_reg_info(
+    std::vector<int64_t>& aic, std::vector<int64_t>& aiv, const int& addr_type, int64_t device_id) {
     uint64_t valid = 0;
     if (!get_pg_mask(valid, device_id)) {
         // If can't get mask, assume all cores valid
@@ -58,9 +58,7 @@ static int get_aicore_reg_info(std::vector<int64_t>& aic, std::vector<int64_t>& 
     uint64_t core_stride = 8 * 1024 * 1024;  // 8M
     uint64_t sub_core_stride = 0x100000ULL;
 
-    auto is_valid = [&valid](int id) {
-        return (valid & (1ULL << id)) != 0;
-    };
+    auto is_valid = [&valid](int id) { return (valid & (1ULL << id)) != 0; };
 
     auto halFunc =
         (int (*)(int type, void* paramValue, size_t paramValueSize, void* outValue, size_t* outSizeRet))dlsym(
@@ -127,15 +125,10 @@ static void get_aicore_regs(std::vector<int64_t>& regs, uint64_t device_id) {
     regs.insert(regs.end(), aic.begin(), aic.end());
     regs.insert(regs.end(), aiv.begin(), aiv.end());
 
-    LOG_INFO("get_aicore_regs: Retrieved %zu AIC and %zu AIV register addresses",
-             aic.size(), aiv.size());
+    LOG_INFO("get_aicore_regs: Retrieved %zu AIC and %zu AIV register addresses", aic.size(), aiv.size());
 }
 
-int init_aicore_register_addresses(
-    uint64_t* runtime_regs_ptr,
-    uint64_t device_id,
-    MemoryAllocator& allocator) {
-
+int init_aicore_register_addresses(uint64_t* runtime_regs_ptr, uint64_t device_id, MemoryAllocator& allocator) {
     if (runtime_regs_ptr == nullptr) {
         LOG_ERROR("init_aicore_register_addresses: Invalid parameters");
         return -1;
@@ -172,7 +165,8 @@ int init_aicore_register_addresses(
     *runtime_regs_ptr = reinterpret_cast<uint64_t>(reg_ptr);
 
     LOG_INFO("Successfully initialized register addresses: %zu addresses at device 0x%llx",
-             host_regs.size(), *runtime_regs_ptr);
+        host_regs.size(),
+        *runtime_regs_ptr);
 
     return 0;
 }

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -20,15 +20,15 @@ extern "C" {
 /* ===========================================================================
  */
 int init_runtime_impl(Runtime* runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    const TaskArg* orch_args,
-                    int orch_args_count,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count);
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count);
 int validate_runtime_impl(Runtime* runtime);
 
 /* Forward declarations for device memory functions used in init_runtime */
@@ -48,15 +48,15 @@ void remove_kernel_binary_wrapper(int func_id);
 size_t get_runtime_size(void) { return sizeof(Runtime); }
 
 int init_runtime(RuntimeHandle runtime,
-                const uint8_t* orch_so_binary,
-                size_t orch_so_size,
-                const char* orch_func_name,
-                const TaskArg* orch_args,
-                int orch_args_count,
-                const int* kernel_func_ids,
-                const uint8_t* const* kernel_binaries,
-                const size_t* kernel_sizes,
-                int kernel_count) {
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count) {
     if (runtime == NULL) {
         return -1;
     }
@@ -78,10 +78,16 @@ int init_runtime(RuntimeHandle runtime,
         LOG_DEBUG("About to call init_runtime_impl, r=%p", (void*)r);
 
         // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
-        int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
-                               orch_func_name, orch_args, orch_args_count,
-                               kernel_func_ids, kernel_binaries,
-                               kernel_sizes, kernel_count);
+        int result = init_runtime_impl(r,
+            orch_so_binary,
+            orch_so_size,
+            orch_func_name,
+            orch_args,
+            orch_args_count,
+            kernel_func_ids,
+            kernel_binaries,
+            kernel_sizes,
+            kernel_count);
 
         LOG_DEBUG("init_runtime_impl returned: %d", result);
 
@@ -230,10 +236,7 @@ int set_device(int device_id) {
  * registration and stores addresses in Runtime's func_id_to_addr_[] array.
  */
 
-void record_tensor_pair(RuntimeHandle runtime,
-                       void* host_ptr,
-                       void* dev_ptr,
-                       size_t size) {
+void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size) {
     if (runtime == NULL) {
         return;
     }

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -34,10 +34,10 @@
 // dsb / mem_dsb_t — CANN provides these on real AICore; perf_collector uses them after dcci flush.
 // Simulation: full fence (same strength as dcci above) so AICPU ordering matches hardware intent.
 typedef int mem_dsb_t;
-#define dsb(_kind)                                                                               \
-    do {                                                                                         \
-        (void)(_kind);                                                                           \
-        std::atomic_thread_fence(std::memory_order_seq_cst);                                    \
+#define dsb(_kind)                                           \
+    do {                                                     \
+        (void)(_kind);                                       \
+        std::atomic_thread_fence(std::memory_order_seq_cst); \
     } while (0)
 
 // Cache coherency constants (no-op in simulation)
@@ -53,9 +53,17 @@ typedef int mem_dsb_t;
 #include <sched.h>
 
 #if defined(__aarch64__)
-#define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()                        \
+    do {                                        \
+        __asm__ volatile("yield" ::: "memory"); \
+        sched_yield();                          \
+    } while (0)
 #elif defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()        \
+    do {                        \
+        __builtin_ia32_pause(); \
+        sched_yield();          \
+    } while (0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif
@@ -88,17 +96,14 @@ typedef int mem_dsb_t;
  */
 inline uint64_t get_sys_cnt_aicore() {
     auto now = std::chrono::high_resolution_clock::now();
-    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        now.time_since_epoch()
-    ).count();
+    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
 
     // Convert nanoseconds to counter ticks
     constexpr uint64_t kNsPerSec = std::nano::den;
     uint64_t seconds = elapsed_ns / kNsPerSec;
     uint64_t remaining_ns = elapsed_ns % kNsPerSec;
 
-    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ +
-                     (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
+    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
 
     return ticks;
 }
@@ -129,8 +134,7 @@ extern thread_local uint32_t g_sim_physical_core_id;
 inline uint64_t read_reg(RegId reg) {
     uint32_t offset = reg_offset(reg);
     FULL_MEMORY_BARRIER();
-    return static_cast<uint64_t>(
-        *reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset));
+    return static_cast<uint64_t>(*reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset));
 }
 
 /**
@@ -141,8 +145,7 @@ inline uint64_t read_reg(RegId reg) {
  */
 inline void write_reg(RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
-    *reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset) =
-        static_cast<uint32_t>(value);
+    *reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset) = static_cast<uint32_t>(value);
     FULL_MEMORY_BARRIER();
 }
 
@@ -151,8 +154,6 @@ inline void write_reg(RegId reg, uint64_t value) {
  *
  * @return Physical core ID for the current simulated core
  */
-inline uint32_t get_physical_core_id() {
-    return g_sim_physical_core_id;
-}
+inline uint32_t get_physical_core_id() { return g_sim_physical_core_id; }
 
 #endif  // PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_

--- a/src/a2a3/platform/sim/aicore/kernel.cpp
+++ b/src/a2a3/platform/sim/aicore/kernel.cpp
@@ -22,7 +22,8 @@ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
 
 // Wrapper with extern "C" for dlsym lookup
 // NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
-extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs) {
+extern "C" void aicore_execute_wrapper(
+    __gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs) {
     // Set up simulated register base for this thread.
     // regs points to an array of uint64_t base addresses (one per core).
     // physical_core_id indexes into it to get this core's register block.

--- a/src/a2a3/platform/sim/aicpu/device_log.cpp
+++ b/src/a2a3/platform/sim/aicpu/device_log.cpp
@@ -35,17 +35,17 @@ const char* TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
 void init_log_switch() {
     // Read PTO_LOG_LEVEL environment variable
     const char* level_str = std::getenv("PTO_LOG_LEVEL");
-    
+
     if (level_str != nullptr) {
         // Convert to lowercase for comparison
         char level[64];
         strncpy(level, level_str, sizeof(level) - 1);
         level[sizeof(level) - 1] = '\0';
-        
+
         for (char* p = level; *p; ++p) {
             *p = tolower(*p);
         }
-        
+
         // Parse log level
         if (strcmp(level, "silent") == 0 || strcmp(level, "error") == 0) {
             // Silent/Error: only errors

--- a/src/a2a3/platform/sim/aicpu/device_malloc.cpp
+++ b/src/a2a3/platform/sim/aicpu/device_malloc.cpp
@@ -10,10 +10,6 @@
 
 #include <cstdlib>
 
-void* aicpu_device_malloc(size_t size) {
-    return malloc(size);
-}
+void* aicpu_device_malloc(size_t size) { return malloc(size); }
 
-void aicpu_device_free(void* ptr) {
-    free(ptr);
-}
+void aicpu_device_free(void* ptr) { free(ptr); }

--- a/src/a2a3/platform/sim/aicpu/device_time.cpp
+++ b/src/a2a3/platform/sim/aicpu/device_time.cpp
@@ -6,13 +6,10 @@
 
 uint64_t get_sys_cnt_aicpu() {
     auto now = std::chrono::high_resolution_clock::now();
-    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        now.time_since_epoch()
-    ).count();
+    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
     constexpr uint64_t kNsPerSec = std::nano::den;
     uint64_t seconds = elapsed_ns / kNsPerSec;
     uint64_t remaining_ns = elapsed_ns % kNsPerSec;
-    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ +
-                     (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
+    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
     return ticks;
 }

--- a/src/a2a3/platform/sim/aicpu/platform_aicpu_affinity.cpp
+++ b/src/a2a3/platform/sim/aicpu/platform_aicpu_affinity.cpp
@@ -18,7 +18,9 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
 
     if (!survive) {
         LOG_INFO("AICPU affinity gate (sim): thread idx=%d DROPPED (logical=%d, launched=%d)",
-                 idx, logical_count, total_launched);
+            idx,
+            logical_count,
+            total_launched);
     }
 
     // Last thread resets state for next invocation

--- a/src/a2a3/platform/sim/aicpu/spin_hint.h
+++ b/src/a2a3/platform/sim/aicpu/spin_hint.h
@@ -19,9 +19,17 @@
 #include <sched.h>
 
 #if defined(__aarch64__)
-#define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()                        \
+    do {                                        \
+        __asm__ volatile("yield" ::: "memory"); \
+        sched_yield();                          \
+    } while (0)
 #elif defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()        \
+    do {                        \
+        __builtin_ia32_pause(); \
+        sched_yield();          \
+    } while (0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -20,7 +20,8 @@
 
 // Function pointer types for dynamically loaded executors
 typedef int (*aicpu_execute_func_t)(Runtime* runtime);
-typedef void (*aicore_execute_func_t)(Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs);
+typedef void (*aicore_execute_func_t)(
+    Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs);
 typedef void (*set_platform_regs_func_t)(uint64_t regs);
 
 // =============================================================================
@@ -32,19 +33,16 @@ DeviceRunner& DeviceRunner::get() {
     return runner;
 }
 
-DeviceRunner::~DeviceRunner() {
-    finalize();
-}
+DeviceRunner::~DeviceRunner() { finalize(); }
 
-int DeviceRunner::ensure_device_initialized(int device_id,
-                                            const std::vector<uint8_t>& aicpu_so_binary,
-                                            const std::vector<uint8_t>& aicore_kernel_binary) {
+int DeviceRunner::ensure_device_initialized(
+    int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
     device_id_ = device_id;
     return ensure_binaries_loaded(aicpu_so_binary, aicore_kernel_binary);
 }
 
-int DeviceRunner::ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_binary,
-                                         const std::vector<uint8_t>& aicore_kernel_binary) {
+int DeviceRunner::ensure_binaries_loaded(
+    const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
     // Skip if already loaded
     if (aicpu_execute_func_ != nullptr && aicore_execute_func_ != nullptr) {
         return 0;
@@ -67,13 +65,13 @@ int DeviceRunner::ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_bi
             return -1;
         }
 
-        aicpu_execute_func_ = reinterpret_cast<int(*)(Runtime*)>(dlsym(aicpu_so_handle_, "aicpu_execute"));
+        aicpu_execute_func_ = reinterpret_cast<int (*)(Runtime*)>(dlsym(aicpu_so_handle_, "aicpu_execute"));
         if (aicpu_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicpu_execute: %s", dlerror());
             return -1;
         }
 
-        set_platform_regs_func_ = reinterpret_cast<void(*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_regs"));
+        set_platform_regs_func_ = reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_regs"));
         if (set_platform_regs_func_ == nullptr) {
             LOG_ERROR("dlsym failed for set_platform_regs: %s", dlerror());
             return -1;
@@ -99,7 +97,8 @@ int DeviceRunner::ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_bi
             return -1;
         }
 
-        aicore_execute_func_ = reinterpret_cast<void(*)(Runtime*, int, CoreType, uint32_t, uint64_t)>(dlsym(aicore_so_handle_, "aicore_execute_wrapper"));
+        aicore_execute_func_ = reinterpret_cast<void (*)(Runtime*, int, CoreType, uint32_t, uint64_t)>(
+            dlsym(aicore_so_handle_, "aicore_execute_wrapper"));
         if (aicore_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicore_execute_wrapper: %s", dlerror());
             return -1;
@@ -110,9 +109,7 @@ int DeviceRunner::ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_bi
     return 0;
 }
 
-void* DeviceRunner::allocate_tensor(size_t bytes) {
-    return mem_alloc_.alloc(bytes);
-}
+void* DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
 
 void DeviceRunner::free_tensor(void* dev_ptr) {
     if (dev_ptr != nullptr) {
@@ -133,23 +130,20 @@ int DeviceRunner::copy_from_device(void* host_ptr, const void* dev_ptr, size_t b
 }
 
 int DeviceRunner::run(Runtime& runtime,
-                      int block_dim,
-                      int device_id,
-                      const std::vector<uint8_t>& aicpu_so_binary,
-                      const std::vector<uint8_t>& aicore_kernel_binary,
-                      int launch_aicpu_num) {
-
+    int block_dim,
+    int device_id,
+    const std::vector<uint8_t>& aicpu_so_binary,
+    const std::vector<uint8_t>& aicore_kernel_binary,
+    int launch_aicpu_num) {
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]",
-                       launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
+        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
         return -1;
     }
 
     // Validate block_dim
     if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
-        LOG_ERROR("block_dim (%d) must be in range [1, %d]",
-                       block_dim, PLATFORM_MAX_BLOCKDIM);
+        LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
         return -1;
     }
 
@@ -157,26 +151,28 @@ int DeviceRunner::run(Runtime& runtime,
     int scheduler_thread_num = launch_aicpu_num - runtime.orch_thread_num;
 
     if (runtime.orch_thread_num > launch_aicpu_num) {
-        LOG_ERROR("orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)",
-                  runtime.orch_thread_num, launch_aicpu_num);
+        LOG_ERROR(
+            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num);
         return -1;
     }
 
     // Validate even core distribution for initial scheduler threads
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
-            LOG_ERROR("block_dim (%d) not evenly divisible by scheduler_thread_num (%d)",
-                     block_dim, scheduler_thread_num);
+            LOG_ERROR(
+                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num);
             return -1;
         }
     } else {
-        LOG_INFO("All %d threads are orchestrators, cores will be assigned after orchestration completes",
-                 launch_aicpu_num);
+        LOG_INFO(
+            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num);
         // Post-transition: all threads become schedulers
         if (block_dim % launch_aicpu_num != 0) {
-            LOG_WARN("block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
-                     "some threads will have different core counts after transition",
-                     block_dim, launch_aicpu_num);
+            LOG_WARN(
+                "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
+                "some threads will have different core counts after transition",
+                block_dim,
+                launch_aicpu_num);
         }
     }
 
@@ -192,8 +188,7 @@ int DeviceRunner::run(Runtime& runtime,
     int num_aicore = block_dim * cores_per_blockdim_;
 
     if (num_aicore > RUNTIME_MAX_WORKER) {
-        LOG_ERROR("num_aicore (%d) exceeds RUNTIME_MAX_WORKER (%d)",
-                       num_aicore, RUNTIME_MAX_WORKER);
+        LOG_ERROR("num_aicore (%d) exceeds RUNTIME_MAX_WORKER (%d)", num_aicore, RUNTIME_MAX_WORKER);
         return -1;
     }
 
@@ -223,8 +218,7 @@ int DeviceRunner::run(Runtime& runtime,
         if (task != nullptr) {
             uint64_t addr = runtime.get_function_bin_addr(task->func_id);
             task->function_bin_addr = addr;
-            LOG_DEBUG("Task %d (func_id=%d) -> function_bin_addr=0x%lx",
-                          i, task->func_id, addr);
+            LOG_DEBUG("Task %d (func_id=%d) -> function_bin_addr=0x%lx", i, task->func_id, addr);
         }
     }
 
@@ -258,9 +252,7 @@ int DeviceRunner::run(Runtime& runtime,
     }
     std::memset(reg_blocks, 0, total_reg_size);
 
-    auto reg_blocks_cleanup = RAIIScopeGuard([this, reg_blocks]() {
-        mem_alloc_.free(reg_blocks);
-    });
+    auto reg_blocks_cleanup = RAIIScopeGuard([this, reg_blocks]() { mem_alloc_.free(reg_blocks); });
 
     // Build array of per-core register base addresses
     size_t regs_array_size = num_aicore * sizeof(uint64_t);
@@ -270,8 +262,7 @@ int DeviceRunner::run(Runtime& runtime,
         return -1;
     }
     for (int i = 0; i < num_aicore; i++) {
-        regs_array[i] = reinterpret_cast<uint64_t>(
-            static_cast<uint8_t*>(reg_blocks) + i * SIM_REG_BLOCK_SIZE);
+        regs_array[i] = reinterpret_cast<uint64_t>(static_cast<uint8_t*>(reg_blocks) + i * SIM_REG_BLOCK_SIZE);
     }
     kernel_args_.regs = reinterpret_cast<uint64_t>(regs_array);
 
@@ -320,9 +311,8 @@ int DeviceRunner::run(Runtime& runtime,
     // Poll and collect performance data during execution (if enabled)
     std::thread collector_thread;
     if (runtime.enable_profiling) {
-        collector_thread = std::thread([this, &runtime]() {
-            poll_and_collect_performance_data(runtime.get_task_count());
-        });
+        collector_thread =
+            std::thread([this, &runtime]() { poll_and_collect_performance_data(runtime.get_task_count()); });
     }
 
     // Wait for all threads to complete
@@ -363,11 +353,11 @@ void DeviceRunner::print_handshake_results() {
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
         LOG_DEBUG("  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d",
-                      i,
-                      last_runtime_->workers[i].aicore_done,
-                      last_runtime_->workers[i].aicpu_ready,
-                      last_runtime_->workers[i].control,
-                      last_runtime_->workers[i].task);
+            i,
+            last_runtime_->workers[i].aicore_done,
+            last_runtime_->workers[i].aicpu_ready,
+            last_runtime_->workers[i].control,
+            last_runtime_->workers[i].task);
     }
 }
 
@@ -390,8 +380,7 @@ int DeviceRunner::finalize() {
 
     // Kernel binaries should have been removed by validate_runtime_impl()
     if (!func_id_to_addr_.empty()) {
-        LOG_ERROR("finalize() called with %zu kernel binaries still cached",
-                  func_id_to_addr_.size());
+        LOG_ERROR("finalize() called with %zu kernel binaries still cached", func_id_to_addr_.size());
         // Cleanup leaked handles
         for (auto& pair : func_id_to_addr_) {
             MappedKernel& kernel = pair.second;
@@ -493,8 +482,7 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
 
     func_id_to_addr_[func_id] = kernel;
 
-    LOG_DEBUG("Registered kernel (dlopen): func_id=%d -> addr=0x%lx, handle=%p",
-                  func_id, kernel.func_addr, handle);
+    LOG_DEBUG("Registered kernel (dlopen): func_id=%d -> addr=0x%lx, handle=%p", func_id, kernel.func_addr, handle);
 
     return kernel.func_addr;
 }
@@ -533,8 +521,7 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
     };
 
     // Simulation: no registration needed (pass nullptr)
-    return perf_collector_.initialize(runtime, num_aicore, device_id,
-                                       alloc_cb, nullptr, free_cb, nullptr);
+    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, nullptr, free_cb, nullptr);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
@@ -544,4 +531,3 @@ void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
 int DeviceRunner::export_swimlane_json(const std::string& output_path) {
     return perf_collector_.export_swimlane_json(output_path);
 }
-

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -45,8 +45,8 @@
  * proper handling of external symbols (e.g., std::exp) via PLT/GOT.
  */
 struct MappedKernel {
-    void* dl_handle{nullptr};    // dlopen handle
-    uint64_t func_addr{0};       // Function pointer address (from dlsym)
+    void* dl_handle{nullptr};  // dlopen handle
+    uint64_t func_addr{0};     // Function pointer address (from dlsym)
 };
 
 /**
@@ -122,11 +122,11 @@ public:
      * @return 0 on success
      */
     int run(Runtime& runtime,
-            int block_dim,
-            int device_id,
-            const std::vector<uint8_t>& aicpu_so_binary,
-            const std::vector<uint8_t>& aicore_kernel_binary,
-            int launch_aicpu_num = 1);
+        int block_dim,
+        int device_id,
+        const std::vector<uint8_t>& aicpu_so_binary,
+        const std::vector<uint8_t>& aicore_kernel_binary,
+        int launch_aicpu_num = 1);
 
     /**
      * Print handshake results
@@ -227,11 +227,10 @@ private:
     PerformanceCollector perf_collector_;
 
     // Private helper methods
-    int ensure_device_initialized(int device_id,
-                                  const std::vector<uint8_t>& aicpu_so_binary,
-                                  const std::vector<uint8_t>& aicore_kernel_binary);
-    int ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_binary,
-                               const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_device_initialized(
+        int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_binaries_loaded(
+        const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
 
     /**
      * Initialize performance profiling shared memory

--- a/src/a2a3/platform/sim/host/memory_allocator.cpp
+++ b/src/a2a3/platform/sim/host/memory_allocator.cpp
@@ -9,9 +9,7 @@
 #include <cstdlib>
 #include "common/unified_log.h"
 
-MemoryAllocator::~MemoryAllocator() {
-    finalize();
-}
+MemoryAllocator::~MemoryAllocator() { finalize(); }
 
 void* MemoryAllocator::alloc(size_t size) {
     void* ptr = std::malloc(size);

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -23,15 +23,15 @@ extern "C" {
  * ===========================================================================
  */
 int init_runtime_impl(Runtime* runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    const TaskArg* orch_args,
-                    int orch_args_count,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count);
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count);
 int validate_runtime_impl(Runtime* runtime);
 
 /* Forward declarations */
@@ -47,20 +47,18 @@ void remove_kernel_binary_wrapper(int func_id);
  * ===========================================================================
  */
 
-size_t get_runtime_size(void) {
-    return sizeof(Runtime);
-}
+size_t get_runtime_size(void) { return sizeof(Runtime); }
 
 int init_runtime(RuntimeHandle runtime,
-                const uint8_t* orch_so_binary,
-                size_t orch_so_size,
-                const char* orch_func_name,
-                const TaskArg* orch_args,
-                int orch_args_count,
-                const int* kernel_func_ids,
-                const uint8_t* const* kernel_binaries,
-                const size_t* kernel_sizes,
-                int kernel_count) {
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count) {
     if (runtime == NULL) {
         return -1;
     }
@@ -80,10 +78,16 @@ int init_runtime(RuntimeHandle runtime,
         r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
 
         // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
-        int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
-                               orch_func_name, orch_args, orch_args_count,
-                               kernel_func_ids, kernel_binaries,
-                               kernel_sizes, kernel_count);
+        int result = init_runtime_impl(r,
+            orch_so_binary,
+            orch_so_size,
+            orch_func_name,
+            orch_args,
+            orch_args_count,
+            kernel_func_ids,
+            kernel_binaries,
+            kernel_sizes,
+            kernel_count);
 
         if (result != 0) {
             // Clear SM pointer so validate_runtime_impl skips reading
@@ -169,14 +173,14 @@ void remove_kernel_binary_wrapper(int func_id) {
 }
 
 int launch_runtime(RuntimeHandle runtime,
-                   int aicpu_thread_num,
-                   int block_dim,
-                   int device_id,
-                   const uint8_t* aicpu_binary,
-                   size_t aicpu_size,
-                   const uint8_t* aicore_binary,
-                   size_t aicore_size,
-                   int orch_thread_num) {
+    int aicpu_thread_num,
+    int block_dim,
+    int device_id,
+    const uint8_t* aicpu_binary,
+    size_t aicpu_size,
+    const uint8_t* aicore_binary,
+    size_t aicore_size,
+    int orch_thread_num) {
     if (runtime == NULL) {
         return -1;
     }
@@ -242,10 +246,7 @@ int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
  * registration and stores addresses in Runtime's func_id_to_addr_[] array.
  */
 
-void record_tensor_pair(RuntimeHandle runtime,
-                       void* host_ptr,
-                       void* dev_ptr,
-                       size_t size) {
+void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size) {
     if (runtime == NULL) {
         return;
     }

--- a/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -115,14 +115,14 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
 }
 
 int perf_aicpu_complete_record(PerfBuffer* perf_buf,
-                                uint32_t expected_reg_task_id,
-                                uint64_t task_id,
-                                uint32_t func_id,
-                                CoreType core_type,
-                                uint64_t dispatch_time,
-                                uint64_t finish_time,
-                                const uint64_t* fanout,
-                                int32_t fanout_count) {
+    uint32_t expected_reg_task_id,
+    uint64_t task_id,
+    uint32_t func_id,
+    CoreType core_type,
+    uint64_t dispatch_time,
+    uint64_t finish_time,
+    const uint64_t* fanout,
+    int32_t fanout_count) {
     rmb();
     uint32_t count = perf_buf->count;
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
@@ -137,8 +137,7 @@ int perf_aicpu_complete_record(PerfBuffer* perf_buf,
     record->finish_time = finish_time;
 
     if (fanout != nullptr && fanout_count > 0) {
-        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT)
-                        ? RUNTIME_MAX_FANOUT : fanout_count;
+        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT) ? RUNTIME_MAX_FANOUT : fanout_count;
         for (int32_t i = 0; i < n; i++) {
             record->fanout[i] = fanout[i];
         }
@@ -168,16 +167,13 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
         return;
     }
 
-    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)",
-         thread_idx, core_id, full_buf->count);
+    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)", thread_idx, core_id, full_buf->count);
 
     // Enqueue to ReadyQueue
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
-        state->current_buf_ptr, seq, 0);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, state->current_buf_ptr, seq, 0);
     if (rc != 0) {
-        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
-             thread_idx, core_id);
+        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
         // Revert: discard data and keep writing
         full_buf->count = 0;
         wmb();
@@ -205,12 +201,10 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
         h->perf_records_addr = new_buf_ptr;
         wmb();
 
-        LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", 
-            thread_idx, core_id, new_buf_ptr);
+        LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
     } else {
         // No free buffer available, stop profiling
-        LOG_WARN("Thread %d: Core %d no free buffer available, stopping profiling", 
-            thread_idx, core_id);
+        LOG_WARN("Thread %d: Core %d no free buffer available, stopping profiling", thread_idx, core_id);
         state->current_buf_ptr = 0;
         Handshake* h = &runtime->workers[core_id];
         h->perf_records_addr = 0;
@@ -218,10 +212,7 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
     }
 }
 
-void perf_aicpu_flush_buffers(Runtime* runtime, 
-    int thread_idx, 
-    const int* cur_thread_cores, 
-    int core_num) {
+void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
     if (!runtime->enable_profiling) {
         return;
     }
@@ -255,24 +246,20 @@ void perf_aicpu_flush_buffers(Runtime* runtime,
         }
 
         uint32_t seq = state->current_buf_seq;
-        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
-            buf_ptr, seq, 0);
+        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, buf_ptr, seq, 0);
         if (rc == 0) {
-            LOG_INFO("Thread %d: Core %d flushed buffer with %u records",
-                thread_idx, core_id, buf->count);
+            LOG_INFO("Thread %d: Core %d flushed buffer with %u records", thread_idx, core_id, buf->count);
             flushed_count++;
             state->current_buf_ptr = 0;
             wmb();
         } else {
-            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
-                thread_idx, core_id);
+            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
         }
     }
 
     wmb();
 
-    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", 
-        thread_idx, flushed_count);
+    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
 }
 
 void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
@@ -349,7 +336,9 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
     wmb();
 
     LOG_INFO("Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread",
-        num_sched_threads, num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD);
+        num_sched_threads,
+        num_orch_threads,
+        PLATFORM_PHASE_RECORDS_PER_THREAD);
 }
 
 /**
@@ -366,16 +355,13 @@ static void switch_phase_buffer(int thread_idx) {
     PhaseBuffer* full_buf = s_current_phase_buf[thread_idx];
     if (full_buf == nullptr) return;
 
-    LOG_INFO("Thread %d: phase buffer is full (count=%u)",
-        thread_idx, full_buf->count);
+    LOG_INFO("Thread %d: phase buffer is full (count=%u)", thread_idx, full_buf->count);
 
     // Enqueue to ReadyQueue
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-        state->current_buf_ptr, seq, 1);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, state->current_buf_ptr, seq, 1);
     if (rc != 0) {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data",
-            thread_idx);
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data", thread_idx);
         full_buf->count = 0;
         wmb();
         return;
@@ -401,8 +387,7 @@ static void switch_phase_buffer(int thread_idx) {
         LOG_INFO("Thread %d: switched to new phase buffer", thread_idx);
     } else {
         // No free buffer available, drop subsequent records
-        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up",
-            thread_idx);
+        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up", thread_idx);
         s_current_phase_buf[thread_idx] = nullptr;
         state->current_buf_ptr = 0;
         wmb();
@@ -411,8 +396,10 @@ static void switch_phase_buffer(int thread_idx) {
 
 void perf_aicpu_record_phase(int thread_idx,
     AicpuPhaseId phase_id,
-    uint64_t start_time, uint64_t end_time,
-    uint32_t loop_iter, uint64_t tasks_processed) {
+    uint64_t start_time,
+    uint64_t end_time,
+    uint32_t loop_iter,
+    uint64_t tasks_processed) {
     if (s_phase_header == nullptr) {
         return;
     }
@@ -486,13 +473,10 @@ void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src) {
         cycles_to_us(src->end_time - src->start_time));
 }
 
-void perf_aicpu_set_orch_thread_idx(int thread_idx) { 
-    s_orch_thread_idx = thread_idx; 
-}
+void perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }
 
-void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
-    uint64_t start_time, uint64_t end_time,
-    uint32_t submit_idx, uint64_t task_id) {
+void perf_aicpu_record_orch_phase(
+    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id) {
     if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
     perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
 }
@@ -518,17 +502,14 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
     }
 
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-        buf_ptr, seq, 1);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, buf_ptr, seq, 1);
     if (rc == 0) {
-        LOG_INFO("Thread %d: flushed phase buffer with %u records",
-            thread_idx, buf->count);
+        LOG_INFO("Thread %d: flushed phase buffer with %u records", thread_idx, buf->count);
         state->current_buf_ptr = 0;
         s_current_phase_buf[thread_idx] = nullptr;
         wmb();
     } else {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!",
-            thread_idx);
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!", thread_idx);
     }
 
     wmb();

--- a/src/a2a3/platform/src/aicpu/platform_regs.cpp
+++ b/src/a2a3/platform/src/aicpu/platform_regs.cpp
@@ -22,17 +22,12 @@
 
 static uint64_t g_platform_regs = 0;
 
-void set_platform_regs(uint64_t regs) {
-    g_platform_regs = regs;
-}
+void set_platform_regs(uint64_t regs) { g_platform_regs = regs; }
 
-uint64_t get_platform_regs() {
-    return g_platform_regs;
-}
+uint64_t get_platform_regs() { return g_platform_regs; }
 
 uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        reg_base_addr + reg_offset(reg));
+    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(reg_base_addr + reg_offset(reg));
 
     __sync_synchronize();
 
@@ -45,8 +40,7 @@ uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
 }
 
 void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        reg_base_addr + reg_offset(reg));
+    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(reg_base_addr + reg_offset(reg));
 
     __sync_synchronize();
 

--- a/src/a2a3/platform/src/aicpu/unified_log_device.cpp
+++ b/src/a2a3/platform/src/aicpu/unified_log_device.cpp
@@ -24,14 +24,14 @@ void unified_log_warn(const char* func, const char* fmt, ...) {
     if (!is_log_enable_warn()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_warn(func, "%s", buffer);
 }
 
@@ -39,14 +39,14 @@ void unified_log_info(const char* func, const char* fmt, ...) {
     if (!is_log_enable_info()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_info(func, "%s", buffer);
 }
 
@@ -54,14 +54,14 @@ void unified_log_debug(const char* func, const char* fmt, ...) {
     if (!is_log_enable_debug()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_debug(func, "%s", buffer);
 }
 

--- a/src/a2a3/platform/src/host/host_log.cpp
+++ b/src/a2a3/platform/src/host/host_log.cpp
@@ -18,19 +18,14 @@ HostLogger& HostLogger::get_instance() {
     return instance;
 }
 
-HostLogger::HostLogger() 
-    : current_level_(HostLogLevel::INFO),
-      log_file_path_(""),
-      log_file_handle_(nullptr),
-      initialized_(false) {
+HostLogger::HostLogger()
+    : current_level_(HostLogLevel::INFO), log_file_path_(""), log_file_handle_(nullptr), initialized_(false) {
     init_from_env();
 }
 
 HostLogger::~HostLogger() {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (log_file_handle_ != nullptr && 
-        log_file_handle_ != stdout && 
-        log_file_handle_ != stderr) {
+    if (log_file_handle_ != nullptr && log_file_handle_ != stdout && log_file_handle_ != stderr) {
         fclose(log_file_handle_);
         log_file_handle_ = nullptr;
     }
@@ -38,17 +33,17 @@ HostLogger::~HostLogger() {
 
 void HostLogger::init_from_env() {
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     // Parse PTO_LOG_LEVEL environment variable
     const char* level_str = std::getenv("PTO_LOG_LEVEL");
     if (level_str != nullptr) {
         std::string level(level_str);
-        
+
         // Convert to lowercase for comparison
         for (char& c : level) {
             c = std::tolower(c);
         }
-        
+
         // Map log level strings to enum values (1-to-1 mapping)
         if (level == "error") {
             current_level_ = HostLogLevel::ERROR;
@@ -66,19 +61,17 @@ void HostLogger::init_from_env() {
         // Default to INFO
         current_level_ = HostLogLevel::INFO;
     }
-    
+
     // Parse PTO_LOG_FILE environment variable
     const char* file_path = std::getenv("PTO_LOG_FILE");
     if (file_path != nullptr && strlen(file_path) > 0) {
         log_file_path_ = file_path;
-        
+
         // Close previous file handle if it exists
-        if (log_file_handle_ != nullptr && 
-            log_file_handle_ != stdout && 
-            log_file_handle_ != stderr) {
+        if (log_file_handle_ != nullptr && log_file_handle_ != stdout && log_file_handle_ != stderr) {
             fclose(log_file_handle_);
         }
-        
+
         // Open log file in append mode
         log_file_handle_ = fopen(log_file_path_.c_str(), "a");
         if (log_file_handle_ == nullptr) {
@@ -88,7 +81,7 @@ void HostLogger::init_from_env() {
             log_file_path_.clear();
         }
     }
-    
+
     initialized_ = true;
 }
 
@@ -123,7 +116,7 @@ FILE* HostLogger::get_output_file(HostLogLevel level) {
     if (log_file_handle_ != nullptr) {
         return log_file_handle_;
     }
-    
+
     // Otherwise, use stderr for ERROR/WARN, stdout for INFO/DEBUG
     if (level == HostLogLevel::ERROR || level == HostLogLevel::WARN) {
         return stderr;
@@ -137,30 +130,29 @@ void HostLogger::log(HostLogLevel level, const char* format, ...) {
     if (!is_enabled(level)) {
         return;
     }
-    
+
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     // Get output file
     FILE* output = get_output_file(level);
     if (output == nullptr) {
         return;
     }
-    
+
     // Print log level prefix (matching Python format)
     fprintf(output, "[%s] ", get_level_name(level));
-    
+
     // Print formatted message
     va_list args;
     va_start(args, format);
     vfprintf(output, format, args);
     va_end(args);
-    
+
     // Add newline if not already present
     if (format[strlen(format) - 1] != '\n') {
         fprintf(output, "\n");
     }
-    
+
     // Flush to ensure immediate output
     fflush(output);
 }
-

--- a/src/a2a3/platform/src/host/host_log.h
+++ b/src/a2a3/platform/src/host/host_log.h
@@ -30,11 +30,11 @@
 // =============================================================================
 
 enum class HostLogLevel {
-    ALWAYS = -1, // always logging
-    ERROR = 0,   // error level only
-    WARN = 1,    // warn level and above
-    INFO = 2,    // info level and above (default)
-    DEBUG = 3    // debug level (all messages)
+    ALWAYS = -1,  // always logging
+    ERROR = 0,    // error level only
+    WARN = 1,     // warn level and above
+    INFO = 2,     // info level and above (default)
+    DEBUG = 3     // debug level (all messages)
 };
 
 // =============================================================================
@@ -48,7 +48,7 @@ public:
 
     // Log a message with specified level
     void log(HostLogLevel level, const char* format, ...);
-    
+
     // Check if a log level is enabled
     bool is_enabled(HostLogLevel level) const;
 
@@ -58,7 +58,7 @@ public:
 private:
     HostLogger();
     ~HostLogger();
-    
+
     // Delete copy/move constructors
     HostLogger(const HostLogger&) = delete;
     HostLogger& operator=(const HostLogger&) = delete;
@@ -67,10 +67,10 @@ private:
 
     // Initialize from environment variables
     void init_from_env();
-    
+
     // Get level name string
     const char* get_level_name(HostLogLevel level) const;
-    
+
     // Get output file handle (FILE* for stdout/stderr or file)
     FILE* get_output_file(HostLogLevel level);
 
@@ -86,29 +86,28 @@ private:
 // Logging Macros (High-Level Interface)
 // =============================================================================
 
-#define HOST_LOG_ERROR(fmt, ...) \
-    do { \
+#define HOST_LOG_ERROR(fmt, ...)                                                 \
+    do {                                                                         \
         HostLogger::get_instance().log(HostLogLevel::ERROR, fmt, ##__VA_ARGS__); \
-    } while(0)
+    } while (0)
 
-#define HOST_LOG_WARN(fmt, ...) \
-    do { \
+#define HOST_LOG_WARN(fmt, ...)                                                 \
+    do {                                                                        \
         HostLogger::get_instance().log(HostLogLevel::WARN, fmt, ##__VA_ARGS__); \
-    } while(0)
+    } while (0)
 
-#define HOST_LOG_INFO(fmt, ...) \
-    do { \
-        if (HostLogger::get_instance().is_enabled(HostLogLevel::INFO)) { \
+#define HOST_LOG_INFO(fmt, ...)                                                     \
+    do {                                                                            \
+        if (HostLogger::get_instance().is_enabled(HostLogLevel::INFO)) {            \
             HostLogger::get_instance().log(HostLogLevel::INFO, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                                           \
+    } while (0)
 
-#define HOST_LOG_DEBUG(fmt, ...) \
-    do { \
-        if (HostLogger::get_instance().is_enabled(HostLogLevel::DEBUG)) { \
+#define HOST_LOG_DEBUG(fmt, ...)                                                     \
+    do {                                                                             \
+        if (HostLogger::get_instance().is_enabled(HostLogLevel::DEBUG)) {            \
             HostLogger::get_instance().log(HostLogLevel::DEBUG, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                                            \
+    } while (0)
 
-#endif // PLATFORM_HOST_LOG_H_
-
+#endif  // PLATFORM_HOST_LOG_H_

--- a/src/a2a3/platform/src/host/performance_collector.cpp
+++ b/src/a2a3/platform/src/host/performance_collector.cpp
@@ -30,9 +30,14 @@ ProfMemoryManager::~ProfMemoryManager() {
     }
 }
 
-void ProfMemoryManager::start(void* shared_mem_host, int num_cores, int num_phase_threads,
-                               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-                               PerfFreeCallback free_cb, void* user_data, int device_id) {
+void ProfMemoryManager::start(void* shared_mem_host,
+    int num_cores,
+    int num_phase_threads,
+    PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb,
+    void* user_data,
+    int device_id) {
     shared_mem_host_ = shared_mem_host;
     num_cores_ = num_cores;
     num_phase_threads_ = num_phase_threads;
@@ -79,7 +84,7 @@ bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo& info) {
 
 bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout) {
     std::unique_lock<std::mutex> lock(ready_mutex_);
-    if (ready_cv_.wait_for(lock, timeout, [this]{ return !ready_queue_.empty(); })) {
+    if (ready_cv_.wait_for(lock, timeout, [this] { return !ready_queue_.empty(); })) {
         info = ready_queue_.front();
         ready_queue_.pop();
         return true;
@@ -138,12 +143,10 @@ void* ProfMemoryManager::resolve_host_ptr(void* dev_ptr) {
     return nullptr;
 }
 
-void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) {
-    dev_to_host_[dev_ptr] = host_ptr;
-}
+void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
 
-void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*thread_idx*/,
-                                              const ReadyQueueEntry& entry) {
+void ProfMemoryManager::process_ready_entry(
+    PerfDataHeader* /*header*/, int /*thread_idx*/, const ReadyQueueEntry& entry) {
     bool is_phase = (entry.is_phase != 0);
     uint64_t old_dev_ptr = entry.buffer_ptr;
     uint32_t seq = entry.buffer_seq;
@@ -283,7 +286,10 @@ void ProfMemoryManager::mgmt_loop() {
             // Validate indices to prevent OOB access from corrupted shared memory
             if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
                 LOG_ERROR("mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)",
-                          t, head, tail, PLATFORM_PROF_READYQUEUE_SIZE);
+                    t,
+                    head,
+                    tail,
+                    PLATFORM_PROF_READYQUEUE_SIZE);
                 continue;
             }
 
@@ -321,8 +327,7 @@ void ProfMemoryManager::mgmt_loop() {
         uint32_t head = hdr->queue_heads[t];
         uint32_t tail = hdr->queue_tails[t];
         if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u",
-                      t, head, tail);
+            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u", t, head, tail);
             continue;
         }
         while (head != tail) {
@@ -387,12 +392,12 @@ void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out
 }
 
 int PerformanceCollector::initialize(Runtime& runtime,
-                                      int num_aicore,
-                                      int device_id,
-                                      PerfAllocCallback alloc_cb,
-                                      PerfRegisterCallback register_cb,
-                                      PerfFreeCallback free_cb,
-                                      void* user_data) {
+    int num_aicore,
+    int device_id,
+    PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb,
+    void* user_data) {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
         return -1;
@@ -421,8 +426,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("  Header size:          %zu bytes", sizeof(PerfDataHeader));
     LOG_DEBUG("  PerfBufferState size: %zu bytes each", sizeof(PerfBufferState));
     LOG_DEBUG("  PhaseBufferState size:%zu bytes each", sizeof(PhaseBufferState));
-    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)",
-              total_size, total_size / 1024);
+    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
 
     // Step 2: Allocate shared memory for slot arrays
     void* perf_dev_ptr = alloc_cb(total_size, user_data);
@@ -498,8 +502,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PerfBufferStates with %d buffers each",
-              num_aicore, PLATFORM_PROF_SLOT_COUNT);
+    LOG_DEBUG("Initialized %d PerfBufferStates with %d buffers each", num_aicore, PLATFORM_PROF_SLOT_COUNT);
 
     // Step 6: Initialize PhaseBufferStates and pre-fill free_queues
     for (int t = 0; t < num_phase_threads; t++) {
@@ -530,8 +533,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PhaseBufferStates with %d buffers each",
-              num_phase_threads, PLATFORM_PROF_SLOT_COUNT);
+    LOG_DEBUG("Initialized %d PhaseBufferStates with %d buffers each", num_phase_threads, PLATFORM_PROF_SLOT_COUNT);
 
     wmb();
 
@@ -551,10 +553,14 @@ void PerformanceCollector::start_memory_manager() {
         return;
     }
 
-    memory_manager_.start(perf_shared_mem_host_, num_aicore_,
-                           PLATFORM_MAX_AICPU_THREADS,
-                           alloc_cb_, register_cb_, free_cb_,
-                           user_data_, device_id_);
+    memory_manager_.start(perf_shared_mem_host_,
+        num_aicore_,
+        PLATFORM_MAX_AICPU_THREADS,
+        alloc_cb_,
+        register_cb_,
+        free_cb_,
+        user_data_,
+        device_id_);
 }
 
 void PerformanceCollector::stop_memory_manager() {
@@ -592,7 +598,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
                 LOG_ERROR("Timeout waiting for AICPU task count after %ld seconds",
-                         std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
                 return;
             }
 
@@ -661,7 +667,10 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 }
 
                 LOG_DEBUG("Collected %u perf records from core %u (total: %d/%d)",
-                         count, core_index, total_records_collected, expected_tasks);
+                    count,
+                    core_index,
+                    total_records_collected,
+                    expected_tasks);
 
             } else {
                 PhaseBuffer* buf = (PhaseBuffer*)info.host_buffer_ptr;
@@ -691,9 +700,8 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
                 LOG_ERROR("Performance data collection idle timeout after %ld seconds",
-                         std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
-                LOG_ERROR("Collected %d / %d records before timeout",
-                         total_records_collected, expected_tasks);
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                LOG_ERROR("Collected %d / %d records before timeout", total_records_collected, expected_tasks);
                 break;
             }
         }
@@ -703,8 +711,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     LOG_INFO("Total records collected: %d", total_records_collected);
 
     if (total_records_collected < expected_tasks) {
-        LOG_WARN("Incomplete collection (%d / %d records)",
-                 total_records_collected, expected_tasks);
+        LOG_WARN("Incomplete collection (%d / %d records)", total_records_collected, expected_tasks);
     }
 
     LOG_INFO("Performance data collection complete");
@@ -763,8 +770,7 @@ void PerformanceCollector::drain_remaining_buffers() {
     }
 
     if (drained_perf > 0 || drained_phase > 0) {
-        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records",
-                 drained_perf, drained_phase);
+        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records", drained_perf, drained_phase);
     }
 
     if (drained_phase > 0) {
@@ -783,15 +789,15 @@ void PerformanceCollector::collect_phase_data() {
 
     // Validate magic
     if (phase_header->magic != AICPU_PHASE_MAGIC) {
-        LOG_INFO("No phase profiling data found (magic mismatch: 0x%x vs 0x%x)",
-                 phase_header->magic, AICPU_PHASE_MAGIC);
+        LOG_INFO(
+            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC);
         return;
     }
 
     int num_sched_threads = phase_header->num_sched_threads;
     if (num_sched_threads > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("Invalid num_sched_threads %d from shared memory (max=%d)",
-                  num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
+        LOG_ERROR(
+            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
         return;
     }
     LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
@@ -811,8 +817,7 @@ void PerformanceCollector::collect_phase_data() {
         if (buf_ptr != 0) {
             void* host_ptr = memory_manager_.resolve_host_ptr((void*)buf_ptr);
             if (host_ptr == nullptr) {
-                LOG_ERROR("collect_phase_data: no host mapping for dev_ptr=%p (thread %d)",
-                          (void*)buf_ptr, t);
+                LOG_ERROR("collect_phase_data: no host mapping for dev_ptr=%p (thread %d)", (void*)buf_ptr, t);
                 continue;
             }
             PhaseBuffer* pbuf = (PhaseBuffer*)host_ptr;
@@ -835,11 +840,16 @@ void PerformanceCollector::collect_phase_data() {
         if (!collected_phase_records_[t].empty()) {
             size_t sched_count = 0, orch_count = 0;
             for (const auto& r : collected_phase_records_[t]) {
-                if (is_scheduler_phase(r.phase_id)) sched_count++;
-                else orch_count++;
+                if (is_scheduler_phase(r.phase_id))
+                    sched_count++;
+                else
+                    orch_count++;
             }
             LOG_INFO("  Thread %zu: %zu records (sched=%zu, orch=%zu)",
-                     t, collected_phase_records_[t].size(), sched_count, orch_count);
+                t,
+                collected_phase_records_[t].size(),
+                sched_count,
+                orch_count);
         }
     }
 
@@ -849,8 +859,8 @@ void PerformanceCollector::collect_phase_data() {
 
     if (orch_valid) {
         LOG_INFO("  Orchestrator: %lld tasks, %.3fus",
-                 (long long)collected_orch_summary_.submit_count,
-                 cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time));
+            (long long)collected_orch_summary_.submit_count,
+            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time));
     } else {
         LOG_INFO("  Orchestrator: no summary data");
     }
@@ -859,7 +869,10 @@ void PerformanceCollector::collect_phase_data() {
     bool has_accumulated = has_phase_data_;
     if (!has_accumulated) {
         for (const auto& v : collected_phase_records_) {
-            if (!v.empty()) { has_accumulated = true; break; }
+            if (!v.empty()) {
+                has_accumulated = true;
+                break;
+            }
         }
     }
     has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
@@ -867,13 +880,13 @@ void PerformanceCollector::collect_phase_data() {
     // Read core-to-thread mapping
     int num_cores = static_cast<int>(phase_header->num_cores);
     if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
-        core_to_thread_.assign(phase_header->core_to_thread,
-                                phase_header->core_to_thread + num_cores);
+        core_to_thread_.assign(phase_header->core_to_thread, phase_header->core_to_thread + num_cores);
         LOG_INFO("  Core-to-thread mapping: %d cores", num_cores);
     }
 
     LOG_INFO("Phase data collection complete: %d remaining records, orch_summary=%s",
-             total_phase_records, orch_valid ? "yes" : "no");
+        total_phase_records,
+        orch_valid ? "yes" : "no");
 }
 
 int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
@@ -917,10 +930,9 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     }
 
     // Sort by canonical task_id (64-bit PTO2 raw)
-    std::sort(tagged_records.begin(), tagged_records.end(),
-              [](const TaggedRecord& a, const TaggedRecord& b) {
-                  return a.record->task_id < b.record->task_id;
-              });
+    std::sort(tagged_records.begin(), tagged_records.end(), [](const TaggedRecord& a, const TaggedRecord& b) {
+        return a.record->task_id < b.record->task_id;
+    });
 
     // Step 4: Calculate base time (minimum timestamp across all records)
     uint64_t base_time_cycles = UINT64_MAX;
@@ -942,8 +954,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                 }
             }
         }
-        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC &&
-            collected_orch_summary_.start_time > 0 &&
+        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC && collected_orch_summary_.start_time > 0 &&
             collected_orch_summary_.start_time < base_time_cycles) {
             base_time_cycles = collected_orch_summary_.start_time;
         }
@@ -954,8 +965,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     std::tm* timeinfo = std::localtime(&now);
     char time_buffer[32];
     std::strftime(time_buffer, sizeof(time_buffer), "%Y%m%d_%H%M%S", timeinfo);
-    std::string filepath = output_path + "/perf_swimlane_"
-                          + std::string(time_buffer) + ".json";
+    std::string filepath = output_path + "/perf_swimlane_" + std::string(time_buffer) + ".json";
 
     // Step 6: Open JSON file for writing
     std::ofstream outfile(filepath);
@@ -995,8 +1005,8 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         outfile << "      \"dispatch_time_us\": " << std::fixed << std::setprecision(3) << dispatch_us << ",\n";
         outfile << "      \"finish_time_us\": " << std::fixed << std::setprecision(3) << finish_us << ",\n";
         outfile << "      \"fanout\": [";
-        int safe_fanout_count = (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT)
-                                ? record.fanout_count : 0;
+        int safe_fanout_count =
+            (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT) ? record.fanout_count : 0;
         for (int j = 0; j < safe_fanout_count; ++j) {
             outfile << record.fanout[j];
             if (j < safe_fanout_count - 1) {
@@ -1017,26 +1027,41 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     if (has_phase_data_) {
         auto sched_phase_name = [](AicpuPhaseId id) -> const char* {
             switch (id) {
-                case AicpuPhaseId::SCHED_COMPLETE:    return "complete";
-                case AicpuPhaseId::SCHED_DISPATCH:    return "dispatch";
-                case AicpuPhaseId::SCHED_SCAN:        return "scan";
-                case AicpuPhaseId::SCHED_IDLE_WAIT:   return "idle";
-                default: return "unknown";
+                case AicpuPhaseId::SCHED_COMPLETE:
+                    return "complete";
+                case AicpuPhaseId::SCHED_DISPATCH:
+                    return "dispatch";
+                case AicpuPhaseId::SCHED_SCAN:
+                    return "scan";
+                case AicpuPhaseId::SCHED_IDLE_WAIT:
+                    return "idle";
+                default:
+                    return "unknown";
             }
         };
 
         auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
             switch (id) {
-                case AicpuPhaseId::ORCH_SYNC:      return "orch_sync";
-                case AicpuPhaseId::ORCH_ALLOC:     return "orch_alloc";
-                case AicpuPhaseId::ORCH_PARAMS:    return "orch_params";
-                case AicpuPhaseId::ORCH_LOOKUP:    return "orch_lookup";
-                case AicpuPhaseId::ORCH_HEAP:      return "orch_heap";
-                case AicpuPhaseId::ORCH_INSERT:    return "orch_insert";
-                case AicpuPhaseId::ORCH_FANIN:     return "orch_fanin";
-                case AicpuPhaseId::ORCH_FINALIZE:  return "orch_finalize";
-                case AicpuPhaseId::ORCH_SCOPE_END: return "orch_scope_end";
-                default: return "unknown";
+                case AicpuPhaseId::ORCH_SYNC:
+                    return "orch_sync";
+                case AicpuPhaseId::ORCH_ALLOC:
+                    return "orch_alloc";
+                case AicpuPhaseId::ORCH_PARAMS:
+                    return "orch_params";
+                case AicpuPhaseId::ORCH_LOOKUP:
+                    return "orch_lookup";
+                case AicpuPhaseId::ORCH_HEAP:
+                    return "orch_heap";
+                case AicpuPhaseId::ORCH_INSERT:
+                    return "orch_insert";
+                case AicpuPhaseId::ORCH_FANIN:
+                    return "orch_fanin";
+                case AicpuPhaseId::ORCH_FINALIZE:
+                    return "orch_finalize";
+                case AicpuPhaseId::ORCH_SCOPE_END:
+                    return "orch_scope_end";
+                default:
+                    return "unknown";
             }
         };
 
@@ -1051,10 +1076,9 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                 double end_us = cycles_to_us(pr.end_time - base_time_cycles);
                 if (!first) outfile << ",\n";
                 outfile << "      {\"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
-                        << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                        << ", \"phase\": \"" << sched_phase_name(pr.phase_id) << "\""
-                        << ", \"loop_iter\": " << pr.loop_iter
-                        << ", \"tasks_processed\": " << pr.tasks_processed
+                        << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us << ", \"phase\": \""
+                        << sched_phase_name(pr.phase_id) << "\""
+                        << ", \"loop_iter\": " << pr.loop_iter << ", \"tasks_processed\": " << pr.tasks_processed
                         << "}";
                 first = false;
             }
@@ -1075,14 +1099,22 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
             outfile << "    \"end_time_us\": " << std::fixed << std::setprecision(3) << orch_end_us << ",\n";
             outfile << "    \"submit_count\": " << collected_orch_summary_.submit_count << ",\n";
             outfile << "    \"phase_us\": {\n";
-            outfile << "      \"sync\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.sync_cycle) << ",\n";
-            outfile << "      \"alloc\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
-            outfile << "      \"params\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.params_cycle) << ",\n";
-            outfile << "      \"lookup\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
-            outfile << "      \"heap\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
-            outfile << "      \"insert\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
-            outfile << "      \"fanin\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
-            outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
+            outfile << "      \"sync\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.sync_cycle) << ",\n";
+            outfile << "      \"alloc\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
+            outfile << "      \"params\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.params_cycle) << ",\n";
+            outfile << "      \"lookup\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
+            outfile << "      \"heap\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
+            outfile << "      \"insert\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
+            outfile << "      \"fanin\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
+            outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
             outfile << "    }\n";
             outfile << "  }";
         }
@@ -1091,7 +1123,10 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         bool has_orch_phases = false;
         for (const auto& v : collected_phase_records_) {
             for (const auto& r : v) {
-                if (!is_scheduler_phase(r.phase_id)) { has_orch_phases = true; break; }
+                if (!is_scheduler_phase(r.phase_id)) {
+                    has_orch_phases = true;
+                    break;
+                }
             }
             if (has_orch_phases) break;
         }
@@ -1108,9 +1143,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                     outfile << "      {\"phase\": \"" << orch_phase_name(pr.phase_id) << "\""
                             << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                             << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                            << ", \"submit_idx\": " << pr.loop_iter
-                            << ", \"task_id\": " << pr.task_id
-                            << "}";
+                            << ", \"submit_idx\": " << pr.loop_iter << ", \"task_id\": " << pr.task_id << "}";
                     first = false;
                 }
                 if (!first) outfile << "\n";
@@ -1145,9 +1178,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     return 0;
 }
 
-int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
-                                    PerfFreeCallback free_cb,
-                                    void* user_data) {
+int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data) {
     if (perf_shared_mem_host_ == nullptr) {
         return 0;
     }
@@ -1182,8 +1213,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
             head++;
         }
         if (head != tail) {
-            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)",
-                     i, head, tail);
+            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)", i, head, tail);
         }
     }
 
@@ -1209,8 +1239,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
             head++;
         }
         if (head != tail) {
-            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)",
-                     t, head, tail);
+            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)", t, head, tail);
         }
     }
 

--- a/src/a2a3/platform/src/host/unified_log_host.cpp
+++ b/src/a2a3/platform/src/host/unified_log_host.cpp
@@ -21,11 +21,11 @@ void unified_log_error(const char* func, const char* fmt, ...) {
 void unified_log_warn(const char* func, const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     HostLogger::get_instance().log(HostLogLevel::WARN, "%s: %s", func, buffer);
 }
 

--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -20,9 +20,7 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(
-    __gm__ PTO2DispatchPayload* payload
-) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
@@ -73,8 +71,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     // Cache payload address (set once by AICPU during initialization, never changes)
-    __gm__ PTO2DispatchPayload* payload =
-        reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
 
@@ -116,8 +113,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, task_id,
-                                       start_time, end_time);
+                perf_aicore_record_task(perf_buf, task_id, start_time, end_time);
             }
 
             last_reg_val = reg_val;

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -39,7 +39,12 @@
 #if PTO2_PROFILING
 // Accumulated nanoseconds per sub-step
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
-#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+#define CYCLE_COUNT_LAP(acc)       \
+    do {                           \
+        _t1 = get_sys_cnt_aicpu(); \
+        acc += (_t1 - _t0);        \
+        _t0 = _t1;                 \
+    } while (0)
 #else
 #define CYCLE_COUNT_START()
 #define CYCLE_COUNT_LAP(acc)
@@ -48,7 +53,8 @@
 // Device orchestration function signature (loaded via dlopen).
 // The orchestration .so receives a PTO2Runtime* (with ops table populated)
 // instead of a raw shared-memory pointer.
-typedef void (*DeviceOrchestrationFunc)(PTO2Runtime* rt, TaskArg* orch_args, int32_t orch_thread_num, int32_t orch_thread_index);
+typedef void (*DeviceOrchestrationFunc)(
+    PTO2Runtime* rt, TaskArg* orch_args, int32_t orch_thread_num, int32_t orch_thread_index);
 
 // Config function exported by orchestration .so
 typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(TaskArg* orch_args);
@@ -58,8 +64,8 @@ constexpr int32_t MAX_AIC_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD;
 constexpr int32_t MAX_AIV_PER_THREAD = PLATFORM_MAX_AIV_PER_THREAD;
 constexpr int32_t MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 
-constexpr int32_t MAX_IDLE_ITERATIONS = 800000;  // ~20s idle then scheduler gives up (avoid long hang)
-constexpr int32_t STALL_LOG_INTERVAL = 50000;    // DEV_ALWAYS every N idle iters to debug hang
+constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
+constexpr int32_t STALL_LOG_INTERVAL = 50000;         // DEV_ALWAYS every N idle iters to debug hang
 constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
 constexpr int32_t STALL_DUMP_WAIT_MAX = 4;
@@ -67,14 +73,14 @@ constexpr int32_t STALL_DUMP_CORE_MAX = 8;
 constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
 constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
 
-static PTO2Runtime *rt{nullptr};
+static PTO2Runtime* rt{nullptr};
 
 // Per-core dispatch payload storage (one per physical core)
 static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
 
 // Core information for discovery (with register address for fast dispatch)
 struct CoreInfo {
-    int32_t worker_id;              // Index in runtime.workers[]
+    int32_t worker_id;          // Index in runtime.workers[]
     uint32_t physical_core_id;  // Hardware physical core ID (from AICore)
     uint64_t reg_addr;          // Cached register address for fast access
     CoreType core_type;
@@ -117,30 +123,32 @@ struct CoreStateTracker {
     CoreTypeTracker& aic() { return by_type[0]; }
     CoreTypeTracker& aiv() { return by_type[1]; }
 
-    template<CoreType CT>
-    CoreTypeTracker& get() { return by_type[static_cast<int32_t>(CT)]; }
+    template <CoreType CT>
+    CoreTypeTracker& get() {
+        return by_type[static_cast<int32_t>(CT)];
+    }
 
     int32_t find_cluster_for_shape(PTO2ResourceShape shape, bool* core_idle) {
         for (int32_t i = 0; i < cluster_count; i++) {
             Cluster& c = clusters[i];
             switch (shape) {
-            case PTO2ResourceShape::AIC_ONLY:
-                if (core_idle[c.aic_core_id]) return i;
-                break;
-            case PTO2ResourceShape::AIV_X1:
-                if (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]]) return i;
-                break;
-            case PTO2ResourceShape::AIV_X2:
-                if (core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]]) return i;
-                break;
-            case PTO2ResourceShape::AIC_AIV_X1:
-                if (core_idle[c.aic_core_id] &&
-                    (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]])) return i;
-                break;
-            case PTO2ResourceShape::AIC_AIV_X2:
-                if (core_idle[c.aic_core_id] &&
-                    core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]]) return i;
-                break;
+                case PTO2ResourceShape::AIC_ONLY:
+                    if (core_idle[c.aic_core_id]) return i;
+                    break;
+                case PTO2ResourceShape::AIV_X1:
+                    if (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]]) return i;
+                    break;
+                case PTO2ResourceShape::AIV_X2:
+                    if (core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]]) return i;
+                    break;
+                case PTO2ResourceShape::AIC_AIV_X1:
+                    if (core_idle[c.aic_core_id] && (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]]))
+                        return i;
+                    break;
+                case PTO2ResourceShape::AIC_AIV_X2:
+                    if (core_idle[c.aic_core_id] && core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]])
+                        return i;
+                    break;
             }
         }
         return -1;
@@ -209,7 +217,7 @@ struct AicpuExecutor {
     std::atomic<bool> pto2_init_done_{false};
     std::atomic<bool> runtime_init_ready_{false};
     std::atomic<bool> pto2_init_complete_{false};  // init block finished; others wait for this
-    std::atomic<int32_t> orch_finished_count_{0};      // Number of orchestrator threads that have finished
+    std::atomic<int32_t> orch_finished_count_{0};  // Number of orchestrator threads that have finished
 
     // ===== Dynamic core transition state =====
     std::atomic<bool> transition_requested_{false};
@@ -227,7 +235,8 @@ struct AicpuExecutor {
 
     // ===== Performance profiling state =====
     uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];  // Per-core AICPU dispatch timestamp
-    uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER]; // Per-core total dispatched task counter (for buffer management)
+    uint32_t
+        core_dispatch_counts_[RUNTIME_MAX_WORKER];  // Per-core total dispatched task counter (for buffer management)
 
     uint64_t* func_id_to_addr_;
     uint64_t get_function_bin_addr(int func_id) const {
@@ -251,9 +260,7 @@ struct AicpuExecutor {
     // Build slim PTO2DispatchPayload: only function_bin_addr + args.
     // Metadata (task_id, subslot, kernel_id, core_type) stays in TaskDescriptor.
     // Dispatch order: tensor args first, then scalar args.
-    void build_pto2_payload(PTO2DispatchPayload& out,
-        int32_t kernel_id,
-        PTO2TaskPayload& task_pl) {
+    void build_pto2_payload(PTO2DispatchPayload& out, int32_t kernel_id, PTO2TaskPayload& task_pl) {
         out.function_bin_addr = get_function_bin_addr(kernel_id);
         int32_t n = 0;
         for (int32_t i = 0; i < task_pl.tensor_count; i++) {
@@ -320,7 +327,8 @@ struct AicpuExecutor {
                 bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state, subslot);
                 if (mixed_complete) {
 #if PTO2_SCHED_PROFILING
-                    PTO2CompletionStats cstats = rt->scheduler.on_mixed_task_complete(slot_state, thread_idx, local_bufs);
+                    PTO2CompletionStats cstats =
+                        rt->scheduler.on_mixed_task_complete(slot_state, thread_idx, local_bufs);
                     notify_edges_total += cstats.fanout_edges;
                     if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
                     notify_tasks_enqueued += cstats.tasks_enqueued;
@@ -374,13 +382,17 @@ struct AicpuExecutor {
 
                     int32_t perf_slot_idx = static_cast<int32_t>(executing_subslot_by_core_[core_id]);
                     if (perf_aicpu_complete_record(perf_buf,
-                        static_cast<uint32_t>(expected_reg_task_id),
-                        slot_state.task->task_id.raw,
-                        slot_state.task->kernel_id[perf_slot_idx], CT,
-                        dispatch_timestamps_[core_id], finish_ts,
-                        fanout_arr, fanout_n) != 0) {
+                            static_cast<uint32_t>(expected_reg_task_id),
+                            slot_state.task->task_id.raw,
+                            slot_state.task->kernel_id[perf_slot_idx],
+                            CT,
+                            dispatch_timestamps_[core_id],
+                            finish_ts,
+                            fanout_arr,
+                            fanout_n) != 0) {
                         DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task 0x%llx",
-                            core_id, (unsigned long long)slot_state.task->task_id.raw);
+                            core_id,
+                            (unsigned long long)slot_state.task->task_id.raw);
                     }
 #if PTO2_SCHED_PROFILING
                     sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
@@ -405,11 +417,16 @@ struct AicpuExecutor {
 
     static const char* shape_name(PTO2ResourceShape shape) {
         switch (shape) {
-        case PTO2ResourceShape::AIC_ONLY:   return "AIC_ONLY";
-        case PTO2ResourceShape::AIV_X1:     return "AIV_X1";
-        case PTO2ResourceShape::AIV_X2:     return "AIV_X2";
-        case PTO2ResourceShape::AIC_AIV_X1: return "AIC_AIV_X1";
-        case PTO2ResourceShape::AIC_AIV_X2: return "AIC_AIV_X2";
+            case PTO2ResourceShape::AIC_ONLY:
+                return "AIC_ONLY";
+            case PTO2ResourceShape::AIV_X1:
+                return "AIV_X1";
+            case PTO2ResourceShape::AIV_X2:
+                return "AIV_X2";
+            case PTO2ResourceShape::AIC_AIV_X1:
+                return "AIC_AIV_X1";
+            case PTO2ResourceShape::AIC_AIV_X2:
+                return "AIC_AIV_X2";
         }
         return "UNKNOWN";
     }
@@ -456,18 +473,21 @@ struct AicpuExecutor {
         return (thread_idx % 2 == 0) ? kEvenOrder : kOddOrder;
     }
 
-    PTO2TaskSlotState* pop_ready_task(PTO2ResourceShape shape, int32_t thread_idx
+    PTO2TaskSlotState* pop_ready_task(PTO2ResourceShape shape,
+        int32_t thread_idx
 #if PTO2_SCHED_PROFILING
-        , uint64_t& pop_hit, uint64_t& pop_miss
-        , uint64_t& sched_dispatch_pop_cycle
+        ,
+        uint64_t& pop_hit,
+        uint64_t& pop_miss,
+        uint64_t& sched_dispatch_pop_cycle
 #endif
     ) {
         (void)thread_idx;
 #if PTO2_SCHED_PROFILING
         extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
         uint64_t t_pop_start = get_sys_cnt_aicpu();
-        PTO2TaskSlotState* slot_state = rt->scheduler.get_ready_task(shape,
-            g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]);
+        PTO2TaskSlotState* slot_state = rt->scheduler.get_ready_task(
+            shape, g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]);
         sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
 #else
         PTO2TaskSlotState* slot_state = rt->scheduler.get_ready_task(shape);
@@ -581,7 +601,9 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
             DEV_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                      i, physical_core_id, max_physical_cores_count);
+                i,
+                physical_core_id,
+                max_physical_cores_count);
             handshake_failed = true;
             continue;
         }
@@ -638,14 +660,16 @@ void AicpuExecutor::assign_cores_to_threads() {
     int32_t cluster_count = aic_count_;
 
     DEV_INFO("Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)",
-             cluster_count, divisor, aic_count_, aiv_count_);
+        cluster_count,
+        divisor,
+        aic_count_,
+        aiv_count_);
 
     memset(core_idle_, true, sizeof(core_idle_));
     for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
         executing_reg_task_ids_[i] = AICPU_TASK_INVALID;
     }
     for (int32_t i = 0; i < thread_num_; i++) {
-        
         trackers_[i].aic().running_count = 0;
         trackers_[i].aiv().running_count = 0;
         trackers_[i].aic().idle_count = 0;
@@ -667,7 +691,7 @@ void AicpuExecutor::assign_cores_to_threads() {
         CoreStateTracker& tracker = trackers_[t];
         int32_t& idx = core_idx[t];
 
-        int32_t aic_wid  = aic_cores_[ci].worker_id;
+        int32_t aic_wid = aic_cores_[ci].worker_id;
         int32_t aiv0_wid = aiv_cores_[2 * ci].worker_id;
         int32_t aiv1_wid = aiv_cores_[2 * ci + 1].worker_id;
 
@@ -681,8 +705,7 @@ void AicpuExecutor::assign_cores_to_threads() {
         tracker.aiv().idle[tracker.aiv().idle_count++] = aiv0_wid;
         tracker.aiv().idle[tracker.aiv().idle_count++] = aiv1_wid;
 
-        DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)",
-                 t, ci, aic_wid, aiv0_wid, aiv1_wid);
+        DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
     }
 
     for (int32_t t = 0; t < divisor; t++) {
@@ -701,8 +724,7 @@ void AicpuExecutor::assign_cores_to_threads() {
  * Writes into new_core_assignments_ / new_core_count_per_thread_.
  */
 void AicpuExecutor::reassign_cores_for_all_threads() {
-    DEV_INFO("Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV",
-             thread_num_, aic_count_, aiv_count_);
+    DEV_INFO("Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_);
 
     // Collect running/idle state from all threads before reassignment
     bool running_cores[MAX_CORES_PER_THREAD];
@@ -730,15 +752,14 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
     }
 
     // Restore a single core's running/idle state into its new thread's tracker
-    auto reassign_core =
-        [&](int32_t worker_id, CoreTypeTracker& type_tracker, int32_t thread_idx) {
-            core_assignments_[thread_idx][core_count_per_thread_[thread_idx]++] = worker_id;
-            if (running_cores[worker_id]) {
-                type_tracker.running[type_tracker.running_count++] = worker_id;
-            } else {
-                type_tracker.idle[type_tracker.idle_count++] = worker_id;
-            }
-        };
+    auto reassign_core = [&](int32_t worker_id, CoreTypeTracker& type_tracker, int32_t thread_idx) {
+        core_assignments_[thread_idx][core_count_per_thread_[thread_idx]++] = worker_id;
+        if (running_cores[worker_id]) {
+            type_tracker.running[type_tracker.running_count++] = worker_id;
+        } else {
+            type_tracker.idle[type_tracker.idle_count++] = worker_id;
+        }
+    };
 
     // Assign whole clusters round-robin across all threads
     for (int32_t ci = 0; ci < aic_count_; ci++) {
@@ -760,9 +781,13 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
     DEV_INFO("Core reassignment complete:");
     for (int32_t t = 0; t < thread_num_; t++) {
         DEV_INFO("  Thread %d: %d cores, %d clusters (AIC: running=%d idle=%d, AIV: running=%d idle=%d)",
-                 t, core_count_per_thread_[t], trackers_[t].cluster_count,
-                 trackers_[t].aic().running_count, trackers_[t].aic().idle_count,
-                 trackers_[t].aiv().running_count, trackers_[t].aiv().idle_count);
+            t,
+            core_count_per_thread_[t],
+            trackers_[t].cluster_count,
+            trackers_[t].aic().running_count,
+            trackers_[t].aic().idle_count,
+            trackers_[t].aiv().running_count,
+            trackers_[t].aiv().idle_count);
     }
 }
 
@@ -865,7 +890,8 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
 /**
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
-int32_t AicpuExecutor::shutdown_aicore(Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num) {
+int32_t AicpuExecutor::shutdown_aicore(
+    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num) {
     (void)runtime;
     if (core_num == 0) return 0;
 
@@ -885,7 +911,7 @@ int32_t AicpuExecutor::shutdown_aicore(Runtime* runtime, int32_t thread_idx, con
 }
 
 int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx) {
-    int32_t &core_num = core_count_per_thread_[thread_idx];
+    int32_t& core_num = core_count_per_thread_[thread_idx];
     CoreStateTracker& tracker = trackers_[thread_idx];
     DEV_INFO("Thread %d: resolve_and_dispatch_pto2 entry", thread_idx);
 
@@ -898,12 +924,16 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
     PTO2SharedMemoryHeader* header = static_cast<PTO2SharedMemoryHeader*>(sm_base);
     DEV_INFO("Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu",
-             thread_idx, (void*)header, (unsigned long)header->rings[0].task_descriptors_offset,
-             (unsigned long)header->rings[0].task_window_size);
+        thread_idx,
+        (void*)header,
+        (unsigned long)header->rings[0].task_descriptors_offset,
+        (unsigned long)header->rings[0].task_window_size);
 
     Handshake* hank = static_cast<Handshake*>(runtime->workers);
     DEV_INFO("Thread %d: hank=%p, window_size=%lu",
-             thread_idx, (void*)hank, (unsigned long)header->rings[0].task_window_size);
+        thread_idx,
+        (void*)hank,
+        (unsigned long)header->rings[0].task_window_size);
 
     // One-time init: assign perf buffers (one thread does it; others wait)
     if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
@@ -949,10 +979,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     uint64_t complete_probe_count = 0;
     uint64_t complete_hit_count = 0;
     uint64_t notify_edges_total = 0;
-    int32_t  notify_max_degree = 0;
+    int32_t notify_max_degree = 0;
     uint64_t notify_tasks_enqueued = 0;
     uint64_t fanin_edges_total = 0;
-    int32_t  fanin_max_degree = 0;
+    int32_t fanin_max_degree = 0;
     uint64_t pop_hit = 0;
     uint64_t pop_miss = 0;
     uint64_t local_dispatch_count = 0;
@@ -990,11 +1020,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 // Check for orchestrator fatal error — exit immediately
                 int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
                 if (orch_err != PTO2_ERROR_NONE) {
-                    DEV_ERROR("Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
-                               "completed_tasks=%d, total_tasks=%d",
-                               thread_idx, orch_err,
-                               completed_tasks_.load(std::memory_order_relaxed),
-                               total_tasks_);
+                    DEV_ERROR(
+                        "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
+                        "completed_tasks=%d, total_tasks=%d",
+                        thread_idx,
+                        orch_err,
+                        completed_tasks_.load(std::memory_order_relaxed),
+                        total_tasks_);
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1004,7 +1036,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 task_count = total_tasks_;
                 if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
                     completed_.store(true, std::memory_order_release);
-                    DEV_INFO("Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed), task_count);
+                    DEV_INFO("Thread %d: PTO2 completed tasks %d/%d",
+                        thread_idx,
+                        completed_tasks_.load(std::memory_order_relaxed),
+                        task_count);
                     break;
                 }
             }
@@ -1040,21 +1075,34 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
         // Check AIC running cores
         bool try_completed = false;
-        always_assert(local_bufs[0].count == 0 && local_bufs[1].count == 0);  // Invariant: previous iteration fully consumed
+        always_assert(
+            local_bufs[0].count == 0 && local_bufs[1].count == 0);  // Invariant: previous iteration fully consumed
         if (tracker.aic().running_count > 0) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIC>(
-                thread_idx, tracker.aic(), hank,
-                completed_this_turn, cur_thread_completed, made_progress,
-                deferred_release_slot_states, deferred_release_count,
+            check_running_cores_for_completion<CoreType::AIC>(thread_idx,
+                tracker.aic(),
+                hank,
+                completed_this_turn,
+                cur_thread_completed,
+                made_progress,
+                deferred_release_slot_states,
+                deferred_release_count,
                 local_bufs
 #if PTO2_PROFILING
-                , profiling_enabled, phase_complete_count
+                ,
+                profiling_enabled,
+                phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
-                , complete_probe_count, complete_hit_count,
-                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
+                ,
+                complete_probe_count,
+                complete_hit_count,
+                notify_edges_total,
+                notify_max_degree,
+                notify_tasks_enqueued,
+                fanin_edges_total,
+                fanin_max_degree,
+                sched_complete_perf_cycle
 #endif
             );
         }
@@ -1062,18 +1110,30 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Check AIV running cores
         if (tracker.aiv().running_count > 0) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIV>(
-                thread_idx, tracker.aiv(), hank,
-                completed_this_turn, cur_thread_completed, made_progress,
-                deferred_release_slot_states, deferred_release_count,
+            check_running_cores_for_completion<CoreType::AIV>(thread_idx,
+                tracker.aiv(),
+                hank,
+                completed_this_turn,
+                cur_thread_completed,
+                made_progress,
+                deferred_release_slot_states,
+                deferred_release_count,
                 local_bufs
 #if PTO2_PROFILING
-                , profiling_enabled, phase_complete_count
+                ,
+                profiling_enabled,
+                phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
-                , complete_probe_count, complete_hit_count,
-                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
+                ,
+                complete_probe_count,
+                complete_hit_count,
+                notify_edges_total,
+                notify_max_degree,
+                notify_tasks_enqueued,
+                fanin_edges_total,
+                fanin_max_degree,
+                sched_complete_perf_cycle
 #endif
             );
         }
@@ -1085,11 +1145,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             int32_t new_total = prev + completed_this_turn;
             last_progress_count = new_total;
             if (thread_idx == 0 && task_count > 0) {
-                if (new_total <= PROGRESS_VERBOSE_THRESHOLD
-                    || new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL
-                    || new_total >= task_count) {
+                if (new_total <= PROGRESS_VERBOSE_THRESHOLD ||
+                    new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL || new_total >= task_count) {
                     DEV_ALWAYS("PTO2 progress: completed=%d total=%d (%.1f%%)",
-                               new_total, task_count, 100.0 * new_total / task_count);
+                        new_total,
+                        task_count,
+                        100.0 * new_total / task_count);
                 }
             }
         }
@@ -1130,27 +1191,45 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     ResourceCount rc = shape_resource_count(shape);
 
                     if (rc.aic) {
-                        dispatch_subtask_to_core(runtime, tracker,
-                            c.aic_core_id, CoreType::AIC, *slot_state, PTO2SubtaskSlot::AIC
+                        dispatch_subtask_to_core(runtime,
+                            tracker,
+                            c.aic_core_id,
+                            CoreType::AIC,
+                            *slot_state,
+                            PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
-                            , profiling_enabled, thread_idx
+                            ,
+                            profiling_enabled,
+                            thread_idx
 #endif
                         );
                     }
                     if (rc.aiv >= 1) {
                         int32_t aiv0 = core_idle_[c.aiv_core_ids[0]] ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
-                        dispatch_subtask_to_core(runtime, tracker,
-                            aiv0, CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV0
+                        dispatch_subtask_to_core(runtime,
+                            tracker,
+                            aiv0,
+                            CoreType::AIV,
+                            *slot_state,
+                            PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
-                            , profiling_enabled, thread_idx
+                            ,
+                            profiling_enabled,
+                            thread_idx
 #endif
                         );
                     }
                     if (rc.aiv >= 2) {
-                        dispatch_subtask_to_core(runtime, tracker,
-                            c.aiv_core_ids[1], CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV1
+                        dispatch_subtask_to_core(runtime,
+                            tracker,
+                            c.aiv_core_ids[1],
+                            CoreType::AIV,
+                            *slot_state,
+                            PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
-                            , profiling_enabled, thread_idx
+                            ,
+                            profiling_enabled,
+                            thread_idx
 #endif
                         );
                     }
@@ -1193,10 +1272,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 int32_t ci = tracker.find_cluster_for_shape(shape, core_idle_);
                 if (ci < 0) break;
 
-                PTO2TaskSlotState* slot_state = pop_ready_task(shape, thread_idx
+                PTO2TaskSlotState* slot_state = pop_ready_task(shape,
+                    thread_idx
 #if PTO2_SCHED_PROFILING
-                    , pop_hit, pop_miss
-                    , sched_dispatch_pop_cycle
+                    ,
+                    pop_hit,
+                    pop_miss,
+                    sched_dispatch_pop_cycle
 #endif
                 );
                 if (!slot_state) break;
@@ -1212,28 +1294,45 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 ResourceCount rc = shape_resource_count(shape);
 
                 if (rc.aic) {
-                    dispatch_subtask_to_core(runtime, tracker,
-                        c.aic_core_id, CoreType::AIC, *slot_state, PTO2SubtaskSlot::AIC
+                    dispatch_subtask_to_core(runtime,
+                        tracker,
+                        c.aic_core_id,
+                        CoreType::AIC,
+                        *slot_state,
+                        PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
-                        , profiling_enabled, thread_idx
+                        ,
+                        profiling_enabled,
+                        thread_idx
 #endif
                     );
                 }
                 if (rc.aiv >= 1) {
-                    int32_t aiv_id = core_idle_[c.aiv_core_ids[0]]
-                        ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
-                    dispatch_subtask_to_core(runtime, tracker,
-                        aiv_id, CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV0
+                    int32_t aiv_id = core_idle_[c.aiv_core_ids[0]] ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
+                    dispatch_subtask_to_core(runtime,
+                        tracker,
+                        aiv_id,
+                        CoreType::AIV,
+                        *slot_state,
+                        PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
-                        , profiling_enabled, thread_idx
+                        ,
+                        profiling_enabled,
+                        thread_idx
 #endif
                     );
                 }
                 if (rc.aiv >= 2) {
-                    dispatch_subtask_to_core(runtime, tracker,
-                        c.aiv_core_ids[1], CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV1
+                    dispatch_subtask_to_core(runtime,
+                        tracker,
+                        c.aiv_core_ids[1],
+                        CoreType::AIV,
+                        *slot_state,
+                        PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
-                        , profiling_enabled, thread_idx
+                        ,
+                        profiling_enabled,
+                        thread_idx
 #endif
                     );
                 }
@@ -1271,9 +1370,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             // freeing heap space for the orchestrator without blocking completion polling.
             while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
-                int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
+                int32_t fe =
+                    rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
 #else
-                int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
+            int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
                 (void)fe;
 #if PTO2_SCHED_PROFILING
@@ -1290,7 +1390,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
                 if (orch_err != PTO2_ERROR_NONE) {
                     DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores",
-                               thread_idx, orch_err);
+                        thread_idx,
+                        orch_err);
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1300,7 +1401,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
                 int32_t c = completed_tasks_.load(std::memory_order_relaxed);
                 DEV_ALWAYS("PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
-                           idle_iterations, c, task_count, last_progress_count);
+                    idle_iterations,
+                    c,
+                    task_count,
+                    last_progress_count);
                 // Scan all task slots to find truly stuck tasks using scheduler state
                 PTO2SchedulerState* sched = &rt->scheduler;
                 PTO2SharedMemoryHeader* sm_header_diag = static_cast<PTO2SharedMemoryHeader*>(sm_base);
@@ -1314,33 +1418,56 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
                         int32_t fi = slot_state.fanin_count;
                         int32_t kid = slot_state.task->kernel_id[0];
-                        if (st >= PTO2_TASK_COMPLETED) continue; // Already done
-                        if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) { cnt_inflight++; continue; }
+                        if (st >= PTO2_TASK_COMPLETED) continue;  // Already done
+                        if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) {
+                            cnt_inflight++;
+                            continue;
+                        }
                         // PENDING
                         if (rc >= fi) {
                             // Ready (all deps satisfied) but not enqueued — this is the real bug
                             cnt_ready++;
                             if (cnt_ready <= STALL_DUMP_READY_MAX) {
-                                DEV_ALWAYS("  STUCK-READY  ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
-                                            r, (long long)slot_state.task->task_id.raw, kid, rc, fi, (int32_t)st);
+                                DEV_ALWAYS(
+                                    "  STUCK-READY  ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
+                                    r,
+                                    (long long)slot_state.task->task_id.raw,
+                                    kid,
+                                    rc,
+                                    fi,
+                                    (int32_t)st);
                             }
                         } else {
                             cnt_waiting++;
                             if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
-                                DEV_ALWAYS("  STUCK-WAIT   ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
-                                            r, (long long)slot_state.task->task_id.raw, kid, rc, fi, (int32_t)st);
+                                DEV_ALWAYS(
+                                    "  STUCK-WAIT   ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
+                                    r,
+                                    (long long)slot_state.task->task_id.raw,
+                                    kid,
+                                    rc,
+                                    fi,
+                                    (int32_t)st);
                             }
                         }
                     }
                 }
                 DEV_ALWAYS("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d",
-                           cnt_ready, cnt_waiting, cnt_inflight);
+                    cnt_ready,
+                    cnt_waiting,
+                    cnt_inflight);
                 // Log this thread's dispatch state
                 int32_t total_idle = tracker.aic().idle_count + tracker.aiv().idle_count;
                 int32_t total_running = tracker.aic().running_count + tracker.aiv().running_count;
                 DEV_ALWAYS("  thread=%d idle_cores=%d (AIC=%d AIV=%d) running_cores=%d (AIC=%d AIV=%d) core_num=%d",
-                           thread_idx, total_idle, tracker.aic().idle_count, tracker.aiv().idle_count,
-                           total_running, tracker.aic().running_count, tracker.aiv().running_count, core_num);
+                    thread_idx,
+                    total_idle,
+                    tracker.aic().idle_count,
+                    tracker.aiv().idle_count,
+                    total_running,
+                    tracker.aic().running_count,
+                    tracker.aiv().running_count,
+                    core_num);
                 // Dump AIC running cores
                 for (int32_t ci = 0; ci < tracker.aic().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
                     int32_t cid = tracker.aic().running[ci];
@@ -1352,9 +1479,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     }
                     uint64_t cond_reg = read_reg(core_id_to_reg_addr_[cid], RegId::COND);
                     DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
-                               cid, (unsigned)cond_reg,
-                               EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
-                               sw_tid, hw_kernel);
+                        cid,
+                        (unsigned)cond_reg,
+                        EXTRACT_TASK_STATE(cond_reg),
+                        EXTRACT_TASK_ID(cond_reg),
+                        sw_tid,
+                        hw_kernel);
                 }
                 // Dump AIV running cores
                 for (int32_t ci = 0; ci < tracker.aiv().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
@@ -1367,17 +1497,24 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     }
                     uint64_t cond_reg = read_reg(core_id_to_reg_addr_[cid], RegId::COND);
                     DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
-                               cid, (unsigned)cond_reg,
-                               EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
-                               sw_tid, hw_kernel);
+                        cid,
+                        (unsigned)cond_reg,
+                        EXTRACT_TASK_STATE(cond_reg),
+                        EXTRACT_TASK_ID(cond_reg),
+                        sw_tid,
+                        hw_kernel);
                 }
                 // Dump cluster state
                 for (int32_t cli = 0; cli < tracker.cluster_count && cli < STALL_DUMP_CORE_MAX; cli++) {
                     Cluster& cl = tracker.clusters[cli];
                     DEV_ALWAYS("    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)",
-                               cli, cl.aic_core_id, core_idle_[cl.aic_core_id] ? "idle" : "busy",
-                               cl.aiv_core_ids[0], core_idle_[cl.aiv_core_ids[0]] ? "idle" : "busy",
-                               cl.aiv_core_ids[1], core_idle_[cl.aiv_core_ids[1]] ? "idle" : "busy");
+                        cli,
+                        cl.aic_core_id,
+                        core_idle_[cl.aic_core_id] ? "idle" : "busy",
+                        cl.aiv_core_ids[0],
+                        core_idle_[cl.aiv_core_ids[0]] ? "idle" : "busy",
+                        cl.aiv_core_ids[1],
+                        core_idle_[cl.aiv_core_ids[1]] ? "idle" : "busy");
                 }
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
@@ -1389,8 +1526,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_PROFILING
             CYCLE_COUNT_LAP(sched_idle_cycle);
             if (profiling_enabled) {
-                perf_aicpu_record_phase(thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT,
-                                        _t0_phase, _t1, sched_loop_count, 0);
+                perf_aicpu_record_phase(thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT, _t0_phase, _t1, sched_loop_count, 0);
                 _t0_phase = _t1;
             }
 #endif
@@ -1399,8 +1535,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
 #if PTO2_PROFILING
     // Scheduler summary logging (always print when PTO2_PROFILING=1)
-    uint64_t sched_total =
-        sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
+    uint64_t sched_total = sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
 
 #if PTO2_SCHED_PROFILING
@@ -1409,71 +1544,87 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
         uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
         uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle)
-            ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle) : 0;
+                                     ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle)
+                                     : 0;
         uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle)
-            ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) : 0;
+                                     ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle)
+                                     : 0;
 
         DEV_ALWAYS("Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===",
-            thread_idx, cycles_to_us(sched_total), cur_thread_completed);
+            thread_idx,
+            cycles_to_us(sched_total),
+            cur_thread_completed);
 
         // Level 1: complete
-        double notify_avg = cur_thread_completed > 0
-            ? (double)notify_edges_total / cur_thread_completed : 0.0;
-        double fanin_avg = cur_thread_completed > 0
-            ? (double)fanin_edges_total / cur_thread_completed : 0.0;
-        DEV_ALWAYS("Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%llu, max_degree=%d, avg=%.1f]  [fanin: edges=%llu, max_degree=%d, avg=%.1f]",
-            thread_idx, cycles_to_us(sched_complete_cycle),
+        double notify_avg = cur_thread_completed > 0 ? (double)notify_edges_total / cur_thread_completed : 0.0;
+        double fanin_avg = cur_thread_completed > 0 ? (double)fanin_edges_total / cur_thread_completed : 0.0;
+        DEV_ALWAYS(
+            "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%llu, max_degree=%d, avg=%.1f]  [fanin: "
+            "edges=%llu, max_degree=%d, avg=%.1f]",
+            thread_idx,
+            cycles_to_us(sched_complete_cycle),
             sched_complete_cycle * 100.0 / sched_total,
-            (unsigned long long)notify_edges_total, notify_max_degree, notify_avg,
-            (unsigned long long)fanin_edges_total, fanin_max_degree, fanin_avg);
+            (unsigned long long)notify_edges_total,
+            notify_max_degree,
+            notify_avg,
+            (unsigned long long)fanin_edges_total,
+            fanin_max_degree,
+            fanin_avg);
 
         // Level 2: complete sub-phases (percentage relative to complete)
         uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
-        uint64_t complete_miss_count = (complete_probe_count > complete_hit_count)
-            ? (complete_probe_count - complete_hit_count) : 0;
-        double complete_hit_rate = complete_probe_count > 0
-            ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
+        uint64_t complete_miss_count =
+            (complete_probe_count > complete_hit_count) ? (complete_probe_count - complete_hit_count) : 0;
+        double complete_hit_rate = complete_probe_count > 0 ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
         DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)  hit=%llu, miss=%llu, hit_rate=%.1f%%",
-            thread_idx, cycles_to_us(complete_poll),
+            thread_idx,
+            cycles_to_us(complete_poll),
             complete_poll * 100.0 / c_parent,
             (unsigned long long)complete_hit_count,
             (unsigned long long)complete_miss_count,
             complete_hit_rate);
         DEV_ALWAYS("Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-            thread_idx, cycles_to_us(sp.lock_cycle),
+            thread_idx,
+            cycles_to_us(sp.lock_cycle),
             sp.lock_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
+            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle),
+            cycles_to_us(sp.lock_wait_cycle),
             (unsigned long long)sp.lock_atomic_count);
         DEV_ALWAYS("Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-            thread_idx, cycles_to_us(sp.fanout_cycle),
+            thread_idx,
+            cycles_to_us(sp.fanout_cycle),
             sp.fanout_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
+            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle),
+            cycles_to_us(sp.push_wait_cycle),
             (unsigned long long)sp.fanout_atomic_count);
         DEV_ALWAYS("Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%llu",
-            thread_idx, cycles_to_us(sp.fanin_cycle),
+            thread_idx,
+            cycles_to_us(sp.fanin_cycle),
             sp.fanin_cycle * 100.0 / c_parent,
             (unsigned long long)sp.fanin_atomic_count);
         DEV_ALWAYS("Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%llu",
-            thread_idx, cycles_to_us(sp.self_consumed_cycle),
+            thread_idx,
+            cycles_to_us(sp.self_consumed_cycle),
             sp.self_consumed_cycle * 100.0 / c_parent,
             (unsigned long long)sp.self_atomic_count);
         DEV_ALWAYS("Thread %d:     perf         : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_complete_perf_cycle),
+            thread_idx,
+            cycles_to_us(sched_complete_perf_cycle),
             sched_complete_perf_cycle * 100.0 / c_parent);
 
         // Level 1: dispatch
         uint64_t pop_total = pop_hit + pop_miss;
         double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
         DEV_ALWAYS("Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%llu, miss=%llu, hit_rate=%.1f%%]",
-            thread_idx, cycles_to_us(sched_dispatch_cycle),
+            thread_idx,
+            cycles_to_us(sched_dispatch_cycle),
             sched_dispatch_cycle * 100.0 / sched_total,
             (unsigned long long)pop_hit,
             (unsigned long long)pop_miss,
             pop_hit_rate);
         uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
         uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
-        double local_hit_rate = total_dispatched > 0
-            ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
+        double local_hit_rate = total_dispatched > 0 ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
         DEV_ALWAYS("Thread %d:     local_disp   : local=%llu, global=%llu, overflow=%llu, local_rate=%.1f%%",
             thread_idx,
             (unsigned long long)local_dispatch_count,
@@ -1484,31 +1635,38 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Level 2: dispatch sub-phases (percentage relative to dispatch)
         uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
         DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(dispatch_poll),
+            thread_idx,
+            cycles_to_us(dispatch_poll),
             dispatch_poll * 100.0 / d_parent);
         DEV_ALWAYS("Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-            thread_idx, cycles_to_us(sched_dispatch_pop_cycle),
+            thread_idx,
+            cycles_to_us(sched_dispatch_pop_cycle),
             sched_dispatch_pop_cycle * 100.0 / d_parent,
-            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle),
+            cycles_to_us(sp.pop_wait_cycle),
             (unsigned long long)sp.pop_atomic_count);
         DEV_ALWAYS("Thread %d:     setup        : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
+            thread_idx,
+            cycles_to_us(sched_dispatch_setup_cycle),
             sched_dispatch_setup_cycle * 100.0 / d_parent);
 
         // Level 1: scan
         DEV_ALWAYS("Thread %d:   scan           : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_scan_cycle),
+            thread_idx,
+            cycles_to_us(sched_scan_cycle),
             sched_scan_cycle * 100.0 / sched_total);
 
         // Level 1: idle
         DEV_ALWAYS("Thread %d:   idle           : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_idle_cycle),
+            thread_idx,
+            cycles_to_us(sched_idle_cycle),
             sched_idle_cycle * 100.0 / sched_total);
 
         // Average per completion
         if (cur_thread_completed > 0) {
             DEV_ALWAYS("Thread %d:   avg/complete   : %.3fus",
-                thread_idx, cycles_to_us(sched_complete_cycle) / cur_thread_completed);
+                thread_idx,
+                cycles_to_us(sched_complete_cycle) / cur_thread_completed);
         }
     }
 #endif
@@ -1558,28 +1716,26 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 char so_path[256];
                 bool file_created = false;
                 const char* candidate_dirs[] = {
-                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device",
-                    "/usr/lib64",
-                    "/lib64",
-                    "/var/tmp",
-                    "/tmp"
-                };
+                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"};
                 const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
 
                 for (int32_t i = 0; i < num_candidates && !file_created; i++) {
-                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so",
-                             candidate_dirs[i], getpid());
+                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
                     int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
                     if (fd < 0) {
                         DEV_INFO("Thread %d: Cannot create SO at %s (errno=%d), trying next path",
-                                 thread_idx, so_path, errno);
+                            thread_idx,
+                            so_path,
+                            errno);
                         continue;
                     }
                     ssize_t written = write(fd, so_data, so_size);
                     close(fd);
                     if (written != static_cast<ssize_t>(so_size)) {
                         DEV_INFO("Thread %d: Cannot write SO to %s (errno=%d), trying next path",
-                                 thread_idx, so_path, errno);
+                            thread_idx,
+                            so_path,
+                            errno);
                         unlink(so_path);
                         continue;
                     }
@@ -1603,8 +1759,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
 
                 dlerror();
-                auto config_func = reinterpret_cast<DeviceOrchestrationConfigFunc>(
-                    dlsym(handle, "aicpu_orchestration_config"));
+                auto config_func =
+                    reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
 
                 dlerror();
                 DeviceOrchestrationFunc orch_func =
@@ -1629,10 +1785,14 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 for (int32_t i = 0; i < arg_count && i < 20; i++) {
                     if (args[i].kind == TaskArgKind::TENSOR) {
                         DEV_INFO("Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)",
-                                 thread_idx, i, (unsigned long)args[i].tensor.data, args[i].tensor.ndims, (unsigned)args[i].tensor.dtype);
+                            thread_idx,
+                            i,
+                            (unsigned long)args[i].tensor.data,
+                            args[i].tensor.ndims,
+                            (unsigned)args[i].tensor.dtype);
                     } else {
-                        DEV_INFO("Thread %d: orch_args[%d] = SCALAR(0x%lx)",
-                                 thread_idx, i, (unsigned long)args[i].scalar);
+                        DEV_INFO(
+                            "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, i, (unsigned long)args[i].scalar);
                     }
                 }
 
@@ -1665,15 +1825,17 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
                 }
                 DEV_INFO("Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d",
-                         thread_idx, (unsigned long)task_window_size, (unsigned long)heap_size, dep_pool_capacity);
+                    thread_idx,
+                    (unsigned long)task_window_size,
+                    (unsigned long)heap_size,
+                    dep_pool_capacity);
 
                 void* sm_ptr = runtime->get_pto2_gm_sm_ptr();
                 void* gm_heap = runtime->get_pto2_gm_heap_ptr();
 
                 uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
                 PTO2SharedMemoryHandle* sm_handle =
-                    pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size,
-                                                heap_size);
+                    pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
                 if (!sm_handle) {
                     DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
                     dlclose(handle);
@@ -1681,9 +1843,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     return -1;
                 }
 
-                rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE,
-                                                 sm_handle, gm_heap, heap_size, orch_thread_num_,
-                                                 dep_pool_capacity);
+                rt = pto2_runtime_create_from_sm(
+                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity);
                 if (!rt) {
                     DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                     pto2_sm_destroy(sm_handle);
@@ -1746,7 +1907,9 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 
             // Call orchestration function wrapped in an outer scope
             DEV_ALWAYS("Thread %d: Calling aicpu_orchestration_entry from SO (orch_idx=%d/(0~%d))",
-                       thread_idx, orch_idx, orch_thread_num_ - 1);
+                thread_idx,
+                orch_idx,
+                orch_thread_num_ - 1);
 #if PTO2_PROFILING
             uint64_t orch_cycle_start = get_sys_cnt_aicpu();
 #endif
@@ -1754,8 +1917,10 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
             DEV_ALWAYS("Thread %d: orch_start=%llu orch_func_cost=%.3fus (orch_idx=%d)",
-                thread_idx, (unsigned long long)orch_cycle_start,
-                cycles_to_us(orch_cycle_end - orch_cycle_start), orch_idx);
+                thread_idx,
+                (unsigned long long)orch_cycle_start,
+                cycles_to_us(orch_cycle_end - orch_cycle_start),
+                orch_idx);
 #endif
 
             // Print orchestrator profiling data
@@ -1836,14 +2001,15 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 void* sm = runtime->get_pto2_gm_sm_ptr();
                 PTO2SharedMemoryHeader* sm_header = static_cast<PTO2SharedMemoryHeader*>(sm);
                 int32_t pto2_task_count = 0;
-                    if (sm_header) {
-                        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                            pto2_task_count +=
-                                sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
-                        }
+                if (sm_header) {
+                    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                        pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                     }
+                }
 #if PTO2_PROFILING
-                DEV_ALWAYS("PTO2 total submitted tasks = %d, already executed %d tasks", pto2_task_count, completed_tasks_.load(std::memory_order_acquire));
+                DEV_ALWAYS("PTO2 total submitted tasks = %d, already executed %d tasks",
+                    pto2_task_count,
+                    completed_tasks_.load(std::memory_order_acquire));
 #endif
                 total_tasks_ = pto2_task_count;
                 if (runtime->enable_profiling && pto2_task_count > 0) {
@@ -1854,8 +2020,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     int32_t orch_err = 0;
                     void* sm = runtime->get_pto2_gm_sm_ptr();
                     if (sm) {
-                        orch_err = static_cast<PTO2SharedMemoryHeader*>(sm)->orch_error_code.load(
-                            std::memory_order_relaxed);
+                        orch_err =
+                            static_cast<PTO2SharedMemoryHeader*>(sm)->orch_error_code.load(std::memory_order_relaxed);
                     }
 
                     // Fatal error: shutdown AICore immediately before core transition.
@@ -1927,8 +2093,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
-    if (!completed_.load(std::memory_order_acquire) &&
-        (thread_idx < sched_thread_num_ || orch_to_sched_)) {
+    if (!completed_.load(std::memory_order_acquire) && (thread_idx < sched_thread_num_ || orch_to_sched_)) {
         DEV_ALWAYS("Thread %d: Starting PTO2 dispatch", thread_idx);
         // Device orchestration: wait for primary orchestrator to initialize SM header
         if (!runtime->get_orch_built_on_host()) {
@@ -2051,17 +2216,15 @@ void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
     DEV_WARN("Emergency shutdown complete");
 }
 
-void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
-                                         const int32_t* cur_thread_cores, int32_t core_num,
-                                         Handshake* hank) {
+void AicpuExecutor::diagnose_stuck_state(
+    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank) {
     (void)runtime;
     PTO2SchedulerState* sched = &rt->scheduler;
     DEV_ALWAYS("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
 
     int32_t completed = completed_tasks_.load(std::memory_order_acquire);
     int32_t total = total_tasks_;
-    DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)",
-             completed, total, total > 0 ? completed * 100.0 / total : 0.0);
+    DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)", completed, total, total > 0 ? completed * 100.0 / total : 0.0);
 
     uint64_t aic_ready = 0, aiv_ready = 0, aiv_x2_ready = 0, mixed_x1_ready = 0, mixed_x2_ready = 0;
     if (rt) {
@@ -2072,7 +2235,11 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
         mixed_x2_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC_AIV_X2)].size();
     }
     DEV_ALWAYS("Ready Queues: AIC=%lu, AIV=%lu, AIV_X2=%lu, AIC_AIV_X1=%lu, AIC_AIV_X2=%lu",
-               aic_ready, aiv_ready, aiv_x2_ready, mixed_x1_ready, mixed_x2_ready);
+        aic_ready,
+        aiv_ready,
+        aiv_x2_ready,
+        mixed_x1_ready,
+        mixed_x2_ready);
 
     int32_t busy_cores = 0;
     int32_t idle_cores = 0;
@@ -2097,14 +2264,23 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
                     int32_t diag_slot = static_cast<int32_t>(executing_subslot_by_core_[core_id]);
                     kernel_id = executing_slot_state_by_core_[core_id]->task->kernel_id[diag_slot];
                 }
-                DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_reg_task_id=%d, kernel_id=%d",
-                        core_id, core_type_str, reg_val, reg_task_id,
-                        reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
-                        task_id, kernel_id);
+                DEV_ALWAYS(
+                    "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_reg_task_id=%d, "
+                    "kernel_id=%d",
+                    core_id,
+                    core_type_str,
+                    reg_val,
+                    reg_task_id,
+                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
+                    task_id,
+                    kernel_id);
             } else {
                 DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked",
-                        core_id, core_type_str, reg_val, reg_task_id,
-                        reg_state == TASK_FIN_STATE ? "FIN" : "ACK");
+                    core_id,
+                    core_type_str,
+                    reg_val,
+                    reg_task_id,
+                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK");
             }
         } else {
             idle_cores++;

--- a/src/a2a3/runtime/aicpu_build_graph/build_config.py
+++ b/src/a2a3/runtime/aicpu_build_graph/build_config.py
@@ -11,20 +11,17 @@
 # by the Tensor constructor's validation logic).
 
 BUILD_CONFIG = {
-    "aicore": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicore", "orchestration"]
-    },
+    "aicore": {"include_dirs": ["runtime"], "source_dirs": ["aicore", "orchestration"]},
     "aicpu": {
         "include_dirs": ["runtime"],
-        "source_dirs": ["aicpu", "runtime", "orchestration"]
+        "source_dirs": ["aicpu", "runtime", "orchestration"],
     },
     "host": {
         "include_dirs": ["runtime"],
-        "source_dirs": ["host", "runtime", "orchestration"]
+        "source_dirs": ["host", "runtime", "orchestration"],
     },
     "orchestration": {
         "include_dirs": ["runtime", "orchestration"],
-        "source_dirs": ["orchestration"]
-    }
+        "source_dirs": ["orchestration"],
+    },
 }

--- a/src/a2a3/runtime/aicpu_build_graph/host/runtime_compile_info.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/host/runtime_compile_info.cpp
@@ -14,5 +14,4 @@ ToolchainType get_orchestration_compiler(void) {
     if (strcmp(get_platform(), "a2a3") == 0) return TOOLCHAIN_AARCH64_GXX;
     return TOOLCHAIN_HOST_GXX;
 }
-
 }

--- a/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
@@ -48,13 +48,11 @@ static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool requir
     errno = 0;
     unsigned long long val = strtoull(env, &endptr, 10);
     if (errno == ERANGE || endptr == env || *endptr != '\0' || val < min_val) {
-        LOG_WARN("%s=%s invalid (must be a valid integer >= %lu), ignored",
-                 name, env, (unsigned long)min_val);
+        LOG_WARN("%s=%s invalid (must be a valid integer >= %lu), ignored", name, env, (unsigned long)min_val);
         return 0;
     }
     if (require_power_of_2 && (val & (val - 1)) != 0) {
-        LOG_WARN("%s=%s invalid (must be a power of 2, >= %lu), ignored",
-                 name, env, (unsigned long)min_val);
+        LOG_WARN("%s=%s invalid (must be a power of 2, >= %lu), ignored", name, env, (unsigned long)min_val);
         return 0;
     }
     return static_cast<uint64_t>(val);
@@ -79,16 +77,16 @@ static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool requir
  * @param func_args_count   Number of arguments
  * @return 0 on success, -1 on failure
  */
-extern "C" int init_runtime_impl(Runtime *runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    const TaskArg* orch_args,
-                    int orch_args_count,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count) {
+extern "C" int init_runtime_impl(Runtime* runtime,
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count) {
     // Suppress unused parameter warning
     (void)orch_func_name;
 
@@ -99,12 +97,11 @@ extern "C" int init_runtime_impl(Runtime *runtime,
     }
 
     // Register kernel binaries via platform-provided upload function
-    if (kernel_count > 0 && kernel_func_ids != nullptr &&
-        kernel_binaries != nullptr && kernel_sizes != nullptr) {
+    if (kernel_count > 0 && kernel_func_ids != nullptr && kernel_binaries != nullptr && kernel_sizes != nullptr) {
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", kernel_count);
         for (int i = 0; i < kernel_count; i++) {
-            uint64_t addr = runtime->host_api.upload_kernel_binary(
-                kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
+            uint64_t addr =
+                runtime->host_api.upload_kernel_binary(kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
             if (addr == 0) {
                 LOG_ERROR("Failed to upload kernel binary for func_id=%d", kernel_func_ids[i]);
                 return -1;
@@ -190,7 +187,9 @@ extern "C" int init_runtime_impl(Runtime *runtime,
                 runtime->ready_queue_shards = static_cast<int>(val);
             } else {
                 LOG_WARN("PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d",
-                         env_shards, PLATFORM_MAX_AICPU_THREADS, RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
+                    env_shards,
+                    PLATFORM_MAX_AICPU_THREADS,
+                    RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
                 runtime->ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
             }
         }
@@ -208,20 +207,22 @@ extern "C" int init_runtime_impl(Runtime *runtime,
 
     // Read ring buffer size overrides from environment
     {
-        runtime->pto2_task_window_size  = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
-        runtime->pto2_heap_size         = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
-        runtime->pto2_dep_pool_size     = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
+        runtime->pto2_task_window_size = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
+        runtime->pto2_heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
+        runtime->pto2_dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
         if (runtime->pto2_task_window_size || runtime->pto2_heap_size || runtime->pto2_dep_pool_size) {
             LOG_INFO("Ring buffer overrides: task_window=%lu heap=%lu dep_pool=%lu",
-                     (unsigned long)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE),
-                     (unsigned long)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
-                     (unsigned long)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE));
+                (unsigned long)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size
+                                                               : PTO2_TASK_WINDOW_SIZE),
+                (unsigned long)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
+                (unsigned long)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE));
         }
     }
 
     // Resolve effective sizes (env override or compile-time default)
     uint64_t eff_heap_size = runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE;
-    uint64_t eff_task_window_size = runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE;
+    uint64_t eff_task_window_size =
+        runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE;
 
     // Allocate GM heap for orchestrator output buffers (all rings combined)
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
@@ -274,7 +275,7 @@ extern "C" int init_runtime_impl(Runtime *runtime,
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime *runtime) {
+extern "C" int validate_runtime_impl(Runtime* runtime) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -303,7 +304,9 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
             graph_out_ptr = host_header.graph_output_ptr;
             graph_out_size = host_header.graph_output_size;
             if (graph_out_ptr != 0) {
-                LOG_INFO("Graph output buffer: ptr=0x%lx, size=%lu", (unsigned long)graph_out_ptr, (unsigned long)graph_out_size);
+                LOG_INFO("Graph output buffer: ptr=0x%lx, size=%lu",
+                    (unsigned long)graph_out_ptr,
+                    (unsigned long)graph_out_size);
             }
         } else {
             LOG_WARN("Failed to copy PTO2 header from device");

--- a/src/a2a3/runtime/aicpu_build_graph/orchestration/common.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/orchestration/common.cpp
@@ -17,8 +17,7 @@
  * 如果存在内联，同时通过 inline_chain 返回外层调用链
  */
 #ifdef __linux__
-static std::string addr_to_line(const char* executable, void* addr,
-                                std::string* inline_chain = nullptr) {
+static std::string addr_to_line(const char* executable, void* addr, std::string* inline_chain = nullptr) {
     char cmd[512];
     snprintf(cmd, sizeof(cmd), "addr2line -e %s -f -C -p -i %p 2>/dev/null", executable, addr);
 
@@ -140,7 +139,9 @@ static std::string build_assert_message(const char* condition, const char* file,
 
 AssertionError::AssertionError(const char* condition, const char* file, int line)
     : std::runtime_error(build_assert_message(condition, file, line)),
-      condition_(condition), file_(file), line_(line) {}
+      condition_(condition),
+      file_(file),
+      line_(line) {}
 
 [[noreturn]] void assert_impl(const char* condition, const char* file, int line) {
     fprintf(stderr, "\n========================================\n");

--- a/src/a2a3/runtime/aicpu_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/aicpu_build_graph/orchestration/pto_orchestration_api.h
@@ -22,19 +22,21 @@
 #include <stddef.h>
 
 // Type headers needed by orchestration
-#include "pto_types.h"          // PTOParam, PTOTensorEntry, PTOParamType
-#include "tensor.h"             // Tensor, make_tensor, make_tensor_external
-#include "pto_submit_types.h"   // MixedKernels, INVALID_KERNEL_ID, subtask slots
-#include "pto_runtime2_types.h" // PTO2TaskId
-#include "task_arg.h"           // TaskArg, TaskArgKind
+#include "pto_types.h"           // PTOParam, PTOTensorEntry, PTOParamType
+#include "tensor.h"              // Tensor, make_tensor, make_tensor_external
+#include "pto_submit_types.h"    // MixedKernels, INVALID_KERNEL_ID, subtask slots
+#include "pto_runtime2_types.h"  // PTO2TaskId
+#include "task_arg.h"            // TaskArg, TaskArgKind
 
 // Convert TaskArg to Tensor (needs make_tensor_external from tensor.h)
 static_assert(TASK_ARG_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "TaskArg and runtime max dims must match");
 inline Tensor from_task_arg(const TaskArg& arg, bool manual_dep = false, int32_t version = 0) {
-    return make_tensor_external(
-        reinterpret_cast<void*>(static_cast<uintptr_t>(arg.tensor.data)),
-        arg.tensor.shapes, arg.tensor.ndims, arg.tensor.dtype,
-        manual_dep, version);
+    return make_tensor_external(reinterpret_cast<void*>(static_cast<uintptr_t>(arg.tensor.data)),
+        arg.tensor.shapes,
+        arg.tensor.ndims,
+        arg.tensor.dtype,
+        manual_dep,
+        version);
 }
 
 // =============================================================================
@@ -53,8 +55,7 @@ typedef struct PTO2Runtime PTO2Runtime;
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
 typedef struct PTO2RuntimeOps {
-    PTO2TaskId (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                              const PTOParam& params);
+    PTO2TaskId (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params);
     void (*add_dependency)(PTO2Runtime* rt, PTO2TaskId producer, PTO2TaskId consumer);
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
@@ -84,16 +85,15 @@ struct PTO2Runtime {
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline PTO2TaskId pto2_rt_submit_task(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                                        const PTOParam& params) {
+static inline PTO2TaskId pto2_rt_submit_task(
+    PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params) {
     return rt->ops->submit_task(rt, mixed_kernels, params);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
-static inline PTO2TaskId pto2_rt_submit_aic_task(PTO2Runtime* rt, int32_t kernel_id,
-                                            const PTOParam& params) {
+static inline PTO2TaskId pto2_rt_submit_aic_task(PTO2Runtime* rt, int32_t kernel_id, const PTOParam& params) {
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, params);
@@ -102,8 +102,7 @@ static inline PTO2TaskId pto2_rt_submit_aic_task(PTO2Runtime* rt, int32_t kernel
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
-static inline PTO2TaskId pto2_rt_submit_aiv_task(PTO2Runtime* rt, int32_t kernel_id,
-                                            const PTOParam& params) {
+static inline PTO2TaskId pto2_rt_submit_aiv_task(PTO2Runtime* rt, int32_t kernel_id, const PTOParam& params) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, params);
@@ -116,29 +115,21 @@ static inline void pto2_rt_add_dependency(PTO2Runtime* rt, PTO2TaskId producer, 
     rt->ops->add_dependency(rt, producer, consumer);
 }
 
-static inline void pto2_rt_scope_begin(PTO2Runtime* rt) {
-    rt->ops->scope_begin(rt);
-}
+static inline void pto2_rt_scope_begin(PTO2Runtime* rt) { rt->ops->scope_begin(rt); }
 
-static inline void pto2_rt_scope_end(PTO2Runtime* rt) {
-    rt->ops->scope_end(rt);
-}
+static inline void pto2_rt_scope_end(PTO2Runtime* rt) { rt->ops->scope_end(rt); }
 
-static inline void pto2_rt_orchestration_done(PTO2Runtime* rt) {
-    rt->ops->orchestration_done(rt);
-}
+static inline void pto2_rt_orchestration_done(PTO2Runtime* rt) { rt->ops->orchestration_done(rt); }
 
-static inline bool pto2_rt_is_fatal(PTO2Runtime* rt) {
-    return rt->ops->is_fatal(rt);
-}
+static inline bool pto2_rt_is_fatal(PTO2Runtime* rt) { return rt->ops->is_fatal(rt); }
 
 // =============================================================================
 // Logging Macros for Orchestration (call through ops table)
 // =============================================================================
 
 #define LOG_ERROR(rt, fmt, ...) (rt)->ops->log_error(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_WARN(rt, fmt, ...)  (rt)->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_INFO(rt, fmt, ...)  (rt)->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_WARN(rt, fmt, ...) (rt)->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_INFO(rt, fmt, ...) (rt)->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
 #define LOG_DEBUG(rt, fmt, ...) (rt)->ops->log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
 #define LOG_ALWAYS(rt, fmt, ...) (rt)->ops->log_always(__FUNCTION__, fmt, ##__VA_ARGS__)
 
@@ -151,17 +142,14 @@ static inline bool pto2_rt_is_fatal(PTO2Runtime* rt) {
  */
 class PTO2ScopeGuard {
 public:
-    PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) {
-        rt_->ops->scope_begin(rt_);
-    }
-    ~PTO2ScopeGuard() {
-        rt_->ops->scope_end(rt_);
-    }
+    PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) { rt_->ops->scope_begin(rt_); }
+    ~PTO2ScopeGuard() { rt_->ops->scope_end(rt_); }
+
 private:
     PTO2Runtime* rt_;
 };
 
-#define _PTO2_CONCATENATE_IMPL(x, y) x ## y
+#define _PTO2_CONCATENATE_IMPL(x, y) x##y
 #define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
 
 #define PTO2_SCOPE_GUARD(rt) [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__)(rt)
@@ -188,8 +176,8 @@ private:
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
 struct PTO2OrchestrationConfig {
-    int         expected_arg_count;
+    int expected_arg_count;
 };
 #endif
 
-#endif // PTO_ORCHESTRATION_API_H
+#endif  // PTO_ORCHESTRATION_API_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto2_dispatch_payload.h
@@ -26,7 +26,7 @@
  * AICore reads function_bin_addr, casts to UnifiedKernelFunc, calls with args.
  */
 struct PTO2DispatchPayload {
-    uint64_t function_bin_addr; /**< Kernel entry in GM: (UnifiedKernelFunc)function_bin_addr */
+    uint64_t function_bin_addr;            /**< Kernel entry in GM: (UnifiedKernelFunc)function_bin_addr */
     uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers + scalars) */
 };
 

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.cpp
@@ -39,7 +39,7 @@ static uint64_t g_orch_params_cycle = 0;
 static uint64_t g_orch_heap_cycle = 0;
 static uint64_t g_orch_fanin_cycle = 0;
 static uint64_t g_orch_scope_end_cycle = 0;
-static int64_t  g_orch_submit_count = 0;
+static int64_t g_orch_submit_count = 0;
 static uint32_t g_orch_submit_idx = 0;
 uint64_t g_orch_alloc_wait_cycle = 0;
 uint64_t g_orch_heap_wait_cycle = 0;
@@ -50,7 +50,12 @@ uint64_t g_orch_heap_atomic_count = 0;
 uint64_t g_orch_fanin_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
-#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+#define CYCLE_COUNT_LAP(acc)       \
+    do {                           \
+        _t1 = get_sys_cnt_aicpu(); \
+        acc += (_t1 - _t0);        \
+        _t0 = _t1;                 \
+    } while (0)
 #define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                    \
     do {                                                                              \
         _t1 = get_sys_cnt_aicpu();                                                    \
@@ -65,17 +70,19 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
     AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 static uint32_t g_orch_submit_idx = 0;
-#define CYCLE_COUNT_START()                                                           \
-    bool _prof_active = orch->enable_profiling;                                       \
+#define CYCLE_COUNT_START()                     \
+    bool _prof_active = orch->enable_profiling; \
     uint64_t _t0 = _prof_active ? get_sys_cnt_aicpu() : 0, _t1 = 0
-#define CYCLE_COUNT_LAP(acc) do { } while(0)
-#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                    \
-    do {                                                                              \
-        if (_prof_active) {                                                           \
-            _t1 = get_sys_cnt_aicpu();                                                \
+#define CYCLE_COUNT_LAP(acc) \
+    do {                     \
+    } while (0)
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                        \
+    do {                                                                                  \
+        if (_prof_active) {                                                               \
+            _t1 = get_sys_cnt_aicpu();                                                    \
             perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
-            _t0 = _t1;                                                                \
-        }                                                                             \
+            _t0 = _t1;                                                                    \
+        }                                                                                 \
     } while (0)
 #else
 #define CYCLE_COUNT_START()
@@ -87,8 +94,10 @@ static uint32_t g_orch_submit_idx = 0;
 // Orchestrator Initialization
 // =============================================================================
 
-bool pto2_orchestrator_init(
-    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, uint64_t heap_size,
+bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
     int32_t dep_pool_capacity) {
     *orch = PTO2OrchestratorState{};
 
@@ -100,7 +109,7 @@ bool pto2_orchestrator_init(
     // Initialize per-ring resources
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         void* ring_heap_base = (char*)gm_heap + r * heap_size;
-        auto &fc = sm_handle->header->rings[r].fc;
+        auto& fc = sm_handle->header->rings[r].fc;
 
         pto2_heap_ring_init(&orch->rings[r].heap_ring, ring_heap_base, heap_size, &fc.heap_tail, &fc.heap_top);
         orch->rings[r].heap_ring.error_code_ptr = &sm_handle->header->orch_error_code;
@@ -163,10 +172,11 @@ void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerS
 // Scope Management
 // =============================================================================
 
-static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState *task_slot_state) {
+static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState* task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         int32_t new_cap = orch->scope_tasks_capacity * 2;
-        PTO2TaskSlotState** new_buf = (PTO2TaskSlotState**)realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState*));
+        PTO2TaskSlotState** new_buf =
+            (PTO2TaskSlotState**)realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState*));
         assert(new_buf && "Failed to grow scope task buffer");
         orch->scope_tasks = new_buf;
         orch->scope_tasks_capacity = new_cap;
@@ -175,7 +185,9 @@ static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState *tas
 }
 
 void pto2_scope_begin(PTO2OrchestratorState* orch) {
-    if (orch->fatal) { return; }
+    if (orch->fatal) {
+        return;
+    }
     assert(orch->scope_stack_top < (int32_t)(orch->scope_stack_capacity - 1) && "Scope stack overflow");
 
     ++orch->scope_stack_top;
@@ -183,7 +195,9 @@ void pto2_scope_begin(PTO2OrchestratorState* orch) {
 }
 
 void pto2_scope_end(PTO2OrchestratorState* orch) {
-    if (orch->fatal) { return; }
+    if (orch->fatal) {
+        return;
+    }
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
 
 #if PTO2_ORCH_PROFILING
@@ -248,8 +262,7 @@ PTO2TaskId pto2_submit_mixed_task(
         LOG_ERROR("Error: %s", params.error_msg ? params.error_msg : "(unknown)");
         LOG_ERROR("  tensor_count: %d, scalar_count: %d", params.tensor_count, params.scalar_count);
         LOG_ERROR("========================================");
-        orch->sm_handle->header->orch_error_code.store(
-            PTO2_ERROR_INVALID_PARAM, std::memory_order_release);
+        orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_INVALID_PARAM, std::memory_order_release);
         orch->fatal = true;
         return invalid_id;
     }
@@ -285,8 +298,7 @@ PTO2TaskId pto2_submit_mixed_task(
             LOG_ERROR("========================================");
             LOG_ERROR("FATAL: Scope Deadlock Detected! (ring %d)", ring_id);
             LOG_ERROR("========================================");
-            LOG_ERROR("Tasks in current scope (%d) >= task_window_size (%d).",
-                      scope_task_count, task_ring.window_size);
+            LOG_ERROR("Tasks in current scope (%d) >= task_window_size (%d).", scope_task_count, task_ring.window_size);
             LOG_ERROR("  scope_depth:        %d", orch->scope_stack_top + 1);
             LOG_ERROR("  ring_id:            %d", ring_id);
             LOG_ERROR("  scope_task_count:   %d", scope_task_count);
@@ -294,8 +306,7 @@ PTO2TaskId pto2_submit_mixed_task(
             LOG_ERROR("  last_task_alive:    %d", last_alive);
             LOG_ERROR("  active_tasks:       %d / %d", active_count, task_ring.window_size);
             LOG_ERROR("========================================");
-            orch->sm_handle->header->orch_error_code.store(
-                PTO2_ERROR_SCOPE_DEADLOCK, std::memory_order_release);
+            orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_SCOPE_DEADLOCK, std::memory_order_release);
             orch->fatal = true;
             return invalid_id;
         }
@@ -303,7 +314,10 @@ PTO2TaskId pto2_submit_mixed_task(
 
     // === STEP 1: Allocate task slot from Task Ring ===
     int32_t local_id = task_ring.pto2_task_ring_alloc();
-    if (local_id < 0) { orch->fatal = true; return invalid_id; }
+    if (local_id < 0) {
+        orch->fatal = true;
+        return invalid_id;
+    }
     int32_t slot = task_ring.get_task_slot(local_id);
     PTO2TaskId task_id = pto2_make_task_id(ring_id, static_cast<uint32_t>(local_id));
 
@@ -353,8 +367,7 @@ PTO2TaskId pto2_submit_mixed_task(
     // === STEP 2: Heap allocation for OUTPUT tensors ===
     int32_t total_output_size = 0;
     for (int i = 0; i < params.tensor_count; i++) {
-        if (params.tensor_types[i] == PTOParamType::OUTPUT
-            && params.tensors[i]->buffer.addr == 0) {
+        if (params.tensor_types[i] == PTOParamType::OUTPUT && params.tensors[i]->buffer.addr == 0) {
             total_output_size += PTO2_ALIGN_UP(params.tensors[i]->buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
         }
     }
@@ -363,15 +376,17 @@ PTO2TaskId pto2_submit_mixed_task(
     void* local_packed_end = nullptr;
     if (total_output_size > 0) {
         local_packed_base = orch->pto2_alloc_packed_buffer(total_output_size);
-        if (!local_packed_base) { orch->fatal = true; return invalid_id; }
+        if (!local_packed_base) {
+            orch->fatal = true;
+            return invalid_id;
+        }
         local_packed_end = (char*)local_packed_base + total_output_size;
     }
 
     // Assign addresses to OUTPUT tensors
     int32_t offset = 0;
     for (int i = 0; i < params.tensor_count; i++) {
-        if (params.tensor_types[i] == PTOParamType::OUTPUT
-            && params.tensors[i]->buffer.addr == 0) {
+        if (params.tensor_types[i] == PTOParamType::OUTPUT && params.tensors[i]->buffer.addr == 0) {
             uint64_t alloc_addr = reinterpret_cast<uint64_t>((char*)local_packed_base + offset);
             params.tensors[i]->buffer.addr = alloc_addr;
             offset += PTO2_ALIGN_UP(params.tensors[i]->buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
@@ -389,7 +404,7 @@ PTO2TaskId pto2_submit_mixed_task(
     // === STEP 3: Write task descriptor and payload ===
     __builtin_prefetch(&task, 1, 1);
     task.task_id = task_id;
-    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)]  = normalized.aic_kernel_id;
+    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)] = normalized.aic_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;
     task.packed_buffer_base = local_packed_base;
@@ -422,8 +437,7 @@ PTO2TaskId pto2_submit_mixed_task(
 // Explicit Dependency Management
 // =============================================================================
 
-void pto2_add_dependency(PTO2OrchestratorState* orch,
-                          PTO2TaskId producer_id, PTO2TaskId consumer_id) {
+void pto2_add_dependency(PTO2OrchestratorState* orch, PTO2TaskId producer_id, PTO2TaskId consumer_id) {
     if (orch->fatal) return;
 
     PTO2SchedulerState* sched = orch->scheduler;
@@ -492,7 +506,12 @@ void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
         auto& pool = orch->rings[r].dep_pool;
         if (pool.top > 0) {
             LOG_INFO("=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===",
-                     r, pool.top, pool.tail, pool.top - pool.tail, pool.high_water, pool.capacity);
+                r,
+                pool.top,
+                pool.tail,
+                pool.top - pool.tail,
+                pool.high_water,
+                pool.capacity);
         }
     }
     orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
@@ -517,12 +536,12 @@ void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
         int32_t active = pto2_task_ring_active_count(&orch->rings[r].task_ring);
         if (active > 0) {
             LOG_INFO("Ring %d task active:  %d", r, active);
-            LOG_INFO("Ring %d heap used:    %" PRIu64 " / %" PRIu64, r,
-                     orch->rings[r].heap_ring.top_ptr->load(std::memory_order_relaxed),
-                     orch->rings[r].heap_ring.size);
-            LOG_INFO("Ring %d dep pool:     %d / %d", r,
-                     orch->rings[r].dep_pool.used(),
-                     orch->rings[r].dep_pool.capacity);
+            LOG_INFO("Ring %d heap used:    %" PRIu64 " / %" PRIu64,
+                r,
+                orch->rings[r].heap_ring.top_ptr->load(std::memory_order_relaxed),
+                orch->rings[r].heap_ring.size);
+            LOG_INFO(
+                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity);
         }
     }
     LOG_INFO("===============================");

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.h
@@ -45,12 +45,12 @@ struct PTO2OrchestratorState {
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    PTO2TaskSlotState** scope_tasks; // Flat buffer of taskSlotState (all scopes concatenated)
-    int32_t scope_tasks_size;       // Number of task IDs currently in the buffer
-    int32_t scope_tasks_capacity;   // Allocated capacity of scope_tasks
-    int32_t* scope_begins;         // scope_begins[i] = start index of scope i in scope_tasks
-    int32_t scope_stack_top;       // Current top of stack (-1 = no scope open)
-    uint64_t scope_stack_capacity;   // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+    PTO2TaskSlotState** scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
+    int32_t scope_tasks_size;         // Number of task IDs currently in the buffer
+    int32_t scope_tasks_capacity;     // Allocated capacity of scope_tasks
+    int32_t* scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
+    int32_t scope_stack_top;          // Current top of stack (-1 = no scope open)
+    uint64_t scope_stack_capacity;    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
 
     // === SCHEDULER REFERENCE ===
     // Note: In simulated mode, orchestrator and scheduler share address space
@@ -62,8 +62,8 @@ struct PTO2OrchestratorState {
 #endif
 
     // === GM HEAP (for output buffers) ===
-    void* gm_heap_base;    // Base address of GM heap
-    uint64_t gm_heap_size;   // Total size of GM heap (all rings)
+    void* gm_heap_base;     // Base address of GM heap
+    uint64_t gm_heap_size;  // Total size of GM heap (all rings)
 
     // === FATAL ERROR ===
     // Fatal error flag (single-thread access by orchestrator, no atomic needed)
@@ -120,8 +120,10 @@ struct PTO2OrchestratorState {
  * @param heap_size  Size of GM heap
  * @return true on success
  */
-bool pto2_orchestrator_init(
-    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, uint64_t heap_size,
+bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
     int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
 
 /**
@@ -133,7 +135,6 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState* orch);
  * Set scheduler reference (for simulated mode)
  */
 void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler);
-
 
 // =============================================================================
 // Scope Management
@@ -182,9 +183,8 @@ void pto2_scope_end(PTO2OrchestratorState* orch);
  * @param params      Aggregated tensor and scalar parameters
  * @return PTO2TaskId for use in pto2_add_dependency()
  */
-PTO2TaskId pto2_submit_mixed_task(PTO2OrchestratorState* orch,
-    const MixedKernels& mixed_kernels,
-    const PTOParam& params);
+PTO2TaskId pto2_submit_mixed_task(
+    PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const PTOParam& params);
 
 // =============================================================================
 // Explicit Dependency Management
@@ -205,8 +205,7 @@ PTO2TaskId pto2_submit_mixed_task(PTO2OrchestratorState* orch,
  * @param producer  Producer task ID (must complete before consumer starts)
  * @param consumer  Consumer task ID (depends on producer)
  */
-void pto2_add_dependency(PTO2OrchestratorState* orch,
-    PTO2TaskId producer, PTO2TaskId consumer);
+void pto2_add_dependency(PTO2OrchestratorState* orch, PTO2TaskId producer, PTO2TaskId consumer);
 
 // =============================================================================
 // Flow Control
@@ -244,11 +243,11 @@ struct PTO2OrchProfilingData {
     uint64_t heap_cycle;
     uint64_t fanin_cycle;
     uint64_t scope_end_cycle;
-    int64_t  submit_count;
+    int64_t submit_count;
     // Wait time tracking for blocking phases
-    uint64_t alloc_wait_cycle;      // Cycles spent waiting in task_ring_alloc
-    uint64_t heap_wait_cycle;       // Cycles spent waiting in heap_ring_alloc
-    uint64_t fanin_wait_cycle;      // Cycles spent waiting in fanout_lock
+    uint64_t alloc_wait_cycle;  // Cycles spent waiting in task_ring_alloc
+    uint64_t heap_wait_cycle;   // Cycles spent waiting in heap_ring_alloc
+    uint64_t fanin_wait_cycle;  // Cycles spent waiting in fanout_lock
     // Atomic operation counts per phase
     uint64_t alloc_atomic_count;
     uint64_t params_atomic_count;

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.cpp
@@ -18,9 +18,8 @@
 // Heap Ring Buffer Implementation
 // =============================================================================
 
-void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
-                          std::atomic<uint64_t>* tail_ptr,
-                          std::atomic<uint64_t>* top_ptr) {
+void pto2_heap_ring_init(
+    PTO2HeapRing* ring, void* base, uint64_t size, std::atomic<uint64_t>* tail_ptr, std::atomic<uint64_t>* top_ptr) {
     ring->base = base;
     ring->size = size;
     ring->top_ptr = top_ptr;
@@ -31,9 +30,11 @@ void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
 // Task Ring Buffer Implementation
 // =============================================================================
 
-void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
-                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr,
-                          std::atomic<int32_t>* current_index_ptr) {
+void pto2_task_ring_init(PTO2TaskRing* ring,
+    PTO2TaskDescriptor* descriptors,
+    int32_t window_size,
+    std::atomic<int32_t>* last_alive_ptr,
+    std::atomic<int32_t>* current_index_ptr) {
     ring->descriptors = descriptors;
     ring->window_size = window_size;
     ring->current_index_ptr = current_index_ptr;

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.h
@@ -1,25 +1,25 @@
 /**
  * PTO Runtime2 - Ring Buffer Data Structures
- * 
+ *
  * Implements ring buffer designs for zero-overhead memory management:
- * 
+ *
  * 1. HeapRing - Output buffer allocation from GM Heap
  *    - O(1) bump allocation
  *    - Wrap-around at end, skip to beginning if buffer doesn't fit
  *    - Implicit reclamation via heap_tail advancement
  *    - Back-pressure: stalls when no space available
- * 
+ *
  * 2. TaskRing - Task slot allocation
  *    - Fixed window size (TASK_WINDOW_SIZE)
  *    - Wrap-around modulo window size
  *    - Implicit reclamation via last_task_alive advancement
  *    - Back-pressure: stalls when window is full
- * 
+ *
  * 3. DepListPool - Dependency list entry allocation
  *    - Ring buffer for linked list entries
  *    - O(1) prepend operation
  *    - Implicit reclamation with task ring
- * 
+ *
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
@@ -40,15 +40,15 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 #endif
 
 // Block notification interval (in spin counts)
-#define PTO2_BLOCK_NOTIFY_INTERVAL  10000
+#define PTO2_BLOCK_NOTIFY_INTERVAL 10000
 // Heap ring spin limit - after this, report deadlock and exit
-#define PTO2_HEAP_SPIN_LIMIT        100000
+#define PTO2_HEAP_SPIN_LIMIT 100000
 
 // Flow control spin limit - if exceeded, likely deadlock due to scope/fanout_count
-#define PTO2_FLOW_CONTROL_SPIN_LIMIT  100000
+#define PTO2_FLOW_CONTROL_SPIN_LIMIT 100000
 
 // Dep pool spin limit - if exceeded, dep pool capacity too small for workload
-#define PTO2_DEP_POOL_SPIN_LIMIT      100000
+#define PTO2_DEP_POOL_SPIN_LIMIT 100000
 
 // =============================================================================
 // Heap Ring Buffer
@@ -56,13 +56,13 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 
 /**
  * Heap ring buffer structure
- * 
+ *
  * Allocates output buffers from a contiguous GM Heap.
  * Wrap-around design with implicit reclamation.
  */
 struct PTO2HeapRing {
-    void*    base;        // GM_Heap_Base pointer
-    uint64_t size;        // GM_Heap_Size (total heap size in bytes)
+    void* base;                      // GM_Heap_Base pointer
+    uint64_t size;                   // GM_Heap_Size (total heap size in bytes)
     std::atomic<uint64_t>* top_ptr;  // Allocation pointer (shared atomic in SM header)
 
     // Reference to shared memory tail (for back-pressure)
@@ -111,7 +111,8 @@ struct PTO2HeapRing {
                 }
                 {
                     extern uint64_t g_orch_heap_atomic_count;
-                    g_orch_heap_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
+                    g_orch_heap_atomic_count +=
+                        spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
                 }
 #endif
                 return ptr;
@@ -120,7 +121,10 @@ struct PTO2HeapRing {
             // No space available, spin-wait
             spin_count++;
 #if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+            if (!waiting) {
+                wait_start = get_sys_cnt_aicpu();
+                waiting = true;
+            }
 #endif
 
             // Progress detection: reset spin counter if heap_tail advances
@@ -128,7 +132,9 @@ struct PTO2HeapRing {
             if (cur_tail != prev_tail) {
 #if PTO2_SPIN_VERBOSE_LOGGING
                 LOG_INFO("[HeapRing] Progress: tail %" PRIu64 " -> %" PRIu64 " (reset spin_count=%d)",
-                         prev_tail, cur_tail, spin_count);
+                    prev_tail,
+                    cur_tail,
+                    spin_count);
 #endif
                 spin_count = 0;
                 prev_tail = cur_tail;
@@ -138,9 +144,13 @@ struct PTO2HeapRing {
             // Periodic block notification
             if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 && spin_count < PTO2_HEAP_SPIN_LIMIT) {
                 uint64_t top = top_ptr->load(std::memory_order_acquire);
-                LOG_WARN("[HeapRing] BLOCKED: requesting %" PRIu64 " bytes"
-                     ", top=%" PRIu64 ", tail=%" PRIu64 ", spins=%d",
-                     size, top, cur_tail, spin_count);
+                LOG_WARN("[HeapRing] BLOCKED: requesting %" PRIu64
+                         " bytes"
+                         ", top=%" PRIu64 ", tail=%" PRIu64 ", spins=%d",
+                    size,
+                    top,
+                    cur_tail,
+                    spin_count);
                 notified = true;
             }
 #endif
@@ -161,8 +171,8 @@ struct PTO2HeapRing {
                 LOG_ERROR("  is stuck. Check TaskRing diagnostics for root cause.");
                 LOG_ERROR("Solution: Increase heap size or investigate task stall.");
                 LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
-                LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %lu)",
-                          (unsigned long)(this->size * 2));
+                LOG_ERROR(
+                    "  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %lu)", (unsigned long)(this->size * 2));
                 LOG_ERROR("========================================");
                 if (error_code_ptr) {
                     error_code_ptr->store(PTO2_ERROR_HEAP_RING_DEADLOCK, std::memory_order_release);
@@ -216,8 +226,7 @@ struct PTO2HeapRing {
                 }
             }
 
-            if (top_ptr->compare_exchange_weak(top, new_top,
-                    std::memory_order_acq_rel, std::memory_order_acquire)) {
+            if (top_ptr->compare_exchange_weak(top, new_top, std::memory_order_acq_rel, std::memory_order_acquire)) {
                 return result;
             }
             // CAS failed, retry with updated top
@@ -243,15 +252,14 @@ struct PTO2HeapRing {
 
 /**
  * Initialize heap ring buffer
- * 
+ *
  * @param ring      Heap ring to initialize
  * @param base      Base address of heap memory
  * @param size      Total heap size in bytes
  * @param tail_ptr  Pointer to shared memory heap_tail
  */
-void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
-                          std::atomic<uint64_t>* tail_ptr,
-                          std::atomic<uint64_t>* top_ptr);
+void pto2_heap_ring_init(
+    PTO2HeapRing* ring, void* base, uint64_t size, std::atomic<uint64_t>* tail_ptr, std::atomic<uint64_t>* top_ptr);
 
 // =============================================================================
 // Task Ring Buffer
@@ -259,13 +267,13 @@ void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
 
 /**
  * Task ring buffer structure
- * 
+ *
  * Fixed-size sliding window for task management.
  * Provides back-pressure when window is full.
  */
 struct PTO2TaskRing {
-    PTO2TaskDescriptor* descriptors;  // Task descriptor array (from shared memory)
-    int32_t window_size;              // Window size (power of 2)
+    PTO2TaskDescriptor* descriptors;          // Task descriptor array (from shared memory)
+    int32_t window_size;                      // Window size (power of 2)
     std::atomic<int32_t>* current_index_ptr;  // Shared atomic in SM header
 
     // Reference to shared memory last_task_alive (for back-pressure)
@@ -309,7 +317,8 @@ struct PTO2TaskRing {
                 }
                 {
                     extern uint64_t g_orch_alloc_atomic_count;
-                    g_orch_alloc_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
+                    g_orch_alloc_atomic_count +=
+                        spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
                 }
 #endif
                 return task_id;
@@ -318,7 +327,10 @@ struct PTO2TaskRing {
             // Window is full, spin-wait (with yield to prevent CPU starvation)
             spin_count++;
 #if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+            if (!waiting) {
+                wait_start = get_sys_cnt_aicpu();
+                waiting = true;
+            }
 #endif
 
             // Progress detection: reset spin counter if last_task_alive advances
@@ -326,7 +338,9 @@ struct PTO2TaskRing {
             if (cur_last_alive > prev_last_alive) {
 #if PTO2_SPIN_VERBOSE_LOGGING
                 LOG_INFO("[TaskRing] Progress: last_alive %d -> %d (reset spin_count=%d)",
-                         prev_last_alive, cur_last_alive, spin_count);
+                    prev_last_alive,
+                    cur_last_alive,
+                    spin_count);
 #endif
                 spin_count = 0;
                 prev_last_alive = cur_last_alive;
@@ -334,13 +348,19 @@ struct PTO2TaskRing {
 
 #if PTO2_SPIN_VERBOSE_LOGGING
             // Periodic block notification
-            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 && spin_count < PTO2_FLOW_CONTROL_SPIN_LIMIT) {
+            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 &&
+                spin_count < PTO2_FLOW_CONTROL_SPIN_LIMIT) {
                 int32_t current = current_index_ptr->load(std::memory_order_acquire);
                 int32_t active_count = current - cur_last_alive;
-                LOG_WARN("[TaskRing] BLOCKED (Flow Control): current=%d, last_alive=%d, "
-                     "active=%d/%d (%.1f%%), spins=%d",
-                     current, cur_last_alive, active_count, window_size,
-                     100.0 * active_count / window_size, spin_count);
+                LOG_WARN(
+                    "[TaskRing] BLOCKED (Flow Control): current=%d, last_alive=%d, "
+                    "active=%d/%d (%.1f%%), spins=%d",
+                    current,
+                    cur_last_alive,
+                    active_count,
+                    window_size,
+                    100.0 * active_count / window_size,
+                    spin_count);
                 notified = true;
             }
 #endif
@@ -359,8 +379,7 @@ struct PTO2TaskRing {
                 LOG_ERROR("  - Active tasks:        %d / %d", active_count, window_size);
                 LOG_ERROR("  - Window utilization:  %.1f%%", 100.0 * active_count / window_size);
                 LOG_ERROR("Diagnosis:");
-                LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d",
-                          cur_last_alive, cur_last_alive);
+                LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d", cur_last_alive, cur_last_alive);
                 LOG_ERROR("  cannot transition to CONSUMED. Possible causes:");
                 LOG_ERROR("  1. Task %d still executing (subtasks not complete)", cur_last_alive);
                 LOG_ERROR("  2. Task %d fanout not fully released (downstream not done)", cur_last_alive);
@@ -405,27 +424,29 @@ struct PTO2TaskRing {
     int32_t get_task_slot(int32_t task_id) const { return task_id & (window_size - 1); }
 
     /**
-    * Get task descriptor by ID
-    */
+     * Get task descriptor by ID
+     */
     PTO2TaskDescriptor& get_task(int32_t task_id) { return descriptors[task_id & (window_size - 1)]; }
 
     /**
-    * Get task descriptor by task slot
-    */
+     * Get task descriptor by task slot
+     */
     PTO2TaskDescriptor& get_task_by_slot(int32_t task_slot) { return descriptors[task_slot]; }
 };
 
 /**
  * Initialize task ring buffer
- * 
+ *
  * @param ring            Task ring to initialize
  * @param descriptors     Task descriptor array from shared memory
  * @param window_size     Window size (must be power of 2)
  * @param last_alive_ptr  Pointer to shared memory last_task_alive
  */
-void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
-                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr,
-                          std::atomic<int32_t>* current_index_ptr);
+void pto2_task_ring_init(PTO2TaskRing* ring,
+    PTO2TaskDescriptor* descriptors,
+    int32_t window_size,
+    std::atomic<int32_t>* last_alive_ptr,
+    std::atomic<int32_t>* current_index_ptr);
 
 /**
  * Get number of active tasks in window
@@ -465,12 +486,12 @@ static inline PTO2TaskDescriptor* pto2_task_ring_get(PTO2TaskRing* ring, int32_t
  * is obtained via modulo: base[linear_index % capacity].
  */
 struct PTO2DepListPool {
-    PTO2DepListEntry* base;   // Pool base address
-    int32_t capacity;         // Total number of entries
-    int32_t top;              // Linear next-allocation counter (starts from 1)
-    int32_t tail;             // Linear first-alive counter (entries before this are dead)
-    int32_t high_water;       // Peak concurrent usage (top - tail)
-    int32_t last_reclaimed{0}; // last_task_alive at last successful reclamation
+    PTO2DepListEntry* base;     // Pool base address
+    int32_t capacity;           // Total number of entries
+    int32_t top;                // Linear next-allocation counter (starts from 1)
+    int32_t tail;               // Linear first-alive counter (entries before this are dead)
+    int32_t high_water;         // Peak concurrent usage (top - tail)
+    int32_t last_reclaimed{0};  // last_task_alive at last successful reclamation
 
     // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
     std::atomic<int32_t>* error_code_ptr = nullptr;
@@ -510,7 +531,7 @@ struct PTO2DepListPool {
      * Ensure dep pool for a specific ring has at least `needed` entries available.
      * Spin-waits for reclamation if under pressure. Detects deadlock if no progress.
      */
-    void ensure_space(PTO2SchedulerState& sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed);
+    void ensure_space(PTO2SchedulerState& sched, PTO2RingFlowControl& fc, uint8_t ring_id, int32_t needed);
 
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)
@@ -572,20 +593,16 @@ struct PTO2DepListPool {
     }
 
     /**
-    * Get entry by offset
-    */
+     * Get entry by offset
+     */
     PTO2DepListEntry* pto2_dep_pool_get(int32_t offset) {
         if (offset <= 0) return NULL;
         return &base[offset];
     }
 
-    int32_t used() const {
-        return top - tail;
-    }
+    int32_t used() const { return top - tail; }
 
-    int32_t available() const {
-        return capacity - used();
-    }
+    int32_t available() const { return capacity - used(); }
 };
 
 // =============================================================================
@@ -597,9 +614,9 @@ struct PTO2DepListPool {
  * PTO2_MAX_RING_DEPTH instances provide independent reclamation per scope depth.
  */
 struct PTO2RingSet {
-    PTO2HeapRing    heap_ring;
-    PTO2TaskRing    task_ring;
+    PTO2HeapRing heap_ring;
+    PTO2TaskRing task_ring;
     PTO2DepListPool dep_pool;
 };
 
-#endif // PTO_RING_BUFFER_H
+#endif  // PTO_RING_BUFFER_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.cpp
@@ -18,52 +18,40 @@
 
 thread_local int pto2_current_orch_idx = 0;
 
-void pto2_set_orch_thread_idx(int idx) {
-    pto2_current_orch_idx = idx;
-}
+void pto2_set_orch_thread_idx(int idx) { pto2_current_orch_idx = idx; }
 
 // =============================================================================
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
-static PTO2TaskId submit_task_impl(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                             const PTOParam& params) {
-    return pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels,
-                           params);
+static PTO2TaskId submit_task_impl(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params) {
+    return pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels, params);
 }
 
 static void add_dependency_impl(PTO2Runtime* rt, PTO2TaskId producer, PTO2TaskId consumer) {
     pto2_add_dependency(&rt->orchestrators[pto2_current_orch_idx], producer, consumer);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime* rt) {
-    pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_scope_begin(PTO2Runtime* rt) { pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_scope_end(PTO2Runtime* rt) {
-    pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_scope_end(PTO2Runtime* rt) { pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_orchestration_done(PTO2Runtime* rt) {
-    pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_orchestration_done(PTO2Runtime* rt) { pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]); }
 
-static bool is_fatal_impl(PTO2Runtime* rt) {
-    return rt->orchestrators[pto2_current_orch_idx].fatal;
-}
+static bool is_fatal_impl(PTO2Runtime* rt) { return rt->orchestrators[pto2_current_orch_idx].fatal; }
 
 static const PTO2RuntimeOps s_runtime_ops = {
-    .submit_task          = submit_task_impl,
-    .add_dependency       = add_dependency_impl,
-    .scope_begin          = pto2_rt_scope_begin,
-    .scope_end            = pto2_rt_scope_end,
-    .orchestration_done   = pto2_rt_orchestration_done,
-    .is_fatal             = is_fatal_impl,
-    .log_error            = unified_log_error,
-    .log_warn             = unified_log_warn,
-    .log_info             = unified_log_info,
-    .log_debug            = unified_log_debug,
-    .log_always           = unified_log_always,
+    .submit_task = submit_task_impl,
+    .add_dependency = add_dependency_impl,
+    .scope_begin = pto2_rt_scope_begin,
+    .scope_end = pto2_rt_scope_end,
+    .orchestration_done = pto2_rt_orchestration_done,
+    .is_fatal = is_fatal_impl,
+    .log_error = unified_log_error,
+    .log_warn = unified_log_warn,
+    .log_info = unified_log_info,
+    .log_debug = unified_log_debug,
+    .log_always = unified_log_always,
 };
 
 // =============================================================================
@@ -71,15 +59,11 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // =============================================================================
 
 PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode) {
-    return pto2_runtime_create_custom(mode,
-                                       PTO2_TASK_WINDOW_SIZE,
-                                       PTO2_HEAP_SIZE);
+    return pto2_runtime_create_custom(mode, PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
 }
 
-PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
-                                         uint64_t task_window_size,
-                                         uint64_t heap_size,
-                                         int32_t dep_pool_capacity) {
+PTO2Runtime* pto2_runtime_create_custom(
+    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity) {
     // Allocate runtime context
     PTO2Runtime* rt = (PTO2Runtime*)calloc(1, sizeof(PTO2Runtime));
     if (!rt) {
@@ -98,25 +82,24 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
     // Allocate GM heap for output buffers (all rings combined)
     uint64_t total_heap_size = heap_size * PTO2_MAX_RING_DEPTH;
     rt->gm_heap_size = total_heap_size;
-    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-        if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, total_heap_size) != 0) {
-            pto2_sm_destroy(rt->sm_handle);
-            free(rt);
-            return NULL;
-        }
-    #else
-        rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, total_heap_size);
-        if (!rt->gm_heap) {
-            pto2_sm_destroy(rt->sm_handle);
-            free(rt);
-            return NULL;
-        }
-    #endif
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+    if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, total_heap_size) != 0) {
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+#else
+    rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, total_heap_size);
+    if (!rt->gm_heap) {
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+#endif
     rt->gm_heap_owned = true;
 
     // Initialize first orchestrator
-    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle,
-                                 rt->gm_heap, heap_size, dep_pool_capacity)) {
+    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
         free(rt);
@@ -139,11 +122,11 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
 }
 
 PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-                                          PTO2SharedMemoryHandle* sm_handle,
-                                          void* gm_heap,
-                                          uint64_t heap_size,
-                                          int orch_count,
-                                          int32_t dep_pool_capacity) {
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
+    int orch_count,
+    int32_t dep_pool_capacity) {
     if (!sm_handle) return NULL;
     if (orch_count < 1) orch_count = 1;
     if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
@@ -161,8 +144,7 @@ PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
 
     // Initialize all orchestrator states
     for (int i = 0; i < orch_count; i++) {
-        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle,
-                                    rt->gm_heap, heap_size, dep_pool_capacity)) {
+        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
             for (int j = 0; j < i; j++) {
                 pto2_orchestrator_destroy(&rt->orchestrators[j]);
             }

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.h
@@ -58,8 +58,7 @@ enum PTO2RuntimeMode {
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
-    PTO2TaskId (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                              const PTOParam& params);
+    PTO2TaskId (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params);
     void (*add_dependency)(PTO2Runtime* rt, PTO2TaskId producer, PTO2TaskId consumer);
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
@@ -82,24 +81,24 @@ struct PTO2RuntimeOps {
  */
 struct PTO2Runtime {
     // Ops table (first field — used by orchestration .so via function pointers)
-    const PTO2RuntimeOps*   ops;
+    const PTO2RuntimeOps* ops;
 
     // Components
     PTO2SharedMemoryHandle* sm_handle;
-    PTO2OrchestratorState   orchestrators[PTO2_MAX_ORCH_THREADS];
-    int                     orch_count;     // Number of active orchestrator states
-    PTO2SchedulerState      scheduler;
+    PTO2OrchestratorState orchestrators[PTO2_MAX_ORCH_THREADS];
+    int orch_count;  // Number of active orchestrator states
+    PTO2SchedulerState scheduler;
 
     // GM Heap for output buffers
-    void*                   gm_heap;
-    uint64_t                  gm_heap_size;
-    bool                    gm_heap_owned;  // True if we allocated it
+    void* gm_heap;
+    uint64_t gm_heap_size;
+    bool gm_heap_owned;  // True if we allocated it
 
     // Mode
-    PTO2RuntimeMode         mode;
+    PTO2RuntimeMode mode;
 
     // Statistics
-    int64_t                 total_cycles;
+    int64_t total_cycles;
 };
 
 // =============================================================================
@@ -123,9 +122,9 @@ PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode);
  * @return Runtime context, or NULL on failure
  */
 PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
-                                         uint64_t task_window_size,
-                                         uint64_t heap_size,
-                                         int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    uint64_t task_window_size,
+    uint64_t heap_size,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
 
 /**
  * Create runtime from existing shared memory and GM heap (e.g. on device).
@@ -138,11 +137,11 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
  * @return Runtime context, or NULL on failure
  */
 PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-                                          PTO2SharedMemoryHandle* sm_handle,
-                                          void* gm_heap,
-                                          uint64_t heap_size,
-                                          int orch_count = 1,
-                                          int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
+    int orch_count = 1,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
 
 /**
  * Destroy runtime and free all resources
@@ -201,7 +200,7 @@ void pto2_rt_orchestration_done(PTO2Runtime* rt);
  *   PTO2_SCOPE_END(rt);
  */
 #define PTO2_SCOPE_BEGIN(rt) pto2_rt_scope_begin(rt)
-#define PTO2_SCOPE_END(rt)   pto2_rt_scope_end(rt)
+#define PTO2_SCOPE_END(rt) pto2_rt_scope_end(rt)
 
 /**
  * RAII Scope Guard for C++
@@ -235,12 +234,9 @@ void pto2_rt_orchestration_done(PTO2Runtime* rt);
  */
 class PTO2ScopeGuard {
 public:
-    PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) {
-        pto2_rt_scope_begin(rt_);
-    }
-    ~PTO2ScopeGuard() {
-        pto2_rt_scope_end(rt_);
-    }
+    PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) { pto2_rt_scope_begin(rt_); }
+    ~PTO2ScopeGuard() { pto2_rt_scope_end(rt_); }
+
 private:
     PTO2Runtime* rt_;
 };
@@ -254,7 +250,7 @@ private:
  *   PTO2_SCOPE_GUARD(rt);
  *   pto2_rt_submit_task(...);
  */
-#define _PTO2_CONCATENATE_IMPL(x, y) x ## y
+#define _PTO2_CONCATENATE_IMPL(x, y) x##y
 #define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
 #define PTO2_SCOPE_GUARD(rt) [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__)(rt)
 
@@ -276,8 +272,8 @@ private:
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
 struct PTO2OrchestrationConfig {
-    int         expected_arg_count;
+    int expected_arg_count;
 };
 #endif
 
-#endif // PTO_RUNTIME2_H
+#endif  // PTO_RUNTIME2_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2_types.h
@@ -51,15 +51,15 @@
 // =============================================================================
 
 // Orchestrator errors (1-99): detected in orchestrator thread
-#define PTO2_ERROR_NONE                       0
-#define PTO2_ERROR_SCOPE_DEADLOCK             1
-#define PTO2_ERROR_HEAP_RING_DEADLOCK         2
-#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK      3
-#define PTO2_ERROR_DEP_POOL_OVERFLOW          4
-#define PTO2_ERROR_INVALID_PARAM              5   // PTOParam construction error (invalid params)
+#define PTO2_ERROR_NONE 0
+#define PTO2_ERROR_SCOPE_DEADLOCK 1
+#define PTO2_ERROR_HEAP_RING_DEADLOCK 2
+#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK 3
+#define PTO2_ERROR_DEP_POOL_OVERFLOW 4
+#define PTO2_ERROR_INVALID_PARAM 5  // PTOParam construction error (invalid params)
 
 // Scheduler errors (100+): detected in scheduler threads
-#define PTO2_ERROR_SCHEDULER_TIMEOUT          100
+#define PTO2_ERROR_SCHEDULER_TIMEOUT 100
 
 // =============================================================================
 // Configuration Constants
@@ -69,27 +69,27 @@
 // NOTE: PTO2_TASK_WINDOW_SIZE is now a per-ring default value.
 // Actual window size is passed at runtime to pto2_runtime_create_threaded_custom().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
-#define PTO2_TASK_WINDOW_SIZE     16384   // Default per-ring task window size (power of 2)
+#define PTO2_TASK_WINDOW_SIZE 16384  // Default per-ring task window size (power of 2)
 
 // Multi-ring: number of independent ring layers (HeapRing + TaskRing + DepPool per layer)
 // Scope depth maps to ring index via: min(scope_depth, PTO2_MAX_RING_DEPTH - 1)
-#define PTO2_MAX_RING_DEPTH       4
+#define PTO2_MAX_RING_DEPTH 4
 
 // Memory pools (per-ring defaults; total = value × PTO2_MAX_RING_DEPTH)
-#define PTO2_HEAP_SIZE            (256 * 1024 * 1024)  // 256MB per ring (1GB total)
-#define PTO2_DEP_LIST_POOL_SIZE    16384    // Per-ring dependency list pool entries
+#define PTO2_HEAP_SIZE (256 * 1024 * 1024)  // 256MB per ring (1GB total)
+#define PTO2_DEP_LIST_POOL_SIZE 16384       // Per-ring dependency list pool entries
 
 // Scope management
-#define PTO2_MAX_SCOPE_DEPTH      64      // Maximum nesting depth
-#define PTO2_SCOPE_TASKS_INIT_CAP 65536     // Initial capacity for scope task buffer
+#define PTO2_MAX_SCOPE_DEPTH 64          // Maximum nesting depth
+#define PTO2_SCOPE_TASKS_INIT_CAP 65536  // Initial capacity for scope task buffer
 
 // Ready queue
-#define PTO2_READY_QUEUE_SIZE     65536   // Per-shape queue size
+#define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size
 
 // Memory alignment
-#define PTO2_ALIGN_SIZE           64      // Cache line alignment
-#define PTO2_PACKED_OUTPUT_ALIGN  1024    // Each output in packed buffer aligned to 1024B; gap is padding
-#define PTO2_ALIGN_UP(x, align)   (((x) + (align) - 1) & ~((align) - 1))
+#define PTO2_ALIGN_SIZE 64             // Cache line alignment
+#define PTO2_PACKED_OUTPUT_ALIGN 1024  // Each output in packed buffer aligned to 1024B; gap is padding
+#define PTO2_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
 
 // Dep pool cleanup interval
 #define PTO2_DEP_POOL_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
@@ -125,17 +125,11 @@ static inline PTO2TaskId pto2_make_task_id(uint8_t ring_id, uint32_t local_id) {
     return PTO2TaskId{(static_cast<uint64_t>(ring_id) << 32) | static_cast<uint64_t>(local_id)};
 }
 
-static inline uint8_t pto2_task_id_ring(PTO2TaskId task_id) {
-    return task_id.ring();
-}
+static inline uint8_t pto2_task_id_ring(PTO2TaskId task_id) { return task_id.ring(); }
 
-static inline uint32_t pto2_task_id_local(PTO2TaskId task_id) {
-    return task_id.local();
-}
+static inline uint32_t pto2_task_id_local(PTO2TaskId task_id) { return task_id.local(); }
 
-static inline uint64_t pto2_task_id_raw(PTO2TaskId task_id) {
-    return task_id.raw;
-}
+static inline uint64_t pto2_task_id_raw(PTO2TaskId task_id) { return task_id.raw; }
 
 // =============================================================================
 // Worker Types
@@ -146,10 +140,10 @@ static inline uint64_t pto2_task_id_raw(PTO2TaskId task_id) {
  * Each worker type has its own ready queue for load balancing
  */
 typedef enum {
-    PTO2_WORKER_CUBE = 0,       // AICore CUBE unit (matrix ops)
-    PTO2_WORKER_VECTOR = 1,     // AICore VECTOR unit (element-wise ops)
-    PTO2_WORKER_AI_CPU = 2,     // AI_CPU (scalar ops, control flow)
-    PTO2_WORKER_ACCELERATOR = 3,// Fixed-function accelerators (DMA, etc.)
+    PTO2_WORKER_CUBE = 0,         // AICore CUBE unit (matrix ops)
+    PTO2_WORKER_VECTOR = 1,       // AICore VECTOR unit (element-wise ops)
+    PTO2_WORKER_AI_CPU = 2,       // AI_CPU (scalar ops, control flow)
+    PTO2_WORKER_ACCELERATOR = 3,  // Fixed-function accelerators (DMA, etc.)
     PTO2_NUM_WORKER_TYPES = 4
 } PTO2WorkerType;
 
@@ -187,8 +181,8 @@ typedef enum {
  */
 struct PTO2TaskSlotState;  // Forward declaration
 struct PTO2DepListEntry {
-    PTO2TaskSlotState* slot_state;    // Consumer slot state (direct pointer)
-    PTO2DepListEntry* next;           // next entry
+    PTO2TaskSlotState* slot_state;  // Consumer slot state (direct pointer)
+    PTO2DepListEntry* next;         // next entry
 };
 
 // =============================================================================
@@ -206,14 +200,14 @@ struct PTO2DepListEntry {
  */
 struct PTO2TaskDescriptor {
     // Mixed-task identification (encodes ring_id in upper 32 bits)
-    PTO2TaskId task_id;         // raw: (ring_id << 32) | local_id
+    PTO2TaskId task_id;  // raw: (ring_id << 32) | local_id
 
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];
 
     // Packed output buffer (all outputs packed into single contiguous buffer)
-    void*    packed_buffer_base;  // Start of packed buffer in GM Heap
-    void*    packed_buffer_end;   // End of packed buffer (for heap reclamation)
+    void* packed_buffer_base;  // Start of packed buffer in GM Heap
+    void* packed_buffer_end;   // End of packed buffer (for heap reclamation)
 };
 
 // =============================================================================
@@ -232,9 +226,9 @@ struct PTO2TaskPayload {
     // === Cache line 0 (64B) — metadata ===
     int32_t tensor_count{0};
     int32_t scalar_count{0};
-    int32_t fanin_actual_count{0};             // Actual fanin count (without the +1 redundance)
-    int32_t _reserved{0};                      // Reserved (dep_pool_mark moved to SlotState for local access)
-    PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS]; // Producer slot states (used by on_task_release)
+    int32_t fanin_actual_count{0};  // Actual fanin count (without the +1 redundance)
+    int32_t _reserved{0};           // Reserved (dep_pool_mark moved to SlotState for local access)
+    PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
     // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[PTO2_MAX_TENSOR_PARAMS];
     // === Cache lines 35-50 (1024B) — scalars ===
@@ -250,8 +244,7 @@ struct PTO2TaskPayload {
         static_assert(sizeof(scalars) == sizeof(params.scalars));
         // Round up to cache line boundary. Both arrays are 1024B so no overrun.
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
-        memcpy(scalars, params.scalars,
-               PTO2_ALIGN_UP(params.scalar_count * sizeof(uint64_t), 64));
+        memcpy(scalars, params.scalars, PTO2_ALIGN_UP(params.scalar_count * sizeof(uint64_t), 64));
     }
 };
 
@@ -269,17 +262,17 @@ struct PTO2TaskPayload {
  */
 struct alignas(64) PTO2TaskSlotState {
     // Fanout lock + list (accessed together under lock in on_task_complete)
-    std::atomic<int32_t> fanout_lock;       // Per-task spinlock (0=unlocked, 1=locked)
-    int32_t fanout_count;                    // 1 (owning scope) + number of consumers
+    std::atomic<int32_t> fanout_lock;  // Per-task spinlock (0=unlocked, 1=locked)
+    int32_t fanout_count;              // 1 (owning scope) + number of consumers
 
-    PTO2DepListEntry* fanout_head;           // Pointer to first fanout entry (nullptr = empty)
+    PTO2DepListEntry* fanout_head;  // Pointer to first fanout entry (nullptr = empty)
 
     // Task state (completion, consumed check, ready check)
-    std::atomic<PTO2TaskState> task_state;   // PENDING/READY/RUNNING/COMPLETED/CONSUMED
+    std::atomic<PTO2TaskState> task_state;  // PENDING/READY/RUNNING/COMPLETED/CONSUMED
 
     // Fanin (accessed together in release_fanin_and_check_ready)
-    std::atomic<int32_t> fanin_refcount;     // Dynamic: counts completed producers
-    int32_t fanin_count;                      // Number of producer dependencies (set once)
+    std::atomic<int32_t> fanin_refcount;  // Dynamic: counts completed producers
+    int32_t fanin_count;                  // Number of producer dependencies (set once)
 
     // Fanout refcount (accessed with fanout_count in check_and_handle_consumed)
     std::atomic<int32_t> fanout_refcount;  // Dynamic: counts released references
@@ -289,10 +282,10 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2TaskDescriptor* task;
 
     // Hot-path completion fields (moved from TaskDescriptor to avoid cross-struct access)
-    uint8_t active_mask;                         // Bitmask of active subtask slots (set once)
-    std::atomic<uint8_t> subtask_done_mask;      // Each subtask sets its done bit on completion
-    uint8_t ring_id;                             // Ring layer this task belongs to (for per-ring reclamation)
-    int32_t dep_pool_mark{0};                    // Dep pool top after this task's submission (orchestrator-only, local memory)
+    uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
+    std::atomic<uint8_t> subtask_done_mask;  // Each subtask sets its done bit on completion
+    uint8_t ring_id;                         // Ring layer this task belongs to (for per-ring reclamation)
+    int32_t dep_pool_mark{0};  // Dep pool top after this task's submission (orchestrator-only, local memory)
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);
@@ -325,11 +318,11 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
  * Memory barrier macros for different architectures
  */
 #if defined(__aarch64__)
-    #define PTO2_MEMORY_BARRIER()     __asm__ __volatile__("dmb sy" ::: "memory")
+#define PTO2_MEMORY_BARRIER() __asm__ __volatile__("dmb sy" ::: "memory")
 #elif defined(__x86_64__)
-    #define PTO2_MEMORY_BARRIER()     __asm__ __volatile__("mfence" ::: "memory")
+#define PTO2_MEMORY_BARRIER() __asm__ __volatile__("mfence" ::: "memory")
 #else
-    #define PTO2_MEMORY_BARRIER()     __sync_synchronize()
+#define PTO2_MEMORY_BARRIER() __sync_synchronize()
 #endif
 
 // Spin-wait hint for AICPU threads.  On real hardware the AICPU has dedicated
@@ -360,8 +353,7 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 #endif
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state,
-                                     uint64_t& atomic_count, uint64_t& wait_cycle) {
+static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& atomic_count, uint64_t& wait_cycle) {
     uint64_t t0 = get_sys_cnt_aicpu();
     bool contended = false;
     uint32_t atomic_ops = 0;
@@ -373,8 +365,8 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state,
             SPIN_WAIT_HINT();
         }
         int32_t expected = 0;
-        if (slot_state.fanout_lock.compare_exchange_weak(expected, 1,
-                                        std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (slot_state.fanout_lock.compare_exchange_weak(
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             atomic_ops++;  // successful CAS = 1 atomic
             atomic_count += atomic_ops;
             if (contended) {
@@ -394,8 +386,8 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state) {
             SPIN_WAIT_HINT();
         }
         int32_t expected = 0;
-        if (slot_state.fanout_lock.compare_exchange_weak(expected, 1,
-                                        std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (slot_state.fanout_lock.compare_exchange_weak(
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             return;
         }
     }
@@ -405,4 +397,4 @@ static inline void pto2_fanout_unlock(PTO2TaskSlotState& slot_state) {
     slot_state.fanout_lock.store(0, std::memory_order_release);
 }
 
-#endif // PTO_RUNTIME2_TYPES_H
+#endif  // PTO_RUNTIME2_TYPES_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_scheduler.cpp
@@ -59,12 +59,18 @@ PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
 
 const char* pto2_task_state_name(PTO2TaskState state) {
     switch (state) {
-        case PTO2_TASK_PENDING:   return "PENDING";
-        case PTO2_TASK_READY:     return "READY";
-        case PTO2_TASK_RUNNING:   return "RUNNING";
-        case PTO2_TASK_COMPLETED: return "COMPLETED";
-        case PTO2_TASK_CONSUMED:  return "CONSUMED";
-        default:                  return "UNKNOWN";
+        case PTO2_TASK_PENDING:
+            return "PENDING";
+        case PTO2_TASK_READY:
+            return "READY";
+        case PTO2_TASK_RUNNING:
+            return "RUNNING";
+        case PTO2_TASK_COMPLETED:
+            return "COMPLETED";
+        case PTO2_TASK_CONSUMED:
+            return "CONSUMED";
+        default:
+            return "UNKNOWN";
     }
 }
 
@@ -103,8 +109,7 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
 // =============================================================================
 
 bool PTO2SchedulerState::RingSchedState::init(
-    PTO2SharedMemoryHandle* sm_handle, int32_t ring_id,
-    void* gm_heap_base, uint64_t per_ring_heap_size) {
+    PTO2SharedMemoryHandle* sm_handle, int32_t ring_id, void* gm_heap_base, uint64_t per_ring_heap_size) {
     task_descriptors = sm_handle->task_descriptors[ring_id];
     heap_base = (char*)gm_heap_base + ring_id * per_ring_heap_size;
     task_window_size = sm_handle->header->rings[ring_id].task_window_size;
@@ -146,9 +151,8 @@ void PTO2SchedulerState::RingSchedState::destroy() {
     slot_states = nullptr;
 }
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle,
-                          void* gm_heap_base, uint64_t per_ring_heap_size) {
+bool pto2_scheduler_init(
+    PTO2SchedulerState* sched, PTO2SharedMemoryHandle* sm_handle, void* gm_heap_base, uint64_t per_ring_heap_size) {
     sched->sm_handle = sm_handle;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -199,8 +203,7 @@ void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
 void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
     LOG_INFO("=== Scheduler Statistics ===");
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (sched->ring_sched_states[r].last_task_alive > 0 ||
-            sched->ring_sched_states[r].heap_tail > 0) {
+        if (sched->ring_sched_states[r].last_task_alive > 0 || sched->ring_sched_states[r].heap_tail > 0) {
             LOG_INFO("Ring %d:", r);
             LOG_INFO("  last_task_alive: %d", sched->ring_sched_states[r].last_task_alive);
             LOG_INFO("  heap_tail:       %" PRIu64, sched->ring_sched_states[r].heap_tail);
@@ -219,8 +222,7 @@ void pto2_scheduler_print_queues(PTO2SchedulerState* sched) {
     const char* shape_names[] = {"AIC_ONLY", "AIV_X1", "AIV_X2", "AIC_AIV_X1", "AIC_AIV_X2"};
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        LOG_INFO("  %s: count=%" PRIu64, shape_names[i],
-                 sched->ready_queues[i].size());
+        LOG_INFO("  %s: count=%" PRIu64, shape_names[i], sched->ready_queues[i].size());
     }
 
     LOG_INFO("====================");

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_scheduler.h
@@ -30,7 +30,12 @@
 #if PTO2_SCHED_PROFILING
 #include "aicpu/device_time.h"
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
-#define PTO2_SCHED_CYCLE_LAP(acc) do { _st1 = get_sys_cnt_aicpu(); acc += (_st1 - _st0); _st0 = _st1; } while(0)
+#define PTO2_SCHED_CYCLE_LAP(acc)   \
+    do {                            \
+        _st1 = get_sys_cnt_aicpu(); \
+        acc += (_st1 - _st0);       \
+        _st0 = _st1;                \
+    } while (0)
 #endif
 
 // =============================================================================
@@ -78,9 +83,7 @@ struct PTO2LocalReadyBuffer {
         return false;
     }
 
-    PTO2TaskSlotState* pop() {
-        return (count > 0) ? slot_states[--count] : nullptr;
-    }
+    PTO2TaskSlotState* pop() { return (count > 0) ? slot_states[--count] : nullptr; }
 };
 
 /**
@@ -96,14 +99,14 @@ struct PTO2LocalReadyBuffer {
 struct alignas(64) PTO2ReadyQueue {
     PTO2ReadyQueueSlot* slots;
     uint64_t capacity;
-    uint64_t mask;                          // capacity - 1
-    char _pad0[64 - 24];                   // Pad to own cache line
+    uint64_t mask;        // capacity - 1
+    char _pad0[64 - 24];  // Pad to own cache line
 
     std::atomic<uint64_t> enqueue_pos;
-    char _pad1[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad1[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     std::atomic<uint64_t> dequeue_pos;
-    char _pad2[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad2[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     uint64_t size() {
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -120,8 +123,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)pos;
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     break;
                 }
             } else if (diff < 0) {
@@ -148,8 +151,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - (int64_t)pos;
             atomic_ops += 2;  // enqueue_pos.load + sequence.load
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -189,8 +192,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)(pos + 1);
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed))
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed))
                     break;
             } else if (diff < 0) {
                 return nullptr;  // Queue empty
@@ -224,8 +227,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - (int64_t)(pos + 1);
             atomic_ops += 2;  // dequeue_pos.load + sequence.load
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -263,10 +266,10 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
  * Statistics returned by mixed-task completion processing
  */
 struct PTO2CompletionStats {
-    int32_t fanout_edges;      // Number of fanout edges traversed (notify consumers)
-    int32_t tasks_enqueued;    // Number of consumers that became READY
-    int32_t fanin_edges;       // Number of fanin edges traversed (release producers)
-    bool mixed_task_completed; // True only when this callback completed a mixed task
+    int32_t fanout_edges;       // Number of fanout edges traversed (notify consumers)
+    int32_t tasks_enqueued;     // Number of consumers that became READY
+    int32_t fanin_edges;        // Number of fanin edges traversed (release producers)
+    bool mixed_task_completed;  // True only when this callback completed a mixed task
 };
 
 /**
@@ -293,16 +296,13 @@ struct PTO2SchedulerState {
         // Try-lock used to advance this ring's pointers (CONSUMED scanning + heap tail update).
         std::atomic<int32_t> advance_lock;
 
-        bool init(PTO2SharedMemoryHandle* sm_handle, int32_t ring_id,
-                  void* gm_heap_base, uint64_t per_ring_heap_size);
+        bool init(PTO2SharedMemoryHandle* sm_handle, int32_t ring_id, void* gm_heap_base, uint64_t per_ring_heap_size);
         void destroy();
 
         PTO2TaskSlotState& get_slot_state_by_task_id(int32_t local_id) {
             return slot_states[local_id & task_window_mask];
         }
-        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) {
-            return slot_states[slot];
-        }
+        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
         void sync_to_sm(PTO2SharedMemoryRingHeader& ring) {
             ring.fc.last_task_alive.store(last_task_alive, std::memory_order_release);
@@ -355,8 +355,8 @@ struct PTO2SchedulerState {
         if (slot_state.fanout_refcount.load(std::memory_order_acquire) != slot_state.fanout_count) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire)) {
             return;
         }
 
@@ -367,8 +367,8 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
         }
@@ -384,8 +384,8 @@ struct PTO2SchedulerState {
         if (rc != fc) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire)) {
             atomic_count += 1;  // failed CAS
             return;
         }
@@ -399,8 +399,8 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
             atomic_count += 2;  // try-lock CAS + unlock store
@@ -423,8 +423,7 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state,
-                                        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+    bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state, PTO2LocalReadyBuffer* local_bufs = nullptr) {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
         // init release, making fanin_count visible — plain load suffices.
@@ -449,8 +448,9 @@ struct PTO2SchedulerState {
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
     bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state,
-                                        uint64_t& atomic_count, uint64_t& push_wait,
-                                        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+        uint64_t& atomic_count,
+        uint64_t& push_wait,
+        PTO2LocalReadyBuffer* local_bufs = nullptr) {
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
         atomic_count += 1;  // fanin_refcount.fetch_add
 
@@ -480,7 +480,7 @@ struct PTO2SchedulerState {
         return ready_queues[static_cast<int32_t>(shape)].pop();
     }
 
-    template<CoreType CT>
+    template <CoreType CT>
     PTO2TaskSlotState* get_ready_task(PTO2LocalReadyBuffer* local_bufs) {
         constexpr int ct = static_cast<int>(CT);
         if (local_bufs && local_bufs[ct].count > 0) {
@@ -494,9 +494,8 @@ struct PTO2SchedulerState {
         return ready_queues[static_cast<int32_t>(shape)].pop(atomic_count, wait_cycle);
     }
 
-    template<CoreType CT>
-    PTO2TaskSlotState* get_ready_task(PTO2LocalReadyBuffer* local_bufs,
-                           uint64_t& atomic_count, uint64_t& wait_cycle) {
+    template <CoreType CT>
+    PTO2TaskSlotState* get_ready_task(PTO2LocalReadyBuffer* local_bufs, uint64_t& atomic_count, uint64_t& wait_cycle) {
         constexpr int ct = static_cast<int>(CT);
         if (local_bufs && local_bufs[ct].count > 0) {
             return local_bufs[ct].pop();
@@ -553,7 +552,7 @@ struct PTO2SchedulerState {
 #else
     void
 #endif
-    on_mixed_task_complete(PTO2TaskSlotState& slot_state, 
+    on_mixed_task_complete(PTO2TaskSlotState& slot_state,
 #if PTO2_SCHED_PROFILING
         int thread_idx,
 #endif
@@ -594,8 +593,7 @@ struct PTO2SchedulerState {
             PTO2TaskSlotState& consumer_slot = *current->slot_state;
 #if PTO2_SCHED_PROFILING
             stats.fanout_edges++;
-            if (release_fanin_and_check_ready(consumer_slot,
-                                               fanout_atomics, push_wait, local_bufs)) {
+            if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait, local_bufs)) {
                 stats.tasks_enqueued++;
             }
 #else
@@ -660,9 +658,8 @@ struct PTO2SchedulerState {
 // Scheduler API (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle,
-                          void* gm_heap_base, uint64_t per_ring_heap_size);
+bool pto2_scheduler_init(
+    PTO2SchedulerState* sched, PTO2SharedMemoryHandle* sm_handle, void* gm_heap_base, uint64_t per_ring_heap_size);
 void pto2_scheduler_destroy(PTO2SchedulerState* sched);
 
 // =============================================================================
@@ -686,9 +683,9 @@ struct PTO2SchedProfilingData {
     uint64_t self_consumed_cycle;  // self check_and_handle_consumed
 
     // Wait times
-    uint64_t lock_wait_cycle;      // spin-wait in fanout_lock
-    uint64_t push_wait_cycle;      // CAS contention in push()
-    uint64_t pop_wait_cycle;       // CAS contention in pop()
+    uint64_t lock_wait_cycle;  // spin-wait in fanout_lock
+    uint64_t push_wait_cycle;  // CAS contention in push()
+    uint64_t pop_wait_cycle;   // CAS contention in pop()
 
     // Atomic counts per sub-phase
     uint64_t lock_atomic_count;
@@ -697,7 +694,7 @@ struct PTO2SchedProfilingData {
     uint64_t self_atomic_count;
     uint64_t pop_atomic_count;
 
-    int64_t  complete_count;
+    int64_t complete_count;
 };
 
 /**
@@ -707,4 +704,4 @@ struct PTO2SchedProfilingData {
 PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
 #endif
 
-#endif // PTO_SCHEDULER_H
+#endif  // PTO_SCHEDULER_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_shared_memory.cpp
@@ -45,8 +45,7 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
 // =============================================================================
 
 static void pto2_sm_setup_pointers_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+    PTO2SharedMemoryHandle* handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
     char* ptr = (char*)handle->sm_base;
 
     // Header
@@ -71,8 +70,7 @@ static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle* handle, uint64_t task
     pto2_sm_setup_pointers_per_ring(handle, task_window_sizes);
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size) {
+PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size, uint64_t heap_size) {
     // Allocate handle
     PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) {
@@ -82,19 +80,19 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     // Calculate total size
     uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
 
-    // Allocate shared memory (aligned for DMA efficiency)
-    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-        if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
-            free(handle);
-            return NULL;
-        }
-    #else
-        handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
-        if (!handle->sm_base) {
-            free(handle);
-            return NULL;
-        }
-    #endif
+// Allocate shared memory (aligned for DMA efficiency)
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+    if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
+        free(handle);
+        return NULL;
+    }
+#else
+    handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
+    if (!handle->sm_base) {
+        free(handle);
+        return NULL;
+    }
+#endif
 
     handle->sm_size = sm_size;
     handle->is_owner = true;
@@ -111,15 +109,10 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     return handle;
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create_default(void) {
-    return pto2_sm_create(PTO2_TASK_WINDOW_SIZE,
-                          PTO2_HEAP_SIZE);
-}
+PTO2SharedMemoryHandle* pto2_sm_create_default(void) { return pto2_sm_create(PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE); }
 
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size) {
+PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(
+    void* sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size) {
     if (!sm_base || sm_size == 0) return NULL;
 
     uint64_t required = pto2_sm_calculate_size(task_window_size);
@@ -153,9 +146,7 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle* handle) {
 // =============================================================================
 //
 // no need init data in pool, init pool data when used
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size) {
+void pto2_sm_init_header(PTO2SharedMemoryHandle* handle, uint64_t task_window_size, uint64_t heap_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -165,8 +156,7 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
     pto2_sm_init_header_per_ring(handle, task_window_sizes, heap_sizes);
 }
 
-void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
+void pto2_sm_init_header_per_ring(PTO2SharedMemoryHandle* handle,
     const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]) {
     PTO2SharedMemoryHeader* header = handle->header;
@@ -217,7 +207,8 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
         LOG_INFO("  task_window_size: %" PRIu64, h->rings[r].task_window_size);
         LOG_INFO("  heap_size:        %" PRIu64 " bytes", h->rings[r].heap_size);
         LOG_INFO("  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")",
-                 h->rings[r].task_descriptors_offset, h->rings[r].task_descriptors_offset);
+            h->rings[r].task_descriptors_offset,
+            h->rings[r].task_descriptors_offset);
         LOG_INFO("  heap_top:         %" PRIu64, h->rings[r].fc.heap_top.load(std::memory_order_acquire));
         LOG_INFO("  heap_tail:        %" PRIu64, h->rings[r].fc.heap_tail.load(std::memory_order_acquire));
         LOG_INFO("  current_task_idx: %d", h->rings[r].fc.current_task_index.load(std::memory_order_acquire));

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_shared_memory.h
@@ -50,9 +50,9 @@ struct PTO2RingFlowControl {
     int32_t _pad0;                            // Alignment padding
 
     // Written by Scheduler, Read by Orchestrator (for back-pressure)
-    std::atomic<uint64_t> heap_tail;          // Heap ring free pointer
-    std::atomic<int32_t> last_task_alive;     // Task ring tail (oldest active task)
-    int32_t _pad1;                            // Alignment padding
+    std::atomic<uint64_t> heap_tail;       // Heap ring free pointer
+    std::atomic<int32_t> last_task_alive;  // Task ring tail (oldest active task)
+    int32_t _pad1;                         // Alignment padding
 
     void init() {
         heap_top.store(0, std::memory_order_relaxed);
@@ -86,7 +86,7 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
 
     // === GLOBAL FIELDS ===
-    std::atomic<int32_t> orchestrator_done;   // Flag: orchestration complete
+    std::atomic<int32_t> orchestrator_done;  // Flag: orchestration complete
 
     // Total shared memory size (for validation)
     uint64_t total_size;
@@ -104,13 +104,13 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
 
     // Scheduler error state (Scheduler → Host, independent of orchestrator)
     // Written by scheduler threads on timeout; read by orchestrator and host.
-    std::atomic<int32_t> sched_error_bitmap;   // Bit X set = thread X had error
-    std::atomic<int32_t> sched_error_code;     // Last scheduler error code (last-writer-wins)
-    std::atomic<int32_t> sched_error_thread;   // Thread index of last error writer
+    std::atomic<int32_t> sched_error_bitmap;  // Bit X set = thread X had error
+    std::atomic<int32_t> sched_error_code;    // Last scheduler error code (last-writer-wins)
+    std::atomic<int32_t> sched_error_thread;  // Thread index of last error writer
 };
 
 static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
-              "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)");
+    "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)");
 
 // =============================================================================
 // Shared Memory Handle
@@ -121,17 +121,16 @@ static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
  * Provides both Orchestrator and Scheduler views of the same memory
  */
 struct PTO2SharedMemoryHandle {
-    void*   sm_base;              // Base address of shared memory
-    uint64_t sm_size;             // Total size of shared memory
+    void* sm_base;     // Base address of shared memory
+    uint64_t sm_size;  // Total size of shared memory
 
     // Quick pointers into shared memory regions (per-ring)
     PTO2SharedMemoryHeader* header;
-    PTO2TaskDescriptor*     task_descriptors[PTO2_MAX_RING_DEPTH];
-    PTO2TaskPayload*        task_payloads[PTO2_MAX_RING_DEPTH];
+    PTO2TaskDescriptor* task_descriptors[PTO2_MAX_RING_DEPTH];
+    PTO2TaskPayload* task_payloads[PTO2_MAX_RING_DEPTH];
 
     // Ownership flag
-    bool    is_owner;             // True if this handle allocated the memory
-
+    bool is_owner;  // True if this handle allocated the memory
 };
 
 // =============================================================================
@@ -161,8 +160,7 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
  * @param heap_size         Heap size per ring for output buffers
  * @return Handle with both views, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size);
+PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Create shared memory with default sizes
@@ -179,10 +177,8 @@ PTO2SharedMemoryHandle* pto2_sm_create_default(void);
  * @param heap_size          Heap size per ring (for layout; buffer has no heap region)
  * @return Handle, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size);
+PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(
+    void* sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Destroy shared memory and free resources
@@ -193,15 +189,12 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle* handle);
  * Initialize shared memory header with layout information
  * Called after memory is allocated
  */
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size);
+void pto2_sm_init_header(PTO2SharedMemoryHandle* handle, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Initialize shared memory header with per-ring layout information.
  */
-void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
+void pto2_sm_init_header_per_ring(PTO2SharedMemoryHandle* handle,
     const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]);
 
@@ -224,4 +217,4 @@ bool pto2_sm_validate(PTO2SharedMemoryHandle* handle);
 }
 #endif
 
-#endif // PTO_SHARED_MEMORY_H
+#endif  // PTO_SHARED_MEMORY_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_submit_types.h
@@ -21,7 +21,7 @@ inline constexpr int32_t PTO2_SUBTASK_SLOT_COUNT = 3;
  * Subtask slot indices
  */
 enum class PTO2SubtaskSlot : uint8_t {
-    AIC  = 0,
+    AIC = 0,
     AIV0 = 1,
     AIV1 = 2,
 };
@@ -29,7 +29,7 @@ enum class PTO2SubtaskSlot : uint8_t {
 /**
  * Subtask mask bits (for active_mask / subtask_done_mask)
  */
-inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC  = (1u << 0);  // 0x1
+inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC = (1u << 0);   // 0x1
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV0 = (1u << 1);  // 0x2
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV1 = (1u << 2);  // 0x4
 
@@ -56,11 +56,11 @@ struct MixedKernels {
  * Resource shape — classifies a MixedKernels into one of 5 queue buckets.
  */
 enum class PTO2ResourceShape : uint8_t {
-    AIC_ONLY    = 0,   // AIC only
-    AIV_X1      = 1,   // One AIV slot
-    AIV_X2      = 2,   // Both AIV slots
-    AIC_AIV_X1  = 3,   // AIC + one AIV
-    AIC_AIV_X2  = 4,   // AIC + both AIV
+    AIC_ONLY = 0,    // AIC only
+    AIV_X1 = 1,      // One AIV slot
+    AIV_X2 = 2,      // Both AIV slots
+    AIC_AIV_X1 = 3,  // AIC + one AIV
+    AIC_AIV_X2 = 4,  // AIC + both AIV
 };
 
 inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 5;
@@ -71,8 +71,7 @@ inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 5;
  */
 static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
     bool has_aic = (active_mask & PTO2_SUBTASK_MASK_AIC) != 0;
-    int aiv_count = ((active_mask & PTO2_SUBTASK_MASK_AIV0) != 0)
-                  + ((active_mask & PTO2_SUBTASK_MASK_AIV1) != 0);
+    int aiv_count = ((active_mask & PTO2_SUBTASK_MASK_AIV0) != 0) + ((active_mask & PTO2_SUBTASK_MASK_AIV1) != 0);
 
     if (has_aic) {
         if (aiv_count == 0) return PTO2ResourceShape::AIC_ONLY;
@@ -88,10 +87,10 @@ static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
  */
 static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels& mk) {
     uint8_t mask = 0;
-    if (mk.aic_kernel_id  != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
+    if (mk.aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
     if (mk.aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
     if (mk.aiv1_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV1;
     return mask;
 }
 
-#endif // PTO_SUBMIT_TYPES_H
+#endif  // PTO_SUBMIT_TYPES_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_types.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_types.h
@@ -24,11 +24,11 @@
 #include "tensor.h"
 
 // Task parameters
-#define PTO2_MAX_TENSOR_PARAMS    16      // Maximum tensor parameters per task
-#define PTO2_MAX_SCALAR_PARAMS    128     // Maximum scalar parameters per task
-#define PTO2_MAX_OUTPUTS          16      // Maximum outputs per task
-#define PTO2_MAX_INPUTS           16      // Maximum inputs per task
-#define PTO2_MAX_INOUTS           8       // Maximum in-out params per task
+#define PTO2_MAX_TENSOR_PARAMS 16   // Maximum tensor parameters per task
+#define PTO2_MAX_SCALAR_PARAMS 128  // Maximum scalar parameters per task
+#define PTO2_MAX_OUTPUTS 16         // Maximum outputs per task
+#define PTO2_MAX_INPUTS 16          // Maximum inputs per task
+#define PTO2_MAX_INOUTS 8           // Maximum in-out params per task
 
 // =============================================================================
 // Parameter Types (for pto_submit_task API)
@@ -86,8 +86,9 @@ struct PTOParam {
 
     bool check_add_tensor_valid() {
         if (scalar_count != 0) {
-            set_error("add_input/add_output/add_inout called after add_scalar: "
-                      "all tensors must be added before any scalars");
+            set_error(
+                "add_input/add_output/add_inout called after add_scalar: "
+                "all tensors must be added before any scalars");
             return false;
         }
         if (tensor_count >= PTO2_MAX_TENSOR_PARAMS) {
@@ -98,7 +99,9 @@ struct PTOParam {
     }
 
     void add_input(Tensor& t) {
-        if (!check_add_tensor_valid()) { return; }
+        if (!check_add_tensor_valid()) {
+            return;
+        }
         if (t.buffer.addr == 0) {
             set_error("INPUT tensor must have a non-NULL buffer address");
             return;
@@ -109,14 +112,18 @@ struct PTOParam {
     }
 
     void add_output(Tensor& t) {
-        if (!check_add_tensor_valid()) { return; }
+        if (!check_add_tensor_valid()) {
+            return;
+        }
         tensors[tensor_count] = &t;
         tensor_types[tensor_count] = PTOParamType::OUTPUT;
         tensor_count++;
     }
 
     void add_inout(Tensor& t) {
-        if (!check_add_tensor_valid()) { return; }
+        if (!check_add_tensor_valid()) {
+            return;
+        }
         if (t.buffer.addr == 0) {
             set_error("INOUT tensor must have a non-NULL buffer address");
             return;

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
@@ -68,17 +68,11 @@ void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
     LOG_INFO("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
 }
 
-TensorPair* Runtime::get_tensor_pairs() {
-    return tensor_pairs;
-}
+TensorPair* Runtime::get_tensor_pairs() { return tensor_pairs; }
 
-int Runtime::get_tensor_pair_count() const {
-    return tensor_pair_count;
-}
+int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
-void Runtime::clear_tensor_pairs() {
-    tensor_pair_count = 0;
-}
+void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 
 // =============================================================================
 // Device orchestration
@@ -124,9 +118,7 @@ const void* Runtime::get_device_orch_so_data() const {
     return device_orch_so_size_ > 0 ? device_orch_so_storage_ : nullptr;
 }
 
-size_t Runtime::get_device_orch_so_size() const {
-    return device_orch_so_size_;
-}
+size_t Runtime::get_device_orch_so_size() const { return device_orch_so_size_; }
 
 uint64_t Runtime::get_function_bin_addr(int func_id) const {
     if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
@@ -142,15 +134,11 @@ void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
     }
 }
 
-int Runtime::get_registered_kernel_count() const {
-    return registered_kernel_count_;
-}
+int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }
 
 int Runtime::get_registered_kernel_func_id(int index) const {
     if (index < 0 || index >= registered_kernel_count_) return -1;
     return registered_kernel_func_ids_[index];
 }
 
-void Runtime::clear_registered_kernels() {
-    registered_kernel_count_ = 0;
-}
+void Runtime::clear_registered_kernels() { registered_kernel_count_ = 0; }

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
@@ -86,9 +86,9 @@ struct Handshake {
     volatile CoreType core_type;           // Core type: CoreType::AIC or CoreType::AIV
     volatile uint64_t perf_records_addr;   // Performance records address
     volatile uint32_t perf_buffer_status;  // 0 = not full, 1 == full
-    volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t physical_core_id;    // Physical core ID
     volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;   // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**
@@ -144,8 +144,8 @@ public:
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int sche_cpu_num;  // Number of AICPU threads for scheduling
-    int orch_thread_num;  // Number of orchestrator threads (default 1)
+    int sche_cpu_num;        // Number of AICPU threads for scheduling
+    int orch_thread_num;     // Number of orchestrator threads (default 1)
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)
@@ -158,7 +158,7 @@ public:
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
     // Profiling support
-    bool enable_profiling;    // Enable profiling flag
+    bool enable_profiling;  // Enable profiling flag
 
     // Orchestrator-to-scheduler transition control
     // When true, orchestrator threads convert to scheduler threads after orchestration completes.
@@ -178,10 +178,10 @@ private:
 
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
-    void* pto2_gm_sm_ptr_;  // GM pointer to PTO2 shared memory (device)
-    void* pto2_gm_heap_ptr_;  // GM heap for orchestrator output buffers (device)
+    void* pto2_gm_sm_ptr_;        // GM pointer to PTO2 shared memory (device)
+    void* pto2_gm_heap_ptr_;      // GM heap for orchestrator output buffers (device)
     void* pto2_slot_states_ptr_;  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
-    TaskArg* orch_args_;   // Arguments for device orchestration
+    TaskArg* orch_args_;          // Arguments for device orchestration
     int orch_arg_count_;
     TaskArg orch_args_storage_[RUNTIME_MAX_ARGS];  // Copy of args for device
 

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/tensor.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/tensor.h
@@ -58,15 +58,16 @@ struct Segment {
  */
 struct alignas(64) Tensor {
     // === Cache line 1 (64B) — hot path ===
-    PTOBufferHandle buffer;                        // Underlying memory buffer (addr in bytes, size in bytes)
-    uint64_t start_offset;                         // Cached 1D element offset (precomputed from raw_shapes + offsets), only calc before incore, useless in orch
-    int32_t version;                               // Tensor version for overlap detection
-    DataType dtype;                                // Data type of tensor elements
-    uint32_t ndims;                                // Number of dimensions used
-    bool is_all_offset_zero;                       // True when all offsets[] are zero (skip offset read/write)
-    bool is_raw_eq_shapes;                         // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
-    bool manual_dep;                               // True when dependency is managed manually (skip tensormap lookup/insert)
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
+    PTOBufferHandle buffer;   // Underlying memory buffer (addr in bytes, size in bytes)
+    uint64_t start_offset;    // Cached 1D element offset (precomputed from raw_shapes + offsets), only calc before
+                              // incore, useless in orch
+    int32_t version;          // Tensor version for overlap detection
+    DataType dtype;           // Data type of tensor elements
+    uint32_t ndims;           // Number of dimensions used
+    bool is_all_offset_zero;  // True when all offsets[] are zero (skip offset read/write)
+    bool is_raw_eq_shapes;    // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
+    bool manual_dep;          // True when dependency is managed manually (skip tensormap lookup/insert)
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // Current view shape per dimension
     uint32_t __padding__;
 
     // === Cache line 2 (64B) — warm path ===
@@ -82,9 +83,7 @@ struct alignas(64) Tensor {
 
     /// Return the effective raw_shapes pointer (shapes[] when is_raw_eq_shapes).
     /// Avoids cache line 2 access for the common case.
-    const uint32_t* get_raw_shapes() const {
-        return is_raw_eq_shapes ? shapes : raw_shapes;
-    }
+    const uint32_t* get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
 
     Tensor(void* addr,
         uint64_t buffer_size_bytes,
@@ -97,8 +96,17 @@ struct alignas(64) Tensor {
         bool is_all_offset_zero = false,
         bool is_raw_eq_shapes = false,
         bool manual_dep = false) {
-        init(addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version,
-             is_all_offset_zero, is_raw_eq_shapes, manual_dep);
+        init(addr,
+            buffer_size_bytes,
+            raw_shapes,
+            shapes,
+            offsets,
+            ndims,
+            dtype,
+            version,
+            is_all_offset_zero,
+            is_raw_eq_shapes,
+            manual_dep);
     }
 
     // --- Initialization ---
@@ -136,7 +144,7 @@ struct alignas(64) Tensor {
     }
 
     void init(const Tensor& other) {
-        memcpy(this, &other, 64); // fast copy cache line 1
+        memcpy(this, &other, 64);  // fast copy cache line 1
         if (!other.is_raw_eq_shapes) {
             for (uint32_t i = 0; i < ndims; i++) {
                 raw_shapes[i] = other.raw_shapes[i];
@@ -149,7 +157,8 @@ struct alignas(64) Tensor {
         }
     }
 
-    void init_with_view(const Tensor& other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) {
+    void init_with_view(
+        const Tensor& other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) {
         buffer = other.buffer;
         ndims = other.ndims;
         dtype = other.dtype;
@@ -167,7 +176,10 @@ struct alignas(64) Tensor {
         bool all_zero = true;
         if (other.is_all_offset_zero) {
             for (uint32_t i = 0; i < ndims; i++) {
-                if (view_offsets[i] != 0) { all_zero = false; break; }
+                if (view_offsets[i] != 0) {
+                    all_zero = false;
+                    break;
+                }
             }
             if (!all_zero) {
                 for (uint32_t i = 0; i < ndims; i++) {
@@ -199,9 +211,7 @@ struct alignas(64) Tensor {
         start_offset = result;
     }
 
-    void copy(const Tensor &other) {
-        init(other);
-    }
+    void copy(const Tensor& other) { init(other); }
 
     Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
         Tensor result;
@@ -338,8 +348,17 @@ static inline Tensor make_tensor_external(void* addr,
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(addr, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    return Tensor(addr,
+        total * get_element_size(dtype),
+        shapes,
+        shapes,
+        zero_offsets,
+        ndims,
+        dtype,
+        version,
+        /*is_all_offset_zero=*/true,
+        /*is_raw_eq_shapes=*/true,
+        manual_dep);
 }
 
 /**
@@ -358,6 +377,15 @@ static inline Tensor make_tensor(const uint32_t shapes[],
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(0, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    return Tensor(0,
+        total * get_element_size(dtype),
+        shapes,
+        shapes,
+        zero_offsets,
+        ndims,
+        dtype,
+        version,
+        /*is_all_offset_zero=*/true,
+        /*is_raw_eq_shapes=*/true,
+        manual_dep);
 }

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -70,8 +70,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, actual_task_id,
-                                      start_time, end_time);
+                perf_aicore_record_task(perf_buf, actual_task_id, start_time, end_time);
             }
 
             last_task_id = task_id;

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -36,8 +36,8 @@ struct AicpuExecutor {
     int thread_num_{0};
     int cores_total_num_{0};
     int thread_cores_num_[MAX_AICPU_THREADS]{};  // Total cores (AIC+AIV) assigned to each thread
-    int aic_per_thread_{0};  // Max AIC cores per thread (ceil), used as local queue cap
-    int aiv_per_thread_{0};  // Max AIV cores per thread (ceil), used as local queue cap
+    int aic_per_thread_{0};                      // Max AIC cores per thread (ceil), used as local queue cap
+    int aiv_per_thread_{0};                      // Max AIV cores per thread (ceil), used as local queue cap
     int core_assignments_[MAX_AICPU_THREADS][MAX_CORES_PER_THREAD];
 
     // Core discovery arrays (space-time tradeoff: avoid sorting)
@@ -85,8 +85,8 @@ struct AicpuExecutor {
     std::atomic<int> finished_count_{0};
 
     // ===== Performance profiling state =====
-    uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];  // Per-core AICPU dispatch timestamp
-    uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER]; // Per-core total dispatched task counter
+    uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];   // Per-core AICPU dispatch timestamp
+    uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER];  // Per-core total dispatched task counter
 
     // ===== Methods =====
     int init(Runtime* runtime);
@@ -333,7 +333,9 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
             LOG_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                      i, physical_core_id, max_physical_cores_count);
+                i,
+                physical_core_id,
+                max_physical_cores_count);
             handshake_failed = true;
             continue;
         }
@@ -395,7 +397,11 @@ void AicpuExecutor::assign_cores_to_threads() {
     aiv_per_thread_ = (aiv_count_ + thread_num_ - 1) / thread_num_;
 
     LOG_INFO("Core Assignment: %d AIC cores, %d AIV cores across %d threads (max %d AIC/thread, %d AIV/thread)",
-        aic_count_, aiv_count_, thread_num_, aic_per_thread_, aiv_per_thread_);
+        aic_count_,
+        aiv_count_,
+        thread_num_,
+        aic_per_thread_,
+        aiv_per_thread_);
 
     for (int t = 0; t < thread_num_; t++) {
         int core_idx = 0;
@@ -615,12 +621,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             int reg_state = EXTRACT_TASK_STATE(reg_val);
 
             // Case 1: Pending task finished directly
-            if (reg_task_id == pending_task_ids_[core_id] &&
-                reg_state == TASK_FIN_STATE) {
-
+            if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {
                 LOG_INFO("Thread %d: Core %d completed task %d (running_id=%d)",
-                         thread_idx, core_id, pending_task_ids_[core_id], running_task_ids_[core_id]);
-                
+                    thread_idx,
+                    core_id,
+                    pending_task_ids_[core_id],
+                    running_task_ids_[core_id]);
 
                 int completed_task_id = pending_task_ids_[core_id];
 
@@ -634,13 +640,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
                     }
                     if (perf_aicpu_complete_record(perf_buf,
-                        static_cast<uint32_t>(completed_task_id),
-                        static_cast<uint64_t>(completed_task_id),
-                        task->func_id, h->core_type,
-                        dispatch_timestamps_[core_id], finish_ts,
-                        fanout_arr, task->fanout_count) != 0) {
-                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d",
-                            core_id, completed_task_id);
+                            static_cast<uint32_t>(completed_task_id),
+                            static_cast<uint64_t>(completed_task_id),
+                            task->func_id,
+                            h->core_type,
+                            dispatch_timestamps_[core_id],
+                            finish_ts,
+                            fanout_arr,
+                            task->fanout_count) != 0) {
+                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d", core_id, completed_task_id);
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
@@ -695,8 +703,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         cur_aiv_tail,
                         cur_aiv_ready_count);
 
-                    LOG_INFO("Thread %d: Core %d resolved old running task %d",
-                             thread_idx, core_id, prev_running_id);
+                    LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
                 Task* task = runtime.get_task(completed_task_id);
@@ -718,11 +725,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             }
 
             // Case 2: Pending task received ACK
-            else if (reg_task_id == pending_task_ids_[core_id] &&
-                     reg_state == TASK_ACK_STATE) {
-
+            else if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_ACK_STATE) {
                 LOG_INFO("Thread %d: Core %d ACKed task %d (running_id=%d)",
-                         thread_idx, core_id, pending_task_ids_[core_id], running_task_ids_[core_id]);
+                    thread_idx,
+                    core_id,
+                    pending_task_ids_[core_id],
+                    running_task_ids_[core_id]);
 
                 int prev_running_id = running_task_ids_[core_id];
 
@@ -748,8 +756,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         cur_aiv_tail,
                         cur_aiv_ready_count);
 
-                    LOG_INFO("Thread %d: Core %d resolved old running task %d",
-                             thread_idx, core_id, prev_running_id);
+                    LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
                 // Core can accept new task now (pipeline!)
@@ -757,11 +764,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             }
 
             // Case 3: Running task finished
-            else if (reg_task_id == running_task_ids_[core_id] &&
-                     reg_state == TASK_FIN_STATE) {
-
+            else if (reg_task_id == running_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {
                 LOG_INFO("Thread %d: Core %d completed task %d (pending_id=%d)",
-                         thread_idx, core_id, running_task_ids_[core_id], pending_task_ids_[core_id]);
+                    thread_idx,
+                    core_id,
+                    running_task_ids_[core_id],
+                    pending_task_ids_[core_id]);
 
                 int completed_task_id = running_task_ids_[core_id];
 
@@ -774,13 +782,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
                     }
                     if (perf_aicpu_complete_record(perf_buf,
-                        static_cast<uint32_t>(completed_task_id),
-                        static_cast<uint64_t>(completed_task_id),
-                        task->func_id, h->core_type,
-                        dispatch_timestamps_[core_id], finish_ts,
-                        fanout_arr, task->fanout_count) != 0) {
-                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d",
-                            core_id, completed_task_id);
+                            static_cast<uint32_t>(completed_task_id),
+                            static_cast<uint64_t>(completed_task_id),
+                            task->func_id,
+                            h->core_type,
+                            dispatch_timestamps_[core_id],
+                            finish_ts,
+                            fanout_arr,
+                            task->fanout_count) != 0) {
+                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d", core_id, completed_task_id);
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
@@ -910,7 +920,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
 
             for (int i = 0; i < core_num; i++) {
                 int core_id = cur_thread_cores[i];
-                if (pending_task_ids_[core_id] != AICPU_TASK_INVALID || running_task_ids_[core_id] != AICPU_TASK_INVALID) {
+                if (pending_task_ids_[core_id] != AICPU_TASK_INVALID ||
+                    running_task_ids_[core_id] != AICPU_TASK_INVALID) {
                     all_cores_idle = false;
 
                     if (verification_warning_count == 0) {

--- a/src/a2a3/runtime/host_build_graph/build_config.py
+++ b/src/a2a3/runtime/host_build_graph/build_config.py
@@ -2,16 +2,7 @@
 # All paths are relative to this file's directory (src/runtime/)
 
 BUILD_CONFIG = {
-    "aicore": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicore", "runtime"]
-    },
-    "aicpu": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicpu", "runtime"]
-    },
-    "host": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["host", "runtime"]
-    }
+    "aicore": {"include_dirs": ["runtime"], "source_dirs": ["aicore", "runtime"]},
+    "aicpu": {"include_dirs": ["runtime"], "source_dirs": ["aicpu", "runtime"]},
+    "host": {"include_dirs": ["runtime"], "source_dirs": ["host", "runtime"]},
 }

--- a/src/a2a3/runtime/host_build_graph/host/runtime_compile_info.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_compile_info.cpp
@@ -13,5 +13,4 @@ ToolchainType get_orchestration_compiler(void) {
     // host_build_graph: always host g++ (orchestration runs on host)
     return TOOLCHAIN_HOST_GXX;
 }
-
 }

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -58,16 +58,16 @@ extern "C" {
  * @param orch_args_count   Number of TaskArg entries
  * @return 0 on success, -1 on failure
  */
-int init_runtime_impl(Runtime *runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    const TaskArg* orch_args,
-                    int orch_args_count,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count) {
+int init_runtime_impl(Runtime* runtime,
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count) {
     // Validate inputs
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -75,12 +75,11 @@ int init_runtime_impl(Runtime *runtime,
     }
 
     // Register kernel binaries via platform-provided upload function
-    if (kernel_count > 0 && kernel_func_ids != NULL &&
-        kernel_binaries != NULL && kernel_sizes != NULL) {
+    if (kernel_count > 0 && kernel_func_ids != NULL && kernel_binaries != NULL && kernel_sizes != NULL) {
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", kernel_count);
         for (int i = 0; i < kernel_count; i++) {
-            uint64_t addr = runtime->host_api.upload_kernel_binary(
-                kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
+            uint64_t addr =
+                runtime->host_api.upload_kernel_binary(kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
             if (addr == 0) {
                 LOG_ERROR("Failed to upload kernel binary for func_id=%d", kernel_func_ids[i]);
                 return -1;
@@ -120,8 +119,7 @@ int init_runtime_impl(Runtime *runtime,
     }
 
     dlerror();  // Clear any existing error
-    OrchestrationFunc orch_func =
-        reinterpret_cast<OrchestrationFunc>(dlsym(handle, orch_func_name));
+    OrchestrationFunc orch_func = reinterpret_cast<OrchestrationFunc>(dlsym(handle, orch_func_name));
     const char* dlsym_error = dlerror();
     if (dlsym_error != nullptr) {
         LOG_ERROR("dlsym failed for '%s': %s", orch_func_name, dlsym_error);
@@ -166,7 +164,7 @@ int init_runtime_impl(Runtime *runtime,
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-int validate_runtime_impl(Runtime *runtime) {
+int validate_runtime_impl(Runtime* runtime) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -222,5 +220,5 @@ int validate_runtime_impl(Runtime *runtime) {
 }
 
 #ifdef __cplusplus
-}  /* extern "C" */
+} /* extern "C" */
 #endif

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -71,8 +71,8 @@ int Runtime::add_task(uint64_t* args, int num_args, int func_id, CoreType core_t
     if (args && num_args > 0) {
         memcpy(task->args, args, num_args * sizeof(uint64_t));
     }
-    task->function_bin_addr = 0;    // Will be set by host before copying to device
-    task->core_type = core_type;    // Set core type
+    task->function_bin_addr = 0;  // Will be set by host before copying to device
+    task->core_type = core_type;  // Set core type
     task->fanin = 0;
     task->fanout_count = 0;
     memset(task->fanout, 0, sizeof(task->fanout));
@@ -145,7 +145,7 @@ void Runtime::print_runtime() const {
     // Print initially ready tasks
     LOG_DEBUG("\nInitially Ready Tasks (fanin==0):");
     LOG_DEBUG("----------------------------------------------------------------------");
-    
+
     // Build ready tasks string
     char ready_tasks_str[1024] = "  ";
     int offset = 2;
@@ -175,8 +175,11 @@ void Runtime::print_runtime() const {
         char fanout_str[512];
         int fo_offset = 0;
         for (int j = 0; j < t->fanout_count && fo_offset < 500; j++) {
-            fo_offset += snprintf(fanout_str + fo_offset, sizeof(fanout_str) - fo_offset, 
-                                  "%d%s", t->fanout[j], j < t->fanout_count - 1 ? "," : "");
+            fo_offset += snprintf(fanout_str + fo_offset,
+                sizeof(fanout_str) - fo_offset,
+                "%d%s",
+                t->fanout[j],
+                j < t->fanout_count - 1 ? "," : "");
         }
 
         LOG_DEBUG("  Task %d: func_id=%d, fanin=%d, fanout=%d, args=%d [%s]",
@@ -207,14 +210,8 @@ void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
     LOG_DEBUG("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
 }
 
-TensorPair* Runtime::get_tensor_pairs() {
-    return tensor_pairs;
-}
+TensorPair* Runtime::get_tensor_pairs() { return tensor_pairs; }
 
-int Runtime::get_tensor_pair_count() const {
-    return tensor_pair_count;
-}
+int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
-void Runtime::clear_tensor_pairs() {
-    tensor_pair_count = 0;
-}
+void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -101,17 +101,17 @@
  * - physical_core_id: Written by AICPU, read by AICore (physical core ID)
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;          // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;          // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                 // Task pointer: 0=no task, non-zero=Task* address
-    volatile int32_t task_status;           // Task execution status: 0=idle, 1=busy
-    volatile int32_t control;               // Control signal: 0=execute, 1=quit
-    volatile CoreType core_type;            // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t perf_records_addr;    // Performance records address
-    volatile uint32_t perf_buffer_status;   // 0 = not full, 1 = full
-    volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t aicpu_ready;         // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;         // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                // Task pointer: 0=no task, non-zero=Task* address
+    volatile int32_t task_status;          // Task execution status: 0=idle, 1=busy
+    volatile int32_t control;              // Control signal: 0=execute, 1=quit
+    volatile CoreType core_type;           // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t perf_records_addr;   // Performance records address
+    volatile uint32_t perf_buffer_status;  // 0 = not full, 1 = full
+    volatile uint32_t physical_core_id;    // Physical core ID
     volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;   // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**
@@ -188,26 +188,26 @@ public:
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int sche_cpu_num;  // Number of AICPU threads for scheduling
+    int sche_cpu_num;     // Number of AICPU threads for scheduling
     int orch_thread_num;  // Number of orchestrator threads (unused, for API compatibility)
 
     // Profiling support
-    bool enable_profiling;                  // Enable profiling flag
-    uint64_t perf_data_base;                // Performance data shared memory base address (device-side)
+    bool enable_profiling;    // Enable profiling flag
+    uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
 
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
 
 private:
-    int next_task_id;               // Next available task ID
+    int next_task_id;  // Next available task ID
 
     // Initial ready tasks (computed once, read-only after)
     int initial_ready_tasks[RUNTIME_MAX_TASKS];
     int initial_ready_count;
 
-  // Tensor pairs for host-device memory tracking
-  TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
-  int tensor_pair_count;
+    // Tensor pairs for host-device memory tracking
+    TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
+    int tensor_pair_count;
 
     // Function address mapping (for API compatibility with rt2)
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
@@ -235,7 +235,7 @@ public:
      * @param core_type Core type for this task (CoreType::AIC or CoreType::AIV)
      * @return Task ID (>= 0) on success, -1 on failure
      */
-    int add_task(uint64_t *args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
+    int add_task(uint64_t* args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
 
     /**
      * Add a dependency edge: from_task -> to_task
@@ -258,7 +258,7 @@ public:
      * @param task_id  Task ID to query
      * @return Pointer to task, or nullptr if invalid ID
      */
-    Task *get_task(int task_id);
+    Task* get_task(int task_id);
 
     /**
      * Get the total number of tasks in the runtime
@@ -278,7 +278,7 @@ public:
      * nullptr)
      * @return Number of initially ready tasks
      */
-    int get_initial_ready_tasks(int *ready_tasks);
+    int get_initial_ready_tasks(int* ready_tasks);
 
     // =========================================================================
     // Utility Methods

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -20,9 +20,7 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(
-    __gm__ PTO2DispatchPayload* payload
-) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
@@ -76,8 +74,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
-    __gm__ PTO2DispatchPayload* payload =
-        reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
 
@@ -118,8 +115,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, task_id,
-                                       start_time, end_time);
+                perf_aicore_record_task(perf_buf, task_id, start_time, end_time);
             }
 
             last_reg_val = reg_val;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -39,7 +39,12 @@
 #if PTO2_PROFILING
 // Accumulated nanoseconds per sub-step
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
-#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+#define CYCLE_COUNT_LAP(acc)       \
+    do {                           \
+        _t1 = get_sys_cnt_aicpu(); \
+        acc += (_t1 - _t0);        \
+        _t0 = _t1;                 \
+    } while (0)
 #else
 #define CYCLE_COUNT_START()
 #define CYCLE_COUNT_LAP(acc)
@@ -48,8 +53,7 @@
 // Device orchestration function signature (loaded via dlopen).
 // The executor binds the current thread's PTO2Runtime into orchestration TLS
 // before calling the user entry.
-typedef void (*DeviceOrchestrationFunc)(TaskArg* orch_args,
-                                        int32_t orch_thread_num, int32_t orch_thread_index);
+typedef void (*DeviceOrchestrationFunc)(TaskArg* orch_args, int32_t orch_thread_num, int32_t orch_thread_index);
 typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime* rt);
 
 // Config function exported by orchestration .so
@@ -60,8 +64,8 @@ constexpr int32_t MAX_AIC_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD;
 constexpr int32_t MAX_AIV_PER_THREAD = PLATFORM_MAX_AIV_PER_THREAD;
 constexpr int32_t MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 
-constexpr int32_t MAX_IDLE_ITERATIONS = 800000;  // ~20s idle then scheduler gives up (avoid long hang)
-constexpr int32_t STALL_LOG_INTERVAL = 50000;    // DEV_ALWAYS every N idle iters to debug hang
+constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
+constexpr int32_t STALL_LOG_INTERVAL = 50000;         // DEV_ALWAYS every N idle iters to debug hang
 constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
 constexpr int32_t STALL_DUMP_WAIT_MAX = 4;
@@ -69,7 +73,7 @@ constexpr int32_t STALL_DUMP_CORE_MAX = 8;
 constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
 constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
 
-static PTO2Runtime *rt{nullptr};
+static PTO2Runtime* rt{nullptr};
 
 // Per-core dispatch payload storage (one aligned cache line per physical core)
 static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
@@ -290,7 +294,7 @@ struct AicpuExecutor {
     std::atomic<bool> pto2_init_done_{false};
     std::atomic<bool> runtime_init_ready_{false};
     std::atomic<bool> pto2_init_complete_{false};  // init block finished; others wait for this
-    std::atomic<int32_t> orch_finished_count_{0};      // Number of orchestrator threads that have finished
+    std::atomic<int32_t> orch_finished_count_{0};  // Number of orchestrator threads that have finished
 
     // ===== Dynamic core transition state =====
     std::atomic<bool> transition_requested_{false};
@@ -386,7 +390,8 @@ struct AicpuExecutor {
                 bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state, subslot);
                 if (mixed_complete) {
 #if PTO2_SCHED_PROFILING
-                    PTO2CompletionStats cstats = rt->scheduler.on_mixed_task_complete(slot_state, thread_idx, local_bufs);
+                    PTO2CompletionStats cstats =
+                        rt->scheduler.on_mixed_task_complete(slot_state, thread_idx, local_bufs);
                     notify_edges_total += cstats.fanout_edges;
                     if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
                     notify_tasks_enqueued += cstats.tasks_enqueued;
@@ -439,13 +444,17 @@ struct AicpuExecutor {
 
                     int32_t perf_slot_idx = static_cast<int32_t>(core_exec_state.executing_subslot);
                     if (perf_aicpu_complete_record(perf_buf,
-                        static_cast<uint32_t>(expected_reg_task_id),
-                        slot_state.task->task_id.raw,
-                        slot_state.task->kernel_id[perf_slot_idx], CT,
-                        core_exec_state.dispatch_timestamp, finish_ts,
-                        fanout_arr, fanout_n) != 0) {
+                            static_cast<uint32_t>(expected_reg_task_id),
+                            slot_state.task->task_id.raw,
+                            slot_state.task->kernel_id[perf_slot_idx],
+                            CT,
+                            core_exec_state.dispatch_timestamp,
+                            finish_ts,
+                            fanout_arr,
+                            fanout_n) != 0) {
                         DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task 0x%llx",
-                            core_id, (unsigned long long)slot_state.task->task_id.raw);
+                            core_id,
+                            (unsigned long long)slot_state.task->task_id.raw);
                     }
 #if PTO2_SCHED_PROFILING
                     sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
@@ -519,9 +528,13 @@ struct AicpuExecutor {
 #if PTO2_SCHED_PROFILING
         extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
         uint64_t t_pop_start = get_sys_cnt_aicpu();
-        int count = rt->scheduler.get_ready_tasks_batch(
-            shape, local_buf, out, max_count,
-            g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx], local_dispatch_count);
+        int count = rt->scheduler.get_ready_tasks_batch(shape,
+            local_buf,
+            out,
+            max_count,
+            g_sched_pop_atomic_count[thread_idx],
+            g_sched_pop_wait_cycle[thread_idx],
+            local_dispatch_count);
         sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
         if (count > 0) {
             pop_hit += count;
@@ -633,7 +646,9 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
             DEV_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                      i, physical_core_id, max_physical_cores_count);
+                i,
+                physical_core_id,
+                max_physical_cores_count);
             handshake_failed = true;
             continue;
         }
@@ -694,7 +709,10 @@ bool AicpuExecutor::assign_cores_to_threads() {
     }
 
     DEV_INFO("Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)",
-             cluster_count, divisor, aic_count_, aiv_count_);
+        cluster_count,
+        divisor,
+        aic_count_,
+        aiv_count_);
 
     for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
         core_exec_states_[i].executing_reg_task_id = AICPU_TASK_INVALID;
@@ -733,8 +751,7 @@ bool AicpuExecutor::assign_cores_to_threads() {
         core_assignments_[t][idx++] = aiv0_wid;
         core_assignments_[t][idx++] = aiv1_wid;
 
-        DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)",
-                 t, ci, aic_wid, aiv0_wid, aiv1_wid);
+        DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
     }
 
     for (int32_t t = 0; t < divisor; t++) {
@@ -810,8 +827,11 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
         int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
         int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
         DEV_INFO("  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)",
-                 t, core_count_per_thread_[t], core_trackers_[t].get_cluster_count(),
-                 aic_running, aiv_running);
+            t,
+            core_count_per_thread_[t],
+            core_trackers_[t].get_cluster_count(),
+            aic_running,
+            aiv_running);
     }
 }
 
@@ -905,7 +925,8 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
 /**
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
-int32_t AicpuExecutor::shutdown_aicore(Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num) {
+int32_t AicpuExecutor::shutdown_aicore(
+    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num) {
     (void)runtime;
     if (core_num == 0) return 0;
 
@@ -938,12 +959,16 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
     PTO2SharedMemoryHeader* header = static_cast<PTO2SharedMemoryHeader*>(sm_base);
     DEV_INFO("Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu",
-             thread_idx, (void*)header, (unsigned long)header->rings[0].task_descriptors_offset,
-             (unsigned long)header->rings[0].task_window_size);
+        thread_idx,
+        (void*)header,
+        (unsigned long)header->rings[0].task_descriptors_offset,
+        (unsigned long)header->rings[0].task_window_size);
 
     Handshake* hank = static_cast<Handshake*>(runtime->workers);
     DEV_INFO("Thread %d: hank=%p, window_size=%lu",
-             thread_idx, (void*)hank, (unsigned long)header->rings[0].task_window_size);
+        thread_idx,
+        (void*)hank,
+        (unsigned long)header->rings[0].task_window_size);
 
     // One-time init: assign perf buffers (one thread does it; others wait)
     if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
@@ -989,10 +1014,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     uint64_t complete_probe_count = 0;
     uint64_t complete_hit_count = 0;
     uint64_t notify_edges_total = 0;
-    int32_t  notify_max_degree = 0;
+    int32_t notify_max_degree = 0;
     uint64_t notify_tasks_enqueued = 0;
     uint64_t fanin_edges_total = 0;
-    int32_t  fanin_max_degree = 0;
+    int32_t fanin_max_degree = 0;
     uint64_t pop_hit = 0;
     uint64_t pop_miss = 0;
     uint64_t local_dispatch_count = 0;
@@ -1034,11 +1059,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 // Check for orchestrator fatal error — exit immediately
                 int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
                 if (orch_err != PTO2_ERROR_NONE) {
-                    DEV_ERROR("Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
-                               "completed_tasks=%d, total_tasks=%d",
-                               thread_idx, orch_err,
-                               completed_tasks_.load(std::memory_order_relaxed),
-                               total_tasks_);
+                    DEV_ERROR(
+                        "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
+                        "completed_tasks=%d, total_tasks=%d",
+                        thread_idx,
+                        orch_err,
+                        completed_tasks_.load(std::memory_order_relaxed),
+                        total_tasks_);
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1048,7 +1075,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 task_count = total_tasks_;
                 if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
                     completed_.store(true, std::memory_order_release);
-                    DEV_INFO("Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed), task_count);
+                    DEV_INFO("Thread %d: PTO2 completed tasks %d/%d",
+                        thread_idx,
+                        completed_tasks_.load(std::memory_order_relaxed),
+                        task_count);
                     break;
                 }
             }
@@ -1086,18 +1116,29 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         bool try_completed = false;
         if (tracker.has_running_cores<CoreType::AIC>()) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIC>(
-                thread_idx, hank,
-                completed_this_turn, cur_thread_completed, made_progress,
-                deferred_release_slot_states, deferred_release_count,
+            check_running_cores_for_completion<CoreType::AIC>(thread_idx,
+                hank,
+                completed_this_turn,
+                cur_thread_completed,
+                made_progress,
+                deferred_release_slot_states,
+                deferred_release_count,
                 local_bufs
 #if PTO2_PROFILING
-                , profiling_enabled, phase_complete_count
+                ,
+                profiling_enabled,
+                phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
-                , complete_probe_count, complete_hit_count,
-                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
+                ,
+                complete_probe_count,
+                complete_hit_count,
+                notify_edges_total,
+                notify_max_degree,
+                notify_tasks_enqueued,
+                fanin_edges_total,
+                fanin_max_degree,
+                sched_complete_perf_cycle
 #endif
             );
         }
@@ -1105,18 +1146,29 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Check AIV running cores
         if (tracker.has_running_cores<CoreType::AIV>()) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIV>(
-                thread_idx, hank,
-                completed_this_turn, cur_thread_completed, made_progress,
-                deferred_release_slot_states, deferred_release_count,
+            check_running_cores_for_completion<CoreType::AIV>(thread_idx,
+                hank,
+                completed_this_turn,
+                cur_thread_completed,
+                made_progress,
+                deferred_release_slot_states,
+                deferred_release_count,
                 local_bufs
 #if PTO2_PROFILING
-                , profiling_enabled, phase_complete_count
+                ,
+                profiling_enabled,
+                phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
-                , complete_probe_count, complete_hit_count,
-                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
+                ,
+                complete_probe_count,
+                complete_hit_count,
+                notify_edges_total,
+                notify_max_degree,
+                notify_tasks_enqueued,
+                fanin_edges_total,
+                fanin_max_degree,
+                sched_complete_perf_cycle
 #endif
             );
         }
@@ -1128,11 +1180,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             int32_t new_total = prev + completed_this_turn;
             last_progress_count = new_total;
             if (thread_idx == 0 && task_count > 0) {
-                if (new_total <= PROGRESS_VERBOSE_THRESHOLD
-                    || new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL
-                    || new_total >= task_count) {
+                if (new_total <= PROGRESS_VERBOSE_THRESHOLD ||
+                    new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL || new_total >= task_count) {
                     DEV_ALWAYS("PTO2 progress: completed=%d total=%d (%.1f%%)",
-                               new_total, task_count, 100.0 * new_total / task_count);
+                        new_total,
+                        task_count,
+                        100.0 * new_total / task_count);
                 }
             }
         }
@@ -1318,7 +1371,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             // freeing heap space for the orchestrator without blocking completion polling.
             while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
-                int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
+                int32_t fe =
+                    rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
 #else
                 int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
@@ -1337,7 +1391,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
                 if (orch_err != PTO2_ERROR_NONE) {
                     DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores",
-                               thread_idx, orch_err);
+                        thread_idx,
+                        orch_err);
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1347,7 +1402,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
                 int32_t c = completed_tasks_.load(std::memory_order_relaxed);
                 DEV_ALWAYS("PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
-                           idle_iterations, c, task_count, last_progress_count);
+                    idle_iterations,
+                    c,
+                    task_count,
+                    last_progress_count);
                 // Scan all task slots to find truly stuck tasks using scheduler state
                 PTO2SchedulerState* sched = &rt->scheduler;
                 PTO2SharedMemoryHeader* sm_header_diag = static_cast<PTO2SharedMemoryHeader*>(sm_base);
@@ -1361,33 +1419,54 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
                         int32_t fi = slot_state.fanin_count;
                         int32_t kid = slot_state.task->kernel_id[0];
-                        if (st >= PTO2_TASK_COMPLETED) continue; // Already done
-                        if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) { cnt_inflight++; continue; }
+                        if (st >= PTO2_TASK_COMPLETED) continue;  // Already done
+                        if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) {
+                            cnt_inflight++;
+                            continue;
+                        }
                         // PENDING
                         if (rc >= fi) {
                             // Ready (all deps satisfied) but not enqueued — this is the real bug
                             cnt_ready++;
                             if (cnt_ready <= STALL_DUMP_READY_MAX) {
-                                DEV_ALWAYS("  STUCK-READY  ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
-                                            r, (long long)slot_state.task->task_id.raw, kid, rc, fi, (int32_t)st);
+                                DEV_ALWAYS(
+                                    "  STUCK-READY  ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
+                                    r,
+                                    (long long)slot_state.task->task_id.raw,
+                                    kid,
+                                    rc,
+                                    fi,
+                                    (int32_t)st);
                             }
                         } else {
                             cnt_waiting++;
                             if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
-                                DEV_ALWAYS("  STUCK-WAIT   ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
-                                            r, (long long)slot_state.task->task_id.raw, kid, rc, fi, (int32_t)st);
+                                DEV_ALWAYS(
+                                    "  STUCK-WAIT   ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
+                                    r,
+                                    (long long)slot_state.task->task_id.raw,
+                                    kid,
+                                    rc,
+                                    fi,
+                                    (int32_t)st);
                             }
                         }
                     }
                 }
                 DEV_ALWAYS("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d",
-                           cnt_ready, cnt_waiting, cnt_inflight);
+                    cnt_ready,
+                    cnt_waiting,
+                    cnt_inflight);
                 // Log this thread's dispatch state
                 int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
                 int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
                 int32_t total_running = aic_running + aiv_running;
                 DEV_ALWAYS("  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d",
-                           thread_idx, total_running, aic_running, aiv_running, core_num);
+                    thread_idx,
+                    total_running,
+                    aic_running,
+                    aiv_running,
+                    core_num);
                 // Dump running cores
                 auto all_running = tracker.get_all_running_cores();
                 int32_t dump_count = 0;
@@ -1403,9 +1482,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     }
                     uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
                     DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
-                               cid, (unsigned)cond_reg,
-                               EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
-                               sw_tid, hw_kernel);
+                        cid,
+                        (unsigned)cond_reg,
+                        EXTRACT_TASK_STATE(cond_reg),
+                        EXTRACT_TASK_ID(cond_reg),
+                        sw_tid,
+                        hw_kernel);
                 }
                 // Dump cluster state
                 for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
@@ -1426,9 +1508,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 // Benchmark: scheduler lifetime end timestamp on timeout path
                 uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
                 DEV_ALWAYS("Thread %d: sched_start=%llu sched_end(timeout)=%llu sched_cost=%.3fus",
-                           thread_idx, (unsigned long long)sched_start_ts,
-                           (unsigned long long)sched_timeout_ts,
-                           cycles_to_us(sched_timeout_ts - sched_start_ts));
+                    thread_idx,
+                    (unsigned long long)sched_start_ts,
+                    (unsigned long long)sched_timeout_ts,
+                    cycles_to_us(sched_timeout_ts - sched_start_ts));
 #endif
                 return -1;
             } else {
@@ -1437,8 +1520,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_PROFILING
             CYCLE_COUNT_LAP(sched_idle_cycle);
             if (profiling_enabled) {
-                perf_aicpu_record_phase(thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT,
-                                        _t0_phase, _t1, sched_loop_count, 0);
+                perf_aicpu_record_phase(thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT, _t0_phase, _t1, sched_loop_count, 0);
                 _t0_phase = _t1;
             }
 #endif
@@ -1449,13 +1531,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     // Record sched_end before any DEV_ALWAYS to avoid init cost contamination
     uint64_t sched_end_ts = get_sys_cnt_aicpu();
     DEV_ALWAYS("Thread %d: sched_start=%llu sched_end=%llu sched_cost=%.3fus",
-        thread_idx, (unsigned long long)sched_start_ts,
+        thread_idx,
+        (unsigned long long)sched_start_ts,
         (unsigned long long)sched_end_ts,
         cycles_to_us(sched_end_ts - sched_start_ts));
 
     // Scheduler summary logging (always print when PTO2_PROFILING=1)
-    uint64_t sched_total =
-        sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
+    uint64_t sched_total = sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
 
 #if PTO2_SCHED_PROFILING
@@ -1464,71 +1546,87 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
         uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
         uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle)
-            ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle) : 0;
+                                     ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle)
+                                     : 0;
         uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle)
-            ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) : 0;
+                                     ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle)
+                                     : 0;
 
         DEV_ALWAYS("Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===",
-            thread_idx, cycles_to_us(sched_total), cur_thread_completed);
+            thread_idx,
+            cycles_to_us(sched_total),
+            cur_thread_completed);
 
         // Level 1: complete
-        double notify_avg = cur_thread_completed > 0
-            ? (double)notify_edges_total / cur_thread_completed : 0.0;
-        double fanin_avg = cur_thread_completed > 0
-            ? (double)fanin_edges_total / cur_thread_completed : 0.0;
-        DEV_ALWAYS("Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%llu, max_degree=%d, avg=%.1f]  [fanin: edges=%llu, max_degree=%d, avg=%.1f]",
-            thread_idx, cycles_to_us(sched_complete_cycle),
+        double notify_avg = cur_thread_completed > 0 ? (double)notify_edges_total / cur_thread_completed : 0.0;
+        double fanin_avg = cur_thread_completed > 0 ? (double)fanin_edges_total / cur_thread_completed : 0.0;
+        DEV_ALWAYS(
+            "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%llu, max_degree=%d, avg=%.1f]  [fanin: "
+            "edges=%llu, max_degree=%d, avg=%.1f]",
+            thread_idx,
+            cycles_to_us(sched_complete_cycle),
             sched_complete_cycle * 100.0 / sched_total,
-            (unsigned long long)notify_edges_total, notify_max_degree, notify_avg,
-            (unsigned long long)fanin_edges_total, fanin_max_degree, fanin_avg);
+            (unsigned long long)notify_edges_total,
+            notify_max_degree,
+            notify_avg,
+            (unsigned long long)fanin_edges_total,
+            fanin_max_degree,
+            fanin_avg);
 
         // Level 2: complete sub-phases (percentage relative to complete)
         uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
-        uint64_t complete_miss_count = (complete_probe_count > complete_hit_count)
-            ? (complete_probe_count - complete_hit_count) : 0;
-        double complete_hit_rate = complete_probe_count > 0
-            ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
+        uint64_t complete_miss_count =
+            (complete_probe_count > complete_hit_count) ? (complete_probe_count - complete_hit_count) : 0;
+        double complete_hit_rate = complete_probe_count > 0 ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
         DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)  hit=%llu, miss=%llu, hit_rate=%.1f%%",
-            thread_idx, cycles_to_us(complete_poll),
+            thread_idx,
+            cycles_to_us(complete_poll),
             complete_poll * 100.0 / c_parent,
             (unsigned long long)complete_hit_count,
             (unsigned long long)complete_miss_count,
             complete_hit_rate);
         DEV_ALWAYS("Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-            thread_idx, cycles_to_us(sp.lock_cycle),
+            thread_idx,
+            cycles_to_us(sp.lock_cycle),
             sp.lock_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
+            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle),
+            cycles_to_us(sp.lock_wait_cycle),
             (unsigned long long)sp.lock_atomic_count);
         DEV_ALWAYS("Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-            thread_idx, cycles_to_us(sp.fanout_cycle),
+            thread_idx,
+            cycles_to_us(sp.fanout_cycle),
             sp.fanout_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
+            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle),
+            cycles_to_us(sp.push_wait_cycle),
             (unsigned long long)sp.fanout_atomic_count);
         DEV_ALWAYS("Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%llu",
-            thread_idx, cycles_to_us(sp.fanin_cycle),
+            thread_idx,
+            cycles_to_us(sp.fanin_cycle),
             sp.fanin_cycle * 100.0 / c_parent,
             (unsigned long long)sp.fanin_atomic_count);
         DEV_ALWAYS("Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%llu",
-            thread_idx, cycles_to_us(sp.self_consumed_cycle),
+            thread_idx,
+            cycles_to_us(sp.self_consumed_cycle),
             sp.self_consumed_cycle * 100.0 / c_parent,
             (unsigned long long)sp.self_atomic_count);
         DEV_ALWAYS("Thread %d:     perf         : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_complete_perf_cycle),
+            thread_idx,
+            cycles_to_us(sched_complete_perf_cycle),
             sched_complete_perf_cycle * 100.0 / c_parent);
 
         // Level 1: dispatch
         uint64_t pop_total = pop_hit + pop_miss;
         double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
         DEV_ALWAYS("Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%llu, miss=%llu, hit_rate=%.1f%%]",
-            thread_idx, cycles_to_us(sched_dispatch_cycle),
+            thread_idx,
+            cycles_to_us(sched_dispatch_cycle),
             sched_dispatch_cycle * 100.0 / sched_total,
             (unsigned long long)pop_hit,
             (unsigned long long)pop_miss,
             pop_hit_rate);
         uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
         uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
-        double local_hit_rate = total_dispatched > 0
-            ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
+        double local_hit_rate = total_dispatched > 0 ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
         DEV_ALWAYS("Thread %d:     local_disp   : local=%llu, global=%llu, overflow=%llu, local_rate=%.1f%%",
             thread_idx,
             (unsigned long long)local_dispatch_count,
@@ -1539,31 +1637,38 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Level 2: dispatch sub-phases (percentage relative to dispatch)
         uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
         DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(dispatch_poll),
+            thread_idx,
+            cycles_to_us(dispatch_poll),
             dispatch_poll * 100.0 / d_parent);
         DEV_ALWAYS("Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-            thread_idx, cycles_to_us(sched_dispatch_pop_cycle),
+            thread_idx,
+            cycles_to_us(sched_dispatch_pop_cycle),
             sched_dispatch_pop_cycle * 100.0 / d_parent,
-            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle),
+            cycles_to_us(sp.pop_wait_cycle),
             (unsigned long long)sp.pop_atomic_count);
         DEV_ALWAYS("Thread %d:     setup        : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
+            thread_idx,
+            cycles_to_us(sched_dispatch_setup_cycle),
             sched_dispatch_setup_cycle * 100.0 / d_parent);
 
         // Level 1: scan
         DEV_ALWAYS("Thread %d:   scan           : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_scan_cycle),
+            thread_idx,
+            cycles_to_us(sched_scan_cycle),
             sched_scan_cycle * 100.0 / sched_total);
 
         // Level 1: idle
         DEV_ALWAYS("Thread %d:   idle           : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_idle_cycle),
+            thread_idx,
+            cycles_to_us(sched_idle_cycle),
             sched_idle_cycle * 100.0 / sched_total);
 
         // Average per completion
         if (cur_thread_completed > 0) {
             DEV_ALWAYS("Thread %d:   avg/complete   : %.3fus",
-                thread_idx, cycles_to_us(sched_complete_cycle) / cur_thread_completed);
+                thread_idx,
+                cycles_to_us(sched_complete_cycle) / cur_thread_completed);
         }
     }
 #endif
@@ -1589,7 +1694,6 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 int32_t AicpuExecutor::run(Runtime* runtime) {
     int32_t thread_idx = thread_idx_++;
     DEV_INFO("Thread %d: Start", thread_idx);
-
 
     // Orchestrator check
     if (thread_idx >= sched_thread_num_) {
@@ -1617,28 +1721,26 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 char so_path[256];
                 bool file_created = false;
                 const char* candidate_dirs[] = {
-                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device",
-                    "/usr/lib64",
-                    "/lib64",
-                    "/var/tmp",
-                    "/tmp"
-                };
+                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"};
                 const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
 
                 for (int32_t i = 0; i < num_candidates && !file_created; i++) {
-                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so",
-                             candidate_dirs[i], getpid());
+                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
                     int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
                     if (fd < 0) {
                         DEV_INFO("Thread %d: Cannot create SO at %s (errno=%d), trying next path",
-                                 thread_idx, so_path, errno);
+                            thread_idx,
+                            so_path,
+                            errno);
                         continue;
                     }
                     ssize_t written = write(fd, so_data, so_size);
                     close(fd);
                     if (written != static_cast<ssize_t>(so_size)) {
                         DEV_INFO("Thread %d: Cannot write SO to %s (errno=%d), trying next path",
-                                 thread_idx, so_path, errno);
+                            thread_idx,
+                            so_path,
+                            errno);
                         unlink(so_path);
                         continue;
                     }
@@ -1662,8 +1764,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
 
                 dlerror();
-                auto config_func = reinterpret_cast<DeviceOrchestrationConfigFunc>(
-                    dlsym(handle, "aicpu_orchestration_config"));
+                auto config_func =
+                    reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
 
                 dlerror();
                 DeviceOrchestrationFunc orch_func =
@@ -1683,12 +1785,11 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 }
 
                 dlerror();
-                auto bind_runtime_func = reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(
-                    dlsym(handle, "pto2_framework_bind_runtime"));
+                auto bind_runtime_func =
+                    reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
                 const char* bind_runtime_error = dlerror();
                 if (bind_runtime_error != nullptr) {
-                    DEV_INFO("Thread %d: Optional TLS runtime binder not found: %s",
-                             thread_idx, bind_runtime_error);
+                    DEV_INFO("Thread %d: Optional TLS runtime binder not found: %s", thread_idx, bind_runtime_error);
                     bind_runtime_func = nullptr;
                 }
 
@@ -1698,10 +1799,14 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 for (int32_t i = 0; i < arg_count && i < 20; i++) {
                     if (args[i].kind == TaskArgKind::TENSOR) {
                         DEV_INFO("Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)",
-                                 thread_idx, i, (unsigned long)args[i].tensor.data, args[i].tensor.ndims, (unsigned)args[i].tensor.dtype);
+                            thread_idx,
+                            i,
+                            (unsigned long)args[i].tensor.data,
+                            args[i].tensor.ndims,
+                            (unsigned)args[i].tensor.dtype);
                     } else {
-                        DEV_INFO("Thread %d: orch_args[%d] = SCALAR(0x%lx)",
-                                 thread_idx, i, (unsigned long)args[i].scalar);
+                        DEV_INFO(
+                            "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, i, (unsigned long)args[i].scalar);
                     }
                 }
 
@@ -1734,15 +1839,17 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
                 }
                 DEV_INFO("Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d",
-                         thread_idx, (unsigned long)task_window_size, (unsigned long)heap_size, dep_pool_capacity);
+                    thread_idx,
+                    (unsigned long)task_window_size,
+                    (unsigned long)heap_size,
+                    dep_pool_capacity);
 
                 void* sm_ptr = runtime->get_pto2_gm_sm_ptr();
                 void* gm_heap = runtime->get_pto2_gm_heap_ptr();
 
                 uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
                 PTO2SharedMemoryHandle* sm_handle =
-                    pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size,
-                                                heap_size);
+                    pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
                 if (!sm_handle) {
                     DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
                     dlclose(handle);
@@ -1750,9 +1857,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     return -1;
                 }
 
-                rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE,
-                                                 sm_handle, gm_heap, heap_size, orch_thread_num_,
-                                                 dep_pool_capacity);
+                rt = pto2_runtime_create_from_sm(
+                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity);
                 if (!rt) {
                     DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                     pto2_sm_destroy(sm_handle);
@@ -1831,8 +1937,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             // Print orchestrator profiling data
 #if PTO2_ORCH_PROFILING
             PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
-            uint64_t total = p.sync_cycle + p.alloc_cycle + p.params_cycle + p.lookup_cycle +
-                             p.insert_cycle + p.fanin_cycle;
+            uint64_t total =
+                p.sync_cycle + p.alloc_cycle + p.params_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
             DEV_ALWAYS("Thread %d: === Orchestrator Profiling: %lld tasks, total=%.3fus ===",
                 thread_idx,
@@ -1876,14 +1982,19 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 #if PTO2_TENSORMAP_PROFILING
             PTO2TensorMapProfilingData tp = pto2_tensormap_get_profiling();
             DEV_ALWAYS("Thread %d: === TensorMap Lookup Stats ===", thread_idx);
-            DEV_ALWAYS("Thread %d:   lookups        : %llu, inserts: %llu", thread_idx,
-                (unsigned long long)tp.lookup_count, (unsigned long long)tp.insert_count);
-            DEV_ALWAYS("Thread %d:   chain walked   : total=%llu, avg=%.1f, max=%d", thread_idx,
+            DEV_ALWAYS("Thread %d:   lookups        : %llu, inserts: %llu",
+                thread_idx,
+                (unsigned long long)tp.lookup_count,
+                (unsigned long long)tp.insert_count);
+            DEV_ALWAYS("Thread %d:   chain walked   : total=%llu, avg=%.1f, max=%d",
+                thread_idx,
                 (unsigned long long)tp.lookup_chain_total,
                 tp.lookup_count > 0 ? (double)tp.lookup_chain_total / tp.lookup_count : 0.0,
                 tp.lookup_chain_max);
-            DEV_ALWAYS("Thread %d:   overlap checks : %llu, hits=%llu (%.1f%%)", thread_idx,
-                (unsigned long long)tp.overlap_checks, (unsigned long long)tp.overlap_hits,
+            DEV_ALWAYS("Thread %d:   overlap checks : %llu, hits=%llu (%.1f%%)",
+                thread_idx,
+                (unsigned long long)tp.overlap_checks,
+                (unsigned long long)tp.overlap_hits,
                 tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0);
 #endif
 
@@ -1926,12 +2037,11 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 void* sm = runtime->get_pto2_gm_sm_ptr();
                 PTO2SharedMemoryHeader* sm_header = static_cast<PTO2SharedMemoryHeader*>(sm);
                 int32_t pto2_task_count = 0;
-                    if (sm_header) {
-                        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                            pto2_task_count +=
-                                sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
-                        }
+                if (sm_header) {
+                    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                        pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                     }
+                }
 #if PTO2_PROFILING
                 pto2_submitted_tasks = pto2_task_count;
 #endif
@@ -1944,8 +2054,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     int32_t orch_err = 0;
                     void* sm = runtime->get_pto2_gm_sm_ptr();
                     if (sm) {
-                        orch_err = static_cast<PTO2SharedMemoryHeader*>(sm)->orch_error_code.load(
-                            std::memory_order_relaxed);
+                        orch_err =
+                            static_cast<PTO2SharedMemoryHeader*>(sm)->orch_error_code.load(std::memory_order_relaxed);
                     }
 
                     // Fatal error: shutdown AICore immediately before core transition.
@@ -2016,20 +2126,21 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 #if PTO2_PROFILING
         uint64_t orch_end_ts = get_sys_cnt_aicpu();
         DEV_ALWAYS("Thread %d: orch_start=%llu orch_end=%llu orch_cost=%.3fus",
-            thread_idx, (unsigned long long)orch_cycle_start,
+            thread_idx,
+            (unsigned long long)orch_cycle_start,
             (unsigned long long)orch_end_ts,
             cycles_to_us(orch_end_ts - orch_cycle_start));
         if (pto2_submitted_tasks >= 0) {
             DEV_ALWAYS("PTO2 total submitted tasks = %d, already executed %d tasks",
-                pto2_submitted_tasks, completed_tasks_.load(std::memory_order_acquire));
+                pto2_submitted_tasks,
+                completed_tasks_.load(std::memory_order_acquire));
         }
 #endif
         DEV_INFO("Thread %d: Orchestrator completed (orch_idx=%d)", thread_idx, orch_idx);
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
-    if (!completed_.load(std::memory_order_acquire) &&
-        (thread_idx < sched_thread_num_ || orch_to_sched_)) {
+    if (!completed_.load(std::memory_order_acquire) && (thread_idx < sched_thread_num_ || orch_to_sched_)) {
         // Device orchestration: wait for primary orchestrator to initialize SM header
         if (!runtime->get_orch_built_on_host()) {
             while (!runtime_init_ready_.load(std::memory_order_acquire)) {
@@ -2146,17 +2257,15 @@ void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
     DEV_WARN("Emergency shutdown complete");
 }
 
-void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
-                                         const int32_t* cur_thread_cores, int32_t core_num,
-                                         Handshake* hank) {
+void AicpuExecutor::diagnose_stuck_state(
+    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank) {
     (void)runtime;
     PTO2SchedulerState* sched = &rt->scheduler;
     DEV_ALWAYS("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
 
     int32_t completed = completed_tasks_.load(std::memory_order_acquire);
     int32_t total = total_tasks_;
-    DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)",
-             completed, total, total > 0 ? completed * 100.0 / total : 0.0);
+    DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)", completed, total, total > 0 ? completed * 100.0 / total : 0.0);
 
     uint64_t aic_ready = 0, aiv_ready = 0, mix_ready = 0;
     if (rt) {
@@ -2189,14 +2298,23 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
                     int32_t diag_slot = static_cast<int32_t>(core_exec_states_[core_id].executing_subslot);
                     kernel_id = core_exec_states_[core_id].executing_slot_state->task->kernel_id[diag_slot];
                 }
-                DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_reg_task_id=%d, kernel_id=%d",
-                        core_id, core_type_str, reg_val, reg_task_id,
-                        reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
-                        task_id, kernel_id);
+                DEV_ALWAYS(
+                    "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_reg_task_id=%d, "
+                    "kernel_id=%d",
+                    core_id,
+                    core_type_str,
+                    reg_val,
+                    reg_task_id,
+                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
+                    task_id,
+                    kernel_id);
             } else {
                 DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked",
-                        core_id, core_type_str, reg_val, reg_task_id,
-                        reg_state == TASK_FIN_STATE ? "FIN" : "ACK");
+                    core_id,
+                    core_type_str,
+                    reg_val,
+                    reg_task_id,
+                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK");
             }
         } else {
             idle_cores++;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/build_config.py
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/build_config.py
@@ -11,20 +11,17 @@
 # by the Tensor constructor's validation logic).
 
 BUILD_CONFIG = {
-    "aicore": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicore", "orchestration"]
-    },
+    "aicore": {"include_dirs": ["runtime"], "source_dirs": ["aicore", "orchestration"]},
     "aicpu": {
         "include_dirs": ["runtime"],
-        "source_dirs": ["aicpu", "runtime", "orchestration"]
+        "source_dirs": ["aicpu", "runtime", "orchestration"],
     },
     "host": {
         "include_dirs": ["runtime"],
-        "source_dirs": ["host", "runtime", "orchestration"]
+        "source_dirs": ["host", "runtime", "orchestration"],
     },
     "orchestration": {
         "include_dirs": ["runtime", "orchestration"],
-        "source_dirs": ["orchestration"]
-    }
+        "source_dirs": ["orchestration"],
+    },
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -223,4 +223,3 @@ Final validation:
 3. Per-cluster concurrent capacity is lane-occupancy-driven, not a fixed constant.
 4. Submit-contract types live in one shared header-only surface.
 5. Resource-aware dispatch heuristics are allowed without a strict starvation-free guarantee.
-

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_compile_info.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_compile_info.cpp
@@ -14,5 +14,4 @@ ToolchainType get_orchestration_compiler(void) {
     if (strcmp(get_platform(), "a2a3") == 0) return TOOLCHAIN_AARCH64_GXX;
     return TOOLCHAIN_HOST_GXX;
 }
-
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -48,13 +48,11 @@ static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool requir
     errno = 0;
     unsigned long long val = strtoull(env, &endptr, 10);
     if (errno == ERANGE || endptr == env || *endptr != '\0' || val < min_val) {
-        LOG_WARN("%s=%s invalid (must be a valid integer >= %lu), ignored",
-                 name, env, (unsigned long)min_val);
+        LOG_WARN("%s=%s invalid (must be a valid integer >= %lu), ignored", name, env, (unsigned long)min_val);
         return 0;
     }
     if (require_power_of_2 && (val & (val - 1)) != 0) {
-        LOG_WARN("%s=%s invalid (must be a power of 2, >= %lu), ignored",
-                 name, env, (unsigned long)min_val);
+        LOG_WARN("%s=%s invalid (must be a power of 2, >= %lu), ignored", name, env, (unsigned long)min_val);
         return 0;
     }
     return static_cast<uint64_t>(val);
@@ -79,16 +77,16 @@ static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool requir
  * @param orch_args_count   Number of TaskArg entries
  * @return 0 on success, -1 on failure
  */
-extern "C" int init_runtime_impl(Runtime *runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    const TaskArg* orch_args,
-                    int orch_args_count,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count) {
+extern "C" int init_runtime_impl(Runtime* runtime,
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count) {
     // Suppress unused parameter warning
     (void)orch_func_name;
 
@@ -99,12 +97,11 @@ extern "C" int init_runtime_impl(Runtime *runtime,
     }
 
     // Register kernel binaries via platform-provided upload function
-    if (kernel_count > 0 && kernel_func_ids != nullptr &&
-        kernel_binaries != nullptr && kernel_sizes != nullptr) {
+    if (kernel_count > 0 && kernel_func_ids != nullptr && kernel_binaries != nullptr && kernel_sizes != nullptr) {
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", kernel_count);
         for (int i = 0; i < kernel_count; i++) {
-            uint64_t addr = runtime->host_api.upload_kernel_binary(
-                kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
+            uint64_t addr =
+                runtime->host_api.upload_kernel_binary(kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
             if (addr == 0) {
                 LOG_ERROR("Failed to upload kernel binary for func_id=%d", kernel_func_ids[i]);
                 return -1;
@@ -190,7 +187,9 @@ extern "C" int init_runtime_impl(Runtime *runtime,
                 runtime->ready_queue_shards = static_cast<int>(val);
             } else {
                 LOG_WARN("PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d",
-                         env_shards, PLATFORM_MAX_AICPU_THREADS, RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
+                    env_shards,
+                    PLATFORM_MAX_AICPU_THREADS,
+                    RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
                 runtime->ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
             }
         }
@@ -208,20 +207,22 @@ extern "C" int init_runtime_impl(Runtime *runtime,
 
     // Read ring buffer size overrides from environment
     {
-        runtime->pto2_task_window_size  = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
-        runtime->pto2_heap_size         = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
-        runtime->pto2_dep_pool_size     = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
+        runtime->pto2_task_window_size = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
+        runtime->pto2_heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
+        runtime->pto2_dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
         if (runtime->pto2_task_window_size || runtime->pto2_heap_size || runtime->pto2_dep_pool_size) {
             LOG_INFO("Ring buffer overrides: task_window=%lu heap=%lu dep_pool=%lu",
-                     (unsigned long)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE),
-                     (unsigned long)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
-                     (unsigned long)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE));
+                (unsigned long)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size
+                                                               : PTO2_TASK_WINDOW_SIZE),
+                (unsigned long)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
+                (unsigned long)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE));
         }
     }
 
     // Resolve effective sizes (env override or compile-time default)
     uint64_t eff_heap_size = runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE;
-    uint64_t eff_task_window_size = runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE;
+    uint64_t eff_task_window_size =
+        runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE;
 
     // Allocate GM heap for orchestrator output buffers (all rings combined)
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
@@ -274,7 +275,7 @@ extern "C" int init_runtime_impl(Runtime *runtime,
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime *runtime) {
+extern "C" int validate_runtime_impl(Runtime* runtime) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -303,7 +304,9 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
             graph_out_ptr = host_header.graph_output_ptr;
             graph_out_size = host_header.graph_output_size;
             if (graph_out_ptr != 0) {
-                LOG_INFO("Graph output buffer: ptr=0x%lx, size=%lu", (unsigned long)graph_out_ptr, (unsigned long)graph_out_size);
+                LOG_INFO("Graph output buffer: ptr=0x%lx, size=%lu",
+                    (unsigned long)graph_out_ptr,
+                    (unsigned long)graph_out_size);
             }
         } else {
             LOG_WARN("Failed to copy PTO2 header from device");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -20,7 +20,7 @@ namespace {
 // between execution rounds.  All orchestrator threads bind the same rt
 // value, so per-thread storage is unnecessary.
 PTO2Runtime* g_pto2_current_runtime = nullptr;
-}
+}  // namespace
 
 extern "C" __attribute__((visibility("default"))) void pto2_framework_bind_runtime(PTO2Runtime* rt) {
     g_pto2_current_runtime = rt;
@@ -38,8 +38,7 @@ extern "C" __attribute__((visibility("hidden"))) PTO2Runtime* pto2_framework_cur
  * 如果存在内联，同时通过 inline_chain 返回外层调用链
  */
 #ifdef __linux__
-static std::string addr_to_line(const char* executable, void* addr,
-                                std::string* inline_chain = nullptr) {
+static std::string addr_to_line(const char* executable, void* addr, std::string* inline_chain = nullptr) {
     char cmd[512];
     snprintf(cmd, sizeof(cmd), "addr2line -e %s -f -C -p -i %p 2>/dev/null", executable, addr);
 
@@ -161,7 +160,9 @@ static std::string build_assert_message(const char* condition, const char* file,
 
 AssertionError::AssertionError(const char* condition, const char* file, int line)
     : std::runtime_error(build_assert_message(condition, file, line)),
-      condition_(condition), file_(file), line_(line) {}
+      condition_(condition),
+      file_(file),
+      line_(line) {}
 
 [[noreturn]] void assert_impl(const char* condition, const char* file, int line) {
     LOG_ERROR("\n========================================");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -22,10 +22,10 @@
 #include <stddef.h>
 
 // Type headers needed by orchestration
-#include "tensor.h"             // Tensor
-#include "pto_types.h"          // PTOParam, PTOTensorEntry, PTOParamType
-#include "pto_submit_types.h"   // MixedKernels, INVALID_KERNEL_ID, subtask slots
-#include "task_arg.h"           // TaskArg, TaskArgKind
+#include "tensor.h"            // Tensor
+#include "pto_types.h"         // PTOParam, PTOTensorEntry, PTOParamType
+#include "pto_submit_types.h"  // MixedKernels, INVALID_KERNEL_ID, subtask slots
+#include "task_arg.h"          // TaskArg, TaskArgKind
 
 // =============================================================================
 // Tensor Factory Helpers
@@ -45,8 +45,17 @@ static inline Tensor make_tensor_external(void* addr,
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(addr, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    return Tensor(addr,
+        total * get_element_size(dtype),
+        shapes,
+        shapes,
+        zero_offsets,
+        ndims,
+        dtype,
+        version,
+        /*is_all_offset_zero=*/true,
+        /*is_raw_eq_shapes=*/true,
+        manual_dep);
 }
 
 /**
@@ -65,17 +74,28 @@ static inline Tensor make_tensor(const uint32_t shapes[],
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(0, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    return Tensor(0,
+        total * get_element_size(dtype),
+        shapes,
+        shapes,
+        zero_offsets,
+        ndims,
+        dtype,
+        version,
+        /*is_all_offset_zero=*/true,
+        /*is_raw_eq_shapes=*/true,
+        manual_dep);
 }
 
 // Convert TaskArg to Tensor (needs make_tensor_external above)
 static_assert(TASK_ARG_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "TaskArg and runtime max dims must match");
 inline Tensor from_task_arg(const TaskArg& arg, bool manual_dep = false, int32_t version = 0) {
-    return make_tensor_external(
-        reinterpret_cast<void*>(static_cast<uintptr_t>(arg.tensor.data)),
-        arg.tensor.shapes, arg.tensor.ndims, arg.tensor.dtype,
-        manual_dep, version);
+    return make_tensor_external(reinterpret_cast<void*>(static_cast<uintptr_t>(arg.tensor.data)),
+        arg.tensor.shapes,
+        arg.tensor.ndims,
+        arg.tensor.dtype,
+        manual_dep,
+        version);
 }
 
 // =============================================================================
@@ -112,8 +132,7 @@ void pto2_framework_bind_runtime(PTO2Runtime* rt);
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
 typedef struct PTO2RuntimeOps {
-    void (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                        const PTOParam& params);
+    void (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params);
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
     void (*orchestration_done)(PTO2Runtime* rt);
@@ -128,11 +147,8 @@ typedef struct PTO2RuntimeOps {
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
-                                uint32_t ndims, const uint32_t indices[]);
-    void (*set_tensor_data)(PTO2Runtime* rt, Tensor& tensor,
-                            uint32_t ndims, const uint32_t indices[],
-                            uint64_t value);
+    uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
+    void (*set_tensor_data)(PTO2Runtime* rt, Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value);
 } PTO2RuntimeOps;
 
 /**
@@ -150,12 +166,9 @@ struct PTO2Runtime {
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline PTO2Runtime* pto2_current_runtime() {
-    return pto2_framework_current_runtime();
-}
+static inline PTO2Runtime* pto2_current_runtime() { return pto2_framework_current_runtime(); }
 
-static inline void pto2_rt_submit_task(const MixedKernels& mixed_kernels,
-                                       const PTOParam& params) {
+static inline void pto2_rt_submit_task(const MixedKernels& mixed_kernels, const PTOParam& params) {
     PTO2Runtime* rt = pto2_current_runtime();
     rt->ops->submit_task(rt, mixed_kernels, params);
 }
@@ -205,8 +218,8 @@ static inline bool pto2_rt_is_fatal() {
 // =============================================================================
 
 #define LOG_ERROR(fmt, ...) pto2_current_runtime()->ops->log_error(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_WARN(fmt, ...)  pto2_current_runtime()->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_INFO(fmt, ...)  pto2_current_runtime()->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) pto2_current_runtime()->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...) pto2_current_runtime()->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
 #define LOG_DEBUG(fmt, ...) pto2_current_runtime()->ops->log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
 #define LOG_ALWAYS(fmt, ...) pto2_current_runtime()->ops->log_always(__FUNCTION__, fmt, ##__VA_ARGS__)
 
@@ -223,8 +236,7 @@ static inline bool pto2_rt_is_fatal() {
  *
  * Returns the raw bits as uint64_t; caller reinterprets via bit_cast.
  */
-static inline uint64_t get_tensor_data(const Tensor& tensor,
-                                       uint32_t ndims, const uint32_t indices[]) {
+static inline uint64_t get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[]) {
     PTO2Runtime* rt = pto2_current_runtime();
     return rt->ops->get_tensor_data(rt, tensor, ndims, indices);
 }
@@ -251,9 +263,7 @@ static inline uint64_t get_tensor_data(const Tensor& tensor,
  * For make_tensor() outputs, call this only after the tensor has been
  * submitted as OUTPUT at least once (so HeapRing allocation has occurred).
  */
-static inline void set_tensor_data(Tensor& tensor,
-                                   uint32_t ndims, const uint32_t indices[],
-                                   uint64_t value) {
+static inline void set_tensor_data(Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value) {
     PTO2Runtime* rt = pto2_current_runtime();
     rt->ops->set_tensor_data(rt, tensor, ndims, indices, value);
 }
@@ -267,17 +277,14 @@ static inline void set_tensor_data(Tensor& tensor,
  */
 class PTO2ScopeGuard {
 public:
-    PTO2ScopeGuard() : rt_(pto2_current_runtime()) {
-        rt_->ops->scope_begin(rt_);
-    }
-    ~PTO2ScopeGuard() {
-        rt_->ops->scope_end(rt_);
-    }
+    PTO2ScopeGuard() : rt_(pto2_current_runtime()) { rt_->ops->scope_begin(rt_); }
+    ~PTO2ScopeGuard() { rt_->ops->scope_end(rt_); }
+
 private:
     PTO2Runtime* rt_;
 };
 
-#define _PTO2_CONCATENATE_IMPL(x, y) x ## y
+#define _PTO2_CONCATENATE_IMPL(x, y) x##y
 #define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
 
 #define PTO2_SCOPE_GUARD() [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__)
@@ -304,8 +311,8 @@ private:
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
 struct PTO2OrchestrationConfig {
-    int         expected_arg_count;
+    int expected_arg_count;
 };
 #endif
 
-#endif // PTO_ORCHESTRATION_API_H
+#endif  // PTO_ORCHESTRATION_API_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -38,8 +38,8 @@
  * Handshake.task) and reads both fields after each DATA_MAIN_BASE change.
  */
 struct alignas(64) PTO2DispatchPayload {
-    uint64_t function_bin_addr;    /**< Kernel entry address in GM (set by Scheduler) */
-    __gm__ uint64_t* args;         /**< Pre-built args in task payload GM (set by Scheduler) */
+    uint64_t function_bin_addr; /**< Kernel entry address in GM (set by Scheduler) */
+    __gm__ uint64_t* args;      /**< Pre-built args in task payload GM (set by Scheduler) */
 };
 
 #endif  // RT2_PTO2_DISPATCH_PAYLOAD_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -52,7 +52,7 @@ static uint64_t g_orch_lookup_cycle = 0;     // tensormap lookup + dep building
 static uint64_t g_orch_insert_cycle = 0;     // tensormap insert
 static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
 static uint64_t g_orch_scope_end_cycle = 0;  // scope_end overhead
-static int64_t  g_orch_submit_count = 0;
+static int64_t g_orch_submit_count = 0;
 static uint32_t g_orch_submit_idx = 0;
 uint64_t g_orch_alloc_wait_cycle = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
@@ -62,7 +62,12 @@ uint64_t g_orch_fanin_atomic_count = 0;
 uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
-#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+#define CYCLE_COUNT_LAP(acc)       \
+    do {                           \
+        _t1 = get_sys_cnt_aicpu(); \
+        acc += (_t1 - _t0);        \
+        _t0 = _t1;                 \
+    } while (0)
 #define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                    \
     do {                                                                              \
         _t1 = get_sys_cnt_aicpu();                                                    \
@@ -78,17 +83,19 @@ __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
     AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 // submit_idx needed for swimlane task_id tagging (no cycle accumulation at this level)
 static uint32_t g_orch_submit_idx = 0;
-#define CYCLE_COUNT_START()                                                           \
-    bool _prof_active = orch->enable_profiling;                                       \
+#define CYCLE_COUNT_START()                     \
+    bool _prof_active = orch->enable_profiling; \
     uint64_t _t0 = _prof_active ? get_sys_cnt_aicpu() : 0, _t1 = 0
-#define CYCLE_COUNT_LAP(acc) do { } while(0)
-#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                    \
-    do {                                                                              \
-        if (_prof_active) {                                                           \
-            _t1 = get_sys_cnt_aicpu();                                                \
+#define CYCLE_COUNT_LAP(acc) \
+    do {                     \
+    } while (0)
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                        \
+    do {                                                                                  \
+        if (_prof_active) {                                                               \
+            _t1 = get_sys_cnt_aicpu();                                                    \
             perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
-            _t0 = _t1;                                                                \
-        }                                                                             \
+            _t0 = _t1;                                                                    \
+        }                                                                                 \
     } while (0)
 #else
 #define CYCLE_COUNT_START()
@@ -100,8 +107,10 @@ static uint32_t g_orch_submit_idx = 0;
 // Orchestrator Initialization
 // =============================================================================
 
-bool pto2_orchestrator_init(
-    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, uint64_t heap_size,
+bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
     int32_t dep_pool_capacity) {
     *orch = PTO2OrchestratorState{};
 
@@ -113,15 +122,15 @@ bool pto2_orchestrator_init(
     // Initialize per-ring resources
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         void* ring_heap_base = (char*)gm_heap + r * heap_size;
-        auto &fc = sm_handle->header->rings[r].fc;
+        auto& fc = sm_handle->header->rings[r].fc;
 
         // Initialize unified task allocator
-        orch->rings[r].task_allocator.init(
-            sm_handle->task_descriptors[r],
+        orch->rings[r].task_allocator.init(sm_handle->task_descriptors[r],
             sm_handle->header->rings[r].task_window_size,
             &fc.current_task_index,
             &fc.last_task_alive,
-            ring_heap_base, heap_size,
+            ring_heap_base,
+            heap_size,
             &sm_handle->header->orch_error_code);
 
         // Allocate and initialize dependency list pool (per-ring)
@@ -193,10 +202,11 @@ void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerS
 // Scope Management
 // =============================================================================
 
-static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState *task_slot_state) {
+static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState* task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         int32_t new_cap = orch->scope_tasks_capacity * 2;
-        PTO2TaskSlotState** new_buf = (PTO2TaskSlotState**)realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState*));
+        PTO2TaskSlotState** new_buf =
+            (PTO2TaskSlotState**)realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState*));
         assert(new_buf && "Failed to grow scope task buffer");
         orch->scope_tasks = new_buf;
         orch->scope_tasks_capacity = new_cap;
@@ -205,7 +215,9 @@ static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState *tas
 }
 
 void pto2_scope_begin(PTO2OrchestratorState* orch) {
-    if (orch->fatal) { return; }
+    if (orch->fatal) {
+        return;
+    }
     assert(orch->scope_stack_top < (int32_t)(orch->scope_stack_capacity - 1) && "Scope stack overflow");
 
     ++orch->scope_stack_top;
@@ -213,7 +225,9 @@ void pto2_scope_begin(PTO2OrchestratorState* orch) {
 }
 
 void pto2_scope_end(PTO2OrchestratorState* orch) {
-    if (orch->fatal) { return; }
+    if (orch->fatal) {
+        return;
+    }
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
 
 #if PTO2_ORCH_PROFILING
@@ -240,8 +254,7 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
 // =============================================================================
 // Task Submission
 // =============================================================================
-void pto2_submit_mixed_task(
-    PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const PTOParam& params) {
+void pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const PTOParam& params) {
     CYCLE_COUNT_START();
 
     // Fast path after fatal error — all subsequent submits are no-ops
@@ -258,18 +271,16 @@ void pto2_submit_mixed_task(
         LOG_ERROR("  tensor_count: %d, scalar_count: %d", params.tensor_count, params.scalar_count);
         LOG_ERROR("This is a bug in the orchestration code.");
         LOG_ERROR("========================================");
-        orch->sm_handle->header->orch_error_code.store(
-            PTO2_ERROR_INVALID_PARAM, std::memory_order_release);
+        orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_INVALID_PARAM, std::memory_order_release);
         orch->fatal = true;
         return;
     }
-
 
     // Determine which ring this task belongs to
     uint8_t ring_id = orch->current_ring_id();
     auto& allocator = orch->rings[ring_id].task_allocator;
     PTO2SchedulerState* sched = orch->scheduler;
-    PTO2RingFlowControl &fc = orch->sm_handle->header->rings[ring_id].fc;
+    PTO2RingFlowControl& fc = orch->sm_handle->header->rings[ring_id].fc;
 
     // === Validate submit inputs ===
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
@@ -281,7 +292,7 @@ void pto2_submit_mixed_task(
     // Mixed tasks (AIC+AIV) keep their original AIV identity so the correct
     // hardware channel (AIV0→AIC vs AIV1→AIC) is used at dispatch time.
     MixedKernels normalized = mixed_kernels;
-    bool has_aic  = (active_mask & PTO2_SUBTASK_MASK_AIC) != 0;
+    bool has_aic = (active_mask & PTO2_SUBTASK_MASK_AIC) != 0;
     bool has_aiv0 = (active_mask & PTO2_SUBTASK_MASK_AIV0) != 0;
     bool has_aiv1 = (active_mask & PTO2_SUBTASK_MASK_AIV1) != 0;
     if (!has_aic && has_aiv1 && !has_aiv0) {
@@ -304,8 +315,8 @@ void pto2_submit_mixed_task(
             LOG_ERROR("========================================");
             LOG_ERROR("FATAL: Scope Deadlock Detected! (ring %d)", ring_id);
             LOG_ERROR("========================================");
-            LOG_ERROR("Tasks in current scope (%d) >= task_window_size (%d).",
-                      scope_task_count, allocator.window_size());
+            LOG_ERROR(
+                "Tasks in current scope (%d) >= task_window_size (%d).", scope_task_count, allocator.window_size());
             LOG_ERROR("  scope_depth:        %d", orch->scope_stack_top + 1);
             LOG_ERROR("  ring_id:            %d", ring_id);
             LOG_ERROR("  scope_task_count:   %d", scope_task_count);
@@ -321,8 +332,7 @@ void pto2_submit_mixed_task(
             LOG_ERROR("     Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2>");
             LOG_ERROR("  3. Split work across multiple scopes");
             LOG_ERROR("========================================");
-            orch->sm_handle->header->orch_error_code.store(
-                PTO2_ERROR_SCOPE_DEADLOCK, std::memory_order_release);
+            orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_SCOPE_DEADLOCK, std::memory_order_release);
             orch->fatal = true;
             return;
         }
@@ -332,8 +342,7 @@ void pto2_submit_mixed_task(
     bool needs_alloc[PTO2_MAX_TENSOR_PARAMS] = {};
     int32_t total_output_size = 0;
     for (int i = 0; i < params.tensor_count; i++) {
-        if (params.tensor_types[i] == PTOParamType::OUTPUT
-            && params.tensors[i]->buffer.addr == 0) {
+        if (params.tensor_types[i] == PTOParamType::OUTPUT && params.tensors[i]->buffer.addr == 0) {
             needs_alloc[i] = true;
             total_output_size += PTO2_ALIGN_UP(params.tensors[i]->buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
         }
@@ -341,7 +350,10 @@ void pto2_submit_mixed_task(
 
     // === STEP 1: Unified alloc — task slot + packed output buffer (blocks until available) ===
     PTO2TaskAllocResult alloc_result = allocator.alloc(total_output_size);
-    if (alloc_result.failed()) { orch->fatal = true; return; }
+    if (alloc_result.failed()) {
+        orch->fatal = true;
+        return;
+    }
 
     int32_t local_id = alloc_result.task_id;
     int32_t slot = alloc_result.slot;
@@ -474,13 +486,10 @@ void pto2_submit_mixed_task(
                         char* dst = reinterpret_cast<char*>(alloc_addr);
                         constexpr uint64_t BLK = 64;
                         uint64_t blk = (total < BLK) ? total : BLK;
-                        for (uint64_t b = 0; b < blk; b += elem_size)
-                            memcpy(dst + b, &tensor.initial_value, elem_size);
+                        for (uint64_t b = 0; b < blk; b += elem_size) memcpy(dst + b, &tensor.initial_value, elem_size);
                         uint64_t off = blk;
-                        for (; off + blk <= total; off += blk)
-                            memcpy(dst + off, dst, blk);
-                        if (off < total)
-                            memcpy(dst + off, dst, total - off);
+                        for (; off + blk <= total; off += blk) memcpy(dst + off, dst, blk);
+                        if (off < total) memcpy(dst + off, dst, total - off);
                     }
                 }
                 break;
@@ -507,7 +516,7 @@ void pto2_submit_mixed_task(
     // evicted by TensorMap lookup/insert cache pressure.
     __builtin_prefetch(&task, 1, 1);
     task.task_id = task_id;
-    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)]  = normalized.aic_kernel_id;
+    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)] = normalized.aic_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;
     task.packed_buffer_base = alloc_result.packed_base;
@@ -572,8 +581,8 @@ void pto2_submit_mixed_task(
         // Combined release: merge early_finished batch with the +1 init release
         // into a single atomic fetch_add (saves one acq_rel cache-line bounce per task).
         int32_t initial_refcount = early_finished + 1;  // +1 for the init release
-        int32_t new_rc = cur_slot_state.fanin_refcount.fetch_add(initial_refcount, std::memory_order_acq_rel)
-                         + initial_refcount;
+        int32_t new_rc =
+            cur_slot_state.fanin_refcount.fetch_add(initial_refcount, std::memory_order_acq_rel) + initial_refcount;
         if (new_rc >= fanin_count + 1) {
             PTO2ResourceShape shape = pto2_active_mask_to_shape(active_mask);
             sched->ready_queues[static_cast<int32_t>(shape)].push(&cur_slot_state);
@@ -614,7 +623,12 @@ void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
         auto& pool = orch->rings[r].dep_pool;
         if (pool.top > 0) {
             LOG_INFO("=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===",
-                     r, pool.top, pool.tail, pool.top - pool.tail, pool.high_water, pool.capacity);
+                r,
+                pool.top,
+                pool.tail,
+                pool.top - pool.tail,
+                pool.high_water,
+                pool.capacity);
         }
     }
     orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
@@ -639,12 +653,12 @@ void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
         int32_t active = orch->rings[r].task_allocator.active_count();
         if (active > 0) {
             LOG_INFO("Ring %d task active:  %d", r, active);
-            LOG_INFO("Ring %d heap used:    %" PRIu64 " / %" PRIu64, r,
-                     orch->rings[r].task_allocator.heap_top(),
-                     orch->rings[r].task_allocator.heap_capacity());
-            LOG_INFO("Ring %d dep pool:     %d / %d", r,
-                     orch->rings[r].dep_pool.used(),
-                     orch->rings[r].dep_pool.capacity);
+            LOG_INFO("Ring %d heap used:    %" PRIu64 " / %" PRIu64,
+                r,
+                orch->rings[r].task_allocator.heap_top(),
+                orch->rings[r].task_allocator.heap_capacity());
+            LOG_INFO(
+                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity);
         }
     }
     LOG_INFO("TensorMap valid:     %d", orch->tensor_map.valid_count());

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -43,18 +43,18 @@ struct PTO2OrchestratorState {
     PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
 
     // === TENSOR MAP (Private) ===
-    PTO2TensorMap tensor_map;        // Producer lookup
+    PTO2TensorMap tensor_map;  // Producer lookup
 
     // === SCOPE STACK (Private) ===
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    PTO2TaskSlotState** scope_tasks; // Flat buffer of taskSlotState (all scopes concatenated)
-    int32_t scope_tasks_size;       // Number of task IDs currently in the buffer
-    int32_t scope_tasks_capacity;   // Allocated capacity of scope_tasks
-    int32_t* scope_begins;         // scope_begins[i] = start index of scope i in scope_tasks
-    int32_t scope_stack_top;       // Current top of stack (-1 = no scope open)
-    uint64_t scope_stack_capacity;   // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+    PTO2TaskSlotState** scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
+    int32_t scope_tasks_size;         // Number of task IDs currently in the buffer
+    int32_t scope_tasks_capacity;     // Allocated capacity of scope_tasks
+    int32_t* scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
+    int32_t scope_stack_top;          // Current top of stack (-1 = no scope open)
+    uint64_t scope_stack_capacity;    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
 
     // === SCHEDULER REFERENCE ===
     // Note: In simulated mode, orchestrator and scheduler share address space
@@ -66,8 +66,8 @@ struct PTO2OrchestratorState {
 #endif
 
     // === GM HEAP (for output buffers) ===
-    void* gm_heap_base;    // Base address of GM heap
-    uint64_t gm_heap_size;   // Total size of GM heap (all rings)
+    void* gm_heap_base;     // Base address of GM heap
+    uint64_t gm_heap_size;  // Total size of GM heap (all rings)
 
     // === FATAL ERROR ===
     // Fatal error flag (single-thread access by orchestrator, no atomic needed)
@@ -90,7 +90,6 @@ struct PTO2OrchestratorState {
         if (depth < 0) depth = 0;
         return depth < PTO2_MAX_RING_DEPTH ? static_cast<uint8_t>(depth) : PTO2_MAX_RING_DEPTH - 1;
     }
-
 };
 
 // =============================================================================
@@ -106,8 +105,10 @@ struct PTO2OrchestratorState {
  * @param heap_size  Size of GM heap
  * @return true on success
  */
-bool pto2_orchestrator_init(
-    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, uint64_t heap_size,
+bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
     int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
 
 /**
@@ -119,7 +120,6 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState* orch);
  * Set scheduler reference (for simulated mode)
  */
 void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler);
-
 
 // =============================================================================
 // Scope Management
@@ -161,9 +161,7 @@ void pto2_scope_end(PTO2OrchestratorState* orch);
  * @param mixed_kernels  Kernel IDs for AIC/AIV0/AIV1 slots
  * @param params      Aggregated tensor and scalar parameters
  */
-void pto2_submit_mixed_task(PTO2OrchestratorState* orch,
-    const MixedKernels& mixed_kernels,
-    const PTOParam& params);
+void pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const PTOParam& params);
 
 // =============================================================================
 // Flow Control
@@ -197,16 +195,16 @@ void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch);
 #if PTO2_ORCH_PROFILING
 struct PTO2OrchProfilingData {
     uint64_t sync_cycle;
-    uint64_t alloc_cycle;           // Combined task slot + heap allocation
+    uint64_t alloc_cycle;  // Combined task slot + heap allocation
     uint64_t params_cycle;
     uint64_t lookup_cycle;
     uint64_t insert_cycle;
     uint64_t fanin_cycle;
     uint64_t scope_end_cycle;
-    int64_t  submit_count;
+    int64_t submit_count;
     // Wait time tracking for blocking phases
-    uint64_t alloc_wait_cycle;      // Cycles spent waiting in unified alloc
-    uint64_t fanin_wait_cycle;      // Cycles spent waiting in fanout_lock
+    uint64_t alloc_wait_cycle;  // Cycles spent waiting in unified alloc
+    uint64_t fanin_wait_cycle;  // Cycles spent waiting in fanout_lock
     // Atomic operation counts per phase
     uint64_t alloc_atomic_count;
     uint64_t params_atomic_count;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -12,7 +12,7 @@
  *    - Ring buffer for linked list entries
  *    - O(1) prepend operation
  *    - Implicit reclamation with task ring
- * 
+ *
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
@@ -33,12 +33,12 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 #endif
 
 // Block notification interval (in spin counts)
-#define PTO2_BLOCK_NOTIFY_INTERVAL  10000
+#define PTO2_BLOCK_NOTIFY_INTERVAL 10000
 // Alloc spin limit - after this, report deadlock and exit
-#define PTO2_ALLOC_SPIN_LIMIT       100000
+#define PTO2_ALLOC_SPIN_LIMIT 100000
 
 // Dep pool spin limit - if exceeded, dep pool capacity too small for workload
-#define PTO2_DEP_POOL_SPIN_LIMIT      100000
+#define PTO2_DEP_POOL_SPIN_LIMIT 100000
 
 // =============================================================================
 // Task Allocator (unified task slot + heap buffer allocation)
@@ -48,10 +48,10 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
  * Result of a unified task allocation.
  */
 struct PTO2TaskAllocResult {
-    int32_t task_id;      // Absolute task ID (not wrapped), -1 on failure
-    int32_t slot;         // task_id & (window_size - 1)
-    void* packed_base;    // Heap allocation result (nullptr if output_size == 0)
-    void* packed_end;     // packed_base + aligned output_size
+    int32_t task_id;    // Absolute task ID (not wrapped), -1 on failure
+    int32_t slot;       // task_id & (window_size - 1)
+    void* packed_base;  // Heap allocation result (nullptr if output_size == 0)
+    void* packed_end;   // packed_base + aligned output_size
 
     bool failed() const { return task_id < 0; }
 };
@@ -71,11 +71,13 @@ public:
     /**
      * Initialize the allocator with task ring and heap ring resources.
      */
-    void init(PTO2TaskDescriptor* descriptors, int32_t window_size,
-              std::atomic<int32_t>* current_index_ptr,
-              std::atomic<int32_t>* last_alive_ptr,
-              void* heap_base, uint64_t heap_size,
-              std::atomic<int32_t>* error_code_ptr) {
+    void init(PTO2TaskDescriptor* descriptors,
+        int32_t window_size,
+        std::atomic<int32_t>* current_index_ptr,
+        std::atomic<int32_t>* last_alive_ptr,
+        void* heap_base,
+        uint64_t heap_size,
+        std::atomic<int32_t>* error_code_ptr) {
         descriptors_ = descriptors;
         window_size_ = window_size;
         window_mask_ = window_size - 1;
@@ -101,8 +103,8 @@ public:
      * @return Allocation result; check failed() for errors
      */
     PTO2TaskAllocResult alloc(int32_t output_size) {
-        uint64_t aligned_size = output_size > 0
-            ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
+        uint64_t aligned_size =
+            output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
 
         int spin_count = 0;
         int32_t prev_last_alive = last_alive_ptr_->load(std::memory_order_acquire);
@@ -116,15 +118,14 @@ public:
 
         while (true) {
             // Check both resources; commit only if both available
-            if (local_task_id_ - last_alive  + 1 < window_size_) {
+            if (local_task_id_ - last_alive + 1 < window_size_) {
                 void* heap_ptr = try_bump_heap(aligned_size);
                 if (heap_ptr) {
                     int32_t task_id = commit_task();
 #if PTO2_ORCH_PROFILING
                     record_wait(spin_count, wait_start, waiting);
 #endif
-                    return {task_id, task_id & window_mask_,
-                            heap_ptr, static_cast<char*>(heap_ptr) + aligned_size};
+                    return {task_id, task_id & window_mask_, heap_ptr, static_cast<char*>(heap_ptr) + aligned_size};
                 }
                 blocked_on_heap = true;
             } else {
@@ -134,7 +135,10 @@ public:
             // Spin: wait for scheduler to advance last_task_alive
             spin_count++;
 #if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+            if (!waiting) {
+                wait_start = get_sys_cnt_aicpu();
+                waiting = true;
+            }
 #endif
             last_alive = last_alive_ptr_->load(std::memory_order_acquire);
             update_heap_tail(last_alive);
@@ -166,13 +170,9 @@ public:
     // Task descriptor accessors
     // =========================================================================
 
-    PTO2TaskDescriptor& task(int32_t task_id) const {
-        return descriptors_[task_id & window_mask_];
-    }
+    PTO2TaskDescriptor& task(int32_t task_id) const { return descriptors_[task_id & window_mask_]; }
 
-    PTO2TaskDescriptor& task_by_slot(int32_t slot) const {
-        return descriptors_[slot];
-    }
+    PTO2TaskDescriptor& task_by_slot(int32_t slot) const { return descriptors_[slot]; }
 
     // =========================================================================
     // State queries
@@ -207,14 +207,14 @@ private:
     std::atomic<int32_t>* last_alive_ptr_ = nullptr;
 
     // --- Heap ---
-    void*    heap_base_ = nullptr;
+    void* heap_base_ = nullptr;
     uint64_t heap_size_ = 0;
 
     // --- Local state (single-writer, no atomics needed) ---
-    int32_t  local_task_id_ = 0;      // Next task ID to allocate
-    uint64_t heap_top_ = 0;     // Current heap allocation pointer
-    uint64_t heap_tail_ = 0;    // Heap reclamation pointer (derived from consumed tasks)
-    int32_t  last_alive_seen_ = 0;    // last_task_alive at last heap_tail derivation
+    int32_t local_task_id_ = 0;    // Next task ID to allocate
+    uint64_t heap_top_ = 0;        // Current heap allocation pointer
+    uint64_t heap_tail_ = 0;       // Heap reclamation pointer (derived from consumed tasks)
+    int32_t last_alive_seen_ = 0;  // last_task_alive at last heap_tail derivation
 
     // --- Shared ---
     std::atomic<int32_t>* error_code_ptr_ = nullptr;
@@ -245,8 +245,7 @@ private:
         last_alive_seen_ = last_alive;
 
         PTO2TaskDescriptor& desc = descriptors_[(last_alive - 1) & window_mask_];
-        heap_tail_ = static_cast<uint64_t>(
-            static_cast<char*>(desc.packed_buffer_end) - static_cast<char*>(heap_base_));
+        heap_tail_ = static_cast<uint64_t>(static_cast<char*>(desc.packed_buffer_end) - static_cast<char*>(heap_base_));
     }
 
     /**
@@ -315,17 +314,21 @@ private:
         LOG_ERROR("========================================");
         LOG_ERROR("No progress after %d spins.", PTO2_ALLOC_SPIN_LIMIT);
         LOG_ERROR("  Task ring:  current=%d, last_alive=%d, active=%d/%d (%.1f%%)",
-                  local_task_id_, last_alive, active_tasks, window_size_,
-                  100.0 * active_tasks / window_size_);
-        LOG_ERROR("  Heap ring:  top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64
-                  ", available=%" PRIu64,
-                  heap_top_, htail, heap_size_, heap_available());
+            local_task_id_,
+            last_alive,
+            active_tasks,
+            window_size_,
+            100.0 * active_tasks / window_size_);
+        LOG_ERROR("  Heap ring:  top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64 ", available=%" PRIu64,
+            heap_top_,
+            htail,
+            heap_size_,
+            heap_available());
         if (heap_blocked) {
             LOG_ERROR("  Requested:  %d bytes", requested_output_size);
         }
         LOG_ERROR("Diagnosis:");
-        LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d",
-                  last_alive, last_alive);
+        LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d", last_alive, last_alive);
         LOG_ERROR("  cannot transition to CONSUMED. Possible causes:");
         LOG_ERROR("  1. Task %d still executing (subtasks not complete)", last_alive);
         LOG_ERROR("  2. Task %d fanout not fully released (downstream not done)", last_alive);
@@ -333,22 +336,18 @@ private:
         LOG_ERROR("  4. Orchestrator blocked here -> can't call scope_end -> circular wait");
         LOG_ERROR("Solution:");
         if (heap_blocked) {
-            LOG_ERROR("  Increase heap size (current: %" PRIu64 ", recommended: %" PRIu64 ")",
-                      heap_size_, heap_size_ * 2);
+            LOG_ERROR(
+                "  Increase heap size (current: %" PRIu64 ", recommended: %" PRIu64 ")", heap_size_, heap_size_ * 2);
             LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
-            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %" PRIu64 ")",
-                      heap_size_ * 2);
+            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %" PRIu64 ")", heap_size_ * 2);
         } else {
-            LOG_ERROR("  Increase task window size (current: %d, recommended: %d)",
-                      window_size_, active_tasks * 2);
+            LOG_ERROR("  Increase task window size (current: %d, recommended: %d)", window_size_, active_tasks * 2);
             LOG_ERROR("  Compile-time: PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");
-            LOG_ERROR("  Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2> (e.g. %d)",
-                      active_tasks * 2);
+            LOG_ERROR("  Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2> (e.g. %d)", active_tasks * 2);
         }
         LOG_ERROR("========================================");
         if (error_code_ptr_) {
-            int32_t code = heap_blocked ? PTO2_ERROR_HEAP_RING_DEADLOCK
-                                        : PTO2_ERROR_FLOW_CONTROL_DEADLOCK;
+            int32_t code = heap_blocked ? PTO2_ERROR_HEAP_RING_DEADLOCK : PTO2_ERROR_FLOW_CONTROL_DEADLOCK;
             error_code_ptr_->store(code, std::memory_order_release);
         }
     }
@@ -369,12 +368,12 @@ private:
  * is obtained via modulo: base[linear_index % capacity].
  */
 struct PTO2DepListPool {
-    PTO2DepListEntry* base;   // Pool base address
-    int32_t capacity;         // Total number of entries
-    int32_t top;              // Linear next-allocation counter (starts from 1)
-    int32_t tail;             // Linear first-alive counter (entries before this are dead)
-    int32_t high_water;       // Peak concurrent usage (top - tail)
-    int32_t last_reclaimed{0}; // last_task_alive at last successful reclamation
+    PTO2DepListEntry* base;     // Pool base address
+    int32_t capacity;           // Total number of entries
+    int32_t top;                // Linear next-allocation counter (starts from 1)
+    int32_t tail;               // Linear first-alive counter (entries before this are dead)
+    int32_t high_water;         // Peak concurrent usage (top - tail)
+    int32_t last_reclaimed{0};  // last_task_alive at last successful reclamation
 
     // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
     std::atomic<int32_t>* error_code_ptr = nullptr;
@@ -414,7 +413,7 @@ struct PTO2DepListPool {
      * Ensure dep pool for a specific ring has at least `needed` entries available.
      * Spin-waits for reclamation if under pressure. Detects deadlock if no progress.
      */
-    void ensure_space(PTO2SchedulerState& sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed);
+    void ensure_space(PTO2SchedulerState& sched, PTO2RingFlowControl& fc, uint8_t ring_id, int32_t needed);
 
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)
@@ -476,20 +475,16 @@ struct PTO2DepListPool {
     }
 
     /**
-    * Get entry by offset
-    */
+     * Get entry by offset
+     */
     PTO2DepListEntry* pto2_dep_pool_get(int32_t offset) {
         if (offset <= 0) return NULL;
         return &base[offset];
     }
 
-    int32_t used() const {
-        return top - tail;
-    }
+    int32_t used() const { return top - tail; }
 
-    int32_t available() const {
-        return capacity - used();
-    }
+    int32_t available() const { return capacity - used(); }
 };
 
 // =============================================================================
@@ -502,7 +497,7 @@ struct PTO2DepListPool {
  */
 struct PTO2RingSet {
     PTO2TaskAllocator task_allocator;
-    PTO2DepListPool   dep_pool;
+    PTO2DepListPool dep_pool;
 };
 
-#endif // PTO_RING_BUFFER_H
+#endif  // PTO_RING_BUFFER_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -24,35 +24,23 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 
 thread_local int pto2_current_orch_idx = 0;
 
-void pto2_set_orch_thread_idx(int idx) {
-    pto2_current_orch_idx = idx;
-}
+void pto2_set_orch_thread_idx(int idx) { pto2_current_orch_idx = idx; }
 
 // =============================================================================
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
-static void submit_task_impl(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                             const PTOParam& params) {
-    pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels,
-                           params);
+static void submit_task_impl(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params) {
+    pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels, params);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime* rt) {
-    pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_scope_begin(PTO2Runtime* rt) { pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_scope_end(PTO2Runtime* rt) {
-    pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_scope_end(PTO2Runtime* rt) { pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_orchestration_done(PTO2Runtime* rt) {
-    pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_orchestration_done(PTO2Runtime* rt) { pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]); }
 
-static bool is_fatal_impl(PTO2Runtime* rt) {
-    return rt->orchestrators[pto2_current_orch_idx].fatal;
-}
+static bool is_fatal_impl(PTO2Runtime* rt) { return rt->orchestrators[pto2_current_orch_idx].fatal; }
 
 // Wait for TensorMap producers of this tensor to be safe for data access.
 // For reads: wait until producer COMPLETED (done writing).
@@ -60,8 +48,7 @@ static bool is_fatal_impl(PTO2Runtime* rt) {
 //   (fanout_refcount >= fanout_count - 1, excluding scope reference).
 // Uses cycle-based timeout (checked every 1024 spins).
 // Returns false on timeout (sets orch.fatal).
-static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor,
-                                  bool wait_for_consumers, const char* caller) {
+static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor, bool wait_for_consumers, const char* caller) {
     PTO2OrchestratorState& orch = rt->orchestrators[pto2_current_orch_idx];
     PTO2LookupResult lookup_result;
     orch.tensor_map.lookup(tensor, lookup_result);
@@ -71,20 +58,20 @@ static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor,
         PTO2TaskId producer_id = entry.producer_task_id;
         uint8_t ring_id = producer_id.ring();
         int32_t local_id = producer_id.local();
-        PTO2TaskSlotState& slot =
-            rt->scheduler.ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
+        PTO2TaskSlotState& slot = rt->scheduler.ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
 
         // Wait for producer to complete (WAW safety)
         uint64_t t0 = get_sys_cnt_aicpu();
         int32_t spin_count = 0;
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
             SPIN_WAIT_HINT();
-            if ((++spin_count & 1023) == 0 &&
-                get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+            if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
                 orch.fatal = true;
                 unified_log_error(caller,
                     "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
-                    (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id);
+                    (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES,
+                    ring_id,
+                    local_id);
                 return false;
             }
         }
@@ -95,15 +82,15 @@ static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor,
         if (wait_for_consumers) {
             t0 = get_sys_cnt_aicpu();
             spin_count = 0;
-            while (slot.fanout_refcount.load(std::memory_order_acquire)
-                   < slot.fanout_count - 1) {
+            while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
                 SPIN_WAIT_HINT();
-                if ((++spin_count & 1023) == 0 &&
-                    get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+                if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
                     orch.fatal = true;
                     unified_log_error(caller,
                         "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
-                        (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id);
+                        (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES,
+                        ring_id,
+                        local_id);
                     return false;
                 }
             }
@@ -112,8 +99,7 @@ static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor,
     return true;
 }
 
-uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
-                              uint32_t ndims, const uint32_t indices[]) {
+uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor, uint32_t ndims, const uint32_t indices[]) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(__FUNCTION__,
             "get_tensor_data: buffer not allocated (addr=0). "
@@ -127,16 +113,13 @@ uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
 
     uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
     uint64_t elem_size = get_element_size(tensor.dtype);
-    const void* ptr = reinterpret_cast<const void*>(
-        tensor.buffer.addr + flat_offset * elem_size);
+    const void* ptr = reinterpret_cast<const void*>(tensor.buffer.addr + flat_offset * elem_size);
     uint64_t result = 0;
     memcpy(&result, ptr, elem_size);
     return result;
 }
 
-void pto2_set_tensor_data(PTO2Runtime* rt, Tensor& tensor,
-                          uint32_t ndims, const uint32_t indices[],
-                          uint64_t value) {
+void pto2_set_tensor_data(PTO2Runtime* rt, Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(__FUNCTION__,
             "set_tensor_data: buffer not allocated (addr=0). "
@@ -151,24 +134,23 @@ void pto2_set_tensor_data(PTO2Runtime* rt, Tensor& tensor,
 
     uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
     uint64_t elem_size = get_element_size(tensor.dtype);
-    void* ptr = reinterpret_cast<void*>(
-        tensor.buffer.addr + flat_offset * elem_size);
+    void* ptr = reinterpret_cast<void*>(tensor.buffer.addr + flat_offset * elem_size);
     memcpy(ptr, &value, elem_size);
 }
 
 static const PTO2RuntimeOps s_runtime_ops = {
-    .submit_task          = submit_task_impl,
-    .scope_begin          = pto2_rt_scope_begin,
-    .scope_end            = pto2_rt_scope_end,
-    .orchestration_done   = pto2_rt_orchestration_done,
-    .is_fatal             = is_fatal_impl,
-    .log_error            = unified_log_error,
-    .log_warn             = unified_log_warn,
-    .log_info             = unified_log_info,
-    .log_debug            = unified_log_debug,
-    .log_always           = unified_log_always,
-    .get_tensor_data      = pto2_get_tensor_data,
-    .set_tensor_data      = pto2_set_tensor_data,
+    .submit_task = submit_task_impl,
+    .scope_begin = pto2_rt_scope_begin,
+    .scope_end = pto2_rt_scope_end,
+    .orchestration_done = pto2_rt_orchestration_done,
+    .is_fatal = is_fatal_impl,
+    .log_error = unified_log_error,
+    .log_warn = unified_log_warn,
+    .log_info = unified_log_info,
+    .log_debug = unified_log_debug,
+    .log_always = unified_log_always,
+    .get_tensor_data = pto2_get_tensor_data,
+    .set_tensor_data = pto2_set_tensor_data,
 };
 
 // =============================================================================
@@ -176,15 +158,11 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // =============================================================================
 
 PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode) {
-    return pto2_runtime_create_custom(mode,
-                                       PTO2_TASK_WINDOW_SIZE,
-                                       PTO2_HEAP_SIZE);
+    return pto2_runtime_create_custom(mode, PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
 }
 
-PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
-                                         uint64_t task_window_size,
-                                         uint64_t heap_size,
-                                         int32_t dep_pool_capacity) {
+PTO2Runtime* pto2_runtime_create_custom(
+    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity) {
     // Allocate runtime context
     PTO2Runtime* rt = (PTO2Runtime*)calloc(1, sizeof(PTO2Runtime));
     if (!rt) {
@@ -203,25 +181,24 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
     // Allocate GM heap for output buffers (all rings combined)
     uint64_t total_heap_size = heap_size * PTO2_MAX_RING_DEPTH;
     rt->gm_heap_size = total_heap_size;
-    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-        if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, total_heap_size) != 0) {
-            pto2_sm_destroy(rt->sm_handle);
-            free(rt);
-            return NULL;
-        }
-    #else
-        rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, total_heap_size);
-        if (!rt->gm_heap) {
-            pto2_sm_destroy(rt->sm_handle);
-            free(rt);
-            return NULL;
-        }
-    #endif
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+    if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, total_heap_size) != 0) {
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+#else
+    rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, total_heap_size);
+    if (!rt->gm_heap) {
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+#endif
     rt->gm_heap_owned = true;
 
     // Initialize first orchestrator
-    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle,
-                                 rt->gm_heap, heap_size, dep_pool_capacity)) {
+    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
         free(rt);
@@ -244,11 +221,11 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
 }
 
 PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-                                          PTO2SharedMemoryHandle* sm_handle,
-                                          void* gm_heap,
-                                          uint64_t heap_size,
-                                          int orch_count,
-                                          int32_t dep_pool_capacity) {
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
+    int orch_count,
+    int32_t dep_pool_capacity) {
     if (!sm_handle) return NULL;
     if (orch_count < 1) orch_count = 1;
     if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
@@ -266,8 +243,7 @@ PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
 
     // Initialize all orchestrator states
     for (int i = 0; i < orch_count; i++) {
-        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle,
-                                    rt->gm_heap, heap_size, dep_pool_capacity)) {
+        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
             for (int j = 0; j < i; j++) {
                 pto2_orchestrator_destroy(&rt->orchestrators[j]);
             }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -59,8 +59,7 @@ enum PTO2RuntimeMode {
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
-    void (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                        const PTOParam& params);
+    void (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params);
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
     void (*orchestration_done)(PTO2Runtime* rt);
@@ -75,11 +74,8 @@ struct PTO2RuntimeOps {
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
-                                uint32_t ndims, const uint32_t indices[]);
-    void (*set_tensor_data)(PTO2Runtime* rt, Tensor& tensor,
-                            uint32_t ndims, const uint32_t indices[],
-                            uint64_t value);
+    uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
+    void (*set_tensor_data)(PTO2Runtime* rt, Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value);
 };
 
 /**
@@ -90,24 +86,24 @@ struct PTO2RuntimeOps {
  */
 struct PTO2Runtime {
     // Ops table (first field — used by orchestration .so via function pointers)
-    const PTO2RuntimeOps*   ops;
+    const PTO2RuntimeOps* ops;
 
     // Components
     PTO2SharedMemoryHandle* sm_handle;
-    PTO2OrchestratorState   orchestrators[PTO2_MAX_ORCH_THREADS];
-    int                     orch_count;     // Number of active orchestrator states
-    PTO2SchedulerState      scheduler;
+    PTO2OrchestratorState orchestrators[PTO2_MAX_ORCH_THREADS];
+    int orch_count;  // Number of active orchestrator states
+    PTO2SchedulerState scheduler;
 
     // GM Heap for output buffers
-    void*                   gm_heap;
-    uint64_t                  gm_heap_size;
-    bool                    gm_heap_owned;  // True if we allocated it
+    void* gm_heap;
+    uint64_t gm_heap_size;
+    bool gm_heap_owned;  // True if we allocated it
 
     // Mode
-    PTO2RuntimeMode         mode;
+    PTO2RuntimeMode mode;
 
     // Statistics
-    int64_t                 total_cycles;
+    int64_t total_cycles;
 };
 
 // =============================================================================
@@ -131,9 +127,9 @@ PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode);
  * @return Runtime context, or NULL on failure
  */
 PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
-                                         uint64_t task_window_size,
-                                         uint64_t heap_size,
-                                         int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    uint64_t task_window_size,
+    uint64_t heap_size,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
 
 /**
  * Create runtime from existing shared memory and GM heap (e.g. on device).
@@ -146,11 +142,11 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
  * @return Runtime context, or NULL on failure
  */
 PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-                                          PTO2SharedMemoryHandle* sm_handle,
-                                          void* gm_heap,
-                                          uint64_t heap_size,
-                                          int orch_count = 1,
-                                          int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
+    int orch_count = 1,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
 
 /**
  * Destroy runtime and free all resources
@@ -199,17 +195,14 @@ void pto2_rt_orchestration_done(PTO2Runtime* rt);
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.
  */
-uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
-                              uint32_t ndims, const uint32_t indices[]);
+uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
 
 /**
  * Cross-layer data access: write a value to a tensor at given indices.
  * Waits for producer completion (WAW) and all consumers (WAR) via TensorMap.
  * See set_tensor_data in pto_orchestration_api.h for full documentation.
  */
-void pto2_set_tensor_data(PTO2Runtime* rt, Tensor& tensor,
-                          uint32_t ndims, const uint32_t indices[],
-                          uint64_t value);
+void pto2_set_tensor_data(PTO2Runtime* rt, Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value);
 
 /**
  * Slim config struct exported by orchestration .so via aicpu_orchestration_config().
@@ -218,8 +211,8 @@ void pto2_set_tensor_data(PTO2Runtime* rt, Tensor& tensor,
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
 struct PTO2OrchestrationConfig {
-    int         expected_arg_count;
+    int expected_arg_count;
 };
 #endif
 
-#endif // PTO_RUNTIME2_H
+#endif  // PTO_RUNTIME2_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -60,15 +60,15 @@
 // =============================================================================
 
 // Orchestrator errors (1-99): detected in orchestrator thread
-#define PTO2_ERROR_NONE                       0
-#define PTO2_ERROR_SCOPE_DEADLOCK             1
-#define PTO2_ERROR_HEAP_RING_DEADLOCK         2
-#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK      3
-#define PTO2_ERROR_DEP_POOL_OVERFLOW          4
-#define PTO2_ERROR_INVALID_PARAM              5   // PTOParam construction error (invalid params)
+#define PTO2_ERROR_NONE 0
+#define PTO2_ERROR_SCOPE_DEADLOCK 1
+#define PTO2_ERROR_HEAP_RING_DEADLOCK 2
+#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK 3
+#define PTO2_ERROR_DEP_POOL_OVERFLOW 4
+#define PTO2_ERROR_INVALID_PARAM 5  // PTOParam construction error (invalid params)
 
 // Scheduler errors (100+): detected in scheduler threads
-#define PTO2_ERROR_SCHEDULER_TIMEOUT          100
+#define PTO2_ERROR_SCHEDULER_TIMEOUT 100
 
 // =============================================================================
 // Configuration Constants
@@ -78,33 +78,33 @@
 // NOTE: PTO2_TASK_WINDOW_SIZE is now a per-ring default value.
 // Actual window size is passed at runtime to pto2_runtime_create_threaded_custom().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
-#define PTO2_TASK_WINDOW_SIZE     16384   // Default per-ring task window size (power of 2)
+#define PTO2_TASK_WINDOW_SIZE 16384  // Default per-ring task window size (power of 2)
 
 // Multi-ring: number of independent ring layers (HeapRing + TaskRing + DepPool per layer)
 // Scope depth maps to ring index via: min(scope_depth, PTO2_MAX_RING_DEPTH - 1)
-#define PTO2_MAX_RING_DEPTH       4
+#define PTO2_MAX_RING_DEPTH 4
 
 // Memory pools (per-ring defaults; total = value × PTO2_MAX_RING_DEPTH)
-#define PTO2_HEAP_SIZE            (256 * 1024 * 1024)  // 256MB per ring (1GB total)
-#define PTO2_DEP_LIST_POOL_SIZE    16384    // Per-ring dependency list pool entries
-#define PTO2_TENSORMAP_POOL_SIZE   (65536)   // TensorMap entry pool
+#define PTO2_HEAP_SIZE (256 * 1024 * 1024)  // 256MB per ring (1GB total)
+#define PTO2_DEP_LIST_POOL_SIZE 16384       // Per-ring dependency list pool entries
+#define PTO2_TENSORMAP_POOL_SIZE (65536)    // TensorMap entry pool
 #define PTO2_TENSORMAP_NUM_BUCKETS 4096     // Power of 2 for fast hash (4096×8B=32KB fits L1)
 
 // Scope management
-#define PTO2_MAX_SCOPE_DEPTH      64      // Maximum nesting depth
-#define PTO2_SCOPE_TASKS_INIT_CAP 65536     // Initial capacity for scope task buffer
+#define PTO2_MAX_SCOPE_DEPTH 64          // Maximum nesting depth
+#define PTO2_SCOPE_TASKS_INIT_CAP 65536  // Initial capacity for scope task buffer
 
 // Ready queue
-#define PTO2_READY_QUEUE_SIZE     65536   // Per-shape queue size
+#define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size
 
 // Memory alignment
-#define PTO2_ALIGN_SIZE           64      // Cache line alignment
-#define PTO2_PACKED_OUTPUT_ALIGN  1024    // Each output in packed buffer aligned to 1024B; gap is padding
-#define PTO2_ALIGN_UP(x, align)   (((x) + (align) - 1) & ~((align) - 1))
+#define PTO2_ALIGN_SIZE 64             // Cache line alignment
+#define PTO2_PACKED_OUTPUT_ALIGN 1024  // Each output in packed buffer aligned to 1024B; gap is padding
+#define PTO2_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
 
 // TensorMap cleanup interval
 #define PTO2_TENSORMAP_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
-#define PTO2_DEP_POOL_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
+#define PTO2_DEP_POOL_CLEANUP_INTERVAL 64   // Cleanup every N retired tasks
 
 // get_tensor_data/set_tensor_data spin wait timeout in cycles.
 // ~10s on hardware (1.5 GHz counter), ~10s on simulation (chrono-based).
@@ -150,10 +150,10 @@ static inline PTO2TaskId pto2_make_task_id(uint8_t ring_id, uint32_t local_id) {
  * Each worker type has its own ready queue for load balancing
  */
 typedef enum {
-    PTO2_WORKER_CUBE = 0,       // AICore CUBE unit (matrix ops)
-    PTO2_WORKER_VECTOR = 1,     // AICore VECTOR unit (element-wise ops)
-    PTO2_WORKER_AI_CPU = 2,     // AI_CPU (scalar ops, control flow)
-    PTO2_WORKER_ACCELERATOR = 3,// Fixed-function accelerators (DMA, etc.)
+    PTO2_WORKER_CUBE = 0,         // AICore CUBE unit (matrix ops)
+    PTO2_WORKER_VECTOR = 1,       // AICore VECTOR unit (element-wise ops)
+    PTO2_WORKER_AI_CPU = 2,       // AI_CPU (scalar ops, control flow)
+    PTO2_WORKER_ACCELERATOR = 3,  // Fixed-function accelerators (DMA, etc.)
     PTO2_NUM_WORKER_TYPES = 4
 } PTO2WorkerType;
 
@@ -186,21 +186,21 @@ typedef enum {
 /**
  * Maximum dimensions supported for logical tensors
  */
-#define PTO2_MAX_TENSOR_DIM   8
+#define PTO2_MAX_TENSOR_DIM 8
 
 /**
  * Maximum depth of layout history for HBB overlap detection
  * Simple (contiguous) tensor has depth=1, non-contiguous has depth>1
  */
-#define PTO2_MAX_LAYOUT_DEPTH     8
+#define PTO2_MAX_LAYOUT_DEPTH 8
 
 /**
  * Layout operation type for HBB
  */
 typedef enum {
-    PTO2_LAYOUT_VIEW = 0,         // View/slice: records bounding box
-    PTO2_LAYOUT_RESHAPE = 1,      // Reshape: records new shape
-    PTO2_LAYOUT_TRANSPOSE = 2     // Transpose: records permutation
+    PTO2_LAYOUT_VIEW = 0,      // View/slice: records bounding box
+    PTO2_LAYOUT_RESHAPE = 1,   // Reshape: records new shape
+    PTO2_LAYOUT_TRANSPOSE = 2  // Transpose: records permutation
 } PTO2LayoutOpType;
 
 /**
@@ -210,9 +210,9 @@ typedef enum {
 typedef struct {
     PTO2LayoutOpType type;
     union {
-        struct {  // PTO2_LAYOUT_VIEW
-            int64_t bbox_min;     // First byte accessed
-            int64_t bbox_max;     // Last byte accessed
+        struct {               // PTO2_LAYOUT_VIEW
+            int64_t bbox_min;  // First byte accessed
+            int64_t bbox_max;  // Last byte accessed
         } view;
         struct {  // PTO2_LAYOUT_RESHAPE
             int32_t ndim;
@@ -229,13 +229,13 @@ typedef struct {
  * Tensor extraction type (for tracking how tensor was created)
  */
 typedef enum {
-    PTO2_TENSOR_RAW = 0,           // Original raw tensor (owns storage)
-    PTO2_TENSOR_VIEW = 1,          // view() - subset selection, shared storage
-    PTO2_TENSOR_RESHAPE = 2,       // reshape() - shape change, shared storage
-    PTO2_TENSOR_TRANSPOSE = 3,     // transpose() - dimension permute, shared storage
-    PTO2_TENSOR_DEEP_VIEW = 4,     // deep_view() - copied subset, new storage
-    PTO2_TENSOR_DEEP_RESHAPE = 5,  // deep_reshape() - copied reshape, new storage
-    PTO2_TENSOR_DEEP_TRANSPOSE = 6 // deep_transpose() - copied transpose, new storage
+    PTO2_TENSOR_RAW = 0,            // Original raw tensor (owns storage)
+    PTO2_TENSOR_VIEW = 1,           // view() - subset selection, shared storage
+    PTO2_TENSOR_RESHAPE = 2,        // reshape() - shape change, shared storage
+    PTO2_TENSOR_TRANSPOSE = 3,      // transpose() - dimension permute, shared storage
+    PTO2_TENSOR_DEEP_VIEW = 4,      // deep_view() - copied subset, new storage
+    PTO2_TENSOR_DEEP_RESHAPE = 5,   // deep_reshape() - copied reshape, new storage
+    PTO2_TENSOR_DEEP_TRANSPOSE = 6  // deep_transpose() - copied transpose, new storage
 } PTO2TensorExtractionType;
 
 /**
@@ -245,10 +245,10 @@ typedef enum {
  * Multiple logical tensors can share the same raw tensor (aliasing).
  */
 typedef struct {
-    void*    base_ptr;        // Base pointer of allocated memory
-    int64_t  total_size;      // Total size in bytes
-    int32_t  refcount;        // Number of logical tensors referencing this storage
-                              // (for memory management, 0 = can be freed)
+    void* base_ptr;      // Base pointer of allocated memory
+    int64_t total_size;  // Total size in bytes
+    int32_t refcount;    // Number of logical tensors referencing this storage
+                         // (for memory management, 0 = can be freed)
 } PTO2RawTensor;
 
 /**
@@ -272,32 +272,32 @@ typedef struct {
  */
 typedef struct {
     // === Raw tensor reference (shared storage) ===
-    void*    raw_base;            // Pointer to raw tensor's base (for aliasing check)
-    int64_t  raw_total_size;      // Total size of raw tensor in bytes
+    void* raw_base;          // Pointer to raw tensor's base (for aliasing check)
+    int64_t raw_total_size;  // Total size of raw tensor in bytes
 
     // === Storage offset ===
-    int64_t  storage_offset;      // Byte offset from raw_base to first element
+    int64_t storage_offset;  // Byte offset from raw_base to first element
 
     // === Shape and strides ===
-    int64_t  shape[PTO2_MAX_TENSOR_DIM];    // Size in each dimension
-    int64_t  strides[PTO2_MAX_TENSOR_DIM];  // Byte stride in each dimension
-    int32_t  ndim;                          // Number of dimensions (0 = scalar)
+    int64_t shape[PTO2_MAX_TENSOR_DIM];    // Size in each dimension
+    int64_t strides[PTO2_MAX_TENSOR_DIM];  // Byte stride in each dimension
+    int32_t ndim;                          // Number of dimensions (0 = scalar)
 
     // === Precomputed bounding box (for fast overlap detection) ===
-    int64_t  min_byte_offset;     // First byte accessed (relative to raw_base)
-    int64_t  max_byte_offset;     // Last byte accessed (relative to raw_base)
+    int64_t min_byte_offset;  // First byte accessed (relative to raw_base)
+    int64_t max_byte_offset;  // Last byte accessed (relative to raw_base)
 
     // === Element info ===
-    int64_t  elem_size;           // Size of each element in bytes
-    int64_t  numel;               // Total number of elements
+    int64_t elem_size;  // Size of each element in bytes
+    int64_t numel;      // Total number of elements
 
     // === Extraction tracking ===
     PTO2TensorExtractionType extraction_type;  // How this tensor was created
-    bool     is_contiguous;       // True if memory is contiguous (no gaps)
-                                  // Equivalent to layout_depth == 1
+    bool is_contiguous;                        // True if memory is contiguous (no gaps)
+                                               // Equivalent to layout_depth == 1
 
     // === Layout history for HBB overlap detection ===
-    int32_t  layout_depth;                           // Number of layout ops (1=simple)
+    int32_t layout_depth;                            // Number of layout ops (1=simple)
     PTO2LayoutOp layout_ops[PTO2_MAX_LAYOUT_DEPTH];  // Derivation history
 
 } PTO2LogicalTensor;
@@ -314,8 +314,8 @@ typedef struct {
  */
 struct PTO2TaskSlotState;  // Forward declaration
 struct PTO2DepListEntry {
-    PTO2TaskSlotState* slot_state;    // Consumer slot state (direct pointer)
-    PTO2DepListEntry* next;           // next entry
+    PTO2TaskSlotState* slot_state;  // Consumer slot state (direct pointer)
+    PTO2DepListEntry* next;         // next entry
 };
 
 // =============================================================================
@@ -333,14 +333,14 @@ struct PTO2DepListEntry {
  */
 struct PTO2TaskDescriptor {
     // Mixed-task identification (encodes ring_id in upper 32 bits)
-    PTO2TaskId task_id;         // raw: (ring_id << 32) | local_id
+    PTO2TaskId task_id;  // raw: (ring_id << 32) | local_id
 
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];
 
     // Packed output buffer (all outputs packed into single contiguous buffer)
-    void*    packed_buffer_base;  // Start of packed buffer in GM Heap
-    void*    packed_buffer_end;   // End of packed buffer (for heap reclamation)
+    void* packed_buffer_base;  // Start of packed buffer in GM Heap
+    void* packed_buffer_end;   // End of packed buffer (for heap reclamation)
 };
 
 // =============================================================================
@@ -362,9 +362,9 @@ struct PTO2TaskPayload {
     // === Cache line 0 (64B) — metadata ===
     int32_t tensor_count{0};
     int32_t scalar_count{0};
-    int32_t fanin_actual_count{0};             // Actual fanin count (without the +1 redundance)
-    int32_t _reserved{0};                      // Reserved (dep_pool_mark moved to SlotState for local access)
-    PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS]; // Producer slot states (used by on_task_release)
+    int32_t fanin_actual_count{0};  // Actual fanin count (without the +1 redundance)
+    int32_t _reserved{0};           // Reserved (dep_pool_mark moved to SlotState for local access)
+    PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
     // === Tensors (2048B) — alignas(64) Tensor forces alignment ===
     Tensor tensors[PTO2_MAX_TENSOR_PARAMS];
     // === Pre-built args for AICore dispatch (1152B = 16 tensor ptrs + 128 scalars) ===
@@ -388,8 +388,9 @@ struct PTO2TaskPayload {
         }
         // Bulk-copy scalars into dispatch_args[tensor_count..], rounded up to
         // cache-line boundary (extra bytes within the same CL cost nothing).
-        memcpy(&dispatch_args[params.tensor_count], params.scalars,
-               PTO2_ALIGN_UP(params.scalar_count * sizeof(uint64_t), 64));
+        memcpy(&dispatch_args[params.tensor_count],
+            params.scalars,
+            PTO2_ALIGN_UP(params.scalar_count * sizeof(uint64_t), 64));
     }
 };
 
@@ -407,17 +408,17 @@ struct PTO2TaskPayload {
  */
 struct alignas(64) PTO2TaskSlotState {
     // Fanout lock + list (accessed together under lock in on_task_complete)
-    std::atomic<int32_t> fanout_lock;       // Per-task spinlock (0=unlocked, 1=locked)
-    int32_t fanout_count;                    // 1 (owning scope) + number of consumers
+    std::atomic<int32_t> fanout_lock;  // Per-task spinlock (0=unlocked, 1=locked)
+    int32_t fanout_count;              // 1 (owning scope) + number of consumers
 
-    PTO2DepListEntry* fanout_head;           // Pointer to first fanout entry (nullptr = empty)
+    PTO2DepListEntry* fanout_head;  // Pointer to first fanout entry (nullptr = empty)
 
     // Task state (completion, consumed check, ready check)
-    std::atomic<PTO2TaskState> task_state;   // PENDING/READY/RUNNING/COMPLETED/CONSUMED
+    std::atomic<PTO2TaskState> task_state;  // PENDING/READY/RUNNING/COMPLETED/CONSUMED
 
     // Fanin (accessed together in release_fanin_and_check_ready)
-    std::atomic<int32_t> fanin_refcount;     // Dynamic: counts completed producers
-    int32_t fanin_count;                      // Number of producer dependencies (set once)
+    std::atomic<int32_t> fanin_refcount;  // Dynamic: counts completed producers
+    int32_t fanin_count;                  // Number of producer dependencies (set once)
 
     // Fanout refcount (accessed with fanout_count in check_and_handle_consumed)
     std::atomic<int32_t> fanout_refcount;  // Dynamic: counts released references
@@ -427,10 +428,10 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2TaskDescriptor* task;
 
     // Hot-path completion fields (moved from TaskDescriptor to avoid cross-struct access)
-    uint8_t active_mask;                         // Bitmask of active subtask slots (set once)
-    std::atomic<uint8_t> subtask_done_mask;      // Each subtask sets its done bit on completion
-    uint8_t ring_id;                             // Ring layer this task belongs to (for per-ring reclamation)
-    int32_t dep_pool_mark{0};                    // Dep pool top after this task's submission (orchestrator-only, local memory)
+    uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
+    std::atomic<uint8_t> subtask_done_mask;  // Each subtask sets its done bit on completion
+    uint8_t ring_id;                         // Ring layer this task belongs to (for per-ring reclamation)
+    int32_t dep_pool_mark{0};  // Dep pool top after this task's submission (orchestrator-only, local memory)
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);
@@ -463,11 +464,11 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
  * Memory barrier macros for different architectures
  */
 #if defined(__aarch64__)
-    #define PTO2_MEMORY_BARRIER()     __asm__ __volatile__("dmb sy" ::: "memory")
+#define PTO2_MEMORY_BARRIER() __asm__ __volatile__("dmb sy" ::: "memory")
 #elif defined(__x86_64__)
-    #define PTO2_MEMORY_BARRIER()     __asm__ __volatile__("mfence" ::: "memory")
+#define PTO2_MEMORY_BARRIER() __asm__ __volatile__("mfence" ::: "memory")
 #else
-    #define PTO2_MEMORY_BARRIER()     __sync_synchronize()
+#define PTO2_MEMORY_BARRIER() __sync_synchronize()
 #endif
 
 // Spin-wait hint for AICPU threads.  On real hardware the AICPU has dedicated
@@ -498,8 +499,7 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 #endif
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state,
-                                     uint64_t& atomic_count, uint64_t& wait_cycle) {
+static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& atomic_count, uint64_t& wait_cycle) {
     uint64_t t0 = get_sys_cnt_aicpu();
     bool contended = false;
     uint32_t atomic_ops = 0;
@@ -511,8 +511,8 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state,
             SPIN_WAIT_HINT();
         }
         int32_t expected = 0;
-        if (slot_state.fanout_lock.compare_exchange_weak(expected, 1,
-                                        std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (slot_state.fanout_lock.compare_exchange_weak(
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             atomic_ops++;  // successful CAS = 1 atomic
             atomic_count += atomic_ops;
             if (contended) {
@@ -532,8 +532,8 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state) {
             SPIN_WAIT_HINT();
         }
         int32_t expected = 0;
-        if (slot_state.fanout_lock.compare_exchange_weak(expected, 1,
-                                        std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (slot_state.fanout_lock.compare_exchange_weak(
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             return;
         }
     }
@@ -543,4 +543,4 @@ static inline void pto2_fanout_unlock(PTO2TaskSlotState& slot_state) {
     slot_state.fanout_lock.store(0, std::memory_order_release);
 }
 
-#endif // PTO_RUNTIME2_TYPES_H
+#endif  // PTO_RUNTIME2_TYPES_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -59,12 +59,18 @@ PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
 
 const char* pto2_task_state_name(PTO2TaskState state) {
     switch (state) {
-        case PTO2_TASK_PENDING:   return "PENDING";
-        case PTO2_TASK_READY:     return "READY";
-        case PTO2_TASK_RUNNING:   return "RUNNING";
-        case PTO2_TASK_COMPLETED: return "COMPLETED";
-        case PTO2_TASK_CONSUMED:  return "CONSUMED";
-        default:                  return "UNKNOWN";
+        case PTO2_TASK_PENDING:
+            return "PENDING";
+        case PTO2_TASK_READY:
+            return "READY";
+        case PTO2_TASK_RUNNING:
+            return "RUNNING";
+        case PTO2_TASK_COMPLETED:
+            return "COMPLETED";
+        case PTO2_TASK_CONSUMED:
+            return "CONSUMED";
+        default:
+            return "UNKNOWN";
     }
 }
 
@@ -102,8 +108,7 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
 // Scheduler Initialization
 // =============================================================================
 
-bool PTO2SchedulerState::RingSchedState::init(
-    PTO2SharedMemoryHandle* sm_handle, int32_t ring_id) {
+bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHandle* sm_handle, int32_t ring_id) {
     task_descriptors = sm_handle->task_descriptors[ring_id];
     task_window_size = sm_handle->header->rings[ring_id].task_window_size;
     task_window_mask = static_cast<int32_t>(task_window_size - 1);
@@ -142,8 +147,7 @@ void PTO2SchedulerState::RingSchedState::destroy() {
     slot_states = nullptr;
 }
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle) {
+bool pto2_scheduler_init(PTO2SchedulerState* sched, PTO2SharedMemoryHandle* sm_handle) {
     sched->sm_handle = sm_handle;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -212,8 +216,7 @@ void pto2_scheduler_print_queues(PTO2SchedulerState* sched) {
     const char* shape_names[] = {"AIC", "AIV", "MIX"};
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        LOG_INFO("  %s: count=%" PRIu64, shape_names[i],
-                 sched->ready_queues[i].size());
+        LOG_INFO("  %s: count=%" PRIu64, shape_names[i], sched->ready_queues[i].size());
     }
 
     LOG_INFO("====================");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -30,7 +30,12 @@
 #if PTO2_SCHED_PROFILING
 #include "aicpu/device_time.h"
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
-#define PTO2_SCHED_CYCLE_LAP(acc) do { _st1 = get_sys_cnt_aicpu(); acc += (_st1 - _st0); _st0 = _st1; } while(0)
+#define PTO2_SCHED_CYCLE_LAP(acc)   \
+    do {                            \
+        _st1 = get_sys_cnt_aicpu(); \
+        acc += (_st1 - _st0);       \
+        _st0 = _st1;                \
+    } while (0)
 #endif
 
 // =============================================================================
@@ -78,9 +83,7 @@ struct PTO2LocalReadyBuffer {
         return false;
     }
 
-    PTO2TaskSlotState* pop() {
-        return (count > 0) ? slot_states[--count] : nullptr;
-    }
+    PTO2TaskSlotState* pop() { return (count > 0) ? slot_states[--count] : nullptr; }
 };
 
 /**
@@ -96,14 +99,14 @@ struct PTO2LocalReadyBuffer {
 struct alignas(64) PTO2ReadyQueue {
     PTO2ReadyQueueSlot* slots;
     uint64_t capacity;
-    uint64_t mask;                          // capacity - 1
-    char _pad0[64 - 24];                   // Pad to own cache line
+    uint64_t mask;        // capacity - 1
+    char _pad0[64 - 24];  // Pad to own cache line
 
     std::atomic<uint64_t> enqueue_pos;
-    char _pad1[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad1[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     std::atomic<uint64_t> dequeue_pos;
-    char _pad2[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad2[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     uint64_t size() {
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -120,8 +123,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)pos;
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     break;
                 }
             } else if (diff < 0) {
@@ -155,8 +158,8 @@ struct alignas(64) PTO2ReadyQueue {
             if (!ready) {
                 continue;
             }
-            if (enqueue_pos.compare_exchange_weak(pos, pos + count,
-                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+            if (enqueue_pos.compare_exchange_weak(
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed)) {
                 break;
             }
         }
@@ -182,8 +185,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - (int64_t)pos;
             atomic_ops += 2;  // enqueue_pos.load + sequence.load
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -223,8 +226,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)(pos + 1);
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed))
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed))
                     break;
             } else if (diff < 0) {
                 return nullptr;  // Queue empty
@@ -258,8 +261,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - (int64_t)(pos + 1);
             atomic_ops += 2;  // dequeue_pos.load + sequence.load
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -308,8 +311,8 @@ struct alignas(64) PTO2ReadyQueue {
             }
             if (count == 0) return 0;
             if (count < 0) continue;
-            if (dequeue_pos.compare_exchange_weak(pos, pos + count,
-                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+            if (dequeue_pos.compare_exchange_weak(
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed)) {
                 break;
             }
         }
@@ -356,8 +359,8 @@ struct alignas(64) PTO2ReadyQueue {
             if (count < 0) {
                 continue;
             }
-            if (dequeue_pos.compare_exchange_weak(pos, pos + count,
-                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+            if (dequeue_pos.compare_exchange_weak(
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed)) {
                 atomic_ops++;  // successful CAS
                 break;
             }
@@ -392,10 +395,10 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
  * Statistics returned by mixed-task completion processing
  */
 struct PTO2CompletionStats {
-    int32_t fanout_edges;      // Number of fanout edges traversed (notify consumers)
-    int32_t tasks_enqueued;    // Number of consumers that became READY
-    int32_t fanin_edges;       // Number of fanin edges traversed (release producers)
-    bool mixed_task_completed; // True only when this callback completed a mixed task
+    int32_t fanout_edges;       // Number of fanout edges traversed (notify consumers)
+    int32_t tasks_enqueued;     // Number of consumers that became READY
+    int32_t fanin_edges;        // Number of fanin edges traversed (release producers)
+    bool mixed_task_completed;  // True only when this callback completed a mixed task
 };
 
 /**
@@ -425,9 +428,7 @@ struct PTO2SchedulerState {
         PTO2TaskSlotState& get_slot_state_by_task_id(int32_t local_id) {
             return slot_states[local_id & task_window_mask];
         }
-        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) {
-            return slot_states[slot];
-        }
+        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
         void sync_to_sm(PTO2SharedMemoryRingHeader& ring) {
             ring.fc.last_task_alive.store(last_task_alive, std::memory_order_release);
@@ -470,8 +471,8 @@ struct PTO2SchedulerState {
         if (slot_state.fanout_refcount.load(std::memory_order_acquire) != slot_state.fanout_count) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire)) {
             return;
         }
 
@@ -482,8 +483,8 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
         }
@@ -499,8 +500,8 @@ struct PTO2SchedulerState {
         if (rc != fc) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire)) {
             atomic_count += 1;  // failed CAS
             return;
         }
@@ -514,8 +515,8 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
             atomic_count += 2;  // try-lock CAS + unlock store
@@ -581,8 +582,8 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    int get_ready_tasks_batch(PTO2ResourceShape shape, PTO2LocalReadyBuffer& local_buf,
-                              PTO2TaskSlotState** out, int max_count) {
+    int get_ready_tasks_batch(
+        PTO2ResourceShape shape, PTO2LocalReadyBuffer& local_buf, PTO2TaskSlotState** out, int max_count) {
         int count = 0;
         while (count < max_count && local_buf.count > 0) {
             out[count++] = local_buf.slot_states[--local_buf.count];
@@ -595,9 +596,13 @@ struct PTO2SchedulerState {
     }
 
 #if PTO2_SCHED_PROFILING
-    int get_ready_tasks_batch(PTO2ResourceShape shape, PTO2LocalReadyBuffer& local_buf,
-                              PTO2TaskSlotState** out, int max_count,
-                              uint64_t& atomic_count, uint64_t& wait_cycle, uint64_t& local_dispatch_count) {
+    int get_ready_tasks_batch(PTO2ResourceShape shape,
+        PTO2LocalReadyBuffer& local_buf,
+        PTO2TaskSlotState** out,
+        int max_count,
+        uint64_t& atomic_count,
+        uint64_t& wait_cycle,
+        uint64_t& local_dispatch_count) {
         int count = 0;
         while (count < max_count && local_buf.count > 0) {
             local_dispatch_count++;
@@ -605,8 +610,8 @@ struct PTO2SchedulerState {
         }
         int remaining = max_count - count;
         if (remaining > 0) {
-            count += ready_queues[static_cast<int32_t>(shape)].pop_batch(
-                out + count, remaining, atomic_count, wait_cycle);
+            count +=
+                ready_queues[static_cast<int32_t>(shape)].pop_batch(out + count, remaining, atomic_count, wait_cycle);
         }
         return count;
     }
@@ -655,7 +660,7 @@ struct PTO2SchedulerState {
 #else
     void
 #endif
-    on_mixed_task_complete(PTO2TaskSlotState& slot_state, 
+    on_mixed_task_complete(PTO2TaskSlotState& slot_state,
 #if PTO2_SCHED_PROFILING
         int thread_idx,
 #endif
@@ -696,8 +701,7 @@ struct PTO2SchedulerState {
             PTO2TaskSlotState& consumer_slot = *current->slot_state;
 #if PTO2_SCHED_PROFILING
             stats.fanout_edges++;
-            if (release_fanin_and_check_ready(consumer_slot,
-                                               fanout_atomics, push_wait, local_bufs)) {
+            if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait, local_bufs)) {
                 stats.tasks_enqueued++;
             }
 #else
@@ -762,8 +766,7 @@ struct PTO2SchedulerState {
 // Scheduler API (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle);
+bool pto2_scheduler_init(PTO2SchedulerState* sched, PTO2SharedMemoryHandle* sm_handle);
 void pto2_scheduler_destroy(PTO2SchedulerState* sched);
 
 // =============================================================================
@@ -787,9 +790,9 @@ struct PTO2SchedProfilingData {
     uint64_t self_consumed_cycle;  // self check_and_handle_consumed
 
     // Wait times
-    uint64_t lock_wait_cycle;      // spin-wait in fanout_lock
-    uint64_t push_wait_cycle;      // CAS contention in push()
-    uint64_t pop_wait_cycle;       // CAS contention in pop()
+    uint64_t lock_wait_cycle;  // spin-wait in fanout_lock
+    uint64_t push_wait_cycle;  // CAS contention in push()
+    uint64_t pop_wait_cycle;   // CAS contention in pop()
 
     // Atomic counts per sub-phase
     uint64_t lock_atomic_count;
@@ -798,7 +801,7 @@ struct PTO2SchedProfilingData {
     uint64_t self_atomic_count;
     uint64_t pop_atomic_count;
 
-    int64_t  complete_count;
+    int64_t complete_count;
 };
 
 /**
@@ -808,4 +811,4 @@ struct PTO2SchedProfilingData {
 PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
 #endif
 
-#endif // PTO_SCHEDULER_H
+#endif  // PTO_SCHEDULER_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -45,8 +45,7 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
 // =============================================================================
 
 static void pto2_sm_setup_pointers_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+    PTO2SharedMemoryHandle* handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
     char* ptr = (char*)handle->sm_base;
 
     // Header
@@ -71,8 +70,7 @@ static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle* handle, uint64_t task
     pto2_sm_setup_pointers_per_ring(handle, task_window_sizes);
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size) {
+PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size, uint64_t heap_size) {
     // Allocate handle
     PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) {
@@ -82,19 +80,19 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     // Calculate total size
     uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
 
-    // Allocate shared memory (aligned for DMA efficiency)
-    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-        if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
-            free(handle);
-            return NULL;
-        }
-    #else
-        handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
-        if (!handle->sm_base) {
-            free(handle);
-            return NULL;
-        }
-    #endif
+// Allocate shared memory (aligned for DMA efficiency)
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+    if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
+        free(handle);
+        return NULL;
+    }
+#else
+    handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
+    if (!handle->sm_base) {
+        free(handle);
+        return NULL;
+    }
+#endif
 
     handle->sm_size = sm_size;
     handle->is_owner = true;
@@ -111,15 +109,10 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     return handle;
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create_default(void) {
-    return pto2_sm_create(PTO2_TASK_WINDOW_SIZE,
-                          PTO2_HEAP_SIZE);
-}
+PTO2SharedMemoryHandle* pto2_sm_create_default(void) { return pto2_sm_create(PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE); }
 
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size) {
+PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(
+    void* sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size) {
     if (!sm_base || sm_size == 0) return NULL;
 
     uint64_t required = pto2_sm_calculate_size(task_window_size);
@@ -153,9 +146,7 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle* handle) {
 // =============================================================================
 //
 // no need init data in pool, init pool data when used
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size) {
+void pto2_sm_init_header(PTO2SharedMemoryHandle* handle, uint64_t task_window_size, uint64_t heap_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -165,8 +156,7 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
     pto2_sm_init_header_per_ring(handle, task_window_sizes, heap_sizes);
 }
 
-void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
+void pto2_sm_init_header_per_ring(PTO2SharedMemoryHandle* handle,
     const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]) {
     PTO2SharedMemoryHeader* header = handle->header;
@@ -217,7 +207,8 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
         LOG_INFO("  task_window_size: %" PRIu64, h->rings[r].task_window_size);
         LOG_INFO("  heap_size:        %" PRIu64 " bytes", h->rings[r].heap_size);
         LOG_INFO("  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")",
-                 h->rings[r].task_descriptors_offset, h->rings[r].task_descriptors_offset);
+            h->rings[r].task_descriptors_offset,
+            h->rings[r].task_descriptors_offset);
         LOG_INFO("  heap_top:         %" PRIu64, h->rings[r].fc.heap_top.load(std::memory_order_acquire));
         LOG_INFO("  heap_tail:        %" PRIu64, h->rings[r].fc.heap_tail.load(std::memory_order_acquire));
         LOG_INFO("  current_task_idx: %d", h->rings[r].fc.current_task_index.load(std::memory_order_acquire));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -50,9 +50,9 @@ struct PTO2RingFlowControl {
     int32_t _pad0;                            // Alignment padding
 
     // Written by Scheduler, Read by Orchestrator (for back-pressure)
-    std::atomic<uint64_t> heap_tail;          // Heap ring free pointer
-    std::atomic<int32_t> last_task_alive;     // Task ring tail (oldest active task)
-    int32_t _pad1;                            // Alignment padding
+    std::atomic<uint64_t> heap_tail;       // Heap ring free pointer
+    std::atomic<int32_t> last_task_alive;  // Task ring tail (oldest active task)
+    int32_t _pad1;                         // Alignment padding
 
     void init() {
         heap_top.store(0, std::memory_order_relaxed);
@@ -86,7 +86,7 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
 
     // === GLOBAL FIELDS ===
-    std::atomic<int32_t> orchestrator_done;   // Flag: orchestration complete
+    std::atomic<int32_t> orchestrator_done;  // Flag: orchestration complete
 
     // Total shared memory size (for validation)
     uint64_t total_size;
@@ -104,13 +104,13 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
 
     // Scheduler error state (Scheduler → Host, independent of orchestrator)
     // Written by scheduler threads on timeout; read by orchestrator and host.
-    std::atomic<int32_t> sched_error_bitmap;   // Bit X set = thread X had error
-    std::atomic<int32_t> sched_error_code;     // Last scheduler error code (last-writer-wins)
-    std::atomic<int32_t> sched_error_thread;   // Thread index of last error writer
+    std::atomic<int32_t> sched_error_bitmap;  // Bit X set = thread X had error
+    std::atomic<int32_t> sched_error_code;    // Last scheduler error code (last-writer-wins)
+    std::atomic<int32_t> sched_error_thread;  // Thread index of last error writer
 };
 
 static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
-              "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)");
+    "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)");
 
 // =============================================================================
 // Shared Memory Handle
@@ -121,17 +121,16 @@ static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
  * Provides both Orchestrator and Scheduler views of the same memory
  */
 struct PTO2SharedMemoryHandle {
-    void*   sm_base;              // Base address of shared memory
-    uint64_t sm_size;             // Total size of shared memory
+    void* sm_base;     // Base address of shared memory
+    uint64_t sm_size;  // Total size of shared memory
 
     // Quick pointers into shared memory regions (per-ring)
     PTO2SharedMemoryHeader* header;
-    PTO2TaskDescriptor*     task_descriptors[PTO2_MAX_RING_DEPTH];
-    PTO2TaskPayload*        task_payloads[PTO2_MAX_RING_DEPTH];
+    PTO2TaskDescriptor* task_descriptors[PTO2_MAX_RING_DEPTH];
+    PTO2TaskPayload* task_payloads[PTO2_MAX_RING_DEPTH];
 
     // Ownership flag
-    bool    is_owner;             // True if this handle allocated the memory
-
+    bool is_owner;  // True if this handle allocated the memory
 };
 
 // =============================================================================
@@ -161,8 +160,7 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
  * @param heap_size         Heap size per ring for output buffers
  * @return Handle with both views, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size);
+PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Create shared memory with default sizes
@@ -179,10 +177,8 @@ PTO2SharedMemoryHandle* pto2_sm_create_default(void);
  * @param heap_size          Heap size per ring (for layout; buffer has no heap region)
  * @return Handle, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size);
+PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(
+    void* sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Destroy shared memory and free resources
@@ -193,15 +189,12 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle* handle);
  * Initialize shared memory header with layout information
  * Called after memory is allocated
  */
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size);
+void pto2_sm_init_header(PTO2SharedMemoryHandle* handle, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Initialize shared memory header with per-ring layout information.
  */
-void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
+void pto2_sm_init_header_per_ring(PTO2SharedMemoryHandle* handle,
     const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]);
 
@@ -224,4 +217,4 @@ bool pto2_sm_validate(PTO2SharedMemoryHandle* handle);
 }
 #endif
 
-#endif // PTO_SHARED_MEMORY_H
+#endif  // PTO_SHARED_MEMORY_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -21,7 +21,7 @@ inline constexpr int32_t PTO2_SUBTASK_SLOT_COUNT = 3;
  * Subtask slot indices
  */
 enum class PTO2SubtaskSlot : uint8_t {
-    AIC  = 0,
+    AIC = 0,
     AIV0 = 1,
     AIV1 = 2,
 };
@@ -29,7 +29,7 @@ enum class PTO2SubtaskSlot : uint8_t {
 /**
  * Subtask mask bits (for active_mask / subtask_done_mask)
  */
-inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC  = (1u << 0);  // 0x1
+inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC = (1u << 0);   // 0x1
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV0 = (1u << 1);  // 0x2
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV1 = (1u << 2);  // 0x4
 
@@ -61,9 +61,9 @@ struct MixedKernels {
  * cluster remain idle and available for single-core tasks.
  */
 enum class PTO2ResourceShape : uint8_t {
-    AIC = 0,   // Single AIC
-    AIV = 1,   // Single AIV
-    MIX = 2,   // Full cluster (dispatch uses active_mask)
+    AIC = 0,  // Single AIC
+    AIV = 1,  // Single AIV
+    MIX = 2,  // Full cluster (dispatch uses active_mask)
 };
 
 inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 3;
@@ -84,10 +84,10 @@ static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
  */
 static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels& mk) {
     uint8_t mask = 0;
-    if (mk.aic_kernel_id  != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
+    if (mk.aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
     if (mk.aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
     if (mk.aiv1_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV1;
     return mask;
 }
 
-#endif // PTO_SUBMIT_TYPES_H
+#endif  // PTO_SUBMIT_TYPES_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -28,7 +28,7 @@
 #if PTO2_TENSORMAP_PROFILING
 uint64_t g_lookup_chain_total = 0;
 uint64_t g_lookup_count = 0;
-int32_t  g_lookup_chain_max = 0;
+int32_t g_lookup_chain_max = 0;
 uint64_t g_lookup_overlap_checks = 0;
 uint64_t g_lookup_overlap_hits = 0;
 uint64_t g_insert_count = 0;
@@ -38,7 +38,8 @@ uint64_t g_insert_count = 0;
 // Initialization and Destruction
 // =============================================================================
 
-bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+bool PTO2TensorMap::init(
+    int32_t new_num_buckets, int32_t new_pool_size, const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]) {
     // Validate power of 2 for fast modulo
     if ((new_num_buckets & (new_num_buckets - 1)) != 0) {
         return false;  // num_buckets must be power of 2
@@ -58,7 +59,8 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const i
     num_buckets = new_num_buckets;
 
     // Allocate entry pool (64-byte aligned for cache-line-aligned entries)
-    entry_pool = (PTO2TensorMapEntry*)aligned_alloc(alignof(PTO2TensorMapEntry), new_pool_size * sizeof(PTO2TensorMapEntry));
+    entry_pool =
+        (PTO2TensorMapEntry*)aligned_alloc(alignof(PTO2TensorMapEntry), new_pool_size * sizeof(PTO2TensorMapEntry));
     if (!entry_pool) {
         free(buckets);
         buckets = NULL;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -47,7 +47,7 @@ struct PTO2OrchestratorState;  // forward declare
 #if PTO2_TENSORMAP_PROFILING
 extern uint64_t g_lookup_chain_total;
 extern uint64_t g_lookup_count;
-extern int32_t  g_lookup_chain_max;
+extern int32_t g_lookup_chain_max;
 extern uint64_t g_lookup_overlap_checks;
 extern uint64_t g_lookup_overlap_hits;
 extern uint64_t g_insert_count;
@@ -74,23 +74,23 @@ extern uint64_t g_insert_count;
  */
 struct alignas(64) PTO2TensorMapEntry {
     // === Cache line 1 (64B) — lookup hot path ===
-    PTO2TensorMapEntry* next_in_bucket;    // 8B: next entry in hash bucket chain
-    PTO2TaskId producer_task_id;           // 8B: raw (ring_id << 32) | local_id
-    uint64_t buffer_addr;                  // 8B: tensor base address (hash key)
-    int32_t version;                       // 4B: tensor version for overlap detection
-    uint32_t ndims;                        // 4B: number of dimensions
-    int32_t bucket_index;                  // 4B: bucket index (-1 if unlinked)
-    bool is_all_offset_zero;               // 1B: fast-path flag
-    bool with_alloc;                       // 1B: true=OUTPUT, false=INOUT
+    PTO2TensorMapEntry* next_in_bucket;  // 8B: next entry in hash bucket chain
+    PTO2TaskId producer_task_id;         // 8B: raw (ring_id << 32) | local_id
+    uint64_t buffer_addr;                // 8B: tensor base address (hash key)
+    int32_t version;                     // 4B: tensor version for overlap detection
+    uint32_t ndims;                      // 4B: number of dimensions
+    int32_t bucket_index;                // 4B: bucket index (-1 if unlinked)
+    bool is_all_offset_zero;             // 1B: fast-path flag
+    bool with_alloc;                     // 1B: true=OUTPUT, false=INOUT
     // padding: 2B
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS]; // 20B: shape per dimension
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // 20B: shape per dimension
     // padding: 4B to fill 64B
 
     // === Cache line 2 (64B) — insert/remove/slow-path ===
-    PTO2TensorMapEntry* prev_in_bucket;    // 8B: prev in hash bucket chain
-    PTO2TensorMapEntry* next_in_task;      // 8B: next entry for same task
-    PTO2TensorMapEntry* prev_in_task;      // 8B: prev entry for same task
-    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS]; // 20B: only when !is_all_offset_zero
+    PTO2TensorMapEntry* prev_in_bucket;         // 8B: prev in hash bucket chain
+    PTO2TensorMapEntry* next_in_task;           // 8B: next entry for same task
+    PTO2TensorMapEntry* prev_in_task;           // 8B: prev entry for same task
+    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];  // 20B: only when !is_all_offset_zero
     // padding: 20B to fill 64B
 
     /**
@@ -180,15 +180,15 @@ struct PTO2LookupResult {
  */
 struct PTO2TensorMap {
     // Hash table buckets (fixed size, power of 2)
-    PTO2TensorMapEntry** buckets;     // Array of offsets into entry_pool (-1 = empty)
-    int32_t num_buckets;  // Must be power of 2 for fast modulo
+    PTO2TensorMapEntry** buckets;  // Array of offsets into entry_pool (-1 = empty)
+    int32_t num_buckets;           // Must be power of 2 for fast modulo
 
     // Entry pool as ring buffer
-    PTO2TensorMapEntry* entry_pool;  // Ring buffer of entries
-    PTO2TensorMapEntry** free_entry_list;        // free entry ids
-    int32_t pool_size;               // Total pool capacity
-    int32_t next_entry_idx;          // id when next entry insert
-    int32_t free_num;                // free entry number in entry pool
+    PTO2TensorMapEntry* entry_pool;        // Ring buffer of entries
+    PTO2TensorMapEntry** free_entry_list;  // free entry ids
+    int32_t pool_size;                     // Total pool capacity
+    int32_t next_entry_idx;                // id when next entry insert
+    int32_t free_num;                      // free entry number in entry pool
 
     // Per-ring per-task entry tracking (for efficient bucket cleanup)
     // Indexed by [ring_id][local_id & (task_window_sizes[ring_id] - 1)]
@@ -217,7 +217,7 @@ struct PTO2TensorMap {
     }
 
     void free_entry(PTO2TensorMapEntry& entry) {
-        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+        always_assert(entry.bucket_index != -1);  // 必须保证仍在桶中
 
         // Update predecessor's next pointer (O(1) via prev_in_bucket)
         if (entry.prev_in_bucket == nullptr) {
@@ -270,9 +270,7 @@ struct PTO2TensorMap {
      *
      * @param last_task_alive  Current value from shared memory
      */
-    void sync_validity(int32_t ring_id, int32_t last_task_alive) {
-        this->last_task_alives[ring_id] = last_task_alive;
-    }
+    void sync_validity(int32_t ring_id, int32_t last_task_alive) { this->last_task_alives[ring_id] = last_task_alive; }
 
     /**
      * Lookup producer for a tensor region
@@ -401,8 +399,7 @@ struct PTO2TensorMap {
                 // Only remove if this entry belongs to the retiring task
                 // (slot may have been reused by a newer task)
                 debug_assert(cur_entry->producer_task_id ==
-                             pto2_make_task_id(static_cast<uint8_t>(ring_id),
-                                               static_cast<uint32_t>(local_id)));
+                             pto2_make_task_id(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id)));
                 free_entry(*cur_entry);
                 cur_entry = next_entry;
             }
@@ -446,7 +443,7 @@ struct PTO2TensorMap {
      * Called during pool wrap-around to unlink reused entries.
      */
     void remove_from_task(PTO2TensorMapEntry& entry) {
-        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+        always_assert(entry.bucket_index != -1);  // 必须保证仍在桶中
         // Update predecessor's next pointer (O(1) via prev_in_task)
         if (entry.prev_in_task == nullptr) {
             // Entry is the head of its task chain, update task_entry_heads
@@ -498,7 +495,7 @@ struct PTO2TensorMap {
 struct PTO2TensorMapProfilingData {
     uint64_t lookup_chain_total;
     uint64_t lookup_count;
-    int32_t  lookup_chain_max;
+    int32_t lookup_chain_max;
     uint64_t overlap_checks;
     uint64_t overlap_hits;
     uint64_t insert_count;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -24,11 +24,11 @@
 #include "tensor.h"
 
 // Task parameters
-#define PTO2_MAX_TENSOR_PARAMS    16      // Maximum tensor parameters per task
-#define PTO2_MAX_SCALAR_PARAMS    128     // Maximum scalar parameters per task
-#define PTO2_MAX_OUTPUTS          16      // Maximum outputs per task
-#define PTO2_MAX_INPUTS           16      // Maximum inputs per task
-#define PTO2_MAX_INOUTS           8       // Maximum in-out params per task
+#define PTO2_MAX_TENSOR_PARAMS 16   // Maximum tensor parameters per task
+#define PTO2_MAX_SCALAR_PARAMS 128  // Maximum scalar parameters per task
+#define PTO2_MAX_OUTPUTS 16         // Maximum outputs per task
+#define PTO2_MAX_INPUTS 16          // Maximum inputs per task
+#define PTO2_MAX_INOUTS 8           // Maximum in-out params per task
 
 // =============================================================================
 // Parameter Types (for pto_submit_task API)
@@ -86,8 +86,9 @@ struct PTOParam {
 
     bool check_add_tensor_valid() {
         if (scalar_count != 0) {
-            set_error("add_input/add_output/add_inout called after add_scalar: "
-                      "all tensors must be added before any scalars");
+            set_error(
+                "add_input/add_output/add_inout called after add_scalar: "
+                "all tensors must be added before any scalars");
             return false;
         }
         if (tensor_count >= PTO2_MAX_TENSOR_PARAMS) {
@@ -98,7 +99,9 @@ struct PTOParam {
     }
 
     void add_input(Tensor& t) {
-        if (!check_add_tensor_valid()) { return; }
+        if (!check_add_tensor_valid()) {
+            return;
+        }
         if (t.buffer.addr == 0) {
             set_error("INPUT tensor must have a non-NULL buffer address");
             return;
@@ -109,14 +112,18 @@ struct PTOParam {
     }
 
     void add_output(Tensor& t) {
-        if (!check_add_tensor_valid()) { return; }
+        if (!check_add_tensor_valid()) {
+            return;
+        }
         tensors[tensor_count] = &t;
         tensor_types[tensor_count] = PTOParamType::OUTPUT;
         tensor_count++;
     }
 
     void add_inout(Tensor& t) {
-        if (!check_add_tensor_valid()) { return; }
+        if (!check_add_tensor_valid()) {
+            return;
+        }
         if (t.buffer.addr == 0) {
             set_error("INOUT tensor must have a non-NULL buffer address");
             return;
@@ -139,10 +146,13 @@ struct PTOParam {
      * For already-allocated tensors, use add_inout() instead.
      */
     void add_output(Tensor& t, uint64_t initial_value) {
-        if (!check_add_tensor_valid()) { return; }
+        if (!check_add_tensor_valid()) {
+            return;
+        }
         if (t.buffer.addr != 0) {
-            set_error("add_output with initial_value requires unallocated tensor (addr==0). "
-                      "Use add_inout() for already-allocated tensors");
+            set_error(
+                "add_output with initial_value requires unallocated tensor (addr==0). "
+                "Use add_inout() for already-allocated tensors");
             return;
         }
         tensors[tensor_count] = &t;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -68,17 +68,11 @@ void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
     LOG_INFO("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
 }
 
-TensorPair* Runtime::get_tensor_pairs() {
-    return tensor_pairs;
-}
+TensorPair* Runtime::get_tensor_pairs() { return tensor_pairs; }
 
-int Runtime::get_tensor_pair_count() const {
-    return tensor_pair_count;
-}
+int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
-void Runtime::clear_tensor_pairs() {
-    tensor_pair_count = 0;
-}
+void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 
 // =============================================================================
 // Device orchestration
@@ -124,9 +118,7 @@ const void* Runtime::get_device_orch_so_data() const {
     return device_orch_so_size_ > 0 ? device_orch_so_storage_ : nullptr;
 }
 
-size_t Runtime::get_device_orch_so_size() const {
-    return device_orch_so_size_;
-}
+size_t Runtime::get_device_orch_so_size() const { return device_orch_so_size_; }
 
 uint64_t Runtime::get_function_bin_addr(int func_id) const {
     if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
@@ -142,15 +134,11 @@ void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
     }
 }
 
-int Runtime::get_registered_kernel_count() const {
-    return registered_kernel_count_;
-}
+int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }
 
 int Runtime::get_registered_kernel_func_id(int index) const {
     if (index < 0 || index >= registered_kernel_count_) return -1;
     return registered_kernel_func_ids_[index];
 }
 
-void Runtime::clear_registered_kernels() {
-    registered_kernel_count_ = 0;
-}
+void Runtime::clear_registered_kernels() { registered_kernel_count_ = 0; }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -88,9 +88,9 @@ struct Handshake {
     volatile CoreType core_type;           // Core type: CoreType::AIC or CoreType::AIV
     volatile uint64_t perf_records_addr;   // Performance records address
     volatile uint32_t perf_buffer_status;  // 0 = not full, 1 == full
-    volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t physical_core_id;    // Physical core ID
     volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;   // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**
@@ -146,8 +146,8 @@ public:
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int sche_cpu_num;  // Number of AICPU threads for scheduling
-    int orch_thread_num;  // Number of orchestrator threads (default 1)
+    int sche_cpu_num;        // Number of AICPU threads for scheduling
+    int orch_thread_num;     // Number of orchestrator threads (default 1)
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)
@@ -160,7 +160,7 @@ public:
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
     // Profiling support
-    bool enable_profiling;    // Enable profiling flag
+    bool enable_profiling;  // Enable profiling flag
 
     // Orchestrator-to-scheduler transition control
     // When true, orchestrator threads convert to scheduler threads after orchestration completes.
@@ -180,10 +180,10 @@ private:
 
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
-    void* pto2_gm_sm_ptr_;  // GM pointer to PTO2 shared memory (device)
-    void* pto2_gm_heap_ptr_;  // GM heap for orchestrator output buffers (device)
+    void* pto2_gm_sm_ptr_;        // GM pointer to PTO2 shared memory (device)
+    void* pto2_gm_heap_ptr_;      // GM heap for orchestrator output buffers (device)
     void* pto2_slot_states_ptr_;  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
-    TaskArg* orch_args_;   // Arguments for device orchestration
+    TaskArg* orch_args_;          // Arguments for device orchestration
     int orch_arg_count_;
     TaskArg orch_args_storage_[RUNTIME_MAX_ARGS];  // Copy of args for device
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -58,16 +58,17 @@ struct Segment {
  */
 struct alignas(64) Tensor {
     // === Cache line 1 (64B) — hot path ===
-    PTOBufferHandle buffer;                        // Underlying memory buffer (addr in bytes, size in bytes)
-    uint64_t start_offset;                         // Cached 1D element offset (precomputed from raw_shapes + offsets), only calc before incore, useless in orch
-    int32_t version;                               // Tensor version for overlap detection
-    DataType dtype;                                // Data type of tensor elements
-    uint32_t ndims;                                // Number of dimensions used
-    bool is_all_offset_zero;                       // True when all offsets[] are zero (skip offset read/write)
-    bool is_raw_eq_shapes;                         // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
-    bool manual_dep;                               // True when dependency is managed manually (skip tensormap lookup/insert)
-    bool has_initial_value{false};                 // True when initial_value should be written after HeapRing allocation
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
+    PTOBufferHandle buffer;   // Underlying memory buffer (addr in bytes, size in bytes)
+    uint64_t start_offset;    // Cached 1D element offset (precomputed from raw_shapes + offsets), only calc before
+                              // incore, useless in orch
+    int32_t version;          // Tensor version for overlap detection
+    DataType dtype;           // Data type of tensor elements
+    uint32_t ndims;           // Number of dimensions used
+    bool is_all_offset_zero;  // True when all offsets[] are zero (skip offset read/write)
+    bool is_raw_eq_shapes;    // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
+    bool manual_dep;          // True when dependency is managed manually (skip tensormap lookup/insert)
+    bool has_initial_value{false};             // True when initial_value should be written after HeapRing allocation
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // Current view shape per dimension
     uint32_t __padding__;
 
     // === Cache line 2 (64B) — warm path ===
@@ -84,9 +85,7 @@ struct alignas(64) Tensor {
 
     /// Return the effective raw_shapes pointer (shapes[] when is_raw_eq_shapes).
     /// Avoids cache line 2 access for the common case.
-    const uint32_t* get_raw_shapes() const {
-        return is_raw_eq_shapes ? shapes : raw_shapes;
-    }
+    const uint32_t* get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
 
     Tensor(void* addr,
         uint64_t buffer_size_bytes,
@@ -99,8 +98,17 @@ struct alignas(64) Tensor {
         bool is_all_offset_zero = false,
         bool is_raw_eq_shapes = false,
         bool manual_dep = false) {
-        init(addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version,
-             is_all_offset_zero, is_raw_eq_shapes, manual_dep);
+        init(addr,
+            buffer_size_bytes,
+            raw_shapes,
+            shapes,
+            offsets,
+            ndims,
+            dtype,
+            version,
+            is_all_offset_zero,
+            is_raw_eq_shapes,
+            manual_dep);
     }
 
     // --- Initialization ---
@@ -138,7 +146,7 @@ struct alignas(64) Tensor {
     }
 
     void init(const Tensor& other) {
-        memcpy(this, &other, 64); // fast copy cache line 1
+        memcpy(this, &other, 64);  // fast copy cache line 1
         if (!other.is_raw_eq_shapes) {
             for (uint32_t i = 0; i < ndims; i++) {
                 raw_shapes[i] = other.raw_shapes[i];
@@ -151,7 +159,8 @@ struct alignas(64) Tensor {
         }
     }
 
-    void init_with_view(const Tensor& other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) {
+    void init_with_view(
+        const Tensor& other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) {
         buffer = other.buffer;
         ndims = other.ndims;
         dtype = other.dtype;
@@ -169,7 +178,10 @@ struct alignas(64) Tensor {
         bool all_zero = true;
         if (other.is_all_offset_zero) {
             for (uint32_t i = 0; i < ndims; i++) {
-                if (view_offsets[i] != 0) { all_zero = false; break; }
+                if (view_offsets[i] != 0) {
+                    all_zero = false;
+                    break;
+                }
             }
             if (!all_zero) {
                 for (uint32_t i = 0; i < ndims; i++) {
@@ -192,11 +204,9 @@ struct alignas(64) Tensor {
         const uint32_t* rs = get_raw_shapes();
         uint64_t offset = 0;
         if (is_all_offset_zero) {
-            for (uint32_t d = 0; d < in_ndims; d++)
-                offset = offset * rs[d] + indices[d];
+            for (uint32_t d = 0; d < in_ndims; d++) offset = offset * rs[d] + indices[d];
         } else {
-            for (uint32_t d = 0; d < in_ndims; d++)
-                offset = offset * rs[d] + indices[d] + offsets[d];
+            for (uint32_t d = 0; d < in_ndims; d++) offset = offset * rs[d] + indices[d] + offsets[d];
         }
         return offset;
     }
@@ -217,9 +227,7 @@ struct alignas(64) Tensor {
         start_offset = result;
     }
 
-    void copy(const Tensor &other) {
-        init(other);
-    }
+    void copy(const Tensor& other) { init(other); }
 
     Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
         Tensor result;

--- a/src/a5/platform/include/aicore/performance_collector_aicore.h
+++ b/src/a5/platform/include/aicore/performance_collector_aicore.h
@@ -35,13 +35,8 @@
  * @param start_time Start timestamp
  * @param end_time End timestamp
  */
-__aicore__ __attribute__((always_inline))
-static inline void perf_aicore_record_task(
-    __gm__ PerfBuffer* perf_buf,
-    uint32_t task_id,
-    uint64_t start_time,
-    uint64_t end_time) {
-
+__aicore__ __attribute__((always_inline)) static inline void perf_aicore_record_task(
+    __gm__ PerfBuffer* perf_buf, uint32_t task_id, uint64_t start_time, uint64_t end_time) {
     // Read current buffer count (AICPU owns the count, AICore reads only)
     dcci(&perf_buf->count, SINGLE_CACHE_LINE);
     uint32_t idx = perf_buf->count;

--- a/src/a5/platform/include/aicpu/device_log.h
+++ b/src/a5/platform/include/aicpu/device_log.h
@@ -57,41 +57,41 @@ void dev_log_always(const char* func, const char* fmt, ...);
 // High-Level Logging Macros (Platform-Independent Layer)
 // =============================================================================
 
-#define D_DEV_LOGD(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_debug()) { \
+#define D_DEV_LOGD(MODE_NAME, fmt, ...)                      \
+    do {                                                     \
+        if (is_log_enable_debug()) {                         \
             dev_log_debug(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                    \
+    } while (0)
 
-#define D_DEV_LOGI(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_info()) { \
+#define D_DEV_LOGI(MODE_NAME, fmt, ...)                     \
+    do {                                                    \
+        if (is_log_enable_info()) {                         \
             dev_log_info(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                   \
+    } while (0)
 
-#define D_DEV_LOGW(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_warn()) { \
+#define D_DEV_LOGW(MODE_NAME, fmt, ...)                     \
+    do {                                                    \
+        if (is_log_enable_warn()) {                         \
             dev_log_warn(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                   \
+    } while (0)
 
-#define D_DEV_LOGE(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_error()) { \
+#define D_DEV_LOGE(MODE_NAME, fmt, ...)                      \
+    do {                                                     \
+        if (is_log_enable_error()) {                         \
             dev_log_error(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                    \
+    } while (0)
 
 // =============================================================================
 // Convenience Macros
 // =============================================================================
 
 #define DEV_DEBUG(fmt, args...) D_DEV_LOGD(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_INFO(fmt, args...)  D_DEV_LOGI(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_WARN(fmt, args...)  D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
+#define DEV_INFO(fmt, args...) D_DEV_LOGI(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
+#define DEV_WARN(fmt, args...) D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
 #define DEV_ERROR(fmt, args...) D_DEV_LOGE(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
 #define DEV_ALWAYS(fmt, args...) dev_log_always(__FUNCTION__, fmt, ##args)
 
@@ -110,32 +110,32 @@ void dev_log_always(const char* func, const char* fmt, ...);
 // Conditional Check Macros
 // =============================================================================
 
-#define DEV_CHECK_COND_RETURN_VOID(cond, fmt, ...)          \
-    do {                                                    \
-        if (!(cond)) {                                      \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return;                                         \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_COND_RETURN_VOID(cond, fmt, ...) \
+    do {                                           \
+        if (!(cond)) {                             \
+            DEV_ERROR(fmt, ##__VA_ARGS__);         \
+            DEV_ASSERT(0);                         \
+            return;                                \
+        }                                          \
+    } while (0)
 
-#define DEV_CHECK_COND_RETURN(cond, retval, fmt, ...)       \
-    do {                                                    \
-        if (!(cond)) {                                      \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return (retval);                                \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_COND_RETURN(cond, retval, fmt, ...) \
+    do {                                              \
+        if (!(cond)) {                                \
+            DEV_ERROR(fmt, ##__VA_ARGS__);            \
+            DEV_ASSERT(0);                            \
+            return (retval);                          \
+        }                                             \
+    } while (0)
 
-#define DEV_CHECK_POINTER_NULL_RETURN_VOID(ptr, fmt, ...)   \
-    do {                                                    \
-        if ((ptr) == nullptr) {                             \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return;                                         \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_POINTER_NULL_RETURN_VOID(ptr, fmt, ...) \
+    do {                                                  \
+        if ((ptr) == nullptr) {                           \
+            DEV_ERROR(fmt, ##__VA_ARGS__);                \
+            DEV_ASSERT(0);                                \
+            return;                                       \
+        }                                                 \
+    } while (0)
 
 // =============================================================================
 // Helper Functions
@@ -143,8 +143,8 @@ void dev_log_always(const char* func, const char* fmt, ...);
 
 // Check if log level is enabled (inline for efficiency)
 inline bool is_log_enable_debug() { return g_is_log_enable_debug; }
-inline bool is_log_enable_info()  { return g_is_log_enable_info; }
-inline bool is_log_enable_warn()  { return g_is_log_enable_warn; }
+inline bool is_log_enable_info() { return g_is_log_enable_info; }
+inline bool is_log_enable_warn() { return g_is_log_enable_warn; }
 inline bool is_log_enable_error() { return g_is_log_enable_error; }
 
 // Initialize log switch (platform-specific implementation)

--- a/src/a5/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/performance_collector_aicpu.h
@@ -46,14 +46,14 @@ void perf_aicpu_init_profiling(Runtime* runtime);
  * @param fanout_count     Number of entries in fanout array (0 if none)
  */
 int perf_aicpu_complete_record(PerfBuffer* perf_buf,
-                                uint32_t expected_task_id,
-                                uint32_t func_id,
-                                CoreType core_type,
-                                uint64_t dispatch_time,
-                                uint64_t finish_time,
-                                uint8_t ring_id,
-                                const int32_t* fanout,
-                                int32_t fanout_count);
+    uint32_t expected_task_id,
+    uint32_t func_id,
+    CoreType core_type,
+    uint64_t dispatch_time,
+    uint64_t finish_time,
+    uint8_t ring_id,
+    const int32_t* fanout,
+    int32_t fanout_count);
 
 /**
  * Switch performance buffer when current buffer is full
@@ -76,10 +76,7 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx);
  * @param cur_thread_cores Array of core IDs managed by this thread
  * @param core_num Number of cores managed by this thread
  */
-void perf_aicpu_flush_buffers(Runtime* runtime,
-                               int thread_idx,
-                               const int* cur_thread_cores,
-                               int core_num);
+void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num);
 
 /**
  * Update total task count in performance header
@@ -118,9 +115,11 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
  * @param tasks_processed Number of tasks processed in this phase
  */
 void perf_aicpu_record_phase(int thread_idx,
-                              AicpuPhaseId phase_id,
-                              uint64_t start_time, uint64_t end_time,
-                              uint32_t loop_iter, uint32_t tasks_processed);
+    AicpuPhaseId phase_id,
+    uint64_t start_time,
+    uint64_t end_time,
+    uint32_t loop_iter,
+    uint32_t tasks_processed);
 
 /**
  * Write orchestrator cumulative summary
@@ -154,9 +153,8 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx);
  * @param submit_idx Task submission index (acts as loop_iter)
  * @param task_id Task ID (stored in tasks_processed field for task tracking)
  */
-void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
-                                   uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx, uint32_t task_id);
+void perf_aicpu_record_orch_phase(
+    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint32_t task_id);
 
 /**
  * Write core-to-thread assignment mapping to shared memory
@@ -170,9 +168,9 @@ void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
  * @param total_cores Total number of cores
  */
 void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
-                                        const int* core_counts,
-                                        int num_threads,
-                                        int total_cores);
+    const int* core_counts,
+    int num_threads,
+    int total_cores);
 
 /**
  * Flush remaining phase records for a thread

--- a/src/a5/platform/include/common/compile_strategy.h
+++ b/src/a5/platform/include/common/compile_strategy.h
@@ -16,10 +16,10 @@
 #define COMPILE_STRATEGY_H
 
 typedef enum {
-    TOOLCHAIN_CCEC = 0,          // ccec (Ascend AICore compiler)
-    TOOLCHAIN_HOST_GXX_15 = 1,   // g++-15 (host, simulation kernels)
-    TOOLCHAIN_HOST_GXX = 2,      // g++ (host, orchestration .so)
-    TOOLCHAIN_AARCH64_GXX = 3,   // aarch64-target-linux-gnu-g++ (cross-compile)
+    TOOLCHAIN_CCEC = 0,         // ccec (Ascend AICore compiler)
+    TOOLCHAIN_HOST_GXX_15 = 1,  // g++-15 (host, simulation kernels)
+    TOOLCHAIN_HOST_GXX = 2,     // g++ (host, orchestration .so)
+    TOOLCHAIN_AARCH64_GXX = 3,  // aarch64-target-linux-gnu-g++ (cross-compile)
 } ToolchainType;
 
 #endif /* COMPILE_STRATEGY_H */

--- a/src/a5/platform/include/common/core_type.h
+++ b/src/a5/platform/include/common/core_type.h
@@ -53,9 +53,12 @@ inline CoreType core_type_from_string(const char* type_str) {
  */
 inline const char* core_type_to_string(CoreType core_type) {
     switch (core_type) {
-        case CoreType::AIC: return "AIC";
-        case CoreType::AIV: return "AIV";
-        default: return "UNKNOWN";
+        case CoreType::AIC:
+            return "AIC";
+        case CoreType::AIV:
+            return "AIV";
+        default:
+            return "UNKNOWN";
     }
 }
 

--- a/src/a5/platform/include/common/memory_barrier.h
+++ b/src/a5/platform/include/common/memory_barrier.h
@@ -21,24 +21,24 @@
 // =============================================================================
 
 #ifdef __aarch64__
-    /**
-     * Read memory barrier (ARM64)
-     * Ensures all loads before this point complete before any loads after.
-     */
-    #define rmb() __asm__ __volatile__("dsb ld" ::: "memory")
+/**
+ * Read memory barrier (ARM64)
+ * Ensures all loads before this point complete before any loads after.
+ */
+#define rmb() __asm__ __volatile__("dsb ld" ::: "memory")
 
-    /**
-     * Write memory barrier (ARM64)
-     * Ensures all stores before this point complete before any stores after.
-     */
-    #define wmb() __asm__ __volatile__("dsb st" ::: "memory")
+/**
+ * Write memory barrier (ARM64)
+ * Ensures all stores before this point complete before any stores after.
+ */
+#define wmb() __asm__ __volatile__("dsb st" ::: "memory")
 #else
-    /**
-     * Compiler barrier (fallback for non-ARM64 platforms)
-     * Prevents compiler reordering but does not emit hardware barriers.
-     */
-    #define rmb() __asm__ __volatile__("" ::: "memory")
-    #define wmb() __asm__ __volatile__("" ::: "memory")
+/**
+ * Compiler barrier (fallback for non-ARM64 platforms)
+ * Prevents compiler reordering but does not emit hardware barriers.
+ */
+#define rmb() __asm__ __volatile__("" ::: "memory")
+#define wmb() __asm__ __volatile__("" ::: "memory")
 #endif
 
 #endif  // PLATFORM_COMMON_MEMORY_BARRIER_H_

--- a/src/a5/platform/include/common/perf_profiling.h
+++ b/src/a5/platform/include/common/perf_profiling.h
@@ -63,28 +63,27 @@
  */
 struct PerfRecord {
     // Timing information (device clock timestamps)
-    uint64_t start_time;         // Task start timestamp (get_sys_cnt)
-    uint64_t end_time;           // Task end timestamp
-    uint64_t duration;           // Execution duration (end - start)
+    uint64_t start_time;  // Task start timestamp (get_sys_cnt)
+    uint64_t end_time;    // Task end timestamp
+    uint64_t duration;    // Execution duration (end - start)
 
     // AICPU-side timestamps (written by AICPU, not AICore)
-    uint64_t dispatch_time;      // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
-    uint64_t finish_time;        // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
+    uint64_t dispatch_time;  // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
+    uint64_t finish_time;    // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
 
     // Task identification
-    uint32_t task_id;         // Register dispatch id (per-core monotonic counter, NOT mixed_task_id).
-                              // May collide across cores; use (ring_id, task_id, core_id) as unique key.
-    uint32_t func_id;         // Kernel function identifier
-    CoreType core_type;       // Core type (AIC/AIV)
-    uint8_t ring_id;          // Ring layer (0 for single-ring / legacy)
+    uint32_t task_id;    // Register dispatch id (per-core monotonic counter, NOT mixed_task_id).
+                         // May collide across cores; use (ring_id, task_id, core_id) as unique key.
+    uint32_t func_id;    // Kernel function identifier
+    CoreType core_type;  // Core type (AIC/AIV)
+    uint8_t ring_id;     // Ring layer (0 for single-ring / legacy)
 
     // Dependency relationship (fanout only)
     int32_t fanout[RUNTIME_MAX_FANOUT];  // Successor task ID array
-    int32_t fanout_count;                 // Number of successor tasks
+    int32_t fanout_count;                // Number of successor tasks
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfRecord) % 64 == 0,
-              "PerfRecord must be 64-byte aligned for optimal cache performance");
+static_assert(sizeof(PerfRecord) % 64 == 0, "PerfRecord must be 64-byte aligned for optimal cache performance");
 
 // =============================================================================
 // PerfBuffer - Fixed-Size Record Buffer
@@ -98,7 +97,7 @@ static_assert(sizeof(PerfRecord) % 64 == 0,
  */
 struct PerfBuffer {
     PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Record array
-    volatile uint32_t count;                         // Current record count
+    volatile uint32_t count;                        // Current record count
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -122,13 +121,12 @@ struct PerfBuffer {
  */
 struct PerfFreeQueue {
     volatile uint64_t buffer_ptrs[PLATFORM_PROF_SLOT_COUNT];  // Free buffer addresses
-    volatile uint32_t head;  // Consumer read position (Device increments)
-    volatile uint32_t tail;  // Producer write position (Host increments)
-    uint32_t pad[13];        // Pad to 128 bytes (aligned to cache line)
+    volatile uint32_t head;                                   // Consumer read position (Device increments)
+    volatile uint32_t tail;                                   // Producer write position (Host increments)
+    uint32_t pad[13];                                         // Pad to 128 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfFreeQueue) == 128,
-              "PerfFreeQueue must be 128 bytes for cache alignment");
+static_assert(sizeof(PerfFreeQueue) == 128, "PerfFreeQueue must be 128 bytes for cache alignment");
 
 // =============================================================================
 // PerfBufferState - Per-Core/Thread Buffer State (Unified for PerfRecord and Phase)
@@ -153,14 +151,13 @@ static_assert(sizeof(PerfFreeQueue) == 128,
  * - current_buf_seq: Device writes (monotonic counter)
  */
 struct PerfBufferState {
-    PerfFreeQueue free_queue;            // SPSC queue of free buffer addresses
-    volatile uint64_t current_buf_ptr;   // Current active buffer (0 = none)
-    volatile uint32_t current_buf_seq;   // Sequence number for ordering
-    uint32_t pad[13];                    // Pad to 192 bytes (aligned to cache line)
+    PerfFreeQueue free_queue;           // SPSC queue of free buffer addresses
+    volatile uint64_t current_buf_ptr;  // Current active buffer (0 = none)
+    volatile uint32_t current_buf_seq;  // Sequence number for ordering
+    uint32_t pad[13];                   // Pad to 192 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfBufferState) == 192,
-              "PerfBufferState must be 192 bytes for cache alignment");
+static_assert(sizeof(PerfBufferState) == 192, "PerfBufferState must be 192 bytes for cache alignment");
 
 // Type alias for semantic clarity in Phase profiling context
 using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
@@ -180,11 +177,11 @@ using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
  * - Phase entry:      core_index = thread_idx, is_phase = 1
  */
 struct ReadyQueueEntry {
-    uint32_t core_index;      // Core index (0 ~ num_cores-1), or thread_idx for phase entries
-    uint32_t is_phase;        // 0 = PerfRecord, 1 = Phase
-    uint64_t buffer_ptr;      // Device pointer to the full buffer
-    uint32_t buffer_seq;      // Sequence number for ordering
-    uint32_t pad;             // Alignment padding
+    uint32_t core_index;  // Core index (0 ~ num_cores-1), or thread_idx for phase entries
+    uint32_t is_phase;    // 0 = PerfRecord, 1 = Phase
+    uint64_t buffer_ptr;  // Device pointer to the full buffer
+    uint32_t buffer_seq;  // Sequence number for ordering
+    uint32_t pad;         // Alignment padding
 } __attribute__((aligned(32)));
 
 // =============================================================================
@@ -215,8 +212,8 @@ struct PerfDataHeader {
     volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // Producer write positions (AICPU modifies)
 
     // Metadata (Host initializes, Device read-only)
-    uint32_t num_cores;                              // Actual number of cores launched
-    volatile uint32_t total_tasks;                   // Total tasks (AICPU writes after orchestration)
+    uint32_t num_cores;             // Actual number of cores launched
+    volatile uint32_t total_tasks;  // Total tasks (AICPU writes after orchestration)
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -231,21 +228,21 @@ struct PerfDataHeader {
  */
 enum class AicpuPhaseId : uint32_t {
     // Scheduler phases (0-3)
-    SCHED_COMPLETE    = 0,  // Process completed tasks (fanout traversal)
-    SCHED_DISPATCH    = 1,  // Dispatch ready tasks to idle cores
-    SCHED_SCAN        = 2,  // Incremental scan for root tasks
-    SCHED_IDLE_WAIT   = 3,  // Idle/spinning (no progress)
+    SCHED_COMPLETE = 0,     // Process completed tasks (fanout traversal)
+    SCHED_DISPATCH = 1,     // Dispatch ready tasks to idle cores
+    SCHED_SCAN = 2,         // Incremental scan for root tasks
+    SCHED_IDLE_WAIT = 3,    // Idle/spinning (no progress)
     SCHED_PHASE_COUNT = 4,  // Sentinel: number of scheduler phases
     // Orchestrator phases (16-24)
-    ORCH_SYNC      = 16,  // tensormap sync
-    ORCH_ALLOC     = 17,  // task_ring_alloc
-    ORCH_PARAMS    = 18,  // param copy
-    ORCH_LOOKUP    = 19,  // tensormap lookup + dep
-    ORCH_HEAP      = 20,  // heap alloc
-    ORCH_INSERT    = 21,  // tensormap insert
-    ORCH_FANIN     = 22,  // fanin + early-ready
-    ORCH_FINALIZE  = 23,  // scheduler init + SM
-    ORCH_SCOPE_END = 24   // scope_end
+    ORCH_SYNC = 16,      // tensormap sync
+    ORCH_ALLOC = 17,     // task_ring_alloc
+    ORCH_PARAMS = 18,    // param copy
+    ORCH_LOOKUP = 19,    // tensormap lookup + dep
+    ORCH_HEAP = 20,      // heap alloc
+    ORCH_INSERT = 21,    // tensormap insert
+    ORCH_FANIN = 22,     // fanin + early-ready
+    ORCH_FINALIZE = 23,  // scheduler init + SM
+    ORCH_SCOPE_END = 24  // scope_end
 };
 
 /**
@@ -280,12 +277,12 @@ struct AicpuOrchSummary {
     uint64_t insert_cycle;     // tensormap_insert phase
     uint64_t fanin_cycle;      // fanin+ready phase
     uint64_t scope_end_cycle;  // scope_end phase
-    int64_t  submit_count;     // Total tasks submitted
+    int64_t submit_count;      // Total tasks submitted
     uint32_t magic;            // Validation magic (AICPU_PHASE_MAGIC)
     uint32_t padding;          // Alignment padding
 } __attribute__((aligned(64)));
 
-constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"
+constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;        // "ACPH"
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per thread
 
 /**
@@ -306,12 +303,12 @@ struct PhaseBuffer {
  * Contains metadata and per-thread tracking.
  */
 struct AicpuPhaseHeader {
-    uint32_t magic;                  // Validation magic (AICPU_PHASE_MAGIC)
-    uint32_t num_sched_threads;      // Number of scheduler threads
-    uint32_t records_per_thread;     // Max records per PhaseBuffer
-    uint32_t num_cores;              // Total number of cores with valid assignments
+    uint32_t magic;                             // Validation magic (AICPU_PHASE_MAGIC)
+    uint32_t num_sched_threads;                 // Number of scheduler threads
+    uint32_t records_per_thread;                // Max records per PhaseBuffer
+    uint32_t num_cores;                         // Total number of cores with valid assignments
     int8_t core_to_thread[PLATFORM_MAX_CORES];  // core_id → scheduler thread index (-1 = unassigned)
-    AicpuOrchSummary orch_summary;   // Orchestrator cumulative data
+    AicpuOrchSummary orch_summary;              // Orchestrator cumulative data
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -341,9 +338,7 @@ inline size_t calc_perf_data_size(int num_cores) {
  * @param base_ptr Shared memory base address (device_ptr or host_ptr)
  * @return PerfDataHeader pointer
  */
-inline PerfDataHeader* get_perf_header(void* base_ptr) {
-    return (PerfDataHeader*)base_ptr;
-}
+inline PerfDataHeader* get_perf_header(void* base_ptr) { return (PerfDataHeader*)base_ptr; }
 
 /**
  * Get PerfBufferState array start address
@@ -374,9 +369,7 @@ inline PerfBufferState* get_perf_buffer_state(void* base_ptr, int core_index) {
  * @return Total bytes needed for header + all buffer states
  */
 inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threads) {
-    return calc_perf_data_size(num_cores)
-         + sizeof(AicpuPhaseHeader)
-         + num_sched_threads * sizeof(PhaseBufferState);
+    return calc_perf_data_size(num_cores) + sizeof(AicpuPhaseHeader) + num_sched_threads * sizeof(PhaseBufferState);
 }
 
 /**

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -60,14 +60,11 @@ constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 7;
  * - MAX_AIC_PER_THREAD = MAX_BLOCKDIM * AIC_CORES_PER_BLOCKDIM = 36 * 1 = 36
  * - MAX_AIV_PER_THREAD = MAX_BLOCKDIM * AIV_CORES_PER_BLOCKDIM = 36 * 2 = 72
  */
-constexpr int PLATFORM_MAX_AIC_PER_THREAD =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_AIC_CORES_PER_BLOCKDIM;  // 36
+constexpr int PLATFORM_MAX_AIC_PER_THREAD = PLATFORM_MAX_BLOCKDIM * PLATFORM_AIC_CORES_PER_BLOCKDIM;  // 36
 
-constexpr int PLATFORM_MAX_AIV_PER_THREAD =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_AIV_CORES_PER_BLOCKDIM;  // 72
+constexpr int PLATFORM_MAX_AIV_PER_THREAD = PLATFORM_MAX_BLOCKDIM * PLATFORM_AIV_CORES_PER_BLOCKDIM;  // 72
 
-constexpr int PLATFORM_MAX_CORES_PER_THREAD =
-    PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD;  // 108
+constexpr int PLATFORM_MAX_CORES_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD;  // 108
 
 // =============================================================================
 // Performance Profiling Configuration
@@ -77,8 +74,7 @@ constexpr int PLATFORM_MAX_CORES_PER_THREAD =
  * Maximum number of cores that can be profiled simultaneously
  * Calculated as: MAX_BLOCKDIM * CORES_PER_BLOCKDIM = 36 * 3 = 108
  */
-constexpr int PLATFORM_MAX_CORES =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 108
+constexpr int PLATFORM_MAX_CORES = PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 108
 
 /**
  * Performance buffer capacity per buffer
@@ -103,8 +99,7 @@ constexpr int PLATFORM_PROF_SLOT_COUNT = 8;
  *   Phase:      PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT
  */
 constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
-    PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT
-    + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT;  // 872
+    PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT;  // 872
 
 /**
  * System counter frequency (get_sys_cnt)
@@ -131,8 +126,8 @@ inline double cycles_to_us(uint64_t cycles) {
 // =============================================================================
 
 // Register offsets for AICore SPR access
-constexpr uint32_t REG_SPR_DATA_MAIN_BASE_OFFSET = 0xD0;    // Task dispatch (AICPU→AICore)
-constexpr uint32_t REG_SPR_COND_OFFSET = 0x5108;             // Status (AICore→AICPU): 0=IDLE, 1=BUSY
+constexpr uint32_t REG_SPR_DATA_MAIN_BASE_OFFSET = 0xD0;  // Task dispatch (AICPU→AICore)
+constexpr uint32_t REG_SPR_COND_OFFSET = 0x5108;          // Status (AICore→AICPU): 0=IDLE, 1=BUSY
 
 // Exit signal for AICore shutdown
 constexpr uint32_t AICORE_EXIT_SIGNAL = 0x7FFFFFF0;
@@ -144,8 +139,8 @@ constexpr uint32_t AICORE_COREID_MASK = 0x0FFF;
  * Register identifier for unified read_reg/write_reg interface
  */
 enum class RegId : uint32_t {
-    DATA_MAIN_BASE = 0,    // Task dispatch (AICPU→AICore)
-    COND = 1,              // Status (AICore→AICPU)
+    DATA_MAIN_BASE = 0,  // Task dispatch (AICPU→AICore)
+    COND = 1,            // Status (AICore→AICPU)
 };
 
 /**
@@ -153,8 +148,10 @@ enum class RegId : uint32_t {
  */
 constexpr uint32_t reg_offset(RegId reg) {
     switch (reg) {
-        case RegId::DATA_MAIN_BASE:  return REG_SPR_DATA_MAIN_BASE_OFFSET;
-        case RegId::COND:            return REG_SPR_COND_OFFSET;
+        case RegId::DATA_MAIN_BASE:
+            return REG_SPR_DATA_MAIN_BASE_OFFSET;
+        case RegId::COND:
+            return REG_SPR_COND_OFFSET;
     }
     return 0;  // unreachable: all RegId cases handled above
 }
@@ -202,7 +199,6 @@ inline volatile uint8_t* sparse_reg_ptr(volatile uint8_t* reg_base, uint32_t off
 // Hardware Configuration Constants
 // =============================================================================
 
-
 /**
  * Number of sub-cores per AICore
  * Hardware architecture: 1 AICore = 1 AIC + 2 AIV sub-cores
@@ -235,26 +231,26 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = PLATFORM_NUM_DIES * PLATFORM_AI
  * State: ACK (0) = task received, FIN (1) = task completed
  */
 
-#define TASK_ID_MASK       0x7FFFFFFFU
-#define TASK_STATE_MASK    0x80000000U
+#define TASK_ID_MASK 0x7FFFFFFFU
+#define TASK_STATE_MASK 0x80000000U
 
-#define TASK_ACK_STATE     0
-#define TASK_FIN_STATE     1
+#define TASK_ACK_STATE 0
+#define TASK_FIN_STATE 1
 
-#define EXTRACT_TASK_ID(regval)    ((int)((regval) & TASK_ID_MASK))
+#define EXTRACT_TASK_ID(regval) ((int)((regval) & TASK_ID_MASK))
 #define EXTRACT_TASK_STATE(regval) ((int)(((regval) & TASK_STATE_MASK) >> 31))
-#define MAKE_ACK_VALUE(task_id)    ((uint64_t)((task_id) & TASK_ID_MASK))
-#define MAKE_FIN_VALUE(task_id)    ((uint64_t)(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
+#define MAKE_ACK_VALUE(task_id) ((uint64_t)((task_id) & TASK_ID_MASK))
+#define MAKE_FIN_VALUE(task_id) ((uint64_t)(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
 
 // These values are RESERVED and must never be used as real task IDs.
 // Valid task IDs: 0 to 0x7FFFFFEF (2147483631)
-#define AICORE_IDLE_TASK_ID        0x7FFFFFFFU
-#define AICORE_IDLE_VALUE          MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
+#define AICORE_IDLE_TASK_ID 0x7FFFFFFFU
+#define AICORE_IDLE_VALUE MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
 
-#define AICORE_EXIT_TASK_ID        0x7FFFFFFEU
-#define AICORE_EXITED_VALUE        MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
+#define AICORE_EXIT_TASK_ID 0x7FFFFFFEU
+#define AICORE_EXITED_VALUE MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
 
-#define AICPU_IDLE_TASK_ID         0x7FFFFFFDU
+#define AICPU_IDLE_TASK_ID 0x7FFFFFFDU
 
 // =============================================================================
 // Task State Constants

--- a/src/a5/platform/include/common/unified_log.h
+++ b/src/a5/platform/include/common/unified_log.h
@@ -32,10 +32,9 @@ void unified_log_always(const char* func, const char* fmt, ...);
 
 // Convenience macros (automatically capture function name)
 #define LOG_ERROR(fmt, ...) unified_log_error(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
-#define LOG_WARN(fmt, ...)  unified_log_warn(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
-#define LOG_INFO(fmt, ...)  unified_log_info(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) unified_log_warn(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...) unified_log_info(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 #define LOG_DEBUG(fmt, ...) unified_log_debug(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 #define LOG_ALWAYS(fmt, ...) unified_log_always(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 
 #endif  // PLATFORM_UNIFIED_LOG_H_
-

--- a/src/a5/platform/include/host/function_cache.h
+++ b/src/a5/platform/include/host/function_cache.h
@@ -85,9 +85,7 @@ struct CoreFunctionBinCache {
      * Get pointer to binary data region
      * @return Pointer to start of binary data
      */
-    uint8_t* get_binary_data() {
-        return reinterpret_cast<uint8_t*>(get_offsets()) + num_kernels * sizeof(uint64_t);
-    }
+    uint8_t* get_binary_data() { return reinterpret_cast<uint8_t*>(get_offsets()) + num_kernels * sizeof(uint64_t); }
 
     /**
      * Get CoreFunctionBin by index

--- a/src/a5/platform/include/host/host_regs.h
+++ b/src/a5/platform/include/host/host_regs.h
@@ -35,8 +35,8 @@ constexpr uint32_t REG_AICORE_MAP_SIZE = 0x300000;
 /**
  * Register offsets for AIV sub-cores relative to AICore base
  */
-constexpr uint64_t REG_AIV_FIRST_OFFSET = REG_SUB_CORE_STRIDE;        // 1M
-constexpr uint64_t REG_AIV_SECOND_OFFSET = 2 * REG_SUB_CORE_STRIDE;   // 2M
+constexpr uint64_t REG_AIV_FIRST_OFFSET = REG_SUB_CORE_STRIDE;       // 1M
+constexpr uint64_t REG_AIV_SECOND_OFFSET = 2 * REG_SUB_CORE_STRIDE;  // 2M
 
 /**
  * Initialize AICore register addresses for runtime
@@ -49,9 +49,6 @@ constexpr uint64_t REG_AIV_SECOND_OFFSET = 2 * REG_SUB_CORE_STRIDE;   // 2M
  * @param allocator Memory allocator for device memory
  * @return 0 on success, negative on failure
  */
-int init_aicore_register_addresses(
-    uint64_t* runtime_regs_ptr,
-    uint64_t device_id,
-    MemoryAllocator& allocator);
+int init_aicore_register_addresses(uint64_t* runtime_regs_ptr, uint64_t device_id, MemoryAllocator& allocator);
 
 #endif  // PLATFORM_HOST_HOST_REGS_H_

--- a/src/a5/platform/include/host/performance_collector.h
+++ b/src/a5/platform/include/host/performance_collector.h
@@ -46,8 +46,7 @@ using PerfAllocCallback = void* (*)(size_t size, void* user_data);
  * @param[out] host_ptr Host-mapped pointer
  * @return 0 on success, error code on failure
  */
-using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id,
-                                      void* user_data, void** host_ptr);
+using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id, void* user_data, void** host_ptr);
 
 /**
  * Memory unregister callback
@@ -82,18 +81,18 @@ enum class ProfBufferType { PERF_RECORD, PHASE };
  */
 struct ReadyBufferInfo {
     ProfBufferType type;
-    uint32_t index;           // core_index (PERF_RECORD) or thread_idx (PHASE)
-    uint32_t slot_idx;        // Reserved (unused in free queue design)
-    void* dev_buffer_ptr;     // Device address of the full buffer
-    void* host_buffer_ptr;    // Host-mapped address (sim: same as dev)
-    uint32_t buffer_seq;      // Sequence number for ordering
+    uint32_t index;         // core_index (PERF_RECORD) or thread_idx (PHASE)
+    uint32_t slot_idx;      // Reserved (unused in free queue design)
+    void* dev_buffer_ptr;   // Device address of the full buffer
+    void* host_buffer_ptr;  // Host-mapped address (sim: same as dev)
+    uint32_t buffer_seq;    // Sequence number for ordering
 };
 
 /**
  * Notification that a buffer has been copied and can be freed
  */
 struct CopyDoneInfo {
-    void* dev_buffer_ptr;     // Device buffer to free
+    void* dev_buffer_ptr;  // Device buffer to free
 };
 
 /**
@@ -130,9 +129,14 @@ public:
      * @param user_data User context for callbacks
      * @param device_id Device ID for registration
      */
-    void start(void* shared_mem_host, int num_cores, int num_phase_threads,
-               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-               PerfFreeCallback free_cb, void* user_data, int device_id);
+    void start(void* shared_mem_host,
+        int num_cores,
+        int num_phase_threads,
+        PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb,
+        void* user_data,
+        int device_id);
 
     /**
      * Stop the memory management thread
@@ -213,8 +217,7 @@ private:
     void register_mapping(void* dev_ptr, void* host_ptr);
 
     // Process one ReadyQueue entry
-    void process_ready_entry(PerfDataHeader* header, int thread_idx,
-                              const ReadyQueueEntry& entry);
+    void process_ready_entry(PerfDataHeader* header, int thread_idx, const ReadyQueueEntry& entry);
 };
 
 // =============================================================================
@@ -257,12 +260,12 @@ public:
      * @return 0 on success, error code on failure
      */
     int initialize(Runtime& runtime,
-                   int num_aicore,
-                   int device_id,
-                   PerfAllocCallback alloc_cb,
-                   PerfRegisterCallback register_cb,
-                   PerfFreeCallback free_cb,
-                   void* user_data);
+        int num_aicore,
+        int device_id,
+        PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb,
+        void* user_data);
 
     /**
      * Start the memory management thread
@@ -305,9 +308,7 @@ public:
      * @param user_data User-provided context pointer
      * @return 0 on success, error code on failure
      */
-    int finalize(PerfUnregisterCallback unregister_cb,
-                 PerfFreeCallback free_cb,
-                 void* user_data);
+    int finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data);
 
     /**
      * Check if collector is initialized

--- a/src/a5/platform/include/host/pto_runtime_c_api.h
+++ b/src/a5/platform/include/host/pto_runtime_c_api.h
@@ -82,15 +82,15 @@ size_t get_runtime_size(void);
  * @return 0 on success, -1 on failure
  */
 int init_runtime(RuntimeHandle runtime,
-                const uint8_t* orch_so_binary,
-                size_t orch_so_size,
-                const char* orch_func_name,
-                const struct TaskArg* orch_args,
-                int orch_args_count,
-                const int* kernel_func_ids,
-                const uint8_t* const* kernel_binaries,
-                const size_t* kernel_sizes,
-                int kernel_count);
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const struct TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count);
 
 /* ===========================================================================
  * Device Memory API (for use by orchestration functions)
@@ -203,11 +203,7 @@ int set_device(int device_id);
  * @param dev_ptr   Device memory pointer
  * @param size      Size of tensor in bytes
  */
-void record_tensor_pair(RuntimeHandle runtime,
-                       void* host_ptr,
-                       void* dev_ptr,
-                       size_t size);
-
+void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size);
 
 /**
  * Enable or disable performance profiling for swimlane visualization.

--- a/src/a5/platform/onboard/aicore/inner_kernel.h
+++ b/src/a5/platform/onboard/aicore/inner_kernel.h
@@ -68,9 +68,7 @@ __aicore__ inline void write_reg(RegId reg, uint64_t value) {
  *
  * @return Physical core ID (masked to 12 bits)
  */
-__aicore__ inline uint32_t get_physical_core_id() {
-    return static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK;
-}
+__aicore__ inline uint32_t get_physical_core_id() { return static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK; }
 
 // =============================================================================
 // System Counter
@@ -81,8 +79,6 @@ __aicore__ inline uint32_t get_physical_core_id() {
  *
  * @return Hardware counter value (ticks)
  */
-__aicore__ __attribute__((always_inline)) inline uint64_t get_sys_cnt_aicore() {
-    return get_sys_cnt();
-}
+__aicore__ __attribute__((always_inline)) inline uint64_t get_sys_cnt_aicore() { return get_sys_cnt(); }
 
 #endif  // PLATFORM_A5_AICORE_INNER_KERNEL_H_

--- a/src/a5/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a5/platform/onboard/aicpu/CMakeLists.txt
@@ -74,4 +74,3 @@ target_link_directories(aicpu_kernel
 
 # Output name
 set_target_properties(aicpu_kernel PROPERTIES OUTPUT_NAME aicpu_kernel)
-

--- a/src/a5/platform/onboard/aicpu/cache_ops.cpp
+++ b/src/a5/platform/onboard/aicpu/cache_ops.cpp
@@ -9,9 +9,9 @@ void cache_invalidate_range(const void* addr, size_t size) {
     }
     const size_t kCacheLineSize = 64;
     uintptr_t start = (uintptr_t)addr & ~(kCacheLineSize - 1);
-    uintptr_t end   = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    uintptr_t end = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
     for (uintptr_t p = start; p < end; p += kCacheLineSize) {
-        __asm__ __volatile__("dc civac, %0" :: "r"(p) : "memory");
+        __asm__ __volatile__("dc civac, %0" ::"r"(p) : "memory");
     }
     __asm__ __volatile__("dsb sy" ::: "memory");
     __asm__ __volatile__("isb" ::: "memory");

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -72,8 +72,7 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_platform_regs(k_args->regs);
 
     // Affinity gate: drop excess threads before entering runtime
-    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num,
-                                      PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
+    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
         LOG_INFO("Thread dropped by cluster affinity");
         return 0;
     }

--- a/src/a5/platform/onboard/aicpu/platform_aicpu_affinity.cpp
+++ b/src/a5/platform/onboard/aicpu/platform_aicpu_affinity.cpp
@@ -21,9 +21,7 @@ static std::atomic<int32_t> s_gate_ready{0};
 static int32_t s_thread_cpu[MAX_GATE_THREADS];
 static bool s_thread_survive[MAX_GATE_THREADS];
 
-static inline int32_t popcount64(uint64_t v) {
-    return __builtin_popcountll(static_cast<unsigned long long>(v));
-}
+static inline int32_t popcount64(uint64_t v) { return __builtin_popcountll(static_cast<unsigned long long>(v)); }
 
 bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched) {
     if (logical_count >= total_launched) {
@@ -60,8 +58,7 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
 
     // CAS winner does cluster classification
     int32_t expected = 0;
-    if (s_gate_init.compare_exchange_strong(expected, 1,
-            std::memory_order_acq_rel, std::memory_order_acquire)) {
+    if (s_gate_init.compare_exchange_strong(expected, 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
         // Initialize survive flags
         for (int32_t i = 0; i < total_launched; ++i) {
             s_thread_survive[i] = false;
@@ -88,7 +85,11 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
         int32_t minor_cnt = clusters[minor_id].count;
 
         LOG_INFO("AICPU affinity gate: major=%d(cnt=%d) minor=%d(cnt=%d) logical=%d",
-                 major_id, major_cnt, minor_id, minor_cnt, logical_count);
+            major_id,
+            major_cnt,
+            minor_id,
+            minor_cnt,
+            logical_count);
 
         if (major_cnt == logical_count && minor_cnt == (total_launched - logical_count)) {
             // Expected topology: major cluster threads survive
@@ -97,9 +98,11 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
             }
         } else {
             // Unexpected topology: fall back to first logical_count threads
-            LOG_WARN("AICPU affinity gate: unexpected topology (major=%d minor=%d), "
-                     "falling back to index-based cutoff",
-                     major_cnt, minor_cnt);
+            LOG_WARN(
+                "AICPU affinity gate: unexpected topology (major=%d minor=%d), "
+                "falling back to index-based cutoff",
+                major_cnt,
+                minor_cnt);
             for (int32_t i = 0; i < logical_count && i < total_launched; ++i) {
                 s_thread_survive[i] = true;
             }

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -279,18 +279,15 @@ int DeviceRunner::run(Runtime& runtime,
     const std::vector<uint8_t>& aicpu_so_binary,
     const std::vector<uint8_t>& aicore_kernel_binary,
     int launch_aicpu_num) {
-
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]",
-                      launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
+        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
         return -1;
     }
 
     // Validate block_dim
     if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
-        LOG_ERROR("block_dim (%d) must be in range [1, %d]",
-                      block_dim, PLATFORM_MAX_BLOCKDIM);
+        LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
         return -1;
     }
 
@@ -298,26 +295,28 @@ int DeviceRunner::run(Runtime& runtime,
     int scheduler_thread_num = launch_aicpu_num - runtime.orch_thread_num;
 
     if (runtime.orch_thread_num > launch_aicpu_num) {
-        LOG_ERROR("orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)",
-                  runtime.orch_thread_num, launch_aicpu_num);
+        LOG_ERROR(
+            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num);
         return -1;
     }
 
     // Validate even core distribution for initial scheduler threads
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
-            LOG_ERROR("block_dim (%d) not evenly divisible by scheduler_thread_num (%d)",
-                     block_dim, scheduler_thread_num);
+            LOG_ERROR(
+                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num);
             return -1;
         }
     } else {
-        LOG_INFO("All %d threads are orchestrators, cores will be assigned after orchestration completes",
-                 launch_aicpu_num);
+        LOG_INFO(
+            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num);
         // Post-transition: all threads become schedulers
         if (block_dim % launch_aicpu_num != 0) {
-            LOG_WARN("block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
-                     "some threads will have different core counts after transition",
-                     block_dim, launch_aicpu_num);
+            LOG_WARN(
+                "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
+                "some threads will have different core counts after transition",
+                block_dim,
+                launch_aicpu_num);
         }
     }
 
@@ -334,8 +333,7 @@ int DeviceRunner::run(Runtime& runtime,
     int num_aicore = block_dim * cores_per_blockdim_;
     // Initialize handshake buffers in runtime
     if (num_aicore > RUNTIME_MAX_WORKER) {
-        LOG_ERROR("block_dim (%d) exceeds RUNTIME_MAX_WORKER (%d)",
-                      block_dim, RUNTIME_MAX_WORKER);
+        LOG_ERROR("block_dim (%d) exceeds RUNTIME_MAX_WORKER (%d)", block_dim, RUNTIME_MAX_WORKER);
         return -1;
     }
 
@@ -361,7 +359,7 @@ int DeviceRunner::run(Runtime& runtime,
         runtime.workers[i].task_status = 0;
         // Set core type: first 1/3 are AIC, remaining 2/3 are AIV
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
-        runtime.workers[i].perf_records_addr = (uint64_t)nullptr;
+        runtime.workers[i].perf_records_addr = (uint64_t) nullptr;
         runtime.workers[i].perf_buffer_status = 0;
     }
 
@@ -373,8 +371,7 @@ int DeviceRunner::run(Runtime& runtime,
         if (task != nullptr) {
             uint64_t addr = runtime.get_function_bin_addr(task->func_id);
             task->function_bin_addr = addr;
-            LOG_DEBUG("Task %d (func_id=%d) -> function_bin_addr=0x%lx",
-                          i, task->func_id, addr);
+            LOG_DEBUG("Task %d (func_id=%d) -> function_bin_addr=0x%lx", i, task->func_id, addr);
         }
     }
     LOG_DEBUG("");
@@ -413,7 +410,8 @@ int DeviceRunner::run(Runtime& runtime,
 
     std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServer===" << '\n';
     // Launch AICPU main kernel (over-launch for affinity gate)
-    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
+    rc = launch_aicpu_kernel(
+        stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
         if (kernel_args_.args.regs != 0) {
@@ -440,9 +438,8 @@ int DeviceRunner::run(Runtime& runtime,
     // Poll and collect performance data in a separate collector thread
     std::thread collector_thread;
     if (runtime.enable_profiling) {
-        collector_thread = std::thread([this, &runtime]() {
-            poll_and_collect_performance_data(runtime.get_task_count());
-        });
+        collector_thread =
+            std::thread([this, &runtime]() { poll_and_collect_performance_data(runtime.get_task_count()); });
     }
 
     std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
@@ -515,8 +512,11 @@ void DeviceRunner::print_handshake_results() {
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
         LOG_DEBUG("  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d",
-                      i, workers[i].aicore_done, workers[i].aicpu_ready,
-                      workers[i].control, workers[i].task);
+            i,
+            workers[i].aicore_done,
+            workers[i].aicpu_ready,
+            workers[i].control,
+            workers[i].task);
     }
 }
 
@@ -533,8 +533,7 @@ int DeviceRunner::finalize() {
 
     // Kernel binaries should have been removed by validate_runtime_impl()
     if (!func_id_to_addr_.empty()) {
-        LOG_ERROR("finalize() called with %zu kernel binaries still cached (memory leak)",
-                  func_id_to_addr_.size());
+        LOG_ERROR("finalize() called with %zu kernel binaries still cached (memory leak)", func_id_to_addr_.size());
         // Cleanup leaked binaries to prevent memory leaks
         for (const auto& pair : func_id_to_addr_) {
             void* gm_addr = reinterpret_cast<void*>(pair.second);
@@ -724,8 +723,7 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
     };
 
     // Define registration callback (a5: use halHostRegister for shared memory)
-    auto register_cb = [](void* dev_ptr, size_t size, int device_id,
-                          void* user_data, void** host_ptr) -> int {
+    auto register_cb = [](void* dev_ptr, size_t size, int device_id, void* user_data, void** host_ptr) -> int {
         (void)user_data;  // Not needed for registration
         if (load_hal_if_needed() != 0) {
             LOG_ERROR("Failed to load ascend_hal for profiling: %s", dlerror());
@@ -744,8 +742,7 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
         return allocator->free(dev_ptr);
     };
 
-    return perf_collector_.initialize(runtime, num_aicore, device_id,
-                                       alloc_cb, register_cb, free_cb, &mem_alloc_);
+    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
@@ -755,4 +752,3 @@ void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
 int DeviceRunner::export_swimlane_json(const std::string& output_path) {
     return perf_collector_.export_swimlane_json(output_path);
 }
-

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -350,7 +350,7 @@ private:
     DeviceArgs device_args_;
 
     // Kernel binary management
-    bool binaries_loaded_{false};            // true after AICPU SO loaded
+    bool binaries_loaded_{false};              // true after AICPU SO loaded
     std::map<int, uint64_t> func_id_to_addr_;  // func_id -> function_bin_addr (device GM)
 
     // Performance profiling
@@ -370,9 +370,8 @@ private:
      * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int ensure_device_initialized(int device_id,
-                                const std::vector<uint8_t>& aicpu_so_binary,
-                                const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_device_initialized(
+        int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
 
     /**
      * Load AICPU SO and initialize device args
@@ -385,7 +384,8 @@ private:
      * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_binaries_loaded(
+        const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
 
     /**
      * Initialize performance profiling shared memory

--- a/src/a5/platform/onboard/host/host_regs.cpp
+++ b/src/a5/platform/onboard/host/host_regs.cpp
@@ -19,10 +19,9 @@
  * 18 AICores per die.
  */
 static int get_aicore_reg_info(std::vector<int64_t>& regs, int64_t device_id) {
-
     // halResMap: Maps individual AICore resources (DAV_3510-specific)
-    auto halFunc = (int (*)(uint32_t devId, struct res_map_info* res_info, uint64_t* va,
-        uint32_t* len))dlsym(nullptr, "halResMap");
+    auto halFunc = (int (*)(uint32_t devId, struct res_map_info* res_info, uint64_t* va, uint32_t* len))dlsym(
+        nullptr, "halResMap");
 
     if (halFunc == nullptr) {
         LOG_ERROR("halResMap not found in symbol table");
@@ -101,11 +100,7 @@ static void get_aicore_regs(std::vector<int64_t>& regs, uint64_t device_id) {
     LOG_INFO("get_aicore_regs: Retrieved %zu register addresses", regs.size());
 }
 
-int init_aicore_register_addresses(
-    uint64_t* runtime_regs_ptr,
-    uint64_t device_id,
-    MemoryAllocator& allocator) {
-
+int init_aicore_register_addresses(uint64_t* runtime_regs_ptr, uint64_t device_id, MemoryAllocator& allocator) {
     if (runtime_regs_ptr == nullptr) {
         LOG_ERROR("init_aicore_register_addresses: Invalid parameters");
         return -1;
@@ -141,7 +136,8 @@ int init_aicore_register_addresses(
     *runtime_regs_ptr = reinterpret_cast<uint64_t>(reg_ptr);
 
     LOG_INFO("Successfully initialized register addresses: %zu addresses at device 0x%llx",
-             host_regs.size(), *runtime_regs_ptr);
+        host_regs.size(),
+        *runtime_regs_ptr);
 
     return 0;
 }

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -20,15 +20,15 @@ extern "C" {
 /* ===========================================================================
  */
 int init_runtime_impl(Runtime* runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    const TaskArg* orch_args,
-                    int orch_args_count,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count);
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count);
 int validate_runtime_impl(Runtime* runtime);
 
 /* Forward declarations for device memory functions used in init_runtime */
@@ -48,15 +48,15 @@ void remove_kernel_binary_wrapper(int func_id);
 size_t get_runtime_size(void) { return sizeof(Runtime); }
 
 int init_runtime(RuntimeHandle runtime,
-                const uint8_t* orch_so_binary,
-                size_t orch_so_size,
-                const char* orch_func_name,
-                const TaskArg* orch_args,
-                int orch_args_count,
-                const int* kernel_func_ids,
-                const uint8_t* const* kernel_binaries,
-                const size_t* kernel_sizes,
-                int kernel_count) {
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count) {
     if (runtime == NULL) {
         return -1;
     }
@@ -78,10 +78,16 @@ int init_runtime(RuntimeHandle runtime,
         LOG_DEBUG("About to call init_runtime_impl, r=%p", (void*)r);
 
         // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
-        int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
-                               orch_func_name, orch_args, orch_args_count,
-                               kernel_func_ids, kernel_binaries,
-                               kernel_sizes, kernel_count);
+        int result = init_runtime_impl(r,
+            orch_so_binary,
+            orch_so_size,
+            orch_func_name,
+            orch_args,
+            orch_args_count,
+            kernel_func_ids,
+            kernel_binaries,
+            kernel_sizes,
+            kernel_count);
 
         LOG_DEBUG("init_runtime_impl returned: %d", result);
 
@@ -225,10 +231,7 @@ int set_device(int device_id) {
  * registration and stores addresses in Runtime's func_id_to_addr_[] array.
  */
 
-void record_tensor_pair(RuntimeHandle runtime,
-                       void* host_ptr,
-                       void* dev_ptr,
-                       size_t size) {
+void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size) {
     if (runtime == NULL) {
         return;
     }

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -44,9 +44,17 @@
 #include <sched.h>
 
 #if defined(__aarch64__)
-#define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()                        \
+    do {                                        \
+        __asm__ volatile("yield" ::: "memory"); \
+        sched_yield();                          \
+    } while (0)
 #elif defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()        \
+    do {                        \
+        __builtin_ia32_pause(); \
+        sched_yield();          \
+    } while (0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif
@@ -79,17 +87,14 @@
  */
 inline uint64_t get_sys_cnt_aicore() {
     auto now = std::chrono::high_resolution_clock::now();
-    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        now.time_since_epoch()
-    ).count();
+    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
 
     // Convert nanoseconds to counter ticks
     constexpr uint64_t kNsPerSec = std::nano::den;
     uint64_t seconds = elapsed_ns / kNsPerSec;
     uint64_t remaining_ns = elapsed_ns % kNsPerSec;
 
-    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ +
-                     (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
+    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
 
     return ticks;
 }
@@ -121,8 +126,7 @@ extern thread_local uint32_t g_sim_physical_core_id;
  */
 inline uint64_t read_reg(RegId reg) {
     uint32_t offset = reg_offset(reg);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        sparse_reg_ptr(g_sim_reg_base, offset));
+    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(sparse_reg_ptr(g_sim_reg_base, offset));
 
     FULL_MEMORY_BARRIER();
     return static_cast<uint64_t>(*ptr);
@@ -138,8 +142,7 @@ inline uint64_t read_reg(RegId reg) {
  */
 inline void write_reg(RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        sparse_reg_ptr(g_sim_reg_base, offset));
+    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(sparse_reg_ptr(g_sim_reg_base, offset));
 
     *ptr = static_cast<uint32_t>(value);
     FULL_MEMORY_BARRIER();
@@ -150,8 +153,6 @@ inline void write_reg(RegId reg, uint64_t value) {
  *
  * @return Physical core ID for the current simulated core
  */
-inline uint32_t get_physical_core_id() {
-    return g_sim_physical_core_id;
-}
+inline uint32_t get_physical_core_id() { return g_sim_physical_core_id; }
 
 #endif  // PLATFORM_A5SIM_AICORE_INNER_KERNEL_H_

--- a/src/a5/platform/sim/aicore/kernel.cpp
+++ b/src/a5/platform/sim/aicore/kernel.cpp
@@ -22,7 +22,8 @@ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
 
 // Wrapper with extern "C" for dlsym lookup
 // NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
-extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs) {
+extern "C" void aicore_execute_wrapper(
+    __gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs) {
     // Set up simulated register base for this thread.
     // regs points to an array of uint64_t base addresses (one per core).
     // physical_core_id indexes into it to get this core's register block.

--- a/src/a5/platform/sim/aicpu/device_log.cpp
+++ b/src/a5/platform/sim/aicpu/device_log.cpp
@@ -35,17 +35,17 @@ const char* TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
 void init_log_switch() {
     // Read PTO_LOG_LEVEL environment variable
     const char* level_str = std::getenv("PTO_LOG_LEVEL");
-    
+
     if (level_str != nullptr) {
         // Convert to lowercase for comparison
         char level[64];
         strncpy(level, level_str, sizeof(level) - 1);
         level[sizeof(level) - 1] = '\0';
-        
+
         for (char* p = level; *p; ++p) {
             *p = tolower(*p);
         }
-        
+
         // Parse log level
         if (strcmp(level, "silent") == 0 || strcmp(level, "error") == 0) {
             // Silent/Error: only errors

--- a/src/a5/platform/sim/aicpu/device_malloc.cpp
+++ b/src/a5/platform/sim/aicpu/device_malloc.cpp
@@ -10,10 +10,6 @@
 
 #include <cstdlib>
 
-void* aicpu_device_malloc(size_t size) {
-    return malloc(size);
-}
+void* aicpu_device_malloc(size_t size) { return malloc(size); }
 
-void aicpu_device_free(void* ptr) {
-    free(ptr);
-}
+void aicpu_device_free(void* ptr) { free(ptr); }

--- a/src/a5/platform/sim/aicpu/device_time.cpp
+++ b/src/a5/platform/sim/aicpu/device_time.cpp
@@ -6,13 +6,10 @@
 
 uint64_t get_sys_cnt_aicpu() {
     auto now = std::chrono::high_resolution_clock::now();
-    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        now.time_since_epoch()
-    ).count();
+    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
     constexpr uint64_t kNsPerSec = std::nano::den;
     uint64_t seconds = elapsed_ns / kNsPerSec;
     uint64_t remaining_ns = elapsed_ns % kNsPerSec;
-    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ +
-                     (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
+    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
     return ticks;
 }

--- a/src/a5/platform/sim/aicpu/inner_platform_regs.cpp
+++ b/src/a5/platform/sim/aicpu/inner_platform_regs.cpp
@@ -15,8 +15,7 @@
 uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
     uint32_t offset = reg_offset(reg);
     volatile uint8_t* reg_base = reinterpret_cast<volatile uint8_t*>(reg_base_addr);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        sparse_reg_ptr(reg_base, offset));
+    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(sparse_reg_ptr(reg_base, offset));
 
     __sync_synchronize();
     uint64_t value = static_cast<uint64_t>(*ptr);
@@ -28,8 +27,7 @@ uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
 void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
     volatile uint8_t* reg_base = reinterpret_cast<volatile uint8_t*>(reg_base_addr);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        sparse_reg_ptr(reg_base, offset));
+    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(sparse_reg_ptr(reg_base, offset));
 
     __sync_synchronize();
     *ptr = static_cast<uint32_t>(value);

--- a/src/a5/platform/sim/aicpu/platform_aicpu_affinity.cpp
+++ b/src/a5/platform/sim/aicpu/platform_aicpu_affinity.cpp
@@ -18,7 +18,9 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
 
     if (!survive) {
         LOG_INFO("AICPU affinity gate (sim): thread idx=%d DROPPED (logical=%d, launched=%d)",
-                 idx, logical_count, total_launched);
+            idx,
+            logical_count,
+            total_launched);
     }
 
     // Last thread resets state for next invocation

--- a/src/a5/platform/sim/aicpu/spin_hint.h
+++ b/src/a5/platform/sim/aicpu/spin_hint.h
@@ -19,9 +19,17 @@
 #include <sched.h>
 
 #if defined(__aarch64__)
-#define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()                        \
+    do {                                        \
+        __asm__ volatile("yield" ::: "memory"); \
+        sched_yield();                          \
+    } while (0)
 #elif defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()        \
+    do {                        \
+        __builtin_ia32_pause(); \
+        sched_yield();          \
+    } while (0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -19,7 +19,8 @@
 
 // Function pointer types for dynamically loaded executors
 typedef int (*aicpu_execute_func_t)(Runtime* runtime);
-typedef void (*aicore_execute_func_t)(Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs);
+typedef void (*aicore_execute_func_t)(
+    Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs);
 typedef void (*set_platform_regs_func_t)(uint64_t regs);
 
 // =============================================================================
@@ -31,19 +32,16 @@ DeviceRunner& DeviceRunner::get() {
     return runner;
 }
 
-DeviceRunner::~DeviceRunner() {
-    finalize();
-}
+DeviceRunner::~DeviceRunner() { finalize(); }
 
-int DeviceRunner::ensure_device_initialized(int device_id,
-                                            const std::vector<uint8_t>& aicpu_so_binary,
-                                            const std::vector<uint8_t>& aicore_kernel_binary) {
+int DeviceRunner::ensure_device_initialized(
+    int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
     device_id_ = device_id;
     return ensure_binaries_loaded(aicpu_so_binary, aicore_kernel_binary);
 }
 
-int DeviceRunner::ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_binary,
-                                         const std::vector<uint8_t>& aicore_kernel_binary) {
+int DeviceRunner::ensure_binaries_loaded(
+    const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
     // Skip if already loaded
     if (aicpu_execute_func_ != nullptr && aicore_execute_func_ != nullptr) {
         return 0;
@@ -66,13 +64,13 @@ int DeviceRunner::ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_bi
             return -1;
         }
 
-        aicpu_execute_func_ = reinterpret_cast<int(*)(Runtime*)>(dlsym(aicpu_so_handle_, "aicpu_execute"));
+        aicpu_execute_func_ = reinterpret_cast<int (*)(Runtime*)>(dlsym(aicpu_so_handle_, "aicpu_execute"));
         if (aicpu_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicpu_execute: %s", dlerror());
             return -1;
         }
 
-        set_platform_regs_func_ = reinterpret_cast<void(*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_regs"));
+        set_platform_regs_func_ = reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_regs"));
         if (set_platform_regs_func_ == nullptr) {
             LOG_ERROR("dlsym failed for set_platform_regs: %s", dlerror());
             return -1;
@@ -98,7 +96,8 @@ int DeviceRunner::ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_bi
             return -1;
         }
 
-        aicore_execute_func_ = reinterpret_cast<void(*)(Runtime*, int, CoreType, uint32_t, uint64_t)>(dlsym(aicore_so_handle_, "aicore_execute_wrapper"));
+        aicore_execute_func_ = reinterpret_cast<void (*)(Runtime*, int, CoreType, uint32_t, uint64_t)>(
+            dlsym(aicore_so_handle_, "aicore_execute_wrapper"));
         if (aicore_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicore_execute_wrapper: %s", dlerror());
             return -1;
@@ -109,9 +108,7 @@ int DeviceRunner::ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_bi
     return 0;
 }
 
-void* DeviceRunner::allocate_tensor(size_t bytes) {
-    return mem_alloc_.alloc(bytes);
-}
+void* DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
 
 void DeviceRunner::free_tensor(void* dev_ptr) {
     if (dev_ptr != nullptr) {
@@ -132,23 +129,20 @@ int DeviceRunner::copy_from_device(void* host_ptr, const void* dev_ptr, size_t b
 }
 
 int DeviceRunner::run(Runtime& runtime,
-                      int block_dim,
-                      int device_id,
-                      const std::vector<uint8_t>& aicpu_so_binary,
-                      const std::vector<uint8_t>& aicore_kernel_binary,
-                      int launch_aicpu_num) {
-
+    int block_dim,
+    int device_id,
+    const std::vector<uint8_t>& aicpu_so_binary,
+    const std::vector<uint8_t>& aicore_kernel_binary,
+    int launch_aicpu_num) {
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", 
-                       launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
+        LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
         return -1;
     }
 
     // Validate block_dim
     if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
-        LOG_ERROR("block_dim (%d) must be in range [1, %d]", 
-                       block_dim, PLATFORM_MAX_BLOCKDIM);
+        LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
         return -1;
     }
 
@@ -156,8 +150,8 @@ int DeviceRunner::run(Runtime& runtime,
     int scheduler_thread_num = launch_aicpu_num - runtime.orch_thread_num;
 
     if (runtime.orch_thread_num > launch_aicpu_num) {
-        LOG_ERROR("orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)",
-                  runtime.orch_thread_num, launch_aicpu_num);
+        LOG_ERROR(
+            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num);
         return -1;
     }
 
@@ -166,17 +160,20 @@ int DeviceRunner::run(Runtime& runtime,
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
             LOG_ERROR("block_dim (%d) must be evenly divisible by scheduler_thread_num (%d)",
-                      block_dim, scheduler_thread_num);
+                block_dim,
+                scheduler_thread_num);
             return -1;
         }
     } else {
-        LOG_INFO("All %d threads are orchestrators, cores will be assigned after orchestration completes",
-                 launch_aicpu_num);
+        LOG_INFO(
+            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num);
         // Post-transition: all threads become schedulers
         if (block_dim % launch_aicpu_num != 0) {
-            LOG_WARN("block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
-                     "some threads will have different core counts after transition",
-                     block_dim, launch_aicpu_num);
+            LOG_WARN(
+                "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
+                "some threads will have different core counts after transition",
+                block_dim,
+                launch_aicpu_num);
         }
     }
 
@@ -192,8 +189,7 @@ int DeviceRunner::run(Runtime& runtime,
     int num_aicore = block_dim * cores_per_blockdim_;
 
     if (num_aicore > RUNTIME_MAX_WORKER) {
-        LOG_ERROR("num_aicore (%d) exceeds RUNTIME_MAX_WORKER (%d)",
-                       num_aicore, RUNTIME_MAX_WORKER);
+        LOG_ERROR("num_aicore (%d) exceeds RUNTIME_MAX_WORKER (%d)", num_aicore, RUNTIME_MAX_WORKER);
         return -1;
     }
 
@@ -223,8 +219,7 @@ int DeviceRunner::run(Runtime& runtime,
         if (task != nullptr) {
             uint64_t addr = runtime.get_function_bin_addr(task->func_id);
             task->function_bin_addr = addr;
-            LOG_DEBUG("Task %d (func_id=%d) -> function_bin_addr=0x%lx",
-                          i, task->func_id, addr);
+            LOG_DEBUG("Task %d (func_id=%d) -> function_bin_addr=0x%lx", i, task->func_id, addr);
         }
     }
 
@@ -261,13 +256,12 @@ int DeviceRunner::run(Runtime& runtime,
         return -1;
     }
     for (int i = 0; i < num_aicore; i++) {
-        regs_array[i] = reinterpret_cast<uint64_t>(
-            static_cast<uint8_t*>(reg_blocks) + i * SIM_REG_TOTAL_SIZE);
+        regs_array[i] = reinterpret_cast<uint64_t>(static_cast<uint8_t*>(reg_blocks) + i * SIM_REG_TOTAL_SIZE);
     }
     kernel_args_.regs = reinterpret_cast<uint64_t>(regs_array);
 
-    LOG_INFO("Allocated simulated registers: %d cores x 0x%x bytes (sparse: 2x4KB pages)",
-             num_aicore, SIM_REG_TOTAL_SIZE);
+    LOG_INFO(
+        "Allocated simulated registers: %d cores x 0x%x bytes (sparse: 2x4KB pages)", num_aicore, SIM_REG_TOTAL_SIZE);
 
     // Check if executors are loaded
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr) {
@@ -305,9 +299,8 @@ int DeviceRunner::run(Runtime& runtime,
     // Poll and collect performance data during execution (if enabled)
     std::thread collector_thread;
     if (runtime.enable_profiling) {
-        collector_thread = std::thread([this, &runtime]() {
-            poll_and_collect_performance_data(runtime.get_task_count());
-        });
+        collector_thread =
+            std::thread([this, &runtime]() { poll_and_collect_performance_data(runtime.get_task_count()); });
     }
 
     // Wait for all threads to complete
@@ -348,11 +341,11 @@ void DeviceRunner::print_handshake_results() {
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
         LOG_DEBUG("  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d",
-                      i,
-                      last_runtime_->workers[i].aicore_done,
-                      last_runtime_->workers[i].aicpu_ready,
-                      last_runtime_->workers[i].control,
-                      last_runtime_->workers[i].task);
+            i,
+            last_runtime_->workers[i].aicore_done,
+            last_runtime_->workers[i].aicpu_ready,
+            last_runtime_->workers[i].control,
+            last_runtime_->workers[i].task);
     }
 }
 
@@ -375,8 +368,7 @@ int DeviceRunner::finalize() {
 
     // Kernel binaries should have been removed by validate_runtime_impl()
     if (!func_id_to_addr_.empty()) {
-        LOG_ERROR("finalize() called with %zu kernel binaries still cached",
-                  func_id_to_addr_.size());
+        LOG_ERROR("finalize() called with %zu kernel binaries still cached", func_id_to_addr_.size());
         // Cleanup leaked handles
         for (auto& pair : func_id_to_addr_) {
             MappedKernel& kernel = pair.second;
@@ -478,8 +470,7 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
 
     func_id_to_addr_[func_id] = kernel;
 
-    LOG_DEBUG("Registered kernel (dlopen): func_id=%d -> addr=0x%lx, handle=%p",
-                  func_id, kernel.func_addr, handle);
+    LOG_DEBUG("Registered kernel (dlopen): func_id=%d -> addr=0x%lx, handle=%p", func_id, kernel.func_addr, handle);
 
     return kernel.func_addr;
 }
@@ -518,8 +509,7 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
     };
 
     // Simulation: no registration needed (pass nullptr for register_cb)
-    return perf_collector_.initialize(runtime, num_aicore, device_id,
-                                       alloc_cb, nullptr, free_cb, nullptr);
+    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, nullptr, free_cb, nullptr);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
@@ -529,4 +519,3 @@ void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
 int DeviceRunner::export_swimlane_json(const std::string& output_path) {
     return perf_collector_.export_swimlane_json(output_path);
 }
-

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -45,8 +45,8 @@
  * proper handling of external symbols (e.g., std::exp) via PLT/GOT.
  */
 struct MappedKernel {
-    void* dl_handle{nullptr};    // dlopen handle
-    uint64_t func_addr{0};       // Function pointer address (from dlsym)
+    void* dl_handle{nullptr};  // dlopen handle
+    uint64_t func_addr{0};     // Function pointer address (from dlsym)
 };
 
 /**
@@ -122,11 +122,11 @@ public:
      * @return 0 on success
      */
     int run(Runtime& runtime,
-            int block_dim,
-            int device_id,
-            const std::vector<uint8_t>& aicpu_so_binary,
-            const std::vector<uint8_t>& aicore_kernel_binary,
-            int launch_aicpu_num = 1);
+        int block_dim,
+        int device_id,
+        const std::vector<uint8_t>& aicpu_so_binary,
+        const std::vector<uint8_t>& aicore_kernel_binary,
+        int launch_aicpu_num = 1);
 
     /**
      * Print handshake results
@@ -227,11 +227,10 @@ private:
     PerformanceCollector perf_collector_;
 
     // Private helper methods
-    int ensure_device_initialized(int device_id,
-                                  const std::vector<uint8_t>& aicpu_so_binary,
-                                  const std::vector<uint8_t>& aicore_kernel_binary);
-    int ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_binary,
-                               const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_device_initialized(
+        int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_binaries_loaded(
+        const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
 
     /**
      * Initialize performance profiling shared memory

--- a/src/a5/platform/sim/host/memory_allocator.cpp
+++ b/src/a5/platform/sim/host/memory_allocator.cpp
@@ -9,9 +9,7 @@
 #include <cstdlib>
 #include "common/unified_log.h"
 
-MemoryAllocator::~MemoryAllocator() {
-    finalize();
-}
+MemoryAllocator::~MemoryAllocator() { finalize(); }
 
 void* MemoryAllocator::alloc(size_t size) {
     void* ptr = std::malloc(size);

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -23,15 +23,15 @@ extern "C" {
  * ===========================================================================
  */
 int init_runtime_impl(Runtime* runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    const TaskArg* orch_args,
-                    int orch_args_count,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count);
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count);
 int validate_runtime_impl(Runtime* runtime);
 
 /* Forward declarations */
@@ -47,20 +47,18 @@ void remove_kernel_binary_wrapper(int func_id);
  * ===========================================================================
  */
 
-size_t get_runtime_size(void) {
-    return sizeof(Runtime);
-}
+size_t get_runtime_size(void) { return sizeof(Runtime); }
 
 int init_runtime(RuntimeHandle runtime,
-                const uint8_t* orch_so_binary,
-                size_t orch_so_size,
-                const char* orch_func_name,
-                const TaskArg* orch_args,
-                int orch_args_count,
-                const int* kernel_func_ids,
-                const uint8_t* const* kernel_binaries,
-                const size_t* kernel_sizes,
-                int kernel_count) {
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count) {
     if (runtime == NULL) {
         return -1;
     }
@@ -80,10 +78,16 @@ int init_runtime(RuntimeHandle runtime,
         r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
 
         // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
-        int result = init_runtime_impl(r, orch_so_binary, orch_so_size,
-                               orch_func_name, orch_args, orch_args_count,
-                               kernel_func_ids, kernel_binaries,
-                               kernel_sizes, kernel_count);
+        int result = init_runtime_impl(r,
+            orch_so_binary,
+            orch_so_size,
+            orch_func_name,
+            orch_args,
+            orch_args_count,
+            kernel_func_ids,
+            kernel_binaries,
+            kernel_sizes,
+            kernel_count);
 
         if (result != 0) {
             r->~Runtime();
@@ -164,14 +168,14 @@ void remove_kernel_binary_wrapper(int func_id) {
 }
 
 int launch_runtime(RuntimeHandle runtime,
-                   int aicpu_thread_num,
-                   int block_dim,
-                   int device_id,
-                   const uint8_t* aicpu_binary,
-                   size_t aicpu_size,
-                   const uint8_t* aicore_binary,
-                   size_t aicore_size,
-                   int orch_thread_num) {
+    int aicpu_thread_num,
+    int block_dim,
+    int device_id,
+    const uint8_t* aicpu_binary,
+    size_t aicpu_size,
+    const uint8_t* aicore_binary,
+    size_t aicore_size,
+    int orch_thread_num) {
     if (runtime == NULL) {
         return -1;
     }
@@ -237,10 +241,7 @@ int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
  * registration and stores addresses in Runtime's func_id_to_addr_[] array.
  */
 
-void record_tensor_pair(RuntimeHandle runtime,
-                       void* host_ptr,
-                       void* dev_ptr,
-                       size_t size) {
+void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size) {
     if (runtime == NULL) {
         return;
     }

--- a/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -39,11 +39,11 @@ static __thread int s_orch_thread_idx = -1;
  * @return 0 on success, -1 if queue full
  */
 static int enqueue_ready_buffer(PerfDataHeader* header,
-                                 int thread_idx,
-                                 uint32_t core_index,
-                                 uint64_t buffer_ptr,
-                                 uint32_t buffer_seq,
-                                 uint32_t is_phase) {
+    int thread_idx,
+    uint32_t core_index,
+    uint64_t buffer_ptr,
+    uint32_t buffer_seq,
+    uint32_t is_phase) {
     uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
     uint32_t current_tail = header->queue_tails[thread_idx];
     uint32_t current_head = header->queue_heads[thread_idx];
@@ -115,14 +115,14 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
 }
 
 int perf_aicpu_complete_record(PerfBuffer* perf_buf,
-                                uint32_t expected_task_id,
-                                uint32_t func_id,
-                                CoreType core_type,
-                                uint64_t dispatch_time,
-                                uint64_t finish_time,
-                                uint8_t ring_id,
-                                const int32_t* fanout,
-                                int32_t fanout_count) {
+    uint32_t expected_task_id,
+    uint32_t func_id,
+    CoreType core_type,
+    uint64_t dispatch_time,
+    uint64_t finish_time,
+    uint8_t ring_id,
+    const int32_t* fanout,
+    int32_t fanout_count) {
     rmb();
     uint32_t count = perf_buf->count;
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
@@ -137,8 +137,7 @@ int perf_aicpu_complete_record(PerfBuffer* perf_buf,
     record->ring_id = ring_id;
 
     if (fanout != nullptr && fanout_count > 0) {
-        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT)
-                        ? RUNTIME_MAX_FANOUT : fanout_count;
+        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT) ? RUNTIME_MAX_FANOUT : fanout_count;
         for (int32_t i = 0; i < n; i++) {
             record->fanout[i] = fanout[i];
         }
@@ -168,16 +167,13 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
         return;
     }
 
-    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)",
-             thread_idx, core_id, full_buf->count);
+    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)", thread_idx, core_id, full_buf->count);
 
     // Enqueue to ReadyQueue
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
-                                   state->current_buf_ptr, seq, 0);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, state->current_buf_ptr, seq, 0);
     if (rc != 0) {
-        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
-                 thread_idx, core_id);
+        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
         // Revert: discard data and keep writing
         full_buf->count = 0;
         wmb();
@@ -205,12 +201,10 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
         h->perf_records_addr = new_buf_ptr;
         wmb();
 
-        LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)",
-                 thread_idx, core_id, new_buf_ptr);
+        LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
     } else {
         // No free buffer available, stop profiling
-        LOG_WARN("Thread %d: Core %d no free buffer available, stopping profiling",
-                 thread_idx, core_id);
+        LOG_WARN("Thread %d: Core %d no free buffer available, stopping profiling", thread_idx, core_id);
         state->current_buf_ptr = 0;
         Handshake* h = &runtime->workers[core_id];
         h->perf_records_addr = 0;
@@ -218,10 +212,7 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
     }
 }
 
-void perf_aicpu_flush_buffers(Runtime* runtime,
-                               int thread_idx,
-                               const int* cur_thread_cores,
-                               int core_num) {
+void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
     if (!runtime->enable_profiling) {
         return;
     }
@@ -255,24 +246,20 @@ void perf_aicpu_flush_buffers(Runtime* runtime,
         }
 
         uint32_t seq = state->current_buf_seq;
-        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
-                                       buf_ptr, seq, 0);
+        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, buf_ptr, seq, 0);
         if (rc == 0) {
-            LOG_INFO("Thread %d: Core %d flushed buffer with %u records",
-                     thread_idx, core_id, buf->count);
+            LOG_INFO("Thread %d: Core %d flushed buffer with %u records", thread_idx, core_id, buf->count);
             flushed_count++;
             state->current_buf_ptr = 0;
             wmb();
         } else {
-            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
-                     thread_idx, core_id);
+            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
         }
     }
 
     wmb();
 
-    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed",
-             thread_idx, flushed_count);
+    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
 }
 
 void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
@@ -349,7 +336,9 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
     wmb();
 
     LOG_INFO("Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread",
-             num_sched_threads, num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD);
+        num_sched_threads,
+        num_orch_threads,
+        PLATFORM_PHASE_RECORDS_PER_THREAD);
 }
 
 /**
@@ -366,16 +355,13 @@ static void switch_phase_buffer(int thread_idx) {
     PhaseBuffer* full_buf = s_current_phase_buf[thread_idx];
     if (full_buf == nullptr) return;
 
-    LOG_INFO("Thread %d: phase buffer is full (count=%u)",
-             thread_idx, full_buf->count);
+    LOG_INFO("Thread %d: phase buffer is full (count=%u)", thread_idx, full_buf->count);
 
     // Enqueue to ReadyQueue
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-                                   state->current_buf_ptr, seq, 1);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, state->current_buf_ptr, seq, 1);
     if (rc != 0) {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data",
-                 thread_idx);
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data", thread_idx);
         full_buf->count = 0;
         wmb();
         return;
@@ -401,8 +387,7 @@ static void switch_phase_buffer(int thread_idx) {
         LOG_INFO("Thread %d: switched to new phase buffer", thread_idx);
     } else {
         // No free buffer available, drop subsequent records
-        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up",
-                 thread_idx);
+        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up", thread_idx);
         s_current_phase_buf[thread_idx] = nullptr;
         state->current_buf_ptr = 0;
         wmb();
@@ -411,8 +396,10 @@ static void switch_phase_buffer(int thread_idx) {
 
 void perf_aicpu_record_phase(int thread_idx,
     AicpuPhaseId phase_id,
-                              uint64_t start_time, uint64_t end_time,
-                              uint32_t loop_iter, uint32_t tasks_processed) {
+    uint64_t start_time,
+    uint64_t end_time,
+    uint32_t loop_iter,
+    uint32_t tasks_processed) {
     if (s_phase_header == nullptr) {
         return;
     }
@@ -483,17 +470,14 @@ void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src) {
     wmb();
 
     LOG_INFO("Orchestrator summary written: %lld tasks, %.3fus",
-             (long long)src->submit_count,
-             cycles_to_us(src->end_time - src->start_time));
+        (long long)src->submit_count,
+        cycles_to_us(src->end_time - src->start_time));
 }
 
-void perf_aicpu_set_orch_thread_idx(int thread_idx) {
-    s_orch_thread_idx = thread_idx;
-}
+void perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }
 
-void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
-                                   uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx, uint32_t task_id) {
+void perf_aicpu_record_orch_phase(
+    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint32_t task_id) {
     if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
     perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
 }
@@ -519,26 +503,23 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
     }
 
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-                                   buf_ptr, seq, 1);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, buf_ptr, seq, 1);
     if (rc == 0) {
-        LOG_INFO("Thread %d: flushed phase buffer with %u records",
-                 thread_idx, buf->count);
+        LOG_INFO("Thread %d: flushed phase buffer with %u records", thread_idx, buf->count);
         state->current_buf_ptr = 0;
         s_current_phase_buf[thread_idx] = nullptr;
         wmb();
     } else {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!",
-                 thread_idx);
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!", thread_idx);
     }
 
     wmb();
 }
 
 void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
-                                        const int* core_counts,
-                                        int num_threads,
-                                        int total_cores) {
+    const int* core_counts,
+    int num_threads,
+    int total_cores) {
     if (s_phase_header == nullptr) {
         return;
     }

--- a/src/a5/platform/src/aicpu/platform_regs.cpp
+++ b/src/a5/platform/src/aicpu/platform_regs.cpp
@@ -14,13 +14,9 @@
 
 static uint64_t g_platform_regs = 0;
 
-void set_platform_regs(uint64_t regs) {
-    g_platform_regs = regs;
-}
+void set_platform_regs(uint64_t regs) { g_platform_regs = regs; }
 
-uint64_t get_platform_regs() {
-    return g_platform_regs;
-}
+uint64_t get_platform_regs() { return g_platform_regs; }
 
 void platform_init_aicore_regs(uint64_t reg_addr) {
     // Initialize task dispatch register to idle state

--- a/src/a5/platform/src/aicpu/unified_log_device.cpp
+++ b/src/a5/platform/src/aicpu/unified_log_device.cpp
@@ -24,14 +24,14 @@ void unified_log_warn(const char* func, const char* fmt, ...) {
     if (!is_log_enable_warn()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_warn(func, "%s", buffer);
 }
 
@@ -39,14 +39,14 @@ void unified_log_info(const char* func, const char* fmt, ...) {
     if (!is_log_enable_info()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_info(func, "%s", buffer);
 }
 
@@ -54,14 +54,14 @@ void unified_log_debug(const char* func, const char* fmt, ...) {
     if (!is_log_enable_debug()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_debug(func, "%s", buffer);
 }
 

--- a/src/a5/platform/src/host/host_log.cpp
+++ b/src/a5/platform/src/host/host_log.cpp
@@ -18,19 +18,14 @@ HostLogger& HostLogger::get_instance() {
     return instance;
 }
 
-HostLogger::HostLogger() 
-    : current_level_(HostLogLevel::INFO),
-      log_file_path_(""),
-      log_file_handle_(nullptr),
-      initialized_(false) {
+HostLogger::HostLogger()
+    : current_level_(HostLogLevel::INFO), log_file_path_(""), log_file_handle_(nullptr), initialized_(false) {
     init_from_env();
 }
 
 HostLogger::~HostLogger() {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (log_file_handle_ != nullptr && 
-        log_file_handle_ != stdout && 
-        log_file_handle_ != stderr) {
+    if (log_file_handle_ != nullptr && log_file_handle_ != stdout && log_file_handle_ != stderr) {
         fclose(log_file_handle_);
         log_file_handle_ = nullptr;
     }
@@ -38,17 +33,17 @@ HostLogger::~HostLogger() {
 
 void HostLogger::init_from_env() {
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     // Parse PTO_LOG_LEVEL environment variable
     const char* level_str = std::getenv("PTO_LOG_LEVEL");
     if (level_str != nullptr) {
         std::string level(level_str);
-        
+
         // Convert to lowercase for comparison
         for (char& c : level) {
             c = std::tolower(c);
         }
-        
+
         // Map log level strings to enum values (1-to-1 mapping)
         if (level == "error") {
             current_level_ = HostLogLevel::ERROR;
@@ -66,19 +61,17 @@ void HostLogger::init_from_env() {
         // Default to INFO
         current_level_ = HostLogLevel::INFO;
     }
-    
+
     // Parse PTO_LOG_FILE environment variable
     const char* file_path = std::getenv("PTO_LOG_FILE");
     if (file_path != nullptr && strlen(file_path) > 0) {
         log_file_path_ = file_path;
-        
+
         // Close previous file handle if it exists
-        if (log_file_handle_ != nullptr && 
-            log_file_handle_ != stdout && 
-            log_file_handle_ != stderr) {
+        if (log_file_handle_ != nullptr && log_file_handle_ != stdout && log_file_handle_ != stderr) {
             fclose(log_file_handle_);
         }
-        
+
         // Open log file in append mode
         log_file_handle_ = fopen(log_file_path_.c_str(), "a");
         if (log_file_handle_ == nullptr) {
@@ -88,7 +81,7 @@ void HostLogger::init_from_env() {
             log_file_path_.clear();
         }
     }
-    
+
     initialized_ = true;
 }
 
@@ -123,7 +116,7 @@ FILE* HostLogger::get_output_file(HostLogLevel level) {
     if (log_file_handle_ != nullptr) {
         return log_file_handle_;
     }
-    
+
     // Otherwise, use stderr for ERROR/WARN, stdout for INFO/DEBUG
     if (level == HostLogLevel::ERROR || level == HostLogLevel::WARN) {
         return stderr;
@@ -137,30 +130,29 @@ void HostLogger::log(HostLogLevel level, const char* format, ...) {
     if (!is_enabled(level)) {
         return;
     }
-    
+
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     // Get output file
     FILE* output = get_output_file(level);
     if (output == nullptr) {
         return;
     }
-    
+
     // Print log level prefix (matching Python format)
     fprintf(output, "[%s] ", get_level_name(level));
-    
+
     // Print formatted message
     va_list args;
     va_start(args, format);
     vfprintf(output, format, args);
     va_end(args);
-    
+
     // Add newline if not already present
     if (format[strlen(format) - 1] != '\n') {
         fprintf(output, "\n");
     }
-    
+
     // Flush to ensure immediate output
     fflush(output);
 }
-

--- a/src/a5/platform/src/host/host_log.h
+++ b/src/a5/platform/src/host/host_log.h
@@ -30,11 +30,11 @@
 // =============================================================================
 
 enum class HostLogLevel {
-    ALWAYS = -1, // always logging
-    ERROR = 0,   // error level only
-    WARN = 1,    // warn level and above
-    INFO = 2,    // info level and above (default)
-    DEBUG = 3    // debug level (all messages)
+    ALWAYS = -1,  // always logging
+    ERROR = 0,    // error level only
+    WARN = 1,     // warn level and above
+    INFO = 2,     // info level and above (default)
+    DEBUG = 3     // debug level (all messages)
 };
 
 // =============================================================================
@@ -48,7 +48,7 @@ public:
 
     // Log a message with specified level
     void log(HostLogLevel level, const char* format, ...);
-    
+
     // Check if a log level is enabled
     bool is_enabled(HostLogLevel level) const;
 
@@ -58,7 +58,7 @@ public:
 private:
     HostLogger();
     ~HostLogger();
-    
+
     // Delete copy/move constructors
     HostLogger(const HostLogger&) = delete;
     HostLogger& operator=(const HostLogger&) = delete;
@@ -67,10 +67,10 @@ private:
 
     // Initialize from environment variables
     void init_from_env();
-    
+
     // Get level name string
     const char* get_level_name(HostLogLevel level) const;
-    
+
     // Get output file handle (FILE* for stdout/stderr or file)
     FILE* get_output_file(HostLogLevel level);
 
@@ -86,29 +86,28 @@ private:
 // Logging Macros (High-Level Interface)
 // =============================================================================
 
-#define HOST_LOG_ERROR(fmt, ...) \
-    do { \
+#define HOST_LOG_ERROR(fmt, ...)                                                 \
+    do {                                                                         \
         HostLogger::get_instance().log(HostLogLevel::ERROR, fmt, ##__VA_ARGS__); \
-    } while(0)
+    } while (0)
 
-#define HOST_LOG_WARN(fmt, ...) \
-    do { \
+#define HOST_LOG_WARN(fmt, ...)                                                 \
+    do {                                                                        \
         HostLogger::get_instance().log(HostLogLevel::WARN, fmt, ##__VA_ARGS__); \
-    } while(0)
+    } while (0)
 
-#define HOST_LOG_INFO(fmt, ...) \
-    do { \
-        if (HostLogger::get_instance().is_enabled(HostLogLevel::INFO)) { \
+#define HOST_LOG_INFO(fmt, ...)                                                     \
+    do {                                                                            \
+        if (HostLogger::get_instance().is_enabled(HostLogLevel::INFO)) {            \
             HostLogger::get_instance().log(HostLogLevel::INFO, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                                           \
+    } while (0)
 
-#define HOST_LOG_DEBUG(fmt, ...) \
-    do { \
-        if (HostLogger::get_instance().is_enabled(HostLogLevel::DEBUG)) { \
+#define HOST_LOG_DEBUG(fmt, ...)                                                     \
+    do {                                                                             \
+        if (HostLogger::get_instance().is_enabled(HostLogLevel::DEBUG)) {            \
             HostLogger::get_instance().log(HostLogLevel::DEBUG, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                                            \
+    } while (0)
 
-#endif // PLATFORM_HOST_LOG_H_
-
+#endif  // PLATFORM_HOST_LOG_H_

--- a/src/a5/platform/src/host/performance_collector.cpp
+++ b/src/a5/platform/src/host/performance_collector.cpp
@@ -30,9 +30,14 @@ ProfMemoryManager::~ProfMemoryManager() {
     }
 }
 
-void ProfMemoryManager::start(void* shared_mem_host, int num_cores, int num_phase_threads,
-                               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-                               PerfFreeCallback free_cb, void* user_data, int device_id) {
+void ProfMemoryManager::start(void* shared_mem_host,
+    int num_cores,
+    int num_phase_threads,
+    PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb,
+    void* user_data,
+    int device_id) {
     shared_mem_host_ = shared_mem_host;
     num_cores_ = num_cores;
     num_phase_threads_ = num_phase_threads;
@@ -79,7 +84,7 @@ bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo& info) {
 
 bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout) {
     std::unique_lock<std::mutex> lock(ready_mutex_);
-    if (ready_cv_.wait_for(lock, timeout, [this]{ return !ready_queue_.empty(); })) {
+    if (ready_cv_.wait_for(lock, timeout, [this] { return !ready_queue_.empty(); })) {
         info = ready_queue_.front();
         ready_queue_.pop();
         return true;
@@ -138,12 +143,10 @@ void* ProfMemoryManager::resolve_host_ptr(void* dev_ptr) {
     return nullptr;
 }
 
-void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) {
-    dev_to_host_[dev_ptr] = host_ptr;
-}
+void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
 
-void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*thread_idx*/,
-                                              const ReadyQueueEntry& entry) {
+void ProfMemoryManager::process_ready_entry(
+    PerfDataHeader* /*header*/, int /*thread_idx*/, const ReadyQueueEntry& entry) {
     bool is_phase = (entry.is_phase != 0);
     uint64_t old_dev_ptr = entry.buffer_ptr;
     uint32_t seq = entry.buffer_seq;
@@ -283,7 +286,10 @@ void ProfMemoryManager::mgmt_loop() {
             // Validate indices to prevent OOB access from corrupted shared memory
             if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
                 LOG_ERROR("mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)",
-                          t, head, tail, PLATFORM_PROF_READYQUEUE_SIZE);
+                    t,
+                    head,
+                    tail,
+                    PLATFORM_PROF_READYQUEUE_SIZE);
                 continue;
             }
 
@@ -321,8 +327,7 @@ void ProfMemoryManager::mgmt_loop() {
         uint32_t head = hdr->queue_heads[t];
         uint32_t tail = hdr->queue_tails[t];
         if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u",
-                      t, head, tail);
+            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u", t, head, tail);
             continue;
         }
         while (head != tail) {
@@ -387,12 +392,12 @@ void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out
 }
 
 int PerformanceCollector::initialize(Runtime& runtime,
-                                      int num_aicore,
-                                      int device_id,
-                                      PerfAllocCallback alloc_cb,
-                                      PerfRegisterCallback register_cb,
-                                      PerfFreeCallback free_cb,
-                                      void* user_data) {
+    int num_aicore,
+    int device_id,
+    PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb,
+    void* user_data) {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
         return -1;
@@ -421,8 +426,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("  Header size:          %zu bytes", sizeof(PerfDataHeader));
     LOG_DEBUG("  PerfBufferState size: %zu bytes each", sizeof(PerfBufferState));
     LOG_DEBUG("  PhaseBufferState size:%zu bytes each", sizeof(PhaseBufferState));
-    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)",
-              total_size, total_size / 1024);
+    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
 
     // Step 2: Allocate shared memory for slot arrays
     void* perf_dev_ptr = alloc_cb(total_size, user_data);
@@ -498,8 +502,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PerfBufferStates with %d buffers each",
-              num_aicore, PLATFORM_PROF_SLOT_COUNT);
+    LOG_DEBUG("Initialized %d PerfBufferStates with %d buffers each", num_aicore, PLATFORM_PROF_SLOT_COUNT);
 
     // Step 6: Initialize PhaseBufferStates and pre-fill free_queues
     for (int t = 0; t < num_phase_threads; t++) {
@@ -530,8 +533,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PhaseBufferStates with %d buffers each",
-              num_phase_threads, PLATFORM_PROF_SLOT_COUNT);
+    LOG_DEBUG("Initialized %d PhaseBufferStates with %d buffers each", num_phase_threads, PLATFORM_PROF_SLOT_COUNT);
 
     wmb();
 
@@ -551,10 +553,14 @@ void PerformanceCollector::start_memory_manager() {
         return;
     }
 
-    memory_manager_.start(perf_shared_mem_host_, num_aicore_,
-                           PLATFORM_MAX_AICPU_THREADS,
-                           alloc_cb_, register_cb_, free_cb_,
-                           user_data_, device_id_);
+    memory_manager_.start(perf_shared_mem_host_,
+        num_aicore_,
+        PLATFORM_MAX_AICPU_THREADS,
+        alloc_cb_,
+        register_cb_,
+        free_cb_,
+        user_data_,
+        device_id_);
 }
 
 void PerformanceCollector::stop_memory_manager() {
@@ -592,7 +598,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
                 LOG_ERROR("Timeout waiting for AICPU task count after %ld seconds",
-                         std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
                 return;
             }
 
@@ -661,7 +667,10 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 }
 
                 LOG_DEBUG("Collected %u perf records from core %u (total: %d/%d)",
-                         count, core_index, total_records_collected, expected_tasks);
+                    count,
+                    core_index,
+                    total_records_collected,
+                    expected_tasks);
 
             } else {
                 PhaseBuffer* buf = (PhaseBuffer*)info.host_buffer_ptr;
@@ -691,9 +700,8 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
                 LOG_ERROR("Performance data collection idle timeout after %ld seconds",
-                         std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
-                LOG_ERROR("Collected %d / %d records before timeout",
-                         total_records_collected, expected_tasks);
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                LOG_ERROR("Collected %d / %d records before timeout", total_records_collected, expected_tasks);
                 break;
             }
         }
@@ -703,8 +711,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     LOG_INFO("Total records collected: %d", total_records_collected);
 
     if (total_records_collected < expected_tasks) {
-        LOG_WARN("Incomplete collection (%d / %d records)",
-                 total_records_collected, expected_tasks);
+        LOG_WARN("Incomplete collection (%d / %d records)", total_records_collected, expected_tasks);
     }
 
     LOG_INFO("Performance data collection complete");
@@ -763,8 +770,7 @@ void PerformanceCollector::drain_remaining_buffers() {
     }
 
     if (drained_perf > 0 || drained_phase > 0) {
-        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records",
-                 drained_perf, drained_phase);
+        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records", drained_perf, drained_phase);
     }
 
     if (drained_phase > 0) {
@@ -783,15 +789,15 @@ void PerformanceCollector::collect_phase_data() {
 
     // Validate magic
     if (phase_header->magic != AICPU_PHASE_MAGIC) {
-        LOG_INFO("No phase profiling data found (magic mismatch: 0x%x vs 0x%x)",
-                 phase_header->magic, AICPU_PHASE_MAGIC);
+        LOG_INFO(
+            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC);
         return;
     }
 
     int num_sched_threads = phase_header->num_sched_threads;
     if (num_sched_threads > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("Invalid num_sched_threads %d from shared memory (max=%d)",
-                  num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
+        LOG_ERROR(
+            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
         return;
     }
     LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
@@ -811,8 +817,7 @@ void PerformanceCollector::collect_phase_data() {
         if (buf_ptr != 0) {
             void* host_ptr = memory_manager_.resolve_host_ptr((void*)buf_ptr);
             if (host_ptr == nullptr) {
-                LOG_ERROR("collect_phase_data: no host mapping for dev_ptr=%p (thread %d)",
-                          (void*)buf_ptr, t);
+                LOG_ERROR("collect_phase_data: no host mapping for dev_ptr=%p (thread %d)", (void*)buf_ptr, t);
                 continue;
             }
             PhaseBuffer* pbuf = (PhaseBuffer*)host_ptr;
@@ -835,11 +840,16 @@ void PerformanceCollector::collect_phase_data() {
         if (!collected_phase_records_[t].empty()) {
             size_t sched_count = 0, orch_count = 0;
             for (const auto& r : collected_phase_records_[t]) {
-                if (is_scheduler_phase(r.phase_id)) sched_count++;
-                else orch_count++;
+                if (is_scheduler_phase(r.phase_id))
+                    sched_count++;
+                else
+                    orch_count++;
             }
             LOG_INFO("  Thread %zu: %zu records (sched=%zu, orch=%zu)",
-                     t, collected_phase_records_[t].size(), sched_count, orch_count);
+                t,
+                collected_phase_records_[t].size(),
+                sched_count,
+                orch_count);
         }
     }
 
@@ -849,8 +859,8 @@ void PerformanceCollector::collect_phase_data() {
 
     if (orch_valid) {
         LOG_INFO("  Orchestrator: %lld tasks, %.3fus",
-                 (long long)collected_orch_summary_.submit_count,
-                 cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time));
+            (long long)collected_orch_summary_.submit_count,
+            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time));
     } else {
         LOG_INFO("  Orchestrator: no summary data");
     }
@@ -859,7 +869,10 @@ void PerformanceCollector::collect_phase_data() {
     bool has_accumulated = has_phase_data_;
     if (!has_accumulated) {
         for (const auto& v : collected_phase_records_) {
-            if (!v.empty()) { has_accumulated = true; break; }
+            if (!v.empty()) {
+                has_accumulated = true;
+                break;
+            }
         }
     }
     has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
@@ -867,13 +880,13 @@ void PerformanceCollector::collect_phase_data() {
     // Read core-to-thread mapping
     int num_cores = static_cast<int>(phase_header->num_cores);
     if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
-        core_to_thread_.assign(phase_header->core_to_thread,
-                                phase_header->core_to_thread + num_cores);
+        core_to_thread_.assign(phase_header->core_to_thread, phase_header->core_to_thread + num_cores);
         LOG_INFO("  Core-to-thread mapping: %d cores", num_cores);
     }
 
     LOG_INFO("Phase data collection complete: %d remaining records, orch_summary=%s",
-             total_phase_records, orch_valid ? "yes" : "no");
+        total_phase_records,
+        orch_valid ? "yes" : "no");
 }
 
 int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
@@ -917,10 +930,9 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     }
 
     // Sort by task_id
-    std::sort(tagged_records.begin(), tagged_records.end(),
-              [](const TaggedRecord& a, const TaggedRecord& b) {
-                  return a.record->task_id < b.record->task_id;
-              });
+    std::sort(tagged_records.begin(), tagged_records.end(), [](const TaggedRecord& a, const TaggedRecord& b) {
+        return a.record->task_id < b.record->task_id;
+    });
 
     // Step 4: Calculate base time (minimum timestamp across all records)
     uint64_t base_time_cycles = UINT64_MAX;
@@ -942,8 +954,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                 }
             }
         }
-        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC &&
-            collected_orch_summary_.start_time > 0 &&
+        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC && collected_orch_summary_.start_time > 0 &&
             collected_orch_summary_.start_time < base_time_cycles) {
             base_time_cycles = collected_orch_summary_.start_time;
         }
@@ -954,8 +965,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     std::tm* timeinfo = std::localtime(&now);
     char time_buffer[32];
     std::strftime(time_buffer, sizeof(time_buffer), "%Y%m%d_%H%M%S", timeinfo);
-    std::string filepath = output_path + "/perf_swimlane_"
-                          + std::string(time_buffer) + ".json";
+    std::string filepath = output_path + "/perf_swimlane_" + std::string(time_buffer) + ".json";
 
     // Step 6: Open JSON file for writing
     std::ofstream outfile(filepath);
@@ -994,8 +1004,8 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         outfile << "      \"dispatch_time_us\": " << std::fixed << std::setprecision(3) << dispatch_us << ",\n";
         outfile << "      \"finish_time_us\": " << std::fixed << std::setprecision(3) << finish_us << ",\n";
         outfile << "      \"fanout\": [";
-        int safe_fanout_count = (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT)
-                                ? record.fanout_count : 0;
+        int safe_fanout_count =
+            (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT) ? record.fanout_count : 0;
         for (int j = 0; j < safe_fanout_count; ++j) {
             outfile << record.fanout[j];
             if (j < safe_fanout_count - 1) {
@@ -1016,26 +1026,41 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     if (has_phase_data_) {
         auto sched_phase_name = [](AicpuPhaseId id) -> const char* {
             switch (id) {
-                case AicpuPhaseId::SCHED_COMPLETE:    return "complete";
-                case AicpuPhaseId::SCHED_DISPATCH:    return "dispatch";
-                case AicpuPhaseId::SCHED_SCAN:        return "scan";
-                case AicpuPhaseId::SCHED_IDLE_WAIT:   return "idle";
-                default: return "unknown";
+                case AicpuPhaseId::SCHED_COMPLETE:
+                    return "complete";
+                case AicpuPhaseId::SCHED_DISPATCH:
+                    return "dispatch";
+                case AicpuPhaseId::SCHED_SCAN:
+                    return "scan";
+                case AicpuPhaseId::SCHED_IDLE_WAIT:
+                    return "idle";
+                default:
+                    return "unknown";
             }
         };
 
         auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
             switch (id) {
-                case AicpuPhaseId::ORCH_SYNC:      return "orch_sync";
-                case AicpuPhaseId::ORCH_ALLOC:     return "orch_alloc";
-                case AicpuPhaseId::ORCH_PARAMS:    return "orch_params";
-                case AicpuPhaseId::ORCH_LOOKUP:    return "orch_lookup";
-                case AicpuPhaseId::ORCH_HEAP:      return "orch_heap";
-                case AicpuPhaseId::ORCH_INSERT:    return "orch_insert";
-                case AicpuPhaseId::ORCH_FANIN:     return "orch_fanin";
-                case AicpuPhaseId::ORCH_FINALIZE:  return "orch_finalize";
-                case AicpuPhaseId::ORCH_SCOPE_END: return "orch_scope_end";
-                default: return "unknown";
+                case AicpuPhaseId::ORCH_SYNC:
+                    return "orch_sync";
+                case AicpuPhaseId::ORCH_ALLOC:
+                    return "orch_alloc";
+                case AicpuPhaseId::ORCH_PARAMS:
+                    return "orch_params";
+                case AicpuPhaseId::ORCH_LOOKUP:
+                    return "orch_lookup";
+                case AicpuPhaseId::ORCH_HEAP:
+                    return "orch_heap";
+                case AicpuPhaseId::ORCH_INSERT:
+                    return "orch_insert";
+                case AicpuPhaseId::ORCH_FANIN:
+                    return "orch_fanin";
+                case AicpuPhaseId::ORCH_FINALIZE:
+                    return "orch_finalize";
+                case AicpuPhaseId::ORCH_SCOPE_END:
+                    return "orch_scope_end";
+                default:
+                    return "unknown";
             }
         };
 
@@ -1050,10 +1075,9 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                 double end_us = cycles_to_us(pr.end_time - base_time_cycles);
                 if (!first) outfile << ",\n";
                 outfile << "      {\"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
-                        << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                        << ", \"phase\": \"" << sched_phase_name(pr.phase_id) << "\""
-                        << ", \"loop_iter\": " << pr.loop_iter
-                        << ", \"tasks_processed\": " << pr.tasks_processed
+                        << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us << ", \"phase\": \""
+                        << sched_phase_name(pr.phase_id) << "\""
+                        << ", \"loop_iter\": " << pr.loop_iter << ", \"tasks_processed\": " << pr.tasks_processed
                         << "}";
                 first = false;
             }
@@ -1074,14 +1098,22 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
             outfile << "    \"end_time_us\": " << std::fixed << std::setprecision(3) << orch_end_us << ",\n";
             outfile << "    \"submit_count\": " << collected_orch_summary_.submit_count << ",\n";
             outfile << "    \"phase_us\": {\n";
-            outfile << "      \"sync\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.sync_cycle) << ",\n";
-            outfile << "      \"alloc\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
-            outfile << "      \"params\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.params_cycle) << ",\n";
-            outfile << "      \"lookup\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
-            outfile << "      \"heap\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
-            outfile << "      \"insert\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
-            outfile << "      \"fanin\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
-            outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
+            outfile << "      \"sync\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.sync_cycle) << ",\n";
+            outfile << "      \"alloc\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
+            outfile << "      \"params\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.params_cycle) << ",\n";
+            outfile << "      \"lookup\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
+            outfile << "      \"heap\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
+            outfile << "      \"insert\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
+            outfile << "      \"fanin\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
+            outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
             outfile << "    }\n";
             outfile << "  }";
         }
@@ -1090,7 +1122,10 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         bool has_orch_phases = false;
         for (const auto& v : collected_phase_records_) {
             for (const auto& r : v) {
-                if (!is_scheduler_phase(r.phase_id)) { has_orch_phases = true; break; }
+                if (!is_scheduler_phase(r.phase_id)) {
+                    has_orch_phases = true;
+                    break;
+                }
             }
             if (has_orch_phases) break;
         }
@@ -1108,8 +1143,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                             << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                             << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
                             << ", \"submit_idx\": " << pr.loop_iter
-                            << ", \"task_id\": " << static_cast<int32_t>(pr.tasks_processed)
-                            << "}";
+                            << ", \"task_id\": " << static_cast<int32_t>(pr.tasks_processed) << "}";
                     first = false;
                 }
                 if (!first) outfile << "\n";
@@ -1144,9 +1178,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     return 0;
 }
 
-int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
-                                    PerfFreeCallback free_cb,
-                                    void* user_data) {
+int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data) {
     if (perf_shared_mem_host_ == nullptr) {
         return 0;
     }
@@ -1181,8 +1213,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
             head++;
         }
         if (head != tail) {
-            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)",
-                     i, head, tail);
+            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)", i, head, tail);
         }
     }
 
@@ -1209,8 +1240,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
             head++;
         }
         if (head != tail) {
-            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)",
-                     t, head, tail);
+            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)", t, head, tail);
         }
     }
 

--- a/src/a5/platform/src/host/unified_log_host.cpp
+++ b/src/a5/platform/src/host/unified_log_host.cpp
@@ -21,11 +21,11 @@ void unified_log_error(const char* func, const char* fmt, ...) {
 void unified_log_warn(const char* func, const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     HostLogger::get_instance().log(HostLogLevel::WARN, "%s: %s", func, buffer);
 }
 

--- a/src/a5/runtime/README.md
+++ b/src/a5/runtime/README.md
@@ -12,4 +12,3 @@ The A5 runtime layer currently contains a temporary copy of A2A3's `host_build_g
 - **Purpose**: Validate A5 platform layer functionality
 - **Source**: Copied from A2A3 baseline
 - **Status**: ⚠️ For validation only, not optimized for A5 hardware
-

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -70,8 +70,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, actual_task_id,
-                                      start_time, end_time);
+                perf_aicore_record_task(perf_buf, actual_task_id, start_time, end_time);
             }
 
             last_task_id = task_id;

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -36,8 +36,8 @@ struct AicpuExecutor {
     int thread_num_{0};
     int cores_total_num_{0};
     int thread_cores_num_[MAX_AICPU_THREADS]{};  // Total cores (AIC+AIV) assigned to each thread
-    int aic_per_thread_{0};  // Max AIC cores per thread (ceil), used as local queue cap
-    int aiv_per_thread_{0};  // Max AIV cores per thread (ceil), used as local queue cap
+    int aic_per_thread_{0};                      // Max AIC cores per thread (ceil), used as local queue cap
+    int aiv_per_thread_{0};                      // Max AIV cores per thread (ceil), used as local queue cap
     int core_assignments_[MAX_AICPU_THREADS][MAX_CORES_PER_THREAD];
 
     // Core discovery arrays (space-time tradeoff: avoid sorting)
@@ -85,8 +85,8 @@ struct AicpuExecutor {
     std::atomic<int> finished_count_{0};
 
     // ===== Performance profiling state =====
-    uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];  // Per-core AICPU dispatch timestamp
-    uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER]; // Per-core total dispatched task counter
+    uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];   // Per-core AICPU dispatch timestamp
+    uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER];  // Per-core total dispatched task counter
 
     // ===== Methods =====
     int init(Runtime* runtime);
@@ -333,7 +333,9 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
             LOG_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                      i, physical_core_id, max_physical_cores_count);
+                i,
+                physical_core_id,
+                max_physical_cores_count);
             handshake_failed = true;
             continue;
         }
@@ -395,7 +397,11 @@ void AicpuExecutor::assign_cores_to_threads() {
     aiv_per_thread_ = (aiv_count_ + thread_num_ - 1) / thread_num_;
 
     LOG_INFO("Core Assignment: %d AIC cores, %d AIV cores across %d threads (max %d AIC/thread, %d AIV/thread)",
-        aic_count_, aiv_count_, thread_num_, aic_per_thread_, aiv_per_thread_);
+        aic_count_,
+        aiv_count_,
+        thread_num_,
+        aic_per_thread_,
+        aiv_per_thread_);
 
     for (int t = 0; t < thread_num_; t++) {
         int core_idx = 0;
@@ -615,12 +621,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             int reg_state = EXTRACT_TASK_STATE(reg_val);
 
             // Case 1: Pending task finished directly
-            if (reg_task_id == pending_task_ids_[core_id] &&
-                reg_state == TASK_FIN_STATE) {
-
+            if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {
                 LOG_INFO("Thread %d: Core %d completed task %d (running_id=%d)",
-                         thread_idx, core_id, pending_task_ids_[core_id], running_task_ids_[core_id]);
-                
+                    thread_idx,
+                    core_id,
+                    pending_task_ids_[core_id],
+                    running_task_ids_[core_id]);
 
                 int completed_task_id = pending_task_ids_[core_id];
 
@@ -630,12 +636,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     PerfBuffer* perf_buf = (PerfBuffer*)h->perf_records_addr;
                     Task* task = &runtime.tasks[completed_task_id];
                     if (perf_aicpu_complete_record(perf_buf,
-                        static_cast<uint32_t>(completed_task_id),
-                        task->func_id, h->core_type,
-                        dispatch_timestamps_[core_id], finish_ts,
-                        0, task->fanout, task->fanout_count) != 0) {
-                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d",
-                            core_id, completed_task_id);
+                            static_cast<uint32_t>(completed_task_id),
+                            task->func_id,
+                            h->core_type,
+                            dispatch_timestamps_[core_id],
+                            finish_ts,
+                            0,
+                            task->fanout,
+                            task->fanout_count) != 0) {
+                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d", core_id, completed_task_id);
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
@@ -690,8 +699,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         cur_aiv_tail,
                         cur_aiv_ready_count);
 
-                    LOG_INFO("Thread %d: Core %d resolved old running task %d",
-                             thread_idx, core_id, prev_running_id);
+                    LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
                 Task* task = runtime.get_task(completed_task_id);
@@ -713,11 +721,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             }
 
             // Case 2: Pending task received ACK
-            else if (reg_task_id == pending_task_ids_[core_id] &&
-                     reg_state == TASK_ACK_STATE) {
-
+            else if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_ACK_STATE) {
                 LOG_INFO("Thread %d: Core %d ACKed task %d (running_id=%d)",
-                         thread_idx, core_id, pending_task_ids_[core_id], running_task_ids_[core_id]);
+                    thread_idx,
+                    core_id,
+                    pending_task_ids_[core_id],
+                    running_task_ids_[core_id]);
 
                 int prev_running_id = running_task_ids_[core_id];
 
@@ -743,8 +752,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         cur_aiv_tail,
                         cur_aiv_ready_count);
 
-                    LOG_INFO("Thread %d: Core %d resolved old running task %d",
-                             thread_idx, core_id, prev_running_id);
+                    LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
                 // Core can accept new task now (pipeline!)
@@ -752,11 +760,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             }
 
             // Case 3: Running task finished
-            else if (reg_task_id == running_task_ids_[core_id] &&
-                     reg_state == TASK_FIN_STATE) {
-
+            else if (reg_task_id == running_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {
                 LOG_INFO("Thread %d: Core %d completed task %d (pending_id=%d)",
-                         thread_idx, core_id, running_task_ids_[core_id], pending_task_ids_[core_id]);
+                    thread_idx,
+                    core_id,
+                    running_task_ids_[core_id],
+                    pending_task_ids_[core_id]);
 
                 int completed_task_id = running_task_ids_[core_id];
 
@@ -765,12 +774,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     PerfBuffer* perf_buf = (PerfBuffer*)h->perf_records_addr;
                     Task* task = &runtime.tasks[completed_task_id];
                     if (perf_aicpu_complete_record(perf_buf,
-                        static_cast<uint32_t>(completed_task_id),
-                        task->func_id, h->core_type,
-                        dispatch_timestamps_[core_id], finish_ts,
-                        0, task->fanout, task->fanout_count) != 0) {
-                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d",
-                            core_id, completed_task_id);
+                            static_cast<uint32_t>(completed_task_id),
+                            task->func_id,
+                            h->core_type,
+                            dispatch_timestamps_[core_id],
+                            finish_ts,
+                            0,
+                            task->fanout,
+                            task->fanout_count) != 0) {
+                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d", core_id, completed_task_id);
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
@@ -900,7 +912,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
 
             for (int i = 0; i < core_num; i++) {
                 int core_id = cur_thread_cores[i];
-                if (pending_task_ids_[core_id] != AICPU_TASK_INVALID || running_task_ids_[core_id] != AICPU_TASK_INVALID) {
+                if (pending_task_ids_[core_id] != AICPU_TASK_INVALID ||
+                    running_task_ids_[core_id] != AICPU_TASK_INVALID) {
                     all_cores_idle = false;
 
                     if (verification_warning_count == 0) {

--- a/src/a5/runtime/host_build_graph/build_config.py
+++ b/src/a5/runtime/host_build_graph/build_config.py
@@ -2,16 +2,7 @@
 # All paths are relative to this file's directory (src/runtime/)
 
 BUILD_CONFIG = {
-    "aicore": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicore", "runtime"]
-    },
-    "aicpu": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicpu", "runtime"]
-    },
-    "host": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["host", "runtime"]
-    }
+    "aicore": {"include_dirs": ["runtime"], "source_dirs": ["aicore", "runtime"]},
+    "aicpu": {"include_dirs": ["runtime"], "source_dirs": ["aicpu", "runtime"]},
+    "host": {"include_dirs": ["runtime"], "source_dirs": ["host", "runtime"]},
 }

--- a/src/a5/runtime/host_build_graph/host/runtime_compile_info.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_compile_info.cpp
@@ -13,5 +13,4 @@ ToolchainType get_orchestration_compiler(void) {
     // host_build_graph: always host g++ (orchestration runs on host)
     return TOOLCHAIN_HOST_GXX;
 }
-
 }

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -58,16 +58,16 @@ extern "C" {
  * @param orch_args_count   Number of TaskArg entries
  * @return 0 on success, -1 on failure
  */
-int init_runtime_impl(Runtime *runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    const TaskArg* orch_args,
-                    int orch_args_count,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count) {
+int init_runtime_impl(Runtime* runtime,
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count) {
     // Validate inputs
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -75,12 +75,11 @@ int init_runtime_impl(Runtime *runtime,
     }
 
     // Register kernel binaries via platform-provided upload function
-    if (kernel_count > 0 && kernel_func_ids != NULL &&
-        kernel_binaries != NULL && kernel_sizes != NULL) {
+    if (kernel_count > 0 && kernel_func_ids != NULL && kernel_binaries != NULL && kernel_sizes != NULL) {
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", kernel_count);
         for (int i = 0; i < kernel_count; i++) {
-            uint64_t addr = runtime->host_api.upload_kernel_binary(
-                kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
+            uint64_t addr =
+                runtime->host_api.upload_kernel_binary(kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
             if (addr == 0) {
                 LOG_ERROR("Failed to upload kernel binary for func_id=%d", kernel_func_ids[i]);
                 return -1;
@@ -120,8 +119,7 @@ int init_runtime_impl(Runtime *runtime,
     }
 
     dlerror();  // Clear any existing error
-    OrchestrationFunc orch_func =
-        reinterpret_cast<OrchestrationFunc>(dlsym(handle, orch_func_name));
+    OrchestrationFunc orch_func = reinterpret_cast<OrchestrationFunc>(dlsym(handle, orch_func_name));
     const char* dlsym_error = dlerror();
     if (dlsym_error != nullptr) {
         LOG_ERROR("dlsym failed for '%s': %s", orch_func_name, dlsym_error);
@@ -166,7 +164,7 @@ int init_runtime_impl(Runtime *runtime,
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-int validate_runtime_impl(Runtime *runtime) {
+int validate_runtime_impl(Runtime* runtime) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -222,5 +220,5 @@ int validate_runtime_impl(Runtime *runtime) {
 }
 
 #ifdef __cplusplus
-}  /* extern "C" */
+} /* extern "C" */
 #endif

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -71,8 +71,8 @@ int Runtime::add_task(uint64_t* args, int num_args, int func_id, CoreType core_t
     if (args && num_args > 0) {
         memcpy(task->args, args, num_args * sizeof(uint64_t));
     }
-    task->function_bin_addr = 0;    // Will be set by host before copying to device
-    task->core_type = core_type;    // Set core type
+    task->function_bin_addr = 0;  // Will be set by host before copying to device
+    task->core_type = core_type;  // Set core type
     task->fanin = 0;
     task->fanout_count = 0;
     memset(task->fanout, 0, sizeof(task->fanout));
@@ -145,7 +145,7 @@ void Runtime::print_runtime() const {
     // Print initially ready tasks
     LOG_DEBUG("\nInitially Ready Tasks (fanin==0):");
     LOG_DEBUG("----------------------------------------------------------------------");
-    
+
     // Build ready tasks string
     char ready_tasks_str[1024] = "  ";
     int offset = 2;
@@ -175,8 +175,11 @@ void Runtime::print_runtime() const {
         char fanout_str[512];
         int fo_offset = 0;
         for (int j = 0; j < t->fanout_count && fo_offset < 500; j++) {
-            fo_offset += snprintf(fanout_str + fo_offset, sizeof(fanout_str) - fo_offset, 
-                                  "%d%s", t->fanout[j], j < t->fanout_count - 1 ? "," : "");
+            fo_offset += snprintf(fanout_str + fo_offset,
+                sizeof(fanout_str) - fo_offset,
+                "%d%s",
+                t->fanout[j],
+                j < t->fanout_count - 1 ? "," : "");
         }
 
         LOG_DEBUG("  Task %d: func_id=%d, fanin=%d, fanout=%d, args=%d [%s]",
@@ -207,14 +210,8 @@ void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
     LOG_DEBUG("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
 }
 
-TensorPair* Runtime::get_tensor_pairs() {
-    return tensor_pairs;
-}
+TensorPair* Runtime::get_tensor_pairs() { return tensor_pairs; }
 
-int Runtime::get_tensor_pair_count() const {
-    return tensor_pair_count;
-}
+int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
-void Runtime::clear_tensor_pairs() {
-    tensor_pair_count = 0;
-}
+void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -101,17 +101,17 @@
  * - physical_core_id: Written by AICPU, read by AICore (physical core ID)
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;          // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;          // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                 // Task pointer: 0=no task, non-zero=Task* address
-    volatile int32_t task_status;           // Task execution status: 0=idle, 1=busy
-    volatile int32_t control;               // Control signal: 0=execute, 1=quit
-    volatile CoreType core_type;            // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t perf_records_addr;    // Performance records address
-    volatile uint32_t perf_buffer_status;   // 0 = not full, 1 = full
-    volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t aicpu_ready;         // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;         // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                // Task pointer: 0=no task, non-zero=Task* address
+    volatile int32_t task_status;          // Task execution status: 0=idle, 1=busy
+    volatile int32_t control;              // Control signal: 0=execute, 1=quit
+    volatile CoreType core_type;           // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t perf_records_addr;   // Performance records address
+    volatile uint32_t perf_buffer_status;  // 0 = not full, 1 = full
+    volatile uint32_t physical_core_id;    // Physical core ID
     volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;   // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**
@@ -188,26 +188,26 @@ public:
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int sche_cpu_num;  // Number of AICPU threads for scheduling
+    int sche_cpu_num;     // Number of AICPU threads for scheduling
     int orch_thread_num;  // Number of orchestrator threads (unused, for API compatibility)
 
     // Profiling support
-    bool enable_profiling;                  // Enable profiling flag
-    uint64_t perf_data_base;                // Performance data shared memory base address (device-side)
+    bool enable_profiling;    // Enable profiling flag
+    uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
 
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
 
 private:
-    int next_task_id;               // Next available task ID
+    int next_task_id;  // Next available task ID
 
     // Initial ready tasks (computed once, read-only after)
     int initial_ready_tasks[RUNTIME_MAX_TASKS];
     int initial_ready_count;
 
-  // Tensor pairs for host-device memory tracking
-  TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
-  int tensor_pair_count;
+    // Tensor pairs for host-device memory tracking
+    TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
+    int tensor_pair_count;
 
     // Function address mapping (for API compatibility with rt2)
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
@@ -235,7 +235,7 @@ public:
      * @param core_type Core type for this task (CoreType::AIC or CoreType::AIV)
      * @return Task ID (>= 0) on success, -1 on failure
      */
-    int add_task(uint64_t *args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
+    int add_task(uint64_t* args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
 
     /**
      * Add a dependency edge: from_task -> to_task
@@ -258,7 +258,7 @@ public:
      * @param task_id  Task ID to query
      * @return Pointer to task, or nullptr if invalid ID
      */
-    Task *get_task(int task_id);
+    Task* get_task(int task_id);
 
     /**
      * Get the total number of tasks in the runtime
@@ -278,7 +278,7 @@ public:
      * nullptr)
      * @return Number of initially ready tasks
      */
-    int get_initial_ready_tasks(int *ready_tasks);
+    int get_initial_ready_tasks(int* ready_tasks);
 
     // =========================================================================
     // Utility Methods

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -20,9 +20,7 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(
-    __gm__ PTO2DispatchPayload* payload
-) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
@@ -73,8 +71,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     // Cache payload address (set once by AICPU during initialization, never changes)
-    __gm__ PTO2DispatchPayload* payload =
-        reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
 
@@ -116,8 +113,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, task_id,
-                                       start_time, end_time);
+                perf_aicore_record_task(perf_buf, task_id, start_time, end_time);
             }
 
             last_reg_val = reg_val;

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -39,7 +39,12 @@
 #if PTO2_PROFILING
 // Accumulated nanoseconds per sub-step
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
-#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+#define CYCLE_COUNT_LAP(acc)       \
+    do {                           \
+        _t1 = get_sys_cnt_aicpu(); \
+        acc += (_t1 - _t0);        \
+        _t0 = _t1;                 \
+    } while (0)
 #else
 #define CYCLE_COUNT_START()
 #define CYCLE_COUNT_LAP(acc)
@@ -48,7 +53,8 @@
 // Device orchestration function signature (loaded via dlopen).
 // The orchestration .so receives a PTO2Runtime* (with ops table populated)
 // instead of a raw shared-memory pointer.
-typedef void (*DeviceOrchestrationFunc)(PTO2Runtime* rt, TaskArg* orch_args, int32_t orch_thread_num, int32_t orch_thread_index);
+typedef void (*DeviceOrchestrationFunc)(
+    PTO2Runtime* rt, TaskArg* orch_args, int32_t orch_thread_num, int32_t orch_thread_index);
 
 // Config function exported by orchestration .so
 typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(TaskArg* orch_args);
@@ -58,8 +64,8 @@ constexpr int32_t MAX_AIC_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD;
 constexpr int32_t MAX_AIV_PER_THREAD = PLATFORM_MAX_AIV_PER_THREAD;
 constexpr int32_t MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 
-constexpr int32_t MAX_IDLE_ITERATIONS = 800000;  // ~20s idle then scheduler gives up (avoid long hang)
-constexpr int32_t STALL_LOG_INTERVAL = 50000;    // DEV_ALWAYS every N idle iters to debug hang
+constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
+constexpr int32_t STALL_LOG_INTERVAL = 50000;         // DEV_ALWAYS every N idle iters to debug hang
 constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
 constexpr int32_t STALL_DUMP_WAIT_MAX = 4;
@@ -67,14 +73,14 @@ constexpr int32_t STALL_DUMP_CORE_MAX = 8;
 constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
 constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
 
-static PTO2Runtime *rt{nullptr};
+static PTO2Runtime* rt{nullptr};
 
 // Per-core dispatch payload storage (one per physical core)
 static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
 
 // Core information for discovery (with register address for fast dispatch)
 struct CoreInfo {
-    int32_t worker_id;              // Index in runtime.workers[]
+    int32_t worker_id;          // Index in runtime.workers[]
     uint32_t physical_core_id;  // Hardware physical core ID (from AICore)
     uint64_t reg_addr;          // Cached register address for fast access
     CoreType core_type;
@@ -117,30 +123,32 @@ struct CoreStateTracker {
     CoreTypeTracker& aic() { return by_type[0]; }
     CoreTypeTracker& aiv() { return by_type[1]; }
 
-    template<CoreType CT>
-    CoreTypeTracker& get() { return by_type[static_cast<int32_t>(CT)]; }
+    template <CoreType CT>
+    CoreTypeTracker& get() {
+        return by_type[static_cast<int32_t>(CT)];
+    }
 
     int32_t find_cluster_for_shape(PTO2ResourceShape shape, bool* core_idle) {
         for (int32_t i = 0; i < cluster_count; i++) {
             Cluster& c = clusters[i];
             switch (shape) {
-            case PTO2ResourceShape::AIC_ONLY:
-                if (core_idle[c.aic_core_id]) return i;
-                break;
-            case PTO2ResourceShape::AIV_X1:
-                if (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]]) return i;
-                break;
-            case PTO2ResourceShape::AIV_X2:
-                if (core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]]) return i;
-                break;
-            case PTO2ResourceShape::AIC_AIV_X1:
-                if (core_idle[c.aic_core_id] &&
-                    (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]])) return i;
-                break;
-            case PTO2ResourceShape::AIC_AIV_X2:
-                if (core_idle[c.aic_core_id] &&
-                    core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]]) return i;
-                break;
+                case PTO2ResourceShape::AIC_ONLY:
+                    if (core_idle[c.aic_core_id]) return i;
+                    break;
+                case PTO2ResourceShape::AIV_X1:
+                    if (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]]) return i;
+                    break;
+                case PTO2ResourceShape::AIV_X2:
+                    if (core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]]) return i;
+                    break;
+                case PTO2ResourceShape::AIC_AIV_X1:
+                    if (core_idle[c.aic_core_id] && (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]]))
+                        return i;
+                    break;
+                case PTO2ResourceShape::AIC_AIV_X2:
+                    if (core_idle[c.aic_core_id] && core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]])
+                        return i;
+                    break;
             }
         }
         return -1;
@@ -209,7 +217,7 @@ struct AicpuExecutor {
     std::atomic<bool> pto2_init_done_{false};
     std::atomic<bool> runtime_init_ready_{false};
     std::atomic<bool> pto2_init_complete_{false};  // init block finished; others wait for this
-    std::atomic<int32_t> orch_finished_count_{0};      // Number of orchestrator threads that have finished
+    std::atomic<int32_t> orch_finished_count_{0};  // Number of orchestrator threads that have finished
 
     // ===== Dynamic core transition state =====
     std::atomic<bool> transition_requested_{false};
@@ -227,7 +235,8 @@ struct AicpuExecutor {
 
     // ===== Performance profiling state =====
     uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];  // Per-core AICPU dispatch timestamp
-    uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER]; // Per-core total dispatched task counter (for buffer management)
+    uint32_t
+        core_dispatch_counts_[RUNTIME_MAX_WORKER];  // Per-core total dispatched task counter (for buffer management)
 
     uint64_t* func_id_to_addr_;
     uint64_t get_function_bin_addr(int func_id) const {
@@ -251,9 +260,7 @@ struct AicpuExecutor {
     // Build slim PTO2DispatchPayload: only function_bin_addr + args.
     // Metadata (mixed_task_id, subslot, kernel_id, core_type) stays in TaskDescriptor.
     // Dispatch order: tensor args first, then scalar args.
-    void build_pto2_payload(PTO2DispatchPayload& out,
-        int32_t kernel_id,
-        PTO2TaskPayload& task_pl) {
+    void build_pto2_payload(PTO2DispatchPayload& out, int32_t kernel_id, PTO2TaskPayload& task_pl) {
         out.function_bin_addr = get_function_bin_addr(kernel_id);
         int32_t n = 0;
         for (int32_t i = 0; i < task_pl.tensor_count; i++) {
@@ -323,7 +330,8 @@ struct AicpuExecutor {
                 bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state, subslot);
                 if (mixed_complete) {
 #if PTO2_SCHED_PROFILING
-                    PTO2CompletionStats cstats = rt->scheduler.on_mixed_task_complete(slot_state, thread_idx, local_bufs);
+                    PTO2CompletionStats cstats =
+                        rt->scheduler.on_mixed_task_complete(slot_state, thread_idx, local_bufs);
                     notify_edges_total += cstats.fanout_edges;
                     if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
                     notify_tasks_enqueued += cstats.tasks_enqueued;
@@ -371,20 +379,23 @@ struct AicpuExecutor {
                     int32_t fanout_n = 0;
                     PTO2DepListEntry* cur = slot_state.fanout_head;
                     while (cur != nullptr && fanout_n < RUNTIME_MAX_FANOUT) {
-                        fanout_arr[fanout_n++] = static_cast<int32_t>(
-                            pto2_task_id_local(cur->slot_state->task->mixed_task_id));
+                        fanout_arr[fanout_n++] =
+                            static_cast<int32_t>(pto2_task_id_local(cur->slot_state->task->mixed_task_id));
                         cur = cur->next;
                     }
 
                     int32_t perf_slot_idx = static_cast<int32_t>(executing_subslot_by_core_[core_id]);
                     if (perf_aicpu_complete_record(perf_buf,
-                        static_cast<uint32_t>(expected_reg_task_id),
-                        slot_state.task->kernel_id[perf_slot_idx], CT,
-                        dispatch_timestamps_[core_id], finish_ts,
-                        slot_state.ring_id,
-                        fanout_arr, fanout_n) != 0) {
-                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %u",
-                            core_id, expected_reg_task_id);
+                            static_cast<uint32_t>(expected_reg_task_id),
+                            slot_state.task->kernel_id[perf_slot_idx],
+                            CT,
+                            dispatch_timestamps_[core_id],
+                            finish_ts,
+                            slot_state.ring_id,
+                            fanout_arr,
+                            fanout_n) != 0) {
+                        DEV_ERROR(
+                            "Core %d: perf_aicpu_complete_record failed for task %u", core_id, expected_reg_task_id);
                     }
 #if PTO2_SCHED_PROFILING
                     sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
@@ -409,11 +420,16 @@ struct AicpuExecutor {
 
     static const char* shape_name(PTO2ResourceShape shape) {
         switch (shape) {
-        case PTO2ResourceShape::AIC_ONLY:   return "AIC_ONLY";
-        case PTO2ResourceShape::AIV_X1:     return "AIV_X1";
-        case PTO2ResourceShape::AIV_X2:     return "AIV_X2";
-        case PTO2ResourceShape::AIC_AIV_X1: return "AIC_AIV_X1";
-        case PTO2ResourceShape::AIC_AIV_X2: return "AIC_AIV_X2";
+            case PTO2ResourceShape::AIC_ONLY:
+                return "AIC_ONLY";
+            case PTO2ResourceShape::AIV_X1:
+                return "AIV_X1";
+            case PTO2ResourceShape::AIV_X2:
+                return "AIV_X2";
+            case PTO2ResourceShape::AIC_AIV_X1:
+                return "AIC_AIV_X1";
+            case PTO2ResourceShape::AIC_AIV_X2:
+                return "AIC_AIV_X2";
         }
         return "UNKNOWN";
     }
@@ -460,18 +476,21 @@ struct AicpuExecutor {
         return (thread_idx % 2 == 0) ? kEvenOrder : kOddOrder;
     }
 
-    PTO2TaskSlotState* pop_ready_task(PTO2ResourceShape shape, int32_t thread_idx
+    PTO2TaskSlotState* pop_ready_task(PTO2ResourceShape shape,
+        int32_t thread_idx
 #if PTO2_SCHED_PROFILING
-        , uint64_t& pop_hit, uint64_t& pop_miss
-        , uint64_t& sched_dispatch_pop_cycle
+        ,
+        uint64_t& pop_hit,
+        uint64_t& pop_miss,
+        uint64_t& sched_dispatch_pop_cycle
 #endif
     ) {
         (void)thread_idx;
 #if PTO2_SCHED_PROFILING
         extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
         uint64_t t_pop_start = get_sys_cnt_aicpu();
-        PTO2TaskSlotState* slot_state = rt->scheduler.get_ready_task(shape,
-            g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]);
+        PTO2TaskSlotState* slot_state = rt->scheduler.get_ready_task(
+            shape, g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]);
         sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
 #else
         PTO2TaskSlotState* slot_state = rt->scheduler.get_ready_task(shape);
@@ -589,7 +608,9 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
             DEV_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                      i, physical_core_id, max_physical_cores_count);
+                i,
+                physical_core_id,
+                max_physical_cores_count);
             handshake_failed = true;
             continue;
         }
@@ -646,14 +667,16 @@ void AicpuExecutor::assign_cores_to_threads() {
     int32_t cluster_count = aic_count_;
 
     DEV_INFO("Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)",
-             cluster_count, divisor, aic_count_, aiv_count_);
+        cluster_count,
+        divisor,
+        aic_count_,
+        aiv_count_);
 
     memset(core_idle_, true, sizeof(core_idle_));
     for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
         executing_reg_task_ids_[i] = AICPU_TASK_INVALID;
     }
     for (int32_t i = 0; i < thread_num_; i++) {
-        
         trackers_[i].aic().running_count = 0;
         trackers_[i].aiv().running_count = 0;
         trackers_[i].aic().idle_count = 0;
@@ -675,7 +698,7 @@ void AicpuExecutor::assign_cores_to_threads() {
         CoreStateTracker& tracker = trackers_[t];
         int32_t& idx = core_idx[t];
 
-        int32_t aic_wid  = aic_cores_[ci].worker_id;
+        int32_t aic_wid = aic_cores_[ci].worker_id;
         int32_t aiv0_wid = aiv_cores_[2 * ci].worker_id;
         int32_t aiv1_wid = aiv_cores_[2 * ci + 1].worker_id;
 
@@ -689,8 +712,7 @@ void AicpuExecutor::assign_cores_to_threads() {
         tracker.aiv().idle[tracker.aiv().idle_count++] = aiv0_wid;
         tracker.aiv().idle[tracker.aiv().idle_count++] = aiv1_wid;
 
-        DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)",
-                 t, ci, aic_wid, aiv0_wid, aiv1_wid);
+        DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
     }
 
     for (int32_t t = 0; t < divisor; t++) {
@@ -709,8 +731,7 @@ void AicpuExecutor::assign_cores_to_threads() {
  * Writes into new_core_assignments_ / new_core_count_per_thread_.
  */
 void AicpuExecutor::reassign_cores_for_all_threads() {
-    DEV_INFO("Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV",
-             thread_num_, aic_count_, aiv_count_);
+    DEV_INFO("Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_);
 
     // Collect running/idle state from all threads before reassignment
     bool running_cores[MAX_CORES_PER_THREAD];
@@ -738,15 +759,14 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
     }
 
     // Restore a single core's running/idle state into its new thread's tracker
-    auto reassign_core =
-        [&](int32_t worker_id, CoreTypeTracker& type_tracker, int32_t thread_idx) {
-            core_assignments_[thread_idx][core_count_per_thread_[thread_idx]++] = worker_id;
-            if (running_cores[worker_id]) {
-                type_tracker.running[type_tracker.running_count++] = worker_id;
-            } else {
-                type_tracker.idle[type_tracker.idle_count++] = worker_id;
-            }
-        };
+    auto reassign_core = [&](int32_t worker_id, CoreTypeTracker& type_tracker, int32_t thread_idx) {
+        core_assignments_[thread_idx][core_count_per_thread_[thread_idx]++] = worker_id;
+        if (running_cores[worker_id]) {
+            type_tracker.running[type_tracker.running_count++] = worker_id;
+        } else {
+            type_tracker.idle[type_tracker.idle_count++] = worker_id;
+        }
+    };
 
     // Assign whole clusters round-robin across all threads
     for (int32_t ci = 0; ci < aic_count_; ci++) {
@@ -768,9 +788,13 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
     DEV_INFO("Core reassignment complete:");
     for (int32_t t = 0; t < thread_num_; t++) {
         DEV_INFO("  Thread %d: %d cores, %d clusters (AIC: running=%d idle=%d, AIV: running=%d idle=%d)",
-                 t, core_count_per_thread_[t], trackers_[t].cluster_count,
-                 trackers_[t].aic().running_count, trackers_[t].aic().idle_count,
-                 trackers_[t].aiv().running_count, trackers_[t].aiv().idle_count);
+            t,
+            core_count_per_thread_[t],
+            trackers_[t].cluster_count,
+            trackers_[t].aic().running_count,
+            trackers_[t].aic().idle_count,
+            trackers_[t].aiv().running_count,
+            trackers_[t].aiv().idle_count);
     }
 }
 
@@ -873,7 +897,8 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
 /**
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
-int32_t AicpuExecutor::shutdown_aicore(Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num) {
+int32_t AicpuExecutor::shutdown_aicore(
+    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num) {
     (void)runtime;
     if (core_num == 0) return 0;
 
@@ -893,7 +918,7 @@ int32_t AicpuExecutor::shutdown_aicore(Runtime* runtime, int32_t thread_idx, con
 }
 
 int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx) {
-    int32_t &core_num = core_count_per_thread_[thread_idx];
+    int32_t& core_num = core_count_per_thread_[thread_idx];
     CoreStateTracker& tracker = trackers_[thread_idx];
     DEV_INFO("Thread %d: resolve_and_dispatch_pto2 entry", thread_idx);
 
@@ -906,12 +931,16 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
     PTO2SharedMemoryHeader* header = static_cast<PTO2SharedMemoryHeader*>(sm_base);
     DEV_INFO("Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu",
-             thread_idx, (void*)header, (unsigned long)header->rings[0].task_descriptors_offset,
-             (unsigned long)header->rings[0].task_window_size);
+        thread_idx,
+        (void*)header,
+        (unsigned long)header->rings[0].task_descriptors_offset,
+        (unsigned long)header->rings[0].task_window_size);
 
     Handshake* hank = static_cast<Handshake*>(runtime->workers);
     DEV_INFO("Thread %d: hank=%p, window_size=%lu",
-             thread_idx, (void*)hank, (unsigned long)header->rings[0].task_window_size);
+        thread_idx,
+        (void*)hank,
+        (unsigned long)header->rings[0].task_window_size);
 
     // One-time init: assign perf buffers (one thread does it; others wait)
     if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
@@ -957,10 +986,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     uint64_t complete_probe_count = 0;
     uint64_t complete_hit_count = 0;
     uint64_t notify_edges_total = 0;
-    int32_t  notify_max_degree = 0;
+    int32_t notify_max_degree = 0;
     uint64_t notify_tasks_enqueued = 0;
     uint64_t fanin_edges_total = 0;
-    int32_t  fanin_max_degree = 0;
+    int32_t fanin_max_degree = 0;
     uint64_t pop_hit = 0;
     uint64_t pop_miss = 0;
     uint64_t local_dispatch_count = 0;
@@ -1003,11 +1032,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 // Check for orchestrator fatal error — exit immediately
                 int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
                 if (orch_err != PTO2_ERROR_NONE) {
-                    DEV_ERROR("Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
-                               "completed_tasks=%d, total_tasks=%d",
-                               thread_idx, orch_err,
-                               completed_tasks_.load(std::memory_order_relaxed),
-                               total_tasks_);
+                    DEV_ERROR(
+                        "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
+                        "completed_tasks=%d, total_tasks=%d",
+                        thread_idx,
+                        orch_err,
+                        completed_tasks_.load(std::memory_order_relaxed),
+                        total_tasks_);
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1017,7 +1048,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 task_count = total_tasks_;
                 if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
                     completed_.store(true, std::memory_order_release);
-                    DEV_INFO("Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed), task_count);
+                    DEV_INFO("Thread %d: PTO2 completed tasks %d/%d",
+                        thread_idx,
+                        completed_tasks_.load(std::memory_order_relaxed),
+                        task_count);
                     break;
                 }
             }
@@ -1053,21 +1087,34 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
         // Check AIC running cores
         bool try_completed = false;
-        always_assert(local_bufs[0].count == 0 && local_bufs[1].count == 0);  // Invariant: previous iteration fully consumed
+        always_assert(
+            local_bufs[0].count == 0 && local_bufs[1].count == 0);  // Invariant: previous iteration fully consumed
         if (tracker.aic().running_count > 0) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIC>(
-                thread_idx, tracker.aic(), hank,
-                completed_this_turn, cur_thread_completed, made_progress,
-                deferred_release_slot_states, deferred_release_count,
+            check_running_cores_for_completion<CoreType::AIC>(thread_idx,
+                tracker.aic(),
+                hank,
+                completed_this_turn,
+                cur_thread_completed,
+                made_progress,
+                deferred_release_slot_states,
+                deferred_release_count,
                 local_bufs
 #if PTO2_PROFILING
-                , profiling_enabled, phase_complete_count
+                ,
+                profiling_enabled,
+                phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
-                , complete_probe_count, complete_hit_count,
-                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
+                ,
+                complete_probe_count,
+                complete_hit_count,
+                notify_edges_total,
+                notify_max_degree,
+                notify_tasks_enqueued,
+                fanin_edges_total,
+                fanin_max_degree,
+                sched_complete_perf_cycle
 #endif
             );
         }
@@ -1075,18 +1122,30 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Check AIV running cores
         if (tracker.aiv().running_count > 0) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIV>(
-                thread_idx, tracker.aiv(), hank,
-                completed_this_turn, cur_thread_completed, made_progress,
-                deferred_release_slot_states, deferred_release_count,
+            check_running_cores_for_completion<CoreType::AIV>(thread_idx,
+                tracker.aiv(),
+                hank,
+                completed_this_turn,
+                cur_thread_completed,
+                made_progress,
+                deferred_release_slot_states,
+                deferred_release_count,
                 local_bufs
 #if PTO2_PROFILING
-                , profiling_enabled, phase_complete_count
+                ,
+                profiling_enabled,
+                phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
-                , complete_probe_count, complete_hit_count,
-                notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
+                ,
+                complete_probe_count,
+                complete_hit_count,
+                notify_edges_total,
+                notify_max_degree,
+                notify_tasks_enqueued,
+                fanin_edges_total,
+                fanin_max_degree,
+                sched_complete_perf_cycle
 #endif
             );
         }
@@ -1098,11 +1157,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             int32_t new_total = prev + completed_this_turn;
             last_progress_count = new_total;
             if (thread_idx == 0 && task_count > 0) {
-                if (new_total <= PROGRESS_VERBOSE_THRESHOLD
-                    || new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL
-                    || new_total >= task_count) {
+                if (new_total <= PROGRESS_VERBOSE_THRESHOLD ||
+                    new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL || new_total >= task_count) {
                     DEV_ALWAYS("PTO2 progress: completed=%d total=%d (%.1f%%)",
-                               new_total, task_count, 100.0 * new_total / task_count);
+                        new_total,
+                        task_count,
+                        100.0 * new_total / task_count);
                 }
             }
         }
@@ -1143,27 +1203,45 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     ResourceCount rc = shape_resource_count(shape);
 
                     if (rc.aic) {
-                        dispatch_subtask_to_core(runtime, tracker,
-                            c.aic_core_id, CoreType::AIC, *slot_state, PTO2SubtaskSlot::AIC
+                        dispatch_subtask_to_core(runtime,
+                            tracker,
+                            c.aic_core_id,
+                            CoreType::AIC,
+                            *slot_state,
+                            PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
-                            , profiling_enabled, thread_idx
+                            ,
+                            profiling_enabled,
+                            thread_idx
 #endif
                         );
                     }
                     if (rc.aiv >= 1) {
                         int32_t aiv0 = core_idle_[c.aiv_core_ids[0]] ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
-                        dispatch_subtask_to_core(runtime, tracker,
-                            aiv0, CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV0
+                        dispatch_subtask_to_core(runtime,
+                            tracker,
+                            aiv0,
+                            CoreType::AIV,
+                            *slot_state,
+                            PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
-                            , profiling_enabled, thread_idx
+                            ,
+                            profiling_enabled,
+                            thread_idx
 #endif
                         );
                     }
                     if (rc.aiv >= 2) {
-                        dispatch_subtask_to_core(runtime, tracker,
-                            c.aiv_core_ids[1], CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV1
+                        dispatch_subtask_to_core(runtime,
+                            tracker,
+                            c.aiv_core_ids[1],
+                            CoreType::AIV,
+                            *slot_state,
+                            PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
-                            , profiling_enabled, thread_idx
+                            ,
+                            profiling_enabled,
+                            thread_idx
 #endif
                         );
                     }
@@ -1206,10 +1284,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 int32_t ci = tracker.find_cluster_for_shape(shape, core_idle_);
                 if (ci < 0) break;
 
-                PTO2TaskSlotState* slot_state = pop_ready_task(shape, thread_idx
+                PTO2TaskSlotState* slot_state = pop_ready_task(shape,
+                    thread_idx
 #if PTO2_SCHED_PROFILING
-                    , pop_hit, pop_miss
-                    , sched_dispatch_pop_cycle
+                    ,
+                    pop_hit,
+                    pop_miss,
+                    sched_dispatch_pop_cycle
 #endif
                 );
                 if (!slot_state) break;
@@ -1225,28 +1306,45 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 ResourceCount rc = shape_resource_count(shape);
 
                 if (rc.aic) {
-                    dispatch_subtask_to_core(runtime, tracker,
-                        c.aic_core_id, CoreType::AIC, *slot_state, PTO2SubtaskSlot::AIC
+                    dispatch_subtask_to_core(runtime,
+                        tracker,
+                        c.aic_core_id,
+                        CoreType::AIC,
+                        *slot_state,
+                        PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
-                        , profiling_enabled, thread_idx
+                        ,
+                        profiling_enabled,
+                        thread_idx
 #endif
                     );
                 }
                 if (rc.aiv >= 1) {
-                    int32_t aiv_id = core_idle_[c.aiv_core_ids[0]]
-                        ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
-                    dispatch_subtask_to_core(runtime, tracker,
-                        aiv_id, CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV0
+                    int32_t aiv_id = core_idle_[c.aiv_core_ids[0]] ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
+                    dispatch_subtask_to_core(runtime,
+                        tracker,
+                        aiv_id,
+                        CoreType::AIV,
+                        *slot_state,
+                        PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
-                        , profiling_enabled, thread_idx
+                        ,
+                        profiling_enabled,
+                        thread_idx
 #endif
                     );
                 }
                 if (rc.aiv >= 2) {
-                    dispatch_subtask_to_core(runtime, tracker,
-                        c.aiv_core_ids[1], CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV1
+                    dispatch_subtask_to_core(runtime,
+                        tracker,
+                        c.aiv_core_ids[1],
+                        CoreType::AIV,
+                        *slot_state,
+                        PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
-                        , profiling_enabled, thread_idx
+                        ,
+                        profiling_enabled,
+                        thread_idx
 #endif
                     );
                 }
@@ -1289,7 +1387,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             // freeing heap space for the orchestrator without blocking completion polling.
             while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
-                int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
+                int32_t fe =
+                    rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
 #else
                 int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
@@ -1308,7 +1407,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
                 if (orch_err != PTO2_ERROR_NONE) {
                     DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores",
-                               thread_idx, orch_err);
+                        thread_idx,
+                        orch_err);
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1318,7 +1418,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
                 int32_t c = completed_tasks_.load(std::memory_order_relaxed);
                 DEV_ALWAYS("PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
-                           idle_iterations, c, task_count, last_progress_count);
+                    idle_iterations,
+                    c,
+                    task_count,
+                    last_progress_count);
                 // Scan all task slots to find truly stuck tasks using scheduler state
                 PTO2SchedulerState* sched = &rt->scheduler;
                 PTO2SharedMemoryHeader* sm_header_diag = static_cast<PTO2SharedMemoryHeader*>(sm_base);
@@ -1332,33 +1435,56 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
                         int32_t fi = slot_state.fanin_count;
                         int32_t kid = slot_state.task->kernel_id[0];
-                        if (st >= PTO2_TASK_COMPLETED) continue; // Already done
-                        if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) { cnt_inflight++; continue; }
+                        if (st >= PTO2_TASK_COMPLETED) continue;  // Already done
+                        if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) {
+                            cnt_inflight++;
+                            continue;
+                        }
                         // PENDING
                         if (rc >= fi) {
                             // Ready (all deps satisfied) but not enqueued — this is the real bug
                             cnt_ready++;
                             if (cnt_ready <= STALL_DUMP_READY_MAX) {
-                                DEV_ALWAYS("  STUCK-READY  ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
-                                            r, (long long)pto2_task_id_raw(slot_state.task->mixed_task_id), kid, rc, fi, (int32_t)st);
+                                DEV_ALWAYS(
+                                    "  STUCK-READY  ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
+                                    r,
+                                    (long long)pto2_task_id_raw(slot_state.task->mixed_task_id),
+                                    kid,
+                                    rc,
+                                    fi,
+                                    (int32_t)st);
                             }
                         } else {
                             cnt_waiting++;
                             if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
-                                DEV_ALWAYS("  STUCK-WAIT   ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
-                                            r, (long long)pto2_task_id_raw(slot_state.task->mixed_task_id), kid, rc, fi, (int32_t)st);
+                                DEV_ALWAYS(
+                                    "  STUCK-WAIT   ring=%d task_id=%lld kernel_id=%d refcount=%d fanin=%d state=%d",
+                                    r,
+                                    (long long)pto2_task_id_raw(slot_state.task->mixed_task_id),
+                                    kid,
+                                    rc,
+                                    fi,
+                                    (int32_t)st);
                             }
                         }
                     }
                 }
                 DEV_ALWAYS("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d",
-                           cnt_ready, cnt_waiting, cnt_inflight);
+                    cnt_ready,
+                    cnt_waiting,
+                    cnt_inflight);
                 // Log this thread's dispatch state
                 int32_t total_idle = tracker.aic().idle_count + tracker.aiv().idle_count;
                 int32_t total_running = tracker.aic().running_count + tracker.aiv().running_count;
                 DEV_ALWAYS("  thread=%d idle_cores=%d (AIC=%d AIV=%d) running_cores=%d (AIC=%d AIV=%d) core_num=%d",
-                           thread_idx, total_idle, tracker.aic().idle_count, tracker.aiv().idle_count,
-                           total_running, tracker.aic().running_count, tracker.aiv().running_count, core_num);
+                    thread_idx,
+                    total_idle,
+                    tracker.aic().idle_count,
+                    tracker.aiv().idle_count,
+                    total_running,
+                    tracker.aic().running_count,
+                    tracker.aiv().running_count,
+                    core_num);
                 // Dump AIC running cores
                 for (int32_t ci = 0; ci < tracker.aic().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
                     int32_t cid = tracker.aic().running[ci];
@@ -1370,9 +1496,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     }
                     uint64_t cond_reg = read_reg(core_id_to_reg_addr_[cid], RegId::COND);
                     DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
-                               cid, (unsigned)cond_reg,
-                               EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
-                               sw_tid, hw_kernel);
+                        cid,
+                        (unsigned)cond_reg,
+                        EXTRACT_TASK_STATE(cond_reg),
+                        EXTRACT_TASK_ID(cond_reg),
+                        sw_tid,
+                        hw_kernel);
                 }
                 // Dump AIV running cores
                 for (int32_t ci = 0; ci < tracker.aiv().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
@@ -1385,25 +1514,31 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     }
                     uint64_t cond_reg = read_reg(core_id_to_reg_addr_[cid], RegId::COND);
                     DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
-                               cid, (unsigned)cond_reg,
-                               EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
-                               sw_tid, hw_kernel);
+                        cid,
+                        (unsigned)cond_reg,
+                        EXTRACT_TASK_STATE(cond_reg),
+                        EXTRACT_TASK_ID(cond_reg),
+                        sw_tid,
+                        hw_kernel);
                 }
                 // Dump cluster state
                 for (int32_t cli = 0; cli < tracker.cluster_count && cli < STALL_DUMP_CORE_MAX; cli++) {
                     Cluster& cl = tracker.clusters[cli];
                     DEV_ALWAYS("    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)",
-                               cli, cl.aic_core_id, core_idle_[cl.aic_core_id] ? "idle" : "busy",
-                               cl.aiv_core_ids[0], core_idle_[cl.aiv_core_ids[0]] ? "idle" : "busy",
-                               cl.aiv_core_ids[1], core_idle_[cl.aiv_core_ids[1]] ? "idle" : "busy");
+                        cli,
+                        cl.aic_core_id,
+                        core_idle_[cl.aic_core_id] ? "idle" : "busy",
+                        cl.aiv_core_ids[0],
+                        core_idle_[cl.aiv_core_ids[0]] ? "idle" : "busy",
+                        cl.aiv_core_ids[1],
+                        core_idle_[cl.aiv_core_ids[1]] ? "idle" : "busy");
                 }
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
                 DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
 #if PTO2_PROFILING
                 // Benchmark: scheduler lifetime end timestamp on timeout path
-                DEV_ALWAYS("Thread %d: sched_end(timeout)=%llu",
-                           thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+                DEV_ALWAYS("Thread %d: sched_end(timeout)=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
 #endif
                 return -1;
             } else {
@@ -1412,8 +1547,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_PROFILING
             CYCLE_COUNT_LAP(sched_idle_cycle);
             if (profiling_enabled) {
-                perf_aicpu_record_phase(thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT,
-                                        _t0_phase, _t1, sched_loop_count, 0);
+                perf_aicpu_record_phase(thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT, _t0_phase, _t1, sched_loop_count, 0);
                 _t0_phase = _t1;
             }
 #endif
@@ -1422,8 +1556,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
 #if PTO2_PROFILING
     // Scheduler summary logging (always print when PTO2_PROFILING=1)
-    uint64_t sched_total =
-        sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
+    uint64_t sched_total = sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
 
 #if PTO2_SCHED_PROFILING
@@ -1432,71 +1565,87 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
         uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
         uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle)
-            ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle) : 0;
+                                     ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle)
+                                     : 0;
         uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle)
-            ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) : 0;
+                                     ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle)
+                                     : 0;
 
         DEV_ALWAYS("Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===",
-            thread_idx, cycles_to_us(sched_total), cur_thread_completed);
+            thread_idx,
+            cycles_to_us(sched_total),
+            cur_thread_completed);
 
         // Level 1: complete
-        double notify_avg = cur_thread_completed > 0
-            ? (double)notify_edges_total / cur_thread_completed : 0.0;
-        double fanin_avg = cur_thread_completed > 0
-            ? (double)fanin_edges_total / cur_thread_completed : 0.0;
-        DEV_ALWAYS("Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%llu, max_degree=%d, avg=%.1f]  [fanin: edges=%llu, max_degree=%d, avg=%.1f]",
-            thread_idx, cycles_to_us(sched_complete_cycle),
+        double notify_avg = cur_thread_completed > 0 ? (double)notify_edges_total / cur_thread_completed : 0.0;
+        double fanin_avg = cur_thread_completed > 0 ? (double)fanin_edges_total / cur_thread_completed : 0.0;
+        DEV_ALWAYS(
+            "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%llu, max_degree=%d, avg=%.1f]  [fanin: "
+            "edges=%llu, max_degree=%d, avg=%.1f]",
+            thread_idx,
+            cycles_to_us(sched_complete_cycle),
             sched_complete_cycle * 100.0 / sched_total,
-            (unsigned long long)notify_edges_total, notify_max_degree, notify_avg,
-            (unsigned long long)fanin_edges_total, fanin_max_degree, fanin_avg);
+            (unsigned long long)notify_edges_total,
+            notify_max_degree,
+            notify_avg,
+            (unsigned long long)fanin_edges_total,
+            fanin_max_degree,
+            fanin_avg);
 
         // Level 2: complete sub-phases (percentage relative to complete)
         uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
-        uint64_t complete_miss_count = (complete_probe_count > complete_hit_count)
-            ? (complete_probe_count - complete_hit_count) : 0;
-        double complete_hit_rate = complete_probe_count > 0
-            ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
+        uint64_t complete_miss_count =
+            (complete_probe_count > complete_hit_count) ? (complete_probe_count - complete_hit_count) : 0;
+        double complete_hit_rate = complete_probe_count > 0 ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
         DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)  hit=%llu, miss=%llu, hit_rate=%.1f%%",
-            thread_idx, cycles_to_us(complete_poll),
+            thread_idx,
+            cycles_to_us(complete_poll),
             complete_poll * 100.0 / c_parent,
             (unsigned long long)complete_hit_count,
             (unsigned long long)complete_miss_count,
             complete_hit_rate);
         DEV_ALWAYS("Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-            thread_idx, cycles_to_us(sp.lock_cycle),
+            thread_idx,
+            cycles_to_us(sp.lock_cycle),
             sp.lock_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
+            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle),
+            cycles_to_us(sp.lock_wait_cycle),
             (unsigned long long)sp.lock_atomic_count);
         DEV_ALWAYS("Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-            thread_idx, cycles_to_us(sp.fanout_cycle),
+            thread_idx,
+            cycles_to_us(sp.fanout_cycle),
             sp.fanout_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
+            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle),
+            cycles_to_us(sp.push_wait_cycle),
             (unsigned long long)sp.fanout_atomic_count);
         DEV_ALWAYS("Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%llu",
-            thread_idx, cycles_to_us(sp.fanin_cycle),
+            thread_idx,
+            cycles_to_us(sp.fanin_cycle),
             sp.fanin_cycle * 100.0 / c_parent,
             (unsigned long long)sp.fanin_atomic_count);
         DEV_ALWAYS("Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%llu",
-            thread_idx, cycles_to_us(sp.self_consumed_cycle),
+            thread_idx,
+            cycles_to_us(sp.self_consumed_cycle),
             sp.self_consumed_cycle * 100.0 / c_parent,
             (unsigned long long)sp.self_atomic_count);
         DEV_ALWAYS("Thread %d:     perf         : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_complete_perf_cycle),
+            thread_idx,
+            cycles_to_us(sched_complete_perf_cycle),
             sched_complete_perf_cycle * 100.0 / c_parent);
 
         // Level 1: dispatch
         uint64_t pop_total = pop_hit + pop_miss;
         double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
         DEV_ALWAYS("Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%llu, miss=%llu, hit_rate=%.1f%%]",
-            thread_idx, cycles_to_us(sched_dispatch_cycle),
+            thread_idx,
+            cycles_to_us(sched_dispatch_cycle),
             sched_dispatch_cycle * 100.0 / sched_total,
             (unsigned long long)pop_hit,
             (unsigned long long)pop_miss,
             pop_hit_rate);
         uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
         uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
-        double local_hit_rate = total_dispatched > 0
-            ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
+        double local_hit_rate = total_dispatched > 0 ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
         DEV_ALWAYS("Thread %d:     local_disp   : local=%llu, global=%llu, overflow=%llu, local_rate=%.1f%%",
             thread_idx,
             (unsigned long long)local_dispatch_count,
@@ -1507,31 +1656,38 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Level 2: dispatch sub-phases (percentage relative to dispatch)
         uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
         DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(dispatch_poll),
+            thread_idx,
+            cycles_to_us(dispatch_poll),
             dispatch_poll * 100.0 / d_parent);
         DEV_ALWAYS("Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%llu",
-            thread_idx, cycles_to_us(sched_dispatch_pop_cycle),
+            thread_idx,
+            cycles_to_us(sched_dispatch_pop_cycle),
             sched_dispatch_pop_cycle * 100.0 / d_parent,
-            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle),
+            cycles_to_us(sp.pop_wait_cycle),
             (unsigned long long)sp.pop_atomic_count);
         DEV_ALWAYS("Thread %d:     setup        : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
+            thread_idx,
+            cycles_to_us(sched_dispatch_setup_cycle),
             sched_dispatch_setup_cycle * 100.0 / d_parent);
 
         // Level 1: scan
         DEV_ALWAYS("Thread %d:   scan           : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_scan_cycle),
+            thread_idx,
+            cycles_to_us(sched_scan_cycle),
             sched_scan_cycle * 100.0 / sched_total);
 
         // Level 1: idle
         DEV_ALWAYS("Thread %d:   idle           : %.3fus (%.1f%%)",
-            thread_idx, cycles_to_us(sched_idle_cycle),
+            thread_idx,
+            cycles_to_us(sched_idle_cycle),
             sched_idle_cycle * 100.0 / sched_total);
 
         // Average per completion
         if (cur_thread_completed > 0) {
             DEV_ALWAYS("Thread %d:   avg/complete   : %.3fus",
-                thread_idx, cycles_to_us(sched_complete_cycle) / cur_thread_completed);
+                thread_idx,
+                cycles_to_us(sched_complete_cycle) / cur_thread_completed);
         }
     }
 #endif
@@ -1558,7 +1714,6 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     int32_t thread_idx = thread_idx_++;
     DEV_INFO("Thread %d: Start", thread_idx);
 
-
     // Orchestrator check
     if (thread_idx >= sched_thread_num_) {
         int32_t orch_idx = thread_idx - sched_thread_num_;
@@ -1581,28 +1736,26 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 char so_path[256];
                 bool file_created = false;
                 const char* candidate_dirs[] = {
-                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device",
-                    "/usr/lib64",
-                    "/lib64",
-                    "/var/tmp",
-                    "/tmp"
-                };
+                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"};
                 const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
 
                 for (int32_t i = 0; i < num_candidates && !file_created; i++) {
-                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so",
-                             candidate_dirs[i], getpid());
+                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
                     int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
                     if (fd < 0) {
                         DEV_INFO("Thread %d: Cannot create SO at %s (errno=%d), trying next path",
-                                 thread_idx, so_path, errno);
+                            thread_idx,
+                            so_path,
+                            errno);
                         continue;
                     }
                     ssize_t written = write(fd, so_data, so_size);
                     close(fd);
                     if (written != static_cast<ssize_t>(so_size)) {
                         DEV_INFO("Thread %d: Cannot write SO to %s (errno=%d), trying next path",
-                                 thread_idx, so_path, errno);
+                            thread_idx,
+                            so_path,
+                            errno);
                         unlink(so_path);
                         continue;
                     }
@@ -1626,8 +1779,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
 
                 dlerror();
-                auto config_func = reinterpret_cast<DeviceOrchestrationConfigFunc>(
-                    dlsym(handle, "aicpu_orchestration_config"));
+                auto config_func =
+                    reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
 
                 dlerror();
                 DeviceOrchestrationFunc orch_func =
@@ -1652,10 +1805,14 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 for (int32_t i = 0; i < arg_count && i < 20; i++) {
                     if (args[i].kind == TaskArgKind::TENSOR) {
                         DEV_INFO("Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)",
-                                 thread_idx, i, (unsigned long)args[i].tensor.data, args[i].tensor.ndims, (unsigned)args[i].tensor.dtype);
+                            thread_idx,
+                            i,
+                            (unsigned long)args[i].tensor.data,
+                            args[i].tensor.ndims,
+                            (unsigned)args[i].tensor.dtype);
                     } else {
-                        DEV_INFO("Thread %d: orch_args[%d] = SCALAR(0x%lx)",
-                                 thread_idx, i, (unsigned long)args[i].scalar);
+                        DEV_INFO(
+                            "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, i, (unsigned long)args[i].scalar);
                     }
                 }
 
@@ -1688,15 +1845,17 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
                 }
                 DEV_INFO("Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d",
-                         thread_idx, (unsigned long)task_window_size, (unsigned long)heap_size, dep_pool_capacity);
+                    thread_idx,
+                    (unsigned long)task_window_size,
+                    (unsigned long)heap_size,
+                    dep_pool_capacity);
 
                 void* sm_ptr = runtime->get_pto2_gm_sm_ptr();
                 void* gm_heap = runtime->get_pto2_gm_heap_ptr();
 
                 uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
                 PTO2SharedMemoryHandle* sm_handle =
-                    pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size,
-                                                heap_size);
+                    pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
                 if (!sm_handle) {
                     DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
                     dlclose(handle);
@@ -1704,9 +1863,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     return -1;
                 }
 
-                rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE,
-                                                 sm_handle, gm_heap, heap_size, orch_thread_num_,
-                                                 dep_pool_capacity);
+                rt = pto2_runtime_create_from_sm(
+                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity);
                 if (!rt) {
                     DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                     pto2_sm_destroy(sm_handle);
@@ -1769,7 +1927,11 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 
 #if PTO2_PROFILING
             uint64_t orch_cycle_start = get_sys_cnt_aicpu();
-            DEV_ALWAYS("Thread %d: orch_start=%llu orch_idx=%d/(0~%d)", thread_idx, (unsigned long long)orch_cycle_start, orch_idx, orch_thread_num_ - 1);
+            DEV_ALWAYS("Thread %d: orch_start=%llu orch_idx=%d/(0~%d)",
+                thread_idx,
+                (unsigned long long)orch_cycle_start,
+                orch_idx,
+                orch_thread_num_ - 1);
 #endif
             PTO2_SCOPE(rt) { orch_func_(rt, orch_args_cached_, orch_thread_num_, orch_idx); }
 #if PTO2_PROFILING
@@ -1778,7 +1940,9 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             // This differs from `orch_end`, which marks stage-level end right before
             // requesting core transition (includes additional post-orchestration work).
             DEV_ALWAYS("Thread %d: aicpu_orchestration_entry returned, orch_func_cost=%.3fus (orch_idx=%d)",
-                thread_idx, cycles_to_us(orch_cycle_end - orch_cycle_start), orch_idx);
+                thread_idx,
+                cycles_to_us(orch_cycle_end - orch_cycle_start),
+                orch_idx);
 #endif
 
             // Print orchestrator profiling data
@@ -1836,14 +2000,19 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 #if PTO2_TENSORMAP_PROFILING
             PTO2TensorMapProfilingData tp = pto2_tensormap_get_profiling();
             DEV_ALWAYS("Thread %d: === TensorMap Lookup Stats ===", thread_idx);
-            DEV_ALWAYS("Thread %d:   lookups        : %llu, inserts: %llu", thread_idx,
-                (unsigned long long)tp.lookup_count, (unsigned long long)tp.insert_count);
-            DEV_ALWAYS("Thread %d:   chain walked   : total=%llu, avg=%.1f, max=%d", thread_idx,
+            DEV_ALWAYS("Thread %d:   lookups        : %llu, inserts: %llu",
+                thread_idx,
+                (unsigned long long)tp.lookup_count,
+                (unsigned long long)tp.insert_count);
+            DEV_ALWAYS("Thread %d:   chain walked   : total=%llu, avg=%.1f, max=%d",
+                thread_idx,
                 (unsigned long long)tp.lookup_chain_total,
                 tp.lookup_count > 0 ? (double)tp.lookup_chain_total / tp.lookup_count : 0.0,
                 tp.lookup_chain_max);
-            DEV_ALWAYS("Thread %d:   overlap checks : %llu, hits=%llu (%.1f%%)", thread_idx,
-                (unsigned long long)tp.overlap_checks, (unsigned long long)tp.overlap_hits,
+            DEV_ALWAYS("Thread %d:   overlap checks : %llu, hits=%llu (%.1f%%)",
+                thread_idx,
+                (unsigned long long)tp.overlap_checks,
+                (unsigned long long)tp.overlap_hits,
                 tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0);
 #endif
 
@@ -1886,14 +2055,15 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 void* sm = runtime->get_pto2_gm_sm_ptr();
                 PTO2SharedMemoryHeader* sm_header = static_cast<PTO2SharedMemoryHeader*>(sm);
                 int32_t pto2_task_count = 0;
-                    if (sm_header) {
-                        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                            pto2_task_count +=
-                                sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
-                        }
+                if (sm_header) {
+                    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                        pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                     }
+                }
 #if PTO2_PROFILING
-                DEV_ALWAYS("PTO2 total submitted tasks = %d, already executed %d tasks", pto2_task_count, completed_tasks_.load(std::memory_order_acquire));
+                DEV_ALWAYS("PTO2 total submitted tasks = %d, already executed %d tasks",
+                    pto2_task_count,
+                    completed_tasks_.load(std::memory_order_acquire));
 #endif
                 total_tasks_ = pto2_task_count;
                 if (runtime->enable_profiling && pto2_task_count > 0) {
@@ -1904,8 +2074,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     int32_t orch_err = 0;
                     void* sm = runtime->get_pto2_gm_sm_ptr();
                     if (sm) {
-                        orch_err = static_cast<PTO2SharedMemoryHeader*>(sm)->orch_error_code.load(
-                            std::memory_order_relaxed);
+                        orch_err =
+                            static_cast<PTO2SharedMemoryHeader*>(sm)->orch_error_code.load(std::memory_order_relaxed);
                     }
 
                     // Fatal error: shutdown AICore immediately before core transition.
@@ -1929,8 +2099,9 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
 #if PTO2_PROFILING
                     // Stage-level end: orchestrator phase finishes before requesting transition.
-                    DEV_ALWAYS("Thread %d: orch_stage_end=%llu, requesting core transition", thread_idx,
-                               (unsigned long long)get_sys_cnt_aicpu());
+                    DEV_ALWAYS("Thread %d: orch_stage_end=%llu, requesting core transition",
+                        thread_idx,
+                        (unsigned long long)get_sys_cnt_aicpu());
 #endif
                     transition_requested_.store(true, std::memory_order_release);
 
@@ -1979,8 +2150,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
-    if (!completed_.load(std::memory_order_acquire) &&
-        (thread_idx < sched_thread_num_ || orch_to_sched_)) {
+    if (!completed_.load(std::memory_order_acquire) && (thread_idx < sched_thread_num_ || orch_to_sched_)) {
         // Device orchestration: wait for primary orchestrator to initialize SM header
         if (!runtime->get_orch_built_on_host()) {
             while (!runtime_init_ready_.load(std::memory_order_acquire)) {
@@ -2000,8 +2170,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
         int32_t shutdown_count = core_count_per_thread_[thread_idx];
         if (shutdown_count > 0) {
 #if PTO2_PROFILING
-            DEV_ALWAYS("Thread %d: sched_end=%llu",
-                       thread_idx, (unsigned long long)get_sys_cnt_aicpu());
+            DEV_ALWAYS("Thread %d: sched_end=%llu", thread_idx, (unsigned long long)get_sys_cnt_aicpu());
 #endif
             auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
             if (rc != 0) {
@@ -2099,17 +2268,15 @@ void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
     DEV_WARN("Emergency shutdown complete");
 }
 
-void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
-                                         const int32_t* cur_thread_cores, int32_t core_num,
-                                         Handshake* hank) {
+void AicpuExecutor::diagnose_stuck_state(
+    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank) {
     (void)runtime;
     PTO2SchedulerState* sched = &rt->scheduler;
     DEV_ALWAYS("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
 
     int32_t completed = completed_tasks_.load(std::memory_order_acquire);
     int32_t total = total_tasks_;
-    DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)",
-             completed, total, total > 0 ? completed * 100.0 / total : 0.0);
+    DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)", completed, total, total > 0 ? completed * 100.0 / total : 0.0);
 
     uint64_t aic_ready = 0, aiv_ready = 0, aiv_x2_ready = 0, mixed_x1_ready = 0, mixed_x2_ready = 0;
     if (rt) {
@@ -2120,7 +2287,11 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
         mixed_x2_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC_AIV_X2)].size();
     }
     DEV_ALWAYS("Ready Queues: AIC=%lu, AIV=%lu, AIV_X2=%lu, AIC_AIV_X1=%lu, AIC_AIV_X2=%lu",
-               aic_ready, aiv_ready, aiv_x2_ready, mixed_x1_ready, mixed_x2_ready);
+        aic_ready,
+        aiv_ready,
+        aiv_x2_ready,
+        mixed_x1_ready,
+        mixed_x2_ready);
 
     int32_t busy_cores = 0;
     int32_t idle_cores = 0;
@@ -2145,14 +2316,23 @@ void AicpuExecutor::diagnose_stuck_state(Runtime* runtime, int32_t thread_idx,
                     int32_t diag_slot = static_cast<int32_t>(executing_subslot_by_core_[core_id]);
                     kernel_id = executing_slot_state_by_core_[core_id]->task->kernel_id[diag_slot];
                 }
-                DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_reg_task_id=%d, kernel_id=%d",
-                        core_id, core_type_str, reg_val, reg_task_id,
-                        reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
-                        task_id, kernel_id);
+                DEV_ALWAYS(
+                    "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_reg_task_id=%d, "
+                    "kernel_id=%d",
+                    core_id,
+                    core_type_str,
+                    reg_val,
+                    reg_task_id,
+                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
+                    task_id,
+                    kernel_id);
             } else {
                 DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked",
-                        core_id, core_type_str, reg_val, reg_task_id,
-                        reg_state == TASK_FIN_STATE ? "FIN" : "ACK");
+                    core_id,
+                    core_type_str,
+                    reg_val,
+                    reg_task_id,
+                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK");
             }
         } else {
             idle_cores++;

--- a/src/a5/runtime/tensormap_and_ringbuffer/build_config.py
+++ b/src/a5/runtime/tensormap_and_ringbuffer/build_config.py
@@ -11,20 +11,17 @@
 # by the Tensor constructor's validation logic).
 
 BUILD_CONFIG = {
-    "aicore": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicore", "orchestration"]
-    },
+    "aicore": {"include_dirs": ["runtime"], "source_dirs": ["aicore", "orchestration"]},
     "aicpu": {
         "include_dirs": ["runtime"],
-        "source_dirs": ["aicpu", "runtime", "orchestration"]
+        "source_dirs": ["aicpu", "runtime", "orchestration"],
     },
     "host": {
         "include_dirs": ["runtime"],
-        "source_dirs": ["host", "runtime", "orchestration"]
+        "source_dirs": ["host", "runtime", "orchestration"],
     },
     "orchestration": {
         "include_dirs": ["runtime", "orchestration"],
-        "source_dirs": ["orchestration"]
-    }
+        "source_dirs": ["orchestration"],
+    },
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -223,4 +223,3 @@ Final validation:
 3. Per-cluster concurrent capacity is lane-occupancy-driven, not a fixed constant.
 4. Submit-contract types live in one shared header-only surface.
 5. Resource-aware dispatch heuristics are allowed without a strict starvation-free guarantee.
-

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_compile_info.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_compile_info.cpp
@@ -14,5 +14,4 @@ ToolchainType get_orchestration_compiler(void) {
     if (strcmp(get_platform(), "a2a3") == 0) return TOOLCHAIN_AARCH64_GXX;
     return TOOLCHAIN_HOST_GXX;
 }
-
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -48,13 +48,11 @@ static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool requir
     errno = 0;
     unsigned long long val = strtoull(env, &endptr, 10);
     if (errno == ERANGE || endptr == env || *endptr != '\0' || val < min_val) {
-        LOG_WARN("%s=%s invalid (must be a valid integer >= %lu), ignored",
-                 name, env, (unsigned long)min_val);
+        LOG_WARN("%s=%s invalid (must be a valid integer >= %lu), ignored", name, env, (unsigned long)min_val);
         return 0;
     }
     if (require_power_of_2 && (val & (val - 1)) != 0) {
-        LOG_WARN("%s=%s invalid (must be a power of 2, >= %lu), ignored",
-                 name, env, (unsigned long)min_val);
+        LOG_WARN("%s=%s invalid (must be a power of 2, >= %lu), ignored", name, env, (unsigned long)min_val);
         return 0;
     }
     return static_cast<uint64_t>(val);
@@ -79,16 +77,16 @@ static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool requir
  * @param orch_args_count   Number of TaskArg entries
  * @return 0 on success, -1 on failure
  */
-extern "C" int init_runtime_impl(Runtime *runtime,
-                    const uint8_t* orch_so_binary,
-                    size_t orch_so_size,
-                    const char* orch_func_name,
-                    const TaskArg* orch_args,
-                    int orch_args_count,
-                    const int* kernel_func_ids,
-                    const uint8_t* const* kernel_binaries,
-                    const size_t* kernel_sizes,
-                    int kernel_count) {
+extern "C" int init_runtime_impl(Runtime* runtime,
+    const uint8_t* orch_so_binary,
+    size_t orch_so_size,
+    const char* orch_func_name,
+    const TaskArg* orch_args,
+    int orch_args_count,
+    const int* kernel_func_ids,
+    const uint8_t* const* kernel_binaries,
+    const size_t* kernel_sizes,
+    int kernel_count) {
     // Suppress unused parameter warning
     (void)orch_func_name;
 
@@ -99,12 +97,11 @@ extern "C" int init_runtime_impl(Runtime *runtime,
     }
 
     // Register kernel binaries via platform-provided upload function
-    if (kernel_count > 0 && kernel_func_ids != nullptr &&
-        kernel_binaries != nullptr && kernel_sizes != nullptr) {
+    if (kernel_count > 0 && kernel_func_ids != nullptr && kernel_binaries != nullptr && kernel_sizes != nullptr) {
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", kernel_count);
         for (int i = 0; i < kernel_count; i++) {
-            uint64_t addr = runtime->host_api.upload_kernel_binary(
-                kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
+            uint64_t addr =
+                runtime->host_api.upload_kernel_binary(kernel_func_ids[i], kernel_binaries[i], kernel_sizes[i]);
             if (addr == 0) {
                 LOG_ERROR("Failed to upload kernel binary for func_id=%d", kernel_func_ids[i]);
                 return -1;
@@ -190,7 +187,9 @@ extern "C" int init_runtime_impl(Runtime *runtime,
                 runtime->ready_queue_shards = static_cast<int>(val);
             } else {
                 LOG_WARN("PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d",
-                         env_shards, PLATFORM_MAX_AICPU_THREADS, RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
+                    env_shards,
+                    PLATFORM_MAX_AICPU_THREADS,
+                    RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
                 runtime->ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
             }
         }
@@ -208,20 +207,22 @@ extern "C" int init_runtime_impl(Runtime *runtime,
 
     // Read ring buffer size overrides from environment
     {
-        runtime->pto2_task_window_size  = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
-        runtime->pto2_heap_size         = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
-        runtime->pto2_dep_pool_size     = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
+        runtime->pto2_task_window_size = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
+        runtime->pto2_heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
+        runtime->pto2_dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
         if (runtime->pto2_task_window_size || runtime->pto2_heap_size || runtime->pto2_dep_pool_size) {
             LOG_INFO("Ring buffer overrides: task_window=%lu heap=%lu dep_pool=%lu",
-                     (unsigned long)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE),
-                     (unsigned long)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
-                     (unsigned long)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE));
+                (unsigned long)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size
+                                                               : PTO2_TASK_WINDOW_SIZE),
+                (unsigned long)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
+                (unsigned long)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE));
         }
     }
 
     // Resolve effective sizes (env override or compile-time default)
     uint64_t eff_heap_size = runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE;
-    uint64_t eff_task_window_size = runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE;
+    uint64_t eff_task_window_size =
+        runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE;
 
     // Allocate GM heap for orchestrator output buffers (all rings combined)
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
@@ -274,7 +275,7 @@ extern "C" int init_runtime_impl(Runtime *runtime,
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime *runtime) {
+extern "C" int validate_runtime_impl(Runtime* runtime) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -303,7 +304,9 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
             graph_out_ptr = host_header.graph_output_ptr;
             graph_out_size = host_header.graph_output_size;
             if (graph_out_ptr != 0) {
-                LOG_INFO("Graph output buffer: ptr=0x%lx, size=%lu", (unsigned long)graph_out_ptr, (unsigned long)graph_out_size);
+                LOG_INFO("Graph output buffer: ptr=0x%lx, size=%lu",
+                    (unsigned long)graph_out_ptr,
+                    (unsigned long)graph_out_size);
             }
         } else {
             LOG_WARN("Failed to copy PTO2 header from device");

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -17,8 +17,7 @@
  * 如果存在内联，同时通过 inline_chain 返回外层调用链
  */
 #ifdef __linux__
-static std::string addr_to_line(const char* executable, void* addr,
-                                std::string* inline_chain = nullptr) {
+static std::string addr_to_line(const char* executable, void* addr, std::string* inline_chain = nullptr) {
     char cmd[512];
     snprintf(cmd, sizeof(cmd), "addr2line -e %s -f -C -p -i %p 2>/dev/null", executable, addr);
 
@@ -140,7 +139,9 @@ static std::string build_assert_message(const char* condition, const char* file,
 
 AssertionError::AssertionError(const char* condition, const char* file, int line)
     : std::runtime_error(build_assert_message(condition, file, line)),
-      condition_(condition), file_(file), line_(line) {}
+      condition_(condition),
+      file_(file),
+      line_(line) {}
 
 [[noreturn]] void assert_impl(const char* condition, const char* file, int line) {
     fprintf(stderr, "\n========================================\n");

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -22,18 +22,20 @@
 #include <stddef.h>
 
 // Type headers needed by orchestration
-#include "pto_types.h"          // PTOParam, PTOTensorEntry, PTOParamType
-#include "tensor.h"             // Tensor, make_tensor, make_tensor_external
-#include "pto_submit_types.h"   // MixedKernels, INVALID_KERNEL_ID, subtask slots
-#include "task_arg.h"           // TaskArg, TaskArgKind
+#include "pto_types.h"         // PTOParam, PTOTensorEntry, PTOParamType
+#include "tensor.h"            // Tensor, make_tensor, make_tensor_external
+#include "pto_submit_types.h"  // MixedKernels, INVALID_KERNEL_ID, subtask slots
+#include "task_arg.h"          // TaskArg, TaskArgKind
 
 // Convert TaskArg to Tensor (needs make_tensor_external from tensor.h)
 static_assert(TASK_ARG_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "TaskArg and runtime max dims must match");
 inline Tensor from_task_arg(const TaskArg& arg, bool manual_dep = false, int32_t version = 0) {
-    return make_tensor_external(
-        reinterpret_cast<void*>(static_cast<uintptr_t>(arg.tensor.data)),
-        arg.tensor.shapes, arg.tensor.ndims, arg.tensor.dtype,
-        manual_dep, version);
+    return make_tensor_external(reinterpret_cast<void*>(static_cast<uintptr_t>(arg.tensor.data)),
+        arg.tensor.shapes,
+        arg.tensor.ndims,
+        arg.tensor.dtype,
+        manual_dep,
+        version);
 }
 
 // =============================================================================
@@ -52,8 +54,7 @@ typedef struct PTO2Runtime PTO2Runtime;
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
 typedef struct PTO2RuntimeOps {
-    void (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                        const PTOParam& params);
+    void (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params);
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
     void (*orchestration_done)(PTO2Runtime* rt);
@@ -82,16 +83,14 @@ struct PTO2Runtime {
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline void pto2_rt_submit_task(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                                        const PTOParam& params) {
+static inline void pto2_rt_submit_task(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params) {
     rt->ops->submit_task(rt, mixed_kernels, params);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
-static inline void pto2_rt_submit_aic_task(PTO2Runtime* rt, int32_t kernel_id,
-                                            const PTOParam& params) {
+static inline void pto2_rt_submit_aic_task(PTO2Runtime* rt, int32_t kernel_id, const PTOParam& params) {
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
     rt->ops->submit_task(rt, mk, params);
@@ -100,36 +99,27 @@ static inline void pto2_rt_submit_aic_task(PTO2Runtime* rt, int32_t kernel_id,
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
-static inline void pto2_rt_submit_aiv_task(PTO2Runtime* rt, int32_t kernel_id,
-                                            const PTOParam& params) {
+static inline void pto2_rt_submit_aiv_task(PTO2Runtime* rt, int32_t kernel_id, const PTOParam& params) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     rt->ops->submit_task(rt, mk, params);
 }
 
-static inline void pto2_rt_scope_begin(PTO2Runtime* rt) {
-    rt->ops->scope_begin(rt);
-}
+static inline void pto2_rt_scope_begin(PTO2Runtime* rt) { rt->ops->scope_begin(rt); }
 
-static inline void pto2_rt_scope_end(PTO2Runtime* rt) {
-    rt->ops->scope_end(rt);
-}
+static inline void pto2_rt_scope_end(PTO2Runtime* rt) { rt->ops->scope_end(rt); }
 
-static inline void pto2_rt_orchestration_done(PTO2Runtime* rt) {
-    rt->ops->orchestration_done(rt);
-}
+static inline void pto2_rt_orchestration_done(PTO2Runtime* rt) { rt->ops->orchestration_done(rt); }
 
-static inline bool pto2_rt_is_fatal(PTO2Runtime* rt) {
-    return rt->ops->is_fatal(rt);
-}
+static inline bool pto2_rt_is_fatal(PTO2Runtime* rt) { return rt->ops->is_fatal(rt); }
 
 // =============================================================================
 // Logging Macros for Orchestration (call through ops table)
 // =============================================================================
 
 #define LOG_ERROR(rt, fmt, ...) (rt)->ops->log_error(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_WARN(rt, fmt, ...)  (rt)->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_INFO(rt, fmt, ...)  (rt)->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_WARN(rt, fmt, ...) (rt)->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_INFO(rt, fmt, ...) (rt)->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
 #define LOG_DEBUG(rt, fmt, ...) (rt)->ops->log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
 #define LOG_ALWAYS(rt, fmt, ...) (rt)->ops->log_always(__FUNCTION__, fmt, ##__VA_ARGS__)
 
@@ -142,17 +132,14 @@ static inline bool pto2_rt_is_fatal(PTO2Runtime* rt) {
  */
 class PTO2ScopeGuard {
 public:
-    PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) {
-        rt_->ops->scope_begin(rt_);
-    }
-    ~PTO2ScopeGuard() {
-        rt_->ops->scope_end(rt_);
-    }
+    PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) { rt_->ops->scope_begin(rt_); }
+    ~PTO2ScopeGuard() { rt_->ops->scope_end(rt_); }
+
 private:
     PTO2Runtime* rt_;
 };
 
-#define _PTO2_CONCATENATE_IMPL(x, y) x ## y
+#define _PTO2_CONCATENATE_IMPL(x, y) x##y
 #define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
 
 #define PTO2_SCOPE_GUARD(rt) [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__)(rt)
@@ -179,8 +166,8 @@ private:
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
 struct PTO2OrchestrationConfig {
-    int         expected_arg_count;
+    int expected_arg_count;
 };
 #endif
 
-#endif // PTO_ORCHESTRATION_API_H
+#endif  // PTO_ORCHESTRATION_API_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -26,7 +26,7 @@
  * AICore reads function_bin_addr, casts to UnifiedKernelFunc, calls with args.
  */
 struct PTO2DispatchPayload {
-    uint64_t function_bin_addr; /**< Kernel entry in GM: (UnifiedKernelFunc)function_bin_addr */
+    uint64_t function_bin_addr;            /**< Kernel entry in GM: (UnifiedKernelFunc)function_bin_addr */
     uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers + scalars) */
 };
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -53,7 +53,7 @@ static uint64_t g_orch_heap_cycle = 0;       // heap alloc + output assign
 static uint64_t g_orch_insert_cycle = 0;     // tensormap insert
 static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
 static uint64_t g_orch_scope_end_cycle = 0;  // scope_end overhead
-static int64_t  g_orch_submit_count = 0;
+static int64_t g_orch_submit_count = 0;
 static uint32_t g_orch_submit_idx = 0;
 uint64_t g_orch_alloc_wait_cycle = 0;
 uint64_t g_orch_heap_wait_cycle = 0;
@@ -65,7 +65,12 @@ uint64_t g_orch_fanin_atomic_count = 0;
 uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
-#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+#define CYCLE_COUNT_LAP(acc)       \
+    do {                           \
+        _t1 = get_sys_cnt_aicpu(); \
+        acc += (_t1 - _t0);        \
+        _t0 = _t1;                 \
+    } while (0)
 #define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                    \
     do {                                                                              \
         _t1 = get_sys_cnt_aicpu();                                                    \
@@ -81,17 +86,19 @@ __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
     AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint32_t) {}
 // submit_idx needed for swimlane task_id tagging (no cycle accumulation at this level)
 static uint32_t g_orch_submit_idx = 0;
-#define CYCLE_COUNT_START()                                                           \
-    bool _prof_active = orch->enable_profiling;                                       \
+#define CYCLE_COUNT_START()                     \
+    bool _prof_active = orch->enable_profiling; \
     uint64_t _t0 = _prof_active ? get_sys_cnt_aicpu() : 0, _t1 = 0
-#define CYCLE_COUNT_LAP(acc) do { } while(0)
-#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                    \
-    do {                                                                              \
-        if (_prof_active) {                                                           \
-            _t1 = get_sys_cnt_aicpu();                                                \
+#define CYCLE_COUNT_LAP(acc) \
+    do {                     \
+    } while (0)
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                        \
+    do {                                                                                  \
+        if (_prof_active) {                                                               \
+            _t1 = get_sys_cnt_aicpu();                                                    \
             perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
-            _t0 = _t1;                                                                \
-        }                                                                             \
+            _t0 = _t1;                                                                    \
+        }                                                                                 \
     } while (0)
 #else
 #define CYCLE_COUNT_START()
@@ -103,8 +110,10 @@ static uint32_t g_orch_submit_idx = 0;
 // Orchestrator Initialization
 // =============================================================================
 
-bool pto2_orchestrator_init(
-    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, uint64_t heap_size,
+bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
     int32_t dep_pool_capacity) {
     *orch = PTO2OrchestratorState{};
 
@@ -117,7 +126,7 @@ bool pto2_orchestrator_init(
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         // Each ring gets its own heap region
         void* ring_heap_base = (char*)gm_heap + r * heap_size;
-        auto &fc = sm_handle->header->rings[r].fc;
+        auto& fc = sm_handle->header->rings[r].fc;
 
         // Initialize heap ring buffer
         pto2_heap_ring_init(&orch->rings[r].heap_ring, ring_heap_base, heap_size, &fc.heap_tail, &fc.heap_top);
@@ -200,10 +209,11 @@ void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerS
 // Scope Management
 // =============================================================================
 
-static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState *task_slot_state) {
+static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState* task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         int32_t new_cap = orch->scope_tasks_capacity * 2;
-        PTO2TaskSlotState** new_buf = (PTO2TaskSlotState**)realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState*));
+        PTO2TaskSlotState** new_buf =
+            (PTO2TaskSlotState**)realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState*));
         assert(new_buf && "Failed to grow scope task buffer");
         orch->scope_tasks = new_buf;
         orch->scope_tasks_capacity = new_cap;
@@ -212,7 +222,9 @@ static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState *tas
 }
 
 void pto2_scope_begin(PTO2OrchestratorState* orch) {
-    if (orch->fatal) { return; }
+    if (orch->fatal) {
+        return;
+    }
     assert(orch->scope_stack_top < (int32_t)(orch->scope_stack_capacity - 1) && "Scope stack overflow");
 
     ++orch->scope_stack_top;
@@ -220,7 +232,9 @@ void pto2_scope_begin(PTO2OrchestratorState* orch) {
 }
 
 void pto2_scope_end(PTO2OrchestratorState* orch) {
-    if (orch->fatal) { return; }
+    if (orch->fatal) {
+        return;
+    }
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
 
 #if PTO2_ORCH_PROFILING
@@ -247,8 +261,7 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
 // =============================================================================
 // Task Submission
 // =============================================================================
-void pto2_submit_mixed_task(
-    PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const PTOParam& params) {
+void pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const PTOParam& params) {
     CYCLE_COUNT_START();
 
     // Fast path after fatal error — all subsequent submits are no-ops
@@ -265,18 +278,16 @@ void pto2_submit_mixed_task(
         LOG_ERROR("  tensor_count: %d, scalar_count: %d", params.tensor_count, params.scalar_count);
         LOG_ERROR("This is a bug in the orchestration code.");
         LOG_ERROR("========================================");
-        orch->sm_handle->header->orch_error_code.store(
-            PTO2_ERROR_INVALID_PARAM, std::memory_order_release);
+        orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_INVALID_PARAM, std::memory_order_release);
         orch->fatal = true;
         return;
     }
 
-    
     // Determine which ring this task belongs to
     uint8_t ring_id = orch->current_ring_id();
     auto& task_ring = orch->rings[ring_id].task_ring;
     PTO2SchedulerState* sched = orch->scheduler;
-    PTO2RingFlowControl &fc = orch->sm_handle->header->rings[ring_id].fc;
+    PTO2RingFlowControl& fc = orch->sm_handle->header->rings[ring_id].fc;
 
     // === Validate submit inputs ===
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
@@ -310,8 +321,7 @@ void pto2_submit_mixed_task(
             LOG_ERROR("========================================");
             LOG_ERROR("FATAL: Scope Deadlock Detected! (ring %d)", ring_id);
             LOG_ERROR("========================================");
-            LOG_ERROR("Tasks in current scope (%d) >= task_window_size (%d).",
-                      scope_task_count, task_ring.window_size);
+            LOG_ERROR("Tasks in current scope (%d) >= task_window_size (%d).", scope_task_count, task_ring.window_size);
             LOG_ERROR("  scope_depth:        %d", orch->scope_stack_top + 1);
             LOG_ERROR("  ring_id:            %d", ring_id);
             LOG_ERROR("  scope_task_count:   %d", scope_task_count);
@@ -329,8 +339,7 @@ void pto2_submit_mixed_task(
             LOG_ERROR("     Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2>");
             LOG_ERROR("  3. Split work across multiple scopes");
             LOG_ERROR("========================================");
-            orch->sm_handle->header->orch_error_code.store(
-                PTO2_ERROR_SCOPE_DEADLOCK, std::memory_order_release);
+            orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_SCOPE_DEADLOCK, std::memory_order_release);
             orch->fatal = true;
             return;
         }
@@ -338,12 +347,15 @@ void pto2_submit_mixed_task(
 
     // === STEP 1: Allocate task slot from Task Ring (blocks until available) ===
     int32_t local_id = task_ring.pto2_task_ring_alloc();
-    if (local_id < 0) { orch->fatal = true; return; }
+    if (local_id < 0) {
+        orch->fatal = true;
+        return;
+    }
     int32_t slot = task_ring.get_task_slot(local_id);
     PTO2TaskId mixed_task_id = pto2_make_task_id(ring_id, static_cast<uint32_t>(local_id));
 
     PTO2TaskDescriptor& task = task_ring.get_task_by_slot(slot);
-    PTO2TaskPayload* payload = &orch->sm_handle->task_payloads[ring_id][slot];    
+    PTO2TaskPayload* payload = &orch->sm_handle->task_payloads[ring_id][slot];
 
     // Early write-prefetch payload GM cache lines to issue RFO in background.
     // ~130 lines of computation (output_size, lookup, insert) follow before
@@ -392,8 +404,7 @@ void pto2_submit_mixed_task(
     // === STEP 2: Calculate output size + heap alloc (read from params only, no GM access) ===
     int32_t total_output_size = 0;
     for (int i = 0; i < params.tensor_count; i++) {
-        if (params.tensor_types[i] == PTOParamType::OUTPUT
-            && params.tensors[i]->buffer.addr == 0) {
+        if (params.tensor_types[i] == PTOParamType::OUTPUT && params.tensors[i]->buffer.addr == 0) {
             total_output_size += PTO2_ALIGN_UP(params.tensors[i]->buffer.size, PTO2_PACKED_OUTPUT_ALIGN);
         }
     }
@@ -402,7 +413,10 @@ void pto2_submit_mixed_task(
     void* local_packed_end = nullptr;
     if (total_output_size > 0) {
         local_packed_base = orch->pto2_alloc_packed_buffer(total_output_size);
-        if (!local_packed_base) { orch->fatal = true; return; }
+        if (!local_packed_base) {
+            orch->fatal = true;
+            return;
+        }
         local_packed_end = (char*)local_packed_base + total_output_size;
     }
     CYCLE_COUNT_LAP_RECORD(g_orch_heap_cycle, AicpuPhaseId::ORCH_HEAP, local_id);
@@ -503,7 +517,7 @@ void pto2_submit_mixed_task(
     // evicted by TensorMap lookup/insert cache pressure.
     __builtin_prefetch(&task, 1, 1);
     task.mixed_task_id = mixed_task_id;
-    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)]  = normalized.aic_kernel_id;
+    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)] = normalized.aic_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;
     task.packed_buffer_base = local_packed_base;
@@ -568,8 +582,8 @@ void pto2_submit_mixed_task(
         // Combined release: merge early_finished batch with the +1 init release
         // into a single atomic fetch_add (saves one acq_rel cache-line bounce per task).
         int32_t initial_refcount = early_finished + 1;  // +1 for the init release
-        int32_t new_rc = cur_slot_state.fanin_refcount.fetch_add(initial_refcount, std::memory_order_acq_rel)
-                         + initial_refcount;
+        int32_t new_rc =
+            cur_slot_state.fanin_refcount.fetch_add(initial_refcount, std::memory_order_acq_rel) + initial_refcount;
         if (new_rc >= fanin_count + 1) {
             PTO2ResourceShape shape = pto2_active_mask_to_shape(active_mask);
             sched->ready_queues[static_cast<int32_t>(shape)].push(&cur_slot_state);
@@ -610,7 +624,12 @@ void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
         auto& pool = orch->rings[r].dep_pool;
         if (pool.top > 0) {
             LOG_INFO("=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===",
-                     r, pool.top, pool.tail, pool.top - pool.tail, pool.high_water, pool.capacity);
+                r,
+                pool.top,
+                pool.tail,
+                pool.top - pool.tail,
+                pool.high_water,
+                pool.capacity);
         }
     }
     orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
@@ -635,12 +654,12 @@ void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
         int32_t active = pto2_task_ring_active_count(&orch->rings[r].task_ring);
         if (active > 0) {
             LOG_INFO("Ring %d task active:  %d", r, active);
-            LOG_INFO("Ring %d heap used:    %" PRIu64 " / %" PRIu64, r,
-                     orch->rings[r].heap_ring.top_ptr->load(std::memory_order_relaxed),
-                     orch->rings[r].heap_ring.size);
-            LOG_INFO("Ring %d dep pool:     %d / %d", r,
-                     orch->rings[r].dep_pool.used(),
-                     orch->rings[r].dep_pool.capacity);
+            LOG_INFO("Ring %d heap used:    %" PRIu64 " / %" PRIu64,
+                r,
+                orch->rings[r].heap_ring.top_ptr->load(std::memory_order_relaxed),
+                orch->rings[r].heap_ring.size);
+            LOG_INFO(
+                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity);
         }
     }
     LOG_INFO("TensorMap valid:     %d", orch->tensor_map.valid_count());

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -43,18 +43,18 @@ struct PTO2OrchestratorState {
     PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
 
     // === TENSOR MAP (Private) ===
-    PTO2TensorMap tensor_map;        // Producer lookup
+    PTO2TensorMap tensor_map;  // Producer lookup
 
     // === SCOPE STACK (Private) ===
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    PTO2TaskSlotState** scope_tasks; // Flat buffer of taskSlotState (all scopes concatenated)
-    int32_t scope_tasks_size;       // Number of task IDs currently in the buffer
-    int32_t scope_tasks_capacity;   // Allocated capacity of scope_tasks
-    int32_t* scope_begins;         // scope_begins[i] = start index of scope i in scope_tasks
-    int32_t scope_stack_top;       // Current top of stack (-1 = no scope open)
-    uint64_t scope_stack_capacity;   // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+    PTO2TaskSlotState** scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
+    int32_t scope_tasks_size;         // Number of task IDs currently in the buffer
+    int32_t scope_tasks_capacity;     // Allocated capacity of scope_tasks
+    int32_t* scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
+    int32_t scope_stack_top;          // Current top of stack (-1 = no scope open)
+    uint64_t scope_stack_capacity;    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
 
     // === SCHEDULER REFERENCE ===
     // Note: In simulated mode, orchestrator and scheduler share address space
@@ -66,8 +66,8 @@ struct PTO2OrchestratorState {
 #endif
 
     // === GM HEAP (for output buffers) ===
-    void* gm_heap_base;    // Base address of GM heap
-    uint64_t gm_heap_size;   // Total size of GM heap (all rings)
+    void* gm_heap_base;     // Base address of GM heap
+    uint64_t gm_heap_size;  // Total size of GM heap (all rings)
 
     // === FATAL ERROR ===
     // Fatal error flag (single-thread access by orchestrator, no atomic needed)
@@ -124,8 +124,10 @@ struct PTO2OrchestratorState {
  * @param heap_size  Size of GM heap
  * @return true on success
  */
-bool pto2_orchestrator_init(
-    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, uint64_t heap_size,
+bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
     int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
 
 /**
@@ -137,7 +139,6 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState* orch);
  * Set scheduler reference (for simulated mode)
  */
 void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler);
-
 
 // =============================================================================
 // Scope Management
@@ -180,9 +181,7 @@ void pto2_scope_end(PTO2OrchestratorState* orch);
  * @param mixed_kernels  Kernel IDs for AIC/AIV0/AIV1 slots
  * @param params      Aggregated tensor and scalar parameters
  */
-void pto2_submit_mixed_task(PTO2OrchestratorState* orch,
-    const MixedKernels& mixed_kernels,
-    const PTOParam& params);
+void pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const PTOParam& params);
 
 // =============================================================================
 // Flow Control
@@ -223,11 +222,11 @@ struct PTO2OrchProfilingData {
     uint64_t insert_cycle;
     uint64_t fanin_cycle;
     uint64_t scope_end_cycle;
-    int64_t  submit_count;
+    int64_t submit_count;
     // Wait time tracking for blocking phases
-    uint64_t alloc_wait_cycle;      // Cycles spent waiting in task_ring_alloc
-    uint64_t heap_wait_cycle;       // Cycles spent waiting in heap_ring_alloc
-    uint64_t fanin_wait_cycle;      // Cycles spent waiting in fanout_lock
+    uint64_t alloc_wait_cycle;  // Cycles spent waiting in task_ring_alloc
+    uint64_t heap_wait_cycle;   // Cycles spent waiting in heap_ring_alloc
+    uint64_t fanin_wait_cycle;  // Cycles spent waiting in fanout_lock
     // Atomic operation counts per phase
     uint64_t alloc_atomic_count;
     uint64_t params_atomic_count;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -18,9 +18,8 @@
 // Heap Ring Buffer Implementation
 // =============================================================================
 
-void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
-                          std::atomic<uint64_t>* tail_ptr,
-                          std::atomic<uint64_t>* top_ptr) {
+void pto2_heap_ring_init(
+    PTO2HeapRing* ring, void* base, uint64_t size, std::atomic<uint64_t>* tail_ptr, std::atomic<uint64_t>* top_ptr) {
     ring->base = base;
     ring->size = size;
     ring->top_ptr = top_ptr;
@@ -31,9 +30,11 @@ void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
 // Task Ring Buffer Implementation
 // =============================================================================
 
-void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
-                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr,
-                          std::atomic<int32_t>* current_index_ptr) {
+void pto2_task_ring_init(PTO2TaskRing* ring,
+    PTO2TaskDescriptor* descriptors,
+    int32_t window_size,
+    std::atomic<int32_t>* last_alive_ptr,
+    std::atomic<int32_t>* current_index_ptr) {
     ring->descriptors = descriptors;
     ring->window_size = window_size;
     ring->current_index_ptr = current_index_ptr;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -1,25 +1,25 @@
 /**
  * PTO Runtime2 - Ring Buffer Data Structures
- * 
+ *
  * Implements ring buffer designs for zero-overhead memory management:
- * 
+ *
  * 1. HeapRing - Output buffer allocation from GM Heap
  *    - O(1) bump allocation
  *    - Wrap-around at end, skip to beginning if buffer doesn't fit
  *    - Implicit reclamation via heap_tail advancement
  *    - Back-pressure: stalls when no space available
- * 
+ *
  * 2. TaskRing - Task slot allocation
  *    - Fixed window size (TASK_WINDOW_SIZE)
  *    - Wrap-around modulo window size
  *    - Implicit reclamation via last_task_alive advancement
  *    - Back-pressure: stalls when window is full
- * 
+ *
  * 3. DepListPool - Dependency list entry allocation
  *    - Ring buffer for linked list entries
  *    - O(1) prepend operation
  *    - Implicit reclamation with task ring
- * 
+ *
  * Based on: docs/runtime_buffer_manager_methods.md
  */
 
@@ -40,15 +40,15 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 #endif
 
 // Block notification interval (in spin counts)
-#define PTO2_BLOCK_NOTIFY_INTERVAL  10000
+#define PTO2_BLOCK_NOTIFY_INTERVAL 10000
 // Heap ring spin limit - after this, report deadlock and exit
-#define PTO2_HEAP_SPIN_LIMIT        100000
+#define PTO2_HEAP_SPIN_LIMIT 100000
 
 // Flow control spin limit - if exceeded, likely deadlock due to scope/fanout_count
-#define PTO2_FLOW_CONTROL_SPIN_LIMIT  100000
+#define PTO2_FLOW_CONTROL_SPIN_LIMIT 100000
 
 // Dep pool spin limit - if exceeded, dep pool capacity too small for workload
-#define PTO2_DEP_POOL_SPIN_LIMIT      100000
+#define PTO2_DEP_POOL_SPIN_LIMIT 100000
 
 // =============================================================================
 // Heap Ring Buffer
@@ -56,13 +56,13 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 
 /**
  * Heap ring buffer structure
- * 
+ *
  * Allocates output buffers from a contiguous GM Heap.
  * Wrap-around design with implicit reclamation.
  */
 struct PTO2HeapRing {
-    void*    base;        // GM_Heap_Base pointer
-    uint64_t size;        // GM_Heap_Size (total heap size in bytes)
+    void* base;                      // GM_Heap_Base pointer
+    uint64_t size;                   // GM_Heap_Size (total heap size in bytes)
     std::atomic<uint64_t>* top_ptr;  // Allocation pointer (shared atomic in SM header)
 
     // Reference to shared memory tail (for back-pressure)
@@ -111,7 +111,8 @@ struct PTO2HeapRing {
                 }
                 {
                     extern uint64_t g_orch_heap_atomic_count;
-                    g_orch_heap_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
+                    g_orch_heap_atomic_count +=
+                        spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
                 }
 #endif
                 return ptr;
@@ -120,7 +121,10 @@ struct PTO2HeapRing {
             // No space available, spin-wait
             spin_count++;
 #if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+            if (!waiting) {
+                wait_start = get_sys_cnt_aicpu();
+                waiting = true;
+            }
 #endif
 
             // Progress detection: reset spin counter if heap_tail advances
@@ -128,7 +132,9 @@ struct PTO2HeapRing {
             if (cur_tail != prev_tail) {
 #if PTO2_SPIN_VERBOSE_LOGGING
                 LOG_INFO("[HeapRing] Progress: tail %" PRIu64 " -> %" PRIu64 " (reset spin_count=%d)",
-                         prev_tail, cur_tail, spin_count);
+                    prev_tail,
+                    cur_tail,
+                    spin_count);
 #endif
                 spin_count = 0;
                 prev_tail = cur_tail;
@@ -138,9 +144,13 @@ struct PTO2HeapRing {
             // Periodic block notification
             if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 && spin_count < PTO2_HEAP_SPIN_LIMIT) {
                 uint64_t top = top_ptr->load(std::memory_order_acquire);
-                LOG_WARN("[HeapRing] BLOCKED: requesting %" PRIu64 " bytes"
-                     ", top=%" PRIu64 ", tail=%" PRIu64 ", spins=%d",
-                     size, top, cur_tail, spin_count);
+                LOG_WARN("[HeapRing] BLOCKED: requesting %" PRIu64
+                         " bytes"
+                         ", top=%" PRIu64 ", tail=%" PRIu64 ", spins=%d",
+                    size,
+                    top,
+                    cur_tail,
+                    spin_count);
                 notified = true;
             }
 #endif
@@ -161,8 +171,8 @@ struct PTO2HeapRing {
                 LOG_ERROR("  is stuck. Check TaskRing diagnostics for root cause.");
                 LOG_ERROR("Solution: Increase heap size or investigate task stall.");
                 LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
-                LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %lu)",
-                          (unsigned long)(this->size * 2));
+                LOG_ERROR(
+                    "  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %lu)", (unsigned long)(this->size * 2));
                 LOG_ERROR("========================================");
                 if (error_code_ptr) {
                     error_code_ptr->store(PTO2_ERROR_HEAP_RING_DEADLOCK, std::memory_order_release);
@@ -216,8 +226,7 @@ struct PTO2HeapRing {
                 }
             }
 
-            if (top_ptr->compare_exchange_weak(top, new_top,
-                    std::memory_order_acq_rel, std::memory_order_acquire)) {
+            if (top_ptr->compare_exchange_weak(top, new_top, std::memory_order_acq_rel, std::memory_order_acquire)) {
                 return result;
             }
             // CAS failed, retry with updated top
@@ -243,15 +252,14 @@ struct PTO2HeapRing {
 
 /**
  * Initialize heap ring buffer
- * 
+ *
  * @param ring      Heap ring to initialize
  * @param base      Base address of heap memory
  * @param size      Total heap size in bytes
  * @param tail_ptr  Pointer to shared memory heap_tail
  */
-void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
-                          std::atomic<uint64_t>* tail_ptr,
-                          std::atomic<uint64_t>* top_ptr);
+void pto2_heap_ring_init(
+    PTO2HeapRing* ring, void* base, uint64_t size, std::atomic<uint64_t>* tail_ptr, std::atomic<uint64_t>* top_ptr);
 
 // =============================================================================
 // Task Ring Buffer
@@ -259,13 +267,13 @@ void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
 
 /**
  * Task ring buffer structure
- * 
+ *
  * Fixed-size sliding window for task management.
  * Provides back-pressure when window is full.
  */
 struct PTO2TaskRing {
-    PTO2TaskDescriptor* descriptors;  // Task descriptor array (from shared memory)
-    int32_t window_size;              // Window size (power of 2)
+    PTO2TaskDescriptor* descriptors;          // Task descriptor array (from shared memory)
+    int32_t window_size;                      // Window size (power of 2)
     std::atomic<int32_t>* current_index_ptr;  // Shared atomic in SM header
 
     // Reference to shared memory last_task_alive (for back-pressure)
@@ -309,7 +317,8 @@ struct PTO2TaskRing {
                 }
                 {
                     extern uint64_t g_orch_alloc_atomic_count;
-                    g_orch_alloc_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
+                    g_orch_alloc_atomic_count +=
+                        spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
                 }
 #endif
                 return task_id;
@@ -318,7 +327,10 @@ struct PTO2TaskRing {
             // Window is full, spin-wait (with yield to prevent CPU starvation)
             spin_count++;
 #if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+            if (!waiting) {
+                wait_start = get_sys_cnt_aicpu();
+                waiting = true;
+            }
 #endif
 
             // Progress detection: reset spin counter if last_task_alive advances
@@ -326,7 +338,9 @@ struct PTO2TaskRing {
             if (cur_last_alive > prev_last_alive) {
 #if PTO2_SPIN_VERBOSE_LOGGING
                 LOG_INFO("[TaskRing] Progress: last_alive %d -> %d (reset spin_count=%d)",
-                         prev_last_alive, cur_last_alive, spin_count);
+                    prev_last_alive,
+                    cur_last_alive,
+                    spin_count);
 #endif
                 spin_count = 0;
                 prev_last_alive = cur_last_alive;
@@ -334,13 +348,19 @@ struct PTO2TaskRing {
 
 #if PTO2_SPIN_VERBOSE_LOGGING
             // Periodic block notification
-            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 && spin_count < PTO2_FLOW_CONTROL_SPIN_LIMIT) {
+            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 &&
+                spin_count < PTO2_FLOW_CONTROL_SPIN_LIMIT) {
                 int32_t current = current_index_ptr->load(std::memory_order_acquire);
                 int32_t active_count = current - cur_last_alive;
-                LOG_WARN("[TaskRing] BLOCKED (Flow Control): current=%d, last_alive=%d, "
-                     "active=%d/%d (%.1f%%), spins=%d",
-                     current, cur_last_alive, active_count, window_size,
-                     100.0 * active_count / window_size, spin_count);
+                LOG_WARN(
+                    "[TaskRing] BLOCKED (Flow Control): current=%d, last_alive=%d, "
+                    "active=%d/%d (%.1f%%), spins=%d",
+                    current,
+                    cur_last_alive,
+                    active_count,
+                    window_size,
+                    100.0 * active_count / window_size,
+                    spin_count);
                 notified = true;
             }
 #endif
@@ -359,8 +379,7 @@ struct PTO2TaskRing {
                 LOG_ERROR("  - Active tasks:        %d / %d", active_count, window_size);
                 LOG_ERROR("  - Window utilization:  %.1f%%", 100.0 * active_count / window_size);
                 LOG_ERROR("Diagnosis:");
-                LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d",
-                          cur_last_alive, cur_last_alive);
+                LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d", cur_last_alive, cur_last_alive);
                 LOG_ERROR("  cannot transition to CONSUMED. Possible causes:");
                 LOG_ERROR("  1. Task %d still executing (subtasks not complete)", cur_last_alive);
                 LOG_ERROR("  2. Task %d fanout not fully released (downstream not done)", cur_last_alive);
@@ -405,27 +424,29 @@ struct PTO2TaskRing {
     int32_t get_task_slot(int32_t task_id) const { return task_id & (window_size - 1); }
 
     /**
-    * Get task descriptor by ID
-    */
+     * Get task descriptor by ID
+     */
     PTO2TaskDescriptor& get_task(int32_t task_id) { return descriptors[task_id & (window_size - 1)]; }
 
     /**
-    * Get task descriptor by task slot
-    */
+     * Get task descriptor by task slot
+     */
     PTO2TaskDescriptor& get_task_by_slot(int32_t task_slot) { return descriptors[task_slot]; }
 };
 
 /**
  * Initialize task ring buffer
- * 
+ *
  * @param ring            Task ring to initialize
  * @param descriptors     Task descriptor array from shared memory
  * @param window_size     Window size (must be power of 2)
  * @param last_alive_ptr  Pointer to shared memory last_task_alive
  */
-void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
-                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr,
-                          std::atomic<int32_t>* current_index_ptr);
+void pto2_task_ring_init(PTO2TaskRing* ring,
+    PTO2TaskDescriptor* descriptors,
+    int32_t window_size,
+    std::atomic<int32_t>* last_alive_ptr,
+    std::atomic<int32_t>* current_index_ptr);
 
 /**
  * Get number of active tasks in window
@@ -465,12 +486,12 @@ static inline PTO2TaskDescriptor* pto2_task_ring_get(PTO2TaskRing* ring, int32_t
  * is obtained via modulo: base[linear_index % capacity].
  */
 struct PTO2DepListPool {
-    PTO2DepListEntry* base;   // Pool base address
-    int32_t capacity;         // Total number of entries
-    int32_t top;              // Linear next-allocation counter (starts from 1)
-    int32_t tail;             // Linear first-alive counter (entries before this are dead)
-    int32_t high_water;       // Peak concurrent usage (top - tail)
-    int32_t last_reclaimed{0}; // last_task_alive at last successful reclamation
+    PTO2DepListEntry* base;     // Pool base address
+    int32_t capacity;           // Total number of entries
+    int32_t top;                // Linear next-allocation counter (starts from 1)
+    int32_t tail;               // Linear first-alive counter (entries before this are dead)
+    int32_t high_water;         // Peak concurrent usage (top - tail)
+    int32_t last_reclaimed{0};  // last_task_alive at last successful reclamation
 
     // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
     std::atomic<int32_t>* error_code_ptr = nullptr;
@@ -510,7 +531,7 @@ struct PTO2DepListPool {
      * Ensure dep pool for a specific ring has at least `needed` entries available.
      * Spin-waits for reclamation if under pressure. Detects deadlock if no progress.
      */
-    void ensure_space(PTO2SchedulerState& sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed);
+    void ensure_space(PTO2SchedulerState& sched, PTO2RingFlowControl& fc, uint8_t ring_id, int32_t needed);
 
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)
@@ -572,20 +593,16 @@ struct PTO2DepListPool {
     }
 
     /**
-    * Get entry by offset
-    */
+     * Get entry by offset
+     */
     PTO2DepListEntry* pto2_dep_pool_get(int32_t offset) {
         if (offset <= 0) return NULL;
         return &base[offset];
     }
 
-    int32_t used() const {
-        return top - tail;
-    }
+    int32_t used() const { return top - tail; }
 
-    int32_t available() const {
-        return capacity - used();
-    }
+    int32_t available() const { return capacity - used(); }
 };
 
 // =============================================================================
@@ -597,9 +614,9 @@ struct PTO2DepListPool {
  * PTO2_MAX_RING_DEPTH instances provide independent reclamation per scope depth.
  */
 struct PTO2RingSet {
-    PTO2HeapRing    heap_ring;
-    PTO2TaskRing    task_ring;
+    PTO2HeapRing heap_ring;
+    PTO2TaskRing task_ring;
     PTO2DepListPool dep_pool;
 };
 
-#endif // PTO_RING_BUFFER_H
+#endif  // PTO_RING_BUFFER_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -18,47 +18,35 @@
 
 thread_local int pto2_current_orch_idx = 0;
 
-void pto2_set_orch_thread_idx(int idx) {
-    pto2_current_orch_idx = idx;
-}
+void pto2_set_orch_thread_idx(int idx) { pto2_current_orch_idx = idx; }
 
 // =============================================================================
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
-static void submit_task_impl(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                             const PTOParam& params) {
-    pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels,
-                           params);
+static void submit_task_impl(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params) {
+    pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels, params);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime* rt) {
-    pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_scope_begin(PTO2Runtime* rt) { pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_scope_end(PTO2Runtime* rt) {
-    pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_scope_end(PTO2Runtime* rt) { pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_orchestration_done(PTO2Runtime* rt) {
-    pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_orchestration_done(PTO2Runtime* rt) { pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]); }
 
-static bool is_fatal_impl(PTO2Runtime* rt) {
-    return rt->orchestrators[pto2_current_orch_idx].fatal;
-}
+static bool is_fatal_impl(PTO2Runtime* rt) { return rt->orchestrators[pto2_current_orch_idx].fatal; }
 
 static const PTO2RuntimeOps s_runtime_ops = {
-    .submit_task          = submit_task_impl,
-    .scope_begin          = pto2_rt_scope_begin,
-    .scope_end            = pto2_rt_scope_end,
-    .orchestration_done   = pto2_rt_orchestration_done,
-    .is_fatal             = is_fatal_impl,
-    .log_error            = unified_log_error,
-    .log_warn             = unified_log_warn,
-    .log_info             = unified_log_info,
-    .log_debug            = unified_log_debug,
-    .log_always           = unified_log_always,
+    .submit_task = submit_task_impl,
+    .scope_begin = pto2_rt_scope_begin,
+    .scope_end = pto2_rt_scope_end,
+    .orchestration_done = pto2_rt_orchestration_done,
+    .is_fatal = is_fatal_impl,
+    .log_error = unified_log_error,
+    .log_warn = unified_log_warn,
+    .log_info = unified_log_info,
+    .log_debug = unified_log_debug,
+    .log_always = unified_log_always,
 };
 
 // =============================================================================
@@ -66,15 +54,11 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // =============================================================================
 
 PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode) {
-    return pto2_runtime_create_custom(mode,
-                                       PTO2_TASK_WINDOW_SIZE,
-                                       PTO2_HEAP_SIZE);
+    return pto2_runtime_create_custom(mode, PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
 }
 
-PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
-                                         uint64_t task_window_size,
-                                         uint64_t heap_size,
-                                         int32_t dep_pool_capacity) {
+PTO2Runtime* pto2_runtime_create_custom(
+    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity) {
     // Allocate runtime context
     PTO2Runtime* rt = (PTO2Runtime*)calloc(1, sizeof(PTO2Runtime));
     if (!rt) {
@@ -93,25 +77,24 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
     // Allocate GM heap for output buffers (all rings combined)
     uint64_t total_heap_size = heap_size * PTO2_MAX_RING_DEPTH;
     rt->gm_heap_size = total_heap_size;
-    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-        if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, total_heap_size) != 0) {
-            pto2_sm_destroy(rt->sm_handle);
-            free(rt);
-            return NULL;
-        }
-    #else
-        rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, total_heap_size);
-        if (!rt->gm_heap) {
-            pto2_sm_destroy(rt->sm_handle);
-            free(rt);
-            return NULL;
-        }
-    #endif
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+    if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, total_heap_size) != 0) {
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+#else
+    rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, total_heap_size);
+    if (!rt->gm_heap) {
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+#endif
     rt->gm_heap_owned = true;
 
     // Initialize first orchestrator
-    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle,
-                                 rt->gm_heap, heap_size, dep_pool_capacity)) {
+    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
         free(rt);
@@ -134,11 +117,11 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
 }
 
 PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-                                          PTO2SharedMemoryHandle* sm_handle,
-                                          void* gm_heap,
-                                          uint64_t heap_size,
-                                          int orch_count,
-                                          int32_t dep_pool_capacity) {
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
+    int orch_count,
+    int32_t dep_pool_capacity) {
     if (!sm_handle) return NULL;
     if (orch_count < 1) orch_count = 1;
     if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
@@ -156,8 +139,7 @@ PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
 
     // Initialize all orchestrator states
     for (int i = 0; i < orch_count; i++) {
-        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle,
-                                    rt->gm_heap, heap_size, dep_pool_capacity)) {
+        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
             for (int j = 0; j < i; j++) {
                 pto2_orchestrator_destroy(&rt->orchestrators[j]);
             }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -59,8 +59,7 @@ enum PTO2RuntimeMode {
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
-    void (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                        const PTOParam& params);
+    void (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const PTOParam& params);
     void (*scope_begin)(PTO2Runtime* rt);
     void (*scope_end)(PTO2Runtime* rt);
     void (*orchestration_done)(PTO2Runtime* rt);
@@ -82,24 +81,24 @@ struct PTO2RuntimeOps {
  */
 struct PTO2Runtime {
     // Ops table (first field — used by orchestration .so via function pointers)
-    const PTO2RuntimeOps*   ops;
+    const PTO2RuntimeOps* ops;
 
     // Components
     PTO2SharedMemoryHandle* sm_handle;
-    PTO2OrchestratorState   orchestrators[PTO2_MAX_ORCH_THREADS];
-    int                     orch_count;     // Number of active orchestrator states
-    PTO2SchedulerState      scheduler;
+    PTO2OrchestratorState orchestrators[PTO2_MAX_ORCH_THREADS];
+    int orch_count;  // Number of active orchestrator states
+    PTO2SchedulerState scheduler;
 
     // GM Heap for output buffers
-    void*                   gm_heap;
-    uint64_t                  gm_heap_size;
-    bool                    gm_heap_owned;  // True if we allocated it
+    void* gm_heap;
+    uint64_t gm_heap_size;
+    bool gm_heap_owned;  // True if we allocated it
 
     // Mode
-    PTO2RuntimeMode         mode;
+    PTO2RuntimeMode mode;
 
     // Statistics
-    int64_t                 total_cycles;
+    int64_t total_cycles;
 };
 
 // =============================================================================
@@ -123,9 +122,9 @@ PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode);
  * @return Runtime context, or NULL on failure
  */
 PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
-                                         uint64_t task_window_size,
-                                         uint64_t heap_size,
-                                         int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    uint64_t task_window_size,
+    uint64_t heap_size,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
 
 /**
  * Create runtime from existing shared memory and GM heap (e.g. on device).
@@ -138,11 +137,11 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
  * @return Runtime context, or NULL on failure
  */
 PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-                                          PTO2SharedMemoryHandle* sm_handle,
-                                          void* gm_heap,
-                                          uint64_t heap_size,
-                                          int orch_count = 1,
-                                          int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    PTO2SharedMemoryHandle* sm_handle,
+    void* gm_heap,
+    uint64_t heap_size,
+    int orch_count = 1,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
 
 /**
  * Destroy runtime and free all resources
@@ -201,7 +200,7 @@ void pto2_rt_orchestration_done(PTO2Runtime* rt);
  *   PTO2_SCOPE_END(rt);
  */
 #define PTO2_SCOPE_BEGIN(rt) pto2_rt_scope_begin(rt)
-#define PTO2_SCOPE_END(rt)   pto2_rt_scope_end(rt)
+#define PTO2_SCOPE_END(rt) pto2_rt_scope_end(rt)
 
 /**
  * RAII Scope Guard for C++
@@ -235,12 +234,9 @@ void pto2_rt_orchestration_done(PTO2Runtime* rt);
  */
 class PTO2ScopeGuard {
 public:
-    PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) {
-        pto2_rt_scope_begin(rt_);
-    }
-    ~PTO2ScopeGuard() {
-        pto2_rt_scope_end(rt_);
-    }
+    PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) { pto2_rt_scope_begin(rt_); }
+    ~PTO2ScopeGuard() { pto2_rt_scope_end(rt_); }
+
 private:
     PTO2Runtime* rt_;
 };
@@ -254,7 +250,7 @@ private:
  *   PTO2_SCOPE_GUARD(rt);
  *   pto2_rt_submit_task(...);
  */
-#define _PTO2_CONCATENATE_IMPL(x, y) x ## y
+#define _PTO2_CONCATENATE_IMPL(x, y) x##y
 #define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
 #define PTO2_SCOPE_GUARD(rt) [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__)(rt)
 
@@ -276,8 +272,8 @@ private:
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
 struct PTO2OrchestrationConfig {
-    int         expected_arg_count;
+    int expected_arg_count;
 };
 #endif
 
-#endif // PTO_RUNTIME2_H
+#endif  // PTO_RUNTIME2_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -59,15 +59,15 @@
 // =============================================================================
 
 // Orchestrator errors (1-99): detected in orchestrator thread
-#define PTO2_ERROR_NONE                       0
-#define PTO2_ERROR_SCOPE_DEADLOCK             1
-#define PTO2_ERROR_HEAP_RING_DEADLOCK         2
-#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK      3
-#define PTO2_ERROR_DEP_POOL_OVERFLOW          4
-#define PTO2_ERROR_INVALID_PARAM              5   // PTOParam construction error (invalid params)
+#define PTO2_ERROR_NONE 0
+#define PTO2_ERROR_SCOPE_DEADLOCK 1
+#define PTO2_ERROR_HEAP_RING_DEADLOCK 2
+#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK 3
+#define PTO2_ERROR_DEP_POOL_OVERFLOW 4
+#define PTO2_ERROR_INVALID_PARAM 5  // PTOParam construction error (invalid params)
 
 // Scheduler errors (100+): detected in scheduler threads
-#define PTO2_ERROR_SCHEDULER_TIMEOUT          100
+#define PTO2_ERROR_SCHEDULER_TIMEOUT 100
 
 // =============================================================================
 // Configuration Constants
@@ -77,33 +77,33 @@
 // NOTE: PTO2_TASK_WINDOW_SIZE is now a per-ring default value.
 // Actual window size is passed at runtime to pto2_runtime_create_threaded_custom().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
-#define PTO2_TASK_WINDOW_SIZE     16384   // Default per-ring task window size (power of 2)
+#define PTO2_TASK_WINDOW_SIZE 16384  // Default per-ring task window size (power of 2)
 
 // Multi-ring: number of independent ring layers (HeapRing + TaskRing + DepPool per layer)
 // Scope depth maps to ring index via: min(scope_depth, PTO2_MAX_RING_DEPTH - 1)
-#define PTO2_MAX_RING_DEPTH       4
+#define PTO2_MAX_RING_DEPTH 4
 
 // Memory pools (per-ring defaults; total = value × PTO2_MAX_RING_DEPTH)
-#define PTO2_HEAP_SIZE            (256 * 1024 * 1024)  // 256MB per ring (1GB total)
-#define PTO2_DEP_LIST_POOL_SIZE    16384    // Per-ring dependency list pool entries
-#define PTO2_TENSORMAP_POOL_SIZE   (65536)   // TensorMap entry pool
+#define PTO2_HEAP_SIZE (256 * 1024 * 1024)  // 256MB per ring (1GB total)
+#define PTO2_DEP_LIST_POOL_SIZE 16384       // Per-ring dependency list pool entries
+#define PTO2_TENSORMAP_POOL_SIZE (65536)    // TensorMap entry pool
 #define PTO2_TENSORMAP_NUM_BUCKETS 65536    // Power of 2 for fast hash
 
 // Scope management
-#define PTO2_MAX_SCOPE_DEPTH      64      // Maximum nesting depth
-#define PTO2_SCOPE_TASKS_INIT_CAP 65536     // Initial capacity for scope task buffer
+#define PTO2_MAX_SCOPE_DEPTH 64          // Maximum nesting depth
+#define PTO2_SCOPE_TASKS_INIT_CAP 65536  // Initial capacity for scope task buffer
 
 // Ready queue
-#define PTO2_READY_QUEUE_SIZE     65536   // Per-shape queue size
+#define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size
 
 // Memory alignment
-#define PTO2_ALIGN_SIZE           64      // Cache line alignment
-#define PTO2_PACKED_OUTPUT_ALIGN  1024    // Each output in packed buffer aligned to 1024B; gap is padding
-#define PTO2_ALIGN_UP(x, align)   (((x) + (align) - 1) & ~((align) - 1))
+#define PTO2_ALIGN_SIZE 64             // Cache line alignment
+#define PTO2_PACKED_OUTPUT_ALIGN 1024  // Each output in packed buffer aligned to 1024B; gap is padding
+#define PTO2_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
 
 // TensorMap cleanup interval
 #define PTO2_TENSORMAP_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
-#define PTO2_DEP_POOL_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
+#define PTO2_DEP_POOL_CLEANUP_INTERVAL 64   // Cleanup every N retired tasks
 
 // =============================================================================
 // Multi-Ring task_id Encoding
@@ -136,17 +136,11 @@ static inline PTO2TaskId pto2_make_task_id(uint8_t ring_id, uint32_t local_id) {
     return PTO2TaskId{(static_cast<uint64_t>(ring_id) << 32) | static_cast<uint64_t>(local_id)};
 }
 
-static inline uint8_t pto2_task_id_ring(PTO2TaskId task_id) {
-    return task_id.ring();
-}
+static inline uint8_t pto2_task_id_ring(PTO2TaskId task_id) { return task_id.ring(); }
 
-static inline uint32_t pto2_task_id_local(PTO2TaskId task_id) {
-    return task_id.local();
-}
+static inline uint32_t pto2_task_id_local(PTO2TaskId task_id) { return task_id.local(); }
 
-static inline uint64_t pto2_task_id_raw(PTO2TaskId task_id) {
-    return task_id.raw;
-}
+static inline uint64_t pto2_task_id_raw(PTO2TaskId task_id) { return task_id.raw; }
 
 // =============================================================================
 // Worker Types
@@ -157,10 +151,10 @@ static inline uint64_t pto2_task_id_raw(PTO2TaskId task_id) {
  * Each worker type has its own ready queue for load balancing
  */
 typedef enum {
-    PTO2_WORKER_CUBE = 0,       // AICore CUBE unit (matrix ops)
-    PTO2_WORKER_VECTOR = 1,     // AICore VECTOR unit (element-wise ops)
-    PTO2_WORKER_AI_CPU = 2,     // AI_CPU (scalar ops, control flow)
-    PTO2_WORKER_ACCELERATOR = 3,// Fixed-function accelerators (DMA, etc.)
+    PTO2_WORKER_CUBE = 0,         // AICore CUBE unit (matrix ops)
+    PTO2_WORKER_VECTOR = 1,       // AICore VECTOR unit (element-wise ops)
+    PTO2_WORKER_AI_CPU = 2,       // AI_CPU (scalar ops, control flow)
+    PTO2_WORKER_ACCELERATOR = 3,  // Fixed-function accelerators (DMA, etc.)
     PTO2_NUM_WORKER_TYPES = 4
 } PTO2WorkerType;
 
@@ -193,21 +187,21 @@ typedef enum {
 /**
  * Maximum dimensions supported for logical tensors
  */
-#define PTO2_MAX_TENSOR_DIM   8
+#define PTO2_MAX_TENSOR_DIM 8
 
 /**
  * Maximum depth of layout history for HBB overlap detection
  * Simple (contiguous) tensor has depth=1, non-contiguous has depth>1
  */
-#define PTO2_MAX_LAYOUT_DEPTH     8
+#define PTO2_MAX_LAYOUT_DEPTH 8
 
 /**
  * Layout operation type for HBB
  */
 typedef enum {
-    PTO2_LAYOUT_VIEW = 0,         // View/slice: records bounding box
-    PTO2_LAYOUT_RESHAPE = 1,      // Reshape: records new shape
-    PTO2_LAYOUT_TRANSPOSE = 2     // Transpose: records permutation
+    PTO2_LAYOUT_VIEW = 0,      // View/slice: records bounding box
+    PTO2_LAYOUT_RESHAPE = 1,   // Reshape: records new shape
+    PTO2_LAYOUT_TRANSPOSE = 2  // Transpose: records permutation
 } PTO2LayoutOpType;
 
 /**
@@ -217,9 +211,9 @@ typedef enum {
 typedef struct {
     PTO2LayoutOpType type;
     union {
-        struct {  // PTO2_LAYOUT_VIEW
-            int64_t bbox_min;     // First byte accessed
-            int64_t bbox_max;     // Last byte accessed
+        struct {               // PTO2_LAYOUT_VIEW
+            int64_t bbox_min;  // First byte accessed
+            int64_t bbox_max;  // Last byte accessed
         } view;
         struct {  // PTO2_LAYOUT_RESHAPE
             int32_t ndim;
@@ -236,13 +230,13 @@ typedef struct {
  * Tensor extraction type (for tracking how tensor was created)
  */
 typedef enum {
-    PTO2_TENSOR_RAW = 0,           // Original raw tensor (owns storage)
-    PTO2_TENSOR_VIEW = 1,          // view() - subset selection, shared storage
-    PTO2_TENSOR_RESHAPE = 2,       // reshape() - shape change, shared storage
-    PTO2_TENSOR_TRANSPOSE = 3,     // transpose() - dimension permute, shared storage
-    PTO2_TENSOR_DEEP_VIEW = 4,     // deep_view() - copied subset, new storage
-    PTO2_TENSOR_DEEP_RESHAPE = 5,  // deep_reshape() - copied reshape, new storage
-    PTO2_TENSOR_DEEP_TRANSPOSE = 6 // deep_transpose() - copied transpose, new storage
+    PTO2_TENSOR_RAW = 0,            // Original raw tensor (owns storage)
+    PTO2_TENSOR_VIEW = 1,           // view() - subset selection, shared storage
+    PTO2_TENSOR_RESHAPE = 2,        // reshape() - shape change, shared storage
+    PTO2_TENSOR_TRANSPOSE = 3,      // transpose() - dimension permute, shared storage
+    PTO2_TENSOR_DEEP_VIEW = 4,      // deep_view() - copied subset, new storage
+    PTO2_TENSOR_DEEP_RESHAPE = 5,   // deep_reshape() - copied reshape, new storage
+    PTO2_TENSOR_DEEP_TRANSPOSE = 6  // deep_transpose() - copied transpose, new storage
 } PTO2TensorExtractionType;
 
 /**
@@ -252,10 +246,10 @@ typedef enum {
  * Multiple logical tensors can share the same raw tensor (aliasing).
  */
 typedef struct {
-    void*    base_ptr;        // Base pointer of allocated memory
-    int64_t  total_size;      // Total size in bytes
-    int32_t  refcount;        // Number of logical tensors referencing this storage
-                              // (for memory management, 0 = can be freed)
+    void* base_ptr;      // Base pointer of allocated memory
+    int64_t total_size;  // Total size in bytes
+    int32_t refcount;    // Number of logical tensors referencing this storage
+                         // (for memory management, 0 = can be freed)
 } PTO2RawTensor;
 
 /**
@@ -279,32 +273,32 @@ typedef struct {
  */
 typedef struct {
     // === Raw tensor reference (shared storage) ===
-    void*    raw_base;            // Pointer to raw tensor's base (for aliasing check)
-    int64_t  raw_total_size;      // Total size of raw tensor in bytes
+    void* raw_base;          // Pointer to raw tensor's base (for aliasing check)
+    int64_t raw_total_size;  // Total size of raw tensor in bytes
 
     // === Storage offset ===
-    int64_t  storage_offset;      // Byte offset from raw_base to first element
+    int64_t storage_offset;  // Byte offset from raw_base to first element
 
     // === Shape and strides ===
-    int64_t  shape[PTO2_MAX_TENSOR_DIM];    // Size in each dimension
-    int64_t  strides[PTO2_MAX_TENSOR_DIM];  // Byte stride in each dimension
-    int32_t  ndim;                          // Number of dimensions (0 = scalar)
+    int64_t shape[PTO2_MAX_TENSOR_DIM];    // Size in each dimension
+    int64_t strides[PTO2_MAX_TENSOR_DIM];  // Byte stride in each dimension
+    int32_t ndim;                          // Number of dimensions (0 = scalar)
 
     // === Precomputed bounding box (for fast overlap detection) ===
-    int64_t  min_byte_offset;     // First byte accessed (relative to raw_base)
-    int64_t  max_byte_offset;     // Last byte accessed (relative to raw_base)
+    int64_t min_byte_offset;  // First byte accessed (relative to raw_base)
+    int64_t max_byte_offset;  // Last byte accessed (relative to raw_base)
 
     // === Element info ===
-    int64_t  elem_size;           // Size of each element in bytes
-    int64_t  numel;               // Total number of elements
+    int64_t elem_size;  // Size of each element in bytes
+    int64_t numel;      // Total number of elements
 
     // === Extraction tracking ===
     PTO2TensorExtractionType extraction_type;  // How this tensor was created
-    bool     is_contiguous;       // True if memory is contiguous (no gaps)
-                                  // Equivalent to layout_depth == 1
+    bool is_contiguous;                        // True if memory is contiguous (no gaps)
+                                               // Equivalent to layout_depth == 1
 
     // === Layout history for HBB overlap detection ===
-    int32_t  layout_depth;                           // Number of layout ops (1=simple)
+    int32_t layout_depth;                            // Number of layout ops (1=simple)
     PTO2LayoutOp layout_ops[PTO2_MAX_LAYOUT_DEPTH];  // Derivation history
 
 } PTO2LogicalTensor;
@@ -321,8 +315,8 @@ typedef struct {
  */
 struct PTO2TaskSlotState;  // Forward declaration
 struct PTO2DepListEntry {
-    PTO2TaskSlotState* slot_state;    // Consumer slot state (direct pointer)
-    PTO2DepListEntry* next;           // next entry
+    PTO2TaskSlotState* slot_state;  // Consumer slot state (direct pointer)
+    PTO2DepListEntry* next;         // next entry
 };
 
 // =============================================================================
@@ -340,14 +334,14 @@ struct PTO2DepListEntry {
  */
 struct PTO2TaskDescriptor {
     // Mixed-task identification (encodes ring_id in upper 32 bits)
-    PTO2TaskId mixed_task_id;         // raw: (ring_id << 32) | local_id
+    PTO2TaskId mixed_task_id;  // raw: (ring_id << 32) | local_id
 
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];
 
     // Packed output buffer (all outputs packed into single contiguous buffer)
-    void*    packed_buffer_base;  // Start of packed buffer in GM Heap
-    void*    packed_buffer_end;   // End of packed buffer (for heap reclamation)
+    void* packed_buffer_base;  // Start of packed buffer in GM Heap
+    void* packed_buffer_end;   // End of packed buffer (for heap reclamation)
 };
 
 // =============================================================================
@@ -366,9 +360,9 @@ struct PTO2TaskPayload {
     // === Cache line 0 (64B) — metadata ===
     int32_t tensor_count{0};
     int32_t scalar_count{0};
-    int32_t fanin_actual_count{0};             // Actual fanin count (without the +1 redundance)
-    int32_t _reserved{0};                      // Reserved (dep_pool_mark moved to SlotState for local access)
-    PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS]; // Producer slot states (used by on_task_release)
+    int32_t fanin_actual_count{0};  // Actual fanin count (without the +1 redundance)
+    int32_t _reserved{0};           // Reserved (dep_pool_mark moved to SlotState for local access)
+    PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
     // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[PTO2_MAX_TENSOR_PARAMS];
     // === Cache lines 35-50 (1024B) — scalars ===
@@ -384,8 +378,7 @@ struct PTO2TaskPayload {
         static_assert(sizeof(scalars) == sizeof(params.scalars));
         // Round up to cache line boundary. Both arrays are 1024B so no overrun.
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
-        memcpy(scalars, params.scalars,
-               PTO2_ALIGN_UP(params.scalar_count * sizeof(uint64_t), 64));
+        memcpy(scalars, params.scalars, PTO2_ALIGN_UP(params.scalar_count * sizeof(uint64_t), 64));
     }
 };
 
@@ -403,17 +396,17 @@ struct PTO2TaskPayload {
  */
 struct alignas(64) PTO2TaskSlotState {
     // Fanout lock + list (accessed together under lock in on_task_complete)
-    std::atomic<int32_t> fanout_lock;       // Per-task spinlock (0=unlocked, 1=locked)
-    int32_t fanout_count;                    // 1 (owning scope) + number of consumers
+    std::atomic<int32_t> fanout_lock;  // Per-task spinlock (0=unlocked, 1=locked)
+    int32_t fanout_count;              // 1 (owning scope) + number of consumers
 
-    PTO2DepListEntry* fanout_head;           // Pointer to first fanout entry (nullptr = empty)
+    PTO2DepListEntry* fanout_head;  // Pointer to first fanout entry (nullptr = empty)
 
     // Task state (completion, consumed check, ready check)
-    std::atomic<PTO2TaskState> task_state;   // PENDING/READY/RUNNING/COMPLETED/CONSUMED
+    std::atomic<PTO2TaskState> task_state;  // PENDING/READY/RUNNING/COMPLETED/CONSUMED
 
     // Fanin (accessed together in release_fanin_and_check_ready)
-    std::atomic<int32_t> fanin_refcount;     // Dynamic: counts completed producers
-    int32_t fanin_count;                      // Number of producer dependencies (set once)
+    std::atomic<int32_t> fanin_refcount;  // Dynamic: counts completed producers
+    int32_t fanin_count;                  // Number of producer dependencies (set once)
 
     // Fanout refcount (accessed with fanout_count in check_and_handle_consumed)
     std::atomic<int32_t> fanout_refcount;  // Dynamic: counts released references
@@ -423,10 +416,10 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2TaskDescriptor* task;
 
     // Hot-path completion fields (moved from TaskDescriptor to avoid cross-struct access)
-    uint8_t active_mask;                         // Bitmask of active subtask slots (set once)
-    std::atomic<uint8_t> subtask_done_mask;      // Each subtask sets its done bit on completion
-    uint8_t ring_id;                             // Ring layer this task belongs to (for per-ring reclamation)
-    int32_t dep_pool_mark{0};                    // Dep pool top after this task's submission (orchestrator-only, local memory)
+    uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
+    std::atomic<uint8_t> subtask_done_mask;  // Each subtask sets its done bit on completion
+    uint8_t ring_id;                         // Ring layer this task belongs to (for per-ring reclamation)
+    int32_t dep_pool_mark{0};  // Dep pool top after this task's submission (orchestrator-only, local memory)
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);
@@ -459,11 +452,11 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
  * Memory barrier macros for different architectures
  */
 #if defined(__aarch64__)
-    #define PTO2_MEMORY_BARRIER()     __asm__ __volatile__("dmb sy" ::: "memory")
+#define PTO2_MEMORY_BARRIER() __asm__ __volatile__("dmb sy" ::: "memory")
 #elif defined(__x86_64__)
-    #define PTO2_MEMORY_BARRIER()     __asm__ __volatile__("mfence" ::: "memory")
+#define PTO2_MEMORY_BARRIER() __asm__ __volatile__("mfence" ::: "memory")
 #else
-    #define PTO2_MEMORY_BARRIER()     __sync_synchronize()
+#define PTO2_MEMORY_BARRIER() __sync_synchronize()
 #endif
 
 // Spin-wait hint for AICPU threads.  On real hardware the AICPU has dedicated
@@ -494,8 +487,7 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 #endif
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state,
-                                     uint64_t& atomic_count, uint64_t& wait_cycle) {
+static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& atomic_count, uint64_t& wait_cycle) {
     uint64_t t0 = get_sys_cnt_aicpu();
     bool contended = false;
     uint32_t atomic_ops = 0;
@@ -507,8 +499,8 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state,
             SPIN_WAIT_HINT();
         }
         int32_t expected = 0;
-        if (slot_state.fanout_lock.compare_exchange_weak(expected, 1,
-                                        std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (slot_state.fanout_lock.compare_exchange_weak(
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             atomic_ops++;  // successful CAS = 1 atomic
             atomic_count += atomic_ops;
             if (contended) {
@@ -528,8 +520,8 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state) {
             SPIN_WAIT_HINT();
         }
         int32_t expected = 0;
-        if (slot_state.fanout_lock.compare_exchange_weak(expected, 1,
-                                        std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (slot_state.fanout_lock.compare_exchange_weak(
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             return;
         }
     }
@@ -539,4 +531,4 @@ static inline void pto2_fanout_unlock(PTO2TaskSlotState& slot_state) {
     slot_state.fanout_lock.store(0, std::memory_order_release);
 }
 
-#endif // PTO_RUNTIME2_TYPES_H
+#endif  // PTO_RUNTIME2_TYPES_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -59,12 +59,18 @@ PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
 
 const char* pto2_task_state_name(PTO2TaskState state) {
     switch (state) {
-        case PTO2_TASK_PENDING:   return "PENDING";
-        case PTO2_TASK_READY:     return "READY";
-        case PTO2_TASK_RUNNING:   return "RUNNING";
-        case PTO2_TASK_COMPLETED: return "COMPLETED";
-        case PTO2_TASK_CONSUMED:  return "CONSUMED";
-        default:                  return "UNKNOWN";
+        case PTO2_TASK_PENDING:
+            return "PENDING";
+        case PTO2_TASK_READY:
+            return "READY";
+        case PTO2_TASK_RUNNING:
+            return "RUNNING";
+        case PTO2_TASK_COMPLETED:
+            return "COMPLETED";
+        case PTO2_TASK_CONSUMED:
+            return "CONSUMED";
+        default:
+            return "UNKNOWN";
     }
 }
 
@@ -103,8 +109,7 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
 // =============================================================================
 
 bool PTO2SchedulerState::RingSchedState::init(
-    PTO2SharedMemoryHandle* sm_handle, int32_t ring_id,
-    void* gm_heap_base, uint64_t per_ring_heap_size) {
+    PTO2SharedMemoryHandle* sm_handle, int32_t ring_id, void* gm_heap_base, uint64_t per_ring_heap_size) {
     task_descriptors = sm_handle->task_descriptors[ring_id];
     heap_base = (char*)gm_heap_base + ring_id * per_ring_heap_size;
     task_window_size = sm_handle->header->rings[ring_id].task_window_size;
@@ -146,9 +151,8 @@ void PTO2SchedulerState::RingSchedState::destroy() {
     slot_states = nullptr;
 }
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle,
-                          void* gm_heap_base, uint64_t per_ring_heap_size) {
+bool pto2_scheduler_init(
+    PTO2SchedulerState* sched, PTO2SharedMemoryHandle* sm_handle, void* gm_heap_base, uint64_t per_ring_heap_size) {
     sched->sm_handle = sm_handle;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -199,8 +203,7 @@ void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
 void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
     LOG_INFO("=== Scheduler Statistics ===");
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (sched->ring_sched_states[r].last_task_alive > 0 ||
-            sched->ring_sched_states[r].heap_tail > 0) {
+        if (sched->ring_sched_states[r].last_task_alive > 0 || sched->ring_sched_states[r].heap_tail > 0) {
             LOG_INFO("Ring %d:", r);
             LOG_INFO("  last_task_alive: %d", sched->ring_sched_states[r].last_task_alive);
             LOG_INFO("  heap_tail:       %" PRIu64, sched->ring_sched_states[r].heap_tail);
@@ -219,8 +222,7 @@ void pto2_scheduler_print_queues(PTO2SchedulerState* sched) {
     const char* shape_names[] = {"AIC_ONLY", "AIV_X1", "AIV_X2", "AIC_AIV_X1", "AIC_AIV_X2"};
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        LOG_INFO("  %s: count=%" PRIu64, shape_names[i],
-                 sched->ready_queues[i].size());
+        LOG_INFO("  %s: count=%" PRIu64, shape_names[i], sched->ready_queues[i].size());
     }
 
     LOG_INFO("====================");

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -30,7 +30,12 @@
 #if PTO2_SCHED_PROFILING
 #include "aicpu/device_time.h"
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
-#define PTO2_SCHED_CYCLE_LAP(acc) do { _st1 = get_sys_cnt_aicpu(); acc += (_st1 - _st0); _st0 = _st1; } while(0)
+#define PTO2_SCHED_CYCLE_LAP(acc)   \
+    do {                            \
+        _st1 = get_sys_cnt_aicpu(); \
+        acc += (_st1 - _st0);       \
+        _st0 = _st1;                \
+    } while (0)
 #endif
 
 // =============================================================================
@@ -78,9 +83,7 @@ struct PTO2LocalReadyBuffer {
         return false;
     }
 
-    PTO2TaskSlotState* pop() {
-        return (count > 0) ? slot_states[--count] : nullptr;
-    }
+    PTO2TaskSlotState* pop() { return (count > 0) ? slot_states[--count] : nullptr; }
 };
 
 /**
@@ -96,14 +99,14 @@ struct PTO2LocalReadyBuffer {
 struct alignas(64) PTO2ReadyQueue {
     PTO2ReadyQueueSlot* slots;
     uint64_t capacity;
-    uint64_t mask;                          // capacity - 1
-    char _pad0[64 - 24];                   // Pad to own cache line
+    uint64_t mask;        // capacity - 1
+    char _pad0[64 - 24];  // Pad to own cache line
 
     std::atomic<uint64_t> enqueue_pos;
-    char _pad1[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad1[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     std::atomic<uint64_t> dequeue_pos;
-    char _pad2[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad2[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     uint64_t size() {
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -120,8 +123,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)pos;
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     break;
                 }
             } else if (diff < 0) {
@@ -148,8 +151,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - (int64_t)pos;
             atomic_ops += 2;  // enqueue_pos.load + sequence.load
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -189,8 +192,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)(pos + 1);
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed))
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed))
                     break;
             } else if (diff < 0) {
                 return nullptr;  // Queue empty
@@ -224,8 +227,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - (int64_t)(pos + 1);
             atomic_ops += 2;  // dequeue_pos.load + sequence.load
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -263,10 +266,10 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
  * Statistics returned by mixed-task completion processing
  */
 struct PTO2CompletionStats {
-    int32_t fanout_edges;      // Number of fanout edges traversed (notify consumers)
-    int32_t tasks_enqueued;    // Number of consumers that became READY
-    int32_t fanin_edges;       // Number of fanin edges traversed (release producers)
-    bool mixed_task_completed; // True only when this callback completed a mixed task
+    int32_t fanout_edges;       // Number of fanout edges traversed (notify consumers)
+    int32_t tasks_enqueued;     // Number of consumers that became READY
+    int32_t fanin_edges;        // Number of fanin edges traversed (release producers)
+    bool mixed_task_completed;  // True only when this callback completed a mixed task
 };
 
 /**
@@ -293,16 +296,13 @@ struct PTO2SchedulerState {
         // Try-lock used to advance this ring's pointers (CONSUMED scanning + heap tail update).
         std::atomic<int32_t> advance_lock;
 
-        bool init(PTO2SharedMemoryHandle* sm_handle, int32_t ring_id,
-                  void* gm_heap_base, uint64_t per_ring_heap_size);
+        bool init(PTO2SharedMemoryHandle* sm_handle, int32_t ring_id, void* gm_heap_base, uint64_t per_ring_heap_size);
         void destroy();
 
         PTO2TaskSlotState& get_slot_state_by_task_id(int32_t local_id) {
             return slot_states[local_id & task_window_mask];
         }
-        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) {
-            return slot_states[slot];
-        }
+        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
         void sync_to_sm(PTO2SharedMemoryRingHeader& ring) {
             ring.fc.last_task_alive.store(last_task_alive, std::memory_order_release);
@@ -355,8 +355,8 @@ struct PTO2SchedulerState {
         if (slot_state.fanout_refcount.load(std::memory_order_acquire) != slot_state.fanout_count) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire)) {
             return;
         }
 
@@ -367,8 +367,8 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
         }
@@ -384,8 +384,8 @@ struct PTO2SchedulerState {
         if (rc != fc) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire)) {
             atomic_count += 1;  // failed CAS
             return;
         }
@@ -399,8 +399,8 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
             atomic_count += 2;  // try-lock CAS + unlock store
@@ -423,8 +423,7 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state,
-                                        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+    bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state, PTO2LocalReadyBuffer* local_bufs = nullptr) {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
         // init release, making fanin_count visible — plain load suffices.
@@ -449,8 +448,9 @@ struct PTO2SchedulerState {
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
     bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state,
-                                        uint64_t& atomic_count, uint64_t& push_wait,
-                                        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+        uint64_t& atomic_count,
+        uint64_t& push_wait,
+        PTO2LocalReadyBuffer* local_bufs = nullptr) {
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
         atomic_count += 1;  // fanin_refcount.fetch_add
 
@@ -480,7 +480,7 @@ struct PTO2SchedulerState {
         return ready_queues[static_cast<int32_t>(shape)].pop();
     }
 
-    template<CoreType CT>
+    template <CoreType CT>
     PTO2TaskSlotState* get_ready_task(PTO2LocalReadyBuffer* local_bufs) {
         constexpr int ct = static_cast<int>(CT);
         if (local_bufs && local_bufs[ct].count > 0) {
@@ -494,9 +494,8 @@ struct PTO2SchedulerState {
         return ready_queues[static_cast<int32_t>(shape)].pop(atomic_count, wait_cycle);
     }
 
-    template<CoreType CT>
-    PTO2TaskSlotState* get_ready_task(PTO2LocalReadyBuffer* local_bufs,
-                           uint64_t& atomic_count, uint64_t& wait_cycle) {
+    template <CoreType CT>
+    PTO2TaskSlotState* get_ready_task(PTO2LocalReadyBuffer* local_bufs, uint64_t& atomic_count, uint64_t& wait_cycle) {
         constexpr int ct = static_cast<int>(CT);
         if (local_bufs && local_bufs[ct].count > 0) {
             return local_bufs[ct].pop();
@@ -553,7 +552,7 @@ struct PTO2SchedulerState {
 #else
     void
 #endif
-    on_mixed_task_complete(PTO2TaskSlotState& slot_state, 
+    on_mixed_task_complete(PTO2TaskSlotState& slot_state,
 #if PTO2_SCHED_PROFILING
         int thread_idx,
 #endif
@@ -594,8 +593,7 @@ struct PTO2SchedulerState {
             PTO2TaskSlotState& consumer_slot = *current->slot_state;
 #if PTO2_SCHED_PROFILING
             stats.fanout_edges++;
-            if (release_fanin_and_check_ready(consumer_slot,
-                                               fanout_atomics, push_wait, local_bufs)) {
+            if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait, local_bufs)) {
                 stats.tasks_enqueued++;
             }
 #else
@@ -660,9 +658,8 @@ struct PTO2SchedulerState {
 // Scheduler API (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle,
-                          void* gm_heap_base, uint64_t per_ring_heap_size);
+bool pto2_scheduler_init(
+    PTO2SchedulerState* sched, PTO2SharedMemoryHandle* sm_handle, void* gm_heap_base, uint64_t per_ring_heap_size);
 void pto2_scheduler_destroy(PTO2SchedulerState* sched);
 
 // =============================================================================
@@ -686,9 +683,9 @@ struct PTO2SchedProfilingData {
     uint64_t self_consumed_cycle;  // self check_and_handle_consumed
 
     // Wait times
-    uint64_t lock_wait_cycle;      // spin-wait in fanout_lock
-    uint64_t push_wait_cycle;      // CAS contention in push()
-    uint64_t pop_wait_cycle;       // CAS contention in pop()
+    uint64_t lock_wait_cycle;  // spin-wait in fanout_lock
+    uint64_t push_wait_cycle;  // CAS contention in push()
+    uint64_t pop_wait_cycle;   // CAS contention in pop()
 
     // Atomic counts per sub-phase
     uint64_t lock_atomic_count;
@@ -697,7 +694,7 @@ struct PTO2SchedProfilingData {
     uint64_t self_atomic_count;
     uint64_t pop_atomic_count;
 
-    int64_t  complete_count;
+    int64_t complete_count;
 };
 
 /**
@@ -707,4 +704,4 @@ struct PTO2SchedProfilingData {
 PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
 #endif
 
-#endif // PTO_SCHEDULER_H
+#endif  // PTO_SCHEDULER_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -45,8 +45,7 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
 // =============================================================================
 
 static void pto2_sm_setup_pointers_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+    PTO2SharedMemoryHandle* handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
     char* ptr = (char*)handle->sm_base;
 
     // Header
@@ -71,8 +70,7 @@ static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle* handle, uint64_t task
     pto2_sm_setup_pointers_per_ring(handle, task_window_sizes);
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size) {
+PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size, uint64_t heap_size) {
     // Allocate handle
     PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) {
@@ -82,19 +80,19 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     // Calculate total size
     uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
 
-    // Allocate shared memory (aligned for DMA efficiency)
-    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-        if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
-            free(handle);
-            return NULL;
-        }
-    #else
-        handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
-        if (!handle->sm_base) {
-            free(handle);
-            return NULL;
-        }
-    #endif
+// Allocate shared memory (aligned for DMA efficiency)
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+    if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
+        free(handle);
+        return NULL;
+    }
+#else
+    handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
+    if (!handle->sm_base) {
+        free(handle);
+        return NULL;
+    }
+#endif
 
     handle->sm_size = sm_size;
     handle->is_owner = true;
@@ -111,15 +109,10 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     return handle;
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create_default(void) {
-    return pto2_sm_create(PTO2_TASK_WINDOW_SIZE,
-                          PTO2_HEAP_SIZE);
-}
+PTO2SharedMemoryHandle* pto2_sm_create_default(void) { return pto2_sm_create(PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE); }
 
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size) {
+PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(
+    void* sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size) {
     if (!sm_base || sm_size == 0) return NULL;
 
     uint64_t required = pto2_sm_calculate_size(task_window_size);
@@ -153,9 +146,7 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle* handle) {
 // =============================================================================
 //
 // no need init data in pool, init pool data when used
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size) {
+void pto2_sm_init_header(PTO2SharedMemoryHandle* handle, uint64_t task_window_size, uint64_t heap_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -165,8 +156,7 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
     pto2_sm_init_header_per_ring(handle, task_window_sizes, heap_sizes);
 }
 
-void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
+void pto2_sm_init_header_per_ring(PTO2SharedMemoryHandle* handle,
     const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]) {
     PTO2SharedMemoryHeader* header = handle->header;
@@ -217,7 +207,8 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
         LOG_INFO("  task_window_size: %" PRIu64, h->rings[r].task_window_size);
         LOG_INFO("  heap_size:        %" PRIu64 " bytes", h->rings[r].heap_size);
         LOG_INFO("  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")",
-                 h->rings[r].task_descriptors_offset, h->rings[r].task_descriptors_offset);
+            h->rings[r].task_descriptors_offset,
+            h->rings[r].task_descriptors_offset);
         LOG_INFO("  heap_top:         %" PRIu64, h->rings[r].fc.heap_top.load(std::memory_order_acquire));
         LOG_INFO("  heap_tail:        %" PRIu64, h->rings[r].fc.heap_tail.load(std::memory_order_acquire));
         LOG_INFO("  current_task_idx: %d", h->rings[r].fc.current_task_index.load(std::memory_order_acquire));

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -50,9 +50,9 @@ struct PTO2RingFlowControl {
     int32_t _pad0;                            // Alignment padding
 
     // Written by Scheduler, Read by Orchestrator (for back-pressure)
-    std::atomic<uint64_t> heap_tail;          // Heap ring free pointer
-    std::atomic<int32_t> last_task_alive;     // Task ring tail (oldest active task)
-    int32_t _pad1;                            // Alignment padding
+    std::atomic<uint64_t> heap_tail;       // Heap ring free pointer
+    std::atomic<int32_t> last_task_alive;  // Task ring tail (oldest active task)
+    int32_t _pad1;                         // Alignment padding
 
     void init() {
         heap_top.store(0, std::memory_order_relaxed);
@@ -86,7 +86,7 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
 
     // === GLOBAL FIELDS ===
-    std::atomic<int32_t> orchestrator_done;   // Flag: orchestration complete
+    std::atomic<int32_t> orchestrator_done;  // Flag: orchestration complete
 
     // Total shared memory size (for validation)
     uint64_t total_size;
@@ -104,13 +104,13 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
 
     // Scheduler error state (Scheduler → Host, independent of orchestrator)
     // Written by scheduler threads on timeout; read by orchestrator and host.
-    std::atomic<int32_t> sched_error_bitmap;   // Bit X set = thread X had error
-    std::atomic<int32_t> sched_error_code;     // Last scheduler error code (last-writer-wins)
-    std::atomic<int32_t> sched_error_thread;   // Thread index of last error writer
+    std::atomic<int32_t> sched_error_bitmap;  // Bit X set = thread X had error
+    std::atomic<int32_t> sched_error_code;    // Last scheduler error code (last-writer-wins)
+    std::atomic<int32_t> sched_error_thread;  // Thread index of last error writer
 };
 
 static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
-              "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)");
+    "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)");
 
 // =============================================================================
 // Shared Memory Handle
@@ -121,17 +121,16 @@ static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
  * Provides both Orchestrator and Scheduler views of the same memory
  */
 struct PTO2SharedMemoryHandle {
-    void*   sm_base;              // Base address of shared memory
-    uint64_t sm_size;             // Total size of shared memory
+    void* sm_base;     // Base address of shared memory
+    uint64_t sm_size;  // Total size of shared memory
 
     // Quick pointers into shared memory regions (per-ring)
     PTO2SharedMemoryHeader* header;
-    PTO2TaskDescriptor*     task_descriptors[PTO2_MAX_RING_DEPTH];
-    PTO2TaskPayload*        task_payloads[PTO2_MAX_RING_DEPTH];
+    PTO2TaskDescriptor* task_descriptors[PTO2_MAX_RING_DEPTH];
+    PTO2TaskPayload* task_payloads[PTO2_MAX_RING_DEPTH];
 
     // Ownership flag
-    bool    is_owner;             // True if this handle allocated the memory
-
+    bool is_owner;  // True if this handle allocated the memory
 };
 
 // =============================================================================
@@ -161,8 +160,7 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
  * @param heap_size         Heap size per ring for output buffers
  * @return Handle with both views, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size);
+PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Create shared memory with default sizes
@@ -179,10 +177,8 @@ PTO2SharedMemoryHandle* pto2_sm_create_default(void);
  * @param heap_size          Heap size per ring (for layout; buffer has no heap region)
  * @return Handle, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size);
+PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(
+    void* sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Destroy shared memory and free resources
@@ -193,15 +189,12 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle* handle);
  * Initialize shared memory header with layout information
  * Called after memory is allocated
  */
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size);
+void pto2_sm_init_header(PTO2SharedMemoryHandle* handle, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Initialize shared memory header with per-ring layout information.
  */
-void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
+void pto2_sm_init_header_per_ring(PTO2SharedMemoryHandle* handle,
     const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]);
 
@@ -224,4 +217,4 @@ bool pto2_sm_validate(PTO2SharedMemoryHandle* handle);
 }
 #endif
 
-#endif // PTO_SHARED_MEMORY_H
+#endif  // PTO_SHARED_MEMORY_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -21,7 +21,7 @@ inline constexpr int32_t PTO2_SUBTASK_SLOT_COUNT = 3;
  * Subtask slot indices
  */
 enum class PTO2SubtaskSlot : uint8_t {
-    AIC  = 0,
+    AIC = 0,
     AIV0 = 1,
     AIV1 = 2,
 };
@@ -29,7 +29,7 @@ enum class PTO2SubtaskSlot : uint8_t {
 /**
  * Subtask mask bits (for active_mask / subtask_done_mask)
  */
-inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC  = (1u << 0);  // 0x1
+inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC = (1u << 0);   // 0x1
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV0 = (1u << 1);  // 0x2
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV1 = (1u << 2);  // 0x4
 
@@ -56,11 +56,11 @@ struct MixedKernels {
  * Resource shape — classifies a MixedKernels into one of 5 queue buckets.
  */
 enum class PTO2ResourceShape : uint8_t {
-    AIC_ONLY    = 0,   // AIC only
-    AIV_X1      = 1,   // One AIV slot
-    AIV_X2      = 2,   // Both AIV slots
-    AIC_AIV_X1  = 3,   // AIC + one AIV
-    AIC_AIV_X2  = 4,   // AIC + both AIV
+    AIC_ONLY = 0,    // AIC only
+    AIV_X1 = 1,      // One AIV slot
+    AIV_X2 = 2,      // Both AIV slots
+    AIC_AIV_X1 = 3,  // AIC + one AIV
+    AIC_AIV_X2 = 4,  // AIC + both AIV
 };
 
 inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 5;
@@ -71,8 +71,7 @@ inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 5;
  */
 static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
     bool has_aic = (active_mask & PTO2_SUBTASK_MASK_AIC) != 0;
-    int aiv_count = ((active_mask & PTO2_SUBTASK_MASK_AIV0) != 0)
-                  + ((active_mask & PTO2_SUBTASK_MASK_AIV1) != 0);
+    int aiv_count = ((active_mask & PTO2_SUBTASK_MASK_AIV0) != 0) + ((active_mask & PTO2_SUBTASK_MASK_AIV1) != 0);
 
     if (has_aic) {
         if (aiv_count == 0) return PTO2ResourceShape::AIC_ONLY;
@@ -88,10 +87,10 @@ static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
  */
 static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels& mk) {
     uint8_t mask = 0;
-    if (mk.aic_kernel_id  != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
+    if (mk.aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
     if (mk.aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
     if (mk.aiv1_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV1;
     return mask;
 }
 
-#endif // PTO_SUBMIT_TYPES_H
+#endif  // PTO_SUBMIT_TYPES_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -28,7 +28,7 @@
 #if PTO2_TENSORMAP_PROFILING
 uint64_t g_lookup_chain_total = 0;
 uint64_t g_lookup_count = 0;
-int32_t  g_lookup_chain_max = 0;
+int32_t g_lookup_chain_max = 0;
 uint64_t g_lookup_overlap_checks = 0;
 uint64_t g_lookup_overlap_hits = 0;
 uint64_t g_insert_count = 0;
@@ -38,7 +38,8 @@ uint64_t g_insert_count = 0;
 // Initialization and Destruction
 // =============================================================================
 
-bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+bool PTO2TensorMap::init(
+    int32_t new_num_buckets, int32_t new_pool_size, const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]) {
     // Validate power of 2 for fast modulo
     if ((new_num_buckets & (new_num_buckets - 1)) != 0) {
         return false;  // num_buckets must be power of 2
@@ -58,7 +59,8 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const i
     num_buckets = new_num_buckets;
 
     // Allocate entry pool (64-byte aligned for cache-line-aligned entries)
-    entry_pool = (PTO2TensorMapEntry*)aligned_alloc(alignof(PTO2TensorMapEntry), new_pool_size * sizeof(PTO2TensorMapEntry));
+    entry_pool =
+        (PTO2TensorMapEntry*)aligned_alloc(alignof(PTO2TensorMapEntry), new_pool_size * sizeof(PTO2TensorMapEntry));
     if (!entry_pool) {
         free(buckets);
         buckets = NULL;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -47,7 +47,7 @@ struct PTO2OrchestratorState;  // forward declare
 #if PTO2_TENSORMAP_PROFILING
 extern uint64_t g_lookup_chain_total;
 extern uint64_t g_lookup_count;
-extern int32_t  g_lookup_chain_max;
+extern int32_t g_lookup_chain_max;
 extern uint64_t g_lookup_overlap_checks;
 extern uint64_t g_lookup_overlap_hits;
 extern uint64_t g_insert_count;
@@ -74,23 +74,23 @@ extern uint64_t g_insert_count;
  */
 struct alignas(64) PTO2TensorMapEntry {
     // === Cache line 1 (64B) — lookup hot path ===
-    PTO2TensorMapEntry* next_in_bucket;    // 8B: next entry in hash bucket chain
-    PTO2TaskId producer_task_id;           // 8B: raw (ring_id << 32) | local_id
-    uint64_t buffer_addr;                  // 8B: tensor base address (hash key)
-    int32_t version;                       // 4B: tensor version for overlap detection
-    uint32_t ndims;                        // 4B: number of dimensions
-    int32_t bucket_index;                  // 4B: bucket index (-1 if unlinked)
-    bool is_all_offset_zero;               // 1B: fast-path flag
-    bool with_alloc;                       // 1B: true=OUTPUT, false=INOUT
+    PTO2TensorMapEntry* next_in_bucket;  // 8B: next entry in hash bucket chain
+    PTO2TaskId producer_task_id;         // 8B: raw (ring_id << 32) | local_id
+    uint64_t buffer_addr;                // 8B: tensor base address (hash key)
+    int32_t version;                     // 4B: tensor version for overlap detection
+    uint32_t ndims;                      // 4B: number of dimensions
+    int32_t bucket_index;                // 4B: bucket index (-1 if unlinked)
+    bool is_all_offset_zero;             // 1B: fast-path flag
+    bool with_alloc;                     // 1B: true=OUTPUT, false=INOUT
     // padding: 2B
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS]; // 20B: shape per dimension
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // 20B: shape per dimension
     // padding: 4B to fill 64B
 
     // === Cache line 2 (64B) — insert/remove/slow-path ===
-    PTO2TensorMapEntry* prev_in_bucket;    // 8B: prev in hash bucket chain
-    PTO2TensorMapEntry* next_in_task;      // 8B: next entry for same task
-    PTO2TensorMapEntry* prev_in_task;      // 8B: prev entry for same task
-    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS]; // 20B: only when !is_all_offset_zero
+    PTO2TensorMapEntry* prev_in_bucket;         // 8B: prev in hash bucket chain
+    PTO2TensorMapEntry* next_in_task;           // 8B: next entry for same task
+    PTO2TensorMapEntry* prev_in_task;           // 8B: prev entry for same task
+    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];  // 20B: only when !is_all_offset_zero
     // padding: 20B to fill 64B
 
     /**
@@ -180,15 +180,15 @@ struct PTO2LookupResult {
  */
 struct PTO2TensorMap {
     // Hash table buckets (fixed size, power of 2)
-    PTO2TensorMapEntry** buckets;     // Array of offsets into entry_pool (-1 = empty)
-    int32_t num_buckets;  // Must be power of 2 for fast modulo
+    PTO2TensorMapEntry** buckets;  // Array of offsets into entry_pool (-1 = empty)
+    int32_t num_buckets;           // Must be power of 2 for fast modulo
 
     // Entry pool as ring buffer
-    PTO2TensorMapEntry* entry_pool;  // Ring buffer of entries
-    PTO2TensorMapEntry** free_entry_list;        // free entry ids
-    int32_t pool_size;               // Total pool capacity
-    int32_t next_entry_idx;          // id when next entry insert
-    int32_t free_num;                // free entry number in entry pool
+    PTO2TensorMapEntry* entry_pool;        // Ring buffer of entries
+    PTO2TensorMapEntry** free_entry_list;  // free entry ids
+    int32_t pool_size;                     // Total pool capacity
+    int32_t next_entry_idx;                // id when next entry insert
+    int32_t free_num;                      // free entry number in entry pool
 
     // Per-ring per-task entry tracking (for efficient bucket cleanup)
     // Indexed by [ring_id][local_id & (task_window_sizes[ring_id] - 1)]
@@ -217,7 +217,7 @@ struct PTO2TensorMap {
     }
 
     void free_entry(PTO2TensorMapEntry& entry) {
-        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+        always_assert(entry.bucket_index != -1);  // 必须保证仍在桶中
 
         // Update predecessor's next pointer (O(1) via prev_in_bucket)
         if (entry.prev_in_bucket == nullptr) {
@@ -270,9 +270,7 @@ struct PTO2TensorMap {
      *
      * @param last_task_alive  Current value from shared memory
      */
-    void sync_validity(int32_t ring_id, int32_t last_task_alive) {
-        this->last_task_alives[ring_id] = last_task_alive;
-    }
+    void sync_validity(int32_t ring_id, int32_t last_task_alive) { this->last_task_alives[ring_id] = last_task_alive; }
 
     /**
      * Lookup producer for a tensor region
@@ -412,8 +410,7 @@ struct PTO2TensorMap {
                 // Only remove if this entry belongs to the retiring task
                 // (slot may have been reused by a newer task)
                 debug_assert(cur_entry->producer_task_id ==
-                             pto2_make_task_id(static_cast<uint8_t>(ring_id),
-                                               static_cast<uint32_t>(local_id)));
+                             pto2_make_task_id(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id)));
                 free_entry(*cur_entry);
                 cur_entry = next_entry;
             }
@@ -458,7 +455,7 @@ struct PTO2TensorMap {
      * Called during pool wrap-around to unlink reused entries.
      */
     void remove_from_task(PTO2TensorMapEntry& entry) {
-        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+        always_assert(entry.bucket_index != -1);  // 必须保证仍在桶中
         // Update predecessor's next pointer (O(1) via prev_in_task)
         if (entry.prev_in_task == nullptr) {
             // Entry is the head of its task chain, update task_entry_heads
@@ -510,7 +507,7 @@ struct PTO2TensorMap {
 struct PTO2TensorMapProfilingData {
     uint64_t lookup_chain_total;
     uint64_t lookup_count;
-    int32_t  lookup_chain_max;
+    int32_t lookup_chain_max;
     uint64_t overlap_checks;
     uint64_t overlap_hits;
     uint64_t insert_count;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -24,11 +24,11 @@
 #include "tensor.h"
 
 // Task parameters
-#define PTO2_MAX_TENSOR_PARAMS    16      // Maximum tensor parameters per task
-#define PTO2_MAX_SCALAR_PARAMS    128     // Maximum scalar parameters per task
-#define PTO2_MAX_OUTPUTS          16      // Maximum outputs per task
-#define PTO2_MAX_INPUTS           16      // Maximum inputs per task
-#define PTO2_MAX_INOUTS           8       // Maximum in-out params per task
+#define PTO2_MAX_TENSOR_PARAMS 16   // Maximum tensor parameters per task
+#define PTO2_MAX_SCALAR_PARAMS 128  // Maximum scalar parameters per task
+#define PTO2_MAX_OUTPUTS 16         // Maximum outputs per task
+#define PTO2_MAX_INPUTS 16          // Maximum inputs per task
+#define PTO2_MAX_INOUTS 8           // Maximum in-out params per task
 
 // =============================================================================
 // Parameter Types (for pto_submit_task API)
@@ -86,8 +86,9 @@ struct PTOParam {
 
     bool check_add_tensor_valid() {
         if (scalar_count != 0) {
-            set_error("add_input/add_output/add_inout called after add_scalar: "
-                      "all tensors must be added before any scalars");
+            set_error(
+                "add_input/add_output/add_inout called after add_scalar: "
+                "all tensors must be added before any scalars");
             return false;
         }
         if (tensor_count >= PTO2_MAX_TENSOR_PARAMS) {
@@ -98,7 +99,9 @@ struct PTOParam {
     }
 
     void add_input(Tensor& t) {
-        if (!check_add_tensor_valid()) { return; }
+        if (!check_add_tensor_valid()) {
+            return;
+        }
         if (t.buffer.addr == 0) {
             set_error("INPUT tensor must have a non-NULL buffer address");
             return;
@@ -109,14 +112,18 @@ struct PTOParam {
     }
 
     void add_output(Tensor& t) {
-        if (!check_add_tensor_valid()) { return; }
+        if (!check_add_tensor_valid()) {
+            return;
+        }
         tensors[tensor_count] = &t;
         tensor_types[tensor_count] = PTOParamType::OUTPUT;
         tensor_count++;
     }
 
     void add_inout(Tensor& t) {
-        if (!check_add_tensor_valid()) { return; }
+        if (!check_add_tensor_valid()) {
+            return;
+        }
         if (t.buffer.addr == 0) {
             set_error("INOUT tensor must have a non-NULL buffer address");
             return;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -68,17 +68,11 @@ void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
     LOG_INFO("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
 }
 
-TensorPair* Runtime::get_tensor_pairs() {
-    return tensor_pairs;
-}
+TensorPair* Runtime::get_tensor_pairs() { return tensor_pairs; }
 
-int Runtime::get_tensor_pair_count() const {
-    return tensor_pair_count;
-}
+int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
-void Runtime::clear_tensor_pairs() {
-    tensor_pair_count = 0;
-}
+void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 
 // =============================================================================
 // Device orchestration
@@ -124,9 +118,7 @@ const void* Runtime::get_device_orch_so_data() const {
     return device_orch_so_size_ > 0 ? device_orch_so_storage_ : nullptr;
 }
 
-size_t Runtime::get_device_orch_so_size() const {
-    return device_orch_so_size_;
-}
+size_t Runtime::get_device_orch_so_size() const { return device_orch_so_size_; }
 
 uint64_t Runtime::get_function_bin_addr(int func_id) const {
     if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
@@ -142,15 +134,11 @@ void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
     }
 }
 
-int Runtime::get_registered_kernel_count() const {
-    return registered_kernel_count_;
-}
+int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }
 
 int Runtime::get_registered_kernel_func_id(int index) const {
     if (index < 0 || index >= registered_kernel_count_) return -1;
     return registered_kernel_func_ids_[index];
 }
 
-void Runtime::clear_registered_kernels() {
-    registered_kernel_count_ = 0;
-}
+void Runtime::clear_registered_kernels() { registered_kernel_count_ = 0; }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -86,9 +86,9 @@ struct Handshake {
     volatile CoreType core_type;           // Core type: CoreType::AIC or CoreType::AIV
     volatile uint64_t perf_records_addr;   // Performance records address
     volatile uint32_t perf_buffer_status;  // 0 = not full, 1 == full
-    volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t physical_core_id;    // Physical core ID
     volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;   // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**
@@ -144,8 +144,8 @@ public:
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int sche_cpu_num;  // Number of AICPU threads for scheduling
-    int orch_thread_num;  // Number of orchestrator threads (default 1)
+    int sche_cpu_num;        // Number of AICPU threads for scheduling
+    int orch_thread_num;     // Number of orchestrator threads (default 1)
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)
@@ -158,7 +158,7 @@ public:
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
     // Profiling support
-    bool enable_profiling;    // Enable profiling flag
+    bool enable_profiling;  // Enable profiling flag
 
     // Orchestrator-to-scheduler transition control
     // When true, orchestrator threads convert to scheduler threads after orchestration completes.
@@ -178,10 +178,10 @@ private:
 
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
-    void* pto2_gm_sm_ptr_;  // GM pointer to PTO2 shared memory (device)
-    void* pto2_gm_heap_ptr_;  // GM heap for orchestrator output buffers (device)
+    void* pto2_gm_sm_ptr_;        // GM pointer to PTO2 shared memory (device)
+    void* pto2_gm_heap_ptr_;      // GM heap for orchestrator output buffers (device)
     void* pto2_slot_states_ptr_;  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
-    TaskArg* orch_args_;   // Arguments for device orchestration
+    TaskArg* orch_args_;          // Arguments for device orchestration
     int orch_arg_count_;
     TaskArg orch_args_storage_[RUNTIME_MAX_ARGS];  // Copy of args for device
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -58,15 +58,16 @@ struct Segment {
  */
 struct alignas(64) Tensor {
     // === Cache line 1 (64B) — hot path ===
-    PTOBufferHandle buffer;                        // Underlying memory buffer (addr in bytes, size in bytes)
-    uint64_t start_offset;                         // Cached 1D element offset (precomputed from raw_shapes + offsets), only calc before incore, useless in orch
-    int32_t version;                               // Tensor version for overlap detection
-    DataType dtype;                                // Data type of tensor elements
-    uint32_t ndims;                                // Number of dimensions used
-    bool is_all_offset_zero;                       // True when all offsets[] are zero (skip offset read/write)
-    bool is_raw_eq_shapes;                         // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
-    bool manual_dep;                               // True when dependency is managed manually (skip tensormap lookup/insert)
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];      // Current view shape per dimension
+    PTOBufferHandle buffer;   // Underlying memory buffer (addr in bytes, size in bytes)
+    uint64_t start_offset;    // Cached 1D element offset (precomputed from raw_shapes + offsets), only calc before
+                              // incore, useless in orch
+    int32_t version;          // Tensor version for overlap detection
+    DataType dtype;           // Data type of tensor elements
+    uint32_t ndims;           // Number of dimensions used
+    bool is_all_offset_zero;  // True when all offsets[] are zero (skip offset read/write)
+    bool is_raw_eq_shapes;    // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
+    bool manual_dep;          // True when dependency is managed manually (skip tensormap lookup/insert)
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // Current view shape per dimension
     uint32_t __padding__;
 
     // === Cache line 2 (64B) — warm path ===
@@ -82,9 +83,7 @@ struct alignas(64) Tensor {
 
     /// Return the effective raw_shapes pointer (shapes[] when is_raw_eq_shapes).
     /// Avoids cache line 2 access for the common case.
-    const uint32_t* get_raw_shapes() const {
-        return is_raw_eq_shapes ? shapes : raw_shapes;
-    }
+    const uint32_t* get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
 
     Tensor(void* addr,
         uint64_t buffer_size_bytes,
@@ -97,8 +96,17 @@ struct alignas(64) Tensor {
         bool is_all_offset_zero = false,
         bool is_raw_eq_shapes = false,
         bool manual_dep = false) {
-        init(addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version,
-             is_all_offset_zero, is_raw_eq_shapes, manual_dep);
+        init(addr,
+            buffer_size_bytes,
+            raw_shapes,
+            shapes,
+            offsets,
+            ndims,
+            dtype,
+            version,
+            is_all_offset_zero,
+            is_raw_eq_shapes,
+            manual_dep);
     }
 
     // --- Initialization ---
@@ -136,7 +144,7 @@ struct alignas(64) Tensor {
     }
 
     void init(const Tensor& other) {
-        memcpy(this, &other, 64); // fast copy cache line 1
+        memcpy(this, &other, 64);  // fast copy cache line 1
         if (!other.is_raw_eq_shapes) {
             for (uint32_t i = 0; i < ndims; i++) {
                 raw_shapes[i] = other.raw_shapes[i];
@@ -149,7 +157,8 @@ struct alignas(64) Tensor {
         }
     }
 
-    void init_with_view(const Tensor& other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) {
+    void init_with_view(
+        const Tensor& other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) {
         buffer = other.buffer;
         ndims = other.ndims;
         dtype = other.dtype;
@@ -167,7 +176,10 @@ struct alignas(64) Tensor {
         bool all_zero = true;
         if (other.is_all_offset_zero) {
             for (uint32_t i = 0; i < ndims; i++) {
-                if (view_offsets[i] != 0) { all_zero = false; break; }
+                if (view_offsets[i] != 0) {
+                    all_zero = false;
+                    break;
+                }
             }
             if (!all_zero) {
                 for (uint32_t i = 0; i < ndims; i++) {
@@ -199,9 +211,7 @@ struct alignas(64) Tensor {
         start_offset = result;
     }
 
-    void copy(const Tensor &other) {
-        init(other);
-    }
+    void copy(const Tensor& other) { init(other); }
 
     Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
         Tensor result;
@@ -338,8 +348,17 @@ static inline Tensor make_tensor_external(void* addr,
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(addr, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    return Tensor(addr,
+        total * get_element_size(dtype),
+        shapes,
+        shapes,
+        zero_offsets,
+        ndims,
+        dtype,
+        version,
+        /*is_all_offset_zero=*/true,
+        /*is_raw_eq_shapes=*/true,
+        manual_dep);
 }
 
 /**
@@ -358,6 +377,15 @@ static inline Tensor make_tensor(const uint32_t shapes[],
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(0, total * get_element_size(dtype), shapes, shapes, zero_offsets, ndims, dtype, version,
-                  /*is_all_offset_zero=*/true, /*is_raw_eq_shapes=*/true, manual_dep);
+    return Tensor(0,
+        total * get_element_size(dtype),
+        shapes,
+        shapes,
+        zero_offsets,
+        ndims,
+        dtype,
+        version,
+        /*is_all_offset_zero=*/true,
+        /*is_raw_eq_shapes=*/true,
+        manual_dep);
 }

--- a/src/common/task_interface/data_type.h
+++ b/src/common/task_interface/data_type.h
@@ -34,15 +34,15 @@ enum class DataType : uint32_t {
 inline uint64_t get_element_size(DataType dtype) {
     // Order must match the enum definition exactly
     static uint64_t data_type_size[static_cast<int>(DataType::DATA_TYPE_NUM)] = {
-        4, // case DataType::FLOAT32
-        2, // DataType::FLOAT16
-        4, // DataType::INT32
-        2, // DataType::INT16
-        1, // DataType::INT8
-        1, // DataType::UINT8
-        2, // DataType::BFLOAT16
-        8, // DataType::INT64
-        8, // DataType::UINT64
+        4,  // case DataType::FLOAT32
+        2,  // DataType::FLOAT16
+        4,  // DataType::INT32
+        2,  // DataType::INT16
+        1,  // DataType::INT8
+        1,  // DataType::UINT8
+        2,  // DataType::BFLOAT16
+        8,  // DataType::INT64
+        8,  // DataType::UINT64
     };
     return data_type_size[static_cast<int>(dtype)];
 }

--- a/src/common/task_interface/task_arg.h
+++ b/src/common/task_interface/task_arg.h
@@ -24,35 +24,34 @@ enum class TaskArgKind : uint32_t {
 };
 
 struct TaskArg {
-    TaskArgKind kind;         // 4B: TENSOR or SCALAR
+    TaskArgKind kind;  // 4B: TENSOR or SCALAR
 
     union {
-        struct {                                    // --- Tensor metadata ---
-            uint64_t data;                          // Host/device memory address
-            uint32_t shapes[TASK_ARG_MAX_DIMS];     // Shape per dim (element count)
-            uint32_t ndims;                         // Number of dimensions (1..5)
-            DataType dtype;                         // DataType : uint32_t
-        } tensor;                                   // 36B
+        struct {                                 // --- Tensor metadata ---
+            uint64_t data;                       // Host/device memory address
+            uint32_t shapes[TASK_ARG_MAX_DIMS];  // Shape per dim (element count)
+            uint32_t ndims;                      // Number of dimensions (1..5)
+            DataType dtype;                      // DataType : uint32_t
+        } tensor;                                // 36B
 
-        uint64_t scalar;                            // --- Scalar value ---  8B
+        uint64_t scalar;  // --- Scalar value ---  8B
     };
 
     // Compute total bytes for this tensor from shape x element_size
     uint64_t nbytes() const {
         uint64_t total = 1;
-        for (uint32_t i = 0; i < tensor.ndims; i++)
-            total *= tensor.shapes[i];
+        for (uint32_t i = 0; i < tensor.ndims; i++) total *= tensor.shapes[i];
         return total * get_element_size(tensor.dtype);
     }
 
     // Get raw pointer to tensor data
-    template<typename T>
+    template <typename T>
     T* data() const {
         return reinterpret_cast<T*>(static_cast<uintptr_t>(tensor.data));
     }
 
     // Reinterpret scalar bits as target type (compliant type-punning via memcpy)
-    template<typename T>
+    template <typename T>
     T value_as() const {
         static_assert(sizeof(T) <= sizeof(uint64_t), "");
         T result;

--- a/src/common/task_interface/task_arg_array.h
+++ b/src/common/task_interface/task_arg_array.h
@@ -17,7 +17,7 @@
 #include <vector>
 
 static_assert(std::is_trivially_copyable<TaskArg>::value,
-              "TaskArg must be trivially copyable for contiguous array access via data_ptr()");
+    "TaskArg must be trivially copyable for contiguous array access via data_ptr()");
 
 struct TaskArgArray {
     std::vector<TaskArg> args;
@@ -27,19 +27,15 @@ struct TaskArgArray {
     size_t size() const { return args.size(); }
 
     TaskArg& get(size_t idx) {
-        if (idx >= args.size())
-            throw std::out_of_range("TaskArgArray index out of range");
+        if (idx >= args.size()) throw std::out_of_range("TaskArgArray index out of range");
         return args[idx];
     }
 
     const TaskArg& get(size_t idx) const {
-        if (idx >= args.size())
-            throw std::out_of_range("TaskArgArray index out of range");
+        if (idx >= args.size()) throw std::out_of_range("TaskArgArray index out of range");
         return args[idx];
     }
 
     /// Raw address of the contiguous TaskArg buffer (for C interop)
-    uintptr_t data_ptr() const {
-        return reinterpret_cast<uintptr_t>(args.data());
-    }
+    uintptr_t data_ptr() const { return reinterpret_cast<uintptr_t>(args.data()); }
 };

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,9 @@ from test_catalog import (
 
 def pytest_configure(config):
     """Register custom markers."""
-    config.addinivalue_line("markers", "requires_hardware: test needs Ascend toolchain and real device")
+    config.addinivalue_line(
+        "markers", "requires_hardware: test needs Ascend toolchain and real device"
+    )
 
 
 def pytest_addoption(parser):
@@ -31,7 +33,7 @@ def pytest_addoption(parser):
         "--platform",
         action="store",
         default=None,
-        help="Platform to test (e.g., a2a3sim, a5sim). If not specified, tests all platforms."
+        help="Platform to test (e.g., a2a3sim, a5sim). If not specified, tests all platforms.",
     )
 
 
@@ -81,17 +83,18 @@ def pytest_generate_tests(metafunc):
                 # Mark hardware platforms (non-sim) as requiring Ascend
                 marks = []
                 if not platform.endswith("sim"):
-                    marks.append(pytest.mark.skipif(
-                        not os.getenv("ASCEND_HOME_PATH"),
-                        reason=f"ASCEND_HOME_PATH not set; Ascend toolkit required for {platform}"
-                    ))
+                    marks.append(
+                        pytest.mark.skipif(
+                            not os.getenv("ASCEND_HOME_PATH"),
+                            reason=f"ASCEND_HOME_PATH not set; Ascend toolkit required for {platform}",
+                        )
+                    )
 
-                test_params.append(pytest.param(
-                    platform,
-                    runtime,
-                    marks=marks,
-                    id=f"{platform}-{runtime}"
-                ))
+                test_params.append(
+                    pytest.param(
+                        platform, runtime, marks=marks, id=f"{platform}-{runtime}"
+                    )
+                )
 
         # Apply parametrization
         metafunc.parametrize("platform,runtime_name", test_params)
@@ -115,13 +118,17 @@ def pytest_collection_modifyitems(session, config, items):
         # Skip aicpu_build_graph tests for architectures that don't have it
         if "test_discovers_aicpu_build_graph" in item.nodeid:
             if "aicpu_build_graph" not in available_runtimes:
-                item.add_marker(pytest.mark.skip(
-                    reason=f"aicpu_build_graph not available for {arch} architecture"
-                ))
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason=f"aicpu_build_graph not available for {arch} architecture"
+                    )
+                )
 
         # Skip tensormap_and_ringbuffer tests for architectures that don't have it
         if "tensormap_and_ringbuffer" in item.nodeid:
             if "tensormap_and_ringbuffer" not in available_runtimes:
-                item.add_marker(pytest.mark.skip(
-                    reason=f"tensormap_and_ringbuffer not available for {arch} architecture"
-                ))
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason=f"tensormap_and_ringbuffer not available for {arch} architecture"
+                    )
+                )

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/golden.py
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/golden.py
@@ -58,13 +58,19 @@ def compute_golden(tensors: dict, params: dict) -> None:
 
     # check values written by orchestration via SetTensorData
     check = torch.as_tensor(tensors["check"])
-    check[0] = 2.0    # GetTensorData(c, {0}): c = a + b, c[0] = 2.0+0.0
+    check[0] = 2.0  # GetTensorData(c, {0}): c = a + b, c[0] = 2.0+0.0
     check[1] = 102.0  # GetTensorData(c, {100}): c[100] = 2.0+100.0
-    check[2] = 77.0   # add_inout initial value (first use, OUTPUT path)
-    check[3] = 77.0   # add_inout second use (INOUT path, value preserved)
-    check[4] = 79.0   # orchestration arithmetic: 2.0 + 77.0
-    check[5] = 42.0   # Orch set→get round-trip: SetTensorData then GetTensorData
-    check[6] = 12.0   # Orch→AICore RAW: SetTensorData(d,10.0) + kernel_add(d,a) → 10.0+2.0
-    check[7] = 88.0   # WAW+WAR: kernel reads c, SetTensorData(c,88.0) auto-waits for consumer
-    check[8] = 55.0   # External WAR: noop(ext_b INOUT) → SetTensorData(ext_b,55.0) auto-waits
+    check[2] = 77.0  # add_inout initial value (first use, OUTPUT path)
+    check[3] = 77.0  # add_inout second use (INOUT path, value preserved)
+    check[4] = 79.0  # orchestration arithmetic: 2.0 + 77.0
+    check[5] = 42.0  # Orch set→get round-trip: SetTensorData then GetTensorData
+    check[6] = (
+        12.0  # Orch→AICore RAW: SetTensorData(d,10.0) + kernel_add(d,a) → 10.0+2.0
+    )
+    check[7] = (
+        88.0  # WAW+WAR: kernel reads c, SetTensorData(c,88.0) auto-waits for consumer
+    )
+    check[8] = (
+        55.0  # External WAR: noop(ext_b INOUT) → SetTensorData(ext_b,55.0) auto-waits
+    )
     # check[9] remains 0.0 (sentinel)

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_add.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_add.cpp
@@ -73,7 +73,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    
+
     set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_noop.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_noop.cpp
@@ -20,6 +20,4 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    (void)args;
-}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) { (void)args; }

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/kernel_config.py
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/kernel_config.py
@@ -18,8 +18,16 @@ ORCHESTRATION = {
 }
 
 KERNELS = [
-    {"func_id": 0, "source": str(_KERNELS_ROOT / "aiv" / "kernel_add.cpp"), "core_type": "aiv"},
-    {"func_id": 1, "source": str(_KERNELS_ROOT / "aiv" / "kernel_noop.cpp"), "core_type": "aiv"},
+    {
+        "func_id": 0,
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_add.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 1,
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_noop.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 RUNTIME_CONFIG = {

--- a/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
+++ b/tests/device_tests/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
@@ -26,7 +26,7 @@
 
 #include "pto_orchestration_api.h"
 
-#define FUNC_ADD  0
+#define FUNC_ADD 0
 #define FUNC_NOOP 1
 
 static uint64_t float_to_u64(float f) {
@@ -50,30 +50,26 @@ static float u64_to_float(uint64_t u) {
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 4,  // a, b, result, check
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(TaskArg* orch_args,
-                               int orch_thread_num,
-                               int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 
     // External tensors from golden.py
-    Tensor ext_a      = from_task_arg(orch_args[0]);
-    Tensor ext_b      = from_task_arg(orch_args[1]);
-    Tensor ext_result  = from_task_arg(orch_args[2]);
-    Tensor ext_check   = from_task_arg(orch_args[3]);
+    Tensor ext_a = from_task_arg(orch_args[0]);
+    Tensor ext_b = from_task_arg(orch_args[1]);
+    Tensor ext_result = from_task_arg(orch_args[2]);
+    Tensor ext_check = from_task_arg(orch_args[3]);
 
     uint32_t SIZE = orch_args[0].tensor.shapes[0];
-    LOG_INFO("scalar_data_test: SIZE=%u, check_size=%u",
-             SIZE, orch_args[3].tensor.shapes[0]);
+    LOG_INFO("scalar_data_test: SIZE=%u, check_size=%u", SIZE, orch_args[3].tensor.shapes[0]);
 
     // =========================================================
     // Step 1: c = a + b (internal tensor, kernel_add)
@@ -107,8 +103,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args,
     // =========================================================
     idx[0] = 100;
     uint64_t c100_raw = get_tensor_data(c, 1, idx);
-    LOG_INFO("get_tensor_data(c, {100}) = %f (expected 102.0)",
-             (double)u64_to_float(c100_raw));
+    LOG_INFO("get_tensor_data(c, {100}) = %f (expected 102.0)", (double)u64_to_float(c100_raw));
 
     check_idx[0] = 1;
     set_tensor_data(ext_check, 1, check_idx, c100_raw);
@@ -133,8 +128,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args,
     idx[0] = 0;
     uint64_t s0_raw = get_tensor_data(scalar_tensor, 1, idx);
     float s0_val = u64_to_float(s0_raw);
-    LOG_INFO("get_tensor_data(scalar_tensor, {0}) after init = %f (expected 77.0)",
-             (double)s0_val);
+    LOG_INFO("get_tensor_data(scalar_tensor, {0}) after init = %f (expected 77.0)", (double)s0_val);
 
     check_idx[0] = 2;
     set_tensor_data(ext_check, 1, check_idx, s0_raw);
@@ -154,8 +148,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args,
     //   Value should be preserved (noop kernel didn't modify it)
     // =========================================================
     uint64_t s1_raw = get_tensor_data(scalar_tensor, 1, idx);
-    LOG_INFO("get_tensor_data(scalar_tensor, {0}) after 2nd noop = %f (expected 77.0)",
-             (double)u64_to_float(s1_raw));
+    LOG_INFO("get_tensor_data(scalar_tensor, {0}) after 2nd noop = %f (expected 77.0)", (double)u64_to_float(s1_raw));
 
     check_idx[0] = 3;
     set_tensor_data(ext_check, 1, check_idx, s1_raw);
@@ -165,8 +158,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args,
     //   Tests set_tensor_data write + orchestration arithmetic
     // =========================================================
     float combined = c0_val + s0_val;  // 2.0 + 77.0 = 79.0
-    LOG_INFO("Orchestration arithmetic: %f + %f = %f",
-             (double)c0_val, (double)s0_val, (double)combined);
+    LOG_INFO("Orchestration arithmetic: %f + %f = %f", (double)c0_val, (double)s0_val, (double)combined);
 
     check_idx[0] = 4;
     set_tensor_data(ext_check, 1, check_idx, float_to_u64(combined));
@@ -179,8 +171,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args,
     set_tensor_data(scalar_tensor, 1, idx, float_to_u64(42.0f));
     uint64_t rw_raw = get_tensor_data(scalar_tensor, 1, idx);
     float rw_val = u64_to_float(rw_raw);
-    LOG_INFO("set_tensor_data→get_tensor_data round-trip = %f (expected 42.0)",
-             (double)rw_val);
+    LOG_INFO("set_tensor_data→get_tensor_data round-trip = %f (expected 42.0)", (double)rw_val);
 
     check_idx[0] = 5;
     set_tensor_data(ext_check, 1, check_idx, rw_raw);
@@ -210,8 +201,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args,
     }
 
     uint64_t e0_raw = get_tensor_data(e, 1, idx);
-    LOG_INFO("Orch→AICore RAW: e[0] = %f (expected 12.0)",
-             (double)u64_to_float(e0_raw));
+    LOG_INFO("Orch→AICore RAW: e[0] = %f (expected 12.0)", (double)u64_to_float(e0_raw));
 
     check_idx[0] = 6;
     set_tensor_data(ext_check, 1, check_idx, e0_raw);
@@ -245,8 +235,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args,
     idx[0] = 0;
     set_tensor_data(c, 1, idx, float_to_u64(88.0f));
     uint64_t waw_raw = get_tensor_data(c, 1, idx);
-    LOG_INFO("WAW+WAR: set_tensor_data(c, 88.0) after consumer = %f (expected 88.0)",
-             (double)u64_to_float(waw_raw));
+    LOG_INFO("WAW+WAR: set_tensor_data(c, 88.0) after consumer = %f (expected 88.0)", (double)u64_to_float(waw_raw));
 
     check_idx[0] = 7;
     set_tensor_data(ext_check, 1, check_idx, waw_raw);
@@ -268,15 +257,15 @@ void aicpu_orchestration_entry(TaskArg* orch_args,
     // =========================================================
     {
         PTOParam params;
-        params.add_inout(ext_b);   // INOUT: creates TensorMap entry (not INPUT!)
+        params.add_inout(ext_b);  // INOUT: creates TensorMap entry (not INPUT!)
         pto2_rt_submit_aiv_task(FUNC_NOOP, params);
     }
 
     idx[0] = 0;
     set_tensor_data(ext_b, 1, idx, float_to_u64(55.0f));
     uint64_t ext_war_raw = get_tensor_data(ext_b, 1, idx);
-    LOG_INFO("External WAR (INOUT): set_tensor_data(ext_b, 55.0) = %f (expected 55.0)",
-             (double)u64_to_float(ext_war_raw));
+    LOG_INFO(
+        "External WAR (INOUT): set_tensor_data(ext_b, 55.0) = %f (expected 55.0)", (double)u64_to_float(ext_war_raw));
 
     check_idx[0] = 8;
     set_tensor_data(ext_check, 1, check_idx, ext_war_raw);

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -61,9 +61,9 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
 
     // Load pij and vj to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, pijGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, vjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -62,9 +62,9 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
 
     // Load A and B to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, qiGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, kjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -126,7 +126,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to the same UB as DN tiles for storing as ND format
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);           // alias same UB as mijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
         TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,21 +173,21 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        TMAX(miNewRow, miRow, mijRow);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        TSUB(alphaRow, miRow, miNewRow);  // alpha_exp = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        TSUB(betaRow, mijRow, miNewRow);  // beta_exp = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        TEXP(betaRow, betaRow);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        TMUL(tmpRow, alphaRow, liRow);  // alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        TMUL(liNewRow, betaRow, lijRow);  // beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         TRESHAPE(alphaDN, alphaRow);
@@ -195,9 +195,9 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
 
         // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
         // Alias ND tiles to the same UB locations as miNewRow and liNewRow
@@ -212,15 +212,15 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -31,11 +31,8 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
-    float scale_value,
-    __gm__ Tensor* pij,
-    __gm__ Tensor* mij,
-    __gm__ Tensor* lij) {
+static __aicore__ void softmax_prepare_impl(
+    __gm__ Tensor* sij, float scale_value, __gm__ Tensor* pij, __gm__ Tensor* mij, __gm__ Tensor* lij) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
     __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
     __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
@@ -102,14 +99,14 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     // Truncate pij to bf16 first
     pipe_barrier(PIPE_V);
     TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);        // pij bf16 ready, can store early
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);  // pij bf16 ready, can store early
 
     // Continue computing: bf16 → f32 and rowsum while pij store proceeds in parallel
     pipe_barrier(PIPE_V);
     TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
     pipe_barrier(PIPE_V);
     TROWSUM(sumTile, pijTile, tmpTile);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);        // sum ready
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);  // sum ready
 
     // Store pij (overlaps with TCVT + TROWSUM above)
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/kernel_config.py
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/kernel_config.py
@@ -25,12 +25,42 @@ ORCHESTRATION = {
 }
 
 KERNELS = [
-    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"), "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"), "core_type": "aic"},
-    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"), "core_type": "aic"},
-    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"), "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"), "core_type": "aiv"},
+    {
+        "func_id": 0,
+        "name": "QK",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 2,
+        "name": "PV",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 4,
+        "name": "AIC_HUB",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "SF",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 3,
+        "name": "UP",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 5,
+        "name": "AIV_HUB",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 RUNTIME_CONFIG = {

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -29,23 +29,23 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 
     // Read dimensions from TaskArg tensor metadata
     // query: shape=[batch, num_heads, head_dim]
-    uint64_t batch     = orch_args[0].tensor.shapes[0];
+    uint64_t batch = orch_args[0].tensor.shapes[0];
     uint64_t num_heads = orch_args[0].tensor.shapes[1];
-    uint64_t head_dim  = orch_args[0].tensor.shapes[2];
+    uint64_t head_dim = orch_args[0].tensor.shapes[2];
     DataType data_type = orch_args[0].tensor.dtype;
 
     // key_cache: shape=[total_blocks, block_size, kv_head_num, head_dim]
@@ -63,9 +63,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
 
     // Reshape tensors for kernel consumption (2D flattened)
     void* query_ptr = orch_args[0].data<void>();
-    void* kc_ptr    = orch_args[1].data<void>();
-    void* vc_ptr    = orch_args[2].data<void>();
-    void* out_ptr   = orch_args[5].data<void>();
+    void* kc_ptr = orch_args[1].data<void>();
+    void* vc_ptr = orch_args[2].data<void>();
+    void* out_ptr = orch_args[5].data<void>();
 
     uint64_t total_blocks_count = orch_args[1].tensor.shapes[0];
 
@@ -78,7 +78,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
-    int* host_block_table  = orch_args[3].data<int>();
+    int* host_block_table = orch_args[3].data<int>();
     int* host_context_lens = orch_args[4].data<int>();
 
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/golden.py
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/golden.py
@@ -52,4 +52,6 @@ def generate_inputs(params: dict) -> list:
 
 
 if __name__ == "__main__":
-    run_golden_test(ALL_CASES, DEFAULT_CASE, generate_inputs, label="Paged Attention Unroll")
+    run_golden_test(
+        ALL_CASES, DEFAULT_CASE, generate_inputs, label="Paged Attention Unroll"
+    )

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -35,13 +35,11 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_n_impl(
-    __gm__ bfloat16_t* pij_base,
+static __aicore__ void pv_matmul_n_impl(__gm__ bfloat16_t* pij_base,
     __gm__ bfloat16_t* val_base,
     __gm__ float* oi_base,
     uint64_t n_blocks,
     __gm__ int32_t* block_table) {
-
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -32,13 +32,11 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_n_impl(
-    __gm__ bfloat16_t* qi_base,
+static __aicore__ void qk_matmul_n_impl(__gm__ bfloat16_t* qi_base,
     __gm__ bfloat16_t* key_base,
     __gm__ float* sij_base,
     uint64_t n_blocks,
     __gm__ int32_t* block_table) {
-
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -126,8 +126,8 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to same UB as DN tiles for ND-format store
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);                    // alias same UB as mijDN
-        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);   // alias same UB as lijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
+        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,21 +173,21 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        TMAX(miNewRow, miRow, mijRow);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        TSUB(alphaRow, miRow, miNewRow);  // alpha_exp = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        TSUB(betaRow, mijRow, miNewRow);  // beta_exp = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        TEXP(betaRow, betaRow);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        TMUL(tmpRow, alphaRow, liRow);  // alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        TMUL(liNewRow, betaRow, lijRow);  // beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         TRESHAPE(alphaDN, alphaRow);
@@ -195,9 +195,9 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
 
         // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
         // Alias ND tiles to the same UB locations as miNewRow and liNewRow
@@ -212,15 +212,15 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -36,15 +36,13 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_n_impl(
-    __gm__ float* sij_base,
+static __aicore__ void softmax_prepare_n_impl(__gm__ float* sij_base,
     float scale_value,
     __gm__ bfloat16_t* pij_base,
     __gm__ float* mij_addr,
     __gm__ float* lij_addr,
     uint64_t n_blocks,
     uint64_t valid_len_last) {
-
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
     constexpr int kScalarCols = 32 / sizeof(float);
     constexpr int kScalarRows = M / kScalarCols;
@@ -100,10 +98,10 @@ static __aicore__ void softmax_prepare_n_impl(
     TASSIGN(sumAccTile, 4 * kDataBytes);
     int scalarBase = 5 * kDataBytes;
     TASSIGN(localMaxDN, scalarBase);
-    TASSIGN(localMaxRow, scalarBase);                     // alias: same UB as localMaxDN
+    TASSIGN(localMaxRow, scalarBase);  // alias: same UB as localMaxDN
     TASSIGN(globalMaxDN, scalarBase + kScalarDNBytes);
-    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
-    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);    // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);  // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
     TASSIGN(sumDN, scalarBase + 2 * kScalarDNBytes);
     TASSIGN(pijBf16Tile, scalarBase + 3 * kScalarDNBytes);
 

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/kernel_config.py
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/kernel_config.py
@@ -25,12 +25,42 @@ ORCHESTRATION = {
 }
 
 KERNELS = [
-    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"), "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"), "core_type": "aic"},
-    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"), "core_type": "aic"},
-    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"), "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"), "core_type": "aiv"},
+    {
+        "func_id": 0,
+        "name": "QK",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 2,
+        "name": "PV",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 4,
+        "name": "AIC_HUB",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "SF",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 3,
+        "name": "UP",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 5,
+        "name": "AIV_HUB",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 RUNTIME_CONFIG = {

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -59,37 +59,37 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
-    uint64_t prof_ext_tensor    = 0;
-    uint64_t prof_make_tensor   = 0;
-    uint64_t prof_tensor_view   = 0;
-    uint64_t prof_param_setup   = 0;
-    uint64_t prof_submit_task   = 0;
+    uint64_t prof_ext_tensor = 0;
+    uint64_t prof_make_tensor = 0;
+    uint64_t prof_tensor_view = 0;
+    uint64_t prof_param_setup = 0;
+    uint64_t prof_submit_task = 0;
     uint64_t prof_scope_and_loop = 0;
-    int      prof_submit_count  = 0;
-    int      prof_make_count    = 0;
-    int      prof_view_count    = 0;
+    int prof_submit_count = 0;
+    int prof_make_count = 0;
+    int prof_view_count = 0;
 #endif
 
     CYCLE_COUNT_START();
 
     // Read dimensions from TaskArg tensor metadata
     // query: shape=[batch, num_heads, head_dim]
-    uint64_t batch     = orch_args[0].tensor.shapes[0];
+    uint64_t batch = orch_args[0].tensor.shapes[0];
     uint64_t num_heads = orch_args[0].tensor.shapes[1];
-    uint64_t head_dim  = orch_args[0].tensor.shapes[2];
+    uint64_t head_dim = orch_args[0].tensor.shapes[2];
     DataType data_type = orch_args[0].tensor.dtype;
 
     // key_cache: shape=[total_blocks, block_size, kv_head_num, head_dim]
@@ -108,9 +108,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
 
     // Reshape tensors for kernel consumption (2D flattened)
     void* query_ptr = orch_args[0].data<void>();
-    void* kc_ptr    = orch_args[1].data<void>();
-    void* vc_ptr    = orch_args[2].data<void>();
-    void* out_ptr   = orch_args[5].data<void>();
+    void* kc_ptr = orch_args[1].data<void>();
+    void* vc_ptr = orch_args[2].data<void>();
+    void* out_ptr = orch_args[5].data<void>();
 
     uint64_t total_blocks_count = orch_args[1].tensor.shapes[0];
 
@@ -123,7 +123,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
-    int* host_block_table  = orch_args[3].data<int>();
+    int* host_block_table = orch_args[3].data<int>();
     int* host_context_lens = orch_args[4].data<int>();
 
 #ifdef ENABLE_PROFILING
@@ -308,29 +308,49 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     CYCLE_COUNT_LAP(prof_scope_and_loop);
 
 #ifdef ENABLE_PROFILING
-    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor +
-                     prof_tensor_view + prof_param_setup + prof_submit_task +
-                     prof_scope_and_loop;
-    LOG_ALWAYS(rt, "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
-        prof_submit_count, prof_make_count, prof_view_count, cycles_to_us(total));
+    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
+                     prof_submit_task + prof_scope_and_loop;
+    LOG_ALWAYS(rt,
+        "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
+        prof_submit_count,
+        prof_make_count,
+        prof_view_count,
+        cycles_to_us(total));
     if (total > 0) {
-        LOG_ALWAYS(rt, "  param_extract    : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_extract), prof_param_extract * 100.0 / total);
-        LOG_ALWAYS(rt, "  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
-        LOG_ALWAYS(rt, "  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_make_count, cycles_to_us(prof_make_tensor), prof_make_tensor * 100.0 / total,
+        LOG_ALWAYS(rt,
+            "  param_extract    : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_param_extract),
+            prof_param_extract * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_ext_tensor),
+            prof_ext_tensor * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_make_count,
+            cycles_to_us(prof_make_tensor),
+            prof_make_tensor * 100.0 / total,
             prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
-        LOG_ALWAYS(rt, "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_view_count, cycles_to_us(prof_tensor_view), prof_tensor_view * 100.0 / total,
+        LOG_ALWAYS(rt,
+            "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_view_count,
+            cycles_to_us(prof_tensor_view),
+            prof_tensor_view * 100.0 / total,
             prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
-        LOG_ALWAYS(rt, "  param_setup      : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
-        LOG_ALWAYS(rt, "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_submit_count, cycles_to_us(prof_submit_task), prof_submit_task * 100.0 / total,
+        LOG_ALWAYS(rt,
+            "  param_setup      : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_param_setup),
+            prof_param_setup * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_submit_count,
+            cycles_to_us(prof_submit_task),
+            prof_submit_task * 100.0 / total,
             prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
-        LOG_ALWAYS(rt, "  scope_and_loop   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_scope_and_loop), prof_scope_and_loop * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  scope_and_loop   : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_scope_and_loop),
+            prof_scope_and_loop * 100.0 / total);
     }
 #endif
 

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -22,19 +22,18 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw)
-{
+static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw) {
     __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
-    __gm__ bfloat16_t* vj  = reinterpret_cast<__gm__ bfloat16_t*>(vj_raw);
-    __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ bfloat16_t* vj = reinterpret_cast<__gm__ bfloat16_t*>(vj_raw);
+    __gm__ float* oi = reinterpret_cast<__gm__ float*>(oi_raw);
 
     // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
-    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, N, 1>>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   pijGlobal(pij);
-    GlobalB   vjGlobal(vj);
+    GlobalA pijGlobal(pij);
+    GlobalB vjGlobal(vj);
     GlobalOut oiGlobal(oi);
 
     // L1 Mat tiles: standard ND pattern for both A and B
@@ -42,18 +41,18 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<bfloat16_t, M, K, M, K>;
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -81,10 +80,9 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     TSTORE(oiGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* pij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* vj     = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* vj = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
     int q_tile_size = static_cast<int>(args[3]);
     // args[4] = block_size, args[5] = head_dim

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -22,20 +22,19 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw)
-{
-    __gm__ bfloat16_t* qi  = reinterpret_cast<__gm__ bfloat16_t*>(qi_raw);
-    __gm__ bfloat16_t* kj  = reinterpret_cast<__gm__ bfloat16_t*>(kj_raw);
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw) {
+    __gm__ bfloat16_t* qi = reinterpret_cast<__gm__ bfloat16_t*>(qi_raw);
+    __gm__ bfloat16_t* kj = reinterpret_cast<__gm__ bfloat16_t*>(kj_raw);
+    __gm__ float* sij = reinterpret_cast<__gm__ float*>(sij_raw);
 
     // qi (M, K) bf16 in ND (row-major) layout
-    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   qiGlobal(qi);
-    GlobalB   kjGlobal(kj);
+    GlobalA qiGlobal(qi);
+    GlobalB kjGlobal(kj);
     GlobalOut sijGlobal(sij);
 
     // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
@@ -43,18 +42,18 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<bfloat16_t, M, K, M, K>;
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -82,10 +81,9 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     TSTORE(sijGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* qi  = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* kj  = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ uint8_t* qi = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* kj = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
     int q_tile_size = static_cast<int>(args[3]);
     // args[4] = head_dim (128), args[5] = block_size

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -24,18 +24,22 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_t* lij_raw,
-                               __gm__ uint8_t* oi_new_raw, __gm__ uint8_t* mi_raw,
-                               __gm__ uint8_t* li_raw, __gm__ uint8_t* oi_raw,
-                               int is_first, int is_last, __gm__ uint8_t* dst_raw)
-{
-    __gm__ float* mij_ptr    = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float* lij_ptr    = reinterpret_cast<__gm__ float*>(lij_raw);
+static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw,
+    __gm__ uint8_t* lij_raw,
+    __gm__ uint8_t* oi_new_raw,
+    __gm__ uint8_t* mi_raw,
+    __gm__ uint8_t* li_raw,
+    __gm__ uint8_t* oi_raw,
+    int is_first,
+    int is_last,
+    __gm__ uint8_t* dst_raw) {
+    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij_raw);
+    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij_raw);
     __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new_raw);
-    __gm__ float* mi_ptr     = reinterpret_cast<__gm__ float*>(mi_raw);
-    __gm__ float* li_ptr     = reinterpret_cast<__gm__ float*>(li_raw);
-    __gm__ float* oi_ptr     = reinterpret_cast<__gm__ float*>(oi_raw);
-    __gm__ float* dst_ptr    = reinterpret_cast<__gm__ float*>(dst_raw);
+    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi_raw);
+    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li_raw);
+    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst_raw);
 
     // Scalar tile dimensions for RowMajor layout:
     // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
@@ -51,12 +55,11 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
 
     // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
-    using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
-                                        Stride<1, 1, 1, kScalarCols, 1>>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
 
     // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
-                                        Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -78,8 +81,8 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     // --- Tile types ---
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
-    using TileScalarND = Tile<TileType::Vec, float, kScalarRows, kScalarCols,
-                              BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     // --- UB memory layout ---
@@ -124,9 +127,9 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Passthrough to MTE3 (no V compute needed)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, mijND);     // mi = mij
-        TSTORE(liGlobalND, lijND);     // li = lij
-        TSTORE(oiGlobal, oiNewTile);   // oi = oi_new
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
 
         if (is_last) {
             // Single block: normalize dst = oi_new / lij
@@ -157,53 +160,53 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
         // pipe_barrier(PIPE_V) required between each dependent vector operation
         // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
+        TMAX(miNewND, miND, mijND);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
+        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
+        TEXP(alphaND, alphaND);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
+        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
+        TEXP(betaND, betaND);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(liND, alphaND, liND);           // li = alpha * li
+        TMUL(liND, alphaND, liND);  // li = alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
+        TMUL(tmpND, betaND, lijND);  // tmp = beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
+        TADD(liND, liND, tmpND);  // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
         // mi_new → mi accumulator, li_new → li accumulator
         // alpha → mij buffer (reuse), beta → lij buffer (reuse)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, miNewND);         // persist mi_new
-        TSTORE(liGlobalND, liND);            // persist li_new
-        TSTORE(mijGlobalND, alphaND);        // temp: alpha to mij buffer
-        TSTORE(lijGlobalND, betaND);         // temp: beta to lij buffer
+        TSTORE(miGlobalND, miNewND);   // persist mi_new
+        TSTORE(liGlobalND, liND);      // persist li_new
+        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
 
         // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        TLOAD(alphaDN, mijGlobalDN);         // alpha from mij buffer as DN
-        TLOAD(betaDN, lijGlobalDN);          // beta from lij buffer as DN
+        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
         if (is_last) {
-            TLOAD(liDN, liGlobalDN);         // li_new from li buffer as DN
+            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
         }
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
 
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
             pipe_barrier(PIPE_V);
-            TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
+            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             TSTORE(dstGlobal, oiTile);
@@ -217,15 +220,15 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* mij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* lij    = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+    __gm__ uint8_t* mij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mi     = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* li     = reinterpret_cast<__gm__ uint8_t*>(args[4]);
-    __gm__ uint8_t* oi     = reinterpret_cast<__gm__ uint8_t*>(args[5]);
-    int is_first  = static_cast<int>(args[6]);
-    int is_last   = static_cast<int>(args[7]);
-    __gm__ uint8_t* dst    = reinterpret_cast<__gm__ uint8_t*>(args[8]);
+    __gm__ uint8_t* mi = reinterpret_cast<__gm__ uint8_t*>(args[3]);
+    __gm__ uint8_t* li = reinterpret_cast<__gm__ uint8_t*>(args[4]);
+    __gm__ uint8_t* oi = reinterpret_cast<__gm__ uint8_t*>(args[5]);
+    int is_first = static_cast<int>(args[6]);
+    int is_last = static_cast<int>(args[7]);
+    __gm__ uint8_t* dst = reinterpret_cast<__gm__ uint8_t*>(args[8]);
     int q_tile_size = static_cast<int>(args[9]);
     // args[10] = head_dim (128)
 

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -29,14 +29,16 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
-                                 __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
-                                 __gm__ uint8_t* lij_raw, int valid_len)
-{
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw,
+    float scale_value,
+    __gm__ uint8_t* pij_raw,
+    __gm__ uint8_t* mij_raw,
+    __gm__ uint8_t* lij_raw,
+    int valid_len) {
+    __gm__ float* sij = reinterpret_cast<__gm__ float*>(sij_raw);
     __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
-    __gm__ float*      mij = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float*      lij = reinterpret_cast<__gm__ float*>(lij_raw);
+    __gm__ float* mij = reinterpret_cast<__gm__ float*>(mij_raw);
+    __gm__ float* lij = reinterpret_cast<__gm__ float*>(lij_raw);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -52,8 +54,7 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
     // Dynamic-cols tile: marks which columns are valid for TFILLPAD boundary
     using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
     // Padded tile: TFILLPAD_INPLACE fills positions [valid_len, N) with -inf
-    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N,
-                            SLayout::NoneBox, 512, PadValue::Min>;
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N, SLayout::NoneBox, 512, PadValue::Min>;
 
     using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
     using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
@@ -106,7 +107,10 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    union { uint64_t u; float f; } scale_conv;
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[1]);
     float scale_value = scale_conv.f;
     __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[2]);

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/kernel_config.py
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/kernel_config.py
@@ -28,11 +28,31 @@ ORCHESTRATION = {
 # Kernel configs (aiv_normalize removed - merged into aiv_online_update)
 KERNELS = [
     # AIC kernels (matrix multiplication using Cube unit)
-    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
+    {
+        "func_id": 0,
+        "name": "QK",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 2,
+        "name": "PV",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),
+        "core_type": "aic",
+    },
     # AIV kernels (vector operations)
-    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
+    {
+        "func_id": 1,
+        "name": "SF",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 3,
+        "name": "UP",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 # Runtime configuration

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -19,10 +19,10 @@
 #include <algorithm>
 #include <cstring>
 
-#define FUNC_QK_MATMUL       0
+#define FUNC_QK_MATMUL 0
 #define FUNC_SOFTMAX_PREPARE 1
-#define FUNC_PV_MATMUL       2
-#define FUNC_ONLINE_UPDATE   3
+#define FUNC_PV_MATMUL 2
+#define FUNC_ONLINE_UPDATE 3
 
 extern "C" {
 
@@ -33,27 +33,27 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     }
 
     // Extract host pointers from TaskArg tensor metadata
-    void* host_query       = orch_args[0].data<void>();
-    void* host_key_cache   = orch_args[1].data<void>();
+    void* host_query = orch_args[0].data<void>();
+    void* host_key_cache = orch_args[1].data<void>();
     void* host_value_cache = orch_args[2].data<void>();
-    int*  host_block_table = orch_args[3].data<int>();
-    int*  host_context_lens = orch_args[4].data<int>();
-    void* host_out         = orch_args[5].data<void>();
+    int* host_block_table = orch_args[3].data<int>();
+    int* host_context_lens = orch_args[4].data<int>();
+    void* host_out = orch_args[5].data<void>();
 
     // Extract sizes from TaskArg metadata
-    size_t query_size       = orch_args[0].nbytes();
-    size_t key_cache_size   = orch_args[1].nbytes();
+    size_t query_size = orch_args[0].nbytes();
+    size_t key_cache_size = orch_args[1].nbytes();
     size_t value_cache_size = orch_args[2].nbytes();
-    size_t out_size         = orch_args[5].nbytes();
+    size_t out_size = orch_args[5].nbytes();
 
     // Read dimensions from tensor shapes (uint32_t — matches TaskArg::tensor.shapes type)
     // query: (batch, num_heads, head_dim)
-    uint32_t batch       = orch_args[0].tensor.shapes[0];
-    uint32_t num_heads   = orch_args[0].tensor.shapes[1];
-    uint32_t head_dim    = orch_args[0].tensor.shapes[2];
+    uint32_t batch = orch_args[0].tensor.shapes[0];
+    uint32_t num_heads = orch_args[0].tensor.shapes[1];
+    uint32_t head_dim = orch_args[0].tensor.shapes[2];
 
     // key_cache: (total_blocks, block_size, kv_head_num, head_dim)
-    uint32_t block_size  = orch_args[1].tensor.shapes[1];
+    uint32_t block_size = orch_args[1].tensor.shapes[1];
     uint32_t kv_head_num = orch_args[1].tensor.shapes[2];
 
     // block_table: (batch, max_num_blocks_per_req)
@@ -67,8 +67,8 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     uint32_t num_head_tiles = (num_heads + q_tile_size - 1) / q_tile_size;
 
     std::cout << "\n=== build_paged_attention_graph ===" << '\n';
-    std::cout << "batch=" << batch << ", num_heads=" << num_heads
-              << ", kv_head_num=" << kv_head_num << ", head_dim=" << head_dim << '\n';
+    std::cout << "batch=" << batch << ", num_heads=" << num_heads << ", kv_head_num=" << kv_head_num
+              << ", head_dim=" << head_dim << '\n';
     std::cout << "block_size=" << block_size << ", max_num_blocks=" << max_num_blocks << '\n';
     std::cout << "q_tile_size=" << q_tile_size << ", num_head_tiles=" << num_head_tiles << '\n';
 
@@ -89,25 +89,25 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     runtime->record_tensor_pair(host_out, dev_out, out_size);
 
     // Buffer sizes depend on q_tile_size and block_size
-    size_t sij_size    = static_cast<size_t>(q_tile_size) * block_size * sizeof(float);
-    size_t pij_size    = static_cast<size_t>(q_tile_size) * block_size * sizeof(uint16_t);
-    size_t mij_size    = static_cast<size_t>(q_tile_size) * sizeof(float);
-    size_t lij_size    = mij_size;
+    size_t sij_size = static_cast<size_t>(q_tile_size) * block_size * sizeof(float);
+    size_t pij_size = static_cast<size_t>(q_tile_size) * block_size * sizeof(uint16_t);
+    size_t mij_size = static_cast<size_t>(q_tile_size) * sizeof(float);
+    size_t lij_size = mij_size;
     size_t oi_new_size = static_cast<size_t>(q_tile_size) * head_dim * sizeof(float);
 
     // Per-batch-per-block intermediate buffers
     uint32_t total_buffers = batch * max_num_blocks;
-    void** dev_sij_arr    = new void*[total_buffers];
-    void** dev_pij_arr    = new void*[total_buffers];
-    void** dev_mij_arr    = new void*[total_buffers];
-    void** dev_lij_arr    = new void*[total_buffers];
+    void** dev_sij_arr = new void*[total_buffers];
+    void** dev_pij_arr = new void*[total_buffers];
+    void** dev_mij_arr = new void*[total_buffers];
+    void** dev_lij_arr = new void*[total_buffers];
     void** dev_oi_new_arr = new void*[total_buffers];
 
     for (uint32_t i = 0; i < total_buffers; i++) {
-        dev_sij_arr[i]    = runtime->host_api.device_malloc(sij_size);
-        dev_pij_arr[i]    = runtime->host_api.device_malloc(pij_size);
-        dev_mij_arr[i]    = runtime->host_api.device_malloc(mij_size);
-        dev_lij_arr[i]    = runtime->host_api.device_malloc(lij_size);
+        dev_sij_arr[i] = runtime->host_api.device_malloc(sij_size);
+        dev_pij_arr[i] = runtime->host_api.device_malloc(pij_size);
+        dev_mij_arr[i] = runtime->host_api.device_malloc(mij_size);
+        dev_lij_arr[i] = runtime->host_api.device_malloc(lij_size);
         dev_oi_new_arr[i] = runtime->host_api.device_malloc(oi_new_size);
     }
 
@@ -141,12 +141,12 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
             // Query: (batch, q_head_num, head_dim) bf16
             // qi points to heads [cur_offset .. cur_offset+q_tile_size) for batch b_idx
-            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query)
-                + static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
+            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query) +
+                              static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
 
             // Output: (batch * q_head_num, head_dim) float32
-            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out)
-                + static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
+            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out) +
+                               static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
 
             // GQA: which kv_head this head tile maps to
             uint32_t kv_head_idx = cur_offset / (num_heads / kv_head_num);
@@ -164,57 +164,51 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
                 int valid_len = std::min((int)block_size, cur_seq - (int)(bn * block_size));
 
                 // Key: (total_blocks, block_size, kv_head_num, head_dim) bf16
-                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache)
-                    + (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx)
-                      * head_dim * sizeof(uint16_t);
+                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache) +
+                                  (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
+                                      head_dim * sizeof(uint16_t);
 
                 // Value: (total_blocks, block_size, kv_head_num, head_dim) bf16
-                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache)
-                    + (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx)
-                      * head_dim * sizeof(uint16_t);
+                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache) +
+                                  (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
+                                      head_dim * sizeof(uint16_t);
 
                 uint32_t buf_idx = b_idx * max_num_blocks + bn;
-                void* dev_sij    = dev_sij_arr[buf_idx];
-                void* dev_pij    = dev_pij_arr[buf_idx];
-                void* dev_mij    = dev_mij_arr[buf_idx];
-                void* dev_lij    = dev_lij_arr[buf_idx];
+                void* dev_sij = dev_sij_arr[buf_idx];
+                void* dev_pij = dev_pij_arr[buf_idx];
+                void* dev_mij = dev_mij_arr[buf_idx];
+                void* dev_lij = dev_lij_arr[buf_idx];
                 void* dev_oi_new = dev_oi_new_arr[buf_idx];
 
                 // QK: qi(M, K) @ kj.T(K, N) -> sij(M, N)
-                uint64_t qk_args[6] = {
-                    reinterpret_cast<uint64_t>(qi_ptr),
+                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),
                     reinterpret_cast<uint64_t>(kj_ptr),
                     reinterpret_cast<uint64_t>(dev_sij),
                     static_cast<uint64_t>(q_tile_size),
                     static_cast<uint64_t>(head_dim),
-                    static_cast<uint64_t>(block_size)
-                };
+                    static_cast<uint64_t>(block_size)};
                 int t_qk = runtime->add_task(qk_args, 6, FUNC_QK_MATMUL, CoreType::AIC);
                 total_tasks++;
 
                 // SF: scale, rowmax, exp, rowsum -> pij, mij, lij
-                uint64_t sf_args[8] = {
-                    reinterpret_cast<uint64_t>(dev_sij),
+                uint64_t sf_args[8] = {reinterpret_cast<uint64_t>(dev_sij),
                     scale_value_bits,
                     reinterpret_cast<uint64_t>(dev_pij),
                     reinterpret_cast<uint64_t>(dev_mij),
                     reinterpret_cast<uint64_t>(dev_lij),
                     static_cast<uint64_t>(q_tile_size),
                     static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(valid_len)
-                };
+                    static_cast<uint64_t>(valid_len)};
                 int t_sf = runtime->add_task(sf_args, 8, FUNC_SOFTMAX_PREPARE, CoreType::AIV);
                 total_tasks++;
 
                 // PV: pij(M, K') @ vj(K', N') -> oi_new(M, N')
-                uint64_t pv_args[6] = {
-                    reinterpret_cast<uint64_t>(dev_pij),
+                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),
                     reinterpret_cast<uint64_t>(vj_ptr),
                     reinterpret_cast<uint64_t>(dev_oi_new),
                     static_cast<uint64_t>(q_tile_size),
                     static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(head_dim)
-                };
+                    static_cast<uint64_t>(head_dim)};
                 int t_pv = runtime->add_task(pv_args, 6, FUNC_PV_MATMUL, CoreType::AIC);
                 total_tasks++;
 
@@ -223,10 +217,9 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
                 // Online Update: serialized across blocks (each depends on previous)
                 int is_first = (bn == 0) ? 1 : 0;
-                int is_last  = (bn == bn_this_batch - 1) ? 1 : 0;
+                int is_last = (bn == bn_this_batch - 1) ? 1 : 0;
 
-                uint64_t up_args[11] = {
-                    reinterpret_cast<uint64_t>(dev_mij),
+                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),
                     reinterpret_cast<uint64_t>(dev_lij),
                     reinterpret_cast<uint64_t>(dev_oi_new),
                     reinterpret_cast<uint64_t>(dev_mi),
@@ -236,8 +229,7 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
                     static_cast<uint64_t>(is_last),
                     reinterpret_cast<uint64_t>(out_ptr),
                     static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim)
-                };
+                    static_cast<uint64_t>(head_dim)};
                 int t_up = runtime->add_task(up_args, 11, FUNC_ONLINE_UPDATE, CoreType::AIV);
                 total_tasks++;
 
@@ -264,5 +256,4 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
     return 0;
 }
-
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/golden.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/golden.py
@@ -34,7 +34,6 @@ ALL_CASES = {
         "matmul_batch": 4,  # Number of matmul tiles per task
         "add_batch": 5,  # Number of add tiles per task
     },
-
 }
 
 DEFAULT_CASE = "Case1"
@@ -79,9 +78,13 @@ def generate_inputs(params: dict) -> list:
     # Prevent integer overflow in orchestration (task_idx = b * M + m or b * N + n)
     INT32_MAX = 2**31 - 1
     if total_matmul_tasks > INT32_MAX:
-        raise ValueError(f"total_matmul_tasks ({total_matmul_tasks}) exceeds INT32_MAX ({INT32_MAX}), risk of overflow")
+        raise ValueError(
+            f"total_matmul_tasks ({total_matmul_tasks}) exceeds INT32_MAX ({INT32_MAX}), risk of overflow"
+        )
     if total_add_tasks > INT32_MAX:
-        raise ValueError(f"total_add_tasks ({total_add_tasks}) exceeds INT32_MAX ({INT32_MAX}), risk of overflow")
+        raise ValueError(
+            f"total_add_tasks ({total_add_tasks}) exceeds INT32_MAX ({INT32_MAX}), risk of overflow"
+        )
 
     # Fixed sizes: matmul 128x128x128, add 128x128
     matmul_size = 128
@@ -100,9 +103,13 @@ def generate_inputs(params: dict) -> list:
     add_gb = total_add_elements * 4 / 1024**3
 
     if total_matmul_elements > MAX_ELEMENTS:
-        raise ValueError(f"Matmul tensor too large: {matmul_gb:.2f} GB (max {MAX_TENSOR_GB} GB)")
+        raise ValueError(
+            f"Matmul tensor too large: {matmul_gb:.2f} GB (max {MAX_TENSOR_GB} GB)"
+        )
     if total_add_elements > MAX_ELEMENTS:
-        raise ValueError(f"Add tensor too large: {add_gb:.2f} GB (max {MAX_TENSOR_GB} GB)")
+        raise ValueError(
+            f"Add tensor too large: {add_gb:.2f} GB (max {MAX_TENSOR_GB} GB)"
+        )
 
     # If random_seed is False, use fixed seed (42); if True, use random seed
     if not random_seed:

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp
@@ -41,22 +41,18 @@ static __aicore__ inline int get_num_tiles(__gm__ Tensor* tensor, uint64_t tile_
 }
 
 template <int TILE>
-static __aicore__ void matmul_impl(
-    __gm__ float* input_a,
-    __gm__ float* input_b,
-    __gm__ float* output) {
-
+static __aicore__ void matmul_impl(__gm__ float* input_a, __gm__ float* input_b, __gm__ float* output) {
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
     constexpr int M = CeilAlign<int>(TILE, 16);
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);
@@ -107,7 +103,7 @@ static __aicore__ void matmul_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* input_a = reinterpret_cast<__gm__ Tensor*>(args[0]);
     __gm__ Tensor* input_b = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* output  = reinterpret_cast<__gm__ Tensor*>(args[2]);
+    __gm__ Tensor* output = reinterpret_cast<__gm__ Tensor*>(args[2]);
 
     constexpr uint64_t TILE_ELEMS = 128 * 128;
     int num_tiles = get_num_tiles(input_a, TILE_ELEMS);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp
@@ -31,11 +31,7 @@ static __aicore__ inline int get_num_tiles(__gm__ Tensor* tensor, uint64_t tile_
 }
 
 template <int ROWS, int COLS>
-static __aicore__ void add_impl(
-    __gm__ float* src0,
-    __gm__ float* src1,
-    __gm__ float* out) {
-
+static __aicore__ void add_impl(__gm__ float* src0, __gm__ float* src1, __gm__ float* out) {
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -22,23 +22,22 @@
 #include "pto_orchestration_api.h"
 
 #define FUNC_MATMUL 0
-#define FUNC_ADD    1
+#define FUNC_ADD 1
 
 static constexpr uint64_t MATMUL_ELEMS = 128 * 128;
 static constexpr uint64_t ADD_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 11,
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     // Tensor args
     Tensor ext_A = from_task_arg(orch_args[0]);
     Tensor ext_B = from_task_arg(orch_args[1]);
@@ -56,7 +55,11 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
 
     LOG_ALWAYS("[alternating_orch] thread num: %d, idx: %d", orch_thread_num, orch_thread_index);
     LOG_INFO("[alternating_orch] Batch: %d, M: %d, N: %d, matmul_batch: %d, add_batch: %d",
-             batch, M, N, matmul_batch, add_batch);
+        batch,
+        M,
+        N,
+        matmul_batch,
+        add_batch);
 
     int total_matmul_tasks = batch * M;
     int total_add_tasks = batch * N;
@@ -111,8 +114,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
         }
     }
 
-    LOG_ALWAYS("[alternating_orch] Submitted %d matmul groups and %d add groups",
-             total_matmul, total_add);
+    LOG_ALWAYS("[alternating_orch] Submitted %d matmul groups and %d add groups", total_matmul, total_add);
 }
 
 }  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/golden.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/golden.py
@@ -52,4 +52,6 @@ def generate_inputs(params: dict) -> list:
 
 
 if __name__ == "__main__":
-    run_golden_test(ALL_CASES, DEFAULT_CASE, generate_inputs, label="Batch Paged Attention")
+    run_golden_test(
+        ALL_CASES, DEFAULT_CASE, generate_inputs, label="Batch Paged Attention"
+    )

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -25,8 +25,7 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_batch_impl(
-    __gm__ Tensor* pij_batch,
+static __aicore__ void pv_matmul_batch_impl(__gm__ Tensor* pij_batch,
     __gm__ Tensor* value_cache,
     __gm__ Tensor* oi_new_batch,
     uint64_t block_table_ptr,
@@ -34,7 +33,6 @@ static __aicore__ void pv_matmul_batch_impl(
     uint64_t block_idx,
     uint64_t block_num,
     uint64_t batch_start) {
-
     __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_batch->buffer.addr);
     __gm__ bfloat16_t* val_base = reinterpret_cast<__gm__ bfloat16_t*>(value_cache->buffer.addr);
     __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new_batch->buffer.addr);
@@ -113,11 +111,9 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
 
     if (q_tile_size == 16) {
         pv_matmul_batch_impl<16, 128, 128>(
-            pij_batch, value_cache, oi_new_batch,
-            block_table_ptr, batch_count, block_idx, block_num, batch_start);
+            pij_batch, value_cache, oi_new_batch, block_table_ptr, batch_count, block_idx, block_num, batch_start);
     } else {
         pv_matmul_batch_impl<64, 64, 128>(
-            pij_batch, value_cache, oi_new_batch,
-            block_table_ptr, batch_count, block_idx, block_num, batch_start);
+            pij_batch, value_cache, oi_new_batch, block_table_ptr, batch_count, block_idx, block_num, batch_start);
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -25,8 +25,7 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_batch_impl(
-    __gm__ Tensor* query,
+static __aicore__ void qk_matmul_batch_impl(__gm__ Tensor* query,
     __gm__ Tensor* key_cache,
     __gm__ Tensor* sij_batch,
     uint64_t block_table_ptr,
@@ -36,7 +35,6 @@ static __aicore__ void qk_matmul_batch_impl(
     uint64_t block_num,
     uint64_t num_heads,
     uint64_t batch_start) {
-
     __gm__ bfloat16_t* query_base = reinterpret_cast<__gm__ bfloat16_t*>(query->buffer.addr);
     __gm__ bfloat16_t* key_base = reinterpret_cast<__gm__ bfloat16_t*>(key_cache->buffer.addr);
     __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_batch->buffer.addr);
@@ -117,14 +115,26 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t q_tile_size = static_cast<uint64_t>(sij_batch->shapes[0] / batch_count);
 
     if (q_tile_size == 16) {
-        qk_matmul_batch_impl<16, 128, 128>(
-            query, key_cache, sij_batch,
-            block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
+        qk_matmul_batch_impl<16, 128, 128>(query,
+            key_cache,
+            sij_batch,
+            block_table_ptr,
+            batch_count,
+            block_idx,
+            q_offset,
+            block_num,
+            num_heads,
             batch_start);
     } else {
-        qk_matmul_batch_impl<64, 128, 64>(
-            query, key_cache, sij_batch,
-            block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
+        qk_matmul_batch_impl<64, 128, 64>(query,
+            key_cache,
+            sij_batch,
+            block_table_ptr,
+            batch_count,
+            block_idx,
+            q_offset,
+            block_num,
+            num_heads,
             batch_start);
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -30,8 +30,7 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_batch_impl(
-    __gm__ Tensor* mij_batch,
+static __aicore__ void online_update_batch_impl(__gm__ Tensor* mij_batch,
     __gm__ Tensor* lij_batch,
     __gm__ Tensor* oi_new_batch,
     __gm__ Tensor* mi_batch,
@@ -44,7 +43,6 @@ static __aicore__ void online_update_batch_impl(
     uint64_t q_offset,
     uint64_t num_heads,
     uint64_t batch_start) {
-
     __gm__ float* mij_base = reinterpret_cast<__gm__ float*>(mij_batch->buffer.addr);
     __gm__ float* lij_base = reinterpret_cast<__gm__ float*>(lij_batch->buffer.addr);
     __gm__ float* oi_new_base = reinterpret_cast<__gm__ float*>(oi_new_batch->buffer.addr);
@@ -207,14 +205,32 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t q_tile_size = static_cast<uint64_t>(mij_batch->shapes[0] / batch_count);
 
     if (q_tile_size == 16) {
-        online_update_batch_impl<16, 128>(
-            mij_batch, lij_batch, oi_new_batch,
-            mi_batch, li_batch, oi_batch, out,
-            is_first, is_last, batch_count, q_offset, num_heads, batch_start);
+        online_update_batch_impl<16, 128>(mij_batch,
+            lij_batch,
+            oi_new_batch,
+            mi_batch,
+            li_batch,
+            oi_batch,
+            out,
+            is_first,
+            is_last,
+            batch_count,
+            q_offset,
+            num_heads,
+            batch_start);
     } else {
-        online_update_batch_impl<64, 128>(
-            mij_batch, lij_batch, oi_new_batch,
-            mi_batch, li_batch, oi_batch, out,
-            is_first, is_last, batch_count, q_offset, num_heads, batch_start);
+        online_update_batch_impl<64, 128>(mij_batch,
+            lij_batch,
+            oi_new_batch,
+            mi_batch,
+            li_batch,
+            oi_batch,
+            out,
+            is_first,
+            is_last,
+            batch_count,
+            q_offset,
+            num_heads,
+            batch_start);
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -29,8 +29,7 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_batch_impl(
-    __gm__ Tensor* sij_batch,
+static __aicore__ void softmax_prepare_batch_impl(__gm__ Tensor* sij_batch,
     __gm__ Tensor* pij_batch,
     __gm__ Tensor* mij_batch,
     __gm__ Tensor* lij_batch,
@@ -39,7 +38,6 @@ static __aicore__ void softmax_prepare_batch_impl(
     uint64_t batch_count,
     uint64_t block_idx,
     uint64_t batch_start) {
-
     __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_batch->buffer.addr);
     __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_batch->buffer.addr);
     __gm__ float* mij_base = reinterpret_cast<__gm__ float*>(mij_batch->buffer.addr);
@@ -161,7 +159,10 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ Tensor* pij_batch = reinterpret_cast<__gm__ Tensor*>(args[1]);
     __gm__ Tensor* mij_batch = reinterpret_cast<__gm__ Tensor*>(args[2]);
     __gm__ Tensor* lij_batch = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    union { uint64_t u; float f; } scale_conv;
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[4]);
     float scale_value = scale_conv.f;
     uint64_t context_lens_ptr = static_cast<uint64_t>(args[5]);
@@ -172,12 +173,24 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t q_tile_size = static_cast<uint64_t>(sij_batch->shapes[0] / batch_count);
 
     if (q_tile_size == 16) {
-        softmax_prepare_batch_impl<16, 128>(
-            sij_batch, pij_batch, mij_batch, lij_batch,
-            scale_value, context_lens_ptr, batch_count, block_idx, batch_start);
+        softmax_prepare_batch_impl<16, 128>(sij_batch,
+            pij_batch,
+            mij_batch,
+            lij_batch,
+            scale_value,
+            context_lens_ptr,
+            batch_count,
+            block_idx,
+            batch_start);
     } else {
-        softmax_prepare_batch_impl<64, 64>(
-            sij_batch, pij_batch, mij_batch, lij_batch,
-            scale_value, context_lens_ptr, batch_count, block_idx, batch_start);
+        softmax_prepare_batch_impl<64, 64>(sij_batch,
+            pij_batch,
+            mij_batch,
+            lij_batch,
+            scale_value,
+            context_lens_ptr,
+            batch_count,
+            block_idx,
+            batch_start);
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/kernel_config.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/kernel_config.py
@@ -26,13 +26,43 @@ ORCHESTRATION = {
 # Kernel configs
 KERNELS = [
     # AIC kernels (matrix multiplication using Cube unit)
-    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),       "core_type": "aic"},
+    {
+        "func_id": 0,
+        "name": "QK",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 2,
+        "name": "PV",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 4,
+        "name": "AIC_HUB",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),
+        "core_type": "aic",
+    },
     # AIV kernels (vector operations)
-    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),       "core_type": "aiv"},
+    {
+        "func_id": 1,
+        "name": "SF",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 3,
+        "name": "UP",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 5,
+        "name": "AIV_HUB",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 # Runtime configuration

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -41,25 +41,23 @@
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     // Read dimensions from TaskArg tensor metadata
-    uint64_t batch     = orch_args[0].tensor.shapes[0];
+    uint64_t batch = orch_args[0].tensor.shapes[0];
     uint64_t num_heads = orch_args[0].tensor.shapes[1];
-    uint64_t head_dim  = orch_args[0].tensor.shapes[2];
+    uint64_t head_dim = orch_args[0].tensor.shapes[2];
     DataType data_type = orch_args[0].tensor.dtype;
 
     uint64_t block_size = orch_args[1].tensor.shapes[1];
-    uint64_t block_num  = orch_args[3].tensor.shapes[1];
+    uint64_t block_num = orch_args[3].tensor.shapes[1];
 
     uint64_t scale_value = orch_args[6].scalar;
 
@@ -67,15 +65,14 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
     uint64_t q_loop = (num_heads + q_tile - 1) / q_tile;
     uint64_t elem_size = get_element_size(data_type);
 
-    LOG_INFO("batch_paged_attention: batch=%lu, num_heads=%lu",
-             (unsigned long)batch, (unsigned long)num_heads);
+    LOG_INFO("batch_paged_attention: batch=%lu, num_heads=%lu", (unsigned long)batch, (unsigned long)num_heads);
 
     void* query_ptr = orch_args[0].data<void>();
-    void* kc_ptr    = orch_args[1].data<void>();
-    void* vc_ptr    = orch_args[2].data<void>();
-    void* out_ptr   = orch_args[5].data<void>();
+    void* kc_ptr = orch_args[1].data<void>();
+    void* vc_ptr = orch_args[2].data<void>();
+    void* out_ptr = orch_args[5].data<void>();
 
-    int* host_block_table  = orch_args[3].data<int>();
+    int* host_block_table = orch_args[3].data<int>();
     int* host_context_lens = orch_args[4].data<int>();
 
     uint64_t max_bn = 0;
@@ -136,69 +133,70 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
                         Tensor lij_b = make_tensor(vec_shapes, 1, DataType::FLOAT32);
                         Tensor oi_new_b = make_tensor(oi_new_shapes, 2, DataType::FLOAT32);
 
-                    PTOParam params_qk;
-                    params_qk.add_input(query);
-                    params_qk.add_input(key_cache);
-                    params_qk.add_output(sij_b);
-                    params_qk.add_scalar(bt_addr);
-                    params_qk.add_scalar(chunk_bc);
-                    params_qk.add_scalar(bn);
-                    params_qk.add_scalar(q_offset);
-                    params_qk.add_scalar(block_num);
-                    params_qk.add_scalar(num_heads);
-                    params_qk.add_scalar(batch_start);
-                    pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                        PTOParam params_qk;
+                        params_qk.add_input(query);
+                        params_qk.add_input(key_cache);
+                        params_qk.add_output(sij_b);
+                        params_qk.add_scalar(bt_addr);
+                        params_qk.add_scalar(chunk_bc);
+                        params_qk.add_scalar(bn);
+                        params_qk.add_scalar(q_offset);
+                        params_qk.add_scalar(block_num);
+                        params_qk.add_scalar(num_heads);
+                        params_qk.add_scalar(batch_start);
+                        pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
 
-                    PTOParam params_sf;
-                    params_sf.add_input(sij_b);
-                    params_sf.add_output(pij_b);
-                    params_sf.add_output(mij_b);
-                    params_sf.add_output(lij_b);
-                    params_sf.add_scalar(scale_value);
-                    params_sf.add_scalar(cl_addr);
-                    params_sf.add_scalar(chunk_bc);
-                    params_sf.add_scalar(bn);
-                    params_sf.add_scalar(batch_start);
-                    pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                        PTOParam params_sf;
+                        params_sf.add_input(sij_b);
+                        params_sf.add_output(pij_b);
+                        params_sf.add_output(mij_b);
+                        params_sf.add_output(lij_b);
+                        params_sf.add_scalar(scale_value);
+                        params_sf.add_scalar(cl_addr);
+                        params_sf.add_scalar(chunk_bc);
+                        params_sf.add_scalar(bn);
+                        params_sf.add_scalar(batch_start);
+                        pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
 
-                    PTOParam params_pv;
-                    params_pv.add_input(pij_b);
-                    params_pv.add_input(value_cache);
-                    params_pv.add_output(oi_new_b);
-                    params_pv.add_scalar(bt_addr);
-                    params_pv.add_scalar(chunk_bc);
-                    params_pv.add_scalar(bn);
-                    params_pv.add_scalar(block_num);
-                    params_pv.add_scalar(batch_start);
-                    pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                        PTOParam params_pv;
+                        params_pv.add_input(pij_b);
+                        params_pv.add_input(value_cache);
+                        params_pv.add_output(oi_new_b);
+                        params_pv.add_scalar(bt_addr);
+                        params_pv.add_scalar(chunk_bc);
+                        params_pv.add_scalar(bn);
+                        params_pv.add_scalar(block_num);
+                        params_pv.add_scalar(batch_start);
+                        pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
 
-                    uint64_t is_first = (bn == 0) ? 1 : 0;
-                    uint64_t is_last = (bn == max_bn - 1) ? 1 : 0;
-                    PTOParam params_up;
-                    params_up.add_input(mij_b);
-                    params_up.add_input(lij_b);
-                    params_up.add_input(oi_new_b);
-                    params_up.add_inout(mi_batch);
-                    params_up.add_inout(li_batch);
-                    params_up.add_inout(oi_batch);
-                    params_up.add_output(out);
-                    params_up.add_scalar(is_first);
-                    params_up.add_scalar(is_last);
-                    params_up.add_scalar(chunk_bc);
-                    params_up.add_scalar(q_offset);
-                    params_up.add_scalar(num_heads);
-                    params_up.add_scalar(batch_start);
-                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                        uint64_t is_first = (bn == 0) ? 1 : 0;
+                        uint64_t is_last = (bn == max_bn - 1) ? 1 : 0;
+                        PTOParam params_up;
+                        params_up.add_input(mij_b);
+                        params_up.add_input(lij_b);
+                        params_up.add_input(oi_new_b);
+                        params_up.add_inout(mi_batch);
+                        params_up.add_inout(li_batch);
+                        params_up.add_inout(oi_batch);
+                        params_up.add_output(out);
+                        params_up.add_scalar(is_first);
+                        params_up.add_scalar(is_last);
+                        params_up.add_scalar(chunk_bc);
+                        params_up.add_scalar(q_offset);
+                        params_up.add_scalar(num_heads);
+                        params_up.add_scalar(batch_start);
+                        pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                    }
                 }
             }
         }
+
+        LOG_INFO("batch_paged_attention: %lu tasks (batch=%lu, max_bn=%lu, chunks=%lu, IN_CORE_BATCH=%lu)",
+            (unsigned long)(num_chunks * (1 + max_bn * 4)),
+            (unsigned long)batch,
+            (unsigned long)max_bn,
+            (unsigned long)num_chunks,
+            (unsigned long)IN_CORE_BATCH);
     }
-
-    LOG_INFO("batch_paged_attention: %lu tasks (batch=%lu, max_bn=%lu, chunks=%lu, IN_CORE_BATCH=%lu)",
-             (unsigned long)(num_chunks * (1 + max_bn * 4)),
-             (unsigned long)batch, (unsigned long)max_bn,
-             (unsigned long)num_chunks, (unsigned long)IN_CORE_BATCH);
-}
-
 }
 }  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/golden.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/golden.py
@@ -95,18 +95,32 @@ def generate_inputs(params: dict) -> list:
 
     num_groups = matmul_add_task_num // grid_k
 
-    A = torch.randn(incore_loop * num_groups, grid_k, tile_size, tile_size, dtype=torch.float32) * 0.01
-    B = torch.randn(incore_loop * num_groups, grid_k, tile_size, tile_size, dtype=torch.float32) * 0.01
+    A = (
+        torch.randn(
+            incore_loop * num_groups, grid_k, tile_size, tile_size, dtype=torch.float32
+        )
+        * 0.01
+    )
+    B = (
+        torch.randn(
+            incore_loop * num_groups, grid_k, tile_size, tile_size, dtype=torch.float32
+        )
+        * 0.01
+    )
     C = torch.zeros(incore_loop * num_groups, tile_size, tile_size, dtype=torch.float32)
 
     # Reshape A/B to [num_groups, grid_k, incore_loop, tile_size, tile_size]
     # so that incore_loop tiles are contiguous for each (group, k_idx)
     A = A.reshape(num_groups, incore_loop, grid_k, tile_size, tile_size)
-    A = A.permute(0, 2, 1, 3, 4).contiguous()  # [num_groups, grid_k, incore_loop, tile_size, tile_size]
+    A = A.permute(
+        0, 2, 1, 3, 4
+    ).contiguous()  # [num_groups, grid_k, incore_loop, tile_size, tile_size]
     B = B.reshape(num_groups, incore_loop, grid_k, tile_size, tile_size)
     B = B.permute(0, 2, 1, 3, 4).contiguous()
 
-    config = torch.tensor([tile_size, grid_k, num_groups, incore_loop], dtype=torch.int64)
+    config = torch.tensor(
+        [tile_size, grid_k, num_groups, incore_loop], dtype=torch.int64
+    )
 
     A_flat = A.flatten()
     B_flat = B.flatten()
@@ -129,9 +143,15 @@ def compute_golden(tensors: dict, params: dict) -> None:
     num_groups = params["matmul_add_task_num"] // grid_k
 
     # A/B layout: [num_groups, grid_k, incore_loop, tile_size, tile_size]
-    A = torch.as_tensor(tensors["A"]).reshape(num_groups, grid_k, incore_loop, tile_size, tile_size)
-    B = torch.as_tensor(tensors["B"]).reshape(num_groups, grid_k, incore_loop, tile_size, tile_size)
-    C = torch.as_tensor(tensors["C"]).reshape(incore_loop * num_groups, tile_size, tile_size)
+    A = torch.as_tensor(tensors["A"]).reshape(
+        num_groups, grid_k, incore_loop, tile_size, tile_size
+    )
+    B = torch.as_tensor(tensors["B"]).reshape(
+        num_groups, grid_k, incore_loop, tile_size, tile_size
+    )
+    C = torch.as_tensor(tensors["C"]).reshape(
+        incore_loop * num_groups, tile_size, tile_size
+    )
 
     C[:] = 0.0
 
@@ -147,7 +167,9 @@ def compute_golden(tensors: dict, params: dict) -> None:
 if __name__ == "__main__":
     params = {"name": DEFAULT_CASE, **ALL_CASES[DEFAULT_CASE]}
     result = generate_inputs(params)
-    tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
+    tensors = {
+        name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)
+    }
     compute_golden(tensors, params)
 
     granularity = params["incore_task_granularity"]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -40,22 +40,18 @@ AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
 }
 
 template <int TILE>
-static __aicore__ void gemm_tile_impl(
-    __gm__ float* input_a,
-    __gm__ float* input_b,
-    __gm__ float* output) {
-
+static __aicore__ void gemm_tile_impl(__gm__ float* input_a, __gm__ float* input_b, __gm__ float* output) {
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
     constexpr int M = CeilAlign<int>(TILE, 16);
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);
@@ -109,8 +105,8 @@ static __aicore__ void gemm_tile_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ TensorData* input_a = reinterpret_cast<__gm__ TensorData*>(args[0]);
     __gm__ TensorData* input_b = reinterpret_cast<__gm__ TensorData*>(args[1]);
-    __gm__ TensorData* output  = reinterpret_cast<__gm__ TensorData*>(args[2]);
-    __gm__ TensorData* config  = reinterpret_cast<__gm__ TensorData*>(args[3]);
+    __gm__ TensorData* output = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    __gm__ TensorData* config = reinterpret_cast<__gm__ TensorData*>(args[3]);
 
     __gm__ int64_t* cfg = reinterpret_cast<__gm__ int64_t*>(config->buffer.addr);
     uint64_t tile_size = static_cast<uint64_t>(cfg[0]);
@@ -127,11 +123,20 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
         __gm__ float* c_ptr = base_c + (tile_idx * tile_elems);
 
         switch (tile_size) {
-            case 16:  gemm_tile_impl<16>(a_ptr, b_ptr, c_ptr);  break;
-            case 32:  gemm_tile_impl<32>(a_ptr, b_ptr, c_ptr);  break;
-            case 64:  gemm_tile_impl<64>(a_ptr, b_ptr, c_ptr);  break;
-            case 128: gemm_tile_impl<128>(a_ptr, b_ptr, c_ptr); break;
-            default: break;
+            case 16:
+                gemm_tile_impl<16>(a_ptr, b_ptr, c_ptr);
+                break;
+            case 32:
+                gemm_tile_impl<32>(a_ptr, b_ptr, c_ptr);
+                break;
+            case 64:
+                gemm_tile_impl<64>(a_ptr, b_ptr, c_ptr);
+                break;
+            case 128:
+                gemm_tile_impl<128>(a_ptr, b_ptr, c_ptr);
+                break;
+            default:
+                break;
         }
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -30,10 +30,7 @@ using namespace pto;
 #endif
 
 template <int TILE>
-static __aicore__ void tile_add_impl(
-    __gm__ float* c_ptr,
-    __gm__ float* p_ptr) {
-
+static __aicore__ void tile_add_impl(__gm__ float* c_ptr, __gm__ float* p_ptr) {
     using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
     using DynStridDim5 = Stride<1, 1, 1, TILE, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
@@ -68,7 +65,7 @@ static __aicore__ void tile_add_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ TensorData* c_tensor = reinterpret_cast<__gm__ TensorData*>(args[0]);
     __gm__ TensorData* p_tensor = reinterpret_cast<__gm__ TensorData*>(args[1]);
-    __gm__ TensorData* config   = reinterpret_cast<__gm__ TensorData*>(args[2]);
+    __gm__ TensorData* config = reinterpret_cast<__gm__ TensorData*>(args[2]);
 
     __gm__ int64_t* cfg = reinterpret_cast<__gm__ int64_t*>(config->buffer.addr);
     uint64_t tile_size = static_cast<uint64_t>(cfg[0]);
@@ -83,11 +80,20 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
         __gm__ float* p_ptr = base_p + (tile_idx * tile_elems);
 
         switch (tile_size) {
-            case 16:  tile_add_impl<16>(c_ptr, p_ptr);  break;
-            case 32:  tile_add_impl<32>(c_ptr, p_ptr);  break;
-            case 64:  tile_add_impl<64>(c_ptr, p_ptr);  break;
-            case 128: tile_add_impl<128>(c_ptr, p_ptr); break;
-            default: break;
+            case 16:
+                tile_add_impl<16>(c_ptr, p_ptr);
+                break;
+            case 32:
+                tile_add_impl<32>(c_ptr, p_ptr);
+                break;
+            case 64:
+                tile_add_impl<64>(c_ptr, p_ptr);
+                break;
+            case 128:
+                tile_add_impl<128>(c_ptr, p_ptr);
+                break;
+            default:
+                break;
         }
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -23,20 +23,19 @@
 #include "pto_orchestration_api.h"
 
 #define FUNC_GEMM_TILE 0
-#define FUNC_TILE_ADD  1
+#define FUNC_TILE_ADD 1
 
 extern "C" {
 
-__attribute__((visibility("default")))
-PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 4,
     };
 }
 
-__attribute__((visibility("default")))
-void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 
@@ -58,7 +57,12 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
     int grid_n = 1;
 
     LOG_INFO("[bgemm_orch] tile_size: %d, grid_m: %d, grid_n: %d, grid_k: %d, num_groups: %d, incore_loop: %d",
-             tile_size, grid_m, grid_n, grid_k, num_groups, incore_loop);
+        tile_size,
+        grid_m,
+        grid_n,
+        grid_k,
+        num_groups,
+        incore_loop);
 
     uint32_t tile_shapes[1] = {(uint32_t)tile_elems};
     uint64_t group_tile_elems = (uint64_t)incore_loop * tile_elems;
@@ -79,8 +83,7 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
         for (int k_idx = 0; k_idx < grid_k; k_idx++) {
             // In layout [num_groups, grid_k, incore_loop, tile_size, tile_size],
             // offset = (group_idx * grid_k + k_idx) * incore_loop * tile_elems
-            uint64_t ab_offset =
-                ((uint64_t)group_idx * grid_k + (uint64_t)k_idx) * group_tile_elems;
+            uint64_t ab_offset = ((uint64_t)group_idx * grid_k + (uint64_t)k_idx) * group_tile_elems;
 
             uint32_t a_view_offsets[1] = {(uint32_t)ab_offset};
             Tensor A_view = ext_A.view(group_shapes, a_view_offsets);
@@ -106,7 +109,9 @@ void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch
     }
 
     LOG_INFO("[bgemm_orch] Submitted %d gemm tasks and %d add tasks (%d total)",
-             total_gemm, total_add, total_gemm + total_add);
+        total_gemm,
+        total_add,
+        total_gemm + total_add);
 }
 
 }  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -61,9 +61,9 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
 
     // Load pij and vj to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, pijGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, vjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -62,9 +62,9 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
 
     // Load A and B to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, qiGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, kjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -126,7 +126,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to the same UB as DN tiles for storing as ND format
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);           // alias same UB as mijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
         TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,21 +173,21 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        TMAX(miNewRow, miRow, mijRow);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        TSUB(alphaRow, miRow, miNewRow);  // alpha_exp = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        TSUB(betaRow, mijRow, miNewRow);  // beta_exp = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        TEXP(betaRow, betaRow);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        TMUL(tmpRow, alphaRow, liRow);  // alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        TMUL(liNewRow, betaRow, lijRow);  // beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         TRESHAPE(alphaDN, alphaRow);
@@ -195,9 +195,9 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
 
         // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
         // Alias ND tiles to the same UB locations as miNewRow and liNewRow
@@ -212,15 +212,15 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -31,11 +31,8 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
-    float scale_value,
-    __gm__ Tensor* pij,
-    __gm__ Tensor* mij,
-    __gm__ Tensor* lij) {
+static __aicore__ void softmax_prepare_impl(
+    __gm__ Tensor* sij, float scale_value, __gm__ Tensor* pij, __gm__ Tensor* mij, __gm__ Tensor* lij) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
     __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
     __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
@@ -102,14 +99,14 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     // Truncate pij to bf16 first
     pipe_barrier(PIPE_V);
     TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);        // pij bf16 ready, can store early
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);  // pij bf16 ready, can store early
 
     // Continue computing: bf16 → f32 and rowsum while pij store proceeds in parallel
     pipe_barrier(PIPE_V);
     TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
     pipe_barrier(PIPE_V);
     TROWSUM(sumTile, pijTile, tmpTile);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);        // sum ready
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);  // sum ready
 
     // Store pij (overlaps with TCVT + TROWSUM above)
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
@@ -28,13 +28,43 @@ ORCHESTRATION = {
 # Kernel configs (aiv_normalize removed - merged into aiv_online_update)
 KERNELS = [
     # AIC kernels (matrix multiplication using Cube unit)
-    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),       "core_type": "aic"},
+    {
+        "func_id": 0,
+        "name": "QK",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 2,
+        "name": "PV",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 4,
+        "name": "AIC_HUB",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),
+        "core_type": "aic",
+    },
     # AIV kernels (vector operations)
-    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),       "core_type": "aiv"},
+    {
+        "func_id": 1,
+        "name": "SF",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 3,
+        "name": "UP",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 5,
+        "name": "AIV_HUB",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 # Runtime configuration

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -35,19 +35,24 @@ inline uint64_t get_sys_cnt_aicpu() {
 }
 
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
-#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+#define CYCLE_COUNT_LAP(acc)       \
+    do {                           \
+        _t1 = get_sys_cnt_aicpu(); \
+        acc += (_t1 - _t0);        \
+        _t0 = _t1;                 \
+    } while (0)
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
     uint64_t prof_param_extract = 0;
@@ -64,13 +69,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(TaskArg* o
     CYCLE_COUNT_START();
 
     // Read dimensions from TaskArg tensor metadata
-    uint64_t batch     = orch_args[0].tensor.shapes[0];
+    uint64_t batch = orch_args[0].tensor.shapes[0];
     uint64_t num_heads = orch_args[0].tensor.shapes[1];
-    uint64_t head_dim  = orch_args[0].tensor.shapes[2];
+    uint64_t head_dim = orch_args[0].tensor.shapes[2];
     DataType data_type = orch_args[0].tensor.dtype;
 
     uint64_t block_size = orch_args[1].tensor.shapes[1];
-    uint64_t block_num  = orch_args[3].tensor.shapes[1];
+    uint64_t block_num = orch_args[3].tensor.shapes[1];
 
     uint64_t scale_value = orch_args[6].scalar;
 
@@ -83,9 +88,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(TaskArg* o
 
     // Reshape tensors for kernel consumption (2D flattened)
     void* query_ptr = orch_args[0].data<void>();
-    void* kc_ptr    = orch_args[1].data<void>();
-    void* vc_ptr    = orch_args[2].data<void>();
-    void* out_ptr   = orch_args[5].data<void>();
+    void* kc_ptr = orch_args[1].data<void>();
+    void* vc_ptr = orch_args[2].data<void>();
+    void* out_ptr = orch_args[5].data<void>();
 
     uint64_t total_blocks_count = orch_args[1].tensor.shapes[0];
 
@@ -99,7 +104,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(TaskArg* o
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
     CYCLE_COUNT_LAP(prof_ext_tensor);
 
-    int* host_block_table  = orch_args[3].data<int>();
+    int* host_block_table = orch_args[3].data<int>();
     int* host_context_lens = orch_args[4].data<int>();
 
     int total_tasks = 0;
@@ -227,27 +232,36 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(TaskArg* o
         }
     }
 
-    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor +
-                     prof_tensor_view + prof_param_setup + prof_submit_task + prof_scope;
+    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
+                     prof_submit_task + prof_scope;
     LOG_ALWAYS("=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
-        prof_submit_count, prof_make_count, prof_view_count, cycles_to_us(total));
+        prof_submit_count,
+        prof_make_count,
+        prof_view_count,
+        cycles_to_us(total));
     if (total > 0) {
         LOG_ALWAYS("  param_extract    : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_extract), prof_param_extract * 100.0 / total);
-        LOG_ALWAYS("  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
+            cycles_to_us(prof_param_extract),
+            prof_param_extract * 100.0 / total);
+        LOG_ALWAYS(
+            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
         LOG_ALWAYS("  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_make_count, cycles_to_us(prof_make_tensor), prof_make_tensor * 100.0 / total,
+            prof_make_count,
+            cycles_to_us(prof_make_tensor),
+            prof_make_tensor * 100.0 / total,
             prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
         LOG_ALWAYS("  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_view_count, cycles_to_us(prof_tensor_view), prof_tensor_view * 100.0 / total,
+            prof_view_count,
+            cycles_to_us(prof_tensor_view),
+            prof_tensor_view * 100.0 / total,
             prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
-        LOG_ALWAYS("  param_setup      : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_setup),
-            prof_param_setup * 100.0 / total);
+        LOG_ALWAYS(
+            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
         LOG_ALWAYS("  scope            : %7.3fus (%5.1f%%)", cycles_to_us(prof_scope), prof_scope * 100.0 / total);
         LOG_ALWAYS("  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_submit_count, cycles_to_us(prof_submit_task), prof_submit_task * 100.0 / total,
+            prof_submit_count,
+            cycles_to_us(prof_submit_task),
+            prof_submit_task * 100.0 / total,
             prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
     }
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/kernels/kernel_config.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/kernels/kernel_config.py
@@ -25,12 +25,42 @@ ORCHESTRATION = {
 }
 
 KERNELS = [
-    {"func_id": 0, "name": "QK", "source": str(_PA_KERNELS / "aic" / "aic_qk_matmul.cpp"), "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_PA_KERNELS / "aic" / "aic_pv_matmul.cpp"), "core_type": "aic"},
-    {"func_id": 4, "name": "AIC_HUB", "source": str(_PA_KERNELS / "aic" / "aic_hub.cpp"), "core_type": "aic"},
-    {"func_id": 1, "name": "SF", "source": str(_PA_KERNELS / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_PA_KERNELS / "aiv" / "aiv_online_update.cpp"), "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": str(_PA_KERNELS / "aiv" / "aiv_hub.cpp"), "core_type": "aiv"},
+    {
+        "func_id": 0,
+        "name": "QK",
+        "source": str(_PA_KERNELS / "aic" / "aic_qk_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 2,
+        "name": "PV",
+        "source": str(_PA_KERNELS / "aic" / "aic_pv_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 4,
+        "name": "AIC_HUB",
+        "source": str(_PA_KERNELS / "aic" / "aic_hub.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "SF",
+        "source": str(_PA_KERNELS / "aiv" / "aiv_softmax_prepare.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 3,
+        "name": "UP",
+        "source": str(_PA_KERNELS / "aiv" / "aiv_online_update.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 5,
+        "name": "AIV_HUB",
+        "source": str(_PA_KERNELS / "aiv" / "aiv_hub.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 RUNTIME_CONFIG = {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
@@ -52,4 +52,6 @@ def generate_inputs(params: dict) -> list:
 
 
 if __name__ == "__main__":
-    run_golden_test(ALL_CASES, DEFAULT_CASE, generate_inputs, label="Paged Attention Unroll")
+    run_golden_test(
+        ALL_CASES, DEFAULT_CASE, generate_inputs, label="Paged Attention Unroll"
+    )

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -38,13 +38,11 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_n_impl(
-    __gm__ bfloat16_t* pij_base,
+static __aicore__ void pv_matmul_n_impl(__gm__ bfloat16_t* pij_base,
     __gm__ bfloat16_t* val_base,
     __gm__ float* oi_base,
     uint64_t n_blocks,
     __gm__ int32_t* block_table) {
-
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
@@ -96,9 +94,9 @@ static __aicore__ void pv_matmul_n_impl(
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
         wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
         TLOAD(aMatTile[cur], pijGlobal);
-        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);   // forward: A in L1 ready
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: A in L1 ready
         TLOAD(bMatTile[cur], vjGlobal);
-        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);   // forward: B in L1 ready
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: B in L1 ready
 
         // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
         // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
@@ -107,17 +105,17 @@ static __aicore__ void pv_matmul_n_impl(
         TMOV(aTile[cur], aMatTile[cur]);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
         TMOV(bTile[cur], bMatTile[cur]);
-        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur); // reverse: release L1[cur]
+        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);  // reverse: release L1[cur]
 
         // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
-        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);   // forward: L0[cur] ready
+        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);  // forward: L0[cur] ready
         wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
         if (i == 0) {
             TMATMUL(cTile, aTile[cur], bTile[cur]);
         } else {
             TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
         }
-        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);   // reverse: release L0[cur]
+        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);  // reverse: release L0[cur]
     }
 
     // Drain outstanding reverse-dependency flags

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -32,13 +32,11 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_n_impl(
-    __gm__ bfloat16_t* qi_base,
+static __aicore__ void qk_matmul_n_impl(__gm__ bfloat16_t* qi_base,
     __gm__ bfloat16_t* key_base,
     __gm__ float* sij_base,
     uint64_t n_blocks,
     __gm__ int32_t* block_table) {
-
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -126,8 +126,8 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to same UB as DN tiles for ND-format store
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);                    // alias same UB as mijDN
-        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);   // alias same UB as lijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
+        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,21 +173,21 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        TMAX(miNewRow, miRow, mijRow);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        TSUB(alphaRow, miRow, miNewRow);  // alpha_exp = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        TSUB(betaRow, mijRow, miNewRow);  // beta_exp = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        TEXP(betaRow, betaRow);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        TMUL(tmpRow, alphaRow, liRow);  // alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        TMUL(liNewRow, betaRow, lijRow);  // beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         pipe_barrier(PIPE_V);
@@ -195,11 +195,11 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         TRESHAPE(betaDN, betaRow);
 
         // Scale data tiles using row-broadcast multiply
-        TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
+        TROWEXPANDMUL(oiTile, oiTile, alphaDN);  // oi *= alpha
         pipe_barrier(PIPE_V);
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
         // Alias ND tiles to the same UB locations as miNewRow and liNewRow
@@ -214,15 +214,15 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -36,15 +36,13 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_n_impl(
-    __gm__ float* sij_base,
+static __aicore__ void softmax_prepare_n_impl(__gm__ float* sij_base,
     float scale_value,
     __gm__ bfloat16_t* pij_base,
     __gm__ float* mij_addr,
     __gm__ float* lij_addr,
     uint64_t n_blocks,
     uint64_t valid_len_last) {
-
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
     constexpr int kScalarCols = 32 / sizeof(float);
     constexpr int kScalarRows = M / kScalarCols;
@@ -100,10 +98,10 @@ static __aicore__ void softmax_prepare_n_impl(
     TASSIGN(sumAccTile, 4 * kDataBytes);
     int scalarBase = 5 * kDataBytes;
     TASSIGN(localMaxDN, scalarBase);
-    TASSIGN(localMaxRow, scalarBase);                     // alias: same UB as localMaxDN
+    TASSIGN(localMaxRow, scalarBase);  // alias: same UB as localMaxDN
     TASSIGN(globalMaxDN, scalarBase + kScalarDNBytes);
-    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
-    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);    // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);  // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
     TASSIGN(sumDN, scalarBase + 2 * kScalarDNBytes);
     TASSIGN(pijBf16Tile, scalarBase + 3 * kScalarDNBytes);
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
@@ -28,13 +28,43 @@ ORCHESTRATION = {
 # Kernel configs (aiv_normalize removed - merged into aiv_online_update)
 KERNELS = [
     # AIC kernels (matrix multiplication using Cube unit)
-    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),       "core_type": "aic"},
+    {
+        "func_id": 0,
+        "name": "QK",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 2,
+        "name": "PV",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 4,
+        "name": "AIC_HUB",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),
+        "core_type": "aic",
+    },
     # AIV kernels (vector operations)
-    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),       "core_type": "aiv"},
+    {
+        "func_id": 1,
+        "name": "SF",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 3,
+        "name": "UP",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 5,
+        "name": "AIV_HUB",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 # Runtime configuration

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -57,37 +57,37 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
-    uint64_t prof_ext_tensor    = 0;
-    uint64_t prof_make_tensor   = 0;
-    uint64_t prof_tensor_view   = 0;
-    uint64_t prof_param_setup   = 0;
-    uint64_t prof_submit_task   = 0;
+    uint64_t prof_ext_tensor = 0;
+    uint64_t prof_make_tensor = 0;
+    uint64_t prof_tensor_view = 0;
+    uint64_t prof_param_setup = 0;
+    uint64_t prof_submit_task = 0;
     uint64_t prof_scope_and_loop = 0;
-    int      prof_submit_count  = 0;
-    int      prof_make_count    = 0;
-    int      prof_view_count    = 0;
+    int prof_submit_count = 0;
+    int prof_make_count = 0;
+    int prof_view_count = 0;
 #endif
 
     CYCLE_COUNT_START();
 
     // Read dimensions from TaskArg tensor metadata
     // query: shape=[batch, num_heads, head_dim]
-    uint64_t batch     = orch_args[0].tensor.shapes[0];
+    uint64_t batch = orch_args[0].tensor.shapes[0];
     uint64_t num_heads = orch_args[0].tensor.shapes[1];
-    uint64_t head_dim  = orch_args[0].tensor.shapes[2];
+    uint64_t head_dim = orch_args[0].tensor.shapes[2];
     DataType data_type = orch_args[0].tensor.dtype;
 
     // key_cache: shape=[total_blocks, block_size, kv_head_num, head_dim]
@@ -105,9 +105,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(TaskArg* o
 
     // Reshape tensors for kernel consumption (2D flattened)
     void* query_ptr = orch_args[0].data<void>();
-    void* kc_ptr    = orch_args[1].data<void>();
-    void* vc_ptr    = orch_args[2].data<void>();
-    void* out_ptr   = orch_args[5].data<void>();
+    void* kc_ptr = orch_args[1].data<void>();
+    void* vc_ptr = orch_args[2].data<void>();
+    void* out_ptr = orch_args[5].data<void>();
 
     uint64_t total_blocks_count = orch_args[1].tensor.shapes[0];
 
@@ -120,7 +120,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(TaskArg* o
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
-    int* host_block_table  = orch_args[3].data<int>();
+    int* host_block_table = orch_args[3].data<int>();
     int* host_context_lens = orch_args[4].data<int>();
 
 #ifdef ENABLE_PROFILING
@@ -284,29 +284,39 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(TaskArg* o
     CYCLE_COUNT_LAP(prof_scope_and_loop);
 
 #ifdef ENABLE_PROFILING
-    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor +
-                     prof_tensor_view + prof_param_setup + prof_submit_task +
-                     prof_scope_and_loop;
+    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
+                     prof_submit_task + prof_scope_and_loop;
     LOG_ALWAYS("=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
-        prof_submit_count, prof_make_count, prof_view_count, cycles_to_us(total));
+        prof_submit_count,
+        prof_make_count,
+        prof_view_count,
+        cycles_to_us(total));
     if (total > 0) {
         LOG_ALWAYS("  param_extract    : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_extract), prof_param_extract * 100.0 / total);
-        LOG_ALWAYS("  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
+            cycles_to_us(prof_param_extract),
+            prof_param_extract * 100.0 / total);
+        LOG_ALWAYS(
+            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
         LOG_ALWAYS("  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_make_count, cycles_to_us(prof_make_tensor), prof_make_tensor * 100.0 / total,
+            prof_make_count,
+            cycles_to_us(prof_make_tensor),
+            prof_make_tensor * 100.0 / total,
             prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
         LOG_ALWAYS("  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_view_count, cycles_to_us(prof_tensor_view), prof_tensor_view * 100.0 / total,
+            prof_view_count,
+            cycles_to_us(prof_tensor_view),
+            prof_tensor_view * 100.0 / total,
             prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
-        LOG_ALWAYS("  param_setup      : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
+        LOG_ALWAYS(
+            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
         LOG_ALWAYS("  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_submit_count, cycles_to_us(prof_submit_task), prof_submit_task * 100.0 / total,
+            prof_submit_count,
+            cycles_to_us(prof_submit_task),
+            prof_submit_task * 100.0 / total,
             prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
         LOG_ALWAYS("  scope_and_loop   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_scope_and_loop), prof_scope_and_loop * 100.0 / total);
+            cycles_to_us(prof_scope_and_loop),
+            prof_scope_and_loop * 100.0 / total);
     }
 #endif
 

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -22,19 +22,18 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw)
-{
+static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw) {
     __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
-    __gm__ bfloat16_t* vj  = reinterpret_cast<__gm__ bfloat16_t*>(vj_raw);
-    __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ bfloat16_t* vj = reinterpret_cast<__gm__ bfloat16_t*>(vj_raw);
+    __gm__ float* oi = reinterpret_cast<__gm__ float*>(oi_raw);
 
     // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M*K, M*K, M*K, K, 1>>;
-    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K*N, K*N, K*N, N, 1>>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   pijGlobal(pij);
-    GlobalB   vjGlobal(vj);
+    GlobalA pijGlobal(pij);
+    GlobalB vjGlobal(vj);
     GlobalOut oiGlobal(oi);
 
     // L1 Mat tiles: standard ND pattern for both A and B
@@ -42,18 +41,18 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<bfloat16_t, M, K, M, K>;
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -81,10 +80,9 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     TSTORE(oiGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* pij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* vj     = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* vj = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
     int q_tile_size = static_cast<int>(args[3]);
     // args[4] = block_size, args[5] = head_dim

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -22,20 +22,19 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw)
-{
-    __gm__ bfloat16_t* qi  = reinterpret_cast<__gm__ bfloat16_t*>(qi_raw);
-    __gm__ bfloat16_t* kj  = reinterpret_cast<__gm__ bfloat16_t*>(kj_raw);
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw) {
+    __gm__ bfloat16_t* qi = reinterpret_cast<__gm__ bfloat16_t*>(qi_raw);
+    __gm__ bfloat16_t* kj = reinterpret_cast<__gm__ bfloat16_t*>(kj_raw);
+    __gm__ float* sij = reinterpret_cast<__gm__ float*>(sij_raw);
 
     // qi (M, K) bf16 in ND (row-major) layout
-    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   qiGlobal(qi);
-    GlobalB   kjGlobal(kj);
+    GlobalA qiGlobal(qi);
+    GlobalB kjGlobal(kj);
     GlobalOut sijGlobal(sij);
 
     // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
@@ -43,18 +42,18 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<bfloat16_t, M, K, M, K>;
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -82,10 +81,9 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     TSTORE(sijGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* qi  = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* kj  = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ uint8_t* qi = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* kj = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
     int q_tile_size = static_cast<int>(args[3]);
     // args[4] = head_dim (128), args[5] = block_size

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -24,18 +24,22 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_t* lij_raw,
-                               __gm__ uint8_t* oi_new_raw, __gm__ uint8_t* mi_raw,
-                               __gm__ uint8_t* li_raw, __gm__ uint8_t* oi_raw,
-                               int is_first, int is_last, __gm__ uint8_t* dst_raw)
-{
-    __gm__ float* mij_ptr    = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float* lij_ptr    = reinterpret_cast<__gm__ float*>(lij_raw);
+static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw,
+    __gm__ uint8_t* lij_raw,
+    __gm__ uint8_t* oi_new_raw,
+    __gm__ uint8_t* mi_raw,
+    __gm__ uint8_t* li_raw,
+    __gm__ uint8_t* oi_raw,
+    int is_first,
+    int is_last,
+    __gm__ uint8_t* dst_raw) {
+    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij_raw);
+    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij_raw);
     __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new_raw);
-    __gm__ float* mi_ptr     = reinterpret_cast<__gm__ float*>(mi_raw);
-    __gm__ float* li_ptr     = reinterpret_cast<__gm__ float*>(li_raw);
-    __gm__ float* oi_ptr     = reinterpret_cast<__gm__ float*>(oi_raw);
-    __gm__ float* dst_ptr    = reinterpret_cast<__gm__ float*>(dst_raw);
+    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi_raw);
+    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li_raw);
+    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst_raw);
 
     // Scalar tile dimensions for RowMajor layout:
     // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
@@ -51,12 +55,11 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<1, 1, 1, N, 1>>;
 
     // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
-    using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
-                                        pto::Stride<1, 1, 1, kScalarCols, 1>>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, pto::Stride<1, 1, 1, kScalarCols, 1>>;
 
     // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
-                                        pto::Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, pto::Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -78,8 +81,8 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     // --- Tile types ---
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
-    using TileScalarND = Tile<TileType::Vec, float, kScalarRows, kScalarCols,
-                              BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     // --- UB memory layout ---
@@ -124,9 +127,9 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Passthrough to MTE3 (no V compute needed)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, mijND);     // mi = mij
-        TSTORE(liGlobalND, lijND);     // li = lij
-        TSTORE(oiGlobal, oiNewTile);   // oi = oi_new
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
 
         if (is_last) {
             // Single block: normalize dst = oi_new / lij
@@ -156,44 +159,44 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
 
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
         // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
-        TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
-        TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
-        TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
-        TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
-        TMUL(liND, alphaND, liND);           // li = alpha * li
-        TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
-        TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
+        TMAX(miNewND, miND, mijND);    // mi_new = max(mi, mij)
+        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
+        TEXP(alphaND, alphaND);        // alpha = exp(mi - mi_new)
+        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
+        TEXP(betaND, betaND);          // beta = exp(mij - mi_new)
+        TMUL(liND, alphaND, liND);     // li = alpha * li
+        TMUL(tmpND, betaND, lijND);    // tmp = beta * lij
+        TADD(liND, liND, tmpND);       // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
         // mi_new → mi accumulator, li_new → li accumulator
         // alpha → mij buffer (reuse), beta → lij buffer (reuse)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, miNewND);         // persist mi_new
-        TSTORE(liGlobalND, liND);            // persist li_new
-        TSTORE(mijGlobalND, alphaND);        // temp: alpha to mij buffer
-        TSTORE(lijGlobalND, betaND);         // temp: beta to lij buffer
+        TSTORE(miGlobalND, miNewND);   // persist mi_new
+        TSTORE(liGlobalND, liND);      // persist li_new
+        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
 
         // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        TLOAD(alphaDN, mijGlobalDN);         // alpha from mij buffer as DN
-        TLOAD(betaDN, lijGlobalDN);          // beta from lij buffer as DN
+        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
         if (is_last) {
-            TLOAD(liDN, liGlobalDN);         // li_new from li buffer as DN
+            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
         }
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
 
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
-        TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
+        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
-            TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
+            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             TSTORE(dstGlobal, oiTile);
@@ -207,15 +210,15 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* mij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* lij    = reinterpret_cast<__gm__ uint8_t*>(args[1]);
+    __gm__ uint8_t* mij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
+    __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[1]);
     __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mi     = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* li     = reinterpret_cast<__gm__ uint8_t*>(args[4]);
-    __gm__ uint8_t* oi     = reinterpret_cast<__gm__ uint8_t*>(args[5]);
-    int is_first  = static_cast<int>(args[6]);
-    int is_last   = static_cast<int>(args[7]);
-    __gm__ uint8_t* dst    = reinterpret_cast<__gm__ uint8_t*>(args[8]);
+    __gm__ uint8_t* mi = reinterpret_cast<__gm__ uint8_t*>(args[3]);
+    __gm__ uint8_t* li = reinterpret_cast<__gm__ uint8_t*>(args[4]);
+    __gm__ uint8_t* oi = reinterpret_cast<__gm__ uint8_t*>(args[5]);
+    int is_first = static_cast<int>(args[6]);
+    int is_last = static_cast<int>(args[7]);
+    __gm__ uint8_t* dst = reinterpret_cast<__gm__ uint8_t*>(args[8]);
     int q_tile_size = static_cast<int>(args[9]);
     // args[10] = head_dim (128)
 

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -29,14 +29,16 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
-                                 __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
-                                 __gm__ uint8_t* lij_raw, int valid_len)
-{
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw,
+    float scale_value,
+    __gm__ uint8_t* pij_raw,
+    __gm__ uint8_t* mij_raw,
+    __gm__ uint8_t* lij_raw,
+    int valid_len) {
+    __gm__ float* sij = reinterpret_cast<__gm__ float*>(sij_raw);
     __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
-    __gm__ float*      mij = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float*      lij = reinterpret_cast<__gm__ float*>(lij_raw);
+    __gm__ float* mij = reinterpret_cast<__gm__ float*>(mij_raw);
+    __gm__ float* lij = reinterpret_cast<__gm__ float*>(lij_raw);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -52,8 +54,7 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
     // Dynamic-cols tile: marks which columns are valid for TFILLPAD boundary
     using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
     // Padded tile: TFILLPAD_INPLACE fills positions [valid_len, N) with -inf
-    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N,
-                            SLayout::NoneBox, 512, PadValue::Min>;
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N, SLayout::NoneBox, 512, PadValue::Min>;
 
     using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
     using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
@@ -105,7 +106,10 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    union { uint64_t u; float f; } scale_conv;
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[1]);
     float scale_value = scale_conv.f;
     __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[2]);

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/kernel_config.py
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/kernel_config.py
@@ -28,11 +28,31 @@ ORCHESTRATION = {
 # Kernel configs (aiv_normalize removed - merged into aiv_online_update)
 KERNELS = [
     # AIC kernels (matrix multiplication using Cube unit)
-    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
+    {
+        "func_id": 0,
+        "name": "QK",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 2,
+        "name": "PV",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),
+        "core_type": "aic",
+    },
     # AIV kernels (vector operations)
-    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
+    {
+        "func_id": 1,
+        "name": "SF",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 3,
+        "name": "UP",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 # Runtime configuration

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -19,10 +19,10 @@
 #include <algorithm>
 #include <cstring>
 
-#define FUNC_QK_MATMUL       0
+#define FUNC_QK_MATMUL 0
 #define FUNC_SOFTMAX_PREPARE 1
-#define FUNC_PV_MATMUL       2
-#define FUNC_ONLINE_UPDATE   3
+#define FUNC_PV_MATMUL 2
+#define FUNC_ONLINE_UPDATE 3
 
 extern "C" {
 
@@ -33,27 +33,27 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     }
 
     // Extract host pointers from TaskArg tensor metadata
-    void* host_query       = orch_args[0].data<void>();
-    void* host_key_cache   = orch_args[1].data<void>();
+    void* host_query = orch_args[0].data<void>();
+    void* host_key_cache = orch_args[1].data<void>();
     void* host_value_cache = orch_args[2].data<void>();
-    int*  host_block_table = orch_args[3].data<int>();
-    int*  host_context_lens = orch_args[4].data<int>();
-    void* host_out         = orch_args[5].data<void>();
+    int* host_block_table = orch_args[3].data<int>();
+    int* host_context_lens = orch_args[4].data<int>();
+    void* host_out = orch_args[5].data<void>();
 
     // Extract sizes from TaskArg metadata
-    size_t query_size       = orch_args[0].nbytes();
-    size_t key_cache_size   = orch_args[1].nbytes();
+    size_t query_size = orch_args[0].nbytes();
+    size_t key_cache_size = orch_args[1].nbytes();
     size_t value_cache_size = orch_args[2].nbytes();
-    size_t out_size         = orch_args[5].nbytes();
+    size_t out_size = orch_args[5].nbytes();
 
     // Read dimensions from tensor shapes (uint32_t — matches TaskArg::tensor.shapes type)
     // query: (batch, num_heads, head_dim)
-    uint32_t batch       = orch_args[0].tensor.shapes[0];
-    uint32_t num_heads   = orch_args[0].tensor.shapes[1];
-    uint32_t head_dim    = orch_args[0].tensor.shapes[2];
+    uint32_t batch = orch_args[0].tensor.shapes[0];
+    uint32_t num_heads = orch_args[0].tensor.shapes[1];
+    uint32_t head_dim = orch_args[0].tensor.shapes[2];
 
     // key_cache: (total_blocks, block_size, kv_head_num, head_dim)
-    uint32_t block_size  = orch_args[1].tensor.shapes[1];
+    uint32_t block_size = orch_args[1].tensor.shapes[1];
     uint32_t kv_head_num = orch_args[1].tensor.shapes[2];
 
     // block_table: (batch, max_num_blocks_per_req)
@@ -66,8 +66,8 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     uint32_t num_head_tiles = (num_heads + q_tile_size - 1) / q_tile_size;
 
     std::cout << "\n=== build_paged_attention_graph ===" << '\n';
-    std::cout << "batch=" << batch << ", num_heads=" << num_heads
-              << ", kv_head_num=" << kv_head_num << ", head_dim=" << head_dim << '\n';
+    std::cout << "batch=" << batch << ", num_heads=" << num_heads << ", kv_head_num=" << kv_head_num
+              << ", head_dim=" << head_dim << '\n';
     std::cout << "block_size=" << block_size << ", max_num_blocks=" << max_num_blocks << '\n';
     std::cout << "q_tile_size=" << q_tile_size << ", num_head_tiles=" << num_head_tiles << '\n';
 
@@ -88,25 +88,25 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
     runtime->record_tensor_pair(host_out, dev_out, out_size);
 
     // Buffer sizes depend on q_tile_size and block_size
-    size_t sij_size    = static_cast<size_t>(q_tile_size) * block_size * sizeof(float);
-    size_t pij_size    = static_cast<size_t>(q_tile_size) * block_size * sizeof(uint16_t);
-    size_t mij_size    = static_cast<size_t>(q_tile_size) * sizeof(float);
-    size_t lij_size    = mij_size;
+    size_t sij_size = static_cast<size_t>(q_tile_size) * block_size * sizeof(float);
+    size_t pij_size = static_cast<size_t>(q_tile_size) * block_size * sizeof(uint16_t);
+    size_t mij_size = static_cast<size_t>(q_tile_size) * sizeof(float);
+    size_t lij_size = mij_size;
     size_t oi_new_size = static_cast<size_t>(q_tile_size) * head_dim * sizeof(float);
 
     // Per-batch-per-block intermediate buffers
     uint32_t total_buffers = batch * max_num_blocks;
-    void** dev_sij_arr    = new void*[total_buffers];
-    void** dev_pij_arr    = new void*[total_buffers];
-    void** dev_mij_arr    = new void*[total_buffers];
-    void** dev_lij_arr    = new void*[total_buffers];
+    void** dev_sij_arr = new void*[total_buffers];
+    void** dev_pij_arr = new void*[total_buffers];
+    void** dev_mij_arr = new void*[total_buffers];
+    void** dev_lij_arr = new void*[total_buffers];
     void** dev_oi_new_arr = new void*[total_buffers];
 
     for (uint32_t i = 0; i < total_buffers; i++) {
-        dev_sij_arr[i]    = runtime->host_api.device_malloc(sij_size);
-        dev_pij_arr[i]    = runtime->host_api.device_malloc(pij_size);
-        dev_mij_arr[i]    = runtime->host_api.device_malloc(mij_size);
-        dev_lij_arr[i]    = runtime->host_api.device_malloc(lij_size);
+        dev_sij_arr[i] = runtime->host_api.device_malloc(sij_size);
+        dev_pij_arr[i] = runtime->host_api.device_malloc(pij_size);
+        dev_mij_arr[i] = runtime->host_api.device_malloc(mij_size);
+        dev_lij_arr[i] = runtime->host_api.device_malloc(lij_size);
         dev_oi_new_arr[i] = runtime->host_api.device_malloc(oi_new_size);
     }
 
@@ -140,12 +140,12 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
             // Query: (batch, q_head_num, head_dim) bf16
             // qi points to heads [cur_offset .. cur_offset+q_tile_size) for batch b_idx
-            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query)
-                + static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
+            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query) +
+                              static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
 
             // Output: (batch * q_head_num, head_dim) float32
-            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out)
-                + static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
+            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out) +
+                               static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
 
             // GQA: which kv_head this head tile maps to
             uint32_t kv_head_idx = cur_offset / (num_heads / kv_head_num);
@@ -166,57 +166,51 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
                 // Stride to block: cur_block_idx * (block_size * kv_head_num * head_dim)
                 // Then offset to kv_head: kv_head_idx * head_dim (within each token row)
                 // But since we want contiguous (block_size, head_dim), and kv_head_num=1 makes it simple:
-                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache)
-                    + (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx)
-                      * head_dim * sizeof(uint16_t);
+                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache) +
+                                  (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
+                                      head_dim * sizeof(uint16_t);
 
                 // Value: (total_blocks, block_size, kv_head_num, head_dim) bf16 - same layout as key
-                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache)
-                    + (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx)
-                      * head_dim * sizeof(uint16_t);
+                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache) +
+                                  (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
+                                      head_dim * sizeof(uint16_t);
 
                 uint32_t buf_idx = b_idx * max_num_blocks + bn;
-                void* dev_sij    = dev_sij_arr[buf_idx];
-                void* dev_pij    = dev_pij_arr[buf_idx];
-                void* dev_mij    = dev_mij_arr[buf_idx];
-                void* dev_lij    = dev_lij_arr[buf_idx];
+                void* dev_sij = dev_sij_arr[buf_idx];
+                void* dev_pij = dev_pij_arr[buf_idx];
+                void* dev_mij = dev_mij_arr[buf_idx];
+                void* dev_lij = dev_lij_arr[buf_idx];
                 void* dev_oi_new = dev_oi_new_arr[buf_idx];
 
                 // QK: qi(M, K) @ kj.T(K, N) -> sij(M, N)
-                uint64_t qk_args[6] = {
-                    reinterpret_cast<uint64_t>(qi_ptr),
+                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),
                     reinterpret_cast<uint64_t>(kj_ptr),
                     reinterpret_cast<uint64_t>(dev_sij),
                     static_cast<uint64_t>(q_tile_size),
                     static_cast<uint64_t>(head_dim),
-                    static_cast<uint64_t>(block_size)
-                };
+                    static_cast<uint64_t>(block_size)};
                 int t_qk = runtime->add_task(qk_args, 6, FUNC_QK_MATMUL, CoreType::AIC);
                 total_tasks++;
 
                 // SF: scale, rowmax, exp, rowsum -> pij, mij, lij
-                uint64_t sf_args[8] = {
-                    reinterpret_cast<uint64_t>(dev_sij),
+                uint64_t sf_args[8] = {reinterpret_cast<uint64_t>(dev_sij),
                     scale_value_bits,
                     reinterpret_cast<uint64_t>(dev_pij),
                     reinterpret_cast<uint64_t>(dev_mij),
                     reinterpret_cast<uint64_t>(dev_lij),
                     static_cast<uint64_t>(q_tile_size),
                     static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(valid_len)
-                };
+                    static_cast<uint64_t>(valid_len)};
                 int t_sf = runtime->add_task(sf_args, 8, FUNC_SOFTMAX_PREPARE, CoreType::AIV);
                 total_tasks++;
 
                 // PV: pij(M, K') @ vj(K', N') -> oi_new(M, N')
-                uint64_t pv_args[6] = {
-                    reinterpret_cast<uint64_t>(dev_pij),
+                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),
                     reinterpret_cast<uint64_t>(vj_ptr),
                     reinterpret_cast<uint64_t>(dev_oi_new),
                     static_cast<uint64_t>(q_tile_size),
                     static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(head_dim)
-                };
+                    static_cast<uint64_t>(head_dim)};
                 int t_pv = runtime->add_task(pv_args, 6, FUNC_PV_MATMUL, CoreType::AIC);
                 total_tasks++;
 
@@ -225,10 +219,9 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
                 // Online Update: serialized across blocks (each depends on previous)
                 int is_first = (bn == 0) ? 1 : 0;
-                int is_last  = (bn == bn_this_batch - 1) ? 1 : 0;
+                int is_last = (bn == bn_this_batch - 1) ? 1 : 0;
 
-                uint64_t up_args[11] = {
-                    reinterpret_cast<uint64_t>(dev_mij),
+                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),
                     reinterpret_cast<uint64_t>(dev_lij),
                     reinterpret_cast<uint64_t>(dev_oi_new),
                     reinterpret_cast<uint64_t>(dev_mi),
@@ -238,8 +231,7 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
                     static_cast<uint64_t>(is_last),
                     reinterpret_cast<uint64_t>(out_ptr),
                     static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim)
-                };
+                    static_cast<uint64_t>(head_dim)};
                 int t_up = runtime->add_task(up_args, 11, FUNC_ONLINE_UPDATE, CoreType::AIV);
                 total_tasks++;
 
@@ -266,5 +258,4 @@ int build_paged_attention_graph(Runtime* runtime, const TaskArg* orch_args, int 
 
     return 0;
 }
-
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -61,9 +61,9 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
 
     // Load pij and vj to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, pijGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, vjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -62,9 +62,9 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
 
     // Load A and B to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, qiGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, kjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -126,7 +126,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to the same UB as DN tiles for storing as ND format
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);           // alias same UB as mijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
         TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,14 +173,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TMAX(miNewRow, miRow, mijRow);     // mi_new = max(mi, mij)
+        TSUB(alphaRow, miRow, miNewRow);   // alpha_exp = mi - mi_new
+        TEXP(alphaRow, alphaRow);          // alpha = exp(mi - mi_new)
+        TSUB(betaRow, mijRow, miNewRow);   // beta_exp = mij - mi_new
+        TEXP(betaRow, betaRow);            // beta = exp(mij - mi_new)
+        TMUL(tmpRow, alphaRow, liRow);     // alpha * li
+        TMUL(liNewRow, betaRow, lijRow);   // beta * lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         TRESHAPE(alphaDN, alphaRow);
@@ -188,7 +188,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
 
         // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
@@ -203,15 +203,15 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -31,11 +31,8 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
-    float scale_value,
-    __gm__ Tensor* pij,
-    __gm__ Tensor* mij,
-    __gm__ Tensor* lij) {
+static __aicore__ void softmax_prepare_impl(
+    __gm__ Tensor* sij, float scale_value, __gm__ Tensor* pij, __gm__ Tensor* mij, __gm__ Tensor* lij) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
     __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
     __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
@@ -97,12 +94,12 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     TEXP(pijTile, pijTile);
     // Truncate pij to bf16 first
     TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);        // pij bf16 ready, can store early
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);  // pij bf16 ready, can store early
 
     // Continue computing: bf16 → f32 and rowsum while pij store proceeds in parallel
     TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
     TROWSUM(sumTile, pijTile, tmpTile);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);        // sum ready
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);  // sum ready
 
     // Store pij (overlaps with TCVT + TROWSUM above)
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
@@ -28,13 +28,43 @@ ORCHESTRATION = {
 # Kernel configs (aiv_normalize removed - merged into aiv_online_update)
 KERNELS = [
     # AIC kernels (matrix multiplication using Cube unit)
-    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),       "core_type": "aic"},
+    {
+        "func_id": 0,
+        "name": "QK",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 2,
+        "name": "PV",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 4,
+        "name": "AIC_HUB",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),
+        "core_type": "aic",
+    },
     # AIV kernels (vector operations)
-    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),       "core_type": "aiv"},
+    {
+        "func_id": 1,
+        "name": "SF",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 3,
+        "name": "UP",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 5,
+        "name": "AIV_HUB",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 # Runtime configuration

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -35,19 +35,24 @@ inline uint64_t get_sys_cnt_aicpu() {
 }
 
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
-#define CYCLE_COUNT_LAP(acc) do { _t1 = get_sys_cnt_aicpu(); acc += (_t1 - _t0); _t0 = _t1; } while(0)
+#define CYCLE_COUNT_LAP(acc)       \
+    do {                           \
+        _t1 = get_sys_cnt_aicpu(); \
+        acc += (_t1 - _t0);        \
+        _t0 = _t1;                 \
+    } while (0)
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
     uint64_t prof_param_extract = 0;
@@ -64,13 +69,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     CYCLE_COUNT_START();
 
     // Read dimensions from TaskArg tensor metadata
-    uint64_t batch     = orch_args[0].tensor.shapes[0];
+    uint64_t batch = orch_args[0].tensor.shapes[0];
     uint64_t num_heads = orch_args[0].tensor.shapes[1];
-    uint64_t head_dim  = orch_args[0].tensor.shapes[2];
+    uint64_t head_dim = orch_args[0].tensor.shapes[2];
     DataType data_type = orch_args[0].tensor.dtype;
 
     uint64_t block_size = orch_args[1].tensor.shapes[1];
-    uint64_t block_num  = orch_args[3].tensor.shapes[1];
+    uint64_t block_num = orch_args[3].tensor.shapes[1];
 
     uint64_t scale_value = orch_args[6].scalar;
 
@@ -83,9 +88,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
 
     // Reshape tensors for kernel consumption (2D flattened)
     void* query_ptr = orch_args[0].data<void>();
-    void* kc_ptr    = orch_args[1].data<void>();
-    void* vc_ptr    = orch_args[2].data<void>();
-    void* out_ptr   = orch_args[5].data<void>();
+    void* kc_ptr = orch_args[1].data<void>();
+    void* vc_ptr = orch_args[2].data<void>();
+    void* out_ptr = orch_args[5].data<void>();
 
     uint64_t total_blocks_count = orch_args[1].tensor.shapes[0];
 
@@ -99,7 +104,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
     CYCLE_COUNT_LAP(prof_ext_tensor);
 
-    int* host_block_table  = orch_args[3].data<int>();
+    int* host_block_table = orch_args[3].data<int>();
     int* host_context_lens = orch_args[4].data<int>();
 
     int total_tasks = 0;
@@ -227,27 +232,45 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
         }
     }
 
-    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor +
-                     prof_tensor_view + prof_param_setup + prof_submit_task + prof_scope;
-    LOG_ALWAYS(rt, "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
-        prof_submit_count, prof_make_count, prof_view_count, cycles_to_us(total));
+    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
+                     prof_submit_task + prof_scope;
+    LOG_ALWAYS(rt,
+        "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
+        prof_submit_count,
+        prof_make_count,
+        prof_view_count,
+        cycles_to_us(total));
     if (total > 0) {
-        LOG_ALWAYS(rt, "  param_extract    : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_extract), prof_param_extract * 100.0 / total);
-        LOG_ALWAYS(rt, "  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
-        LOG_ALWAYS(rt, "  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_make_count, cycles_to_us(prof_make_tensor), prof_make_tensor * 100.0 / total,
+        LOG_ALWAYS(rt,
+            "  param_extract    : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_param_extract),
+            prof_param_extract * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_ext_tensor),
+            prof_ext_tensor * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_make_count,
+            cycles_to_us(prof_make_tensor),
+            prof_make_tensor * 100.0 / total,
             prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
-        LOG_ALWAYS(rt, "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_view_count, cycles_to_us(prof_tensor_view), prof_tensor_view * 100.0 / total,
+        LOG_ALWAYS(rt,
+            "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_view_count,
+            cycles_to_us(prof_tensor_view),
+            prof_tensor_view * 100.0 / total,
             prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
-        LOG_ALWAYS(rt, "  param_setup      : %7.3fus (%5.1f%%)",
+        LOG_ALWAYS(rt,
+            "  param_setup      : %7.3fus (%5.1f%%)",
             cycles_to_us(prof_param_setup),
             prof_param_setup * 100.0 / total);
         LOG_ALWAYS(rt, "  scope            : %7.3fus (%5.1f%%)", cycles_to_us(prof_scope), prof_scope * 100.0 / total);
-        LOG_ALWAYS(rt, "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_submit_count, cycles_to_us(prof_submit_task), prof_submit_task * 100.0 / total,
+        LOG_ALWAYS(rt,
+            "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_submit_count,
+            cycles_to_us(prof_submit_task),
+            prof_submit_task * 100.0 / total,
             prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
     }
 

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/golden.py
@@ -52,4 +52,6 @@ def generate_inputs(params: dict) -> list:
 
 
 if __name__ == "__main__":
-    run_golden_test(ALL_CASES, DEFAULT_CASE, generate_inputs, label="Paged Attention Unroll")
+    run_golden_test(
+        ALL_CASES, DEFAULT_CASE, generate_inputs, label="Paged Attention Unroll"
+    )

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -38,13 +38,11 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_n_impl(
-    __gm__ bfloat16_t* pij_base,
+static __aicore__ void pv_matmul_n_impl(__gm__ bfloat16_t* pij_base,
     __gm__ bfloat16_t* val_base,
     __gm__ float* oi_base,
     uint64_t n_blocks,
     __gm__ int32_t* block_table) {
-
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, N, 1>>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
@@ -96,9 +94,9 @@ static __aicore__ void pv_matmul_n_impl(
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
         wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
         TLOAD(aMatTile[cur], pijGlobal);
-        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);   // forward: A in L1 ready
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: A in L1 ready
         TLOAD(bMatTile[cur], vjGlobal);
-        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);   // forward: B in L1 ready
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: B in L1 ready
 
         // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
         // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
@@ -107,17 +105,17 @@ static __aicore__ void pv_matmul_n_impl(
         TMOV(aTile[cur], aMatTile[cur]);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
         TMOV(bTile[cur], bMatTile[cur]);
-        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur); // reverse: release L1[cur]
+        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);  // reverse: release L1[cur]
 
         // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
-        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);   // forward: L0[cur] ready
+        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);  // forward: L0[cur] ready
         wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
         if (i == 0) {
             TMATMUL(cTile, aTile[cur], bTile[cur]);
         } else {
             TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
         }
-        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);   // reverse: release L0[cur]
+        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);  // reverse: release L0[cur]
     }
 
     // Drain outstanding reverse-dependency flags

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -32,13 +32,11 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_n_impl(
-    __gm__ bfloat16_t* qi_base,
+static __aicore__ void qk_matmul_n_impl(__gm__ bfloat16_t* qi_base,
     __gm__ bfloat16_t* key_base,
     __gm__ float* sij_base,
     uint64_t n_blocks,
     __gm__ int32_t* block_table) {
-
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -126,8 +126,8 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to same UB as DN tiles for ND-format store
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);                    // alias same UB as mijDN
-        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);   // alias same UB as lijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
+        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,33 +173,33 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
-        
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
-        
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
-        
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
-        
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
-        
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
-        
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
-        
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TMAX(miNewRow, miRow, mijRow);  // mi_new = max(mi, mij)
+
+        TSUB(alphaRow, miRow, miNewRow);  // alpha_exp = mi - mi_new
+
+        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
+
+        TSUB(betaRow, mijRow, miNewRow);  // beta_exp = mij - mi_new
+
+        TEXP(betaRow, betaRow);  // beta = exp(mij - mi_new)
+
+        TMUL(tmpRow, alphaRow, liRow);  // alpha * li
+
+        TMUL(liNewRow, betaRow, lijRow);  // beta * lij
+
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
-        
+
         TRESHAPE(alphaDN, alphaRow);
         TRESHAPE(betaDN, betaRow);
 
         // Scale data tiles using row-broadcast multiply
-        TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
-        
-        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+        TROWEXPANDMUL(oiTile, oiTile, alphaDN);  // oi *= alpha
+
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
+
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
         // Alias ND tiles to the same UB locations as miNewRow and liNewRow
@@ -210,19 +210,19 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         if (is_last) {
             // Normalize and output: dst = oi / li_new
             TRESHAPE(liNewDN, liNewRow);
-            
+
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -36,15 +36,13 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_n_impl(
-    __gm__ float* sij_base,
+static __aicore__ void softmax_prepare_n_impl(__gm__ float* sij_base,
     float scale_value,
     __gm__ bfloat16_t* pij_base,
     __gm__ float* mij_addr,
     __gm__ float* lij_addr,
     uint64_t n_blocks,
     uint64_t valid_len_last) {
-
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
     constexpr int kScalarCols = 32 / sizeof(float);
     constexpr int kScalarRows = M / kScalarCols;
@@ -100,10 +98,10 @@ static __aicore__ void softmax_prepare_n_impl(
     TASSIGN(sumAccTile, 4 * kDataBytes);
     int scalarBase = 5 * kDataBytes;
     TASSIGN(localMaxDN, scalarBase);
-    TASSIGN(localMaxRow, scalarBase);                     // alias: same UB as localMaxDN
+    TASSIGN(localMaxRow, scalarBase);  // alias: same UB as localMaxDN
     TASSIGN(globalMaxDN, scalarBase + kScalarDNBytes);
-    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
-    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);    // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);  // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
     TASSIGN(sumDN, scalarBase + 2 * kScalarDNBytes);
     TASSIGN(pijBf16Tile, scalarBase + 3 * kScalarDNBytes);
 
@@ -122,13 +120,11 @@ static __aicore__ void softmax_prepare_n_impl(
             TileSijDyn sijDynTile(static_cast<size_t>(valid_len_last));
             TASSIGN(sijDynTile, 0x0);
             TFILLPAD_INPLACE(sijPadTile_A, sijDynTile);
-            
         }
 
         TMULS(sijTile_A, sijTile_A, scale_value);
-        
+
         TROWMAX(localMaxDN, sijTile_A, tmpTile);
-        
 
         // TRESHAPE: ColMajor(M,1) → RowMajor(1,M) for element-wise TMAX
         TRESHAPE(localMaxRow, localMaxDN);
@@ -137,7 +133,6 @@ static __aicore__ void softmax_prepare_n_impl(
         } else {
             TMAX(globalMaxRow, globalMaxRow, localMaxRow);
         }
-        
     }
 
     // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for Pass 2's TROWEXPANDSUB
@@ -175,27 +170,25 @@ static __aicore__ void softmax_prepare_n_impl(
                 TASSIGN(curSijDyn, static_cast<int>(kDataBytes));
                 TFILLPAD_INPLACE(sijPadTile_B, curSijDyn);
             }
-            
         }
 
         // Compute on current buffer (select A or B based on iteration parity)
         if (i % 2 == 0) {
             TMULS(sijTile_A, sijTile_A, scale_value);
-            
+
             TROWEXPANDSUB(pijTile, sijTile_A, globalMaxDN);
         } else {
             TMULS(sijTile_B, sijTile_B, scale_value);
-            
+
             TROWEXPANDSUB(pijTile, sijTile_B, globalMaxDN);
         }
-        
+
         TEXP(pijTile, pijTile);
-        
+
         TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
-        
+
         TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
 
-        
         if (i == 0) {
             TMULS(sumAccTile, pijTile, 1.0f);
         } else {
@@ -203,7 +196,7 @@ static __aicore__ void softmax_prepare_n_impl(
         }
 
         // Store pij (must complete before next iteration's TCVT overwrites pijBf16Tile)
-        
+
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         TSTORE(pijGlobal, pijBf16Tile);
@@ -222,7 +215,7 @@ static __aicore__ void softmax_prepare_n_impl(
     }
 
     // Compute final row sum from accumulated pij values
-    
+
     TROWSUM(sumDN, sumAccTile, tmpTile);
 
     // Store lij (total sum). mij already stored after Pass 1.

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
@@ -28,13 +28,43 @@ ORCHESTRATION = {
 # Kernel configs (aiv_normalize removed - merged into aiv_online_update)
 KERNELS = [
     # AIC kernels (matrix multiplication using Cube unit)
-    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),       "core_type": "aic"},
+    {
+        "func_id": 0,
+        "name": "QK",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 2,
+        "name": "PV",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 4,
+        "name": "AIC_HUB",
+        "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),
+        "core_type": "aic",
+    },
     # AIV kernels (vector operations)
-    {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),       "core_type": "aiv"},
+    {
+        "func_id": 1,
+        "name": "SF",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 3,
+        "name": "UP",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 5,
+        "name": "AIV_HUB",
+        "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),
+        "core_type": "aiv",
+    },
 ]
 
 # Runtime configuration

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -57,37 +57,37 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    TaskArg* orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(TaskArg* orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    PTO2Runtime* rt, TaskArg* orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
-    uint64_t prof_ext_tensor    = 0;
-    uint64_t prof_make_tensor   = 0;
-    uint64_t prof_tensor_view   = 0;
-    uint64_t prof_param_setup   = 0;
-    uint64_t prof_submit_task   = 0;
+    uint64_t prof_ext_tensor = 0;
+    uint64_t prof_make_tensor = 0;
+    uint64_t prof_tensor_view = 0;
+    uint64_t prof_param_setup = 0;
+    uint64_t prof_submit_task = 0;
     uint64_t prof_scope_and_loop = 0;
-    int      prof_submit_count  = 0;
-    int      prof_make_count    = 0;
-    int      prof_view_count    = 0;
+    int prof_submit_count = 0;
+    int prof_make_count = 0;
+    int prof_view_count = 0;
 #endif
 
     CYCLE_COUNT_START();
 
     // Read dimensions from TaskArg tensor metadata
     // query: shape=[batch, num_heads, head_dim]
-    uint64_t batch     = orch_args[0].tensor.shapes[0];
+    uint64_t batch = orch_args[0].tensor.shapes[0];
     uint64_t num_heads = orch_args[0].tensor.shapes[1];
-    uint64_t head_dim  = orch_args[0].tensor.shapes[2];
+    uint64_t head_dim = orch_args[0].tensor.shapes[2];
     DataType data_type = orch_args[0].tensor.dtype;
 
     // key_cache: shape=[total_blocks, block_size, kv_head_num, head_dim]
@@ -105,9 +105,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
 
     // Reshape tensors for kernel consumption (2D flattened)
     void* query_ptr = orch_args[0].data<void>();
-    void* kc_ptr    = orch_args[1].data<void>();
-    void* vc_ptr    = orch_args[2].data<void>();
-    void* out_ptr   = orch_args[5].data<void>();
+    void* kc_ptr = orch_args[1].data<void>();
+    void* vc_ptr = orch_args[2].data<void>();
+    void* out_ptr = orch_args[5].data<void>();
 
     uint64_t total_blocks_count = orch_args[1].tensor.shapes[0];
 
@@ -120,7 +120,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
-    int* host_block_table  = orch_args[3].data<int>();
+    int* host_block_table = orch_args[3].data<int>();
     int* host_context_lens = orch_args[4].data<int>();
 
 #ifdef ENABLE_PROFILING
@@ -291,29 +291,49 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(PTO2Runtim
     CYCLE_COUNT_LAP(prof_scope_and_loop);
 
 #ifdef ENABLE_PROFILING
-    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor +
-                     prof_tensor_view + prof_param_setup + prof_submit_task +
-                     prof_scope_and_loop;
-    LOG_ALWAYS(rt, "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
-        prof_submit_count, prof_make_count, prof_view_count, cycles_to_us(total));
+    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
+                     prof_submit_task + prof_scope_and_loop;
+    LOG_ALWAYS(rt,
+        "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
+        prof_submit_count,
+        prof_make_count,
+        prof_view_count,
+        cycles_to_us(total));
     if (total > 0) {
-        LOG_ALWAYS(rt, "  param_extract    : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_extract), prof_param_extract * 100.0 / total);
-        LOG_ALWAYS(rt, "  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
-        LOG_ALWAYS(rt, "  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_make_count, cycles_to_us(prof_make_tensor), prof_make_tensor * 100.0 / total,
+        LOG_ALWAYS(rt,
+            "  param_extract    : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_param_extract),
+            prof_param_extract * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_ext_tensor),
+            prof_ext_tensor * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_make_count,
+            cycles_to_us(prof_make_tensor),
+            prof_make_tensor * 100.0 / total,
             prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
-        LOG_ALWAYS(rt, "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_view_count, cycles_to_us(prof_tensor_view), prof_tensor_view * 100.0 / total,
+        LOG_ALWAYS(rt,
+            "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_view_count,
+            cycles_to_us(prof_tensor_view),
+            prof_tensor_view * 100.0 / total,
             prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
-        LOG_ALWAYS(rt, "  param_setup      : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
-        LOG_ALWAYS(rt, "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_submit_count, cycles_to_us(prof_submit_task), prof_submit_task * 100.0 / total,
+        LOG_ALWAYS(rt,
+            "  param_setup      : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_param_setup),
+            prof_param_setup * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
+            prof_submit_count,
+            cycles_to_us(prof_submit_task),
+            prof_submit_task * 100.0 / total,
             prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
-        LOG_ALWAYS(rt, "  scope_and_loop   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_scope_and_loop), prof_scope_and_loop * 100.0 / total);
+        LOG_ALWAYS(rt,
+            "  scope_and_loop   : %7.3fus (%5.1f%%)",
+            cycles_to_us(prof_scope_and_loop),
+            prof_scope_and_loop * 100.0 / total);
     }
 #endif
 

--- a/tests/ut/test_runtime_builder.py
+++ b/tests/ut/test_runtime_builder.py
@@ -34,17 +34,29 @@ class TestRuntimeBuilderDiscovery:
         runtimes = builder.list_runtimes()
         assert "aicpu_build_graph" in runtimes
 
-    def test_runtime_dir_resolves_to_project_root(self, default_test_platform, test_arch):
+    def test_runtime_dir_resolves_to_project_root(
+        self, default_test_platform, test_arch
+    ):
         """runtime_dir resolves to src/{arch}/runtime/ under the project root."""
         from runtime_builder import RuntimeBuilder
 
         builder = RuntimeBuilder(platform=default_test_platform)
-        assert builder.runtime_dir == builder.runtime_root / "src" / test_arch / "runtime"
+        assert (
+            builder.runtime_dir == builder.runtime_root / "src" / test_arch / "runtime"
+        )
         assert builder.runtime_dir.is_dir()
 
     @patch("runtime_builder.RuntimeCompiler")
     @patch("runtime_builder.KernelCompiler")
-    def test_discovers_configs_in_runtime_dir(self, MockKernel, MockCompiler, tmp_path, monkeypatch, default_test_platform, test_arch):
+    def test_discovers_configs_in_runtime_dir(
+        self,
+        MockKernel,
+        MockCompiler,
+        tmp_path,
+        monkeypatch,
+        default_test_platform,
+        test_arch,
+    ):
         """RuntimeBuilder discovers implementations in the runtime directory."""
         import runtime_builder as rb_module
         from runtime_builder import RuntimeBuilder
@@ -54,16 +66,22 @@ class TestRuntimeBuilderDiscovery:
         # Set up fake runtime tree with architecture-specific structure
         rt_dir = tmp_path / "src" / test_arch / "runtime" / "my_runtime"
         rt_dir.mkdir(parents=True)
-        (rt_dir / "build_config.py").write_text(
-            "BUILD_CONFIG = {}\n"
-        )
+        (rt_dir / "build_config.py").write_text("BUILD_CONFIG = {}\n")
 
         builder = RuntimeBuilder(platform=default_test_platform)
         assert builder.list_runtimes() == ["my_runtime"]
 
     @patch("runtime_builder.RuntimeCompiler")
     @patch("runtime_builder.KernelCompiler")
-    def test_ignores_dirs_without_build_config(self, MockKernel, MockCompiler, tmp_path, monkeypatch, default_test_platform, test_arch):
+    def test_ignores_dirs_without_build_config(
+        self,
+        MockKernel,
+        MockCompiler,
+        tmp_path,
+        monkeypatch,
+        default_test_platform,
+        test_arch,
+    ):
         """Directories without build_config.py are not listed."""
         import runtime_builder as rb_module
         from runtime_builder import RuntimeBuilder
@@ -82,7 +100,15 @@ class TestRuntimeBuilderDiscovery:
 
     @patch("runtime_builder.RuntimeCompiler")
     @patch("runtime_builder.KernelCompiler")
-    def test_empty_runtime_dir(self, MockKernel, MockCompiler, tmp_path, monkeypatch, default_test_platform, test_arch):
+    def test_empty_runtime_dir(
+        self,
+        MockKernel,
+        MockCompiler,
+        tmp_path,
+        monkeypatch,
+        default_test_platform,
+        test_arch,
+    ):
         """Empty src/{arch}/runtime/ directory yields no runtimes."""
         import runtime_builder as rb_module
         from runtime_builder import RuntimeBuilder
@@ -96,7 +122,9 @@ class TestRuntimeBuilderDiscovery:
 
     @patch("runtime_builder.RuntimeCompiler")
     @patch("runtime_builder.KernelCompiler")
-    def test_missing_runtime_dir(self, MockKernel, MockCompiler, tmp_path, monkeypatch, default_test_platform):
+    def test_missing_runtime_dir(
+        self, MockKernel, MockCompiler, tmp_path, monkeypatch, default_test_platform
+    ):
         """Non-existent src/{arch}/runtime/ directory yields no runtimes."""
         import runtime_builder as rb_module
         from runtime_builder import RuntimeBuilder
@@ -108,7 +136,15 @@ class TestRuntimeBuilderDiscovery:
 
     @patch("runtime_builder.RuntimeCompiler")
     @patch("runtime_builder.KernelCompiler")
-    def test_multiple_runtimes_sorted(self, MockKernel, MockCompiler, tmp_path, monkeypatch, default_test_platform, test_arch):
+    def test_multiple_runtimes_sorted(
+        self,
+        MockKernel,
+        MockCompiler,
+        tmp_path,
+        monkeypatch,
+        default_test_platform,
+        test_arch,
+    ):
         """Multiple implementations are returned in sorted order."""
         import runtime_builder as rb_module
         from runtime_builder import RuntimeBuilder
@@ -149,7 +185,15 @@ class TestRuntimeBuilderBuildErrors:
 
     @patch("runtime_builder.RuntimeCompiler")
     @patch("runtime_builder.KernelCompiler")
-    def test_build_empty_registry_shows_none(self, MockKernel, MockCompiler, tmp_path, monkeypatch, default_test_platform, test_arch):
+    def test_build_empty_registry_shows_none(
+        self,
+        MockKernel,
+        MockCompiler,
+        tmp_path,
+        monkeypatch,
+        default_test_platform,
+        test_arch,
+    ):
         """ValueError message shows '(none)' when no runtimes exist."""
         import runtime_builder as rb_module
         from runtime_builder import RuntimeBuilder
@@ -171,6 +215,7 @@ class TestRuntimeBuilderBuild:
     @pytest.fixture(autouse=True)
     def _patch_runtime_root(self, monkeypatch, tmp_path):
         import runtime_builder as rb_module
+
         monkeypatch.setattr(rb_module, "__file__", str(tmp_path / "python" / "rb.py"))
 
     def _make_runtime(self, tmp_path, test_arch):
@@ -200,7 +245,9 @@ class TestRuntimeBuilderBuild:
 
     @patch("runtime_builder.KernelCompiler")
     @patch("runtime_builder.RuntimeCompiler")
-    def test_build_returns_three_binaries(self, MockCompiler, MockKernel, tmp_path, default_test_platform, test_arch):
+    def test_build_returns_three_binaries(
+        self, MockCompiler, MockKernel, tmp_path, default_test_platform, test_arch
+    ):
         """build() returns (host_binary, aicpu_binary, aicore_binary)."""
         from runtime_builder import RuntimeBuilder
 
@@ -208,9 +255,9 @@ class TestRuntimeBuilderBuild:
 
         mock_instance = MockCompiler.get_instance.return_value
         mock_instance.compile.side_effect = [
-            b"aicore_bin",   # first call: aicore
-            b"aicpu_bin",    # second call: aicpu
-            b"host_bin",     # third call: host
+            b"aicore_bin",  # first call: aicore
+            b"aicpu_bin",  # second call: aicpu
+            b"host_bin",  # third call: host
         ]
 
         builder = RuntimeBuilder(platform=default_test_platform)
@@ -220,7 +267,9 @@ class TestRuntimeBuilderBuild:
 
     @patch("runtime_builder.KernelCompiler")
     @patch("runtime_builder.RuntimeCompiler")
-    def test_build_calls_compiler_three_times(self, MockCompiler, MockKernel, tmp_path, default_test_platform, test_arch):
+    def test_build_calls_compiler_three_times(
+        self, MockCompiler, MockKernel, tmp_path, default_test_platform, test_arch
+    ):
         """build() invokes compiler.compile() exactly 3 times (aicore, aicpu, host)."""
         from runtime_builder import RuntimeBuilder
 
@@ -238,7 +287,9 @@ class TestRuntimeBuilderBuild:
 
     @patch("runtime_builder.KernelCompiler")
     @patch("runtime_builder.RuntimeCompiler")
-    def test_build_resolves_paths_relative_to_config(self, MockCompiler, MockKernel, tmp_path, default_test_platform, test_arch):
+    def test_build_resolves_paths_relative_to_config(
+        self, MockCompiler, MockKernel, tmp_path, default_test_platform, test_arch
+    ):
         """Include/source dirs are resolved relative to the build_config.py directory."""
         from runtime_builder import RuntimeBuilder
 
@@ -259,7 +310,9 @@ class TestRuntimeBuilderBuild:
 
     @patch("runtime_builder.KernelCompiler")
     @patch("runtime_builder.RuntimeCompiler")
-    def test_build_propagates_compiler_error(self, MockCompiler, MockKernel, tmp_path, default_test_platform, test_arch):
+    def test_build_propagates_compiler_error(
+        self, MockCompiler, MockKernel, tmp_path, default_test_platform, test_arch
+    ):
         """If RuntimeCompiler.compile() raises, build() propagates the exception."""
         from runtime_builder import RuntimeBuilder
 
@@ -305,6 +358,10 @@ class TestRuntimeBuilderIntegration:
         assert len(result) == 3
 
         host_binary, aicpu_binary, aicore_binary = result
-        for label, binary in [("host", host_binary), ("aicpu", aicpu_binary), ("aicore", aicore_binary)]:
+        for label, binary in [
+            ("host", host_binary),
+            ("aicpu", aicpu_binary),
+            ("aicore", aicore_binary),
+        ]:
             assert isinstance(binary, bytes), f"{label} binary is not bytes"
             assert len(binary) > 0, f"{label} binary is empty"

--- a/tests/ut/test_task_interface.py
+++ b/tests/ut/test_task_interface.py
@@ -27,6 +27,7 @@ from _task_interface import (
 # DataType enum
 # ============================================================================
 
+
 class TestDataType:
     def test_enum_values_exist(self):
         assert DataType.FLOAT32 is not None
@@ -52,33 +53,39 @@ class TestDataType:
 
 
 class TestGetElementSize:
-    @pytest.mark.parametrize("dtype,expected", [
-        (DataType.FLOAT32, 4),
-        (DataType.FLOAT16, 2),
-        (DataType.INT32, 4),
-        (DataType.INT16, 2),
-        (DataType.INT8, 1),
-        (DataType.UINT8, 1),
-        (DataType.BFLOAT16, 2),
-        (DataType.INT64, 8),
-        (DataType.UINT64, 8),
-    ])
+    @pytest.mark.parametrize(
+        "dtype,expected",
+        [
+            (DataType.FLOAT32, 4),
+            (DataType.FLOAT16, 2),
+            (DataType.INT32, 4),
+            (DataType.INT16, 2),
+            (DataType.INT8, 1),
+            (DataType.UINT8, 1),
+            (DataType.BFLOAT16, 2),
+            (DataType.INT64, 8),
+            (DataType.UINT64, 8),
+        ],
+    )
     def test_element_sizes(self, dtype, expected):
         assert get_element_size(dtype) == expected
 
 
 class TestGetDtypeName:
-    @pytest.mark.parametrize("dtype,expected", [
-        (DataType.FLOAT32, "FLOAT32"),
-        (DataType.FLOAT16, "FLOAT16"),
-        (DataType.INT32, "INT32"),
-        (DataType.INT16, "INT16"),
-        (DataType.INT8, "INT8"),
-        (DataType.UINT8, "UINT8"),
-        (DataType.BFLOAT16, "BFLOAT16"),
-        (DataType.INT64, "INT64"),
-        (DataType.UINT64, "UINT64"),
-    ])
+    @pytest.mark.parametrize(
+        "dtype,expected",
+        [
+            (DataType.FLOAT32, "FLOAT32"),
+            (DataType.FLOAT16, "FLOAT16"),
+            (DataType.INT32, "INT32"),
+            (DataType.INT16, "INT16"),
+            (DataType.INT8, "INT8"),
+            (DataType.UINT8, "UINT8"),
+            (DataType.BFLOAT16, "BFLOAT16"),
+            (DataType.INT64, "INT64"),
+            (DataType.UINT64, "UINT64"),
+        ],
+    )
     def test_dtype_names(self, dtype, expected):
         assert get_dtype_name(dtype) == expected
 
@@ -86,6 +93,7 @@ class TestGetDtypeName:
 # ============================================================================
 # TaskArg
 # ============================================================================
+
 
 class TestTaskArg:
     def test_default_constructor(self):
@@ -166,6 +174,7 @@ class TestTaskArg:
 # TaskArgArray
 # ============================================================================
 
+
 class TestTaskArgArray:
     def test_empty(self):
         arr = TaskArgArray()
@@ -226,10 +235,12 @@ class TestTaskArgArray:
 # task_interface.py wrapper (torch integration)
 # ============================================================================
 
+
 class TestTaskInterfaceWrapper:
     def test_torch_dtype_to_datatype(self):
         from task_interface import torch_dtype_to_datatype
         import torch
+
         assert torch_dtype_to_datatype(torch.float32) == DataType.FLOAT32
         assert torch_dtype_to_datatype(torch.int8) == DataType.INT8
         assert torch_dtype_to_datatype(torch.bfloat16) == DataType.BFLOAT16
@@ -237,12 +248,14 @@ class TestTaskInterfaceWrapper:
     def test_torch_dtype_unsupported(self):
         from task_interface import torch_dtype_to_datatype
         import torch
+
         with pytest.raises(KeyError):
             torch_dtype_to_datatype(torch.complex64)
 
     def test_make_tensor_arg(self):
         from task_interface import make_tensor_arg
         import torch
+
         t = torch.zeros(4, 8, dtype=torch.float32)
         arg = make_tensor_arg(t)
         assert arg.kind == TaskArgKind.TENSOR
@@ -253,18 +266,21 @@ class TestTaskInterfaceWrapper:
 
     def test_make_scalar_arg_int(self):
         from task_interface import make_scalar_arg
+
         arg = make_scalar_arg(999)
         assert arg.kind == TaskArgKind.SCALAR
         assert arg.scalar == 999
 
     def test_make_scalar_arg_ctypes(self):
         from task_interface import make_scalar_arg
+
         arg = make_scalar_arg(ctypes.c_int64(42))
         assert arg.kind == TaskArgKind.SCALAR
         assert arg.scalar == 42
 
     def test_make_scalar_arg_float_ctypes(self):
         from task_interface import make_scalar_arg
+
         arg = make_scalar_arg(ctypes.c_float(1.5))
         assert arg.kind == TaskArgKind.SCALAR
         # Verify bit-cast: 1.5f = 0x3FC00000

--- a/tools/device_log_resolver.py
+++ b/tools/device_log_resolver.py
@@ -34,7 +34,9 @@ def _latest_log_from_dir(log_dir: Path) -> Optional[Path]:
     if not log_dir.exists() or not log_dir.is_dir():
         return None
 
-    candidates = sorted(log_dir.glob("*.log"), key=lambda p: p.stat().st_mtime, reverse=True)
+    candidates = sorted(
+        log_dir.glob("*.log"), key=lambda p: p.stat().st_mtime, reverse=True
+    )
     if not candidates:
         return None
     return candidates[0]
@@ -80,7 +82,9 @@ def _resolve_explicit_device_log(device_log: str) -> Tuple[Optional[Path], str]:
     return None, f"explicit --device-log path not found: {path}"
 
 
-def _resolve_nearest_log(root: Path, perf_path: Optional[Path]) -> Tuple[Optional[Path], str]:
+def _resolve_nearest_log(
+    root: Path, perf_path: Optional[Path]
+) -> Tuple[Optional[Path], str]:
     device_dirs = sorted([p for p in root.glob("device-*") if p.is_dir()])
     if not device_dirs:
         return None, f"no device-* directories found under {root}"
@@ -100,7 +104,10 @@ def _resolve_nearest_log(root: Path, perf_path: Optional[Path]) -> Tuple[Optiona
 
     perf_ts = perf_dt.timestamp()
     best = min(candidates, key=lambda p: abs(p.stat().st_mtime - perf_ts))
-    return best, f"auto-scan device-* (closest log to perf timestamp {perf_dt:%Y-%m-%d %H:%M:%S})"
+    return (
+        best,
+        f"auto-scan device-* (closest log to perf timestamp {perf_dt:%Y-%m-%d %H:%M:%S})",
+    )
 
 
 def resolve_device_log_path(

--- a/tools/gen_compile_commands.py
+++ b/tools/gen_compile_commands.py
@@ -63,7 +63,8 @@ def discover_runtimes(arch: str) -> list:
     if not runtime_base.is_dir():
         return []
     return sorted(
-        d.name for d in runtime_base.iterdir()
+        d.name
+        for d in runtime_base.iterdir()
         if d.is_dir() and (d / "build_config.py").exists()
     )
 
@@ -73,7 +74,8 @@ def discover_variants(arch: str) -> list:
     if not platform_base.is_dir():
         return []
     return sorted(
-        d.name for d in platform_base.iterdir()
+        d.name
+        for d in platform_base.iterdir()
         if d.is_dir() and d.name not in ("include", "src")
     )
 
@@ -105,8 +107,12 @@ def generate(arch: str, runtime_name: str, variant: str) -> list:
             continue
 
         target_cfg = build_config[target_name]
-        include_dirs = [str((runtime_dir / p).resolve()) for p in target_cfg["include_dirs"]]
-        source_dirs = [str((runtime_dir / p).resolve()) for p in target_cfg["source_dirs"]]
+        include_dirs = [
+            str((runtime_dir / p).resolve()) for p in target_cfg["include_dirs"]
+        ]
+        source_dirs = [
+            str((runtime_dir / p).resolve()) for p in target_cfg["source_dirs"]
+        ]
 
         target = getattr(compiler, f"{target_name}_target")
         cmake_args = target.gen_cmake_args(include_dirs, source_dirs)
@@ -133,11 +139,17 @@ def generate_for_arch(arch: str, default_runtime: str, default_variant: str) -> 
         return
 
     if default_runtime not in runtimes:
-        print(f"  {arch}: default runtime '{default_runtime}' not found, using {runtimes[0]}", file=sys.stderr)
+        print(
+            f"  {arch}: default runtime '{default_runtime}' not found, using {runtimes[0]}",
+            file=sys.stderr,
+        )
         default_runtime = runtimes[0]
 
     if default_variant not in variants:
-        print(f"  {arch}: default variant '{default_variant}' not found, using {variants[0]}", file=sys.stderr)
+        print(
+            f"  {arch}: default variant '{default_variant}' not found, using {variants[0]}",
+            file=sys.stderr,
+        )
         default_variant = variants[0]
 
     # Cache: (runtime, variant) → entries, to avoid duplicate cmake runs
@@ -153,17 +165,37 @@ def generate_for_arch(arch: str, default_runtime: str, default_variant: str) -> 
     for runtime in runtimes:
         entries = get_entries(runtime, default_variant)
         if entries:
-            output = PROJECT_ROOT / "src" / arch / "runtime" / runtime / "compile_commands.json"
+            output = (
+                PROJECT_ROOT
+                / "src"
+                / arch
+                / "runtime"
+                / runtime
+                / "compile_commands.json"
+            )
             write_compile_commands(entries, output)
-            print(f"  {output.relative_to(PROJECT_ROOT)}  ({len(entries)} entries, variant={default_variant})", file=sys.stderr)
+            print(
+                f"  {output.relative_to(PROJECT_ROOT)}  ({len(entries)} entries, variant={default_variant})",
+                file=sys.stderr,
+            )
 
     # Default runtime × every variant → platform variant dir
     for variant in variants:
         entries = get_entries(default_runtime, variant)
         if entries:
-            output = PROJECT_ROOT / "src" / arch / "platform" / variant / "compile_commands.json"
+            output = (
+                PROJECT_ROOT
+                / "src"
+                / arch
+                / "platform"
+                / variant
+                / "compile_commands.json"
+            )
             write_compile_commands(entries, output)
-            print(f"  {output.relative_to(PROJECT_ROOT)}  ({len(entries)} entries, runtime={default_runtime})", file=sys.stderr)
+            print(
+                f"  {output.relative_to(PROJECT_ROOT)}  ({len(entries)} entries, runtime={default_runtime})",
+                file=sys.stderr,
+            )
 
 
 def main():
@@ -171,14 +203,18 @@ def main():
         description="Generate compile_commands.json for clangd via cmake"
     )
     parser.add_argument(
-        "--default-runtime", default="tensormap_and_ringbuffer",
+        "--default-runtime",
+        default="tensormap_and_ringbuffer",
         help="Default runtime for platform variant generation (default: tensormap_and_ringbuffer)",
     )
     parser.add_argument(
-        "--default-variant", default="onboard",
+        "--default-variant",
+        default="onboard",
         help="Default platform variant for runtime generation (default: onboard)",
     )
-    parser.add_argument("--list", action="store_true", help="List available options per arch")
+    parser.add_argument(
+        "--list", action="store_true", help="List available options per arch"
+    )
     args = parser.parse_args()
 
     if args.list:

--- a/tools/perf_to_mermaid.py
+++ b/tools/perf_to_mermaid.py
@@ -35,17 +35,17 @@ def read_perf_data(filepath):
     Raises:
         ValueError: If JSON format is invalid
     """
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         data = json.load(f)
 
     # Validate required fields
-    required_fields = ['version', 'tasks']
+    required_fields = ["version", "tasks"]
     for field in required_fields:
         if field not in data:
             raise ValueError(f"Missing required field: {field}")
 
     # Validate version
-    if data['version'] != 1:
+    if data["version"] != 1:
         raise ValueError(f"Unsupported version: {data['version']} (expected 1)")
 
     return data
@@ -77,27 +77,35 @@ def load_kernel_config(config_path):
     spec.loader.exec_module(module)
 
     # Extract func_id to name mapping from KERNELS list
-    if not hasattr(module, 'KERNELS'):
+    if not hasattr(module, "KERNELS"):
         raise ValueError(f"kernel_config.py missing KERNELS definition")
 
     func_id_to_name = {}
     for kernel in module.KERNELS:
-        if 'func_id' not in kernel:
-            print(f"Warning: Kernel entry missing 'func_id', skipping: {kernel}", file=sys.stderr)
+        if "func_id" not in kernel:
+            print(
+                f"Warning: Kernel entry missing 'func_id', skipping: {kernel}",
+                file=sys.stderr,
+            )
             continue
 
-        func_id = kernel['func_id']
+        func_id = kernel["func_id"]
 
-        if 'name' not in kernel:
-            print(f"Warning: Kernel entry for func_id={func_id} missing 'name', will use default naming", file=sys.stderr)
+        if "name" not in kernel:
+            print(
+                f"Warning: Kernel entry for func_id={func_id} missing 'name', will use default naming",
+                file=sys.stderr,
+            )
             continue
 
-        func_id_to_name[str(func_id)] = kernel['name']
+        func_id_to_name[str(func_id)] = kernel["name"]
 
     return func_id_to_name
 
 
-def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", direction="LR", verbose=False):
+def generate_mermaid_flowchart(
+    tasks, func_id_to_name=None, style="detailed", direction="LR", verbose=False
+):
     """Generate Mermaid flowchart from task data.
 
     Args:
@@ -111,7 +119,9 @@ def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", di
         str: Mermaid flowchart diagram text
     """
     if verbose:
-        print(f"Generating Mermaid flowchart (style: {style}, direction: {direction})...")
+        print(
+            f"Generating Mermaid flowchart (style: {style}, direction: {direction})..."
+        )
         print(f"  Tasks: {len(tasks)}")
 
     lines = []
@@ -121,8 +131,8 @@ def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", di
 
     # Generate node definitions
     for task in tasks:
-        task_id = task['task_id']
-        func_id = task['func_id']
+        task_id = task["task_id"]
+        func_id = task["func_id"]
 
         # Get function name
         if func_id_to_name and str(func_id) in func_id_to_name:
@@ -139,21 +149,21 @@ def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", di
             label = f"{func_name}({task_id})"
 
         # Node definition with label
-        lines.append(f"    Task{task_id}[\"{label}\"]")
+        lines.append(f'    Task{task_id}["{label}"]')
 
     lines.append("")
 
     # Generate edges (dependencies)
     for task in tasks:
-        task_id = task['task_id']
-        for succ_task_id in task['fanout']:
+        task_id = task["task_id"]
+        for succ_task_id in task["fanout"]:
             lines.append(f"    Task{task_id} --> Task{succ_task_id}")
 
     lines.append("")
 
     # Generate styling based on core_type using classDef and class
     # Build set of unique core_types
-    unique_core_types = set(task['core_type'] for task in tasks)
+    unique_core_types = set(task["core_type"] for task in tasks)
 
     # Define color palette for core types
     core_type_colors = {
@@ -166,14 +176,18 @@ def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", di
     # Define style classes
     for core_type in sorted(unique_core_types):
         color = core_type_colors.get(core_type, "#E0E0E0")  # Default gray if unknown
-        lines.append(f"    classDef {core_type}Style fill:{color},stroke:#333,stroke-width:2px,color:#000")
+        lines.append(
+            f"    classDef {core_type}Style fill:{color},stroke:#333,stroke-width:2px,color:#000"
+        )
 
     lines.append("")
 
     # Apply classes to nodes
     for core_type in sorted(unique_core_types):
         # Find all tasks with this core_type
-        task_ids = [str(task['task_id']) for task in tasks if task['core_type'] == core_type]
+        task_ids = [
+            str(task["task_id"]) for task in tasks if task["core_type"] == core_type
+        ]
         task_list = ",".join(f"Task{tid}" for tid in task_ids)
         lines.append(f"    class {task_list} {core_type}Style")
 
@@ -184,7 +198,7 @@ def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", di
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Convert swimlane performance JSON to Mermaid flowchart',
+        description="Convert swimlane performance JSON to Mermaid flowchart",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 示例：
@@ -199,17 +213,37 @@ def main():
   1. 直接在 GitHub/GitLab Markdown 中渲染
   2. 在 https://mermaid.live/ 中可视化
   3. 在支持 Mermaid 的编辑器中查看（如 VS Code + Mermaid 插件）
-        """
+        """,
     )
 
-    parser.add_argument('input', nargs='?', help='输入 JSON 文件 (.json)。如果未指定，使用 outputs/ 目录中最新的 perf_swimlane_*.json 文件')
-    parser.add_argument('-o', '--output', help='输出 Markdown 文件（默认：outputs/mermaid_diagram_<timestamp>.md）')
-    parser.add_argument('-k', '--kernel-config', help='kernel_config.py 文件路径，用于 func_id 到函数名的映射')
-    parser.add_argument('--style', choices=['detailed', 'compact'], default='detailed',
-                        help='节点信息密度：detailed（详细，包含核心和时间）或 compact（紧凑，仅函数名）')
-    parser.add_argument('--direction', choices=['TD', 'LR'], default='TD',
-                        help='流程图方向：TD（从上到下，默认）或 LR（从左到右）')
-    parser.add_argument('-v', '--verbose', action='store_true', help='详细输出')
+    parser.add_argument(
+        "input",
+        nargs="?",
+        help="输入 JSON 文件 (.json)。如果未指定，使用 outputs/ 目录中最新的 perf_swimlane_*.json 文件",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="输出 Markdown 文件（默认：outputs/mermaid_diagram_<timestamp>.md）",
+    )
+    parser.add_argument(
+        "-k",
+        "--kernel-config",
+        help="kernel_config.py 文件路径，用于 func_id 到函数名的映射",
+    )
+    parser.add_argument(
+        "--style",
+        choices=["detailed", "compact"],
+        default="detailed",
+        help="节点信息密度：detailed（详细，包含核心和时间）或 compact（紧凑，仅函数名）",
+    )
+    parser.add_argument(
+        "--direction",
+        choices=["TD", "LR"],
+        default="TD",
+        help="流程图方向：TD（从上到下，默认）或 LR（从左到右）",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="详细输出")
 
     args = parser.parse_args()
 
@@ -219,7 +253,10 @@ def main():
         json_files = list(outputs_dir.glob("perf_swimlane_*.json"))
 
         if not json_files:
-            print(f"错误：在 {outputs_dir} 中未找到 perf_swimlane_*.json 文件", file=sys.stderr)
+            print(
+                f"错误：在 {outputs_dir} 中未找到 perf_swimlane_*.json 文件",
+                file=sys.stderr,
+            )
             print("请指定输入文件或确保 outputs/ 中存在 .json 文件", file=sys.stderr)
             return 1
 
@@ -257,7 +294,9 @@ def main():
             func_names = load_kernel_config(args.kernel_config)
             if args.verbose:
                 print(f"  加载了 {len(func_names)} 个函数名映射")
-                for func_id, name in sorted(func_names.items(), key=lambda x: int(x[0])):
+                for func_id, name in sorted(
+                    func_names.items(), key=lambda x: int(x[0])
+                ):
                     print(f"    func_id={func_id}: {name}")
                 print()
 
@@ -270,7 +309,9 @@ def main():
 
             # Try to extract timestamp from filename
             if input_stem.startswith("perf_swimlane_"):
-                timestamp_part = input_stem[len("perf_swimlane_"):]  # e.g., "20260210_143526"
+                timestamp_part = input_stem[
+                    len("perf_swimlane_") :
+                ]  # e.g., "20260210_143526"
             else:
                 # Fallback: use current timestamp
                 timestamp_part = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -281,10 +322,12 @@ def main():
             output_path = outputs_dir / f"mermaid_diagram_{timestamp_part}.md"
 
         # Generate Mermaid diagram
-        mermaid_text = generate_mermaid_flowchart(data['tasks'], func_names, args.style, args.direction, args.verbose)
+        mermaid_text = generate_mermaid_flowchart(
+            data["tasks"], func_names, args.style, args.direction, args.verbose
+        )
 
         # Write to file
-        with open(output_path, 'w', encoding='utf-8') as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             f.write("# Task Dependency Graph\n\n")
             f.write(f"生成自：`{input_path.name}`\n\n")
             f.write(mermaid_text)
@@ -299,9 +342,10 @@ def main():
         print(f"错误：{e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc()
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/tools/sched_overhead_analysis.py
+++ b/tools/sched_overhead_analysis.py
@@ -13,6 +13,7 @@ Usage:
     python sched_overhead_analysis.py --device-log <path>      # specify device log
     python sched_overhead_analysis.py --perf-json <path> -d 0  # resolve from device-0
 """
+
 import argparse
 import json
 import re
@@ -20,15 +21,25 @@ import sys
 from pathlib import Path
 
 try:
-    from device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
+    from device_log_resolver import (
+        infer_device_id_from_log_path,
+        resolve_device_log_path,
+    )
 except ImportError:
-    from tools.device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
+    from tools.device_log_resolver import (
+        infer_device_id_from_log_path,
+        resolve_device_log_path,
+    )
 
 
 def auto_select_perf_json():
     """Find the latest perf_swimlane_*.json in outputs/ directory."""
-    outputs_dir = Path(__file__).parent.parent / 'outputs'
-    files = sorted(outputs_dir.glob('perf_swimlane_*.json'), key=lambda p: p.stat().st_mtime, reverse=True)
+    outputs_dir = Path(__file__).parent.parent / "outputs"
+    files = sorted(
+        outputs_dir.glob("perf_swimlane_*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
     if not files:
         raise FileNotFoundError(f"No perf_swimlane_*.json files found in {outputs_dir}")
     return files[0]
@@ -44,18 +55,18 @@ def parse_scheduler_from_json_phases(data):
         dict: Thread data keyed by thread index, same schema as parse_scheduler_threads.
               Returns empty dict if Phase data not available.
     """
-    if data.get('version', 1) < 2:
+    if data.get("version", 1) < 2:
         return {}
-    phases_by_thread = data.get('aicpu_scheduler_phases', [])
+    phases_by_thread = data.get("aicpu_scheduler_phases", [])
     if not phases_by_thread:
         return {}
 
     # Map JSON phase names to internal names
     phase_map = {
-        'complete': 'complete',
-        'dispatch': 'dispatch',
-        'scan': 'scan',
-        'idle': 'idle',
+        "complete": "complete",
+        "dispatch": "dispatch",
+        "scan": "scan",
+        "idle": "idle",
     }
 
     threads = {}
@@ -63,20 +74,20 @@ def parse_scheduler_from_json_phases(data):
         if not records:
             continue
 
-        phase_us = {p: 0.0 for p in ['complete', 'scan', 'dispatch', 'idle']}
+        phase_us = {p: 0.0 for p in ["complete", "scan", "dispatch", "idle"]}
         total_tasks = 0
         max_loop_iter = 0
 
         for rec in records:
-            phase = phase_map.get(rec.get('phase', ''))
+            phase = phase_map.get(rec.get("phase", ""))
             if phase is None:
                 continue
-            dur = rec.get('end_time_us', 0) - rec.get('start_time_us', 0)
+            dur = rec.get("end_time_us", 0) - rec.get("start_time_us", 0)
             if dur > 0:
                 phase_us[phase] += dur
-            if rec.get('tasks_processed', 0) > 0 and phase == 'complete':
-                total_tasks += rec['tasks_processed']
-            loop_iter = rec.get('loop_iter', 0)
+            if rec.get("tasks_processed", 0) > 0 and phase == "complete":
+                total_tasks += rec["tasks_processed"]
+            loop_iter = rec.get("loop_iter", 0)
             if loop_iter > max_loop_iter:
                 max_loop_iter = loop_iter
 
@@ -85,15 +96,15 @@ def parse_scheduler_from_json_phases(data):
         tasks_per_loop = total_tasks / loops if loops > 0 else 0.0
 
         t = {
-            'completed': total_tasks,
-            'total_us': total_us,
-            'loops': loops,
-            'tasks_per_loop': tasks_per_loop,
-            'format': 'json_phase',
+            "completed": total_tasks,
+            "total_us": total_us,
+            "loops": loops,
+            "tasks_per_loop": tasks_per_loop,
+            "format": "json_phase",
         }
         for p, us in phase_us.items():
-            t[f'{p}_us'] = us
-            t[f'{p}_pct'] = us / total_us * 100 if total_us > 0 else 0
+            t[f"{p}_us"] = us
+            t[f"{p}_pct"] = us / total_us * 100 if total_us > 0 else 0
 
         threads[tid] = t
 
@@ -115,20 +126,26 @@ def parse_scheduler_threads(log_path):
         Thread N: Scheduler summary: total_time=Xus, loops=Y, tasks_scheduled=Z
     """
     threads = {}
-    with open(log_path, 'r', errors='ignore') as f:
+    with open(log_path, "r", errors="ignore") as f:
         for line in f:
             # New format: Thread N: === Scheduler Phase Breakdown: total=Xus, Y tasks ===
-            m = re.search(r'Thread (\d+): === Scheduler Phase Breakdown: total=([\d.]+)us, (\d+) tasks ===', line)
+            m = re.search(
+                r"Thread (\d+): === Scheduler Phase Breakdown: total=([\d.]+)us, (\d+) tasks ===",
+                line,
+            )
             if m:
                 tid = int(m.group(1))
                 threads[tid] = {
-                    'completed': int(m.group(3)),
-                    'total_us': float(m.group(2)),
-                    'format': 'two-level',
+                    "completed": int(m.group(3)),
+                    "total_us": float(m.group(2)),
+                    "format": "two-level",
                 }
 
             # Summary format: Thread N: Scheduler summary: total_time=Xus, loops=Y, tasks_scheduled=Z
-            m = re.search(r'Thread (\d+): Scheduler summary: total_time=([\d.]+)us, loops=(\d+), tasks_scheduled=(\d+)', line)
+            m = re.search(
+                r"Thread (\d+): Scheduler summary: total_time=([\d.]+)us, loops=(\d+), tasks_scheduled=(\d+)",
+                line,
+            )
             if m:
                 tid = int(m.group(1))
                 total_us = float(m.group(2))
@@ -137,59 +154,63 @@ def parse_scheduler_threads(log_path):
                 tasks_per_loop = completed / loops if loops > 0 else 0.0
                 if tid in threads:
                     # Enrich existing entry (e.g. two-level) with loop stats
-                    threads[tid]['loops'] = loops
-                    threads[tid]['tasks_per_loop'] = tasks_per_loop
+                    threads[tid]["loops"] = loops
+                    threads[tid]["tasks_per_loop"] = tasks_per_loop
                 else:
                     threads[tid] = {
-                        'completed': completed,
-                        'total_us': total_us,
-                        'loops': loops,
-                        'tasks_per_loop': tasks_per_loop,
-                        'format': 'summary',
+                        "completed": completed,
+                        "total_us": total_us,
+                        "loops": loops,
+                        "tasks_per_loop": tasks_per_loop,
+                        "format": "summary",
                     }
 
             # New format: complete with fanout/fanin stats
             m = re.search(
-                r'Thread (\d+):\s+complete\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)'
-                r'\s+\[fanout: edges=(\d+), max_degree=(\d+), avg=([\d.]+)\]'
-                r'\s+\[fanin: edges=(\d+), max_degree=(\d+), avg=([\d.]+)\]',
-                line)
+                r"Thread (\d+):\s+complete\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)"
+                r"\s+\[fanout: edges=(\d+), max_degree=(\d+), avg=([\d.]+)\]"
+                r"\s+\[fanin: edges=(\d+), max_degree=(\d+), avg=([\d.]+)\]",
+                line,
+            )
             if m:
                 tid = int(m.group(1))
                 if tid in threads:
-                    threads[tid]['complete_us'] = float(m.group(2))
-                    threads[tid]['complete_pct'] = float(m.group(3))
-                    threads[tid]['fanout_edges'] = int(m.group(4))
-                    threads[tid]['fanout_max_degree'] = int(m.group(5))
-                    threads[tid]['fanout_avg'] = float(m.group(6))
-                    threads[tid]['fanin_edges'] = int(m.group(7))
-                    threads[tid]['fanin_max_degree'] = int(m.group(8))
-                    threads[tid]['fanin_avg'] = float(m.group(9))
+                    threads[tid]["complete_us"] = float(m.group(2))
+                    threads[tid]["complete_pct"] = float(m.group(3))
+                    threads[tid]["fanout_edges"] = int(m.group(4))
+                    threads[tid]["fanout_max_degree"] = int(m.group(5))
+                    threads[tid]["fanout_avg"] = float(m.group(6))
+                    threads[tid]["fanin_edges"] = int(m.group(7))
+                    threads[tid]["fanin_max_degree"] = int(m.group(8))
+                    threads[tid]["fanin_avg"] = float(m.group(9))
                 continue
 
             # New format: dispatch with pop stats
             m = re.search(
-                r'Thread (\d+):\s+dispatch\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)'
-                r'\s+\[pop: hit=(\d+), miss=(\d+), hit_rate=([\d.]+)%\]',
-                line)
+                r"Thread (\d+):\s+dispatch\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)"
+                r"\s+\[pop: hit=(\d+), miss=(\d+), hit_rate=([\d.]+)%\]",
+                line,
+            )
             if m:
                 tid = int(m.group(1))
                 if tid in threads:
-                    threads[tid]['dispatch_us'] = float(m.group(2))
-                    threads[tid]['dispatch_pct'] = float(m.group(3))
-                    threads[tid]['pop_hit'] = int(m.group(4))
-                    threads[tid]['pop_miss'] = int(m.group(5))
-                    threads[tid]['pop_hit_rate'] = float(m.group(6))
+                    threads[tid]["dispatch_us"] = float(m.group(2))
+                    threads[tid]["dispatch_pct"] = float(m.group(3))
+                    threads[tid]["pop_hit"] = int(m.group(4))
+                    threads[tid]["pop_miss"] = int(m.group(5))
+                    threads[tid]["pop_hit_rate"] = float(m.group(6))
                 continue
 
             # New format: scan and idle (no extra stats)
-            m = re.search(r'Thread (\d+):\s+(scan|idle)\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)', line)
+            m = re.search(
+                r"Thread (\d+):\s+(scan|idle)\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)", line
+            )
             if m:
                 tid = int(m.group(1))
                 if tid in threads:
                     phase = m.group(2)
-                    threads[tid][f'{phase}_us'] = float(m.group(3))
-                    threads[tid][f'{phase}_pct'] = float(m.group(4))
+                    threads[tid][f"{phase}_us"] = float(m.group(3))
+                    threads[tid][f"{phase}_pct"] = float(m.group(4))
                 continue
 
     return threads
@@ -222,22 +243,24 @@ def validate_perf_tasks_for_overhead_analysis(tasks):
         detail = "; ".join(missing)
         # These fields are produced by runtime-side JSON export in:
         # src/platform/src/host/performance_collector.cpp (dispatch_time_us, finish_time_us)
-        msg = "\n".join([
-            "Perf JSON is incompatible with scheduler overhead deep-dive analysis.",
-            f"Missing required fields (showing up to 5 tasks): {detail}",
-            "",
-            "Why this happens:",
-            "  - The input is not a runtime-generated perf_swimlane_*.json, OR",
-            "  - The runtime binary does not include / emit dispatch+finish timestamps.",
-            "",
-            "How to fix:",
-            "  1) Re-run workload with profiling enabled (e.g. run_example.py --enable-profiling).",
-            "  2) Use the newly generated outputs/perf_swimlane_*.json as --perf-json input.",
-            "  3) Verify each task includes dispatch_time_us and finish_time_us.",
-            "",
-            "Note:",
-            "  - swimlane_converter conversion can still succeed; only deep-dive analysis requires these fields.",
-        ])
+        msg = "\n".join(
+            [
+                "Perf JSON is incompatible with scheduler overhead deep-dive analysis.",
+                f"Missing required fields (showing up to 5 tasks): {detail}",
+                "",
+                "Why this happens:",
+                "  - The input is not a runtime-generated perf_swimlane_*.json, OR",
+                "  - The runtime binary does not include / emit dispatch+finish timestamps.",
+                "",
+                "How to fix:",
+                "  1) Re-run workload with profiling enabled (e.g. run_example.py --enable-profiling).",
+                "  2) Use the newly generated outputs/perf_swimlane_*.json as --perf-json input.",
+                "  3) Verify each task includes dispatch_time_us and finish_time_us.",
+                "",
+                "Note:",
+                "  - swimlane_converter conversion can still succeed; only deep-dive analysis requires these fields.",
+            ]
+        )
         return False, msg
 
     return True, ""
@@ -277,7 +300,7 @@ def run_analysis(perf_path, log_path, print_sources=True, selection_strategy=Non
     # === Part 1: Per-task time breakdown from perf data ===
     with open(perf_path) as f:
         data = json.load(f)
-    tasks = data['tasks']
+    tasks = data["tasks"]
     n_total = len(tasks)
 
     if n_total == 0:
@@ -289,157 +312,208 @@ def run_analysis(perf_path, log_path, print_sources=True, selection_strategy=Non
         print(f"Error: {err}", file=sys.stderr)
         return 1
 
-    all_exec = sum(t['duration_us'] for t in tasks)
-    all_head = sum(t['start_time_us'] - t['dispatch_time_us'] for t in tasks)
-    all_tail = sum(t['finish_time_us'] - t['end_time_us'] for t in tasks)
-    min_disp = min(t['dispatch_time_us'] for t in tasks)
-    max_fin = max(t['finish_time_us'] for t in tasks)
+    all_exec = sum(t["duration_us"] for t in tasks)
+    all_head = sum(t["start_time_us"] - t["dispatch_time_us"] for t in tasks)
+    all_tail = sum(t["finish_time_us"] - t["end_time_us"] for t in tasks)
+    min_disp = min(t["dispatch_time_us"] for t in tasks)
+    max_fin = max(t["finish_time_us"] for t in tasks)
     wall = max_fin - min_disp
 
     all_latency = all_exec + all_head + all_tail
 
     print()
-    print('=' * 90)
-    print('Part 1: Per-task time breakdown (from perf profiling data)')
-    print('=' * 90)
-    print(f'Total tasks: {n_total}')
-    print(f'Wall-clock:  {wall:.1f} us')
+    print("=" * 90)
+    print("Part 1: Per-task time breakdown (from perf profiling data)")
+    print("=" * 90)
+    print(f"Total tasks: {n_total}")
+    print(f"Wall-clock:  {wall:.1f} us")
     print()
     fmt = "  {:<35} {:>12} {:>14} {:>13}"
-    print(fmt.format('Component', 'Total (us)', 'Avg/task (us)', '% of Latency'))
-    print('  ' + '-' * 78)
-    print(fmt.format('Kernel Exec (end-start)', f'{all_exec:.1f}', f'{all_exec/n_total:.2f}', f'{all_exec/all_latency*100:.1f}%'))
-    print(fmt.format('Head OH (start-dispatch)', f'{all_head:.1f}', f'{all_head/n_total:.2f}', f'{all_head/all_latency*100:.1f}%'))
-    print(fmt.format('Tail OH (finish-end)', f'{all_tail:.1f}', f'{all_tail/n_total:.2f}', f'{all_tail/all_latency*100:.1f}%'))
+    print(fmt.format("Component", "Total (us)", "Avg/task (us)", "% of Latency"))
+    print("  " + "-" * 78)
+    print(
+        fmt.format(
+            "Kernel Exec (end-start)",
+            f"{all_exec:.1f}",
+            f"{all_exec / n_total:.2f}",
+            f"{all_exec / all_latency * 100:.1f}%",
+        )
+    )
+    print(
+        fmt.format(
+            "Head OH (start-dispatch)",
+            f"{all_head:.1f}",
+            f"{all_head / n_total:.2f}",
+            f"{all_head / all_latency * 100:.1f}%",
+        )
+    )
+    print(
+        fmt.format(
+            "Tail OH (finish-end)",
+            f"{all_tail:.1f}",
+            f"{all_tail / n_total:.2f}",
+            f"{all_tail / all_latency * 100:.1f}%",
+        )
+    )
     print()
 
     # === Part 2: AICPU scheduler loop breakdown ===
     # Prefer JSON Phase data (version >= 2), fall back to device log
     threads = parse_scheduler_from_json_phases(data)
-    phase_source = 'perf JSON phase data'
+    phase_source = "perf JSON phase data"
     if not threads:
         threads = parse_scheduler_threads(log_path)
-        phase_source = 'device log'
+        phase_source = "device log"
     n_threads = len(threads)
 
-    print('=' * 90)
-    print('Part 2: AICPU scheduler loop breakdown (from ' + phase_source + ')')
-    print(f'  {n_threads} scheduler threads')
-    print('=' * 90)
+    print("=" * 90)
+    print("Part 2: AICPU scheduler loop breakdown (from " + phase_source + ")")
+    print(f"  {n_threads} scheduler threads")
+    print("=" * 90)
     print()
 
     fmt2 = "  {:<10} {:>7} {:>10} {:>12} {:>11}"
-    print(fmt2.format('Thread', 'Loops', 'Completed', 'Tasks/loop', 'Total (us)'))
-    print('  ' + '-' * 54)
+    print(fmt2.format("Thread", "Loops", "Completed", "Tasks/loop", "Total (us)"))
+    print("  " + "-" * 54)
     for tid in sorted(threads.keys()):
         t = threads[tid]
-        print(fmt2.format('T'+str(tid), t['loops'], t['completed'], f"{t['tasks_per_loop']:.1f}", f"{t['total_us']:.1f}"))
-    total_us = sum(t['total_us'] for t in threads.values())
-    total_completed = sum(t['completed'] for t in threads.values())
-    total_loops = sum(t['loops'] for t in threads.values())
+        print(
+            fmt2.format(
+                "T" + str(tid),
+                t["loops"],
+                t["completed"],
+                f"{t['tasks_per_loop']:.1f}",
+                f"{t['total_us']:.1f}",
+            )
+        )
+    total_us = sum(t["total_us"] for t in threads.values())
+    total_completed = sum(t["completed"] for t in threads.values())
+    total_loops = sum(t["loops"] for t in threads.values())
     avg_tpl = total_completed / total_loops if total_loops > 0 else 0
-    print(fmt2.format('SUM', total_loops, total_completed, f'{avg_tpl:.1f}', f'{total_us:.1f}'))
+    print(
+        fmt2.format(
+            "SUM", total_loops, total_completed, f"{avg_tpl:.1f}", f"{total_us:.1f}"
+        )
+    )
     print()
 
     # Phase breakdown
-    phases = ['complete', 'scan', 'dispatch', 'idle']
+    phases = ["complete", "scan", "dispatch", "idle"]
     phase_labels = {
-        'complete':    'Complete (poll handshake, resolve deps)',
-        'scan':        'Scan (update perf header)',
-        'dispatch':    'Dispatch (pop queue, build payload, flush)',
-        'idle':        'Idle (spinning, no progress)',
+        "complete": "Complete (poll handshake, resolve deps)",
+        "scan": "Scan (update perf header)",
+        "dispatch": "Dispatch (pop queue, build payload, flush)",
+        "idle": "Idle (spinning, no progress)",
     }
 
     fmt3 = "  {:<50} {:>11} {:>10} {:>14}"
-    print(fmt3.format('Phase', 'Total (us)', '% of total', 'Avg/task (us)'))
-    print('  ' + '-' * 89)
+    print(fmt3.format("Phase", "Total (us)", "% of total", "Avg/task (us)"))
+    print("  " + "-" * 89)
     phase_totals = {}
     for p in phases:
-        key = p + '_us'
+        key = p + "_us"
         tot = sum(t.get(key, 0) for t in threads.values())
         phase_totals[p] = tot
         pct = tot / total_us * 100 if total_us > 0 else 0
         avg = tot / total_completed if total_completed > 0 else 0
-        print(fmt3.format(phase_labels[p], f'{tot:.1f}', f'{pct:.1f}%', f'{avg:.2f}'))
+        print(fmt3.format(phase_labels[p], f"{tot:.1f}", f"{pct:.1f}%", f"{avg:.2f}"))
     print()
 
     # Fanout stats (from complete phase)
-    fanout_edges = sum(t.get('fanout_edges', 0) for t in threads.values())
-    fanout_max = max((t.get('fanout_max_degree', 0) for t in threads.values()), default=0)
+    fanout_edges = sum(t.get("fanout_edges", 0) for t in threads.values())
+    fanout_max = max(
+        (t.get("fanout_max_degree", 0) for t in threads.values()), default=0
+    )
     fanout_avg = fanout_edges / total_completed if total_completed > 0 else 0
-    print(f'  Fanout (notify consumers): total edges={fanout_edges}, max_degree={fanout_max}, avg_degree={fanout_avg:.1f}')
+    print(
+        f"  Fanout (notify consumers): total edges={fanout_edges}, max_degree={fanout_max}, avg_degree={fanout_avg:.1f}"
+    )
 
     # Fanin stats (from complete phase)
-    fanin_edges = sum(t.get('fanin_edges', 0) for t in threads.values())
-    fanin_max = max((t.get('fanin_max_degree', 0) for t in threads.values()), default=0)
+    fanin_edges = sum(t.get("fanin_edges", 0) for t in threads.values())
+    fanin_max = max((t.get("fanin_max_degree", 0) for t in threads.values()), default=0)
     fanin_avg = fanin_edges / total_completed if total_completed > 0 else 0
-    print(f'  Fanin  (release producers): total edges={fanin_edges}, max_degree={fanin_max}, avg_degree={fanin_avg:.1f}')
+    print(
+        f"  Fanin  (release producers): total edges={fanin_edges}, max_degree={fanin_max}, avg_degree={fanin_avg:.1f}"
+    )
     print()
 
     # Pop stats (from dispatch phase)
-    pop_hit = sum(t.get('pop_hit', 0) for t in threads.values())
-    pop_miss = sum(t.get('pop_miss', 0) for t in threads.values())
+    pop_hit = sum(t.get("pop_hit", 0) for t in threads.values())
+    pop_miss = sum(t.get("pop_miss", 0) for t in threads.values())
     pop_total = pop_hit + pop_miss
     pop_hit_rate = pop_hit / pop_total * 100 if pop_total > 0 else 0
-    print(f'  Pop: hit={pop_hit}, miss={pop_miss}, hit_rate={pop_hit_rate:.1f}%')
+    print(f"  Pop: hit={pop_hit}, miss={pop_miss}, hit_rate={pop_hit_rate:.1f}%")
 
     print()
-    print('=' * 90)
-    print('Part 3: Tail OH distribution & cause analysis')
-    print('=' * 90)
+    print("=" * 90)
+    print("Part 3: Tail OH distribution & cause analysis")
+    print("=" * 90)
     print()
 
-    tails = [t['finish_time_us'] - t['end_time_us'] for t in tasks]
+    tails = [t["finish_time_us"] - t["end_time_us"] for t in tasks]
     tails.sort()
     n = len(tails)
     if n == 0:
-        print('Error: Empty tail-overhead set', file=sys.stderr)
+        print("Error: Empty tail-overhead set", file=sys.stderr)
         return 1
 
-    print(f'  Tail OH distribution (N={n}):')
+    print(f"  Tail OH distribution (N={n}):")
     for pct_val in [10, 25, 50, 75, 90, 95, 99]:
         idx = min(int(n * pct_val / 100), n - 1)
-        print(f'    P{pct_val:<4}  {tails[idx]:>7.1f} us')
-    print(f'    Max:   {tails[-1]:>7.1f} us')
-    print(f'    Mean:  {sum(tails)/n:>7.1f} us')
+        print(f"    P{pct_val:<4}  {tails[idx]:>7.1f} us")
+    print(f"    Max:   {tails[-1]:>7.1f} us")
+    print(f"    Mean:  {sum(tails) / n:>7.1f} us")
     print()
 
     # Scheduler loop time
     avg_loop_us = total_us / total_loops if total_loops > 0 else 0
     avg_tail_oh = sum(tails) / n
     loop_ratio = avg_tail_oh / avg_loop_us if avg_loop_us > 0 else 0
-    print(f'  Avg scheduler loop iteration: {avg_loop_us:.1f} us (approx avg polling interval per loop)')
+    print(
+        f"  Avg scheduler loop iteration: {avg_loop_us:.1f} us (approx avg polling interval per loop)"
+    )
     print()
-    print(f'  Avg Tail OH = {avg_tail_oh:.1f} us ~= {loop_ratio:.1f} x avg loop iteration ({avg_loop_us:.1f} us)')
-    print(f'  -> On average, a completed task waits ~{loop_ratio:.1f} loop iterations before being detected')
+    print(
+        f"  Avg Tail OH = {avg_tail_oh:.1f} us ~= {loop_ratio:.1f} x avg loop iteration ({avg_loop_us:.1f} us)"
+    )
+    print(
+        f"  -> On average, a completed task waits ~{loop_ratio:.1f} loop iterations before being detected"
+    )
     print()
 
     # Data-driven insight: find the dominant phase (excluding idle which is not useful work)
-    work_phases = {p: phase_totals.get(p, 0) for p in ['scan', 'complete', 'dispatch']}
+    work_phases = {p: phase_totals.get(p, 0) for p in ["scan", "complete", "dispatch"]}
     dominant_phase = max(work_phases, key=work_phases.get)
     dominant_pct = work_phases[dominant_phase] / total_us * 100 if total_us > 0 else 0
-    print(f'  Key insight: {phase_labels[dominant_phase].split(" (")[0]} phase consumes ~{dominant_pct:.0f}% of scheduler CPU.')
-    if dominant_phase == 'dispatch':
-        print(f'  Pop hit_rate={pop_hit_rate:.1f}%: {"low hit rate suggests ready queue often empty" if pop_hit_rate < 50 else "good hit rate"}.')
-        print('  Cache flush (dc cvac + dsb sy) is the dominant non-pop cost.')
-    elif dominant_phase == 'complete':
+    print(
+        f"  Key insight: {phase_labels[dominant_phase].split(' (')[0]} phase consumes ~{dominant_pct:.0f}% of scheduler CPU."
+    )
+    if dominant_phase == "dispatch":
+        print(
+            f"  Pop hit_rate={pop_hit_rate:.1f}%: {'low hit rate suggests ready queue often empty' if pop_hit_rate < 50 else 'good hit rate'}."
+        )
+        print("  Cache flush (dc cvac + dsb sy) is the dominant non-pop cost.")
+    elif dominant_phase == "complete":
         total_edges = fanout_edges + fanin_edges
-        print(f'  Fanout: avg_degree={fanout_avg:.1f}, max_degree={fanout_max}.')
-        print(f'  Fanin:  avg_degree={fanin_avg:.1f}, max_degree={fanin_max}.')
+        print(f"  Fanout: avg_degree={fanout_avg:.1f}, max_degree={fanout_max}.")
+        print(f"  Fanin:  avg_degree={fanin_avg:.1f}, max_degree={fanin_max}.")
         if fanin_edges > fanout_edges:
-            print('  Fanin traversal (release_producer + check_consumed) dominates the complete phase.')
+            print(
+                "  Fanin traversal (release_producer + check_consumed) dominates the complete phase."
+            )
         else:
-            print('  Fanout traversal and atomic ops dominate the complete phase.')
-    elif dominant_phase == 'scan':
-        print('  Scan phase overhead indicates frequent perf header updates.')
-    print('=' * 90)
+            print("  Fanout traversal and atomic ops dominate the complete phase.")
+    elif dominant_phase == "scan":
+        print("  Scan phase overhead indicates frequent perf header updates.")
+    print("=" * 90)
 
     return 0
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Scheduler overhead analysis for PTO2',
+        description="Scheduler overhead analysis for PTO2",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -447,11 +521,19 @@ Examples:
   %(prog)s --perf-json outputs/perf_swimlane_*.json
   %(prog)s --device-log ~/ascend/log/debug/device-0/device-*.log
   %(prog)s --perf-json outputs/perf_swimlane_*.json -d 0
-        """
+        """,
     )
-    parser.add_argument('--perf-json', help='Path to perf_swimlane_*.json file. If not specified, uses the latest in outputs/')
-    parser.add_argument('--device-log', help='Path to device log file/path/glob. Overrides auto-resolution when provided')
-    parser.add_argument('-d', '--device-id', help='Device id for auto-selection from device-<id>')
+    parser.add_argument(
+        "--perf-json",
+        help="Path to perf_swimlane_*.json file. If not specified, uses the latest in outputs/",
+    )
+    parser.add_argument(
+        "--device-log",
+        help="Path to device log file/path/glob. Overrides auto-resolution when provided",
+    )
+    parser.add_argument(
+        "-d", "--device-id", help="Device id for auto-selection from device-<id>"
+    )
     args = parser.parse_args()
 
     # Resolve perf path
@@ -479,8 +561,10 @@ Examples:
         print(f"Error: Device log not found: {log_path}", file=sys.stderr)
         return 1
 
-    return run_analysis(perf_path, log_path, print_sources=True, selection_strategy=strategy)
+    return run_analysis(
+        perf_path, log_path, print_sources=True, selection_strategy=strategy
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/tools/swimlane_converter.py
+++ b/tools/swimlane_converter.py
@@ -21,14 +21,26 @@ from datetime import datetime
 import importlib.util
 
 try:
-    from device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
+    from device_log_resolver import (
+        infer_device_id_from_log_path,
+        resolve_device_log_path,
+    )
 except ImportError:
-    from tools.device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
+    from tools.device_log_resolver import (
+        infer_device_id_from_log_path,
+        resolve_device_log_path,
+    )
 
 try:
-    from sched_overhead_analysis import parse_scheduler_threads, run_analysis as run_sched_overhead_analysis
+    from sched_overhead_analysis import (
+        parse_scheduler_threads,
+        run_analysis as run_sched_overhead_analysis,
+    )
 except ImportError:
-    from tools.sched_overhead_analysis import parse_scheduler_threads, run_analysis as run_sched_overhead_analysis
+    from tools.sched_overhead_analysis import (
+        parse_scheduler_threads,
+        run_analysis as run_sched_overhead_analysis,
+    )
 
 
 def normalize_pto2_task_id_int(v):
@@ -80,17 +92,17 @@ def read_perf_data(filepath):
     Raises:
         ValueError: If JSON format is invalid
     """
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         data = json.load(f)
 
     # Validate required fields
-    required_fields = ['version', 'tasks']
+    required_fields = ["version", "tasks"]
     for field in required_fields:
         if field not in data:
             raise ValueError(f"Missing required field: {field}")
 
     # Validate version
-    if data['version'] not in [1, 2]:
+    if data["version"] not in [1, 2]:
         raise ValueError(f"Unsupported version: {data['version']} (expected 1 or 2)")
 
     return data
@@ -124,25 +136,31 @@ def load_kernel_config(config_path):
     spec.loader.exec_module(module)
 
     # Extract func_id to name mapping from KERNELS list
-    if not hasattr(module, 'KERNELS'):
+    if not hasattr(module, "KERNELS"):
         raise ValueError(f"kernel_config.py missing KERNELS definition")
 
     func_id_to_name = {}
     for kernel in module.KERNELS:
         # Skip entries without func_id
-        if 'func_id' not in kernel:
-            print(f"Warning: Kernel entry missing 'func_id', skipping: {kernel}", file=sys.stderr)
+        if "func_id" not in kernel:
+            print(
+                f"Warning: Kernel entry missing 'func_id', skipping: {kernel}",
+                file=sys.stderr,
+            )
             continue
 
-        func_id = kernel['func_id']
+        func_id = kernel["func_id"]
 
         # If name is missing, we'll fall back to default naming (Func_{func_id})
-        if 'name' not in kernel:
-            print(f"Warning: Kernel entry for func_id={func_id} missing 'name', will use default naming", file=sys.stderr)
+        if "name" not in kernel:
+            print(
+                f"Warning: Kernel entry for func_id={func_id} missing 'name', will use default naming",
+                file=sys.stderr,
+            )
             continue
 
         # Store as string to match JSON format
-        func_id_to_name[str(func_id)] = kernel['name']
+        func_id_to_name[str(func_id)] = kernel["name"]
 
     return func_id_to_name
 
@@ -168,20 +186,27 @@ def parse_sched_cpu_from_device_log(log_path, task_count):
     if not threads:
         return None
 
-    total_sched_cpu_us = sum(t.get('total_us', 0.0) for t in threads.values())
+    total_sched_cpu_us = sum(t.get("total_us", 0.0) for t in threads.values())
     if total_sched_cpu_us <= 0:
         return None
 
-    total_completed = sum(t.get('completed', 0) for t in threads.values())
-    if task_count > 0 and total_completed > 0 and abs(total_completed - task_count) / task_count > 0.5:
-        print(f"Warning: device log has {total_completed} completed tasks "
-              f"but perf JSON has {task_count}; skipping Sched CPU metric "
-              f"(device log may be from a different run)", file=sys.stderr)
+    total_completed = sum(t.get("completed", 0) for t in threads.values())
+    if (
+        task_count > 0
+        and total_completed > 0
+        and abs(total_completed - task_count) / task_count > 0.5
+    ):
+        print(
+            f"Warning: device log has {total_completed} completed tasks "
+            f"but perf JSON has {task_count}; skipping Sched CPU metric "
+            f"(device log may be from a different run)",
+            file=sys.stderr,
+        )
         return None
 
     return {
-        'us_per_task': total_sched_cpu_us / task_count,
-        'num_sched_threads': len(threads),
+        "us_per_task": total_sched_cpu_us / task_count,
+        "num_sched_threads": len(threads),
     }
 
 
@@ -203,46 +228,48 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
     from collections import defaultdict
 
     # Group tasks by func_id with extended metrics
-    func_stats = defaultdict(lambda: {
-        'durations': [],
-        'head_overheads': [],
-        'tail_overheads': [],
-        'latencies': [],
-        'total_exec_time': 0.0,
-        'total_latency': 0.0
-    })
+    func_stats = defaultdict(
+        lambda: {
+            "durations": [],
+            "head_overheads": [],
+            "tail_overheads": [],
+            "latencies": [],
+            "total_exec_time": 0.0,
+            "total_latency": 0.0,
+        }
+    )
 
     # Track global min dispatch and max finish times
-    min_dispatch_time = float('inf')
-    max_finish_time = float('-inf')
+    min_dispatch_time = float("inf")
+    max_finish_time = float("-inf")
 
     for task in tasks:
-        func_id = task['func_id']
-        duration = task['duration_us']
-        func_stats[func_id]['durations'].append(duration)
+        func_id = task["func_id"]
+        duration = task["duration_us"]
+        func_stats[func_id]["durations"].append(duration)
 
         # Calculate new metrics if dispatch_time_us and finish_time_us are available
-        if 'dispatch_time_us' in task and 'finish_time_us' in task:
-            dispatch_time = task['dispatch_time_us']
-            finish_time = task['finish_time_us']
-            start_time = task['start_time_us']
-            end_time = task['end_time_us']
+        if "dispatch_time_us" in task and "finish_time_us" in task:
+            dispatch_time = task["dispatch_time_us"]
+            finish_time = task["finish_time_us"]
+            start_time = task["start_time_us"]
+            end_time = task["end_time_us"]
 
             # Head overhead: start_time_us - dispatch_time_us
             head_overhead = start_time - dispatch_time
-            func_stats[func_id]['head_overheads'].append(head_overhead)
+            func_stats[func_id]["head_overheads"].append(head_overhead)
 
             # Tail overhead: finish_time_us - end_time_us
             tail_overhead = finish_time - end_time
-            func_stats[func_id]['tail_overheads'].append(tail_overhead)
+            func_stats[func_id]["tail_overheads"].append(tail_overhead)
 
             # Latency: finish_time_us - dispatch_time_us
             latency = finish_time - dispatch_time
-            func_stats[func_id]['latencies'].append(latency)
+            func_stats[func_id]["latencies"].append(latency)
 
             # Accumulate execution time and latency for ratio calculation
-            func_stats[func_id]['total_exec_time'] += duration
-            func_stats[func_id]['total_latency'] += latency
+            func_stats[func_id]["total_exec_time"] += duration
+            func_stats[func_id]["total_latency"] += latency
 
             # Track global times
             min_dispatch_time = min(min_dispatch_time, dispatch_time)
@@ -251,9 +278,13 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
     # Print statistics
     print("\n" + "=" * 110)
     print("Task Statistics by Function")
-    print("  Exec = kernel time on AICore; Latency = dispatch->finish (incl. head OH + Exec + tail OH)")
+    print(
+        "  Exec = kernel time on AICore; Latency = dispatch->finish (incl. head OH + Exec + tail OH)"
+    )
     print("=" * 110)
-    print(f"{'Func_ID':<8} {'Func_Name':<12} {'Count':>5}   {'Avg Exec(us)':>12}  {'Avg Latency(us)':>15}  {'Exec%':>6}   {'Avg Head OH(us)':>15}  {'Avg Tail OH(us)':>15}")
+    print(
+        f"{'Func_ID':<8} {'Func_Name':<12} {'Count':>5}   {'Avg Exec(us)':>12}  {'Avg Latency(us)':>15}  {'Exec%':>6}   {'Avg Head OH(us)':>15}  {'Avg Tail OH(us)':>15}"
+    )
     print("-" * 110)
 
     # Sort by func_id for consistent output
@@ -262,7 +293,7 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
 
     for func_id in sorted(func_stats.keys()):
         stats = func_stats[func_id]
-        durations = stats['durations']
+        durations = stats["durations"]
         count = len(durations)
         sum_duration = sum(durations)
         avg_duration = sum_duration / count
@@ -278,26 +309,44 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
             func_name = f"Func_{func_id}"
 
         # Calculate averages
-        avg_head_overhead = sum(stats['head_overheads']) / len(stats['head_overheads']) if stats['head_overheads'] else 0
-        avg_tail_overhead = sum(stats['tail_overheads']) / len(stats['tail_overheads']) if stats['tail_overheads'] else 0
-        avg_latency = stats['total_latency'] / count if count > 0 else 0
+        avg_head_overhead = (
+            sum(stats["head_overheads"]) / len(stats["head_overheads"])
+            if stats["head_overheads"]
+            else 0
+        )
+        avg_tail_overhead = (
+            sum(stats["tail_overheads"]) / len(stats["tail_overheads"])
+            if stats["tail_overheads"]
+            else 0
+        )
+        avg_latency = stats["total_latency"] / count if count > 0 else 0
 
         # Calculate execution ratio: total_exec_time / total_latency
-        exec_ratio = (stats['total_exec_time'] / stats['total_latency'] * 100) if stats['total_latency'] > 0 else 0
+        exec_ratio = (
+            (stats["total_exec_time"] / stats["total_latency"] * 100)
+            if stats["total_latency"] > 0
+            else 0
+        )
 
-        print(f"{func_id:<8} {func_name:<12} {count:>5}   {avg_duration:>12.2f}  {avg_latency:>15.2f}  {exec_ratio:>5.1f}%   {avg_head_overhead:>15.2f}  {avg_tail_overhead:>15.2f}")
+        print(
+            f"{func_id:<8} {func_name:<12} {count:>5}   {avg_duration:>12.2f}  {avg_latency:>15.2f}  {exec_ratio:>5.1f}%   {avg_head_overhead:>15.2f}  {avg_tail_overhead:>15.2f}"
+        )
 
     # Print total row
     print("-" * 110)
 
     # Calculate total latency (sum of all latencies)
-    total_latency_sum = sum(stats['total_latency'] for stats in func_stats.values())
-    print(f"{'TOTAL':<21} {total_count:>5}   {total_duration:>12.2f}  {total_latency_sum:>15.2f}")
+    total_latency_sum = sum(stats["total_latency"] for stats in func_stats.values())
+    print(
+        f"{'TOTAL':<21} {total_count:>5}   {total_duration:>12.2f}  {total_latency_sum:>15.2f}"
+    )
 
     # Print total test execution time
-    if min_dispatch_time != float('inf') and max_finish_time != float('-inf'):
+    if min_dispatch_time != float("inf") and max_finish_time != float("-inf"):
         total_test_time = max_finish_time - min_dispatch_time
-        print(f"\nTotal Test Time: {total_test_time:.2f} us (from earliest dispatch to latest finish)")
+        print(
+            f"\nTotal Test Time: {total_test_time:.2f} us (from earliest dispatch to latest finish)"
+        )
 
     # Task execution vs Scheduler overhead summary
     if total_count > 0 and total_latency_sum > 0:
@@ -305,27 +354,40 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
         avg_latency_us = total_latency_sum / total_count
         exec_latency_ratio_pct = total_duration / total_latency_sum * 100
         print("\n--- Task execution vs Scheduler overhead ---")
-        print(f"  Per-task (all):  Avg Exec = {avg_exec_us:.2f} us,  Avg Latency (dispatch->finish) = {avg_latency_us:.2f} us,  Exec/Latency = {exec_latency_ratio_pct:.2f}%")
+        print(
+            f"  Per-task (all):  Avg Exec = {avg_exec_us:.2f} us,  Avg Latency (dispatch->finish) = {avg_latency_us:.2f} us,  Exec/Latency = {exec_latency_ratio_pct:.2f}%"
+        )
         if sched_info is not None:
-            sched_cpu = sched_info['us_per_task']
-            num_cores = len(set(t['core_id'] for t in tasks))
+            sched_cpu = sched_info["us_per_task"]
+            num_cores = len(set(t["core_id"] for t in tasks))
             exec_sched_ratio = (avg_exec_us / sched_cpu * 100) if sched_cpu > 0 else 0
             per_core_exec = avg_exec_us / num_cores if num_cores > 0 else 0
             per_core_ratio = (per_core_exec / sched_cpu * 100) if sched_cpu > 0 else 0
-            num_threads = sched_info['num_sched_threads']
-            print(f"  Sched CPU (from device log): {sched_cpu:.2f} us/task  (Exec/Sched = {exec_sched_ratio:.1f}%, PerCore/Sched = {per_core_ratio:.1f}%)")
-            print(f"  (Latency = dispatch→finish; Sched CPU = scheduler thread CPU per task; PerCore = avg_exec/{num_cores}_cores vs sched_cpu, {num_threads} sched threads)")
+            num_threads = sched_info["num_sched_threads"]
+            print(
+                f"  Sched CPU (from device log): {sched_cpu:.2f} us/task  (Exec/Sched = {exec_sched_ratio:.1f}%, PerCore/Sched = {per_core_ratio:.1f}%)"
+            )
+            print(
+                f"  (Latency = dispatch→finish; Sched CPU = scheduler thread CPU per task; PerCore = avg_exec/{num_cores}_cores vs sched_cpu, {num_threads} sched threads)"
+            )
         else:
-            print("  (Latency = dispatch→finish; Sched CPU = scheduler thread CPU per task)")
+            print(
+                "  (Latency = dispatch→finish; Sched CPU = scheduler thread CPU per task)"
+            )
 
     print("=" * 110)
 
 
-
-
-def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose=False,
-                                scheduler_phases=None, orchestrator_data=None,
-                                orchestrator_phases=None, core_to_thread=None):
+def generate_chrome_trace_json(
+    tasks,
+    output_path,
+    func_id_to_name=None,
+    verbose=False,
+    scheduler_phases=None,
+    orchestrator_data=None,
+    orchestrator_phases=None,
+    core_to_thread=None,
+):
     """Generate Chrome Trace Event Format JSON from task data.
 
     Args:
@@ -358,7 +420,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
     # Step 1: Build core_to_tid mapping (using only core_id, not core_type)
     unique_cores = set()
     for task in tasks:
-        unique_cores.add(task['core_id'])
+        unique_cores.add(task["core_id"])
 
     core_to_tid = {}
     tid_counter = 1000
@@ -374,74 +436,86 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
     # Metadata event: Process names and sort order
     # Display order: Orchestrator (pid=4) → Scheduler (pid=3) → AICPU View (pid=2) → AICore View (pid=1)
-    events.append({
-        "args": {"name": "AICore View"},
-        "cat": "__metadata",
-        "name": "process_name",
-        "ph": "M",
-        "pid": 1
-    })
-    events.append({
-        "args": {"sort_index": 4},
-        "cat": "__metadata",
-        "name": "process_sort_index",
-        "ph": "M",
-        "pid": 1
-    })
+    events.append(
+        {
+            "args": {"name": "AICore View"},
+            "cat": "__metadata",
+            "name": "process_name",
+            "ph": "M",
+            "pid": 1,
+        }
+    )
+    events.append(
+        {
+            "args": {"sort_index": 4},
+            "cat": "__metadata",
+            "name": "process_sort_index",
+            "ph": "M",
+            "pid": 1,
+        }
+    )
 
     # Check if any task has AICPU timestamps
     has_aicpu_data = any(
-        task.get('dispatch_time_us', 0) > 0 and task.get('finish_time_us', 0) > 0
+        task.get("dispatch_time_us", 0) > 0 and task.get("finish_time_us", 0) > 0
         for task in tasks
     )
 
     if has_aicpu_data:
-        events.append({
-            "args": {"name": "AICPU View"},
-            "cat": "__metadata",
-            "name": "process_name",
-            "ph": "M",
-            "pid": 2
-        })
-        events.append({
-            "args": {"sort_index": 3},
-            "cat": "__metadata",
-            "name": "process_sort_index",
-            "ph": "M",
-            "pid": 2
-        })
+        events.append(
+            {
+                "args": {"name": "AICPU View"},
+                "cat": "__metadata",
+                "name": "process_name",
+                "ph": "M",
+                "pid": 2,
+            }
+        )
+        events.append(
+            {
+                "args": {"sort_index": 3},
+                "cat": "__metadata",
+                "name": "process_sort_index",
+                "ph": "M",
+                "pid": 2,
+            }
+        )
 
     # Metadata events: Thread names (one per core)
     for core_id, tid in core_to_tid.items():
         # Find first task with this core_id to get core_type
         core_type = None
         for task in tasks:
-            if task['core_id'] == core_id:
-                core_type = task['core_type']
+            if task["core_id"] == core_id:
+                core_type = task["core_type"]
                 break
 
         # core_type is now a string ("aic" or "aiv")
         core_type_str = core_type.upper()
         thread_name = f"{core_type_str}_{core_id}"
-        events.append({
-            "args": {"name": thread_name},
-            "cat": "__metadata",
-            "name": "thread_name",
-            "ph": "M",
-            "pid": 1,
-            "tid": tid
-        })
-
-        # Also add thread name for AICPU View if data exists
-        if has_aicpu_data:
-            events.append({
+        events.append(
+            {
                 "args": {"name": thread_name},
                 "cat": "__metadata",
                 "name": "thread_name",
                 "ph": "M",
-                "pid": 2,
-                "tid": tid
-            })
+                "pid": 1,
+                "tid": tid,
+            }
+        )
+
+        # Also add thread name for AICPU View if data exists
+        if has_aicpu_data:
+            events.append(
+                {
+                    "args": {"name": thread_name},
+                    "cat": "__metadata",
+                    "name": "thread_name",
+                    "ph": "M",
+                    "pid": 2,
+                    "tid": tid,
+                }
+            )
 
     # Duration events (Complete events "X")
     # Build task_id -> event_id mapping for flow events
@@ -449,91 +523,97 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
     event_id = 0
 
     for task in tasks:
-        tid = core_to_tid[task['core_id']]
-        ts = task['start_time_us']
-        dur = task['duration_us']
+        tid = core_to_tid[task["core_id"]]
+        ts = task["start_time_us"]
+        dur = task["duration_us"]
 
         # Build fanout hint string (packed ids → rXtY / tY for readability)
-        fanout_str = "[" + ", ".join(format_task_display(x) for x in task['fanout']) + "]"
+        fanout_str = (
+            "[" + ", ".join(format_task_display(x) for x in task["fanout"]) + "]"
+        )
 
         # Get function name if available
-        func_id = task['func_id']
-        tdisp = format_task_display(task['task_id'])
+        func_id = task["func_id"]
+        tdisp = format_task_display(task["task_id"])
         if func_id_to_name and str(func_id) in func_id_to_name:
             func_name = func_id_to_name[str(func_id)]
             task_name = f"{func_name}({tdisp})"
         else:
             task_name = f"Func_{func_id}({tdisp})"
 
-        events.append({
-            "args": {
-                "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
-                "fanout-hint": fanout_str,
-                "duration-us": dur,
-                "taskId": task['task_id']
-            },
-            "cat": "event",
-            "id": event_id,
-            "name": task_name,
-            "ph": "X",
-            "pid": 1,
-            "tid": tid,
-            "ts": ts,
-            "dur": dur
-        })
+        events.append(
+            {
+                "args": {
+                    "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
+                    "fanout-hint": fanout_str,
+                    "duration-us": dur,
+                    "taskId": task["task_id"],
+                },
+                "cat": "event",
+                "id": event_id,
+                "name": task_name,
+                "ph": "X",
+                "pid": 1,
+                "tid": tid,
+                "ts": ts,
+                "dur": dur,
+            }
+        )
 
         # Record mapping for flow events
-        task_to_event_id[task['task_id']] = event_id
+        task_to_event_id[task["task_id"]] = event_id
         event_id += 1
 
     # AICPU View duration events (dispatch_time to finish_time)
     if has_aicpu_data:
         for task in tasks:
-            dispatch_us = task.get('dispatch_time_us', 0)
-            finish_us = task.get('finish_time_us', 0)
+            dispatch_us = task.get("dispatch_time_us", 0)
+            finish_us = task.get("finish_time_us", 0)
             if dispatch_us <= 0 or finish_us <= 0:
                 continue
 
-            tid = core_to_tid[task['core_id']]
+            tid = core_to_tid[task["core_id"]]
             aicpu_dur = finish_us - dispatch_us
 
             # Get function name if available
-            func_id = task['func_id']
-            tdisp = format_task_display(task['task_id'])
+            func_id = task["func_id"]
+            tdisp = format_task_display(task["task_id"])
             if func_id_to_name and str(func_id) in func_id_to_name:
                 func_name = func_id_to_name[str(func_id)]
                 task_name = f"{func_name}({tdisp})"
             else:
                 task_name = f"Func_{func_id}({tdisp})"
 
-            events.append({
-                "args": {
-                    "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
-                    "dispatch-time-us": dispatch_us,
-                    "finish-time-us": finish_us,
-                    "aicpu-duration-us": aicpu_dur,
-                    "taskId": task['task_id']
-                },
-                "cat": "event",
-                "id": event_id,
-                "name": task_name,
-                "ph": "X",
-                "pid": 2,
-                "tid": tid,
-                "ts": dispatch_us,
-                "dur": aicpu_dur
-            })
+            events.append(
+                {
+                    "args": {
+                        "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
+                        "dispatch-time-us": dispatch_us,
+                        "finish-time-us": finish_us,
+                        "aicpu-duration-us": aicpu_dur,
+                        "taskId": task["task_id"],
+                    },
+                    "cat": "event",
+                    "id": event_id,
+                    "name": task_name,
+                    "ph": "X",
+                    "pid": 2,
+                    "tid": tid,
+                    "ts": dispatch_us,
+                    "dur": aicpu_dur,
+                }
+            )
             event_id += 1
 
     # Flow events (Flow events "s" and "f" for dependencies)
-    task_map = {t['task_id']: t for t in tasks}
+    task_map = {t["task_id"]: t for t in tasks}
     flow_id = 0
 
     for task in tasks:
-        src_tid = core_to_tid[task['core_id']]
-        src_ts_end = task['end_time_us']
+        src_tid = core_to_tid[task["core_id"]]
+        src_ts_end = task["end_time_us"]
 
-        for succ_task_id in task['fanout']:
+        for succ_task_id in task["fanout"]:
             if succ_task_id not in task_map:
                 if verbose:
                     print(
@@ -543,66 +623,74 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                 continue
 
             succ_task = task_map[succ_task_id]
-            dst_tid = core_to_tid[succ_task['core_id']]
-            dst_ts_start = succ_task['start_time_us']
+            dst_tid = core_to_tid[succ_task["core_id"]]
+            dst_ts_start = succ_task["start_time_us"]
 
             # Get event IDs for source and destination tasks
-            src_event_id = task_to_event_id[task['task_id']]
-            dst_event_id = task_to_event_id[succ_task['task_id']]
+            src_event_id = task_to_event_id[task["task_id"]]
+            dst_event_id = task_to_event_id[succ_task["task_id"]]
 
             # Flow start timestamp (at end of source task, slightly before)
             # Use a small offset (0.01 us) for visual clarity
             flow_start_us = src_ts_end - 0.01
 
             # Flow start event (at end of source task)
-            events.append({
-                "cat": "flow",
-                "id": flow_id,
-                "name": "dependency",
-                "ph": "s",
-                "pid": 1,
-                "tid": src_tid,
-                "ts": flow_start_us,
-                "bind_id": src_event_id
-            })
+            events.append(
+                {
+                    "cat": "flow",
+                    "id": flow_id,
+                    "name": "dependency",
+                    "ph": "s",
+                    "pid": 1,
+                    "tid": src_tid,
+                    "ts": flow_start_us,
+                    "bind_id": src_event_id,
+                }
+            )
 
             # Flow finish event (at start of destination task)
-            events.append({
-                "cat": "flow",
-                "id": flow_id,
-                "name": "dependency",
-                "ph": "f",
-                "pid": 1,
-                "tid": dst_tid,
-                "ts": dst_ts_start,
-                "bp": "e",
-                "bind_id": dst_event_id
-            })
+            events.append(
+                {
+                    "cat": "flow",
+                    "id": flow_id,
+                    "name": "dependency",
+                    "ph": "f",
+                    "pid": 1,
+                    "tid": dst_tid,
+                    "ts": dst_ts_start,
+                    "bp": "e",
+                    "bind_id": dst_event_id,
+                }
+            )
 
             flow_id += 1
 
     # AICPU Scheduler phase events (version 2)
     if scheduler_phases:
         # Process metadata
-        events.append({
-            "args": {"name": "AICPU Scheduler"},
-            "cat": "__metadata",
-            "name": "process_name",
-            "ph": "M",
-            "pid": 3
-        })
-        events.append({
-            "args": {"sort_index": 2},
-            "cat": "__metadata",
-            "name": "process_sort_index",
-            "ph": "M",
-            "pid": 3
-        })
+        events.append(
+            {
+                "args": {"name": "AICPU Scheduler"},
+                "cat": "__metadata",
+                "name": "process_name",
+                "ph": "M",
+                "pid": 3,
+            }
+        )
+        events.append(
+            {
+                "args": {"sort_index": 2},
+                "cat": "__metadata",
+                "name": "process_sort_index",
+                "ph": "M",
+                "pid": 3,
+            }
+        )
 
         # Phase color mapping
         phase_colors = {
-            "complete": "good",       # green
-            "dispatch": "terrible",   # red
+            "complete": "good",  # green
+            "dispatch": "terrible",  # red
             "scan": "thread_state_running",  # blue
             "idle": "yellow",  # yellow
         }
@@ -611,14 +699,16 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
             tid = 3000 + thread_idx
 
             # Thread name metadata
-            events.append({
-                "args": {"name": f"Sched_{thread_idx}"},
-                "cat": "__metadata",
-                "name": "thread_name",
-                "ph": "M",
-                "pid": 3,
-                "tid": tid
-            })
+            events.append(
+                {
+                    "args": {"name": f"Sched_{thread_idx}"},
+                    "cat": "__metadata",
+                    "name": "thread_name",
+                    "ph": "M",
+                    "pid": 3,
+                    "tid": tid,
+                }
+            )
 
             for record in thread_records:
                 phase = record.get("phase", "unknown")
@@ -631,7 +721,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     "args": {
                         "phase": phase,
                         "loop_iter": record.get("loop_iter", 0),
-                        "tasks_processed": tasks_processed
+                        "tasks_processed": tasks_processed,
                     },
                     "cat": "scheduler",
                     "cname": phase_colors.get(phase, "generic_work"),
@@ -640,27 +730,31 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     "pid": 3,
                     "tid": tid,
                     "ts": start_us,
-                    "dur": dur
+                    "dur": dur,
                 }
                 events.append(event)
 
     # AICPU Orchestrator event (version 2)
     if orchestrator_phases or orchestrator_data:
         # Process metadata
-        events.append({
-            "args": {"name": "AICPU Orchestrator"},
-            "cat": "__metadata",
-            "name": "process_name",
-            "ph": "M",
-            "pid": 4
-        })
-        events.append({
-            "args": {"sort_index": 1},
-            "cat": "__metadata",
-            "name": "process_sort_index",
-            "ph": "M",
-            "pid": 4
-        })
+        events.append(
+            {
+                "args": {"name": "AICPU Orchestrator"},
+                "cat": "__metadata",
+                "name": "process_name",
+                "ph": "M",
+                "pid": 4,
+            }
+        )
+        events.append(
+            {
+                "args": {"sort_index": 1},
+                "cat": "__metadata",
+                "name": "process_sort_index",
+                "ph": "M",
+                "pid": 4,
+            }
+        )
 
         # Normalize orchestrator_phases: support both per-thread nested format
         # (list of lists) and legacy flat format (list of dicts)
@@ -670,31 +764,35 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
         for orch_idx in range(len(orch_threads)):
             tid = 4000 + orch_idx
             name = f"Orch_{orch_idx}"
-            events.append({
-                "args": {"name": name},
-                "cat": "__metadata",
-                "name": "thread_name",
-                "ph": "M",
-                "pid": 4,
-                "tid": tid
-            })
+            events.append(
+                {
+                    "args": {"name": name},
+                    "cat": "__metadata",
+                    "name": "thread_name",
+                    "ph": "M",
+                    "pid": 4,
+                    "tid": tid,
+                }
+            )
         if not orch_threads and orchestrator_data:
-            events.append({
-                "args": {"name": "Orchestrator"},
-                "cat": "__metadata",
-                "name": "thread_name",
-                "ph": "M",
-                "pid": 4,
-                "tid": 4000
-            })
+            events.append(
+                {
+                    "args": {"name": "Orchestrator"},
+                    "cat": "__metadata",
+                    "name": "thread_name",
+                    "ph": "M",
+                    "pid": 4,
+                    "tid": 4000,
+                }
+            )
 
     if orchestrator_phases:
         # Per-task orchestrator phase bars
         orch_phase_colors = {
-            "orch_sync": "thread_state_iowait",      # orange
-            "orch_alloc": "terrible",                  # red
-            "orch_params": "good",                     # green
-            "orch_lookup": "thread_state_running",     # blue
+            "orch_sync": "thread_state_iowait",  # orange
+            "orch_alloc": "terrible",  # red
+            "orch_params": "good",  # green
+            "orch_lookup": "thread_state_running",  # blue
             "orch_heap": "yellow",
             "orch_insert": "olive",
             "orch_fanin": "rail_animation",
@@ -713,7 +811,9 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                 task_id = record.get("task_id", -1)
 
                 # Strip "orch_" prefix for display name
-                display_name = phase.replace("orch_", "") if phase.startswith("orch_") else phase
+                display_name = (
+                    phase.replace("orch_", "") if phase.startswith("orch_") else phase
+                )
 
                 # Full PTO2TaskId in JSON (device uses task_id.raw, same as TensorMap) → rXtY / tY
                 if task_id >= 0:
@@ -725,7 +825,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     "args": {
                         "phase": phase,
                         "submit_idx": submit_idx,
-                        "task_id": task_id
+                        "task_id": task_id,
                     },
                     "cat": "orchestrator",
                     "cname": orch_phase_colors.get(phase, "generic_work"),
@@ -734,7 +834,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     "pid": 4,
                     "tid": tid,
                     "ts": start_us,
-                    "dur": dur
+                    "dur": dur,
                 }
                 events.append(event)
 
@@ -758,56 +858,62 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     orch_args[f"{phase_name}_%"] = round(pct, 1)
 
         # Total orchestrator bar
-        events.append({
-            "args": orch_args,
-            "cat": "orchestrator",
-            "name": f"Orchestrator({orchestrator_data.get('submit_count', 0)} tasks)",
-            "ph": "X",
-            "pid": 4,
-            "tid": 4000,
-            "ts": orch_start,
-            "dur": orch_dur
-        })
+        events.append(
+            {
+                "args": orch_args,
+                "cat": "orchestrator",
+                "name": f"Orchestrator({orchestrator_data.get('submit_count', 0)} tasks)",
+                "ph": "X",
+                "pid": 4,
+                "tid": 4000,
+                "ts": orch_start,
+                "dur": orch_dur,
+            }
+        )
 
     # AICPU View fanout arrows (duplicate AICore View flow events using AICPU timestamps)
     if has_aicpu_data:
         for task in tasks:
-            src_finish_us = task.get('finish_time_us', 0)
+            src_finish_us = task.get("finish_time_us", 0)
             if src_finish_us <= 0:
                 continue
 
-            src_tid = core_to_tid[task['core_id']]
+            src_tid = core_to_tid[task["core_id"]]
 
-            for succ_task_id in task['fanout']:
+            for succ_task_id in task["fanout"]:
                 if succ_task_id not in task_map:
                     continue
 
                 succ_task = task_map[succ_task_id]
-                dst_dispatch_us = succ_task.get('dispatch_time_us', 0)
+                dst_dispatch_us = succ_task.get("dispatch_time_us", 0)
                 if dst_dispatch_us <= 0:
                     continue
 
-                dst_tid = core_to_tid[succ_task['core_id']]
+                dst_tid = core_to_tid[succ_task["core_id"]]
 
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dependency",
-                    "ph": "s",
-                    "pid": 2,
-                    "tid": src_tid,
-                    "ts": src_finish_us - 0.01
-                })
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dependency",
-                    "ph": "f",
-                    "pid": 2,
-                    "tid": dst_tid,
-                    "ts": dst_dispatch_us,
-                    "bp": "e"
-                })
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dependency",
+                        "ph": "s",
+                        "pid": 2,
+                        "tid": src_tid,
+                        "ts": src_finish_us - 0.01,
+                    }
+                )
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dependency",
+                        "ph": "f",
+                        "pid": 2,
+                        "tid": dst_tid,
+                        "ts": dst_dispatch_us,
+                        "bp": "e",
+                    }
+                )
                 flow_id += 1
 
     # Scheduler DISPATCH → task execution arrows
@@ -822,22 +928,27 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                 if thread_idx >= 0:
                     core_to_sched_thread[core_id] = thread_idx
             if verbose:
-                print(f"  Core-to-thread mapping: {len(core_to_sched_thread)} cores (from perf JSON)")
+                print(
+                    f"  Core-to-thread mapping: {len(core_to_sched_thread)} cores (from perf JSON)"
+                )
         else:
             # Fallback: infer via voting (for perf JSON without core_to_thread field)
             dispatch_phases_by_thread = {}
             for thread_idx, thread_records in enumerate(scheduler_phases):
-                dispatch_records = [r for r in thread_records if r.get("phase") == "dispatch"]
+                dispatch_records = [
+                    r for r in thread_records if r.get("phase") == "dispatch"
+                ]
                 if dispatch_records:
                     dispatch_phases_by_thread[thread_idx] = dispatch_records
 
             from collections import defaultdict
+
             core_thread_votes = defaultdict(lambda: defaultdict(int))
             for task in tasks:
-                dispatch_us = task.get('dispatch_time_us', 0)
+                dispatch_us = task.get("dispatch_time_us", 0)
                 if dispatch_us <= 0:
                     continue
-                core_id = task['core_id']
+                core_id = task["core_id"]
                 for thread_idx, dispatch_records in dispatch_phases_by_thread.items():
                     for dr in dispatch_records:
                         if dr["start_time_us"] <= dispatch_us <= dr["end_time_us"]:
@@ -847,61 +958,71 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
             for core_id, votes in core_thread_votes.items():
                 core_to_sched_thread[core_id] = max(votes, key=votes.get)
             if verbose:
-                print(f"  Core-to-thread mapping: {len(core_to_sched_thread)} cores (inferred via voting)")
+                print(
+                    f"  Core-to-thread mapping: {len(core_to_sched_thread)} cores (inferred via voting)"
+                )
 
         for task in tasks:
-            dispatch_us = task.get('dispatch_time_us', 0)
+            dispatch_us = task.get("dispatch_time_us", 0)
             if dispatch_us <= 0:
                 continue
 
-            matched_thread = core_to_sched_thread.get(task['core_id'])
+            matched_thread = core_to_sched_thread.get(task["core_id"])
 
             if matched_thread is not None:
                 sched_tid = 3000 + matched_thread
-                core_tid = core_to_tid[task['core_id']]
+                core_tid = core_to_tid[task["core_id"]]
 
                 # Flow: scheduler DISPATCH → AICore View task start
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dispatch",
-                    "ph": "s",
-                    "pid": 3,
-                    "tid": sched_tid,
-                    "ts": dispatch_us
-                })
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dispatch",
-                    "ph": "f",
-                    "pid": 1,
-                    "tid": core_tid,
-                    "ts": task['start_time_us'],
-                    "bp": "e"
-                })
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dispatch",
+                        "ph": "s",
+                        "pid": 3,
+                        "tid": sched_tid,
+                        "ts": dispatch_us,
+                    }
+                )
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dispatch",
+                        "ph": "f",
+                        "pid": 1,
+                        "tid": core_tid,
+                        "ts": task["start_time_us"],
+                        "bp": "e",
+                    }
+                )
                 flow_id += 1
 
                 # Flow: scheduler DISPATCH → AICPU View task start
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dispatch",
-                    "ph": "s",
-                    "pid": 3,
-                    "tid": sched_tid,
-                    "ts": dispatch_us
-                })
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dispatch",
-                    "ph": "f",
-                    "pid": 2,
-                    "tid": core_tid,
-                    "ts": dispatch_us,
-                    "bp": "e"
-                })
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dispatch",
+                        "ph": "s",
+                        "pid": 3,
+                        "tid": sched_tid,
+                        "ts": dispatch_us,
+                    }
+                )
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dispatch",
+                        "ph": "f",
+                        "pid": 2,
+                        "tid": core_tid,
+                        "ts": dispatch_us,
+                        "bp": "e",
+                    }
+                )
                 flow_id += 1
 
     # Orchestrator → scheduler dispatch:
@@ -926,15 +1047,15 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
         if has_aicpu_data and (orch_fanin_by_task or orch_params_by_task):
             for task in tasks:
-                tid = normalize_pto2_task_id_int(task.get('task_id'))
+                tid = normalize_pto2_task_id_int(task.get("task_id"))
                 if tid is None:
                     continue
 
-                dispatch_us = task.get('dispatch_time_us', 0)
+                dispatch_us = task.get("dispatch_time_us", 0)
                 if dispatch_us <= 0:
                     continue
 
-                matched_thread = core_to_sched_thread.get(task['core_id'])
+                matched_thread = core_to_sched_thread.get(task["core_id"])
                 if matched_thread is None:
                     continue
 
@@ -954,25 +1075,29 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
                 orch_tid = 4000 + orch_idx
 
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": flow_name,
-                    "ph": "s",
-                    "pid": 4,
-                    "tid": orch_tid,
-                    "ts": anchor_us
-                })
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": flow_name,
-                    "ph": "f",
-                    "pid": 3,
-                    "tid": sched_tid,
-                    "ts": dispatch_us,
-                    "bp": "e"
-                })
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": flow_name,
+                        "ph": "s",
+                        "pid": 4,
+                        "tid": orch_tid,
+                        "ts": anchor_us,
+                    }
+                )
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": flow_name,
+                        "ph": "f",
+                        "pid": 3,
+                        "tid": sched_tid,
+                        "ts": dispatch_us,
+                        "bp": "e",
+                    }
+                )
                 flow_id += 1
 
     if verbose:
@@ -980,7 +1105,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
         print(f"  Flow events: {flow_id}")
 
     # Step 3: Write JSON file (with traceEvents wrapper to match C++ output)
-    with open(output_path, 'w') as f:
+    with open(output_path, "w") as f:
         json.dump({"traceEvents": events}, f, indent=2)
 
     if verbose:
@@ -989,7 +1114,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Convert swimlane performance JSON to Chrome Trace Event JSON',
+        description="Convert swimlane performance JSON to Chrome Trace Event JSON",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -999,15 +1124,32 @@ Examples:
   %(prog)s perf_swimlane_20260210_143526.json -k examples/host_build_graph/paged_attention/kernels/kernel_config.py
   %(prog)s perf_swimlane_20260210_143526.json -d 0
   %(prog)s perf_swimlane_20260210_143526.json -v
-        """
+        """,
     )
 
-    parser.add_argument('input', nargs='?', help='Input JSON file (.json). If not specified, uses the latest perf_swimlane_*.json file in outputs/ directory')
-    parser.add_argument('-o', '--output', help='Output JSON file (default: outputs/merged_swimlane_<timestamp>.json)')
-    parser.add_argument('-k', '--kernel-config', help='Path to kernel_config.py file for func_id to function name mapping')
-    parser.add_argument('--device-log', help='Device log file/path/glob override used for scheduler analysis')
-    parser.add_argument('-d', '--device-id', help='Device id for auto-selection from device-<id>')
-    parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
+    parser.add_argument(
+        "input",
+        nargs="?",
+        help="Input JSON file (.json). If not specified, uses the latest perf_swimlane_*.json file in outputs/ directory",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output JSON file (default: outputs/merged_swimlane_<timestamp>.json)",
+    )
+    parser.add_argument(
+        "-k",
+        "--kernel-config",
+        help="Path to kernel_config.py file for func_id to function name mapping",
+    )
+    parser.add_argument(
+        "--device-log",
+        help="Device log file/path/glob override used for scheduler analysis",
+    )
+    parser.add_argument(
+        "-d", "--device-id", help="Device id for auto-selection from device-<id>"
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
 
     args = parser.parse_args()
 
@@ -1017,8 +1159,14 @@ Examples:
         json_files = list(outputs_dir.glob("perf_swimlane_*.json"))
 
         if not json_files:
-            print(f"Error: No perf_swimlane_*.json files found in {outputs_dir}", file=sys.stderr)
-            print("Please specify an input file or ensure .json files exist in outputs/", file=sys.stderr)
+            print(
+                f"Error: No perf_swimlane_*.json files found in {outputs_dir}",
+                file=sys.stderr,
+            )
+            print(
+                "Please specify an input file or ensure .json files exist in outputs/",
+                file=sys.stderr,
+            )
             return 1
 
         # Get the most recently modified file
@@ -1047,12 +1195,14 @@ Examples:
             print(f"  Task Count: {len(data['tasks'])}")
 
             # Calculate time range
-            if data['tasks']:
-                start_times = [t['start_time_us'] for t in data['tasks']]
-                end_times = [t['end_time_us'] for t in data['tasks']]
+            if data["tasks"]:
+                start_times = [t["start_time_us"] for t in data["tasks"]]
+                end_times = [t["end_time_us"] for t in data["tasks"]]
                 min_time = min(start_times)
                 max_time = max(end_times)
-                print(f"  Time Range: {min_time:.3f} us - {max_time:.3f} us (span: {max_time - min_time:.3f} us)")
+                print(
+                    f"  Time Range: {min_time:.3f} us - {max_time:.3f} us (span: {max_time - min_time:.3f} us)"
+                )
             print()
 
         # Load function name mapping from kernel_config.py if provided
@@ -1062,8 +1212,12 @@ Examples:
                 print(f"Loading kernel config from: {args.kernel_config}")
             func_names = load_kernel_config(args.kernel_config)
             if args.verbose:
-                print(f"  Loaded {len(func_names)} function name mappings from kernel_config.py:")
-                for func_id, name in sorted(func_names.items(), key=lambda x: int(x[0])):
+                print(
+                    f"  Loaded {len(func_names)} function name mappings from kernel_config.py:"
+                )
+                for func_id, name in sorted(
+                    func_names.items(), key=lambda x: int(x[0])
+                ):
                     print(f"    func_id={func_id}: {name}")
                 print()
 
@@ -1077,7 +1231,9 @@ Examples:
 
             # Try to extract timestamp from filename
             if input_stem.startswith("perf_swimlane_"):
-                timestamp_part = input_stem[len("perf_swimlane_"):]  # e.g., "20260210_143526"
+                timestamp_part = input_stem[
+                    len("perf_swimlane_") :
+                ]  # e.g., "20260210_143526"
             else:
                 # Fallback: use current timestamp
                 timestamp_part = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -1095,18 +1251,20 @@ Examples:
         )
 
         # Extract version 2 data if available
-        scheduler_phases = data.get('aicpu_scheduler_phases')
-        orchestrator_data = data.get('aicpu_orchestrator')
-        orchestrator_phases = data.get('aicpu_orchestrator_phases')
-        core_to_thread = data.get('core_to_thread')
+        scheduler_phases = data.get("aicpu_scheduler_phases")
+        orchestrator_data = data.get("aicpu_orchestrator")
+        orchestrator_phases = data.get("aicpu_orchestrator_phases")
+        core_to_thread = data.get("core_to_thread")
 
-        if args.verbose and data['version'] == 2:
+        if args.verbose and data["version"] == 2:
             if scheduler_phases:
                 total_phase_records = sum(len(t) for t in scheduler_phases)
                 print(f"  Scheduler threads: {len(scheduler_phases)}")
                 print(f"  Total phase records: {total_phase_records}")
             if orchestrator_data:
-                print(f"  Orchestrator: {orchestrator_data.get('submit_count', 0)} tasks")
+                print(
+                    f"  Orchestrator: {orchestrator_data.get('submit_count', 0)} tasks"
+                )
             if orchestrator_phases:
                 total_orch = sum(len(t) for t in orchestrator_phases)
                 print(f"  Orchestrator threads: {len(orchestrator_phases)}")
@@ -1115,16 +1273,23 @@ Examples:
                 print(f"  Core-to-thread mapping: {len(core_to_thread)} cores")
 
         # Generate Perfetto JSON
-        generate_chrome_trace_json(data['tasks'], str(output_path), func_names, args.verbose,
-                                   scheduler_phases=scheduler_phases,
-                                   orchestrator_data=orchestrator_data,
-                                   orchestrator_phases=orchestrator_phases,
-                                   core_to_thread=core_to_thread)
+        generate_chrome_trace_json(
+            data["tasks"],
+            str(output_path),
+            func_names,
+            args.verbose,
+            scheduler_phases=scheduler_phases,
+            orchestrator_data=orchestrator_data,
+            orchestrator_phases=orchestrator_phases,
+            core_to_thread=core_to_thread,
+        )
 
         print(f"\n✓ Conversion complete")
         print(f"  Input:  {input_path}")
         print(f"  Output: {output_path}")
-        print(f"\nTo visualize: Open https://ui.perfetto.dev/ and drag in {output_path}")
+        print(
+            f"\nTo visualize: Open https://ui.perfetto.dev/ and drag in {output_path}"
+        )
 
         if resolved_device_log is not None:
             print(f"\nDevice log: {resolved_device_log}")
@@ -1139,12 +1304,16 @@ Examples:
         # Optional: parse sched CPU from device log
         sched_info = None
         if resolved_device_log is not None:
-            sched_info = parse_sched_cpu_from_device_log(resolved_device_log, len(data['tasks']))
+            sched_info = parse_sched_cpu_from_device_log(
+                resolved_device_log, len(data["tasks"])
+            )
             if args.verbose and sched_info is not None:
-                print(f"  Parsed sched CPU from device log: {sched_info['us_per_task']:.2f} us/task")
+                print(
+                    f"  Parsed sched CPU from device log: {sched_info['us_per_task']:.2f} us/task"
+                )
 
         # Print task statistics (incl. task execution vs scheduler overhead)
-        print_task_statistics(data['tasks'], func_names, sched_info=sched_info)
+        print_task_statistics(data["tasks"], func_names, sched_info=sched_info)
 
         # Integrated deep-dive overhead analysis
         if resolved_device_log is not None:
@@ -1163,7 +1332,9 @@ Examples:
                     file=sys.stderr,
                 )
         else:
-            print("\n[Info] Scheduler overhead deep-dive skipped (no device log resolved).")
+            print(
+                "\n[Info] Scheduler overhead deep-dive skipped (no device log resolved)."
+            )
 
         return 0
 
@@ -1171,9 +1342,10 @@ Examples:
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc()
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/tools/test_catalog.py
+++ b/tools/test_catalog.py
@@ -60,7 +60,9 @@ def discover_platforms(project_root: Path | None = None) -> list[str]:
     return platforms
 
 
-def discover_runtimes_for_arch(arch: str, project_root: Path | None = None) -> list[str]:
+def discover_runtimes_for_arch(
+    arch: str, project_root: Path | None = None
+) -> list[str]:
     """Discover available runtimes for a specific architecture.
 
     Args:
@@ -107,11 +109,11 @@ def arch_from_platform(platform: str) -> str:
 class TestCase:
     """A discoverable test case (example or scene test)."""
 
-    name: str       # Relative name: "a2a3/host_build_graph/vector_example"
-    dir: str        # Full path to the case directory
-    arch: str       # Architecture: "a2a3", "a5"
-    runtime: str    # Runtime: "host_build_graph", etc.
-    source: str     # "example" or "st"
+    name: str  # Relative name: "a2a3/host_build_graph/vector_example"
+    dir: str  # Full path to the case directory
+    arch: str  # Architecture: "a2a3", "a5"
+    runtime: str  # Runtime: "host_build_graph", etc.
+    source: str  # "example" or "st"
 
 
 def _scan_case_dir(base_dir: Path, source: str) -> list[TestCase]:
@@ -152,13 +154,15 @@ def _scan_case_dir(base_dir: Path, source: str) -> list[TestCase]:
                 golden = case_dir / "golden.py"
                 if kernel_config.is_file() and golden.is_file():
                     name = f"{arch}/{runtime}/{case_dir.name}"
-                    cases.append(TestCase(
-                        name=name,
-                        dir=str(case_dir),
-                        arch=arch,
-                        runtime=runtime,
-                        source=source,
-                    ))
+                    cases.append(
+                        TestCase(
+                            name=name,
+                            dir=str(case_dir),
+                            arch=arch,
+                            runtime=runtime,
+                            source=source,
+                        )
+                    )
 
     return cases
 
@@ -194,8 +198,7 @@ def discover_test_cases(
         target_arch = arch_from_platform(platform)
         platform_runtimes = discover_runtimes_for_arch(target_arch, root)
         cases = [
-            c for c in cases
-            if c.arch == target_arch and c.runtime in platform_runtimes
+            c for c in cases if c.arch == target_arch and c.runtime in platform_runtimes
         ]
 
     # Apply runtime filter
@@ -227,10 +230,15 @@ def main():
     cases = sub.add_parser("cases", help="List discoverable test cases")
     cases.add_argument("--platform", default=None, help="Filter by platform")
     cases.add_argument("--runtime", default=None, help="Filter by runtime")
-    cases.add_argument("--source", default=None, choices=["example", "st"],
-                       help="Filter by source (example or st)")
-    cases.add_argument("--format", default="text", choices=["text", "json"],
-                       help="Output format")
+    cases.add_argument(
+        "--source",
+        default=None,
+        choices=["example", "st"],
+        help="Filter by source (example or st)",
+    )
+    cases.add_argument(
+        "--format", default="text", choices=["text", "json"], help="Output format"
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
- Basic checks: large files, YAML syntax, EOF fixer, trailing whitespace
- C++ formatting via clang-format v18.1.8 (uses existing .clang-format)
- Python formatting via ruff-format v0.9.10 (format only, no lint)