### PR TITLE
feat(runtime): add SPMD context accessors for AICore kernels

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/golden.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/golden.py
@@ -1,0 +1,65 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Golden test for SPMD context accessors (Phase 2: block_dim=1).
+
+Verifies that get_block_idx and get_block_num return correct values for all
+three subtask slots (AIC, AIV0, AIV1) in a MIX task, and that AIV
+kernels read the correct sub_block_id from GlobalContext.
+
+Phase 2 invariants: block_idx=0, block_num=1.
+GlobalContext: sub_block_id 0 (AIV0/left), 1 (AIV1/right).
+
+Output layout (float32[48], 3 cache lines):
+  [0..15]  = AIC  slot: [block_idx, block_num, pad x14]
+  [16..31] = AIV0 slot: [block_idx, block_num, sub_block_id=0, pad x13]
+  [32..47] = AIV1 slot: [block_idx, block_num, sub_block_id=1, pad x13]
+
+Args layout: [output]
+"""
+
+import torch
+
+__outputs__ = ["output"]
+RTOL = 0
+ATOL = 0
+
+ALL_CASES = {
+    "Case1": {},
+}
+
+DEFAULT_CASE = "Case1"
+
+# 16 floats per slot = 64 bytes = 1 cache line
+FLOATS_PER_CACHE_LINE = 16
+
+
+def generate_inputs(params: dict) -> list:
+    output = torch.zeros(3 * FLOATS_PER_CACHE_LINE, dtype=torch.float32)
+    return [
+        ("output", output),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    out = torch.as_tensor(tensors["output"])
+    # Cache line 0: AIC (no sub_block_id)
+    out[0] = 0.0  # block_idx
+    out[1] = 1.0  # block_num
+    # Cache line 1: AIV0 (sub_block_id=0)
+    base = 1 * FLOATS_PER_CACHE_LINE
+    out[base + 0] = 0.0  # block_idx
+    out[base + 1] = 1.0  # block_num
+    out[base + 2] = 0.0  # sub_block_id
+    # Cache line 2: AIV1 (sub_block_id=1)
+    base = 2 * FLOATS_PER_CACHE_LINE
+    out[base + 0] = 0.0  # block_idx
+    out[base + 1] = 1.0  # block_num
+    out[base + 2] = 1.0  # sub_block_id
+    tensors["output"][:] = out

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/aic/kernel_spmd_read.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/aic/kernel_spmd_read.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Context Read Kernel (AIC version)
+ *
+ * Reads SPMD local context (block_idx, block_num) and writes values to
+ * cache line 0 of the shared output tensor.  AIC does not use
+ * get_sub_block_id (sub_block_id is only meaningful for AIV).
+ *
+ * Args:
+ *   args[0] = output Tensor* (OUTPUT, 48 float32 elements)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+// Cache line = 64B = 16 float32.  Each slot owns one cache line.
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+
+// dcci + constants: CCEC provides these as builtins; provide fallbacks for sim.
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    // AIC writes at fixed cache line 0 (no sub_block_id needed)
+    out[0] = static_cast<float>(get_block_idx(args));
+    out[1] = static_cast<float>(get_block_num(args));
+
+    // Flush this cache line to HBM so host can read the output.
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/aiv/kernel_spmd_read.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/aiv/kernel_spmd_read.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Context Read Kernel (AIV version)
+ *
+ * Reads SPMD context via Get* accessors and writes values to the shared
+ * output tensor.  AIV uses get_sub_block_id to determine its lane (0=left,
+ * 1=right) and writes at cache line (1 + sub_block_id) to avoid
+ * overlapping with the AIC slot at cache line 0.
+ *
+ * Args:
+ *   args[0] = output Tensor* (OUTPUT, 48 float32 elements)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+// Cache line = 64B = 16 float32.  Each slot owns one cache line.
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+
+// dcci + constants: CCEC provides these as builtins; provide fallbacks for sim.
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int32_t sub_block_id = get_sub_block_id(args);
+    // AIV writes at cache line (1 + sub_block_id), skipping AIC's cache line 0
+    int32_t offset = (1 + sub_block_id) * FLOATS_PER_CACHE_LINE;
+
+    out[offset + 0] = static_cast<float>(get_block_idx(args));
+    out[offset + 1] = static_cast<float>(get_block_num(args));
+    out[offset + 2] = static_cast<float>(sub_block_id);
+
+    // Flush this cache line to HBM so host can read the output.
+    dcci(&out[offset], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/kernel_config.py
@@ -1,0 +1,51 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Kernel configuration for SPMD basic test (tensormap_and_ringbuffer Runtime).
+
+Submits a single MIX task (AIC + AIV0 + AIV1) so all three sub_block_id
+values are exercised in one dispatch.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "spmd_basic_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "SPMD_READ_AIC",
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_spmd_read.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "SPMD_READ_AIV0",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_spmd_read.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 2,
+        "name": "SPMD_READ_AIV1",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_spmd_read.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "orch_thread_num": 1,
+    "block_dim": 24,
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Basic Orchestration
+ *
+ * Submits a single MIX task (AIC + AIV0 + AIV1) with a shared output
+ * tensor. Each subtask writes its SPMD context at a sub_block_id-based
+ * offset, so the host can verify all three slots independently.
+ *
+ * Args layout: [output]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_SPMD_READ_AIC 0
+#define FUNC_SPMD_READ_AIV0 1
+#define FUNC_SPMD_READ_AIV1 2
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
+    const ChipStorageTaskArgs& orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 1,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+    (void)orch_thread_num;  // NOLINT(readability/casting)
+    if (orch_thread_index != 0) return;
+
+    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+
+    MixedKernels mk;
+    mk.aic_kernel_id = FUNC_SPMD_READ_AIC;
+    mk.aiv0_kernel_id = FUNC_SPMD_READ_AIV0;
+    mk.aiv1_kernel_id = FUNC_SPMD_READ_AIV1;
+
+    Arg args;
+    args.add_inout(ext_output);
+
+    pto2_rt_submit_task(mk, args);
+
+    LOG_ALWAYS("[spmd_basic_orch] Submitted 1 MIX task (AIC+AIV0+AIV1)");
+}
+
+}  // extern "C"

--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -696,7 +696,7 @@ class CodeRunner:
 
         return orch_args
 
-    def run(self) -> None:  # noqa: PLR0912
+    def run(self) -> None:  # noqa: PLR0912, PLR0915
         """
         Execute the full test flow:
         1. Check environment
@@ -753,10 +753,24 @@ class CodeRunner:
         else:
             arch = "a2a3"
 
-        runtime_include_dirs = [
-            os.path.join(self.project_root, "src", arch, "runtime", self.runtime_name, "runtime"),
-            os.path.join(self.project_root, "src", "common", "task_interface"),
-        ]
+        runtime_base_dir = os.path.join(self.project_root, "src", arch, "runtime", self.runtime_name)
+
+        # Read include_dirs from build_config.py for kernel compilation
+        build_config_path = os.path.join(runtime_base_dir, "build_config.py")
+        runtime_include_dirs = []
+        if os.path.isfile(build_config_path):
+            import importlib.util  # noqa: PLC0415
+
+            spec = importlib.util.spec_from_file_location("build_config", build_config_path)
+            assert spec is not None and spec.loader is not None
+            bc_module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(bc_module)
+            aicore_cfg = bc_module.BUILD_CONFIG.get("aicore", {})
+            for p in aicore_cfg.get("include_dirs", []):
+                runtime_include_dirs.append(os.path.join(runtime_base_dir, p))
+        else:
+            runtime_include_dirs.append(os.path.join(runtime_base_dir, "runtime"))
+        runtime_include_dirs.append(os.path.join(self.project_root, "src", "common", "task_interface"))
 
         def _build_runtime():
             return builder.get_binaries(self.runtime_name, build=self.build_runtime)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -562,6 +562,40 @@ struct AicpuExecutor {
         return count;
     }
 
+    /**
+     * Build per-core dispatch payload: copy tensor pointers and scalars into
+     * the per-core args[] array, then populate SPMD local context at the tail.
+     *
+     * Current phase (block_dim=1): block_idx is always 0, block_num is always 1.
+     * When block_dim>1 is implemented, block_idx will vary per dispatch and
+     * block_num will reflect the task's block_dim.
+     *
+     * GlobalContext (sub_block_id) is NOT written here — it is initialized once
+     * at runtime startup by init_global_context().
+     */
+    void build_payload(PTO2DispatchPayload& dispatch_payload, PTO2TaskSlotState& slot_state, PTO2SubtaskSlot subslot) {
+        int32_t slot_idx = static_cast<int32_t>(subslot);
+        uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
+        const CoreCallable* callable = reinterpret_cast<const CoreCallable*>(callable_addr);
+        dispatch_payload.function_bin_addr = callable->resolved_addr();
+        auto& payload = *slot_state.payload;
+        int n = 0;
+        for (int32_t i = 0; i < payload.tensor_count; i++) {
+            dispatch_payload.args[n++] = reinterpret_cast<uint64_t>(&payload.tensors[i]);
+        }
+        for (int32_t i = 0; i < payload.scalar_count; i++) {
+            dispatch_payload.args[n++] = payload.scalars[i];
+        }
+        // Per-dispatch local context (block_idx, block_num)
+        dispatch_payload.local_context.block_idx = 0;  // Phase 2: fixed
+        dispatch_payload.local_context.block_num = 1;  // Phase 2: fixed
+        // Store context pointers at fixed suffix positions in args[]
+        // (GlobalContext content is already set by init_global_context, but the
+        //  pointer must be written each dispatch since args[] is rebuilt entirely)
+        dispatch_payload.args[SPMD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
+        dispatch_payload.args[SPMD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.global_context);
+    }
+
     void dispatch_subtask_to_core(Runtime* runtime,
         int32_t thread_idx,
         int32_t core_offset,
@@ -579,11 +613,7 @@ struct AicpuExecutor {
 #endif
         CoreExecState& core_exec_state = core_exec_states_[core_id];
         PTO2DispatchPayload& payload = s_pto2_payload_per_core[core_id];
-        int32_t slot_idx = static_cast<int32_t>(subslot);
-        uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
-        const CoreCallable* callable = reinterpret_cast<const CoreCallable*>(callable_addr);
-        payload.function_bin_addr = callable->resolved_addr();
-        payload.args = slot_state.payload->dispatch_args;
+        build_payload(payload, slot_state, subslot);
         core_exec_state.executing_subslot = subslot;
         core_exec_state.executing_slot_state = &slot_state;
 #if PTO2_PROFILING
@@ -929,6 +959,19 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
 
     // Clear per-core dispatch payloads
     memset(s_pto2_payload_per_core, 0, sizeof(s_pto2_payload_per_core));
+
+    // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
+    // This is done once at startup and never modified afterwards.
+    for (int32_t t = 0; t < sched_thread_num_; t++) {
+        CoreTracker& tracker = core_trackers_[t];
+        for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
+            int32_t cluster_offset = c * 3;  // Each cluster = 1 AIC + 2 AIV
+            auto aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
+            auto aiv1_id = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(cluster_offset));
+            s_pto2_payload_per_core[aiv0_id].global_context.sub_block_id = 0;
+            s_pto2_payload_per_core[aiv1_id].global_context.sub_block_id = 1;
+        }
+    }
 
     DEV_INFO("Init: PTO2 mode, task count from shared memory");
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/build_config.py
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/build_config.py
@@ -1,3 +1,11 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 # Tensormap and Ringbuffer Runtime build configuration
 # All paths are relative to this file's directory (src/runtime/tensormap_and_ringbuffer/)
 #
@@ -11,20 +19,8 @@
 # by the Tensor constructor's validation logic).
 
 BUILD_CONFIG = {
-    "aicore": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicore", "orchestration"]
-    },
-    "aicpu": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicpu", "runtime", "orchestration"]
-    },
-    "host": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["host", "runtime", "orchestration"]
-    },
-    "orchestration": {
-        "include_dirs": ["runtime", "orchestration"],
-        "source_dirs": ["orchestration"]
-    }
+    "aicore": {"include_dirs": ["runtime", "common"], "source_dirs": ["aicore", "orchestration"]},
+    "aicpu": {"include_dirs": ["runtime", "common"], "source_dirs": ["aicpu", "runtime", "orchestration"]},
+    "host": {"include_dirs": ["runtime", "common"], "source_dirs": ["host", "runtime", "orchestration"]},
+    "orchestration": {"include_dirs": ["runtime", "orchestration", "common"], "source_dirs": ["orchestration"]},
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file intrinsic.h
+ * @brief SPMD execution context for AICore user kernels
+ *
+ * Topology data exposed to user kernels has two distinct lifetimes:
+ *
+ *   1. Global topology (per-core, fixed after runtime init):
+ *      - sub_block_id : identifies the AIV lane within a cluster
+ *        (0 = AIV0/left, 1 = AIV1/right).  Initialized once at runtime
+ *        startup based on each core's cluster position; never changes.
+ *        Only meaningful for AIV kernels in MIX tasks.
+ *
+ *   2. Local topology (per-dispatch, changes each dispatch):
+ *      - block_idx : which logical block the current worker is executing
+ *      - block_num : total number of blocks in this task (= block_dim)
+ *      Written by build_payload() before each dispatch.
+ *
+ * Both categories are injected via two pointer slots appended at the tail
+ * of the kernel args[] array:
+ *
+ *   args layout:
+ *     [0 .. tensor_count-1]                 = tensor GM pointers
+ *     [tensor_count .. +scalar_count-1]     = scalar values
+ *     ...
+ *     [SPMD_LOCAL_CONTEXT_INDEX]            = (uint64_t)&LocalContext   (per-dispatch)
+ *     [SPMD_GLOBAL_CONTEXT_INDEX]           = (uint64_t)&GlobalContext  (per-core)
+ *
+ * The suffix positions are compile-time constants and do not depend on the
+ * runtime tensor_count or scalar_count.
+ *
+ * Include this header in AICore kernel source files to use the Get* accessors.
+ * Do NOT depend on the raw index constants; always use the accessor functions.
+ *
+ * On CCEC (real hardware), __gm__ and __aicore__ must be defined before
+ * including this header (e.g. via <pto/pto-inst.hpp> or manual #define).
+ * The #ifndef guards below provide fallbacks for non-kernel builds
+ * (AICPU, HOST) where these qualifiers are not needed.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__
+#endif
+
+/** Number of extra pointer slots appended to the args[] tail (LocalContext + GlobalContext). */
+static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
+
+/**
+ * Args[] suffix indices for context pointers.
+ * Derived from MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(128).
+ * Users should not depend on these values; use the Get* functions below.
+ */
+static constexpr int32_t SPMD_LOCAL_CONTEXT_INDEX = 144;
+static constexpr int32_t SPMD_GLOBAL_CONTEXT_INDEX = 145;
+
+/**
+ * Per-core global context, stored in PTO2DispatchPayload.
+ * Initialized once at runtime startup (init_global_context) based on each
+ * core's cluster position.  Never modified after initialization.
+ */
+struct GlobalContext {
+    // AIV lane within cluster: 0=AIV0(left), 1=AIV1(right).
+    // Used by AIV to select the correct intra-cluster hw instruction.
+    // Not meaningful for AIC kernels or single-AIV tasks.
+    int32_t sub_block_id;
+};
+
+/**
+ * Per-dispatch local context, stored in PTO2DispatchPayload.
+ * Written by build_payload() before each dispatch.  Different blocks of the
+ * same task receive different block_idx values but the same block_num.
+ */
+struct LocalContext {
+    int32_t block_idx;  // Logical block index within the task [0, block_num)
+    int32_t block_num;  // How many logical blocks this task requires.
+                        // Currently fixed to 1 (block_dim > 1 not yet implemented).
+                        // NOT the same as RUNTIME_CONFIG.block_dim in kernel_config.py,
+                        // which controls how many physical cores the runtime launches.
+};
+
+/**
+ * Return the AIV lane index within the cluster.
+ * In a MIX 1C2V task: AIV0(left)=0, AIV1(right)=1.
+ *
+ * This value is only meaningful for AIV kernels in MIX tasks.  It tells
+ * the AIV whether it is the left lane or the right lane within the cluster,
+ * which determines the correct hardware instruction for intra-cluster
+ * communication.
+ *
+ * AIC kernels should NOT call this function.
+ * Single-AIV tasks have no intra-cluster communication, so sub_block_id
+ * has no meaning and should not be used.
+ */
+static __aicore__ inline int32_t get_sub_block_id(__gm__ int64_t* args) {
+    __gm__ GlobalContext* ctx =
+        reinterpret_cast<__gm__ GlobalContext*>(static_cast<uint64_t>(args[SPMD_GLOBAL_CONTEXT_INDEX]));
+    return ctx->sub_block_id;
+}
+
+/**
+ * Return the logical block index assigned to the current worker.
+ * Range: [0, get_block_num(args)).
+ * Within the same task, different blocks receive different indices.
+ */
+static __aicore__ inline int32_t get_block_idx(__gm__ int64_t* args) {
+    __gm__ LocalContext* ctx =
+        reinterpret_cast<__gm__ LocalContext*>(static_cast<uint64_t>(args[SPMD_LOCAL_CONTEXT_INDEX]));
+    return ctx->block_idx;
+}
+
+/**
+ * Return how many logical blocks the current task requires.
+ * All blocks of the same task see the same value.
+ * Currently always returns 1 (block_dim>1 not yet implemented).
+ *
+ * Note: this is NOT the same as RUNTIME_CONFIG.block_dim in
+ * kernel_config.py, which controls how many physical cores are launched.
+ */
+static __aicore__ inline int32_t get_block_num(__gm__ int64_t* args) {
+    __gm__ LocalContext* ctx =
+        reinterpret_cast<__gm__ LocalContext*>(static_cast<uint64_t>(args[SPMD_LOCAL_CONTEXT_INDEX]));
+    return ctx->block_num;
+}

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -1,45 +1,85 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file pto2_dispatch_payload.h
  * @brief Per-core dispatch payload for AICore kernel execution
  *
- * PTO2DispatchPayload holds the kernel function address and a pointer to the
- * pre-built args[] array in the task payload. AICPU maintains a static array
- * of these (one per core) and writes both fields before each dispatch. AICore
- * caches a pointer to its per-core slot at startup and reads from it on each
- * dispatch. The struct is cache-line aligned to avoid false sharing across
- * concurrently dispatched cores.
+ * PTO2DispatchPayload holds the kernel function address, a per-core args[]
+ * array, and embedded SPMD context (LocalContext + GlobalContext).  AICPU
+ * maintains a static array of these (one per core).
  *
- * The args[] array (tensor GM pointers followed by scalar values) is built once
- * by the Orchestrator at submit time in PTO2TaskPayload::init().
+ * GlobalContext (sub_block_id) is initialized once at runtime startup via
+ * init_global_context() and never modified afterwards.
+ *
+ * LocalContext (block_idx, block_num) and args[] are rebuilt by
+ * build_payload() before each dispatch.  Both context struct pointers are
+ * written into the args[] suffix on every dispatch (since args[] is rebuilt
+ * entirely each time).
+ *
+ * AICore caches a pointer to its per-core slot at startup and reads from
+ * it on each dispatch.  The struct is cache-line aligned to avoid false
+ * sharing across concurrently dispatched cores.
  *
  * The DATA_MAIN_BASE register protocol is unchanged from the base runtime:
  * a monotonically increasing reg_task_id signals new work to AICore.
  */
 
-#ifndef RT2_PTO2_DISPATCH_PAYLOAD_H_
-#define RT2_PTO2_DISPATCH_PAYLOAD_H_
+#pragma once
 
 #include <stdint.h>
-#include "pto_types.h"
-#include "common/qualifier.h"
 
-/** Max dispatch arguments: 128 scalars + up to 16 tensor pointers */
+#include "intrinsic.h"
+#include "pto_types.h"
+
+/** Max dispatch arguments: 128 scalars + up to 16 tensor pointers + ext params */
 #ifndef PTO2_DISPATCH_MAX_ARGS
-#define PTO2_DISPATCH_MAX_ARGS (MAX_SCALAR_ARGS + MAX_TENSOR_ARGS)
+#define PTO2_DISPATCH_MAX_ARGS (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS + PTO2_EXT_PARAMS_COUNT)
 #endif
 
+#ifndef PTO2_ALIGN_UP
+#define PTO2_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
+#endif
+
+// Verify hardcoded indices in intrinsic.h match the computed values.
+static_assert((MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) == SPMD_LOCAL_CONTEXT_INDEX,
+    "LOCAL_CONTEXT_INDEX out of sync with intrinsic.h");
+static_assert((MAX_TENSOR_ARGS + MAX_SCALAR_ARGS + 1) == SPMD_GLOBAL_CONTEXT_INDEX,
+    "GLOBAL_CONTEXT_INDEX out of sync with intrinsic.h");
+
 /**
- * Per-core dispatch payload: function address + args pointer.
+ * Per-core dispatch payload: function address + args[] + SPMD context.
  *
  * AICPU maintains a static array s_pto2_payload_per_core[RUNTIME_MAX_WORKER].
- * Before each dispatch, AICPU writes function_bin_addr (looked up from
- * func_id_to_addr_[kernel_id]) and args (pointer to pre-built dispatch_args[]
- * in PTO2TaskPayload). AICore caches a pointer to its slot at startup (via
- * Handshake.task) and reads both fields after each DATA_MAIN_BASE change.
+ * AICore caches a pointer to its per-core slot at startup (via Handshake.task)
+ * and reads from it on each dispatch.
+ *
+ * The struct is cache-line aligned to prevent false sharing across
+ * concurrently dispatched cores.
  */
 struct alignas(64) PTO2DispatchPayload {
-    uint64_t function_bin_addr;    /**< Kernel entry address in GM (set by Scheduler) */
-    __gm__ uint64_t* args;         /**< Pre-built args in task payload GM (set by Scheduler) */
-};
+    uint64_t function_bin_addr;            /**< Kernel entry address in GM (set by Scheduler) */
+    uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers + scalars + ext params) */
 
-#endif  // RT2_PTO2_DISPATCH_PAYLOAD_H_
+    /** Per-dispatch context: block_idx and block_num.
+     *  Written by build_payload() before each dispatch.
+     *  args[SPMD_LOCAL_CONTEXT_INDEX] points here. */
+    LocalContext local_context;
+
+    /** Per-core global context: sub_block_id (AIV lane identity).
+     *  Initialized once by init_global_context() at runtime startup.
+     *  args[SPMD_GLOBAL_CONTEXT_INDEX] points here. */
+    GlobalContext global_context;
+
+    static_assert(sizeof(args[0]) == 8);
+    static_assert(PTO2_ALIGN_UP((MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0]), 64) ==
+                  (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0]));
+};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -17,7 +17,7 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#include "pto_orchestrator.h"  // NOLINT(build/include_subdir)
+#include "pto_orchestrator.h"
 
 #include <assert.h>
 #include <inttypes.h>
@@ -26,11 +26,11 @@
 #include <string.h>
 
 #include "common/unified_log.h"
-#include "pto_runtime2_types.h"  // NOLINT(build/include_subdir)
-#include "pto_shared_memory.h"   // NOLINT(build/include_subdir)
-#include "pto_tensormap.h"       // NOLINT(build/include_subdir)
-#include "pto_types.h"           // NOLINT(build/include_subdir)
-#include "tensor.h"              // NOLINT(build/include_subdir)
+#include "pto_runtime2_types.h"
+#include "pto_shared_memory.h"
+#include "pto_tensormap.h"
+#include "pto_types.h"
+#include "tensor.h"
 
 // =============================================================================
 // Orchestrator Profiling (compile-time toggle)
@@ -387,8 +387,8 @@ TaskOutputTensors pto2_submit_mixed_task(
         __builtin_prefetch(&payload->tensors[i], 1, 3);
         __builtin_prefetch(reinterpret_cast<char*>(&payload->tensors[i]) + 64, 1, 3);
     }
-    for (int32_t i = 0; i < args.tensor_count() + args.scalar_count(); i += 8) {
-        __builtin_prefetch(&payload->dispatch_args[i], 1, 3);
+    for (int32_t i = 0; i < args.scalar_count(); i += 8) {
+        __builtin_prefetch(&payload->scalars[i], 1, 3);
     }
     __builtin_prefetch(payload, 1, 3);
     __builtin_prefetch(reinterpret_cast<char*>(payload) + 64, 1, 3);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -31,9 +31,9 @@
 
 #include <atomic>
 
-#include "pto2_dispatch_payload.h"  // NOLINT(build/include_subdir)
-#include "pto_submit_types.h"       // NOLINT(build/include_subdir)
-#include "pto_types.h"              // NOLINT(build/include_subdir)
+#include "pto2_dispatch_payload.h"
+#include "pto_submit_types.h"
+#include "pto_types.h"
 
 // =============================================================================
 // Profiling Configuration
@@ -362,31 +362,32 @@ struct PTO2TaskDescriptor {
  * Task payload data (cold path - only accessed during orchestration and dispatch)
  *
  * Layout: metadata (counts, fanin pointers) packed in the first 3 cache lines,
- * followed by pre-built dispatch args and bulk tensor data. Scalar values are
- * written directly into dispatch_args[] (after tensor pointers), eliminating
- * the separate scalars[] array.
- *
- * The Scheduler writes function_bin_addr and a pointer to dispatch_args[] into
- * PTO2DispatchPayload, then signals AICore via DATA_MAIN_BASE register.
+ * followed by bulk tensor and scalar data. This gives sequential write access
+ * during orchestration and groups scheduler-hot fields (fanin_actual_count +
+ * fanin_slot_states) together for on_task_release.
  */
 struct PTO2TaskPayload {
-    // === Cache line 0 (64B) — metadata ===
+    // === Cache lines 0-2 (192B) — metadata ===
     int32_t tensor_count{0};
     int32_t scalar_count{0};
     int32_t fanin_actual_count{0};  // Actual fanin count (without the +1 redundance)
     int32_t _reserved{0};           // Reserved (dep_pool_mark moved to SlotState for local access)
     PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
-    // === Tensors (2048B) — alignas(64) Tensor forces alignment ===
+    // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
-    // === Pre-built args for AICore dispatch (1152B = 16 tensor ptrs + 128 scalars) ===
-    uint64_t dispatch_args[PTO2_DISPATCH_MAX_ARGS];
+    // === Cache lines 35-50 (1024B) — scalars ===
+    uint64_t scalars[MAX_SCALAR_ARGS];
+
+    // Layout verification (size checks that don't need offsetof).
+    static_assert(sizeof(Tensor) == 128, "Tensor must be 2 cache lines");
+    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 1024, "scalar region must be 1024B (16 cache lines)");
 
     /**
-     * Initialize payload: copy tensors, build dispatch args.
+     * Initialize payload: copy tensors, store scalars.
      *
      * For each param slot, the tensor source is determined by TensorArgType:
-     * - OUTPUT → use materialized_outputs.output_ptr(out_idx++)
-     * - INPUT / INOUT → use refs[i].tensor
+     * - OUTPUT -> use materialized_outputs.output_ptr(out_idx++)
+     * - INPUT / INOUT -> use refs[i].tensor
      *
      * @param args                Task arguments (tensors + scalars)
      * @param materialized_outputs  Materialized output tensors (from TensorCreateInfo path)
@@ -407,15 +408,17 @@ struct PTO2TaskPayload {
                 result.materialize_output(tensors[i]);
             }
             tensors[i].update_start_offset();
-            dispatch_args[i] = reinterpret_cast<uint64_t>(&tensors[i]);
         }
-        // Bulk-copy scalars into dispatch_args[tensor_count..], rounded up to
-        // cache-line boundary (extra bytes within the same CL cost nothing).
-        memcpy(&dispatch_args[args.tensor_count()],
-            args.scalar_data(),
-            PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
+        // Round up to cache line boundary. Both arrays are 1024B so no overrun.
+        // Eliminates branches; extra bytes within the same CL have zero additional cost.
+        memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
     }
 };
+
+// PTO2TaskPayload layout verification (offsetof requires complete type).
+static_assert(offsetof(PTO2TaskPayload, tensors) == 192, "tensors must start at byte 192 (cache line 3)");
+static_assert(offsetof(PTO2TaskPayload, scalars) == 192 + MAX_TENSOR_ARGS * sizeof(Tensor),
+    "scalars must immediately follow tensors");
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
@@ -500,7 +503,7 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 // This header is also compiled into the Host .so (for struct definitions only),
 // where the hint is never called — the fallback no-op keeps Host builds clean.
 #if __has_include("spin_hint.h")
-#include "spin_hint.h"  // NOLINT(build/include_subdir)
+#include "spin_hint.h"
 #else
 #define SPIN_WAIT_HINT() ((void)0)
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -21,8 +21,9 @@
  * - Function address mapping (func_id_to_addr_)
  *
  * Task dispatch uses a per-core PTO2DispatchPayload written by the scheduler.
- * The Orchestrator pre-builds dispatch_args[] in each task payload; the
- * scheduler only fills function_bin_addr + args before signaling AICore.
+ * At dispatch time, build_payload() copies tensor pointers and scalars from
+ * the task payload into the per-core args[], populates SPMD context, then
+ * signals AICore via DATA_MAIN_BASE.
  */
 
 #ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_
@@ -36,8 +37,8 @@
 #include "common/core_type.h"
 #include "common/perf_profiling.h"
 #include "common/platform_config.h"
-#include "pto2_dispatch_payload.h"  // NOLINT(build/include_subdir)
-#include "task_args.h"              // NOLINT(build/include_subdir)
+#include "pto2_dispatch_payload.h"
+#include "task_args.h"
 
 // =============================================================================
 // Configuration Macros
@@ -150,7 +151,7 @@ struct Task {
  * execution control and device orchestration state.
  */
 class Runtime {
-public:  // NOLINT(whitespace/indent)
+ public:  // NOLINT(whitespace/indent)
     // Handshake buffers for AICPU-AICore communication
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
@@ -179,7 +180,7 @@ public:  // NOLINT(whitespace/indent)
     bool orch_to_sched;
     uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
 
-private:  // NOLINT(whitespace/indent)
+ private:  // NOLINT(whitespace/indent)
     // Tensor pairs for host-device memory tracking
     TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
     int tensor_pair_count;
@@ -200,7 +201,7 @@ private:  // NOLINT(whitespace/indent)
     uint8_t device_orch_so_storage_[RUNTIME_MAX_ORCH_SO_SIZE];
     size_t device_orch_so_size_;
 
-public:  // NOLINT(whitespace/indent)
+ public:  // NOLINT(whitespace/indent)
     /**
      * Constructor - zero-initialize all arrays
      */

--- a/src/common/task_interface/task_args.h
+++ b/src/common/task_interface/task_args.h
@@ -95,6 +95,8 @@ struct TaskArgs : TensorTagMixin<TensorTag, MaxT> {
     S scalar(int32_t i) const { return scalars_[i]; }
     S& scalar(int32_t i) { return scalars_[i]; }
 
+    const S* scalars() const { return scalars_; }
+
     const T* tensor_data() const { return tensors_; }
     const S* scalar_data() const { return scalars_; }
 


### PR DESCRIPTION
Extract BlockContext and TaskContext from pto2_dispatch_payload.h into a standalone public header (common/spmd_context.h) with accessor functions GetBlockIdx, GetBlockNum, and GetSubBlockId that hide the internal args[] layout from user kernels.

Phase 2 (block_dim=1): AICPU populates block_context and task_context in build_payload() with hardcoded block_idx=0, block_num=1, and sub_block_id derived from the subtask slot index (AIC=0, AIV0=1, AIV1=2). The dispatch args array is extended by 2 slots to carry pointers to these structs.

Refactor PTO2TaskPayload to separate tensor and scalar storage (removing the merged dispatch_args[] array), with cache-line layout static_asserts. Kernel include paths now read from build_config.py instead of being hardcoded in code_runner.py.

Add spmd_basic example: a MIX task (AIC+AIV0+AIV1) that verifies all three slots read correct SPMD context values, tested on both sim and device.