### PR TITLE
Refactor: defer output tensor materialization to payload init

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
@@ -1,3 +1,12 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
 """
 Paged Attention Kernel and Orchestration Configuration
 
@@ -28,19 +37,19 @@ ORCHESTRATION = {
 # Kernel configs (aiv_normalize removed - merged into aiv_online_update)
 KERNELS = [
     # AIC kernels (matrix multiplication using Cube unit)
-    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"),       "core_type": "aic"},
-    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"),       "core_type": "aic"},
+    {"func_id": 0, "name": "QK", "source": str(_KERNELS_ROOT / "aic" / "aic_qk_matmul.cpp"), "core_type": "aic"},
+    {"func_id": 2, "name": "PV", "source": str(_KERNELS_ROOT / "aic" / "aic_pv_matmul.cpp"), "core_type": "aic"},
+    {"func_id": 4, "name": "AIC_HUB", "source": str(_KERNELS_ROOT / "aic" / "aic_hub.cpp"), "core_type": "aic"},
     # AIV kernels (vector operations)
     {"func_id": 1, "name": "SF", "source": str(_KERNELS_ROOT / "aiv" / "aiv_softmax_prepare.cpp"), "core_type": "aiv"},
-    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"),   "core_type": "aiv"},
-    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"),       "core_type": "aiv"},
+    {"func_id": 3, "name": "UP", "source": str(_KERNELS_ROOT / "aiv" / "aiv_online_update.cpp"), "core_type": "aiv"},
+    {"func_id": 5, "name": "AIV_HUB", "source": str(_KERNELS_ROOT / "aiv" / "aiv_hub.cpp"), "core_type": "aiv"},
 ]
 
 # Runtime configuration
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 2,
+    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/src/a2a3/platform/include/common/perf_profiling.h
+++ b/src/a2a3/platform/include/common/perf_profiling.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file perf_profiling.h
  * @brief Performance profiling data structures
@@ -40,14 +51,14 @@
  * With phases = Base + sizeof(AicpuPhaseHeader) + num_threads * sizeof(PhaseBufferState)
  */
 
-#ifndef PLATFORM_COMMON_PERF_PROFILING_H_
-#define PLATFORM_COMMON_PERF_PROFILING_H_
+#ifndef SRC_A2A3_PLATFORM_INCLUDE_COMMON_PERF_PROFILING_H_
+#define SRC_A2A3_PLATFORM_INCLUDE_COMMON_PERF_PROFILING_H_
 
 #include <cstdint>
 #include <vector>
 
-#include "platform_config.h"
-#include "core_type.h"
+#include "common/core_type.h"
+#include "common/platform_config.h"
 
 // Maximum number of successor tasks per PerfRecord (matches Task::fanout)
 #ifndef RUNTIME_MAX_FANOUT
@@ -63,29 +74,28 @@
  */
 struct PerfRecord {
     // Timing information (device clock timestamps)
-    uint64_t start_time;         // Task start timestamp (get_sys_cnt)
-    uint64_t end_time;           // Task end timestamp
-    uint64_t duration;           // Execution duration (end - start)
+    uint64_t start_time;  // Task start timestamp (get_sys_cnt)
+    uint64_t end_time;    // Task end timestamp
+    uint64_t duration;    // Execution duration (end - start)
 
     // AICPU-side timestamps (written by AICPU, not AICore)
-    uint64_t dispatch_time;      // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
-    uint64_t finish_time;        // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
+    uint64_t dispatch_time;  // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
+    uint64_t finish_time;    // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
 
     // AICore writes the register dispatch token (low 32 bits only) zero-extended into task_id.
     // For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), AICPU overwrites
     // with the full PTO2 encoding (ring_id << 32) | local_id after FIN/perf row match.
     // For host_build_graph, task_id stays as the plain integer task index (ring_id = 0).
     uint64_t task_id;
-    uint32_t func_id;         // Kernel function identifier
-    CoreType core_type;       // Core type (AIC/AIV)
+    uint32_t func_id;    // Kernel function identifier
+    CoreType core_type;  // Core type (AIC/AIV)
 
     // Dependency relationship (fanout only)
     uint64_t fanout[RUNTIME_MAX_FANOUT];  // Successor task task_id array
-    int32_t fanout_count;                  // Number of successor tasks
+    int32_t fanout_count;                 // Number of successor tasks
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfRecord) % 64 == 0,
-              "PerfRecord must be 64-byte aligned for optimal cache performance");
+static_assert(sizeof(PerfRecord) % 64 == 0, "PerfRecord must be 64-byte aligned for optimal cache performance");
 
 // =============================================================================
 // PerfBuffer - Fixed-Size Record Buffer
@@ -99,7 +109,7 @@ static_assert(sizeof(PerfRecord) % 64 == 0,
  */
 struct PerfBuffer {
     PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Record array
-    volatile uint32_t count;                         // Current record count
+    volatile uint32_t count;                        // Current record count
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -123,13 +133,12 @@ struct PerfBuffer {
  */
 struct PerfFreeQueue {
     volatile uint64_t buffer_ptrs[PLATFORM_PROF_SLOT_COUNT];  // Free buffer addresses
-    volatile uint32_t head;  // Consumer read position (Device increments)
-    volatile uint32_t tail;  // Producer write position (Host increments)
-    uint32_t pad[13];        // Pad to 128 bytes (aligned to cache line)
+    volatile uint32_t head;                                   // Consumer read position (Device increments)
+    volatile uint32_t tail;                                   // Producer write position (Host increments)
+    uint32_t pad[13];                                         // Pad to 128 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfFreeQueue) == 128,
-              "PerfFreeQueue must be 128 bytes for cache alignment");
+static_assert(sizeof(PerfFreeQueue) == 128, "PerfFreeQueue must be 128 bytes for cache alignment");
 
 // =============================================================================
 // PerfBufferState - Per-Core/Thread Buffer State (Unified for PerfRecord and Phase)
@@ -154,14 +163,13 @@ static_assert(sizeof(PerfFreeQueue) == 128,
  * - current_buf_seq: Device writes (monotonic counter)
  */
 struct PerfBufferState {
-    PerfFreeQueue free_queue;            // SPSC queue of free buffer addresses
-    volatile uint64_t current_buf_ptr;   // Current active buffer (0 = none)
-    volatile uint32_t current_buf_seq;   // Sequence number for ordering
-    uint32_t pad[13];                    // Pad to 192 bytes (aligned to cache line)
+    PerfFreeQueue free_queue;           // SPSC queue of free buffer addresses
+    volatile uint64_t current_buf_ptr;  // Current active buffer (0 = none)
+    volatile uint32_t current_buf_seq;  // Sequence number for ordering
+    uint32_t pad[13];                   // Pad to 192 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfBufferState) == 192,
-              "PerfBufferState must be 192 bytes for cache alignment");
+static_assert(sizeof(PerfBufferState) == 192, "PerfBufferState must be 192 bytes for cache alignment");
 
 // Type alias for semantic clarity in Phase profiling context
 using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
@@ -181,11 +189,11 @@ using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
  * - Phase entry:      core_index = thread_idx, is_phase = 1
  */
 struct ReadyQueueEntry {
-    uint32_t core_index;      // Core index (0 ~ num_cores-1), or thread_idx for phase entries
-    uint32_t is_phase;        // 0 = PerfRecord, 1 = Phase
-    uint64_t buffer_ptr;      // Device pointer to the full buffer
-    uint32_t buffer_seq;      // Sequence number for ordering
-    uint32_t pad;             // Alignment padding
+    uint32_t core_index;  // Core index (0 ~ num_cores-1), or thread_idx for phase entries
+    uint32_t is_phase;    // 0 = PerfRecord, 1 = Phase
+    uint64_t buffer_ptr;  // Device pointer to the full buffer
+    uint32_t buffer_seq;  // Sequence number for ordering
+    uint32_t pad;         // Alignment padding
 } __attribute__((aligned(32)));
 
 // =============================================================================
@@ -216,8 +224,8 @@ struct PerfDataHeader {
     volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // Producer write positions (AICPU modifies)
 
     // Metadata (Host initializes, Device read-only)
-    uint32_t num_cores;                              // Actual number of cores launched
-    volatile uint32_t total_tasks;                   // Total tasks (AICPU writes after orchestration)
+    uint32_t num_cores;             // Actual number of cores launched
+    volatile uint32_t total_tasks;  // Total tasks (AICPU writes after orchestration)
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -232,21 +240,21 @@ struct PerfDataHeader {
  */
 enum class AicpuPhaseId : uint32_t {
     // Scheduler phases (0-3)
-    SCHED_COMPLETE    = 0,  // Process completed tasks (fanout traversal)
-    SCHED_DISPATCH    = 1,  // Dispatch ready tasks to idle cores
-    SCHED_SCAN        = 2,  // Incremental scan for root tasks
-    SCHED_IDLE_WAIT   = 3,  // Idle/spinning (no progress)
+    SCHED_COMPLETE = 0,     // Process completed tasks (fanout traversal)
+    SCHED_DISPATCH = 1,     // Dispatch ready tasks to idle cores
+    SCHED_SCAN = 2,         // Incremental scan for root tasks
+    SCHED_IDLE_WAIT = 3,    // Idle/spinning (no progress)
     SCHED_PHASE_COUNT = 4,  // Sentinel: number of scheduler phases
     // Orchestrator phases (16-24)
-    ORCH_SYNC      = 16,  // tensormap sync
-    ORCH_ALLOC     = 17,  // task_ring_alloc
-    ORCH_PARAMS    = 18,  // param copy
-    ORCH_LOOKUP    = 19,  // tensormap lookup + dep
-    ORCH_HEAP      = 20,  // heap alloc
-    ORCH_INSERT    = 21,  // tensormap insert
-    ORCH_FANIN     = 22,  // fanin + early-ready
-    ORCH_FINALIZE  = 23,  // scheduler init + SM
-    ORCH_SCOPE_END = 24   // scope_end
+    ORCH_SYNC = 16,      // tensormap sync
+    ORCH_ALLOC = 17,     // task_ring_alloc
+    ORCH_PARAMS = 18,    // param copy
+    ORCH_LOOKUP = 19,    // tensormap lookup + dep
+    ORCH_HEAP = 20,      // heap alloc
+    ORCH_INSERT = 21,    // tensormap insert
+    ORCH_FANIN = 22,     // fanin + early-ready
+    ORCH_FINALIZE = 23,  // scheduler init + SM
+    ORCH_SCOPE_END = 24  // scope_end
 };
 
 /**
@@ -256,14 +264,14 @@ enum class AicpuPhaseId : uint32_t {
  * No thread_id field: identity is derived from array index (position = identity).
  */
 struct AicpuPhaseRecord {
-    uint64_t start_time;       // Phase start timestamp
-    uint64_t end_time;         // Phase end timestamp
-    uint32_t loop_iter;        // Loop iteration number
-    AicpuPhaseId phase_id;     // Phase type
+    uint64_t start_time;    // Phase start timestamp
+    uint64_t end_time;      // Phase end timestamp
+    uint32_t loop_iter;     // Loop iteration number
+    AicpuPhaseId phase_id;  // Phase type
     union {
-        uint64_t task_id;   // Multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph):
-                            // full PTO2 encoding (ring_id << 32) | local_id for cross-view correlation.
-        uint64_t tasks_processed; // Scheduler phases: number of tasks processed in this batch
+        uint64_t task_id;          // Multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph):
+                                   // full PTO2 encoding (ring_id << 32) | local_id for cross-view correlation.
+        uint64_t tasks_processed;  // Scheduler phases: number of tasks processed in this batch
     };
 };
 
@@ -278,18 +286,18 @@ struct AicpuOrchSummary {
     uint64_t end_time;         // Orchestrator end timestamp
     uint64_t sync_cycle;       // sync_tensormap phase
     uint64_t alloc_cycle;      // task_ring_alloc phase
-    uint64_t params_cycle;     // param_copy phase
+    uint64_t args_cycle;       // param_copy phase
     uint64_t lookup_cycle;     // lookup+dep phase
     uint64_t heap_cycle;       // heap_alloc phase
     uint64_t insert_cycle;     // tensormap_insert phase
     uint64_t fanin_cycle;      // fanin+ready phase
     uint64_t scope_end_cycle;  // scope_end phase
-    int64_t  submit_count;     // Total tasks submitted
+    int64_t submit_count;      // Total tasks submitted
     uint32_t magic;            // Validation magic (AICPU_PHASE_MAGIC)
     uint32_t padding;          // Alignment padding
 } __attribute__((aligned(64)));
 
-constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"
+constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;        // "ACPH"
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per thread
 
 /**
@@ -310,12 +318,12 @@ struct PhaseBuffer {
  * Contains metadata and per-thread tracking.
  */
 struct AicpuPhaseHeader {
-    uint32_t magic;                  // Validation magic (AICPU_PHASE_MAGIC)
-    uint32_t num_sched_threads;      // Number of scheduler threads
-    uint32_t records_per_thread;     // Max records per PhaseBuffer
-    uint32_t num_cores;              // Total number of cores with valid assignments
+    uint32_t magic;                             // Validation magic (AICPU_PHASE_MAGIC)
+    uint32_t num_sched_threads;                 // Number of scheduler threads
+    uint32_t records_per_thread;                // Max records per PhaseBuffer
+    uint32_t num_cores;                         // Total number of cores with valid assignments
     int8_t core_to_thread[PLATFORM_MAX_CORES];  // core_id → scheduler thread index (-1 = unassigned)
-    AicpuOrchSummary orch_summary;   // Orchestrator cumulative data
+    AicpuOrchSummary orch_summary;              // Orchestrator cumulative data
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -345,9 +353,7 @@ inline size_t calc_perf_data_size(int num_cores) {
  * @param base_ptr Shared memory base address (device_ptr or host_ptr)
  * @return PerfDataHeader pointer
  */
-inline PerfDataHeader* get_perf_header(void* base_ptr) {
-    return (PerfDataHeader*)base_ptr;
-}
+inline PerfDataHeader* get_perf_header(void* base_ptr) { return reinterpret_cast<PerfDataHeader*>(base_ptr); }
 
 /**
  * Get PerfBufferState array start address
@@ -356,7 +362,7 @@ inline PerfDataHeader* get_perf_header(void* base_ptr) {
  * @return PerfBufferState array pointer
  */
 inline PerfBufferState* get_perf_buffer_states(void* base_ptr) {
-    return (PerfBufferState*)((char*)base_ptr + sizeof(PerfDataHeader));
+    return reinterpret_cast<PerfBufferState*>(reinterpret_cast<char*>(base_ptr) + sizeof(PerfDataHeader));
 }
 
 /**
@@ -378,9 +384,7 @@ inline PerfBufferState* get_perf_buffer_state(void* base_ptr, int core_index) {
  * @return Total bytes needed for header + all buffer states
  */
 inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threads) {
-    return calc_perf_data_size(num_cores)
-         + sizeof(AicpuPhaseHeader)
-         + num_sched_threads * sizeof(PhaseBufferState);
+    return calc_perf_data_size(num_cores) + sizeof(AicpuPhaseHeader) + num_sched_threads * sizeof(PhaseBufferState);
 }
 
 /**
@@ -391,7 +395,7 @@ inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threa
  * @return AicpuPhaseHeader pointer
  */
 inline AicpuPhaseHeader* get_phase_header(void* base_ptr, int num_cores) {
-    return (AicpuPhaseHeader*)((char*)base_ptr + calc_perf_data_size(num_cores));
+    return reinterpret_cast<AicpuPhaseHeader*>(reinterpret_cast<char*>(base_ptr) + calc_perf_data_size(num_cores));
 }
 
 /**
@@ -402,7 +406,8 @@ inline AicpuPhaseHeader* get_phase_header(void* base_ptr, int num_cores) {
  * @return PhaseBufferState array pointer
  */
 inline PhaseBufferState* get_phase_buffer_states(void* base_ptr, int num_cores) {
-    return (PhaseBufferState*)((char*)get_phase_header(base_ptr, num_cores) + sizeof(AicpuPhaseHeader));
+    return reinterpret_cast<PhaseBufferState*>(
+        reinterpret_cast<char*>(get_phase_header(base_ptr, num_cores)) + sizeof(AicpuPhaseHeader));
 }
 
 /**
@@ -421,4 +426,4 @@ inline PhaseBufferState* get_phase_buffer_state(void* base_ptr, int num_cores, i
 }
 #endif
 
-#endif  // PLATFORM_COMMON_PERF_PROFILING_H_
+#endif  // SRC_A2A3_PLATFORM_INCLUDE_COMMON_PERF_PROFILING_H_

--- a/src/a2a3/platform/src/host/performance_collector.cpp
+++ b/src/a2a3/platform/src/host/performance_collector.cpp
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file performance_collector.cpp
  * @brief Platform-agnostic performance data collector implementation
@@ -8,14 +19,18 @@
 
 #include "host/performance_collector.h"
 
+#include <sys/stat.h>
+#include <sys/types.h>
+
 #include <algorithm>
 #include <chrono>
+#include <cinttypes>
+#include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <optional>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <ctime>
+#include <string>
+#include <vector>
 
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
@@ -30,9 +45,14 @@ ProfMemoryManager::~ProfMemoryManager() {
     }
 }
 
-void ProfMemoryManager::start(void* shared_mem_host, int num_cores, int num_phase_threads,
-                               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-                               PerfFreeCallback free_cb, void* user_data, int device_id) {
+void ProfMemoryManager::start(void* shared_mem_host,
+    int num_cores,
+    int num_phase_threads,
+    PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb,
+    void* user_data,
+    int device_id) {
     shared_mem_host_ = shared_mem_host;
     num_cores_ = num_cores;
     num_phase_threads_ = num_phase_threads;
@@ -79,7 +99,7 @@ bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo& info) {
 
 bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout) {
     std::unique_lock<std::mutex> lock(ready_mutex_);
-    if (ready_cv_.wait_for(lock, timeout, [this]{ return !ready_queue_.empty(); })) {
+    if (ready_cv_.wait_for(lock, timeout, [this] { return !ready_queue_.empty(); })) {
         info = ready_queue_.front();
         ready_queue_.pop();
         return true;
@@ -138,12 +158,10 @@ void* ProfMemoryManager::resolve_host_ptr(void* dev_ptr) {
     return nullptr;
 }
 
-void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) {
-    dev_to_host_[dev_ptr] = host_ptr;
-}
+void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
 
-void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*thread_idx*/,
-                                              const ReadyQueueEntry& entry) {
+void ProfMemoryManager::process_ready_entry(
+    PerfDataHeader* /*header*/, int /*thread_idx*/, const ReadyQueueEntry& entry) {
     bool is_phase = (entry.is_phase != 0);
     uint64_t old_dev_ptr = entry.buffer_ptr;
     uint32_t seq = entry.buffer_seq;
@@ -162,7 +180,7 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
         void* new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
         if (new_dev_ptr != nullptr) {
             // Initialize new buffer
-            PhaseBuffer* new_buf = (PhaseBuffer*)host_ptr;
+            PhaseBuffer* new_buf = reinterpret_cast<PhaseBuffer*>(host_ptr);
             new_buf->count = 0;
 
             // Push to free_queue (with overflow guard)
@@ -173,7 +191,8 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
                 LOG_ERROR("ProfMemoryManager: phase free_queue overflow for thread %u", tidx);
                 free_buffer(new_dev_ptr);
             } else {
-                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] = (uint64_t)new_dev_ptr;
+                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] =
+                    reinterpret_cast<uint64_t>(new_dev_ptr);
                 wmb();
                 state->free_queue.tail = tail + 1;
                 wmb();
@@ -183,9 +202,10 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
         }
 
         // Resolve host pointer of old buffer
-        void* old_host_ptr = resolve_host_ptr((void*)old_dev_ptr);
+        void* old_host_ptr = resolve_host_ptr(reinterpret_cast<void*>(old_dev_ptr));
         if (old_host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p", (void*)old_dev_ptr);
+            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p",
+                reinterpret_cast<void*>(old_dev_ptr));
             return;
         }
 
@@ -194,7 +214,7 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
         info.type = ProfBufferType::PHASE;
         info.index = tidx;
         info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = (void*)old_dev_ptr;
+        info.dev_buffer_ptr = reinterpret_cast<void*>(old_dev_ptr);
         info.host_buffer_ptr = old_host_ptr;
         info.buffer_seq = seq;
 
@@ -217,7 +237,7 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
         void* host_ptr = nullptr;
         void* new_dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
         if (new_dev_ptr != nullptr) {
-            PerfBuffer* new_buf = (PerfBuffer*)host_ptr;
+            PerfBuffer* new_buf = reinterpret_cast<PerfBuffer*>(host_ptr);
             new_buf->count = 0;
 
             // Push to free_queue (with overflow guard)
@@ -228,7 +248,8 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
                 LOG_ERROR("ProfMemoryManager: perf free_queue overflow for core %u", core_index);
                 free_buffer(new_dev_ptr);
             } else {
-                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] = (uint64_t)new_dev_ptr;
+                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] =
+                    reinterpret_cast<uint64_t>(new_dev_ptr);
                 wmb();
                 state->free_queue.tail = tail + 1;
                 wmb();
@@ -237,9 +258,10 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
             LOG_ERROR("ProfMemoryManager: perf buffer alloc failed, device may lose data");
         }
 
-        void* old_host_ptr = resolve_host_ptr((void*)old_dev_ptr);
+        void* old_host_ptr = resolve_host_ptr(reinterpret_cast<void*>(old_dev_ptr));
         if (old_host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p", (void*)old_dev_ptr);
+            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p",
+                reinterpret_cast<void*>(old_dev_ptr));
             return;
         }
 
@@ -247,7 +269,7 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
         info.type = ProfBufferType::PERF_RECORD;
         info.index = core_index;
         info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = (void*)old_dev_ptr;
+        info.dev_buffer_ptr = reinterpret_cast<void*>(old_dev_ptr);
         info.host_buffer_ptr = old_host_ptr;
         info.buffer_seq = seq;
 
@@ -283,7 +305,10 @@ void ProfMemoryManager::mgmt_loop() {
             // Validate indices to prevent OOB access from corrupted shared memory
             if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
                 LOG_ERROR("mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)",
-                          t, head, tail, PLATFORM_PROF_READYQUEUE_SIZE);
+                    t,
+                    head,
+                    tail,
+                    PLATFORM_PROF_READYQUEUE_SIZE);
                 continue;
             }
 
@@ -321,8 +346,7 @@ void ProfMemoryManager::mgmt_loop() {
         uint32_t head = hdr->queue_heads[t];
         uint32_t tail = hdr->queue_tails[t];
         if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u",
-                      t, head, tail);
+            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u", t, head, tail);
             continue;
         }
         while (head != tail) {
@@ -387,12 +411,12 @@ void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out
 }
 
 int PerformanceCollector::initialize(Runtime& runtime,
-                                      int num_aicore,
-                                      int device_id,
-                                      PerfAllocCallback alloc_cb,
-                                      PerfRegisterCallback register_cb,
-                                      PerfFreeCallback free_cb,
-                                      void* user_data) {
+    int num_aicore,
+    int device_id,
+    PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb,
+    void* user_data) {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
         return -1;
@@ -421,8 +445,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("  Header size:          %zu bytes", sizeof(PerfDataHeader));
     LOG_DEBUG("  PerfBufferState size: %zu bytes each", sizeof(PerfBufferState));
     LOG_DEBUG("  PhaseBufferState size:%zu bytes each", sizeof(PhaseBufferState));
-    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)",
-              total_size, total_size / 1024);
+    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
 
     // Step 2: Allocate shared memory for slot arrays
     void* perf_dev_ptr = alloc_cb(total_size, user_data);
@@ -487,19 +510,18 @@ int PerformanceCollector::initialize(Runtime& runtime,
                 return -1;
             }
             // Initialize buffer
-            PerfBuffer* buf = (PerfBuffer*)host_buf_ptr;
+            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(host_buf_ptr);
             memset(buf, 0, sizeof(PerfBuffer));
             buf->count = 0;
 
             // Push to free_queue
-            state->free_queue.buffer_ptrs[s] = (uint64_t)dev_buf_ptr;
+            state->free_queue.buffer_ptrs[s] = reinterpret_cast<uint64_t>(dev_buf_ptr);
         }
         wmb();
         state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PerfBufferStates with %d buffers each",
-              num_aicore, PLATFORM_PROF_SLOT_COUNT);
+    LOG_DEBUG("Initialized %d PerfBufferStates with %d buffers each", num_aicore, PLATFORM_PROF_SLOT_COUNT);
 
     // Step 6: Initialize PhaseBufferStates and pre-fill free_queues
     for (int t = 0; t < num_phase_threads; t++) {
@@ -519,24 +541,23 @@ int PerformanceCollector::initialize(Runtime& runtime,
                 LOG_ERROR("Failed to allocate PhaseBuffer for thread %d, buffer %d", t, s);
                 return -1;
             }
-            PhaseBuffer* buf = (PhaseBuffer*)host_buf_ptr;
+            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(host_buf_ptr);
             memset(buf, 0, sizeof(PhaseBuffer));
             buf->count = 0;
 
             // Push to free_queue
-            state->free_queue.buffer_ptrs[s] = (uint64_t)dev_buf_ptr;
+            state->free_queue.buffer_ptrs[s] = reinterpret_cast<uint64_t>(dev_buf_ptr);
         }
         wmb();
         state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PhaseBufferStates with %d buffers each",
-              num_phase_threads, PLATFORM_PROF_SLOT_COUNT);
+    LOG_DEBUG("Initialized %d PhaseBufferStates with %d buffers each", num_phase_threads, PLATFORM_PROF_SLOT_COUNT);
 
     wmb();
 
     // Step 7: Pass base address to Runtime
-    runtime.perf_data_base = (uint64_t)perf_dev_ptr;
+    runtime.perf_data_base = reinterpret_cast<uint64_t>(perf_dev_ptr);
     LOG_DEBUG("Set runtime.perf_data_base = 0x%lx", runtime.perf_data_base);
 
     perf_shared_mem_dev_ = perf_dev_ptr;
@@ -551,10 +572,14 @@ void PerformanceCollector::start_memory_manager() {
         return;
     }
 
-    memory_manager_.start(perf_shared_mem_host_, num_aicore_,
-                           PLATFORM_MAX_AICPU_THREADS,
-                           alloc_cb_, register_cb_, free_cb_,
-                           user_data_, device_id_);
+    memory_manager_.start(perf_shared_mem_host_,
+        num_aicore_,
+        PLATFORM_MAX_AICPU_THREADS,
+        alloc_cb_,
+        register_cb_,
+        free_cb_,
+        user_data_,
+        device_id_);
 }
 
 void PerformanceCollector::stop_memory_manager() {
@@ -592,7 +617,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
                 LOG_ERROR("Timeout waiting for AICPU task count after %ld seconds",
-                         std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
                 return;
             }
 
@@ -645,7 +670,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             idle_start.reset();
 
             if (info.type == ProfBufferType::PERF_RECORD) {
-                PerfBuffer* buf = (PerfBuffer*)info.host_buffer_ptr;
+                PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
                 rmb();
                 uint32_t count = buf->count;
                 if (count > PLATFORM_PROF_BUFFER_SIZE) {
@@ -661,10 +686,13 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 }
 
                 LOG_DEBUG("Collected %u perf records from core %u (total: %d/%d)",
-                         count, core_index, total_records_collected, expected_tasks);
+                    count,
+                    core_index,
+                    total_records_collected,
+                    expected_tasks);
 
             } else {
-                PhaseBuffer* buf = (PhaseBuffer*)info.host_buffer_ptr;
+                PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
                 rmb();
                 uint32_t count = buf->count;
                 if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -691,9 +719,8 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
                 LOG_ERROR("Performance data collection idle timeout after %ld seconds",
-                         std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
-                LOG_ERROR("Collected %d / %d records before timeout",
-                         total_records_collected, expected_tasks);
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                LOG_ERROR("Collected %d / %d records before timeout", total_records_collected, expected_tasks);
                 break;
             }
         }
@@ -703,8 +730,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     LOG_INFO("Total records collected: %d", total_records_collected);
 
     if (total_records_collected < expected_tasks) {
-        LOG_WARN("Incomplete collection (%d / %d records)",
-                 total_records_collected, expected_tasks);
+        LOG_WARN("Incomplete collection (%d / %d records)", total_records_collected, expected_tasks);
     }
 
     LOG_INFO("Performance data collection complete");
@@ -732,7 +758,7 @@ void PerformanceCollector::drain_remaining_buffers() {
     ReadyBufferInfo info;
     while (memory_manager_.try_pop_ready(info)) {
         if (info.type == ProfBufferType::PERF_RECORD) {
-            PerfBuffer* buf = (PerfBuffer*)info.host_buffer_ptr;
+            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
             rmb();
             uint32_t count = buf->count;
             if (count > PLATFORM_PROF_BUFFER_SIZE) {
@@ -746,7 +772,7 @@ void PerformanceCollector::drain_remaining_buffers() {
                 drained_perf += count;
             }
         } else {
-            PhaseBuffer* buf = (PhaseBuffer*)info.host_buffer_ptr;
+            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
             rmb();
             uint32_t count = buf->count;
             if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -763,8 +789,7 @@ void PerformanceCollector::drain_remaining_buffers() {
     }
 
     if (drained_perf > 0 || drained_phase > 0) {
-        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records",
-                 drained_perf, drained_phase);
+        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records", drained_perf, drained_phase);
     }
 
     if (drained_phase > 0) {
@@ -783,15 +808,15 @@ void PerformanceCollector::collect_phase_data() {
 
     // Validate magic
     if (phase_header->magic != AICPU_PHASE_MAGIC) {
-        LOG_INFO("No phase profiling data found (magic mismatch: 0x%x vs 0x%x)",
-                 phase_header->magic, AICPU_PHASE_MAGIC);
+        LOG_INFO(
+            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC);
         return;
     }
 
     int num_sched_threads = phase_header->num_sched_threads;
     if (num_sched_threads > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("Invalid num_sched_threads %d from shared memory (max=%d)",
-                  num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
+        LOG_ERROR(
+            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
         return;
     }
     LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
@@ -809,13 +834,14 @@ void PerformanceCollector::collect_phase_data() {
         rmb();
         uint64_t buf_ptr = state->current_buf_ptr;
         if (buf_ptr != 0) {
-            void* host_ptr = memory_manager_.resolve_host_ptr((void*)buf_ptr);
+            void* host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void*>(buf_ptr));
             if (host_ptr == nullptr) {
                 LOG_ERROR("collect_phase_data: no host mapping for dev_ptr=%p (thread %d)",
-                          (void*)buf_ptr, t);
+                    reinterpret_cast<void*>(buf_ptr),
+                    t);
                 continue;
             }
-            PhaseBuffer* pbuf = (PhaseBuffer*)host_ptr;
+            PhaseBuffer* pbuf = reinterpret_cast<PhaseBuffer*>(host_ptr);
             if (pbuf->count > 0) {
                 uint32_t count = pbuf->count;
                 if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -835,11 +861,16 @@ void PerformanceCollector::collect_phase_data() {
         if (!collected_phase_records_[t].empty()) {
             size_t sched_count = 0, orch_count = 0;
             for (const auto& r : collected_phase_records_[t]) {
-                if (is_scheduler_phase(r.phase_id)) sched_count++;
-                else orch_count++;
+                if (is_scheduler_phase(r.phase_id))
+                    sched_count++;
+                else
+                    orch_count++;
             }
             LOG_INFO("  Thread %zu: %zu records (sched=%zu, orch=%zu)",
-                     t, collected_phase_records_[t].size(), sched_count, orch_count);
+                t,
+                collected_phase_records_[t].size(),
+                sched_count,
+                orch_count);
         }
     }
 
@@ -848,9 +879,9 @@ void PerformanceCollector::collect_phase_data() {
     bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
 
     if (orch_valid) {
-        LOG_INFO("  Orchestrator: %lld tasks, %.3fus",
-                 (long long)collected_orch_summary_.submit_count,
-                 cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time));
+        LOG_INFO("  Orchestrator: %" PRId64 " tasks, %.3fus",
+            static_cast<int64_t>(collected_orch_summary_.submit_count),
+            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time));
     } else {
         LOG_INFO("  Orchestrator: no summary data");
     }
@@ -859,7 +890,10 @@ void PerformanceCollector::collect_phase_data() {
     bool has_accumulated = has_phase_data_;
     if (!has_accumulated) {
         for (const auto& v : collected_phase_records_) {
-            if (!v.empty()) { has_accumulated = true; break; }
+            if (!v.empty()) {
+                has_accumulated = true;
+                break;
+            }
         }
     }
     has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
@@ -867,13 +901,13 @@ void PerformanceCollector::collect_phase_data() {
     // Read core-to-thread mapping
     int num_cores = static_cast<int>(phase_header->num_cores);
     if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
-        core_to_thread_.assign(phase_header->core_to_thread,
-                                phase_header->core_to_thread + num_cores);
+        core_to_thread_.assign(phase_header->core_to_thread, phase_header->core_to_thread + num_cores);
         LOG_INFO("  Core-to-thread mapping: %d cores", num_cores);
     }
 
     LOG_INFO("Phase data collection complete: %d remaining records, orch_summary=%s",
-             total_phase_records, orch_valid ? "yes" : "no");
+        total_phase_records,
+        orch_valid ? "yes" : "no");
 }
 
 int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
@@ -917,10 +951,9 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     }
 
     // Sort by canonical task_id (64-bit PTO2 raw)
-    std::sort(tagged_records.begin(), tagged_records.end(),
-              [](const TaggedRecord& a, const TaggedRecord& b) {
-                  return a.record->task_id < b.record->task_id;
-              });
+    std::sort(tagged_records.begin(), tagged_records.end(), [](const TaggedRecord& a, const TaggedRecord& b) {
+        return a.record->task_id < b.record->task_id;
+    });
 
     // Step 4: Calculate base time (minimum timestamp across all records)
     uint64_t base_time_cycles = UINT64_MAX;
@@ -942,8 +975,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                 }
             }
         }
-        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC &&
-            collected_orch_summary_.start_time > 0 &&
+        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC && collected_orch_summary_.start_time > 0 &&
             collected_orch_summary_.start_time < base_time_cycles) {
             base_time_cycles = collected_orch_summary_.start_time;
         }
@@ -954,8 +986,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     std::tm* timeinfo = std::localtime(&now);
     char time_buffer[32];
     std::strftime(time_buffer, sizeof(time_buffer), "%Y%m%d_%H%M%S", timeinfo);
-    std::string filepath = output_path + "/perf_swimlane_"
-                          + std::string(time_buffer) + ".json";
+    std::string filepath = output_path + "/perf_swimlane_" + std::string(time_buffer) + ".json";
 
     // Step 6: Open JSON file for writing
     std::ofstream outfile(filepath);
@@ -995,8 +1026,8 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         outfile << "      \"dispatch_time_us\": " << std::fixed << std::setprecision(3) << dispatch_us << ",\n";
         outfile << "      \"finish_time_us\": " << std::fixed << std::setprecision(3) << finish_us << ",\n";
         outfile << "      \"fanout\": [";
-        int safe_fanout_count = (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT)
-                                ? record.fanout_count : 0;
+        int safe_fanout_count =
+            (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT) ? record.fanout_count : 0;
         for (int j = 0; j < safe_fanout_count; ++j) {
             outfile << record.fanout[j];
             if (j < safe_fanout_count - 1) {
@@ -1017,26 +1048,41 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     if (has_phase_data_) {
         auto sched_phase_name = [](AicpuPhaseId id) -> const char* {
             switch (id) {
-                case AicpuPhaseId::SCHED_COMPLETE:    return "complete";
-                case AicpuPhaseId::SCHED_DISPATCH:    return "dispatch";
-                case AicpuPhaseId::SCHED_SCAN:        return "scan";
-                case AicpuPhaseId::SCHED_IDLE_WAIT:   return "idle";
-                default: return "unknown";
+                case AicpuPhaseId::SCHED_COMPLETE:
+                    return "complete";
+                case AicpuPhaseId::SCHED_DISPATCH:
+                    return "dispatch";
+                case AicpuPhaseId::SCHED_SCAN:
+                    return "scan";
+                case AicpuPhaseId::SCHED_IDLE_WAIT:
+                    return "idle";
+                default:
+                    return "unknown";
             }
         };
 
         auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
             switch (id) {
-                case AicpuPhaseId::ORCH_SYNC:      return "orch_sync";
-                case AicpuPhaseId::ORCH_ALLOC:     return "orch_alloc";
-                case AicpuPhaseId::ORCH_PARAMS:    return "orch_params";
-                case AicpuPhaseId::ORCH_LOOKUP:    return "orch_lookup";
-                case AicpuPhaseId::ORCH_HEAP:      return "orch_heap";
-                case AicpuPhaseId::ORCH_INSERT:    return "orch_insert";
-                case AicpuPhaseId::ORCH_FANIN:     return "orch_fanin";
-                case AicpuPhaseId::ORCH_FINALIZE:  return "orch_finalize";
-                case AicpuPhaseId::ORCH_SCOPE_END: return "orch_scope_end";
-                default: return "unknown";
+                case AicpuPhaseId::ORCH_SYNC:
+                    return "orch_sync";
+                case AicpuPhaseId::ORCH_ALLOC:
+                    return "orch_alloc";
+                case AicpuPhaseId::ORCH_PARAMS:
+                    return "orch_params";
+                case AicpuPhaseId::ORCH_LOOKUP:
+                    return "orch_lookup";
+                case AicpuPhaseId::ORCH_HEAP:
+                    return "orch_heap";
+                case AicpuPhaseId::ORCH_INSERT:
+                    return "orch_insert";
+                case AicpuPhaseId::ORCH_FANIN:
+                    return "orch_fanin";
+                case AicpuPhaseId::ORCH_FINALIZE:
+                    return "orch_finalize";
+                case AicpuPhaseId::ORCH_SCOPE_END:
+                    return "orch_scope_end";
+                default:
+                    return "unknown";
             }
         };
 
@@ -1051,10 +1097,9 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                 double end_us = cycles_to_us(pr.end_time - base_time_cycles);
                 if (!first) outfile << ",\n";
                 outfile << "      {\"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
-                        << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                        << ", \"phase\": \"" << sched_phase_name(pr.phase_id) << "\""
-                        << ", \"loop_iter\": " << pr.loop_iter
-                        << ", \"tasks_processed\": " << pr.tasks_processed
+                        << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us << ", \"phase\": \""
+                        << sched_phase_name(pr.phase_id) << "\""
+                        << ", \"loop_iter\": " << pr.loop_iter << ", \"tasks_processed\": " << pr.tasks_processed
                         << "}";
                 first = false;
             }
@@ -1075,14 +1120,22 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
             outfile << "    \"end_time_us\": " << std::fixed << std::setprecision(3) << orch_end_us << ",\n";
             outfile << "    \"submit_count\": " << collected_orch_summary_.submit_count << ",\n";
             outfile << "    \"phase_us\": {\n";
-            outfile << "      \"sync\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.sync_cycle) << ",\n";
-            outfile << "      \"alloc\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
-            outfile << "      \"params\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.params_cycle) << ",\n";
-            outfile << "      \"lookup\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
-            outfile << "      \"heap\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
-            outfile << "      \"insert\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
-            outfile << "      \"fanin\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
-            outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
+            outfile << "      \"sync\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.sync_cycle) << ",\n";
+            outfile << "      \"alloc\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
+            outfile << "      \"params\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.args_cycle) << ",\n";
+            outfile << "      \"lookup\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
+            outfile << "      \"heap\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
+            outfile << "      \"insert\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
+            outfile << "      \"fanin\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
+            outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
             outfile << "    }\n";
             outfile << "  }";
         }
@@ -1091,7 +1144,10 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         bool has_orch_phases = false;
         for (const auto& v : collected_phase_records_) {
             for (const auto& r : v) {
-                if (!is_scheduler_phase(r.phase_id)) { has_orch_phases = true; break; }
+                if (!is_scheduler_phase(r.phase_id)) {
+                    has_orch_phases = true;
+                    break;
+                }
             }
             if (has_orch_phases) break;
         }
@@ -1108,9 +1164,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                     outfile << "      {\"phase\": \"" << orch_phase_name(pr.phase_id) << "\""
                             << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                             << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                            << ", \"submit_idx\": " << pr.loop_iter
-                            << ", \"task_id\": " << pr.task_id
-                            << "}";
+                            << ", \"submit_idx\": " << pr.loop_iter << ", \"task_id\": " << pr.task_id << "}";
                     first = false;
                 }
                 if (!first) outfile << "\n";
@@ -1145,9 +1199,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     return 0;
 }
 
-int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
-                                    PerfFreeCallback free_cb,
-                                    void* user_data) {
+int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data) {
     if (perf_shared_mem_host_ == nullptr) {
         return 0;
     }
@@ -1166,7 +1218,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
 
         // Free current buffer if any
         if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            free_cb((void*)state->current_buf_ptr, user_data);
+            free_cb(reinterpret_cast<void*>(state->current_buf_ptr), user_data);
         }
 
         // Free all buffers in free_queue (limit iterations to max capacity)
@@ -1177,13 +1229,12 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
         while (head != tail && max_iters-- > 0) {
             uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
             if (buf_ptr != 0 && free_cb != nullptr) {
-                free_cb((void*)buf_ptr, user_data);
+                free_cb(reinterpret_cast<void*>(buf_ptr), user_data);
             }
             head++;
         }
         if (head != tail) {
-            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)",
-                     i, head, tail);
+            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)", i, head, tail);
         }
     }
 
@@ -1193,7 +1244,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
 
         // Free current buffer if any
         if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            free_cb((void*)state->current_buf_ptr, user_data);
+            free_cb(reinterpret_cast<void*>(state->current_buf_ptr), user_data);
         }
 
         // Free all buffers in free_queue (limit iterations to max capacity)
@@ -1204,13 +1255,12 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
         while (head != tail && max_iters-- > 0) {
             uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
             if (buf_ptr != 0 && free_cb != nullptr) {
-                free_cb((void*)buf_ptr, user_data);
+                free_cb(reinterpret_cast<void*>(buf_ptr), user_data);
             }
             head++;
         }
         if (head != tail) {
-            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)",
-                     t, head, tail);
+            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)", t, head, tail);
         }
     }
 

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -1989,7 +1989,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 orch_summary.end_time = orch_cycle_end;
                 orch_summary.sync_cycle = 0;
                 orch_summary.alloc_cycle = p.alloc_cycle;
-                orch_summary.params_cycle = p.params_cycle;
+                orch_summary.params_cycle = p.args_cycle;
                 orch_summary.lookup_cycle = 0;
                 orch_summary.heap_cycle = p.heap_cycle;
                 orch_summary.insert_cycle = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -2026,7 +2026,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 orch_summary.end_time = orch_cycle_end;
                 orch_summary.sync_cycle = p.sync_cycle;
                 orch_summary.alloc_cycle = p.alloc_cycle;
-                orch_summary.params_cycle = p.params_cycle;
+                orch_summary.args_cycle = p.args_cycle;
                 orch_summary.lookup_cycle = p.lookup_cycle;
                 orch_summary.heap_cycle = 0;  // Now included in alloc_cycle
                 orch_summary.insert_cycle = p.insert_cycle;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -53,14 +53,16 @@ One extra step versus get_tensor_data: wait for all consumers to finish (`fanout
 
 ```cpp
 TensorCreateInfo ci(shapes, ndims, dtype);
-args.add_output(ci, initial_value);
+ci.set_initial_value(initial_value);
+args.add_output(ci);
 ```
 
 **Mechanism**:
 
-1. `add_output(ci, initial_value)` copies `ci` into `Arg` and marks the create-info with an initial value
-2. During orchestrator submit, after HeapRing allocation, the output tensor is materialized from the copied create-info
-3. Fill strategy:
+1. `ci.set_initial_value(value)` marks the create-info with an initial value before submission
+2. `add_output(ci)` stores a pointer to `ci` in `Arg` (the original must remain valid until submit)
+3. During payload init, the output tensor is materialized via `init_from_create_info()` which triggers the fill
+4. Fill strategy:
    - Small buffer (< 64 B): element-by-element memcpy directly into dst
    - Large buffer (≥ 64 B): fill the first 64 bytes as a template block, then bulk-memcpy in 64 B chunks; partial tail copy for remainder
 
@@ -75,8 +77,9 @@ uint32_t shapes[1] = {1};
 TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
 
 // Submit with initial value and keep the returned tensor
+scalar_ci.set_initial_value(float_to_u64(77.0f));
 Arg args;
-args.add_output(scalar_ci, 77.0f);
+args.add_output(scalar_ci);
 TaskOutputTensors outs = pto2_rt_submit_aiv_task(FUNC_NOOP, args);
 const Tensor& scalar_tensor = outs.get_ref(0);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -4,7 +4,7 @@
 
 AICPU logs (via `DEV_ALWAYS`) are written by CANN's **dlog** subsystem and do **not** appear in the `run_example.py` terminal output. They are written to CANN's device log directory:
 
-```
+```text
 $HOME/ascend/log/debug/device-<device_id>/device-<pid>_<timestamp>.log
 ```
 
@@ -19,7 +19,7 @@ ls -lt $HOME/ascend/log/debug/device-<device_id>/ | head -5
 A single run produces two profiling blocks in the device log:
 
 | Block | Emitted by | Function | Content |
-|-------|-----------|----------|---------|
+| ----- | ---------- | -------- | ------- |
 | **Orchestrator Profiling** | Thread 3 (orchestrator) | `aicpu_orchestration_entry` | Time breakdown of graph construction on device |
 | **PTO2 Scheduler Summary** | Threads 0/1/2 (schedulers) | `resolve_and_dispatch_pto2` | Per-thread scheduling statistics, phase timing, and lock contention |
 
@@ -33,7 +33,7 @@ Thread 3 loads the orchestration `.so` via `dlopen`, calls `aicpu_orchestration_
 
 ### Example (from a real run: batch=64, 16704 tasks)
 
-```
+```text
 Thread 3: Calling aicpu_orchestration_entry from SO
 aicpu_orchestration_entry ">>>>>> batch = 64"
 Thread 3: aicpu_orchestration_entry returned, cost 20943.940us
@@ -54,12 +54,12 @@ Thread 3: PTO2 total submitted tasks = 16704
 ### Field Reference
 
 | Field | Source (`pto_orchestrator.cpp`) | Description |
-|-------|-------------------------------|-------------|
+| ----- | ------------------------------- | ----------- |
 | **cost** | Wall-clock around `orch_func()` call | Total time including orchestration logic + scope overhead |
 | **total** | Sum of all sub-steps below | Accumulated time inside `pto2_submit_task` across all tasks |
 | **sync_tensormap** | `g_orch_sync_cycle` | TensorMap validity sync and optional cleanup before each submission |
 | **task_ring_alloc** | `g_orch_alloc_cycle` | Allocating a task slot from the task ring buffer |
-| **param_copy** | `g_orch_params_cycle` | Copying param descriptors + tensor descriptor copies into task-owned storage |
+| **param_copy** | `g_orch_args_cycle` | Copying param descriptors + tensor descriptor copies into task-owned storage |
 | **lookup+dep** | `g_orch_lookup_cycle` | TensorMap lookup for inputs/inouts + building fanin/fanout dependency edges |
 | **heap_alloc** | `g_orch_heap_cycle` | Allocating packed output buffers from the heap ring |
 | **tensormap_ins** | `g_orch_insert_cycle` | Inserting output/inout tensors into the TensorMap |
@@ -82,7 +82,7 @@ Each of the 3 scheduler threads (Thread 0, 1, 2) prints its own summary after co
 
 ### Example (Thread 0, from a different run: batch=1, 1044 tasks)
 
-```
+```text
 Thread 0: completed=352 tasks in 3477.420us (147 loops, 2.4 tasks/loop)
 Thread 0: --- Phase Breakdown ---
 Thread 0:   complete:    1485.020us (42.7%)  [fanout: edges=432, max_degree=2, avg=1.2]  [fanin: edges=320, max_degree=3, avg=0.9]
@@ -93,12 +93,12 @@ Thread 0:   idle:        4.940us (0.1%)
 
 ### Summary Line
 
-```
+```text
 Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
 ```
 
 | Field | Description |
-|-------|-------------|
+| ----- | ----------- |
 | **completed** | Number of tasks this thread processed to completion |
 | **Y us** | Total scheduler loop time (sum of all phase cycles) |
 | **Z loops** | Number of scheduler loop iterations |
@@ -109,7 +109,7 @@ Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
 The scheduler loop runs four phases each iteration. Each phase's time is accumulated across all loop iterations.
 
 | Phase | What it does | Inline stats |
-|-------|-------------|-------------|
+| ----- | ------------ | ------------ |
 | **complete** | Polls handshake on each managed core; when a core completes, calls `on_subtask_complete(task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, triggers `on_mixed_task_complete` which traverses fanout list (notify consumers) and fanin list (release producers) | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
 | **scan** | Updates the perf profiling header with latest scheduler state | — |
 | **dispatch** | For each idle core, pops a task from the shape-based ready queue via `get_ready_task(shape)`, builds the dispatch payload, and writes the task to the core's handshake register | `pop`: `hit` = successful pops (task dispatched), `miss` = empty queue pops, `hit_rate` = hit/(hit+miss) |
@@ -132,7 +132,7 @@ The scheduler loop runs four phases each iteration. Each phase's time is accumul
 Divide each thread's phase times by its `completed` count to get per-task scheduling cost:
 
 | Metric | Formula | Typical value |
-|--------|---------|---------------|
+| ------ | ------- | ------------- |
 | Scheduling overhead per task | total_time / completed | ~5-10 us/task |
 | Dispatch per task | dispatch_time / completed | ~3-6 us/task |
 | Complete per task | complete_time / completed | ~2-4 us/task |
@@ -144,7 +144,7 @@ Divide each thread's phase times by its `completed` count to get per-task schedu
 When `--enable-profiling` is used, the host terminal prints a **Task Statistics by Function** table with `Total_Exec` (total AICore kernel execution time). Combined with device log data:
 
 | Metric | Source | Description |
-|--------|--------|-------------|
+| ------ | ------ | ----------- |
 | Avg kernel exec time | `Total_Exec / total_tasks` (host) | Time AICore spends executing each kernel |
 | Avg scheduling overhead | `sum(thread_total) / total_tasks` (device log) | Time AICPU spends scheduling each task |
 | Sched/Exec ratio | scheduling / execution | Scheduling overhead relative to kernel execution |

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -58,7 +58,7 @@ __attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
 // Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // unified task+heap alloc
-static uint64_t g_orch_params_cycle = 0;     // param copy
+static uint64_t g_orch_args_cycle = 0;       // param copy
 static uint64_t g_orch_lookup_cycle = 0;     // tensormap lookup + dep building
 static uint64_t g_orch_insert_cycle = 0;     // tensormap insert
 static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
@@ -68,7 +68,7 @@ static uint32_t g_orch_submit_idx = 0;
 uint64_t g_orch_alloc_wait_cycle = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
 uint64_t g_orch_alloc_atomic_count = 0;
-uint64_t g_orch_params_atomic_count = 0;
+uint64_t g_orch_args_atomic_count = 0;
 uint64_t g_orch_fanin_atomic_count = 0;
 uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
@@ -354,13 +354,14 @@ TaskOutputTensors pto2_submit_mixed_task(
     }
 
     // === Calculate output size (from runtime-created OUTPUT args) ===
-    bool needs_alloc[MAX_TENSOR_ARGS] = {};
+    uint64_t offsets[MAX_TENSOR_ARGS] = {};
+    uint64_t buffer_sizes[MAX_TENSOR_ARGS] = {};
     int32_t total_output_size = 0;
     for (int i = 0; i < args.tensor_count(); i++) {
         if (args.tag(i) == TensorArgType::OUTPUT) {
-            needs_alloc[i] = true;
-            total_output_size +=
-                PTO2_ALIGN_UP(args.tensor(i).create_info.buffer_size_bytes(), PTO2_PACKED_OUTPUT_ALIGN);
+            offsets[i] = total_output_size;
+            buffer_sizes[i] = PTO2_ALIGN_UP(args.tensor(i).create_info->buffer_size_bytes(), PTO2_PACKED_OUTPUT_ALIGN);
+            total_output_size += buffer_sizes[i];
         }
     }
 
@@ -440,7 +441,6 @@ TaskOutputTensors pto2_submit_mixed_task(
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, task_id.raw);
 
     // === STEP 3: Lookup inputs + materialize runtime-created outputs ===
-    int32_t offset = 0;
     for (int i = 0; i < args.tensor_count(); i++) {
         TensorArgType ptype = args.tag(i);
 
@@ -482,16 +482,8 @@ TaskOutputTensors pto2_submit_mixed_task(
                 }
                 break;
             }
-
-            case TensorArgType::OUTPUT: {
-                const TensorCreateInfo& ci = args.tensor(i).create_info;
-                uint64_t buffer_size = ci.buffer_size_bytes();
-                uint64_t alloc_addr =
-                    reinterpret_cast<uint64_t>(reinterpret_cast<char*>(alloc_result.packed_base) + offset);
-                offset += PTO2_ALIGN_UP(buffer_size, PTO2_PACKED_OUTPUT_ALIGN);
-                result.materialize_output(ci, reinterpret_cast<void*>(alloc_addr), /*version=*/0);
+            default:
                 break;
-            }
         }
     }
 
@@ -499,20 +491,19 @@ TaskOutputTensors pto2_submit_mixed_task(
 
     // === STEP 4: Register outputs/inouts in TensorMap (must be separate from lookup) ===
     {
-        int32_t out_idx = 0;
         for (int i = 0; i < args.tensor_count(); i++) {
             TensorArgType ptype = args.tag(i);
-            if (ptype == TensorArgType::OUTPUT || ptype == TensorArgType::INOUT) {
-                bool skip_dep = (ptype == TensorArgType::OUTPUT) ? args.tensor(i).create_info.manual_dep
-                                                                 : args.tensor(i).ptr->manual_dep;
-                if (!skip_dep) {
-                    const Tensor& t =
-                        (ptype == TensorArgType::OUTPUT) ? *result.output_ptr(out_idx) : *args.tensor(i).ptr;
-                    orch->tensor_map.insert(t, task_id, needs_alloc[i]);
+            if (ptype == TensorArgType::INOUT) {
+                if (!args.tensor(i).ptr->manual_dep) {
+                    orch->tensor_map.insert(*args.tensor(i).ptr, task_id, false);
                 }
-            }
-            if (ptype == TensorArgType::OUTPUT) {
-                out_idx++;
+            } else if (ptype == TensorArgType::OUTPUT) {
+                if (!args.tensor(i).create_info->manual_dep) {
+                    orch->tensor_map.insert(*args.tensor(i).create_info,
+                        reinterpret_cast<void*>(reinterpret_cast<char*>(alloc_result.packed_base) + offsets[i]),
+                        task_id,
+                        true);
+                }
             }
         }
     }
@@ -540,11 +531,11 @@ TaskOutputTensors pto2_submit_mixed_task(
         }
     }
 
-    payload->init(args, result);
+    payload->init(args, result, alloc_result.packed_base, offsets, buffer_sizes);
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS, task_id.raw);
+    CYCLE_COUNT_LAP_RECORD(g_orch_args_cycle, AicpuPhaseId::ORCH_PARAMS, task_id.raw);
 #if PTO2_ORCH_PROFILING
-    g_orch_params_atomic_count += 2;  // fanout_lock.store + fanout_count.store
+    g_orch_args_atomic_count += 2;  // fanout_lock.store + fanout_count.store
 #endif
 
     // === STEP 6: Finalize fanin list ===
@@ -692,7 +683,7 @@ PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     PTO2OrchProfilingData d;
     d.sync_cycle = g_orch_sync_cycle;
     d.alloc_cycle = g_orch_alloc_cycle;
-    d.params_cycle = g_orch_params_cycle;
+    d.args_cycle = g_orch_args_cycle;
     d.lookup_cycle = g_orch_lookup_cycle;
     d.insert_cycle = g_orch_insert_cycle;
     d.fanin_cycle = g_orch_fanin_cycle;
@@ -701,13 +692,13 @@ PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     d.alloc_wait_cycle = g_orch_alloc_wait_cycle;
     d.fanin_wait_cycle = g_orch_fanin_wait_cycle;
     d.alloc_atomic_count = g_orch_alloc_atomic_count;
-    d.params_atomic_count = g_orch_params_atomic_count;
+    d.args_atomic_count = g_orch_args_atomic_count;
     d.fanin_atomic_count = g_orch_fanin_atomic_count;
     d.finalize_atomic_count = g_orch_finalize_atomic_count;
     d.scope_end_atomic_count = g_orch_scope_end_atomic_count;
 
     // Reset
-    g_orch_sync_cycle = g_orch_alloc_cycle = g_orch_params_cycle = 0;
+    g_orch_sync_cycle = g_orch_alloc_cycle = g_orch_args_cycle = 0;
     g_orch_lookup_cycle = g_orch_insert_cycle = 0;
     g_orch_fanin_cycle = g_orch_scope_end_cycle = 0;
     g_orch_submit_count = 0;
@@ -715,7 +706,7 @@ PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     g_orch_alloc_wait_cycle = 0;
     g_orch_fanin_wait_cycle = 0;
     g_orch_alloc_atomic_count = 0;
-    g_orch_params_atomic_count = 0;
+    g_orch_args_atomic_count = 0;
     g_orch_fanin_atomic_count = 0;
     g_orch_finalize_atomic_count = 0;
     g_orch_scope_end_atomic_count = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -391,19 +391,21 @@ struct PTO2TaskPayload {
      * @param args                Task arguments (tensors + scalars)
      * @param materialized_outputs  Materialized output tensors (from TensorCreateInfo path)
      */
-    void init(const Arg& args, const TaskOutputTensors& materialized_outputs) {
+    void init(
+        const Arg& args, TaskOutputTensors& result, void* base_addr, uint64_t offsets[], uint64_t buffer_sizes[]) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
-        int32_t out_idx = 0;
+        // int32_t out_idx = 0;
         for (int32_t i = 0; i < args.tensor_count(); i++) {
-            const Tensor* src;
-            if (args.tag(i) == TensorArgType::OUTPUT) {
-                src = materialized_outputs.output_ptr(out_idx++);
+            if (args.tag(i) != TensorArgType::OUTPUT) {
+                tensors[i].copy(*args.tensor(i).ptr);
             } else {
-                src = args.tensor(i).ptr;
+                tensors[i].init_from_create_info(*args.tensor(i).create_info,
+                    reinterpret_cast<void*>(reinterpret_cast<char*>(base_addr) + offsets[i]),
+                    buffer_sizes[i]);
+                result.materialize_output(tensors[i]);
             }
-            tensors[i].copy(*src);
             tensors[i].update_start_offset();
             dispatch_args[i] = reinterpret_cast<uint64_t>(&tensors[i]);
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * PTO Runtime2 - TensorMap Interface
  *
@@ -31,9 +42,9 @@
 
 #pragma once
 
-#include "common.h"
-#include "pto_runtime2_types.h"
-#include "tensor.h"
+#include "common.h"              // NOLINT(build/include_subdir)
+#include "pto_runtime2_types.h"  // NOLINT(build/include_subdir)
+#include "tensor.h"              // NOLINT(build/include_subdir)
 
 struct PTO2OrchestratorState;  // forward declare
 
@@ -47,7 +58,7 @@ struct PTO2OrchestratorState;  // forward declare
 #if PTO2_TENSORMAP_PROFILING
 extern uint64_t g_lookup_chain_total;
 extern uint64_t g_lookup_count;
-extern int32_t  g_lookup_chain_max;
+extern int32_t g_lookup_chain_max;
 extern uint64_t g_lookup_overlap_checks;
 extern uint64_t g_lookup_overlap_hits;
 extern uint64_t g_insert_count;
@@ -74,41 +85,40 @@ extern uint64_t g_insert_count;
  */
 struct alignas(64) PTO2TensorMapEntry {
     // === Cache line 1 (64B) — lookup hot path ===
-    PTO2TensorMapEntry* next_in_bucket;    // 8B: next entry in hash bucket chain
-    PTO2TaskId producer_task_id;           // 8B: raw (ring_id << 32) | local_id
-    uint64_t buffer_addr;                  // 8B: tensor base address (hash key)
-    int32_t version;                       // 4B: tensor version for overlap detection
-    uint32_t ndims;                        // 4B: number of dimensions
-    int32_t bucket_index;                  // 4B: bucket index (-1 if unlinked)
-    bool is_all_offset_zero;               // 1B: fast-path flag
-    bool with_alloc;                       // 1B: true=OUTPUT, false=INOUT
+    uint64_t buffer_addr;                // 8B: tensor base address (hash key)
+    PTO2TensorMapEntry* next_in_bucket;  // 8B: next entry in hash bucket chain
+    PTO2TaskId producer_task_id;         // 8B: raw (ring_id << 32) | local_id
+    int32_t version;                     // 4B: tensor version for overlap detection
+    int32_t bucket_index;                // 4B: bucket index (-1 if unlinked)
+    uint32_t ndims;                      // 4B: number of dimensions
+    bool is_all_offset_zero;             // 1B: fast-path flag
+    bool with_alloc;                     // 1B: true=OUTPUT, false=INOUT
     // padding: 2B
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS]; // 20B: shape per dimension
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // 20B: shape per dimension
     // padding: 4B to fill 64B
 
     // === Cache line 2 (64B) — insert/remove/slow-path ===
-    PTO2TensorMapEntry* prev_in_bucket;    // 8B: prev in hash bucket chain
-    PTO2TensorMapEntry* next_in_task;      // 8B: next entry for same task
-    PTO2TensorMapEntry* prev_in_task;      // 8B: prev entry for same task
-    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS]; // 20B: only when !is_all_offset_zero
+    PTO2TensorMapEntry* prev_in_bucket;         // 8B: prev in hash bucket chain
+    PTO2TensorMapEntry* next_in_task;           // 8B: next entry for same task
+    PTO2TensorMapEntry* prev_in_task;           // 8B: prev entry for same task
+    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];  // 20B: only when !is_all_offset_zero
     // padding: 20B to fill 64B
 
     /**
      * Copy overlap-relevant fields from a Tensor into this entry.
      */
-    void copy_from_tensor(const Tensor& t) {
-        buffer_addr = t.buffer.addr;
-        version = t.version;
-        ndims = t.ndims;
-        is_all_offset_zero = t.is_all_offset_zero;
-        for (uint32_t i = 0; i < t.ndims; i++) {
-            shapes[i] = t.shapes[i];
-        }
-        if (!t.is_all_offset_zero) {
-            for (uint32_t i = 0; i < t.ndims; i++) {
-                offsets[i] = t.offsets[i];
+    void copy_from_tensor(const Tensor& tensor) {
+        memcpy(this, &tensor, 64);
+        if (!tensor.is_all_offset_zero) {
+            for (uint32_t i = 0; i < tensor.ndims; i++) {
+                offsets[i] = tensor.offsets[i];
             }
         }
+    }
+
+    void copy_tensor_create_info(const TensorCreateInfo& tensor_create_info, uint64_t addr) {
+        memcpy(this, &tensor_create_info, 64);
+        buffer_addr = addr;
     }
 
     /**
@@ -137,8 +147,8 @@ struct alignas(64) PTO2TensorMapEntry {
         for (uint32_t i = 0; i < ndims; i++) {
             uint64_t in_off = input.is_all_offset_zero ? 0 : input.offsets[i];
             uint64_t ent_off = is_all_offset_zero ? 0 : offsets[i];
-            Segment in_range{in_off, in_off + (uint64_t)input.shapes[i]};
-            Segment ent_range{ent_off, ent_off + (uint64_t)shapes[i]};
+            Segment in_range{in_off, in_off + static_cast<uint64_t>(input.shapes[i])};
+            Segment ent_range{ent_off, ent_off + static_cast<uint64_t>(shapes[i])};
             if (!in_range.line_segment_intersection(ent_range)) {
                 return OverlapStatus::NO_OVERLAP;
             } else if (!in_range.contains(ent_range)) {
@@ -150,6 +160,12 @@ struct alignas(64) PTO2TensorMapEntry {
 };
 
 static_assert(sizeof(PTO2TensorMapEntry) == 128, "TensorMapEntry must be exactly 2 cache lines (128 bytes)");
+static_assert(offsetof(PTO2TensorMapEntry, buffer_addr) == offsetof(Tensor, buffer.addr));
+static_assert(offsetof(PTO2TensorMapEntry, version) == offsetof(Tensor, version));
+static_assert(offsetof(PTO2TensorMapEntry, ndims) == offsetof(Tensor, ndims));
+static_assert(offsetof(PTO2TensorMapEntry, is_all_offset_zero) == offsetof(Tensor, is_all_offset_zero));
+static_assert(
+    offsetof(PTO2TensorMapEntry, prev_in_bucket) == 64, "TensorMapEntry must be exactly 2 cache lines (128 bytes)");
 
 /**
  * Stack-allocated lookup result (avoids heap allocation per lookup)
@@ -180,15 +196,15 @@ struct PTO2LookupResult {
  */
 struct PTO2TensorMap {
     // Hash table buckets (fixed size, power of 2)
-    PTO2TensorMapEntry** buckets;     // Array of offsets into entry_pool (-1 = empty)
-    int32_t num_buckets;  // Must be power of 2 for fast modulo
+    PTO2TensorMapEntry** buckets;  // Array of offsets into entry_pool (-1 = empty)
+    int32_t num_buckets;           // Must be power of 2 for fast modulo
 
     // Entry pool as ring buffer
-    PTO2TensorMapEntry* entry_pool;  // Ring buffer of entries
-    PTO2TensorMapEntry** free_entry_list;        // free entry ids
-    int32_t pool_size;               // Total pool capacity
-    int32_t next_entry_idx;          // id when next entry insert
-    int32_t free_num;                // free entry number in entry pool
+    PTO2TensorMapEntry* entry_pool;        // Ring buffer of entries
+    PTO2TensorMapEntry** free_entry_list;  // free entry ids
+    int32_t pool_size;                     // Total pool capacity
+    int32_t next_entry_idx;                // id when next entry insert
+    int32_t free_num;                      // free entry number in entry pool
 
     // Per-ring per-task entry tracking (for efficient bucket cleanup)
     // Indexed by [ring_id][local_id & (task_window_sizes[ring_id] - 1)]
@@ -203,7 +219,7 @@ struct PTO2TensorMap {
 
     PTO2OrchestratorState* orch{nullptr};
 
-    // new_entry目前不负责分配属性，仅分配内存
+    // new_entry only allocates memory, does not assign attributes
     PTO2TensorMapEntry* new_entry() {
         if (free_num > 0) {
             PTO2TensorMapEntry* res = free_entry_list[--free_num];
@@ -217,7 +233,7 @@ struct PTO2TensorMap {
     }
 
     void free_entry(PTO2TensorMapEntry& entry) {
-        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+        always_assert(entry.bucket_index != -1);  // must still be in a bucket
 
         // Update predecessor's next pointer (O(1) via prev_in_bucket)
         if (entry.prev_in_bucket == nullptr) {
@@ -270,9 +286,7 @@ struct PTO2TensorMap {
      *
      * @param last_task_alive  Current value from shared memory
      */
-    void sync_validity(int32_t ring_id, int32_t last_task_alive) {
-        this->last_task_alives[ring_id] = last_task_alive;
-    }
+    void sync_validity(int32_t ring_id, int32_t last_task_alive) { this->last_task_alives[ring_id] = last_task_alive; }
 
     /**
      * Lookup producer for a tensor region
@@ -343,42 +357,23 @@ struct PTO2TensorMap {
      * @param producer_task_id  Task ID of producer
      */
     void insert(const Tensor& tensor, PTO2TaskId producer_task_id, bool with_alloc) {
-#if PTO2_TENSORMAP_PROFILING
-        g_insert_count++;
-#endif
-        // Prefetch bucket head and task_entry_head early; new_entry() + field
-        // initialization below provides hide time for these RFOs.
-        uint32_t bucket_index = hash(tensor.buffer.addr);
-        auto ring_id = producer_task_id.ring();
-        auto local_id = producer_task_id.local();
-        int32_t task_slot = local_id & (task_window_sizes[ring_id] - 1);
-
-        // Allocate entry from ring buffer pool
         PTO2TensorMapEntry* entry = new_entry();
-
-        // Initialize new entry
         entry->copy_from_tensor(tensor);
-        entry->producer_task_id = producer_task_id;
-        entry->with_alloc = with_alloc;
+        link_entry(entry, tensor.buffer.addr, producer_task_id, with_alloc);
+    }
 
-        // Insert at head of hash bucket (maintains task_id descending order)
-        entry->bucket_index = bucket_index;
-        entry->next_in_bucket = buckets[bucket_index];
-        // Update old head's prev pointer
-        if (entry->next_in_bucket != nullptr) {
-            entry->next_in_bucket->prev_in_bucket = entry;
-        }
-        buckets[entry->bucket_index] = entry;
-        entry->prev_in_bucket = nullptr;  // New head has no predecessor
-
-        // Link to task's entry list (for cleanup), indexed by ring and local slot
-        entry->next_in_task = task_entry_heads[ring_id][task_slot];
-        entry->prev_in_task = nullptr;  // New head has no predecessor
-        // Update old head's prev pointer
-        if (entry->next_in_task != nullptr) {
-            entry->next_in_task->prev_in_task = entry;
-        }
-        task_entry_heads[ring_id][task_slot] = entry;
+    /**
+     * Insert a new entry from TensorCreateInfo (for deferred OUTPUT tensors)
+     *
+     * @param tensor_create_info  Create-info describing the output
+     * @param addr                Allocated buffer address
+     * @param producer_task_id    Task ID of producer
+     * @param with_alloc          True if runtime allocated the buffer
+     */
+    void insert(const TensorCreateInfo& tensor_create_info, void* addr, PTO2TaskId producer_task_id, bool with_alloc) {
+        PTO2TensorMapEntry* entry = new_entry();
+        entry->copy_tensor_create_info(tensor_create_info, reinterpret_cast<uint64_t>(addr));
+        link_entry(entry, reinterpret_cast<uint64_t>(addr), producer_task_id, with_alloc);
     }
 
     /**
@@ -401,8 +396,7 @@ struct PTO2TensorMap {
                 // Only remove if this entry belongs to the retiring task
                 // (slot may have been reused by a newer task)
                 debug_assert(cur_entry->producer_task_id ==
-                             pto2_make_task_id(static_cast<uint8_t>(ring_id),
-                                               static_cast<uint32_t>(local_id)));
+                             pto2_make_task_id(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id)));
                 free_entry(*cur_entry);
                 cur_entry = next_entry;
             }
@@ -430,6 +424,39 @@ struct PTO2TensorMap {
     }
 
     /**
+     * Link an initialized entry into bucket and task chains.
+     */
+    void link_entry(PTO2TensorMapEntry* entry, uint64_t addr, PTO2TaskId producer_task_id, bool with_alloc) {
+#if PTO2_TENSORMAP_PROFILING
+        g_insert_count++;
+#endif
+        uint32_t bucket_index = hash(addr);
+        auto ring_id = producer_task_id.ring();
+        auto local_id = producer_task_id.local();
+        int32_t task_slot = local_id & (task_window_sizes[ring_id] - 1);
+
+        entry->producer_task_id = producer_task_id;
+        entry->with_alloc = with_alloc;
+
+        // Insert at head of hash bucket
+        entry->bucket_index = bucket_index;
+        entry->next_in_bucket = buckets[bucket_index];
+        if (entry->next_in_bucket != nullptr) {
+            entry->next_in_bucket->prev_in_bucket = entry;
+        }
+        buckets[bucket_index] = entry;
+        entry->prev_in_bucket = nullptr;
+
+        // Link to task's entry list
+        entry->next_in_task = task_entry_heads[ring_id][task_slot];
+        entry->prev_in_task = nullptr;
+        if (entry->next_in_task != nullptr) {
+            entry->next_in_task->prev_in_task = entry;
+        }
+        task_entry_heads[ring_id][task_slot] = entry;
+    }
+
+    /**
      * Check if entry is valid (producer has not retired)
      */
     bool entry_valid(const PTO2TensorMapEntry& entry) const {
@@ -446,7 +473,7 @@ struct PTO2TensorMap {
      * Called during pool wrap-around to unlink reused entries.
      */
     void remove_from_task(PTO2TensorMapEntry& entry) {
-        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+        always_assert(entry.bucket_index != -1);  // must still be in a bucket
         // Update predecessor's next pointer (O(1) via prev_in_task)
         if (entry.prev_in_task == nullptr) {
             // Entry is the head of its task chain, update task_entry_heads
@@ -498,7 +525,7 @@ struct PTO2TensorMap {
 struct PTO2TensorMapProfilingData {
     uint64_t lookup_chain_total;
     uint64_t lookup_count;
-    int32_t  lookup_chain_max;
+    int32_t lookup_chain_max;
     uint64_t overlap_checks;
     uint64_t overlap_hits;
     uint64_t insert_count;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -69,47 +69,19 @@ public:  // NOLINT(whitespace/indent)
     /// Borrow a materialized output tensor by index (lvalue only).
     const Tensor& get_ref(uint32_t index) const& {
         always_assert(index < output_count_);
-        return *reinterpret_cast<const Tensor*>(_storage + index * sizeof(Tensor));
+        return *tensors_[index];
     }
     const Tensor& get_ref(uint32_t index) const&& = delete;
 
     /// Runtime-internal: append one materialized output Tensor.
-    Tensor& materialize_output(const TensorCreateInfo& ci, void* addr, int32_t version) {
+    void materialize_output(const Tensor& tensor) {
         always_assert(output_count_ < PTO2_MAX_OUTPUTS);
-        Tensor* out = output_ptr(output_count_);
-        out->init_from_create_info(ci, addr, version);
-        if (ci.has_initial_value) {
-            fill_initial_value(addr, ci.buffer_size_bytes(), ci.dtype, ci.initial_value);
-        }
-        output_count_++;
-        return *out;
-    }
-
-    /// Runtime-internal: writable pointer for materialization.
-    Tensor* output_ptr(uint32_t index) { return reinterpret_cast<Tensor*>(_storage + index * sizeof(Tensor)); }
-    const Tensor* output_ptr(uint32_t index) const {
-        return reinterpret_cast<const Tensor*>(_storage + index * sizeof(Tensor));
+        tensors_[output_count_++] = &tensor;
     }
 
 private:  // NOLINT(whitespace/indent)
-    static void fill_initial_value(void* addr, uint64_t buffer_size, DataType dtype, uint64_t initial_value) {
-        uint64_t elem_size = get_element_size(dtype);
-        char* dst = reinterpret_cast<char*>(addr);
-        constexpr uint64_t BLK = 64;
-        uint64_t blk = (buffer_size < BLK) ? buffer_size : BLK;
-        for (uint64_t b = 0; b < blk; b += elem_size) {
-            memcpy(dst + b, &initial_value, elem_size);
-        }
-        uint64_t filled = blk;
-        while (filled < buffer_size) {
-            uint64_t copy_size = ((buffer_size - filled) < filled) ? (buffer_size - filled) : filled;
-            memcpy(dst + filled, dst, copy_size);
-            filled += copy_size;
-        }
-    }
-
     uint32_t output_count_;
-    alignas(Tensor) unsigned char _storage[PTO2_MAX_OUTPUTS * sizeof(Tensor)];
+    const Tensor* tensors_[PTO2_MAX_OUTPUTS];
 };
 
 // =============================================================================
@@ -124,7 +96,7 @@ private:  // NOLINT(whitespace/indent)
  */
 union TensorRef {
     const Tensor* ptr;
-    TensorCreateInfo create_info;
+    const TensorCreateInfo* create_info;
     TensorRef() : ptr(nullptr) {}
 };
 
@@ -143,9 +115,10 @@ union TensorRef {
  *
  * Example:
  *   Tensor x = make_tensor_external(dev_a, shapes, 2);
+ *   TensorCreateInfo ci(shapes, 2);  // must outlive submit
  *   Arg args;
  *   args.add_input(x);
- *   args.add_output(TensorCreateInfo(shapes, 2));
+ *   args.add_output(ci);
  *   args.add_scalar(some_value);
  *   TaskOutputTensors outs = pto2_rt_submit_aic_task(kernel_id, args);
  *   const Tensor& y = outs.get_ref(0);
@@ -192,32 +165,18 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
 
     /// Standard future-output path: runtime allocates buffer from heap,
     /// materializes Tensor into TaskOutputTensors.
+    /// The TensorCreateInfo must outlive the submit call (pointer is stored).
     void add_output(const TensorCreateInfo& ci) {
         if (!check_add_tensor_valid()) {
             return;
         }
-        tensors_[tensor_count_].create_info = ci;
+        tensors_[tensor_count_].create_info = &ci;
         tags_[tensor_count_] = TensorArgType::OUTPUT;
         tensor_count_++;
     }
 
-    /// Runtime-allocated output with an initial element value replicated
-    /// across the full buffer after HeapRing allocation.
-    /// Type is deduced from initial_value; bit-cast to uint64_t internally.
-    ///
-    ///   params.add_output(ci, 77.0f);        // float initial value
-    ///   params.add_output(ci, int32_t(0));    // int32 initial value
-    ///   params.add_output(ci, uint64_t(val)); // existing usage unchanged
-    template <typename T = uint64_t>
-    void add_output(const TensorCreateInfo& ci, T initial_value) {
-        if (!check_add_tensor_valid()) {
-            return;
-        }
-        tensors_[tensor_count_].create_info = ci;
-        tensors_[tensor_count_].create_info.set_initial_value(to_u64(initial_value));
-        tags_[tensor_count_] = TensorArgType::OUTPUT;
-        tensor_count_++;
-    }
+    /// Prevent passing temporaries — the pointer would dangle before submit.
+    void add_output(TensorCreateInfo&&) = delete;
 
     void add_inout(const Tensor& t) {
         if (!check_add_tensor_valid()) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -55,28 +55,36 @@ struct Segment {
  * dtype, ndims, raw_shapes (== shapes), manual_dep, and an optional
  * initial value fill.
  *
- * Arg::add_output() copies this value into Arg immediately, so the
- * original stack object does not need to outlive the add_output() call.
+ * Layout (64B) is aligned with Tensor cacheline 1 so that
+ * init_from_create_info() can copy the entire cacheline with a single memcpy,
+ * then overwrite buffer.addr and buffer.size separately.
+ *
+ * Arg::add_output() stores a pointer to this object, so the original
+ * must remain valid (not a temporary) until after the submit call.
  */
-struct TensorCreateInfo {
-    DataType dtype;
-    uint32_t ndims;
-    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];
-    bool manual_dep;
-    bool has_initial_value;
-    uint64_t initial_value;
-
+class TensorCreateInfo {
+public:  // NOLINT(whitespace/indent)
     TensorCreateInfo(
         const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false)
-        : dtype(dtype), ndims(ndims), manual_dep(manual_dep), has_initial_value(false), initial_value(0) {
+        : initial_value(0),
+          has_initial_value(false),
+          version(0),
+          dtype(dtype),
+          ndims(ndims),
+          is_all_offset_zero(true),
+          is_raw_eq_shapes(true),
+          manual_dep(manual_dep) {
         for (uint32_t i = 0; i < ndims; i++) {
             raw_shapes[i] = shapes[i];
         }
     }
 
-    void set_initial_value(uint64_t value) {
+    void copy(const TensorCreateInfo& other) { memcpy(this, &other, sizeof(other)); }
+
+    template <typename T = uint64_t>
+    void set_initial_value(T value) {
         has_initial_value = true;
-        initial_value = value;
+        initial_value = to_u64(value);
     }
 
     uint64_t buffer_size_bytes() const {
@@ -86,7 +94,33 @@ struct TensorCreateInfo {
         }
         return total * get_element_size(dtype);
     }
+
+public:  // NOLINT(whitespace/indent)
+    // --- Bytes [0, 24): TensorCreateInfo-only fields ---
+    // These occupy the same positions as Tensor::buffer and Tensor::start_offset,
+    // which are overwritten after the memcpy in init_from_create_info().
+    uint64_t initial_value;
+    bool has_initial_value;
+    uint8_t __pad1__[7];
+    uint64_t __pad2__;  // → Tensor::start_offset (zeroed)
+
+    // --- Bytes [24, 64): Matches Tensor cacheline 1 layout ---
+    int32_t version;  // Always 0 for create-info outputs
+    DataType dtype;
+    uint32_t ndims;
+    bool is_all_offset_zero;  // Always true for create-info outputs
+    bool is_raw_eq_shapes;    // Always true for create-info outputs
+    bool manual_dep;
+    uint8_t __pad3__;
+    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // → Tensor::shapes
+    uint32_t __pad4__;
+
+    TensorCreateInfo() = default;
+
+    friend struct Arg;
 };
+
+static_assert(sizeof(TensorCreateInfo) == 64);
 
 /**
  * Tensor descriptor for Task input/output (128B = 2 cache lines)
@@ -184,12 +218,12 @@ struct alignas(64) Tensor {
     void init(const Tensor& other) {
         memcpy(this, &other, 64);  // fast copy cache line 1
         if (!other.is_raw_eq_shapes) {
-            for (uint32_t i = 0; i < ndims; i++) {
+            for (uint32_t i = 0; i < other.ndims; i++) {
                 raw_shapes[i] = other.raw_shapes[i];
             }
         }
         if (!other.is_all_offset_zero) {
-            for (uint32_t i = 0; i < ndims; i++) {
+            for (uint32_t i = 0; i < other.ndims; i++) {
                 offsets[i] = other.offsets[i];
             }
         }
@@ -248,18 +282,30 @@ struct alignas(64) Tensor {
     }
 
     /// Materialize a TensorCreateInfo into this Tensor (fresh contiguous output).
-    void init_from_create_info(const TensorCreateInfo& ci, void* addr, int32_t version_val) {
-        init(addr,
-            ci.buffer_size_bytes(),
-            ci.raw_shapes,
-            ci.raw_shapes,
-            nullptr,
-            ci.ndims,
-            ci.dtype,
-            version_val,
-            /*is_all_offset_zero=*/true,
-            /*is_raw_eq_shapes=*/true,
-            ci.manual_dep);
+    /// Single 64B memcpy covers the entire cacheline 1, then buffer is overwritten.
+    void init_from_create_info(const TensorCreateInfo& ci, void* addr, uint64_t buffer_size) {
+        memcpy(this, &ci, 64);
+        buffer = {reinterpret_cast<uint64_t>(addr), buffer_size};
+        if (ci.has_initial_value) {
+            fill_initial_value(ci.initial_value);
+        }
+    }
+
+    void fill_initial_value(uint64_t initial_value) {
+        always_assert(reinterpret_cast<char*>(buffer.addr) != nullptr);
+        uint64_t elem_size = get_element_size(dtype);
+        char* dst = reinterpret_cast<char*>(buffer.addr);
+        constexpr uint64_t BLK = 64;
+        uint64_t blk = (buffer.size < BLK) ? buffer.size : BLK;
+        for (uint64_t b = 0; b < blk; b += elem_size) {
+            memcpy(dst + b, &initial_value, elem_size);
+        }
+        uint64_t filled = blk;
+        while (filled < buffer.size) {
+            uint64_t copy_size = ((buffer.size - filled) < filled) ? (buffer.size - filled) : filled;
+            memcpy(dst + filled, dst, copy_size);
+            filled += copy_size;
+        }
     }
 
     // --- Operations ---
@@ -429,3 +475,13 @@ private:
 
 static_assert(sizeof(Tensor) == 128, "Tensor must be exactly 2 cache lines (128 bytes)");
 static_assert(offsetof(Tensor, raw_shapes) == 64);
+
+// TensorCreateInfo layout must match Tensor cacheline 1 for memcpy optimization
+static_assert(sizeof(TensorCreateInfo) == 64, "TensorCreateInfo must match Tensor cacheline 1 size (64 bytes)");
+static_assert(offsetof(TensorCreateInfo, version) == offsetof(Tensor, version));
+static_assert(offsetof(TensorCreateInfo, dtype) == offsetof(Tensor, dtype));
+static_assert(offsetof(TensorCreateInfo, ndims) == offsetof(Tensor, ndims));
+static_assert(offsetof(TensorCreateInfo, is_all_offset_zero) == offsetof(Tensor, is_all_offset_zero));
+static_assert(offsetof(TensorCreateInfo, is_raw_eq_shapes) == offsetof(Tensor, is_raw_eq_shapes));
+static_assert(offsetof(TensorCreateInfo, manual_dep) == offsetof(Tensor, manual_dep));
+static_assert(offsetof(TensorCreateInfo, raw_shapes) == offsetof(Tensor, shapes));

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -22,7 +22,7 @@ Both call into the runtime through the ops table — orchestration .so needs no 
 
 ### 3.1 get_tensor_data Flow
 
-```
+```text
 addr null-check → TensorMap lookup → spin-wait producer COMPLETED → compute flat offset → memcpy read
 ```
 
@@ -33,7 +33,7 @@ addr null-check → TensorMap lookup → spin-wait producer COMPLETED → comput
 
 ### 3.2 set_tensor_data Flow
 
-```
+```text
 addr null-check → TensorMap lookup → spin-wait producer COMPLETED → spin-wait consumers done → memcpy write
 ```
 
@@ -49,13 +49,16 @@ One extra step versus get_tensor_data: wait for all consumers to finish (`fanout
 
 ```cpp
 TensorCreateInfo ci(shapes, ndims, dtype);
-args.add_output(ci, initial_value);
+ci.set_initial_value(initial_value);
+args.add_output(ci);
 ```
 
 **Mechanism**:
-1. `add_output(ci, initial_value)` copies `ci` into `Arg` and marks the create-info with an initial value
-2. During orchestrator submit, after HeapRing allocation, the output tensor is materialized from the copied create-info
-3. Fill strategy:
+
+1. `ci.set_initial_value(value)` marks the create-info with an initial value before submission
+2. `add_output(ci)` stores a pointer to `ci` in `Arg` (the original must remain valid until submit)
+3. During payload init, the output tensor is materialized via `init_from_create_info()` which triggers the fill
+4. Fill strategy:
    - Small buffer (< 64 B): element-by-element memcpy directly into dst
    - Large buffer (≥ 64 B): fill the first 64 bytes as a template block, then bulk-memcpy in 64 B chunks; partial tail copy for remainder
 
@@ -70,8 +73,9 @@ uint32_t shapes[1] = {1};
 TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
 
 // Submit with initial value and keep the returned tensor
+scalar_ci.set_initial_value(float_to_u64(77.0f));
 Arg args;
-args.add_output(scalar_ci, float_to_u64(77.0f));
+args.add_output(scalar_ci);
 TaskOutputTensors outs = pto2_rt_submit_aiv_task(FUNC_NOOP, args);
 const Tensor& scalar_tensor = outs.get_ref(0);
 
@@ -85,6 +89,7 @@ uint64_t raw = get_tensor_data(scalar_tensor, 1, idx);
 ## 6. Data Hazard Analysis
 
 Three actors:
+
 - **Kernel**: InCore task submitted via add_input/add_output/add_inout (asynchronous execution)
 - **Orch Read**: orchestration calls `get_tensor_data` (blocking read)
 - **Orch Write**: orchestration calls `set_tensor_data` (blocking write)
@@ -92,7 +97,7 @@ Three actors:
 ### Hazard Matrix (earlier operation → later operation)
 
 | # | Earlier Op | Later Op | Hazard | Guarantee | Safe? |
-|---|------------|----------|--------|-----------|-------|
+| - | ---------- | -------- | ------ | --------- | ----- |
 | 1 | Kernel write (OUTPUT) | Orch Read | RAW | spin-wait producer COMPLETED | Yes |
 | 2 | Kernel write (OUTPUT) | Orch Write | WAW | spin-wait producer COMPLETED | Yes |
 | 3 | Kernel read (INPUT) | Orch Write | WAR | spin-wait fanout_refcount | **Needs INOUT** |
@@ -120,7 +125,7 @@ get/set_tensor_data are blocking calls, and orchestration is single-threaded ser
 `make_tensor_external()` creates tensors with a pre-set `buffer.addr` (pointing to host-allocated device memory).
 
 | Scenario | Behavior |
-|----------|----------|
+| -------- | -------- |
 | External tensor never submitted as OUTPUT/INOUT | No TensorMap entry — get/set execute immediately |
 | External tensor previously submitted as OUTPUT/INOUT | TensorMap has producer entry — get/set spin-wait |
 | External tensor submitted as INPUT, then set_tensor_data | **WAR risk** — must use INOUT instead (same as scenario #3) |

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -4,7 +4,7 @@
 
 AICPU logs (via `DEV_ALWAYS`) are written by CANN's **dlog** subsystem and do **not** appear in the `run_example.py` terminal output. They are written to CANN's device log directory:
 
-```
+```text
 $HOME/ascend/log/debug/device-<device_id>/device-<pid>_<timestamp>.log
 ```
 
@@ -19,7 +19,7 @@ ls -lt $HOME/ascend/log/debug/device-<device_id>/ | head -5
 A single run produces two profiling blocks in the device log:
 
 | Block | Emitted by | Function | Content |
-|-------|-----------|----------|---------|
+| ----- | ---------- | -------- | ------- |
 | **Orchestrator Profiling** | Thread 3 (orchestrator) | `aicpu_orchestration_entry` | Time breakdown of graph construction on device |
 | **PTO2 Scheduler Summary** | Threads 0/1/2 (schedulers) | `resolve_and_dispatch_pto2` | Per-thread scheduling statistics, phase timing, and lock contention |
 
@@ -33,7 +33,7 @@ Thread 3 loads the orchestration `.so` via `dlopen`, calls `aicpu_orchestration_
 
 ### Example (from a real run: batch=64, 16704 tasks)
 
-```
+```text
 Thread 3: Calling aicpu_orchestration_entry from SO
 aicpu_orchestration_entry ">>>>>> batch = 64"
 Thread 3: aicpu_orchestration_entry returned, cost 20943.940us
@@ -54,12 +54,12 @@ Thread 3: PTO2 total submitted tasks = 16704
 ### Field Reference
 
 | Field | Source (`pto_orchestrator.cpp`) | Description |
-|-------|-------------------------------|-------------|
+| ----- | ------------------------------- | ----------- |
 | **cost** | Wall-clock around `orch_func()` call | Total time including orchestration logic + scope overhead |
 | **total** | Sum of all sub-steps below | Accumulated time inside `pto2_submit_task` across all tasks |
 | **sync_tensormap** | `g_orch_sync_cycle` | TensorMap validity sync and optional cleanup before each submission |
 | **task_ring_alloc** | `g_orch_alloc_cycle` | Allocating a task slot from the task ring buffer |
-| **param_copy** | `g_orch_params_cycle` | Copying param descriptors + tensor descriptor copies into task-owned storage |
+| **param_copy** | `g_orch_args_cycle` | Copying param descriptors + tensor descriptor copies into task-owned storage |
 | **lookup+dep** | `g_orch_lookup_cycle` | TensorMap lookup for inputs/inouts + building fanin/fanout dependency edges |
 | **heap_alloc** | `g_orch_heap_cycle` | Allocating packed output buffers from the heap ring |
 | **tensormap_ins** | `g_orch_insert_cycle` | Inserting output/inout tensors into the TensorMap |
@@ -82,7 +82,7 @@ Each of the 3 scheduler threads (Thread 0, 1, 2) prints its own summary after co
 
 ### Example (Thread 0, from a different run: batch=1, 1044 tasks)
 
-```
+```text
 Thread 0: completed=352 tasks in 3477.420us (147 loops, 2.4 tasks/loop)
 Thread 0: --- Phase Breakdown ---
 Thread 0:   complete:    1485.020us (42.7%)  [fanout: edges=432, max_degree=2, avg=1.2]  [fanin: edges=320, max_degree=3, avg=0.9]
@@ -93,12 +93,12 @@ Thread 0:   idle:        4.940us (0.1%)
 
 ### Summary Line
 
-```
+```text
 Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
 ```
 
 | Field | Description |
-|-------|-------------|
+| ----- | ----------- |
 | **completed** | Number of tasks this thread processed to completion |
 | **Y us** | Total scheduler loop time (sum of all phase cycles) |
 | **Z loops** | Number of scheduler loop iterations |
@@ -109,7 +109,7 @@ Thread N: completed=X tasks in Yus (Z loops, W tasks/loop)
 The scheduler loop runs four phases each iteration. Each phase's time is accumulated across all loop iterations.
 
 | Phase | What it does | Inline stats |
-|-------|-------------|-------------|
+| ----- | ------------ | ------------ |
 | **complete** | Polls handshake on each managed core; when a core completes, calls `on_subtask_complete(task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, triggers `on_mixed_task_complete` which traverses fanout list (notify consumers) and fanin list (release producers) | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
 | **scan** | Updates the perf profiling header with latest scheduler state | — |
 | **dispatch** | For each idle core, pops a task from the shape-based ready queue via `get_ready_task(shape)`, builds the dispatch payload, and writes the task to the core's handshake register | `pop`: `hit` = successful pops (task dispatched), `miss` = empty queue pops, `hit_rate` = hit/(hit+miss) |
@@ -132,7 +132,7 @@ The scheduler loop runs four phases each iteration. Each phase's time is accumul
 Divide each thread's phase times by its `completed` count to get per-task scheduling cost:
 
 | Metric | Formula | Typical value |
-|--------|---------|---------------|
+| ------ | ------- | ------------- |
 | Scheduling overhead per task | total_time / completed | ~5-10 us/task |
 | Dispatch per task | dispatch_time / completed | ~3-6 us/task |
 | Complete per task | complete_time / completed | ~2-4 us/task |
@@ -144,7 +144,7 @@ Divide each thread's phase times by its `completed` count to get per-task schedu
 When `--enable-profiling` is used, the host terminal prints a **Task Statistics by Function** table with `Total_Exec` (total AICore kernel execution time). Combined with device log data:
 
 | Metric | Source | Description |
-|--------|--------|-------------|
+| ------ | ------ | ----------- |
 | Avg kernel exec time | `Total_Exec / total_tasks` (host) | Time AICore spends executing each kernel |
 | Avg scheduling overhead | `sum(thread_total) / total_tasks` (device log) | Time AICPU spends scheduling each task |
 | Sched/Exec ratio | scheduling / execution | Scheduling overhead relative to kernel execution |

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -116,9 +116,10 @@ union TensorRef {
  *
  * Example:
  *   Tensor x = make_tensor_external(dev_a, shapes, 2);
+ *   TensorCreateInfo ci(shapes, 2);
  *   Arg args;
  *   args.add_input(x);
- *   args.add_output(TensorCreateInfo(shapes, 2));
+ *   args.add_output(ci);
  *   args.add_scalar(some_value);
  *   TaskOutputTensors outs = pto2_rt_submit_aic_task(kernel_id, args);
  *   const Tensor& y = outs.get_ref(0);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -175,7 +175,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 Tensor qi = query.view(qi_shapes, qi_offsets);
                 uint32_t out_view_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
                 uint32_t out_view_offsets[2] = {static_cast<uint32_t>(cur_offset), 0};
-                Tensor out_view = out.view(out_view_shapes, out_view_offsets);
+                Tensor out_view = out.view(out_view_shapes, out_view_offsets, true);
 #ifdef ENABLE_PROFILING
                 prof_view_count += 2;
                 CYCLE_COUNT_LAP(prof_tensor_view);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
@@ -103,9 +103,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     // =========================================================
     uint32_t scalar_shapes[1] = {1};
     TensorCreateInfo scalar_ci(scalar_shapes, 1, DataType::FLOAT32);
+    scalar_ci.set_initial_value(77.0f);
 
     Arg params_scalar;
-    params_scalar.add_output(scalar_ci, 77.0f);
+    params_scalar.add_output(scalar_ci);
     TaskOutputTensors scalar_outs = pto2_rt_submit_aiv_task(FUNC_NOOP, params_scalar);
     const Tensor& scalar_tensor = scalar_outs.get_ref(0);
 


### PR DESCRIPTION
Move OUTPUT tensor creation from orchestrator lookup (step 3) to payload init (step 5), eliminating an intermediate Tensor copy. Align TensorCreateInfo layout to Tensor cacheline 1 for single-memcpy init. Change TensorRef::create_info from value to pointer. Add TensorMap insert() overload for TensorCreateInfo. Rename params_cycle to args_cycle across profiling. Update docs for new add_output API.