### PR TITLE
Add: SPMD independent multi-block dispatch (block_num > 1)

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/golden.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/golden.py
@@ -1,0 +1,63 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Golden test for SPMD multi-block AIV.
+
+Submits five AIV tasks with block_num = 4, 16, 24, 48, 96 to verify:
+  T0 (block_num=4):  basic multi-block — fits within one sched thread
+  T1 (block_num=16): saturates one sched thread (8 clusters × 2 AIV)
+  T2 (block_num=24): forces cross-thread dispatch via ready_queue re-push
+  T3 (block_num=48): occupies all AIV cores across all 3 sched threads
+  T4 (block_num=96): two full rounds of all AIV cores
+
+Each block writes float(block_idx) at cache line (base_cl + block_idx).
+Output tensor: 188 cache lines = 3008 float32.
+
+Args layout: [output]
+"""
+
+import torch
+
+__outputs__ = ["output"]
+RTOL = 0
+ATOL = 0
+
+ALL_CASES = {
+    "Case1": {},
+}
+
+DEFAULT_CASE = "Case1"
+
+FLOATS_PER_CACHE_LINE = 16
+
+# (block_num, base_cl) for each submitted task
+TASKS = [
+    (4, 0),  # T0: basic
+    (16, 4),  # T1: saturate single thread
+    (24, 20),  # T2: cross-thread
+    (48, 44),  # T3: all AIV cores
+    (96, 92),  # T4: two full rounds
+]
+
+TOTAL_CL = sum(block_num for block_num, _ in TASKS)  # 44
+
+
+def generate_inputs(params: dict) -> list:
+    output = torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)
+    return [
+        ("output", output),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    out = torch.as_tensor(tensors["output"])
+    for block_num, base_cl in TASKS:
+        for block_idx in range(block_num):
+            out[(base_cl + block_idx) * FLOATS_PER_CACHE_LINE] = float(block_idx)
+    tensors["output"][:] = out

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/aiv/kernel_spmd_write.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/aiv/kernel_spmd_write.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Multi-Block Write Kernel (AIV)
+ *
+ * Each block writes float(block_idx) at a cacheline-aligned offset
+ * determined by scalar parameter base_cl:
+ *
+ *   out[(base_cl + block_idx) * FLOATS_PER_CACHE_LINE] = float(block_idx)
+ *
+ * Args:
+ *   args[0] = output Tensor* (INOUT)
+ *   args[1] = scalar: base_cl (starting cache line index for this task)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int32_t base_cl = static_cast<int32_t>(args[1]);
+    int32_t block_idx = get_block_idx(args);
+    int32_t offset = (base_cl + block_idx) * FLOATS_PER_CACHE_LINE;
+
+    out[offset] = static_cast<float>(block_idx);
+
+    dcci(&out[offset], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/kernel_config.py
@@ -1,0 +1,39 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Kernel configuration for SPMD multi-block AIV test (tensormap_and_ringbuffer Runtime).
+
+Submits a single AIV task with block_num=4 so each block writes its
+block_idx at a distinct cacheline-aligned offset.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "spmd_multiblock_aiv_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "SPMD_WRITE_AIV",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_spmd_write.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "orch_thread_num": 1,
+    "block_dim": 24,
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Multi-Block AIV Orchestration
+ *
+ * Submits three AIV tasks with increasing block_num to exercise:
+ *   T0: block_num=4   — fits within a single sched thread
+ *   T1: block_num=16  — saturates one sched thread (8 clusters × 2 AIV)
+ *   T2: block_num=24  — forces cross-thread re-push via ready_queue
+ *
+ * Each task writes to a disjoint region of the output tensor using the
+ * base_cl scalar to offset the block writes.
+ *
+ * Args layout: [output]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_SPMD_WRITE_AIV 0
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
+    const ChipStorageTaskArgs& orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 1,
+    };
+}
+
+static void submit_spmd_aiv(int32_t kernel_id, Tensor& out, int16_t block_num, int64_t base_cl) {
+    Arg args;
+    args.add_inout(out);
+    args.add_scalar(base_cl);
+    args.launch_spec.set_block_num(block_num);
+    pto2_rt_submit_aiv_task(kernel_id, args);
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+    (void)orch_thread_num;  // NOLINT(readability/casting)
+    if (orch_thread_index != 0) return;
+
+    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+
+    // T0: 4 blocks — basic multi-block
+    submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 4, 0);
+
+    // T1: 16 blocks — saturate one sched thread's AIV cores (8 clusters × 2 AIV)
+    submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 16, 4);
+
+    // T2: 24 blocks — cross-thread dispatch via ready_queue re-push
+    submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 24, 20);
+
+    // T3: 48 blocks — occupy all AIV cores across all 3 sched threads
+    submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 48, 44);
+
+    // T4: 96 blocks — two full rounds of all AIV cores
+    submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 96, 92);
+
+    LOG_ALWAYS("[spmd_multiblock_aiv] Submitted 5 AIV tasks: block_num=4,16,24,48,96");
+}
+
+}  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/golden.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/golden.py
@@ -1,0 +1,68 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Golden test for SPMD multi-block MIX.
+
+Submits five MIX tasks (AIC + AIV0 + AIV1) with block_num = 2, 8, 12, 24, 48 to verify:
+  T0 (block_num=2):  basic multi-block MIX
+  T1 (block_num=8):  saturates one sched thread (8 clusters)
+  T2 (block_num=12): forces cross-thread dispatch via ready_queue re-push
+  T3 (block_num=24): occupies all clusters across all 3 sched threads
+  T4 (block_num=48): two full rounds of all clusters
+
+Each block occupies 3 cache lines (AIC, AIV0, AIV1).  All three cores
+in the same block write the same float(block_idx) to their respective CL.
+
+Output tensor: 282 cache lines = 4512 float32.
+
+Args layout: [output]
+"""
+
+import torch
+
+__outputs__ = ["output"]
+RTOL = 0
+ATOL = 0
+
+ALL_CASES = {
+    "Case1": {},
+}
+
+DEFAULT_CASE = "Case1"
+
+FLOATS_PER_CACHE_LINE = 16
+SLOTS_PER_BLOCK = 3  # AIC, AIV0, AIV1
+
+# (block_num, base_cl) for each submitted task
+TASKS = [
+    (2, 0),  # T0: basic MIX (6 CL)
+    (8, 6),  # T1: saturate single thread (24 CL)
+    (12, 30),  # T2: cross-thread (36 CL)
+    (24, 66),  # T3: all clusters (72 CL)
+    (48, 138),  # T4: two full rounds (144 CL)
+]
+
+TOTAL_CL = sum(block_num * SLOTS_PER_BLOCK for block_num, _ in TASKS)  # 66
+
+
+def generate_inputs(params: dict) -> list:
+    output = torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)
+    return [
+        ("output", output),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    out = torch.as_tensor(tensors["output"])
+    for block_num, base_cl in TASKS:
+        for block_idx in range(block_num):
+            for slot in range(SLOTS_PER_BLOCK):
+                cl = base_cl + block_idx * SLOTS_PER_BLOCK + slot
+                out[cl * FLOATS_PER_CACHE_LINE] = float(block_idx)
+    tensors["output"][:] = out

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Multi-Block MIX Kernel (AIC version)
+ *
+ * AIC writes float(block_idx) at cache line (base_cl + block_idx * 3 + 0).
+ *
+ * Args:
+ *   args[0] = output Tensor* (INOUT)
+ *   args[1] = scalar: base_cl (starting cache line index for this task)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+static constexpr int32_t SLOTS_PER_BLOCK = 3;
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int32_t base_cl = static_cast<int32_t>(args[1]);
+    int32_t block_idx = get_block_idx(args);
+    int32_t offset = (base_cl + block_idx * SLOTS_PER_BLOCK + 0) * FLOATS_PER_CACHE_LINE;
+
+    out[offset] = static_cast<float>(block_idx);
+
+    dcci(&out[offset], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Multi-Block MIX Kernel (AIV version)
+ *
+ * AIV writes float(block_idx) at cache line
+ *   (base_cl + block_idx * 3 + 1 + sub_block_id)
+ * where sub_block_id is 0 for AIV0 and 1 for AIV1.
+ *
+ * Args:
+ *   args[0] = output Tensor* (INOUT)
+ *   args[1] = scalar: base_cl (starting cache line index for this task)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+static constexpr int32_t SLOTS_PER_BLOCK = 3;
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
+    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
+    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int32_t base_cl = static_cast<int32_t>(args[1]);
+    int32_t block_idx = get_block_idx(args);
+    int32_t sub_block_id = get_sub_block_id(args);
+    int32_t offset = (base_cl + block_idx * SLOTS_PER_BLOCK + 1 + sub_block_id) * FLOATS_PER_CACHE_LINE;
+
+    out[offset] = static_cast<float>(block_idx);
+
+    dcci(&out[offset], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/kernel_config.py
@@ -1,0 +1,51 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Kernel configuration for SPMD multi-block MIX test (tensormap_and_ringbuffer Runtime).
+
+Submits a single MIX task (AIC + AIV0 + AIV1) with block_num=2 so all
+three subtask slots in both blocks see the correct block_idx.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "spmd_multiblock_mix_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "SPMD_MIX_AIC",
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_spmd_mix.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "SPMD_MIX_AIV0",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_spmd_mix.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 2,
+        "name": "SPMD_MIX_AIV1",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_spmd_mix.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "orch_thread_num": 1,
+    "block_dim": 24,
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Multi-Block MIX Orchestration
+ *
+ * Submits three MIX tasks (AIC + AIV0 + AIV1) with increasing block_num:
+ *   T0: block_num=2   — basic multi-block MIX
+ *   T1: block_num=8   — saturates one sched thread (8 clusters)
+ *   T2: block_num=12  — forces cross-thread re-push via ready_queue
+ *
+ * Each task writes to a disjoint region of the output tensor using the
+ * base_cl scalar to offset the block writes.
+ *
+ * Args layout: [output]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_SPMD_MIX_AIC 0
+#define FUNC_SPMD_MIX_AIV0 1
+#define FUNC_SPMD_MIX_AIV1 2
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
+    const ChipStorageTaskArgs& orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 1,
+    };
+}
+
+static void submit_spmd_mix(
+    int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, Tensor& out, int16_t block_num, int64_t base_cl) {
+    MixedKernels mk;
+    mk.aic_kernel_id = aic_id;
+    mk.aiv0_kernel_id = aiv0_id;
+    mk.aiv1_kernel_id = aiv1_id;
+
+    Arg args;
+    args.add_inout(out);
+    args.add_scalar(base_cl);
+    args.launch_spec.set_block_num(block_num);
+    pto2_rt_submit_task(mk, args);
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(
+    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+    (void)orch_thread_num;  // NOLINT(readability/casting)
+    if (orch_thread_index != 0) return;
+
+    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+
+    // T0: 2 blocks (6 CL) — basic multi-block MIX
+    submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 2, 0);
+
+    // T1: 8 blocks (24 CL) — saturate one sched thread's clusters
+    submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 8, 6);
+
+    // T2: 12 blocks (36 CL) — cross-thread dispatch via ready_queue re-push
+    submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 12, 30);
+
+    // T3: 24 blocks (72 CL) — occupy all clusters across all 3 sched threads
+    submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 24, 66);
+
+    // T4: 48 blocks (144 CL) — two full rounds of all clusters
+    submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 48, 138);
+
+    LOG_ALWAYS("[spmd_multiblock_mix] Submitted 5 MIX tasks: block_num=2,8,12,24,48");
+}
+
+}  // extern "C"

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -398,11 +398,10 @@ struct AicpuExecutor {
 
             if (done) {
                 core_exec_state.executing_reg_task_id = AICPU_TASK_INVALID;
-                PTO2SubtaskSlot subslot = core_exec_state.executing_subslot;
                 PTO2TaskSlotState& slot_state = *core_exec_state.executing_slot_state;
 
-                // Two-stage completion: mark subtask done, then handle mixed-task completion
-                bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state, subslot);
+                // Completion: increment atomic counter, trigger task-level completion on last subtask
+                bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state);
                 if (mixed_complete) {
 #if PTO2_SCHED_PROFILING
                     PTO2CompletionStats cstats =
@@ -566,9 +565,9 @@ struct AicpuExecutor {
      * Build per-core dispatch payload: copy tensor pointers and scalars into
      * the per-core args[] array, then populate SPMD local context at the tail.
      *
-     * Current phase (block_dim=1): block_idx is always 0, block_num is always 1.
-     * When block_dim>1 is implemented, block_idx will vary per dispatch and
-     * block_num will reflect the task's block_dim.
+     * Reads next_block_idx and block_num directly from the task descriptor
+     * to populate LocalContext.  The caller is responsible for incrementing
+     * next_block_idx AFTER dispatch.
      *
      * GlobalContext (sub_block_id) is NOT written here — it is initialized once
      * at runtime startup by init_global_context().
@@ -586,9 +585,9 @@ struct AicpuExecutor {
         for (int32_t i = 0; i < payload.scalar_count; i++) {
             dispatch_payload.args[n++] = payload.scalars[i];
         }
-        // Per-dispatch local context (block_idx, block_num)
-        dispatch_payload.local_context.block_idx = 0;  // Phase 2: fixed
-        dispatch_payload.local_context.block_num = 1;  // Phase 2: fixed
+        // Per-dispatch local context (read from slot state)
+        dispatch_payload.local_context.block_idx = slot_state.next_block_idx;
+        dispatch_payload.local_context.block_num = slot_state.block_num;
         // Store context pointers at fixed suffix positions in args[]
         // (GlobalContext content is already set by init_global_context, but the
         //  pointer must be written each dispatch since args[] is rebuilt entirely)
@@ -1295,22 +1294,57 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 for (int bi = 0; bi < got; bi++) {
                     PTO2TaskSlotState* slot_state = batch[bi];
                     try_pushed = true;
-#if PTO2_PROFILING
-                    phase_dispatch_count++;
-#endif
 #if PTO2_SCHED_PROFILING
                     uint64_t t_setup_start = get_sys_cnt_aicpu();
 #endif
-                    auto current_valid_cluster_offset = valid_cluster_states.pop_first();
-                    if (shape == PTO2ResourceShape::MIX) {
-                        // Full-cluster scheduling: dispatch only to cores indicated by active_mask.
-                        // Unused cores in the cluster remain idle for single-core tasks.
-                        uint8_t mask = slot_state->active_mask;
-                        if (mask & PTO2_SUBTASK_MASK_AIC) {
-                            auto core_offset = tracker.get_aic_core_offset(current_valid_cluster_offset);
+                    // Dispatch as many blocks as possible for this task using available clusters.
+                    // For block_num=1 the inner body executes exactly once (no overhead).
+                    do {
+                        auto current_valid_cluster_offset = valid_cluster_states.pop_first();
+                        if (shape == PTO2ResourceShape::MIX) {
+                            // Full-cluster: all active subtasks share the same block_idx.
+                            uint8_t mask = slot_state->active_mask;
+                            if (mask & PTO2_SUBTASK_MASK_AIC) {
+                                dispatch_subtask_to_core(runtime,
+                                    thread_idx,
+                                    tracker.get_aic_core_offset(current_valid_cluster_offset),
+                                    *slot_state,
+                                    PTO2SubtaskSlot::AIC
+#if PTO2_PROFILING
+                                    ,
+                                    profiling_enabled
+#endif
+                                );
+                            }
+                            if (mask & PTO2_SUBTASK_MASK_AIV0) {
+                                dispatch_subtask_to_core(runtime,
+                                    thread_idx,
+                                    tracker.get_aiv0_core_offset(current_valid_cluster_offset),
+                                    *slot_state,
+                                    PTO2SubtaskSlot::AIV0
+#if PTO2_PROFILING
+                                    ,
+                                    profiling_enabled
+#endif
+                                );
+                            }
+                            if (mask & PTO2_SUBTASK_MASK_AIV1) {
+                                dispatch_subtask_to_core(runtime,
+                                    thread_idx,
+                                    tracker.get_aiv1_core_offset(current_valid_cluster_offset),
+                                    *slot_state,
+                                    PTO2SubtaskSlot::AIV1
+#if PTO2_PROFILING
+                                    ,
+                                    profiling_enabled
+#endif
+                                );
+                            }
+                            slot_state->next_block_idx++;
+                        } else if (shape == PTO2ResourceShape::AIC) {
                             dispatch_subtask_to_core(runtime,
                                 thread_idx,
-                                core_offset,
+                                tracker.get_aic_core_offset(current_valid_cluster_offset),
                                 *slot_state,
                                 PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
@@ -1318,9 +1352,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                                 profiling_enabled
 #endif
                             );
-                        }
-                        if (mask & PTO2_SUBTASK_MASK_AIV0) {
-                            auto core_offset = tracker.get_aiv0_core_offset(current_valid_cluster_offset);
+                            slot_state->next_block_idx++;
+                        } else {  // shape == PTO2ResourceShape::AIV
+                            auto core_offset = tracker.is_aiv0_core_idle(current_valid_cluster_offset)
+                                                   ? tracker.get_aiv0_core_offset(current_valid_cluster_offset)
+                                                   : tracker.get_aiv1_core_offset(current_valid_cluster_offset);
                             dispatch_subtask_to_core(runtime,
                                 thread_idx,
                                 core_offset,
@@ -1331,56 +1367,33 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                                 profiling_enabled
 #endif
                             );
+                            slot_state->next_block_idx++;
+                            // Refresh idle state so the do-while naturally picks up
+                            // the other AIV in the same cluster on the next iteration.
+                            if (slot_state->next_block_idx < slot_state->block_num) {
+                                valid_cluster_states = tracker.get_valid_cluster_offset_states(shape);
+                            }
                         }
-                        if (mask & PTO2_SUBTASK_MASK_AIV1) {
-                            auto core_offset = tracker.get_aiv1_core_offset(current_valid_cluster_offset);
-                            dispatch_subtask_to_core(runtime,
-                                thread_idx,
-                                core_offset,
-                                *slot_state,
-                                PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
-                                ,
-                                profiling_enabled
+                        phase_dispatch_count += __builtin_popcount(slot_state->active_mask);
 #endif
-                            );
-                        }
-                    } else if (shape == PTO2ResourceShape::AIC) {
-                        auto core_offset = tracker.get_aic_core_offset(current_valid_cluster_offset);
-                        dispatch_subtask_to_core(runtime,
+                        DEV_DEBUG("Thread %d: Dispatched %s task %" PRId64 " block %d/%d to cluster_offset %d",
                             thread_idx,
-                            core_offset,
-                            *slot_state,
-                            PTO2SubtaskSlot::AIC
-#if PTO2_PROFILING
-                            ,
-                            profiling_enabled
-#endif
-                        );
-                    } else {  // shape == PTO2ResourceShape::AIV
-                        auto core_offset = tracker.is_aiv0_core_idle(current_valid_cluster_offset)
-                                               ? tracker.get_aiv0_core_offset(current_valid_cluster_offset)
-                                               : tracker.get_aiv1_core_offset(current_valid_cluster_offset);
-                        dispatch_subtask_to_core(runtime,
-                            thread_idx,
-                            core_offset,
-                            *slot_state,
-                            PTO2SubtaskSlot::AIV0
-#if PTO2_PROFILING
-                            ,
-                            profiling_enabled
-#endif
-                        );
+                            shape_name(shape),
+                            static_cast<int64_t>(slot_state->task->task_id.raw),
+                            slot_state->next_block_idx - 1,
+                            slot_state->block_num,
+                            current_valid_cluster_offset);
+                    } while (slot_state->next_block_idx < slot_state->block_num && valid_cluster_states.has_value());
+
+                    // Re-enqueue only if blocks remain after exhausting local clusters
+                    if (slot_state->next_block_idx < slot_state->block_num) {
+                        rt->scheduler.ready_queues[static_cast<int32_t>(shape)].push(slot_state);
                     }
                     made_progress = true;
 #if PTO2_SCHED_PROFILING
                     sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
-                    DEV_DEBUG("Thread %d: Dispatching %s task %" PRId64 " to cluster_offset %d",
-                        thread_idx,
-                        shape_name(shape),
-                        static_cast<int64_t>(slot_state->task->task_id.raw),
-                        current_valid_cluster_offset);
                 }
 
                 // lazy update valid_cluster_states

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -301,6 +301,9 @@ TaskOutputTensors pto2_submit_mixed_task(
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
     always_assert(active_mask != 0 && "MixedKernels must have at least one active slot");
 
+    int16_t block_num = args.launch_spec.block_num();
+    always_assert(block_num >= 1 && "block_num must be >= 1");
+
     // Normalize single-AIV tasks: if only aiv1 is set (no aic, no aiv0), move
     // it to the aiv0 slot.  This guarantees the dispatch path can always use
     // PTO2SubtaskSlot::AIV0 for single-AIV shapes without inspecting active_mask.
@@ -547,6 +550,10 @@ TaskOutputTensors pto2_submit_mixed_task(
         // so concurrent on_mixed_task_complete can safely access task_state/fanout_refcount.
         cur_slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
         cur_slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
+        cur_slot_state.completed_subtasks.store(0, std::memory_order_relaxed);
+        cur_slot_state.total_required_subtasks = static_cast<int16_t>(block_num * __builtin_popcount(active_mask));
+        cur_slot_state.block_num = block_num;
+        cur_slot_state.next_block_idx = 0;
 
         auto& dep_pool = orch->rings[ring_id].dep_pool;
         // Ensure dep pool has space: fanin_count entries + 1 pre-alloc

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -455,9 +455,15 @@ struct alignas(64) PTO2TaskSlotState {
 
     // Hot-path completion fields (moved from TaskDescriptor to avoid cross-struct access)
     uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
-    std::atomic<uint8_t> subtask_done_mask;  // Each subtask sets its done bit on completion
+    std::atomic<uint8_t> subtask_done_mask;  // Deprecated: superseded by completed_subtasks
     uint8_t ring_id;                         // Ring layer this task belongs to (for per-ring reclamation)
     int32_t dep_pool_mark{0};  // Dep pool top after this task's submission (orchestrator-only, local memory)
+
+    // SPMD multi-block (occupies the 8 tail bytes previously implicit padding)
+    std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
+    int16_t total_required_subtasks{0};          // = block_num * popcount(active_mask)
+    int16_t block_num{1};                        // Total logical blocks (set by orchestrator)
+    int16_t next_block_idx{0};                   // Next block to dispatch (scheduler state)
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * PTO Runtime2 - Scheduler Interface
  *
@@ -16,21 +27,24 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#ifndef PTO_SCHEDULER_H
-#define PTO_SCHEDULER_H
+#pragma once
 
 #include <atomic>
 
+#include "common/core_type.h"
+#include "pto_ring_buffer.h"
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
-#include "pto_ring_buffer.h"
-
-#include "common/core_type.h"
 
 #if PTO2_SCHED_PROFILING
 #include "aicpu/device_time.h"
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
-#define PTO2_SCHED_CYCLE_LAP(acc) do { _st1 = get_sys_cnt_aicpu(); acc += (_st1 - _st0); _st0 = _st1; } while(0)
+#define PTO2_SCHED_CYCLE_LAP(acc)   \
+    do {                            \
+        _st1 = get_sys_cnt_aicpu(); \
+        acc += (_st1 - _st0);       \
+        _st0 = _st1;                \
+    } while (0)
 #endif
 
 // =============================================================================
@@ -78,9 +92,7 @@ struct PTO2LocalReadyBuffer {
         return false;
     }
 
-    PTO2TaskSlotState* pop() {
-        return (count > 0) ? slot_states[--count] : nullptr;
-    }
+    PTO2TaskSlotState* pop() { return (count > 0) ? slot_states[--count] : nullptr; }
 };
 
 /**
@@ -96,14 +108,14 @@ struct PTO2LocalReadyBuffer {
 struct alignas(64) PTO2ReadyQueue {
     PTO2ReadyQueueSlot* slots;
     uint64_t capacity;
-    uint64_t mask;                          // capacity - 1
-    char _pad0[64 - 24];                   // Pad to own cache line
+    uint64_t mask;        // capacity - 1
+    char _pad0[64 - 24];  // Pad to own cache line
 
     std::atomic<uint64_t> enqueue_pos;
-    char _pad1[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad1[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     std::atomic<uint64_t> dequeue_pos;
-    char _pad2[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad2[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     uint64_t size() {
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -118,10 +130,10 @@ struct alignas(64) PTO2ReadyQueue {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
-            int64_t diff = seq - (int64_t)pos;
+            int64_t diff = seq - static_cast<int64_t>(pos);
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     break;
                 }
             } else if (diff < 0) {
@@ -130,7 +142,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         slot->slot_state = slot_state;
-        slot->sequence.store((int64_t)(pos + 1), std::memory_order_release);
+        slot->sequence.store(static_cast<int64_t>(pos + 1), std::memory_order_release);
         return true;
     }
 
@@ -146,7 +158,7 @@ struct alignas(64) PTO2ReadyQueue {
             for (int i = 0; i < count; i++) {
                 PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
-                int64_t diff = seq - (int64_t)(pos + i);
+                int64_t diff = seq - static_cast<int64_t>(pos + i);
                 if (diff != 0) {
                     ready = false;
                     break;
@@ -155,8 +167,8 @@ struct alignas(64) PTO2ReadyQueue {
             if (!ready) {
                 continue;
             }
-            if (enqueue_pos.compare_exchange_weak(pos, pos + count,
-                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+            if (enqueue_pos.compare_exchange_weak(
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed)) {
                 break;
             }
         }
@@ -164,7 +176,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
             slot->slot_state = items[i];
-            slot->sequence.store((int64_t)(pos + i + 1), std::memory_order_release);
+            slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
     }
 
@@ -179,11 +191,11 @@ struct alignas(64) PTO2ReadyQueue {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
-            int64_t diff = seq - (int64_t)pos;
+            int64_t diff = seq - static_cast<int64_t>(pos);
             atomic_ops += 2;  // enqueue_pos.load + sequence.load
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -202,7 +214,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         slot->slot_state = slot_state;
-        slot->sequence.store((int64_t)(pos + 1), std::memory_order_release);
+        slot->sequence.store(static_cast<int64_t>(pos + 1), std::memory_order_release);
         return true;
     }
 #endif
@@ -221,10 +233,10 @@ struct alignas(64) PTO2ReadyQueue {
             pos = dequeue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
-            int64_t diff = seq - (int64_t)(pos + 1);
+            int64_t diff = seq - static_cast<int64_t>(pos + 1);
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed))
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed))
                     break;
             } else if (diff < 0) {
                 return nullptr;  // Queue empty
@@ -232,7 +244,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         PTO2TaskSlotState* result = slot->slot_state;
-        slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
+        slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
 
@@ -255,11 +267,11 @@ struct alignas(64) PTO2ReadyQueue {
             pos = dequeue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
-            int64_t diff = seq - (int64_t)(pos + 1);
+            int64_t diff = seq - static_cast<int64_t>(pos + 1);
             atomic_ops += 2;  // dequeue_pos.load + sequence.load
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -279,7 +291,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         PTO2TaskSlotState* result = slot->slot_state;
-        slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
+        slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
 #endif
@@ -295,7 +307,7 @@ struct alignas(64) PTO2ReadyQueue {
             while (count < max_count) {
                 PTO2ReadyQueueSlot* slot = &slots[(pos + count) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
-                int64_t diff = seq - (int64_t)(pos + count + 1);
+                int64_t diff = seq - static_cast<int64_t>(pos + count + 1);
                 if (diff == 0) {
                     count++;
                     continue;
@@ -308,8 +320,8 @@ struct alignas(64) PTO2ReadyQueue {
             }
             if (count == 0) return 0;
             if (count < 0) continue;
-            if (dequeue_pos.compare_exchange_weak(pos, pos + count,
-                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+            if (dequeue_pos.compare_exchange_weak(
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed)) {
                 break;
             }
         }
@@ -317,7 +329,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
-            slot->sequence.store((int64_t)(pos + i + mask + 1), std::memory_order_release);
+            slot->sequence.store(static_cast<int64_t>(pos + i + mask + 1), std::memory_order_release);
         }
         return count;
     }
@@ -336,7 +348,7 @@ struct alignas(64) PTO2ReadyQueue {
             while (count < max_count) {
                 PTO2ReadyQueueSlot* slot = &slots[(pos + count) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
-                int64_t diff = seq - (int64_t)(pos + count + 1);
+                int64_t diff = seq - static_cast<int64_t>(pos + count + 1);
                 atomic_ops++;  // sequence.load
                 if (diff == 0) {
                     count++;
@@ -356,8 +368,8 @@ struct alignas(64) PTO2ReadyQueue {
             if (count < 0) {
                 continue;
             }
-            if (dequeue_pos.compare_exchange_weak(pos, pos + count,
-                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+            if (dequeue_pos.compare_exchange_weak(
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed)) {
                 atomic_ops++;  // successful CAS
                 break;
             }
@@ -368,7 +380,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
-            slot->sequence.store((int64_t)(pos + i + mask + 1), std::memory_order_release);
+            slot->sequence.store(static_cast<int64_t>(pos + i + mask + 1), std::memory_order_release);
             atomic_ops++;  // sequence.store
         }
         atomic_count += atomic_ops;
@@ -392,10 +404,10 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
  * Statistics returned by mixed-task completion processing
  */
 struct PTO2CompletionStats {
-    int32_t fanout_edges;      // Number of fanout edges traversed (notify consumers)
-    int32_t tasks_enqueued;    // Number of consumers that became READY
-    int32_t fanin_edges;       // Number of fanin edges traversed (release producers)
-    bool mixed_task_completed; // True only when this callback completed a mixed task
+    int32_t fanout_edges;       // Number of fanout edges traversed (notify consumers)
+    int32_t tasks_enqueued;     // Number of consumers that became READY
+    int32_t fanin_edges;        // Number of fanin edges traversed (release producers)
+    bool mixed_task_completed;  // True only when this callback completed a mixed task
 };
 
 /**
@@ -425,9 +437,7 @@ struct PTO2SchedulerState {
         PTO2TaskSlotState& get_slot_state_by_task_id(int32_t local_id) {
             return slot_states[local_id & task_window_mask];
         }
-        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) {
-            return slot_states[slot];
-        }
+        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
         void sync_to_sm(PTO2SharedMemoryRingHeader& ring) {
             ring.fc.last_task_alive.store(last_task_alive, std::memory_order_release);
@@ -470,8 +480,8 @@ struct PTO2SchedulerState {
         if (slot_state.fanout_refcount.load(std::memory_order_acquire) != slot_state.fanout_count) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire)) {
             return;
         }
 
@@ -482,8 +492,8 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
         }
@@ -499,8 +509,8 @@ struct PTO2SchedulerState {
         if (rc != fc) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire)) {
             atomic_count += 1;  // failed CAS
             return;
         }
@@ -514,8 +524,8 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
             atomic_count += 2;  // try-lock CAS + unlock store
@@ -581,8 +591,8 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    int get_ready_tasks_batch(PTO2ResourceShape shape, PTO2LocalReadyBuffer& local_buf,
-                              PTO2TaskSlotState** out, int max_count) {
+    int get_ready_tasks_batch(
+        PTO2ResourceShape shape, PTO2LocalReadyBuffer& local_buf, PTO2TaskSlotState** out, int max_count) {
         int count = 0;
         while (count < max_count && local_buf.count > 0) {
             out[count++] = local_buf.slot_states[--local_buf.count];
@@ -595,9 +605,13 @@ struct PTO2SchedulerState {
     }
 
 #if PTO2_SCHED_PROFILING
-    int get_ready_tasks_batch(PTO2ResourceShape shape, PTO2LocalReadyBuffer& local_buf,
-                              PTO2TaskSlotState** out, int max_count,
-                              uint64_t& atomic_count, uint64_t& wait_cycle, uint64_t& local_dispatch_count) {
+    int get_ready_tasks_batch(PTO2ResourceShape shape,
+        PTO2LocalReadyBuffer& local_buf,
+        PTO2TaskSlotState** out,
+        int max_count,
+        uint64_t& atomic_count,
+        uint64_t& wait_cycle,
+        uint64_t& local_dispatch_count) {
         int count = 0;
         while (count < max_count && local_buf.count > 0) {
             local_dispatch_count++;
@@ -605,8 +619,8 @@ struct PTO2SchedulerState {
         }
         int remaining = max_count - count;
         if (remaining > 0) {
-            count += ready_queues[static_cast<int32_t>(shape)].pop_batch(
-                out + count, remaining, atomic_count, wait_cycle);
+            count +=
+                ready_queues[static_cast<int32_t>(shape)].pop_batch(out + count, remaining, atomic_count, wait_cycle);
         }
         return count;
     }
@@ -630,18 +644,16 @@ struct PTO2SchedulerState {
     }
 
     /**
-     * Two-stage completion: first stage.
-     * Called when a single subtask (AIC, AIV0, or AIV1) finishes.
-     * Sets the corresponding done bit in subtask_done_mask.
+     * Subtask completion: atomic counter model.
+     * Called when a single subtask (AIC, AIV0, or AIV1) finishes on any block.
+     * Atomically increments completed_subtasks and checks whether all subtasks
+     * across all blocks are done.
      *
-     * @return true if this subtask was the last one, completing the mixed task.
+     * @return true if this was the last subtask, completing the entire task.
      */
-    bool on_subtask_complete(PTO2TaskSlotState& slot_state, PTO2SubtaskSlot subslot) {
-        uint8_t done_bit = (1u << static_cast<uint8_t>(subslot));
-        uint8_t prev_mask = slot_state.subtask_done_mask.fetch_or(done_bit, std::memory_order_acq_rel);
-        uint8_t new_mask = prev_mask | done_bit;
-
-        return new_mask == slot_state.active_mask;
+    bool on_subtask_complete(PTO2TaskSlotState& slot_state) {
+        int16_t prev = slot_state.completed_subtasks.fetch_add(1, std::memory_order_acq_rel);
+        return (prev + 1) == slot_state.total_required_subtasks;
     }
 
     /**
@@ -655,7 +667,7 @@ struct PTO2SchedulerState {
 #else
     void
 #endif
-    on_mixed_task_complete(PTO2TaskSlotState& slot_state, 
+    on_mixed_task_complete(PTO2TaskSlotState& slot_state,
 #if PTO2_SCHED_PROFILING
         int thread_idx,
 #endif
@@ -696,8 +708,7 @@ struct PTO2SchedulerState {
             PTO2TaskSlotState& consumer_slot = *current->slot_state;
 #if PTO2_SCHED_PROFILING
             stats.fanout_edges++;
-            if (release_fanin_and_check_ready(consumer_slot,
-                                               fanout_atomics, push_wait, local_bufs)) {
+            if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait, local_bufs)) {
                 stats.tasks_enqueued++;
             }
 #else
@@ -756,14 +767,13 @@ struct PTO2SchedulerState {
 #endif
         return fanin_edges;
     }
-};
+};  // NOLINT(readability/braces)
 
 // =============================================================================
 // Scheduler API (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle);
+bool pto2_scheduler_init(PTO2SchedulerState* sched, PTO2SharedMemoryHandle* sm_handle);
 void pto2_scheduler_destroy(PTO2SchedulerState* sched);
 
 // =============================================================================
@@ -787,9 +797,9 @@ struct PTO2SchedProfilingData {
     uint64_t self_consumed_cycle;  // self check_and_handle_consumed
 
     // Wait times
-    uint64_t lock_wait_cycle;      // spin-wait in fanout_lock
-    uint64_t push_wait_cycle;      // CAS contention in push()
-    uint64_t pop_wait_cycle;       // CAS contention in pop()
+    uint64_t lock_wait_cycle;  // spin-wait in fanout_lock
+    uint64_t push_wait_cycle;  // CAS contention in push()
+    uint64_t pop_wait_cycle;   // CAS contention in pop()
 
     // Atomic counts per sub-phase
     uint64_t lock_atomic_count;
@@ -798,7 +808,7 @@ struct PTO2SchedProfilingData {
     uint64_t self_atomic_count;
     uint64_t pop_atomic_count;
 
-    int64_t  complete_count;
+    int64_t complete_count;
 };
 
 /**
@@ -807,5 +817,3 @@ struct PTO2SchedProfilingData {
  */
 PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
 #endif
-
-#endif // PTO_SCHEDULER_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * PTO Submit Types - Shared submit-contract definitions
  *
@@ -5,8 +16,7 @@
  * headers. Keeps orchestration slim (no dependency on pto_runtime2_types.h).
  */
 
-#ifndef PTO_SUBMIT_TYPES_H
-#define PTO_SUBMIT_TYPES_H
+#pragma once
 
 #include <stdint.h>
 
@@ -21,7 +31,7 @@ inline constexpr int32_t PTO2_SUBTASK_SLOT_COUNT = 3;
  * Subtask slot indices
  */
 enum class PTO2SubtaskSlot : uint8_t {
-    AIC  = 0,
+    AIC = 0,
     AIV0 = 1,
     AIV1 = 2,
 };
@@ -29,7 +39,7 @@ enum class PTO2SubtaskSlot : uint8_t {
 /**
  * Subtask mask bits (for active_mask / subtask_done_mask)
  */
-inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC  = (1u << 0);  // 0x1
+inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC = (1u << 0);   // 0x1
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV0 = (1u << 1);  // 0x2
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV1 = (1u << 2);  // 0x4
 
@@ -61,9 +71,9 @@ struct MixedKernels {
  * cluster remain idle and available for single-core tasks.
  */
 enum class PTO2ResourceShape : uint8_t {
-    AIC = 0,   // Single AIC
-    AIV = 1,   // Single AIV
-    MIX = 2,   // Full cluster (dispatch uses active_mask)
+    AIC = 0,  // Single AIC
+    AIV = 1,  // Single AIV
+    MIX = 2,  // Full cluster (dispatch uses active_mask)
 };
 
 inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 3;
@@ -84,10 +94,26 @@ static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
  */
 static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels& mk) {
     uint8_t mask = 0;
-    if (mk.aic_kernel_id  != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
+    if (mk.aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
     if (mk.aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
     if (mk.aiv1_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV1;
     return mask;
 }
 
-#endif // PTO_SUBMIT_TYPES_H
+/**
+ * SPMD launch parameters carried inside Arg.
+ *
+ * Controls how many logical blocks (SPMD dimension) a single task
+ * is expanded into at dispatch time.  Each block receives a unique
+ * block_idx in [0, block_num) via the per-dispatch LocalContext.
+ */
+class PTO2LaunchSpec {
+ public:
+    constexpr PTO2LaunchSpec() = default;
+
+    int16_t block_num() const { return block_num_; }
+    void set_block_num(int16_t n) { block_num_ = n; }
+
+ private:
+    int16_t block_num_{1};
+};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -32,9 +32,10 @@
 #include <arm_neon.h>
 #endif
 
-#include "task_args.h"   // NOLINT(build/include_subdir) -- TaskArgs base class
-#include "tensor.h"      // NOLINT(build/include_subdir)
-#include "tensor_arg.h"  // NOLINT(build/include_subdir) -- canonical TensorArgType definition
+#include "pto_submit_types.h"  // NOLINT(build/include_subdir) -- PTO2LaunchSpec
+#include "task_args.h"         // NOLINT(build/include_subdir) -- TaskArgs base class
+#include "tensor.h"            // NOLINT(build/include_subdir)
+#include "tensor_arg.h"        // NOLINT(build/include_subdir) -- canonical TensorArgType definition
 
 // Task arguments
 #define MAX_TENSOR_ARGS 16   // Maximum tensor arguments per task
@@ -60,7 +61,7 @@
  * binding get_ref() on an rvalue is compile-time rejected to prevent dangling.
  */
 class TaskOutputTensors {
-public:  // NOLINT(whitespace/indent)
+ public:  // NOLINT(whitespace/indent)
     TaskOutputTensors() : output_count_(0) {}
 
     bool empty() const { return output_count_ == 0; }
@@ -79,7 +80,7 @@ public:  // NOLINT(whitespace/indent)
         tensors_[output_count_++] = &tensor;
     }
 
-private:  // NOLINT(whitespace/indent)
+ private:  // NOLINT(whitespace/indent)
     uint32_t output_count_;
     const Tensor* tensors_[PTO2_MAX_OUTPUTS];
 };
@@ -126,6 +127,7 @@ union TensorRef {
 struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType> {
     bool has_error{false};
     const char* error_msg{nullptr};
+    PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
 
     void reset() {
         clear();


### PR DESCRIPTION
- Introduce PTO2LaunchSpec class in pto_submit_types.h with block_num accessor; embed in Arg via launch_spec field
- Extend PTO2TaskSlotState with block_num, next_block_idx, completed_subtasks (atomic), and total_required_subtasks — all fit within the existing 64-byte cache-line constraint
- Replace per-subtask bitmask completion with a unified atomic counter: on_subtask_complete() now increments completed_subtasks and fires task completion when all blocks × subtasks are done
- Dispatch loop uses do-while to greedily consume available clusters for the same multi-block task before re-enqueuing; AIV tasks refresh cluster state after each dispatch so the other idle AIV in the same cluster is naturally picked up on the next iteration
- Fix phase_dispatch_count to track per-subtask granularity via popcount(active_mask) instead of per-task
- Orchestrator reads block_num from Arg, initializes slot state fields, and validates block_num >= 1
- block_num=1 (default) preserves original behavior: the do-while body executes exactly once with zero overhead
- Add spmd_multiblock_aiv test (block_num=4,16,24,48,96)
- Add spmd_multiblock_mix test (block_num=2,8,12,24,48)