### PR TITLE
Support: add pre-commit hooks and apply codebase-wide formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,25 +1,35 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 BasedOnStyle: Google
 IndentWidth: 4
+DerivePointerAlignment: false
+PointerAlignment: Left
 
-# 列宽限制，超过此宽度会自动换行
+# Max line width before auto-wrapping
 ColumnLimit: 120
 
-# 续行缩进宽度（函数参数换行等）
+# Continuation indent for wrapped lines (function args, etc.)
 ContinuationIndentWidth: 4
 
-# 开括号后的对齐方式：DontAlign 表示不对齐到括号位置
-# 可选值：Align, DontAlign, AlwaysBreak, BlockIndent
+# Alignment after open bracket: DontAlign avoids aligning to bracket
+# Options: Align, DontAlign, AlwaysBreak, BlockIndent
 AlignAfterOpenBracket: DontAlign
 
-# 允许函数声明的所有参数放到下一行
+# Allow all declaration parameters on the next line
 AllowAllParametersOfDeclarationOnNextLine: true
 
-# 允许函数调用的所有参数放到下一行
+# Allow all call arguments on the next line
 AllowAllArgumentsOnNextLine: true
 
-# 不紧凑排列参数，每个参数一行（如果需要换行的话）
+# One parameter per line when wrapping is needed
 BinPackParameters: false
 BinPackArguments: false
 
-# 访问修饰符(public/private/protected)的缩进偏移，-4表示与class对齐
+# Access modifier offset: -4 aligns with class keyword
 AccessModifierOffset: -4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,20 @@ concurrency:
 
 jobs:
   # ---------- Python unit tests (no hardware) ----------
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
+
   ut-py:
+    needs: pre-commit
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -45,6 +58,7 @@ jobs:
 
   # ---------- Simulation scene tests ----------
   st-sim-a2a3:
+    needs: pre-commit
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -99,6 +113,7 @@ jobs:
         run: ./ci.sh -p a2a3sim -r ${{ matrix.runtime }} -c 6622890 -t 600 --clone-protocol https
 
   st-sim-a5:
+    needs: pre-commit
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -154,6 +169,7 @@ jobs:
 
   # ---------- Python unit tests (a2a3 hardware) ----------
   ut-py-a2a3:
+    needs: pre-commit
     runs-on: [self-hosted, a2a3]
     timeout-minutes: 30
 
@@ -171,6 +187,7 @@ jobs:
 
   # ---------- Scene tests (a2a3 hardware) ----------
   st-onboard-a2a3:
+    needs: pre-commit
     runs-on: [self-hosted, a2a3]
     timeout-minutes: 60
 
@@ -190,6 +207,7 @@ jobs:
   #       Add the "a5" label to the runner, matching [self-hosted, a5] below.
   #
   # ut-py-a5:
+  #   needs: pre-commit
   #   runs-on: [self-hosted, a5]
   #   timeout-minutes: 30
   #
@@ -206,6 +224,7 @@ jobs:
   #         source ${ASCEND_HOME_PATH}/bin/setenv.bash && pytest tests -m requires_hardware --platform a5 -v
   #
   # st-onboard-a5:
+  #   needs: pre-commit
   #   runs-on: [self-hosted, a5]
   #   timeout-minutes: 60
   #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,78 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+repos:
+
+    # Common
+    - repo: local
+      hooks:
+        - id: check-headers
+          name: check-headers
+          entry: python tests/lint/check_headers.py
+          language: python
+          language_version: python3
+
+        - id: check-english-only
+          name: check-english-only
+          entry: python tests/lint/check_english_only.py
+          language: python
+          language_version: python3
+          exclude: ^(3rdparty/|docs/zh-cn/|README\.zh-CN\.md)
+
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.6.0
+      hooks:
+        - id: check-added-large-files
+        - id: check-yaml
+        - id: end-of-file-fixer
+        - id: trailing-whitespace
+
+    # C++ linting
+    - repo: https://github.com/pre-commit/mirrors-clang-format
+      rev: v21.1.0
+      hooks:
+        - id: clang-format
+          types_or: [c++, c]
+          exclude: ^3rdparty/
+
+    - repo: https://github.com/cpplint/cpplint
+      rev:  2.0.0
+      hooks:
+        - id: cpplint
+          exclude: ^3rdparty/
+          args:
+            - --root=include
+            - --linelength=120
+            - --filter=-whitespace/parens,-whitespace/indent_namespace,-runtime/references
+
+    # Markdown linting
+    - repo: https://github.com/DavidAnson/markdownlint-cli2
+      rev: v0.20.0
+      hooks:
+        - id: markdownlint-cli2
+          args:
+            - --fix
+            - --config
+            - tests/lint/.markdownlint.yaml
+
+    # Python linting
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.14.8
+      hooks:
+        - id: ruff-check
+          types_or: [python, pyi]
+          args: [--fix]
+        - id: ruff-format
+          types_or: [python, pyi]
+
+    - repo: https://github.com/RobertCraigie/pyright-python
+      rev: v1.1.407
+      hooks:
+      - id: pyright
+        additional_dependencies: [pytest==7.0.0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 [build-system]
 requires = ["scikit-build-core>=0.10.0", "nanobind>=2.0.0", "cmake>=3.15"]
 build-backend = "scikit_build_core.build"
@@ -6,6 +15,50 @@ build-backend = "scikit_build_core.build"
 name = "simpler"
 version = "0.1.0"
 requires-python = ">=3.9"
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+required-version = "0.14.8"
+
+[tool.ruff.lint]
+select = [
+    "PL", # pylint, https://docs.astral.sh/ruff/rules/#pylint-pl
+    "I",  # isort, https://docs.astral.sh/ruff/rules/#isort-i
+    "E",  # pycodestyle errors, https://docs.astral.sh/ruff/rules/#error-e
+    "W",  # pycodestyle warnings, https://docs.astral.sh/ruff/rules/#warning-w
+    "F",  # pyflakes, https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "UP", # pyupgrade, https://docs.astral.sh/ruff/rules/#pyupgrade-up
+]
+ignore = [
+  "ANN401",  # flake8-annotations: any-type
+  "PLR2004", # pylint: magic-value-comparison
+  "PLR0911", # too many return statements
+  "PLW2901", # pylint: redefined-loop-variable (DSL reassignment pattern)
+]
+fixable = ["ALL"]
+
+[tool.ruff.lint.pylint]
+max-statements = 100
+max-args = 10
+max-branches = 15
+
+[tool.ruff.format]
+quote-style = "double"
+skip-magic-trailing-comma = false
+line-ending = "lf"
+
+[tool.pyright]
+include = ["python", "tests"]
+exclude = ["**/__pycache__", "build", "dist", "tests/st"]
+typeCheckingMode = "basic"
+pythonVersion = "3.9"
+reportMissingTypeStubs = false
+reportMissingModuleSource = false
+reportCallIssue = false
+reportAssignmentType = false
+reportOperatorIssue = false
+reportRedeclaration = false
 
 [tool.scikit-build]
 wheel.packages = []

--- a/tests/lint/.markdownlint.yaml
+++ b/tests/lint/.markdownlint.yaml
@@ -1,0 +1,6 @@
+MD013: false
+MD024:
+  siblings_only: true
+MD060:
+  style: "compact"
+  aligned_delimiter: true

--- a/tests/lint/check_english_only.py
+++ b/tests/lint/check_english_only.py
@@ -1,0 +1,203 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Script to check that all source files and documentation are in English only.
+Detects non-English text (e.g., Chinese, Japanese, Korean, etc.) in source files.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Default excluded directories (can be overridden via --exclude)
+DEFAULT_EXCLUDED_PATTERNS = ["3rdparty", "reference", "docs/zh-cn", "README.zh-CN.md"]
+
+
+def get_git_tracked_files(root_dir: Path) -> list[Path]:
+    """Get list of files tracked by git."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        files = []
+        for line in result.stdout.strip().split("\n"):
+            if line:
+                file_path = root_dir / line
+                if file_path.is_file():
+                    files.append(file_path)
+        return files
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print("Error: git command not found", file=sys.stderr)
+        sys.exit(1)
+
+
+def contains_non_english(text: str) -> tuple[bool, list[tuple[int, str]]]:
+    """
+    Check if text contains non-English characters.
+
+    Returns:
+        Tuple of (has_non_english, list of (line_number, non-english text) tuples)
+    """
+    # Unicode ranges for common non-English scripts:
+    # - Chinese (CJK Unified Ideographs): \u4e00-\u9fff
+    # - Japanese Hiragana: \u3040-\u309f
+    # - Japanese Katakana: \u30a0-\u30ff
+    # - Korean Hangul: \uac00-\ud7af
+    # - Cyrillic: \u0400-\u04ff
+    # - Arabic: \u0600-\u06ff
+    # - Hebrew: \u0590-\u05ff
+    # - Thai: \u0e00-\u0e7f
+    # - CJK Symbols and Punctuation: \u3000-\u303f (ideographic period, comma, brackets)
+    # - Full-width Latin and Punctuation: \uff01-\uff5e (full-width comma, colon, parens)
+    non_english_pattern = re.compile(
+        r"[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af"
+        r"\u0400-\u04ff\u0600-\u06ff\u0590-\u05ff\u0e00-\u0e7f"
+        r"\u3000-\u303f\uff01-\uff5e]+"
+    )
+
+    violations = []
+    lines = text.split("\n")
+
+    for i, line in enumerate(lines, 1):
+        matches = non_english_pattern.findall(line)
+        if matches:
+            # Join all non-English text found in this line
+            non_english_text = ", ".join(matches)
+            violations.append((i, non_english_text))
+
+    return bool(violations), violations
+
+
+def check_file_english_only(file_path: Path) -> tuple[bool, list[tuple[int, str]]]:
+    """
+    Check if a file contains only English text.
+
+    Returns:
+        Tuple of (is_english_only, list of (line_number, non_english_text) violations)
+    """
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"Warning: Could not read {file_path}: {e}", file=sys.stderr)
+        return True, []  # Skip files we can't read
+
+    has_non_english, violations = contains_non_english(content)
+
+    return not has_non_english, violations
+
+
+SOURCE_EXTENSIONS = {".py", ".pyi", ".cpp", ".cc", ".cxx", ".c", ".h", ".hpp", ".hxx", ".md"}
+
+
+def _collect_files(files: list[str], excluded_patterns: list[str]) -> Optional[list[Path]]:
+    """Collect files to check, either from explicit list or full-repo scan."""
+    if files:
+        result = []
+        for f in files:
+            p = Path(f).resolve()
+            if p.is_file() and p.suffix in SOURCE_EXTENSIONS:
+                if not any(part in str(f) for part in excluded_patterns):
+                    result.append(p)
+        return result
+
+    root_path = Path(".").resolve()
+    if not (root_path / ".git").exists():
+        print(f"Error: '{root_path}' is not a git repository", file=sys.stderr)
+        return None
+
+    all_files = get_git_tracked_files(root_path)
+    filtered = [f for f in all_files if not any(str(f.relative_to(root_path)).startswith(p) for p in excluded_patterns)]
+    return [f for f in filtered if f.suffix in SOURCE_EXTENSIONS]
+
+
+def main() -> int:
+    """Main function."""
+    parser = argparse.ArgumentParser(description="Check that all source files and documentation are in English only")
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Files to check (default: all git-tracked files)",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=None,
+        help="Additional directory patterns to exclude (can be specified multiple times)",
+    )
+
+    args = parser.parse_args()
+
+    excluded_patterns = DEFAULT_EXCLUDED_PATTERNS.copy()
+    if args.exclude:
+        excluded_patterns.extend(args.exclude)
+
+    files_to_check = _collect_files(args.files, excluded_patterns)
+    if files_to_check is None:
+        return 1
+
+    if not files_to_check:
+        print("No source files found to check")
+        return 0
+
+    def _display_path(p: Path) -> str:
+        try:
+            return str(p.relative_to(Path(".").resolve()))
+        except ValueError:
+            return str(p)
+
+    print(f"Checking {len(files_to_check)} file(s) for English-only content...")
+
+    failed_files = []
+    passed_files = []
+
+    for file_path in files_to_check:
+        is_english_only, violations = check_file_english_only(file_path)
+
+        if is_english_only:
+            passed_files.append(file_path)
+            if args.verbose:
+                print(f"✓ {_display_path(file_path)}")
+        else:
+            failed_files.append((file_path, violations))
+            for line_num, non_english_text in violations[:5]:
+                print(f"✗ {_display_path(file_path)}:{line_num} {non_english_text}")
+            if len(violations) > 5:
+                print(f"  ... and {len(violations) - 5} more line(s) in {_display_path(file_path)}")
+
+    print()
+    print(f"Results: {len(passed_files)} passed, {len(failed_files)} failed")
+
+    if failed_files:
+        print("\nFiles with non-English content:")
+        for file_path, _ in failed_files:
+            print(f"  - {_display_path(file_path)}")
+        print(
+            "\n⚠ Please ensure all source files and documentation are written in English "
+            "to maintain consistency and accessibility for all contributors."
+        )
+        return 1
+
+    print("\n✓ All source files and documentation are in English!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lint/check_headers.py
+++ b/tests/lint/check_headers.py
@@ -1,0 +1,244 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Script to check copyright headers in source files.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Define the expected headers
+PY_HEADER = """
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+""".strip()
+
+C_HEADER = """
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+""".strip()
+
+# File extension to header mapping
+FILE_TYPE_HEADERS = {
+    # Python files
+    ".py": PY_HEADER,
+    ".pyi": PY_HEADER,
+    # C/C++ files
+    ".c": C_HEADER,
+    ".cpp": C_HEADER,
+    ".cc": C_HEADER,
+    ".cxx": C_HEADER,
+    ".h": C_HEADER,
+    ".hpp": C_HEADER,
+    ".hxx": C_HEADER,
+    # CMake files
+    ".cmake": PY_HEADER,
+    # Shell scripts
+    ".sh": PY_HEADER,
+    # Configuration files
+    ".toml": PY_HEADER,
+}
+
+# Files matched by name (not extension)
+FILE_NAME_HEADERS = {
+    "CMakeLists.txt": PY_HEADER,
+    ".clang-format": PY_HEADER,
+    ".clang-tidy": PY_HEADER,
+}
+
+
+def get_git_tracked_files(root_dir: Path) -> list[Path]:
+    """Get list of files tracked by git."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        files = []
+        for line in result.stdout.strip().split("\n"):
+            if line:
+                file_path = root_dir / line
+                if file_path.is_file():
+                    files.append(file_path)
+        return files
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print("Error: git command not found", file=sys.stderr)
+        sys.exit(1)
+
+
+MAX_SEARCH_LINES = 5
+
+
+def check_file_header(file_path: Path) -> tuple[bool, str]:
+    """
+    Check if a file has the correct header within the first few lines.
+
+    Allows up to MAX_SEARCH_LINES before the copyright header (e.g. shebang,
+    encoding declarations). The header must appear as a contiguous block.
+
+    Returns:
+        Tuple of (has_correct_header, error_message)
+    """
+    ext = file_path.suffix
+    name = file_path.name
+
+    # Check by filename first, then by extension
+    if name in FILE_NAME_HEADERS:
+        expected_header = FILE_NAME_HEADERS[name]
+    elif ext in FILE_TYPE_HEADERS:
+        expected_header = FILE_TYPE_HEADERS[ext]
+    else:
+        return True, ""  # Skip files we don't know how to check
+
+    expected_lines = expected_header.strip().split("\n")
+
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError) as e:
+        return False, f"Error reading file: {e}"
+
+    if not content:
+        return False, "File is empty"
+
+    actual_lines = content.split("\n")
+
+    # Search for the header start within the first MAX_SEARCH_LINES lines
+    first_expected = expected_lines[0]
+    for offset in range(min(MAX_SEARCH_LINES, len(actual_lines))):
+        if actual_lines[offset] == first_expected:
+            # Found potential start, verify the rest
+            if offset + len(expected_lines) > len(actual_lines):
+                return (
+                    False,
+                    f"Copyright header starts at line {offset + 1} but file is too short",
+                )
+            for i, expected_line in enumerate(expected_lines):
+                if actual_lines[offset + i] != expected_line:
+                    return (
+                        False,
+                        f"Line {offset + i + 1} doesn't match:\n"
+                        f"  Expected: {expected_line}\n"
+                        f"  Got:      {actual_lines[offset + i]}",
+                    )
+            return True, ""
+
+    return (
+        False,
+        f"Copyright header not found within the first {MAX_SEARCH_LINES} lines",
+    )
+
+
+def _is_checkable(p: Path) -> bool:
+    return p.suffix in FILE_TYPE_HEADERS or p.name in FILE_NAME_HEADERS
+
+
+def _collect_files(files: list[str], excluded_patterns: list[str]) -> Optional[list[Path]]:
+    """Collect files to check, either from explicit list or full-repo scan."""
+    if files:
+        result = []
+        for f in files:
+            p = Path(f).resolve()
+            if p.is_file() and _is_checkable(p):
+                if not any(part in str(f) for part in excluded_patterns):
+                    result.append(p)
+        return result
+
+    root_path = Path(".").resolve()
+    if not (root_path / ".git").exists():
+        print(f"Error: '{root_path}' is not a git repository", file=sys.stderr)
+        return None
+
+    all_files = get_git_tracked_files(root_path)
+    filtered = [f for f in all_files if not any(str(f.relative_to(root_path)).startswith(p) for p in excluded_patterns)]
+    return [f for f in filtered if _is_checkable(f)]
+
+
+def main():
+    """Main function."""
+    parser = argparse.ArgumentParser(description="Check copyright headers in source files")
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Files to check (default: all git-tracked files)",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+
+    args = parser.parse_args()
+
+    files_to_check = _collect_files(args.files, ["reference"])
+    if files_to_check is None:
+        return 1
+
+    if not files_to_check:
+        print("No source files found to check")
+        return 0
+
+    def _display_path(p: Path) -> str:
+        try:
+            return str(p.relative_to(Path(".").resolve()))
+        except ValueError:
+            return str(p)
+
+    print(f"Checking {len(files_to_check)} file(s)...")
+
+    failed_files = []
+    passed_files = []
+
+    for file_path in files_to_check:
+        has_header, error_msg = check_file_header(file_path)
+
+        if has_header:
+            passed_files.append(file_path)
+            if args.verbose:
+                print(f"✓ {_display_path(file_path)}")
+        else:
+            failed_files.append((file_path, error_msg))
+            print(f"✗ {_display_path(file_path)}")
+            if error_msg:
+                print(f"  {error_msg}")
+
+    print()
+    print(f"Results: {len(passed_files)} passed, {len(failed_files)} failed")
+
+    if failed_files:
+        print("\nFiles with incorrect or missing headers:")
+        for file_path, _ in failed_files:
+            print(f"  - {_display_path(file_path)}")
+        return 1
+
+    print("\n✓ All files have correct headers!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Support: add pre-commit hooks with ruff and pyright rules

- Add .pre-commit-config.yaml with hooks for headers, English-only,

- clang-format, cpplint, markdownlint, ruff, and pyright

- Add ruff and pyright rule config in pyproject.toml aligned with

- pypto-v2-ir, adapted for line-length 120 and Python 3.9

- Add check_headers.py and check_english_only.py lint scripts with

- incremental file checking and header offset tolerance

- Add pre-commit CI job and gate all other jobs behind it

- Translate .clang-format comments from Chinese to English