### PR TITLE
Refactor: encapsulate TaskOutputTensors materialization

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -414,23 +414,6 @@ TaskOutputTensors pto2_submit_mixed_task(
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, task_id.raw);
 
     // === STEP 3: Lookup inputs + materialize runtime-created outputs ===
-    auto fill_initial_value = [](void* addr, uint64_t buffer_size, DataType dtype, uint64_t initial_value) {
-        uint64_t elem_size = get_element_size(dtype);
-        char* dst = reinterpret_cast<char*>(addr);
-        constexpr uint64_t BLK = 64;
-        uint64_t blk = (buffer_size < BLK) ? buffer_size : BLK;
-        for (uint64_t b = 0; b < blk; b += elem_size) {
-            memcpy(dst + b, &initial_value, elem_size);
-        }
-        uint64_t off = blk;
-        for (; off + blk <= buffer_size; off += blk) {
-            memcpy(dst + off, dst, blk);
-        }
-        if (off < buffer_size) {
-            memcpy(dst + off, dst, buffer_size - off);
-        }
-    };
-
     int32_t offset = 0;
     for (int i = 0; i < args.tensor_count; i++) {
         TensorArgType ptype = args.tensor_types[i];
@@ -479,13 +462,7 @@ TaskOutputTensors pto2_submit_mixed_task(
                 uint64_t buffer_size = ci.buffer_size_bytes();
                 uint64_t alloc_addr = reinterpret_cast<uint64_t>((char*)alloc_result.packed_base + offset);
                 offset += PTO2_ALIGN_UP(buffer_size, PTO2_PACKED_OUTPUT_ALIGN);
-                result.output_ptr(result.output_count)->init_from_create_info(
-                    ci, reinterpret_cast<void*>(alloc_addr), /*version=*/0);
-                if (ci.has_initial_value) {
-                    fill_initial_value(reinterpret_cast<void*>(alloc_addr), buffer_size,
-                                       ci.dtype, ci.initial_value);
-                }
-                result.output_count++;
+                result.materialize_output(ci, reinterpret_cast<void*>(alloc_addr), /*version=*/0);
                 break;
             }
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -49,19 +49,29 @@
  */
 class TaskOutputTensors {
 public:
-    TaskOutputTensors() : output_count(0) {}
+    TaskOutputTensors() : output_count_(0) {}
 
-    uint32_t output_count;
-
-    bool empty() const { return output_count == 0; }
-    uint32_t size() const { return output_count; }
+    bool empty() const { return output_count_ == 0; }
+    uint32_t size() const { return output_count_; }
 
     /// Borrow a materialized output tensor by index (lvalue only).
     const Tensor& get_ref(uint32_t index) const & {
-        always_assert(index < output_count);
+        always_assert(index < output_count_);
         return *reinterpret_cast<const Tensor*>(_storage + index * sizeof(Tensor));
     }
     const Tensor& get_ref(uint32_t index) const && = delete;
+
+    /// Runtime-internal: append one materialized output Tensor.
+    Tensor& materialize_output(const TensorCreateInfo& ci, void* addr, int32_t version) {
+        always_assert(output_count_ < PTO2_MAX_OUTPUTS);
+        Tensor* out = output_ptr(output_count_);
+        out->init_from_create_info(ci, addr, version);
+        if (ci.has_initial_value) {
+            fill_initial_value(addr, ci.buffer_size_bytes(), ci.dtype, ci.initial_value);
+        }
+        output_count_++;
+        return *out;
+    }
 
     /// Runtime-internal: writable pointer for materialization.
     Tensor* output_ptr(uint32_t index) {
@@ -72,6 +82,24 @@ public:
     }
 
 private:
+    static void fill_initial_value(void* addr, uint64_t buffer_size, DataType dtype,
+                                   uint64_t initial_value) {
+        uint64_t elem_size = get_element_size(dtype);
+        char* dst = reinterpret_cast<char*>(addr);
+        constexpr uint64_t BLK = 64;
+        uint64_t blk = (buffer_size < BLK) ? buffer_size : BLK;
+        for (uint64_t b = 0; b < blk; b += elem_size) {
+            memcpy(dst + b, &initial_value, elem_size);
+        }
+        uint64_t filled = blk;
+        while (filled < buffer_size) {
+            uint64_t copy_size = ((buffer_size - filled) < filled) ? (buffer_size - filled) : filled;
+            memcpy(dst + filled, dst, copy_size);
+            filled += copy_size;
+        }
+    }
+
+    uint32_t output_count_;
     alignas(Tensor) unsigned char _storage[PTO2_MAX_OUTPUTS * sizeof(Tensor)];
 };
 


### PR DESCRIPTION
Fix the remaining review feedback from pr384 by making output materialization a single TaskOutputTensors operation.

- make output_count private and expose size()/get_ref() for reads
- fold init_from_create_info, optional initial fill, and count updates into materialize_output()
- remove the open-coded initialization path from the orchestrator