### PR TITLE
Fix: const-qualify set_tensor_data Tensor parameter

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -110,7 +110,7 @@ typedef struct PTO2RuntimeOps {
     // Placed after logging to avoid shifting hot-path field offsets.
     uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
                                 uint32_t ndims, const uint32_t indices[]);
-    void (*set_tensor_data)(PTO2Runtime* rt, Tensor& tensor,
+    void (*set_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
                             uint32_t ndims, const uint32_t indices[],
                             uint64_t value);
 } PTO2RuntimeOps;
@@ -231,7 +231,7 @@ static inline uint64_t get_tensor_data(const Tensor& tensor,
  * For runtime-created outputs, call this only on the Tensor returned by
  * add_output(TensorCreateInfo) after submit returns.
  */
-static inline void set_tensor_data(Tensor& tensor,
+static inline void set_tensor_data(const Tensor& tensor,
                                    uint32_t ndims, const uint32_t indices[],
                                    uint64_t value) {
     PTO2Runtime* rt = pto2_current_runtime();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -134,7 +134,7 @@ uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
     return result;
 }
 
-void pto2_set_tensor_data(PTO2Runtime* rt, Tensor& tensor,
+void pto2_set_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
                           uint32_t ndims, const uint32_t indices[],
                           uint64_t value) {
     if (tensor.buffer.addr == 0) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -77,7 +77,7 @@ struct PTO2RuntimeOps {
     // Placed after logging to avoid shifting hot-path field offsets.
     uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
                                 uint32_t ndims, const uint32_t indices[]);
-    void (*set_tensor_data)(PTO2Runtime* rt, Tensor& tensor,
+    void (*set_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
                             uint32_t ndims, const uint32_t indices[],
                             uint64_t value);
 };
@@ -207,7 +207,7 @@ uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
  * Waits for producer completion (WAW) and all consumers (WAR) via TensorMap.
  * See set_tensor_data in pto_orchestration_api.h for full documentation.
  */
-void pto2_set_tensor_data(PTO2Runtime* rt, Tensor& tensor,
+void pto2_set_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
                           uint32_t ndims, const uint32_t indices[],
                           uint64_t value);
 


### PR DESCRIPTION
set_tensor_data took Tensor& (non-const) but TaskOutputTensors::get_ref() returns const Tensor&, causing compilation failure when orchestration code called set_tensor_data on runtime-created output tensors (e.g. scalar_data_test).

The implementation only reads Tensor metadata to compute offsets and writes to the underlying data buffer — it never modifies the Tensor struct itself. get_tensor_data and wait_for_tensor_ready already used const Tensor&.

Changed Tensor& to const Tensor& in:
- PTO2RuntimeOps function pointer (pto_orchestration_api.h, pto_runtime2.h)
- Inline wrapper (pto_orchestration_api.h)
- Implementation (pto_runtime2.cpp)