### PR TITLE
CI: enable A5 on-board hardware CI with device locking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,11 +207,31 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           source ${ASCEND_HOME_PATH}/bin/setenv.bash && ./ci.sh -p a2a3 -d ${DEVICE_RANGE} --parallel -c 6622890 -t 600 --clone-protocol https
 
+
+  # ---------- Detect A5 changes (runs on GitHub server, not A5 machine) ----------
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      a5_changed: ${{ steps.check.outputs.a5_changed }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check A5 file changes
+        id: check
+        run: |
+          if git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \
+            | grep -qE '^(src/a5/|examples/a5/|tests/(st|device_tests)/a5/)'; then
+            echo "a5_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "a5_changed=false" >> "$GITHUB_OUTPUT"
+          fi
   # TODO: Uncomment when a5 hardware runner is available.
   #       Add the "a5" label to the runner, matching [self-hosted, a5] below.
   #
   # ut-py-a5:
-  #   needs: pre-commit
+  #   needs: pre-commit detect-changes
   #   runs-on: [self-hosted, a5]
   #   timeout-minutes: 30
   #
@@ -227,19 +247,23 @@ jobs:
   #         export PATH="$HOME/.local/bin:$PATH"
   #         source ${ASCEND_HOME_PATH}/bin/setenv.bash && pytest tests -m requires_hardware --platform a5 -v
   #
-  # st-onboard-a5:
-  #   needs: pre-commit
-  #   runs-on: [self-hosted, a5]
-  #   timeout-minutes: 60
-  #
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #
-  #     - name: Build nanobind extension
-  #       run: pip install .
-  #
-  #     - name: Run on-device examples (a5)
-  #       run: |
-  #         export PATH="$HOME/.local/bin:$PATH"
-  #         source ${ASCEND_HOME_PATH}/bin/setenv.bash && ./ci.sh -p a5 -d ${DEVICE_RANGE} --parallel -c 6622890 -t 600 --clone-protocol https
+
+  st-onboard-a5:
+    needs: [pre-commit, detect-changes]
+    if: needs.detect-changes.outputs.a5_changed == 'true'
+    runs-on: [self-hosted, a5]
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build nanobind extension
+        run: |
+          source ${ASCEND_HOME_PATH}/bin/setenv.bash
+          PTO_ARCH=a5 pip install .
+
+      - name: Run on-device examples (a5)
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          source ${ASCEND_HOME_PATH}/bin/setenv.bash && ./ci.sh -p a5 -d ${DEVICE_RANGE} --parallel -c 6622890 -t 600 --clone-protocol https

--- a/ci.sh
+++ b/ci.sh
@@ -313,6 +313,7 @@ MAX_RETRIES=3
 
 # ---- Unified task runner ----
 # Runs a single task and records the result.
+# A5 on-board tasks are submitted via task-submit (privilege escalation) + npu-lock (device lock).
 # Log naming: ${safe_name}_${platform}_attempt${attempt}.log
 # Result format: name|platform|PASS/FAIL|device:X|attempt:N|Xs
 run_task() {
@@ -322,7 +323,7 @@ run_task() {
     local start_time=$SECONDS
 
     local -a cmd
-    cmd=(python examples/scripts/run_example.py
+    cmd=(env PYTHONDONTWRITEBYTECODE=1 python examples/scripts/run_example.py
         -k "${dir}/kernels" -g "${dir}/golden.py"
         -p "$platform" --clone-protocol "$CLONE_PROTOCOL" "${commit_flag[@]}")
     [[ -n "$device_id" ]] && cmd+=(-d "$device_id")
@@ -331,7 +332,20 @@ run_task() {
     echo "[${platform}${device_id:+:dev${device_id}}] Running: $name (attempt $attempt)"
 
     # Command output to log file only
-    "${cmd[@]}" > "$task_log" 2>&1
+    if [[ "$platform" == "a5" && -n "$device_id" ]]; then
+        if [[ "$(id -u)" -eq 0 ]]; then
+            # Already root (e.g. running inside task-daemon), use npu-lock directly
+            npu-lock "$device_id" -- "${cmd[@]}" > "$task_log" 2>&1
+        elif command -v task-submit &>/dev/null; then
+            local task_id
+            task_id=$(task-submit "npu-lock $device_id -- $(printf '%q ' "${cmd[@]}")")
+            task-submit --timeout "$TIMEOUT" --wait "$task_id" > "$task_log" 2>&1
+        else
+            "${cmd[@]}" > "$task_log" 2>&1
+        fi
+    else
+        "${cmd[@]}" > "$task_log" 2>&1
+    fi
     local rc=$?
     local elapsed=$(( SECONDS - start_time ))
 


### PR DESCRIPTION
- Add detect-changes job to gate A5 pipeline on relevant file paths
- Uncomment and enable st-onboard-a5 job with correct runner label (A5)
- Wire PTO_ARCH=a5 into the build step for A5 runtime selection
- Add task-submit / npu-lock dispatch in run_task() for A5 privilege escalation and device-level locking