### PR TITLE
Refactor: rename and downgrade AICore memory barrier macros

### DIFF
--- a/src/a2a3/platform/onboard/aicore/inner_kernel.h
+++ b/src/a2a3/platform/onboard/aicore/inner_kernel.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file inner_kernel.h
  * @brief Platform-specific AICore definitions for real hardware (a2a3)
@@ -6,15 +17,18 @@
  * running on real Ascend hardware with CANN compiler support.
  */
 
+// NOLINT(build/header_guard) -- PLATFORM_* include guards are the project convention here
+
 #ifndef PLATFORM_A2A3_AICORE_INNER_KERNEL_H_
 #define PLATFORM_A2A3_AICORE_INNER_KERNEL_H_
 
 #include <cstdint>
+
 #include "common/platform_config.h"
 
 // AICore function attribute for CANN compiler
 #ifndef __aicore__
-#define __aicore__ [aicore]
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
 // dcci (Data Cache Clean and Invalidate) is provided by CANN headers
@@ -23,11 +37,14 @@
 // SPIN_WAIT_HINT - no-op on real hardware (AICore has dedicated polling support)
 #define SPIN_WAIT_HINT() ((void)0)
 
-// STORE_RELEASE_FENCE - no-op on real hardware (dcci handles cache coherency)
-#define STORE_RELEASE_FENCE() ((void)0)
+// OUT_OF_ORDER_STORE_BARRIER - no-op on real hardware (dcci handles cache coherency)
+#define OUT_OF_ORDER_STORE_BARRIER() ((void)0)
 
-// FULL_MEMORY_BARRIER - no-op on real hardware (dcci handles full cache coherency)
-#define FULL_MEMORY_BARRIER() ((void)0)
+// OUT_OF_ORDER_LOAD_BARRIER - no-op on real hardware (dcci handles cache coherency)
+#define OUT_OF_ORDER_LOAD_BARRIER() ((void)0)
+
+// OUT_OF_ORDER_FULL_BARRIER - no-op on real hardware (dcci handles full cache coherency)
+#define OUT_OF_ORDER_FULL_BARRIER() ((void)0)
 
 /**
  * Read an AICore register via SPR access
@@ -70,9 +87,7 @@ __aicore__ inline void write_reg(RegId reg, uint64_t value) {
  *
  * @return Physical core ID (masked to 12 bits)
  */
-__aicore__ inline uint32_t get_physical_core_id() {
-    return static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK;
-}
+__aicore__ inline uint32_t get_physical_core_id() { return static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK; }
 
 // =============================================================================
 // System Counter
@@ -83,8 +98,6 @@ __aicore__ inline uint32_t get_physical_core_id() {
  *
  * @return Hardware counter value (ticks)
  */
-__aicore__ __attribute__((always_inline)) inline uint64_t get_sys_cnt_aicore() {
-    return get_sys_cnt();
-}
+__aicore__ __attribute__((always_inline)) inline uint64_t get_sys_cnt_aicore() { return get_sys_cnt(); }
 
 #endif  // PLATFORM_A2A3_AICORE_INNER_KERNEL_H_

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file inner_kernel.h
  * @brief Platform-specific AICore definitions for simulation (a2a3sim)
@@ -5,6 +16,8 @@
  * This header provides platform-specific macro definitions for AICore kernels
  * running in host-based simulation environment.
  */
+
+// NOLINT(build/header_guard) -- PLATFORM_* include guards are the project convention here
 
 #ifndef PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
 #define PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
@@ -34,10 +47,10 @@
 // dsb / mem_dsb_t — CANN provides these on real AICore; perf_collector uses them after dcci flush.
 // Simulation: full fence (same strength as dcci above) so AICPU ordering matches hardware intent.
 typedef int mem_dsb_t;
-#define dsb(_kind)                                                                               \
-    do {                                                                                         \
-        (void)(_kind);                                                                           \
-        std::atomic_thread_fence(std::memory_order_seq_cst);                                    \
+#define dsb(_kind)                                           \
+    do {                                                     \
+        (void)(_kind);                                       \
+        std::atomic_thread_fence(std::memory_order_seq_cst); \
     } while (0)
 
 // Cache coherency constants (no-op in simulation)
@@ -53,29 +66,49 @@ typedef int mem_dsb_t;
 #include <sched.h>
 
 #if defined(__aarch64__)
-#define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()                        \
+    do {                                        \
+        __asm__ volatile("yield" ::: "memory"); \
+        sched_yield();                          \
+    } while (0)
 #elif defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()        \
+    do {                        \
+        __builtin_ia32_pause(); \
+        sched_yield();          \
+    } while (0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif
 
-// STORE_RELEASE_FENCE - store-store barrier to prevent reordering of data writes
-// (physical_core_id, core_type) past the signal write (aicore_done) in handshake.
-// Without this fence, aarch64 can reorder stores to different addresses, causing
-// AICPU to read stale physical_core_id after observing aicore_done != 0.
+// OUT_OF_ORDER_STORE_BARRIER - store-store barrier preventing store reordering.
+// Ensures stores preceding the barrier are visible before stores following it.
+// Used in the AICore-AICPU handshake to ensure data fields (core_type) are
+// visible before the signal field (aicore_done), and to flush kernel outputs
+// before writing the FIN signal register.
 #if defined(__aarch64__)
-#define STORE_RELEASE_FENCE() __asm__ volatile("dmb ishst" ::: "memory")
+#define OUT_OF_ORDER_STORE_BARRIER() __asm__ volatile("dmb ishst" ::: "memory")
 #elif defined(__x86_64__)
-#define STORE_RELEASE_FENCE() __asm__ volatile("" ::: "memory")
+#define OUT_OF_ORDER_STORE_BARRIER() __asm__ volatile("" ::: "memory")
 #else
-#define STORE_RELEASE_FENCE() std::atomic_thread_fence(std::memory_order_release)
+#define OUT_OF_ORDER_STORE_BARRIER() std::atomic_thread_fence(std::memory_order_release)
 #endif
 
-// FULL_MEMORY_BARRIER - full memory barrier preventing all load/store reordering.
-// Used after kernel execution to ensure all writes are visible before signalling
-// completion. Equivalent to dmb ish (aarch64) / mfence (x86).
-#define FULL_MEMORY_BARRIER() __sync_synchronize()
+// OUT_OF_ORDER_LOAD_BARRIER - load-acquire barrier preventing load reordering.
+// Ensures loads following the barrier are not reordered before the load
+// immediately preceding it. Used after reading a signal register to ensure
+// subsequent payload reads observe AICPU's writes.
+#if defined(__aarch64__)
+#define OUT_OF_ORDER_LOAD_BARRIER() __asm__ volatile("dmb ishld" ::: "memory")
+#elif defined(__x86_64__)
+#define OUT_OF_ORDER_LOAD_BARRIER() __asm__ volatile("" ::: "memory")
+#else
+#define OUT_OF_ORDER_LOAD_BARRIER() std::atomic_thread_fence(std::memory_order_acquire)
+#endif
+
+// OUT_OF_ORDER_FULL_BARRIER - full memory barrier preventing all load/store reordering.
+// Equivalent to dmb ish (aarch64) / mfence (x86).
+#define OUT_OF_ORDER_FULL_BARRIER() __sync_synchronize()
 
 // =============================================================================
 // System Counter Simulation
@@ -88,17 +121,14 @@ typedef int mem_dsb_t;
  */
 inline uint64_t get_sys_cnt_aicore() {
     auto now = std::chrono::high_resolution_clock::now();
-    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        now.time_since_epoch()
-    ).count();
+    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
 
     // Convert nanoseconds to counter ticks
     constexpr uint64_t kNsPerSec = std::nano::den;
     uint64_t seconds = elapsed_ns / kNsPerSec;
     uint64_t remaining_ns = elapsed_ns % kNsPerSec;
 
-    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ +
-                     (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
+    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
 
     return ticks;
 }
@@ -128,9 +158,9 @@ extern thread_local uint32_t g_sim_physical_core_id;
  */
 inline uint64_t read_reg(RegId reg) {
     uint32_t offset = reg_offset(reg);
-    FULL_MEMORY_BARRIER();
-    return static_cast<uint64_t>(
-        *reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset));
+    uint64_t val = static_cast<uint64_t>(*reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset));
+    OUT_OF_ORDER_LOAD_BARRIER();
+    return val;
 }
 
 /**
@@ -141,9 +171,8 @@ inline uint64_t read_reg(RegId reg) {
  */
 inline void write_reg(RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
-    *reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset) =
-        static_cast<uint32_t>(value);
-    FULL_MEMORY_BARRIER();
+    *reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset) = static_cast<uint32_t>(value);
+    OUT_OF_ORDER_STORE_BARRIER();
 }
 
 /**
@@ -151,8 +180,6 @@ inline void write_reg(RegId reg, uint64_t value) {
  *
  * @return Physical core ID for the current simulated core
  */
-inline uint32_t get_physical_core_id() {
-    return g_sim_physical_core_id;
-}
+inline uint32_t get_physical_core_id() { return g_sim_physical_core_id; }
 
 #endif  // PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_

--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -1,9 +1,20 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 #include "aicore/aicore.h"
-#include "runtime.h"
-#include "pto2_dispatch_payload.h"
-#include "common/perf_profiling.h"
 #include "aicore/performance_collector_aicore.h"
+#include "common/perf_profiling.h"
 #include "common/platform_config.h"  // Register-based communication
+#include "pto2_dispatch_payload.h"   // NOLINT(build/include_subdir)
+#include "runtime.h"                 // NOLINT(build/include_subdir)
 
 /**
  * Unified function pointer type for kernel dispatch
@@ -20,16 +31,14 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(
-    __gm__ PTO2DispatchPayload* payload
-) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
 
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
-    FULL_MEMORY_BARRIER();
+    OUT_OF_ORDER_STORE_BARRIER();
 }
 
 /**
@@ -67,14 +76,13 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
 
     // Phase 3: Report core type, signal ready
     my_hank->core_type = core_type;
-    STORE_RELEASE_FENCE();
+    OUT_OF_ORDER_STORE_BARRIER();
     my_hank->aicore_done = block_idx + 1;  // Signal ready (use block_idx + 1 to avoid 0)
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     // Cache payload address (set once by AICPU during initialization, never changes)
-    __gm__ PTO2DispatchPayload* payload =
-        reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
 
@@ -116,8 +124,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, task_id,
-                                       start_time, end_time);
+                perf_aicore_record_task(perf_buf, task_id, start_time, end_time);
             }
 
             last_reg_val = reg_val;

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -1,8 +1,19 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 #include "aicore/aicore.h"
-#include "runtime.h"
-#include "common/perf_profiling.h"
 #include "aicore/performance_collector_aicore.h"
+#include "common/perf_profiling.h"
 #include "common/platform_config.h"  // Platform configuration (C/C++ compatible)
+#include "runtime.h"                 // NOLINT(build/include_subdir)
 
 typedef void (*KernelFunc)(__gm__ int64_t*);
 
@@ -12,7 +23,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
     }
     KernelFunc kernel = (KernelFunc)task->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
-    FULL_MEMORY_BARRIER();
+    OUT_OF_ORDER_STORE_BARRIER();
 }
 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
@@ -35,7 +46,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
 
     // Phase 3: Report core type, signal ready
     my_hank->core_type = core_type;
-    STORE_RELEASE_FENCE();
+    OUT_OF_ORDER_STORE_BARRIER();
     my_hank->aicore_done = block_idx + 1;
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
@@ -70,8 +81,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, actual_task_id,
-                                      start_time, end_time);
+                perf_aicore_record_task(perf_buf, actual_task_id, start_time, end_time);
             }
 
             last_task_id = task_id;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -1,9 +1,20 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 #include "aicore/aicore.h"
-#include "runtime.h"
-#include "pto2_dispatch_payload.h"
-#include "common/perf_profiling.h"
 #include "aicore/performance_collector_aicore.h"
+#include "common/perf_profiling.h"
 #include "common/platform_config.h"  // Register-based communication
+#include "pto2_dispatch_payload.h"   // NOLINT(build/include_subdir)
+#include "runtime.h"                 // NOLINT(build/include_subdir)
 
 /**
  * Unified function pointer type for kernel dispatch
@@ -20,16 +31,14 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(
-    __gm__ PTO2DispatchPayload* payload
-) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
 
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
-    FULL_MEMORY_BARRIER();
+    OUT_OF_ORDER_STORE_BARRIER();
 }
 
 /**
@@ -70,14 +79,13 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
 
     // Phase 3: Report core type, signal ready
     my_hank->core_type = core_type;
-    STORE_RELEASE_FENCE();
+    OUT_OF_ORDER_STORE_BARRIER();
     my_hank->aicore_done = block_idx + 1;  // Signal ready (use block_idx + 1 to avoid 0)
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
-    __gm__ PTO2DispatchPayload* payload =
-        reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
 
@@ -118,8 +126,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, task_id,
-                                       start_time, end_time);
+                perf_aicore_record_task(perf_buf, task_id, start_time, end_time);
             }
 
             last_reg_val = reg_val;

--- a/src/a5/platform/onboard/aicore/inner_kernel.h
+++ b/src/a5/platform/onboard/aicore/inner_kernel.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file inner_kernel.h
  * @brief Platform-specific AICore definitions for real hardware (a5)
@@ -6,15 +17,18 @@
  * running on real Ascend hardware with CANN compiler support.
  */
 
+// NOLINT(build/header_guard) -- PLATFORM_* include guards are the project convention here
+
 #ifndef PLATFORM_A5_AICORE_INNER_KERNEL_H_
 #define PLATFORM_A5_AICORE_INNER_KERNEL_H_
 
 #include <cstdint>
+
 #include "common/platform_config.h"
 
 // AICore function attribute for CANN compiler
 #ifndef __aicore__
-#define __aicore__ [aicore]
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
 // dcci (Data Cache Clean and Invalidate) is provided by CANN headers
@@ -23,11 +37,14 @@
 // SPIN_WAIT_HINT - no-op on real hardware (AICore has dedicated polling support)
 #define SPIN_WAIT_HINT() ((void)0)
 
-// STORE_RELEASE_FENCE - no-op on real hardware (dcci handles cache coherency)
-#define STORE_RELEASE_FENCE() ((void)0)
+// OUT_OF_ORDER_STORE_BARRIER - no-op on real hardware (dcci handles cache coherency)
+#define OUT_OF_ORDER_STORE_BARRIER() ((void)0)
 
-// FULL_MEMORY_BARRIER - no-op on real hardware (dcci handles full cache coherency)
-#define FULL_MEMORY_BARRIER() ((void)0)
+// OUT_OF_ORDER_LOAD_BARRIER - no-op on real hardware (dcci handles cache coherency)
+#define OUT_OF_ORDER_LOAD_BARRIER() ((void)0)
+
+// OUT_OF_ORDER_FULL_BARRIER - no-op on real hardware (dcci handles full cache coherency)
+#define OUT_OF_ORDER_FULL_BARRIER() ((void)0)
 
 /**
  * Read an AICore register via SPR access
@@ -68,9 +85,7 @@ __aicore__ inline void write_reg(RegId reg, uint64_t value) {
  *
  * @return Physical core ID (masked to 12 bits)
  */
-__aicore__ inline uint32_t get_physical_core_id() {
-    return static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK;
-}
+__aicore__ inline uint32_t get_physical_core_id() { return static_cast<uint32_t>(get_coreid()) & AICORE_COREID_MASK; }
 
 // =============================================================================
 // System Counter
@@ -81,8 +96,6 @@ __aicore__ inline uint32_t get_physical_core_id() {
  *
  * @return Hardware counter value (ticks)
  */
-__aicore__ __attribute__((always_inline)) inline uint64_t get_sys_cnt_aicore() {
-    return get_sys_cnt();
-}
+__aicore__ __attribute__((always_inline)) inline uint64_t get_sys_cnt_aicore() { return get_sys_cnt(); }
 
 #endif  // PLATFORM_A5_AICORE_INNER_KERNEL_H_

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file inner_kernel.h
  * @brief Platform-specific AICore definitions for simulation (a5sim)
@@ -5,6 +16,8 @@
  * This header provides platform-specific macro definitions for AICore kernels
  * running in host-based simulation environment.
  */
+
+// NOLINT(build/header_guard) -- PLATFORM_* include guards are the project convention here
 
 #ifndef PLATFORM_A5SIM_AICORE_INNER_KERNEL_H_
 #define PLATFORM_A5SIM_AICORE_INNER_KERNEL_H_
@@ -34,10 +47,10 @@
 // dsb / mem_dsb_t — CANN provides these on real AICore; perf_collector uses them after dcci flush.
 // Simulation: full fence (same strength as dcci above) so AICPU ordering matches hardware intent.
 typedef int mem_dsb_t;
-#define dsb(_kind)                                                                               \
-    do {                                                                                         \
-        (void)(_kind);                                                                           \
-        std::atomic_thread_fence(std::memory_order_seq_cst);                                    \
+#define dsb(_kind)                                           \
+    do {                                                     \
+        (void)(_kind);                                       \
+        std::atomic_thread_fence(std::memory_order_seq_cst); \
     } while (0)
 
 // Cache coherency constants (no-op in simulation)
@@ -53,29 +66,49 @@ typedef int mem_dsb_t;
 #include <sched.h>
 
 #if defined(__aarch64__)
-#define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()                        \
+    do {                                        \
+        __asm__ volatile("yield" ::: "memory"); \
+        sched_yield();                          \
+    } while (0)
 #elif defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()        \
+    do {                        \
+        __builtin_ia32_pause(); \
+        sched_yield();          \
+    } while (0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif
 
-// STORE_RELEASE_FENCE - store-store barrier to prevent reordering of data writes
-// (physical_core_id, core_type) past the signal write (aicore_done) in handshake.
-// Without this fence, aarch64 can reorder stores to different addresses, causing
-// AICPU to read stale physical_core_id after observing aicore_done != 0.
+// OUT_OF_ORDER_STORE_BARRIER - store-store barrier preventing store reordering.
+// Ensures stores preceding the barrier are visible before stores following it.
+// Used in the AICore-AICPU handshake to ensure data fields (core_type) are
+// visible before the signal field (aicore_done), and to flush kernel outputs
+// before writing the FIN signal register.
 #if defined(__aarch64__)
-#define STORE_RELEASE_FENCE() __asm__ volatile("dmb ishst" ::: "memory")
+#define OUT_OF_ORDER_STORE_BARRIER() __asm__ volatile("dmb ishst" ::: "memory")
 #elif defined(__x86_64__)
-#define STORE_RELEASE_FENCE() __asm__ volatile("" ::: "memory")
+#define OUT_OF_ORDER_STORE_BARRIER() __asm__ volatile("" ::: "memory")
 #else
-#define STORE_RELEASE_FENCE() std::atomic_thread_fence(std::memory_order_release)
+#define OUT_OF_ORDER_STORE_BARRIER() std::atomic_thread_fence(std::memory_order_release)
 #endif
 
-// FULL_MEMORY_BARRIER - full memory barrier preventing all load/store reordering.
-// Used after kernel execution to ensure all writes are visible before signalling
-// completion. Equivalent to dmb ish (aarch64) / mfence (x86).
-#define FULL_MEMORY_BARRIER() __sync_synchronize()
+// OUT_OF_ORDER_LOAD_BARRIER - load-acquire barrier preventing load reordering.
+// Ensures loads following the barrier are not reordered before the load
+// immediately preceding it. Used after reading a signal register to ensure
+// subsequent payload reads observe AICPU's writes.
+#if defined(__aarch64__)
+#define OUT_OF_ORDER_LOAD_BARRIER() __asm__ volatile("dmb ishld" ::: "memory")
+#elif defined(__x86_64__)
+#define OUT_OF_ORDER_LOAD_BARRIER() __asm__ volatile("" ::: "memory")
+#else
+#define OUT_OF_ORDER_LOAD_BARRIER() std::atomic_thread_fence(std::memory_order_acquire)
+#endif
+
+// OUT_OF_ORDER_FULL_BARRIER - full memory barrier preventing all load/store reordering.
+// Equivalent to dmb ish (aarch64) / mfence (x86).
+#define OUT_OF_ORDER_FULL_BARRIER() __sync_synchronize()
 
 // =============================================================================
 // System Counter Simulation
@@ -88,17 +121,14 @@ typedef int mem_dsb_t;
  */
 inline uint64_t get_sys_cnt_aicore() {
     auto now = std::chrono::high_resolution_clock::now();
-    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        now.time_since_epoch()
-    ).count();
+    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
 
     // Convert nanoseconds to counter ticks
     constexpr uint64_t kNsPerSec = std::nano::den;
     uint64_t seconds = elapsed_ns / kNsPerSec;
     uint64_t remaining_ns = elapsed_ns % kNsPerSec;
 
-    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ +
-                     (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
+    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
 
     return ticks;
 }
@@ -130,11 +160,11 @@ extern thread_local uint32_t g_sim_physical_core_id;
  */
 inline uint64_t read_reg(RegId reg) {
     uint32_t offset = reg_offset(reg);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        sparse_reg_ptr(g_sim_reg_base, offset));
+    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(sparse_reg_ptr(g_sim_reg_base, offset));
 
-    FULL_MEMORY_BARRIER();
-    return static_cast<uint64_t>(*ptr);
+    uint64_t val = static_cast<uint64_t>(*ptr);
+    OUT_OF_ORDER_LOAD_BARRIER();
+    return val;
 }
 
 /**
@@ -147,11 +177,10 @@ inline uint64_t read_reg(RegId reg) {
  */
 inline void write_reg(RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        sparse_reg_ptr(g_sim_reg_base, offset));
+    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(sparse_reg_ptr(g_sim_reg_base, offset));
 
     *ptr = static_cast<uint32_t>(value);
-    FULL_MEMORY_BARRIER();
+    OUT_OF_ORDER_STORE_BARRIER();
 }
 
 /**
@@ -159,8 +188,6 @@ inline void write_reg(RegId reg, uint64_t value) {
  *
  * @return Physical core ID for the current simulated core
  */
-inline uint32_t get_physical_core_id() {
-    return g_sim_physical_core_id;
-}
+inline uint32_t get_physical_core_id() { return g_sim_physical_core_id; }
 
 #endif  // PLATFORM_A5SIM_AICORE_INNER_KERNEL_H_

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -1,8 +1,19 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 #include "aicore/aicore.h"
-#include "runtime.h"
-#include "common/perf_profiling.h"
 #include "aicore/performance_collector_aicore.h"
+#include "common/perf_profiling.h"
 #include "common/platform_config.h"  // Platform configuration (C/C++ compatible)
+#include "runtime.h"                 // NOLINT(build/include_subdir)
 
 typedef void (*KernelFunc)(__gm__ int64_t*);
 
@@ -12,7 +23,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
     }
     KernelFunc kernel = (KernelFunc)task->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
-    FULL_MEMORY_BARRIER();
+    OUT_OF_ORDER_STORE_BARRIER();
 }
 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type) {
@@ -35,7 +46,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
 
     // Phase 3: Report core type, signal ready
     my_hank->core_type = core_type;
-    STORE_RELEASE_FENCE();
+    OUT_OF_ORDER_STORE_BARRIER();
     my_hank->aicore_done = core_idx + 1;
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
@@ -70,8 +81,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, actual_task_id,
-                                      start_time, end_time);
+                perf_aicore_record_task(perf_buf, actual_task_id, start_time, end_time);
             }
 
             last_task_id = task_id;

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -1,9 +1,20 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 #include "aicore/aicore.h"
-#include "runtime.h"
-#include "pto2_dispatch_payload.h"
-#include "common/perf_profiling.h"
 #include "aicore/performance_collector_aicore.h"
+#include "common/perf_profiling.h"
 #include "common/platform_config.h"  // Register-based communication
+#include "pto2_dispatch_payload.h"   // NOLINT(build/include_subdir)
+#include "runtime.h"                 // NOLINT(build/include_subdir)
 
 /**
  * Unified function pointer type for kernel dispatch
@@ -20,16 +31,14 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(
-    __gm__ PTO2DispatchPayload* payload
-) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
 
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
     kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
-    FULL_MEMORY_BARRIER();
+    OUT_OF_ORDER_STORE_BARRIER();
 }
 
 /**
@@ -70,14 +79,13 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
 
     // Phase 3: Report core type, signal ready
     my_hank->core_type = core_type;
-    STORE_RELEASE_FENCE();
+    OUT_OF_ORDER_STORE_BARRIER();
     my_hank->aicore_done = core_idx + 1;  // Signal ready (use core_idx + 1 to avoid 0)
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
-    __gm__ PTO2DispatchPayload* payload =
-        reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
 
@@ -118,8 +126,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
-                perf_aicore_record_task(perf_buf, task_id,
-                                       start_time, end_time);
+                perf_aicore_record_task(perf_buf, task_id, start_time, end_time);
             }
 
             last_reg_val = reg_val;


### PR DESCRIPTION
Rename STORE_RELEASE_FENCE and FULL_MEMORY_BARRIER to OUT_OF_ORDER_STORE_BARRIER and OUT_OF_ORDER_FULL_BARRIER to make the "prevents out-of-order execution" intent explicit in the name.

Add OUT_OF_ORDER_LOAD_BARRIER (aarch64: dmb ishld) for load-acquire semantics.

Downgrade over-specified usages:
- execute_task(): FULL -> STORE (only store-store ordering needed)
- write_reg() sim: FULL -> STORE (only store-release needed)
- read_reg() sim: FULL -> LOAD, moved from before to after the load (correct acquire placement: barrier follows the signal load)