### PR TITLE
Fix: profiling buffer recycling and implicit task record emission

### DIFF
--- a/src/a2a3/platform/include/common/perf_profiling.h
+++ b/src/a2a3/platform/include/common/perf_profiling.h
@@ -62,7 +62,7 @@
 
 // Maximum number of successor tasks per PerfRecord (matches Task::fanout)
 #ifndef RUNTIME_MAX_FANOUT
-#define RUNTIME_MAX_FANOUT 512
+#define RUNTIME_MAX_FANOUT 128
 #endif
 
 // =============================================================================

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file platform_config.h
  * @brief Platform-specific configuration and architectural constraints
@@ -11,8 +22,8 @@
  * - Derived: All other limits calculated from base configuration
  */
 
-#ifndef PLATFORM_COMMON_PLATFORM_CONFIG_H_
-#define PLATFORM_COMMON_PLATFORM_CONFIG_H_
+#ifndef SRC_A2A3_PLATFORM_INCLUDE_COMMON_PLATFORM_CONFIG_H_
+#define SRC_A2A3_PLATFORM_INCLUDE_COMMON_PLATFORM_CONFIG_H_
 
 #include <cstdint>
 
@@ -60,14 +71,11 @@ constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 6;
  * - MAX_AIC_PER_THREAD = MAX_BLOCKDIM * AIC_CORES_PER_BLOCKDIM = 24 * 1 = 24
  * - MAX_AIV_PER_THREAD = MAX_BLOCKDIM * AIV_CORES_PER_BLOCKDIM = 24 * 2 = 48
  */
-constexpr int PLATFORM_MAX_AIC_PER_THREAD =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_AIC_CORES_PER_BLOCKDIM;  // 24
+constexpr int PLATFORM_MAX_AIC_PER_THREAD = PLATFORM_MAX_BLOCKDIM * PLATFORM_AIC_CORES_PER_BLOCKDIM;  // 24
 
-constexpr int PLATFORM_MAX_AIV_PER_THREAD =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_AIV_CORES_PER_BLOCKDIM;  // 48
+constexpr int PLATFORM_MAX_AIV_PER_THREAD = PLATFORM_MAX_BLOCKDIM * PLATFORM_AIV_CORES_PER_BLOCKDIM;  // 48
 
-constexpr int PLATFORM_MAX_CORES_PER_THREAD =
-    PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD;  // 72
+constexpr int PLATFORM_MAX_CORES_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD;  // 72
 
 // =============================================================================
 // Performance Profiling Configuration
@@ -77,8 +85,7 @@ constexpr int PLATFORM_MAX_CORES_PER_THREAD =
  * Maximum number of cores that can be profiled simultaneously
  * Calculated as: MAX_BLOCKDIM * CORES_PER_BLOCKDIM = 24 * 3 = 72
  */
-constexpr int PLATFORM_MAX_CORES =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 72
+constexpr int PLATFORM_MAX_CORES = PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 72
 
 /**
  * Performance buffer capacity per buffer
@@ -90,21 +97,30 @@ constexpr int PLATFORM_PROF_BUFFER_SIZE = 1000;
  * Number of buffer slots per core/thread for dynamic profiling
  * Host dynamically allocates buffers and writes addresses into these slots.
  * Device reads slot addresses when switching buffers.
- * Using 8 slots (ring buffer) instead of 2 (double-buffer) to tolerate
- * Host-side latency in replacing full buffers.
+ * Using slots: provides full pipeline depth for buffer recycling.
+ * No runtime rtMalloc — all buffers are pre-allocated and recycled in a closed loop.
  */
-constexpr int PLATFORM_PROF_SLOT_COUNT = 8;
+constexpr int PLATFORM_PROF_SLOT_COUNT = 4;
+
+/**
+ * PerfBuffer pre-allocation count per AICore.
+ * 1 goes into the free_queue at init, the rest into the recycled pool.
+ */
+constexpr int PLATFORM_PROF_BUFFERS_PER_CORE = 8;
+
+/**
+ * PhaseBuffer pre-allocation count per AICPU thread.
+ * 1 goes into the free_queue at init, the rest into the recycled pool.
+ */
+constexpr int PLATFORM_PROF_BUFFERS_PER_THREAD = 16;
 
 /**
  * Ready queue capacity for performance data collection
  * Queue holds ReadyQueueEntry structs for buffers ready to be read by Host.
- * Includes both PerfRecord and PhaseRecord entries:
- *   PerfRecord: PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT
- *   Phase:      PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT
+ * Sized to match pre-allocation total across all cores and threads.
  */
 constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
-    PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT
-    + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT;  // 608
+    PLATFORM_MAX_CORES * PLATFORM_PROF_BUFFERS_PER_CORE + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_BUFFERS_PER_THREAD;
 
 /**
  * System counter frequency (get_sys_cnt)
@@ -124,7 +140,7 @@ constexpr int PLATFORM_PROF_EMPTY_POLLS_CHECK_NUM = 1000;
 
 inline double cycles_to_us(uint64_t cycles) {
     return (static_cast<double>(cycles) / PLATFORM_PROF_SYS_CNT_FREQ) * 1000000.0;
-};
+}
 
 // =============================================================================
 // Register Communication Configuration
@@ -159,9 +175,12 @@ enum class RegId : uint32_t {
  */
 constexpr uint32_t reg_offset(RegId reg) {
     switch (reg) {
-        case RegId::DATA_MAIN_BASE:  return REG_SPR_DATA_MAIN_BASE_OFFSET;
-        case RegId::COND:            return REG_SPR_COND_OFFSET;
-        case RegId::FAST_PATH_ENABLE: return REG_SPR_FAST_PATH_ENABLE_OFFSET;
+        case RegId::DATA_MAIN_BASE:
+            return REG_SPR_DATA_MAIN_BASE_OFFSET;
+        case RegId::COND:
+            return REG_SPR_COND_OFFSET;
+        case RegId::FAST_PATH_ENABLE:
+            return REG_SPR_FAST_PATH_ENABLE_OFFSET;
     }
     return 0;  // unreachable: all RegId cases handled above
 }
@@ -197,26 +216,26 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = 25;
  * State: ACK (0) = task received, FIN (1) = task completed
  */
 
-#define TASK_ID_MASK       0x7FFFFFFFU
-#define TASK_STATE_MASK    0x80000000U
+#define TASK_ID_MASK 0x7FFFFFFFU
+#define TASK_STATE_MASK 0x80000000U
 
-#define TASK_ACK_STATE     0
-#define TASK_FIN_STATE     1
+#define TASK_ACK_STATE 0
+#define TASK_FIN_STATE 1
 
-#define EXTRACT_TASK_ID(regval)    ((int)((regval) & TASK_ID_MASK))
-#define EXTRACT_TASK_STATE(regval) ((int)(((regval) & TASK_STATE_MASK) >> 31))
-#define MAKE_ACK_VALUE(task_id)    ((uint64_t)((task_id) & TASK_ID_MASK))
-#define MAKE_FIN_VALUE(task_id)    ((uint64_t)(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
+#define EXTRACT_TASK_ID(regval) (static_cast<int>((regval) & TASK_ID_MASK))
+#define EXTRACT_TASK_STATE(regval) (static_cast<int>(((regval) & TASK_STATE_MASK) >> 31))
+#define MAKE_ACK_VALUE(task_id) (static_cast<uint64_t>((task_id) & TASK_ID_MASK))
+#define MAKE_FIN_VALUE(task_id) (static_cast<uint64_t>(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
 
 // These values are RESERVED and must never be used as real task IDs.
 // Valid task IDs: 0 to 0x7FFFFFEF (2147483631)
-#define AICORE_IDLE_TASK_ID        0x7FFFFFFFU
-#define AICORE_IDLE_VALUE          MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
+#define AICORE_IDLE_TASK_ID 0x7FFFFFFFU
+#define AICORE_IDLE_VALUE MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
 
-#define AICORE_EXIT_TASK_ID        0x7FFFFFFEU
-#define AICORE_EXITED_VALUE        MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
+#define AICORE_EXIT_TASK_ID 0x7FFFFFFEU
+#define AICORE_EXITED_VALUE MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
 
-#define AICPU_IDLE_TASK_ID         0x7FFFFFFDU
+#define AICPU_IDLE_TASK_ID 0x7FFFFFFDU
 
 // =============================================================================
 // Task State Constants
@@ -228,4 +247,4 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = 25;
  */
 constexpr int AICPU_TASK_INVALID = -1;
 
-#endif  // PLATFORM_COMMON_PLATFORM_CONFIG_H_
+#endif  // SRC_A2A3_PLATFORM_INCLUDE_COMMON_PLATFORM_CONFIG_H_

--- a/src/a2a3/platform/include/host/performance_collector.h
+++ b/src/a2a3/platform/include/host/performance_collector.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file performance_collector.h
  * @brief Platform-agnostic performance data collector with dynamic memory management
@@ -11,8 +22,8 @@
  * Design Pattern: Dependency Injection via Callbacks for memory operations.
  */
 
-#ifndef PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_
-#define PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_
+#ifndef SRC_A2A3_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_
+#define SRC_A2A3_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_
 
 #include <atomic>
 #include <condition_variable>
@@ -46,8 +57,7 @@ using PerfAllocCallback = void* (*)(size_t size, void* user_data);
  * @param[out] host_ptr Host-mapped pointer
  * @return 0 on success, error code on failure
  */
-using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id,
-                                      void* user_data, void** host_ptr);
+using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id, void* user_data, void** host_ptr);
 
 /**
  * Memory unregister callback
@@ -68,6 +78,15 @@ using PerfUnregisterCallback = int (*)(void* dev_ptr, int device_id, void* user_
  */
 using PerfFreeCallback = int (*)(void* dev_ptr, void* user_data);
 
+/**
+ * Device context setup callback (called once on mgmt thread startup)
+ *
+ * @param device_id Device ID to set
+ * @param user_data User-provided context pointer
+ * @return 0 on success, error code on failure
+ */
+using PerfSetDeviceCallback = int (*)(int device_id, void* user_data);
+
 // =============================================================================
 // ProfMemoryManager - Dynamic Buffer Memory Management Thread
 // =============================================================================
@@ -82,18 +101,19 @@ enum class ProfBufferType { PERF_RECORD, PHASE };
  */
 struct ReadyBufferInfo {
     ProfBufferType type;
-    uint32_t index;           // core_index (PERF_RECORD) or thread_idx (PHASE)
-    uint32_t slot_idx;        // Reserved (unused in free queue design)
-    void* dev_buffer_ptr;     // Device address of the full buffer
-    void* host_buffer_ptr;    // Host-mapped address (sim: same as dev)
-    uint32_t buffer_seq;      // Sequence number for ordering
+    uint32_t index;         // core_index (PERF_RECORD) or thread_idx (PHASE)
+    uint32_t slot_idx;      // Reserved (unused in free queue design)
+    void* dev_buffer_ptr;   // Device address of the full buffer
+    void* host_buffer_ptr;  // Host-mapped address (sim: same as dev)
+    uint32_t buffer_seq;    // Sequence number for ordering
 };
 
 /**
  * Notification that a buffer has been copied and can be freed
  */
 struct CopyDoneInfo {
-    void* dev_buffer_ptr;     // Device buffer to free
+    void* dev_buffer_ptr;  // Device buffer to free
+    ProfBufferType type;   // Buffer type (for recycling)
 };
 
 /**
@@ -107,7 +127,7 @@ struct CopyDoneInfo {
  * 5. Frees device buffers after main thread confirms copy is done
  */
 class ProfMemoryManager {
-public:
+ public:
     ProfMemoryManager() = default;
     ~ProfMemoryManager();
 
@@ -129,10 +149,17 @@ public:
      * @param free_cb Device memory free callback
      * @param user_data User context for callbacks
      * @param device_id Device ID for registration
+     * @param set_device_cb Device context setup callback (nullptr to skip)
      */
-    void start(void* shared_mem_host, int num_cores, int num_phase_threads,
-               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-               PerfFreeCallback free_cb, void* user_data, int device_id);
+    void start(void* shared_mem_host,
+        int num_cores,
+        int num_phase_threads,
+        PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb,
+        void* user_data,
+        int device_id,
+        PerfSetDeviceCallback set_device_cb = nullptr);
 
     /**
      * Stop the memory management thread
@@ -169,7 +196,7 @@ public:
      */
     bool is_running() const { return running_.load(); }
 
-private:
+ private:
     std::thread mgmt_thread_;
     std::atomic<bool> running_{false};
 
@@ -182,6 +209,7 @@ private:
     PerfAllocCallback alloc_cb_{nullptr};
     PerfRegisterCallback register_cb_{nullptr};
     PerfFreeCallback free_cb_{nullptr};
+    PerfSetDeviceCallback set_device_cb_{nullptr};
     void* user_data_{nullptr};
     int device_id_{-1};
 
@@ -196,6 +224,10 @@ private:
 
     // Device-to-host pointer mapping (populated during alloc_and_register)
     std::unordered_map<void*, void*> dev_to_host_;
+
+    // Recycled buffer pools (avoids alloc/free churn in mgmt_loop)
+    std::vector<void*> recycled_perf_buffers_;
+    std::vector<void*> recycled_phase_buffers_;
 
     // Management thread main loop
     void mgmt_loop();
@@ -213,8 +245,7 @@ private:
     void register_mapping(void* dev_ptr, void* host_ptr);
 
     // Process one ReadyQueue entry
-    void process_ready_entry(PerfDataHeader* header, int thread_idx,
-                              const ReadyQueueEntry& entry);
+    void process_ready_entry(PerfDataHeader* header, int thread_idx, const ReadyQueueEntry& entry);
 };
 
 // =============================================================================
@@ -233,7 +264,7 @@ private:
  * Platform-agnostic: Memory management delegated to callbacks
  */
 class PerformanceCollector {
-public:
+ public:
     PerformanceCollector() = default;
     ~PerformanceCollector();
 
@@ -254,15 +285,17 @@ public:
      * @param register_cb Memory registration callback (can be nullptr for simulation)
      * @param free_cb Memory free callback
      * @param user_data User-provided context pointer passed to callbacks
+     * @param set_device_cb Device context setup callback (nullptr to skip)
      * @return 0 on success, error code on failure
      */
     int initialize(Runtime& runtime,
-                   int num_aicore,
-                   int device_id,
-                   PerfAllocCallback alloc_cb,
-                   PerfRegisterCallback register_cb,
-                   PerfFreeCallback free_cb,
-                   void* user_data);
+        int num_aicore,
+        int device_id,
+        PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb,
+        void* user_data,
+        PerfSetDeviceCallback set_device_cb = nullptr);
 
     /**
      * Start the memory management thread
@@ -305,9 +338,7 @@ public:
      * @param user_data User-provided context pointer
      * @return 0 on success, error code on failure
      */
-    int finalize(PerfUnregisterCallback unregister_cb,
-                 PerfFreeCallback free_cb,
-                 void* user_data);
+    int finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data);
 
     /**
      * Check if collector is initialized
@@ -334,11 +365,27 @@ public:
     void collect_phase_data();
 
     /**
+     * Scan PerfBufferState::current_buf_ptr for all cores to recover
+     * partial records not delivered through the pipeline.
+     *
+     * Must be called after device execution completes and after
+     * stop_memory_manager(). Follows the same pattern as collect_phase_data()
+     * for PhaseBufferStates.
+     */
+    void scan_remaining_perf_buffers();
+
+    /**
+     * Signal that device execution is complete (streams synchronized).
+     * poll_and_collect() will drain remaining pipeline data and exit.
+     */
+    void signal_execution_complete();
+
+    /**
      * Get collected records (for testing)
      */
     const std::vector<std::vector<PerfRecord>>& get_records() const { return collected_perf_records_; }
 
-private:
+ private:
     // Shared memory pointers
     void* perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
     void* perf_shared_mem_host_{nullptr};  // Host-mapped pointer (slot arrays)
@@ -352,6 +399,7 @@ private:
     PerfAllocCallback alloc_cb_{nullptr};
     PerfRegisterCallback register_cb_{nullptr};
     PerfFreeCallback free_cb_{nullptr};
+    PerfSetDeviceCallback set_device_cb_{nullptr};
     void* user_data_{nullptr};
 
     // Memory manager
@@ -368,8 +416,11 @@ private:
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
     std::vector<int8_t> core_to_thread_;
 
+    // Signal from device_runner that execution is complete
+    std::atomic<bool> execution_complete_{false};
+
     // Allocate a single buffer (PerfBuffer or PhaseBuffer) and register it
     void* alloc_single_buffer(size_t size, void** host_ptr_out);
 };
 
-#endif  // PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_
+#endif  // SRC_A2A3_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -482,12 +482,18 @@ int DeviceRunner::run(Runtime& runtime,
             LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
             return rc;
         }
+
+        // Signal collector that device execution is complete
+        if (runtime.enable_profiling) {
+            perf_collector_.signal_execution_complete();
+        }
     }
 
     // Stop memory management, drain remaining buffers, collect phase data, export
     if (runtime.enable_profiling) {
         perf_collector_.stop_memory_manager();
         perf_collector_.drain_remaining_buffers();
+        perf_collector_.scan_remaining_perf_buffers();
         perf_collector_.collect_phase_data();
         export_swimlane_json();
     }
@@ -748,7 +754,10 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
         return allocator->free(dev_ptr);
     };
 
-    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_);
+    auto set_device_cb = [](int device_id, void* /*user_data*/) -> int { return rtSetDevice(device_id); };
+
+    return perf_collector_.initialize(
+        runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_, set_device_cb);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -339,6 +339,11 @@ int DeviceRunner::run(Runtime& runtime,
         t.join();
     }
 
+    // Signal collector that device execution is complete
+    if (runtime.enable_profiling) {
+        perf_collector_.signal_execution_complete();
+    }
+
     // Wait for collector thread if it was launched
     if (runtime.enable_profiling && collector_thread.joinable()) {
         collector_thread.join();
@@ -350,6 +355,7 @@ int DeviceRunner::run(Runtime& runtime,
     if (runtime.enable_profiling) {
         perf_collector_.stop_memory_manager();
         perf_collector_.drain_remaining_buffers();
+        perf_collector_.scan_remaining_perf_buffers();
         perf_collector_.collect_phase_data();
         export_swimlane_json();
     }
@@ -563,7 +569,7 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
     };
 
     // Simulation: no registration needed (pass nullptr)
-    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, nullptr, free_cb, nullptr);
+    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, nullptr, free_cb, nullptr, nullptr);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {

--- a/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file performance_collector_aicpu.cpp
  * @brief AICPU performance data collection implementation (SPSC free queue)
@@ -8,11 +19,13 @@
  */
 
 #include "aicpu/performance_collector_aicpu.h"
-#include "common/memory_barrier.h"
-#include "common/unified_log.h"
-#include "common/platform_config.h"
 
+#include <cinttypes>
 #include <cstring>
+
+#include "common/memory_barrier.h"
+#include "common/platform_config.h"
+#include "common/unified_log.h"
 
 // Cached pointers for hot-path access (set during init)
 static AicpuPhaseHeader* s_phase_header = nullptr;
@@ -64,7 +77,7 @@ static int enqueue_ready_buffer(PerfDataHeader* header,
 }
 
 void perf_aicpu_init_profiling(Runtime* runtime) {
-    void* perf_base = (void*)runtime->perf_data_base;
+    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize profiling");
         return;
@@ -97,7 +110,7 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
             state->current_buf_seq = 0;
             wmb();
 
-            PerfBuffer* buf = (PerfBuffer*)buf_ptr;
+            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(buf_ptr);
             buf->count = 0;
             h->perf_records_addr = buf_ptr;
 
@@ -115,14 +128,14 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
 }
 
 int perf_aicpu_complete_record(PerfBuffer* perf_buf,
-                                uint32_t expected_reg_task_id,
-                                uint64_t task_id,
-                                uint32_t func_id,
-                                CoreType core_type,
-                                uint64_t dispatch_time,
-                                uint64_t finish_time,
-                                const uint64_t* fanout,
-                                int32_t fanout_count) {
+    uint32_t expected_reg_task_id,
+    uint64_t task_id,
+    uint32_t func_id,
+    CoreType core_type,
+    uint64_t dispatch_time,
+    uint64_t finish_time,
+    const uint64_t* fanout,
+    int32_t fanout_count) {
     rmb();
     uint32_t count = perf_buf->count;
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
@@ -137,8 +150,7 @@ int perf_aicpu_complete_record(PerfBuffer* perf_buf,
     record->finish_time = finish_time;
 
     if (fanout != nullptr && fanout_count > 0) {
-        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT)
-                        ? RUNTIME_MAX_FANOUT : fanout_count;
+        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT) ? RUNTIME_MAX_FANOUT : fanout_count;
         for (int32_t i = 0; i < n; i++) {
             record->fanout[i] = fanout[i];
         }
@@ -153,7 +165,7 @@ int perf_aicpu_complete_record(PerfBuffer* perf_buf,
 }
 
 void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
-    void* perf_base = (void*)runtime->perf_data_base;
+    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
@@ -163,21 +175,31 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
         return;
     }
 
-    PerfBuffer* full_buf = (PerfBuffer*)state->current_buf_ptr;
+    PerfBuffer* full_buf = reinterpret_cast<PerfBuffer*>(state->current_buf_ptr);
     if (full_buf == nullptr) {
         return;
     }
 
-    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)",
-         thread_idx, core_id, full_buf->count);
+    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)", thread_idx, core_id, full_buf->count);
 
-    // Enqueue to ReadyQueue
+    // Check free_queue before committing the full buffer
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head == tail) {
+        // No replacement buffer available — overwrite current buffer to keep AICore alive
+        LOG_WARN("Thread %d: Core %d no free buffer, overwriting current buffer (data lost)", thread_idx, core_id);
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Enqueue full buffer to ReadyQueue
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
-        state->current_buf_ptr, seq, 0);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, state->current_buf_ptr, seq, 0);
     if (rc != 0) {
-        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
-             thread_idx, core_id);
+        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
         // Revert: discard data and keep writing
         full_buf->count = 0;
         wmb();
@@ -185,48 +207,30 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
     }
 
     // Pop next buffer from free_queue
+    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
     rmb();
-    uint32_t head = state->free_queue.head;
-    uint32_t tail = state->free_queue.tail;
+    state->free_queue.head = head + 1;
+    state->current_buf_ptr = new_buf_ptr;
+    state->current_buf_seq = seq + 1;
+    wmb();
 
-    if (head != tail) {
-        uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-        rmb();
-        state->free_queue.head = head + 1;
-        state->current_buf_ptr = new_buf_ptr;
-        state->current_buf_seq = seq + 1;
-        wmb();
+    PerfBuffer* new_buf = reinterpret_cast<PerfBuffer*>(new_buf_ptr);
+    new_buf->count = 0;
 
-        PerfBuffer* new_buf = (PerfBuffer*)new_buf_ptr;
-        new_buf->count = 0;
+    // Update handshake for AICore
+    Handshake* h = &runtime->workers[core_id];
+    h->perf_records_addr = new_buf_ptr;
+    wmb();
 
-        // Update handshake for AICore
-        Handshake* h = &runtime->workers[core_id];
-        h->perf_records_addr = new_buf_ptr;
-        wmb();
-
-        LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", 
-            thread_idx, core_id, new_buf_ptr);
-    } else {
-        // No free buffer available, stop profiling
-        LOG_WARN("Thread %d: Core %d no free buffer available, stopping profiling", 
-            thread_idx, core_id);
-        state->current_buf_ptr = 0;
-        Handshake* h = &runtime->workers[core_id];
-        h->perf_records_addr = 0;
-        wmb();
-    }
+    LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
 }
 
-void perf_aicpu_flush_buffers(Runtime* runtime, 
-    int thread_idx, 
-    const int* cur_thread_cores, 
-    int core_num) {
+void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
     if (!runtime->enable_profiling) {
         return;
     }
 
-    void* perf_base = (void*)runtime->perf_data_base;
+    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
@@ -249,34 +253,30 @@ void perf_aicpu_flush_buffers(Runtime* runtime,
             continue;
         }
 
-        PerfBuffer* buf = (PerfBuffer*)buf_ptr;
+        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(buf_ptr);
         if (buf->count == 0) {
             continue;
         }
 
         uint32_t seq = state->current_buf_seq;
-        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
-            buf_ptr, seq, 0);
+        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, buf_ptr, seq, 0);
         if (rc == 0) {
-            LOG_INFO("Thread %d: Core %d flushed buffer with %u records",
-                thread_idx, core_id, buf->count);
+            LOG_INFO("Thread %d: Core %d flushed buffer with %u records", thread_idx, core_id, buf->count);
             flushed_count++;
             state->current_buf_ptr = 0;
             wmb();
         } else {
-            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
-                thread_idx, core_id);
+            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
         }
     }
 
     wmb();
 
-    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", 
-        thread_idx, flushed_count);
+    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
 }
 
 void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
-    void* perf_base = (void*)runtime->perf_data_base;
+    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
@@ -287,7 +287,7 @@ void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
 }
 
 void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, int num_orch_threads) {
-    void* perf_base = (void*)runtime->perf_data_base;
+    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize phase profiling");
         return;
@@ -328,7 +328,7 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
             state->current_buf_seq = 0;
             wmb();
 
-            PhaseBuffer* buf = (PhaseBuffer*)buf_ptr;
+            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
             buf->count = 0;
             s_current_phase_buf[t] = buf;
 
@@ -349,7 +349,9 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
     wmb();
 
     LOG_INFO("Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread",
-        num_sched_threads, num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD);
+        num_sched_threads,
+        num_orch_threads,
+        PLATFORM_PHASE_RECORDS_PER_THREAD);
 }
 
 /**
@@ -366,16 +368,13 @@ static void switch_phase_buffer(int thread_idx) {
     PhaseBuffer* full_buf = s_current_phase_buf[thread_idx];
     if (full_buf == nullptr) return;
 
-    LOG_INFO("Thread %d: phase buffer is full (count=%u)",
-        thread_idx, full_buf->count);
+    LOG_INFO("Thread %d: phase buffer is full (count=%u)", thread_idx, full_buf->count);
 
     // Enqueue to ReadyQueue
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-        state->current_buf_ptr, seq, 1);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, state->current_buf_ptr, seq, 1);
     if (rc != 0) {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data",
-            thread_idx);
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data", thread_idx);
         full_buf->count = 0;
         wmb();
         return;
@@ -394,15 +393,14 @@ static void switch_phase_buffer(int thread_idx) {
         state->current_buf_seq = seq + 1;
         wmb();
 
-        PhaseBuffer* new_buf = (PhaseBuffer*)new_buf_ptr;
+        PhaseBuffer* new_buf = reinterpret_cast<PhaseBuffer*>(new_buf_ptr);
         new_buf->count = 0;
         s_current_phase_buf[thread_idx] = new_buf;
 
         LOG_INFO("Thread %d: switched to new phase buffer", thread_idx);
     } else {
         // No free buffer available, drop subsequent records
-        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up",
-            thread_idx);
+        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up", thread_idx);
         s_current_phase_buf[thread_idx] = nullptr;
         state->current_buf_ptr = 0;
         wmb();
@@ -411,8 +409,10 @@ static void switch_phase_buffer(int thread_idx) {
 
 void perf_aicpu_record_phase(int thread_idx,
     AicpuPhaseId phase_id,
-    uint64_t start_time, uint64_t end_time,
-    uint32_t loop_iter, uint64_t tasks_processed) {
+    uint64_t start_time,
+    uint64_t end_time,
+    uint32_t loop_iter,
+    uint64_t tasks_processed) {
     if (s_phase_header == nullptr) {
         return;
     }
@@ -436,7 +436,7 @@ void perf_aicpu_record_phase(int thread_idx,
             state->current_buf_seq = state->current_buf_seq + 1;
             wmb();
 
-            buf = (PhaseBuffer*)buf_ptr;
+            buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
             buf->count = 0;
             s_current_phase_buf[thread_idx] = buf;
 
@@ -481,18 +481,15 @@ void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src) {
 
     wmb();
 
-    LOG_INFO("Orchestrator summary written: %lld tasks, %.3fus",
-        (long long)src->submit_count,
+    LOG_INFO("Orchestrator summary written: %" PRId64 " tasks, %.3fus",
+        static_cast<int64_t>(src->submit_count),
         cycles_to_us(src->end_time - src->start_time));
 }
 
-void perf_aicpu_set_orch_thread_idx(int thread_idx) { 
-    s_orch_thread_idx = thread_idx; 
-}
+void perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }
 
-void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
-    uint64_t start_time, uint64_t end_time,
-    uint32_t submit_idx, uint64_t task_id) {
+void perf_aicpu_record_orch_phase(
+    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id) {
     if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
     perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
 }
@@ -512,23 +509,20 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
         return;
     }
 
-    PhaseBuffer* buf = (PhaseBuffer*)buf_ptr;
+    PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
     if (buf->count == 0) {
         return;
     }
 
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-        buf_ptr, seq, 1);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, buf_ptr, seq, 1);
     if (rc == 0) {
-        LOG_INFO("Thread %d: flushed phase buffer with %u records",
-            thread_idx, buf->count);
+        LOG_INFO("Thread %d: flushed phase buffer with %u records", thread_idx, buf->count);
         state->current_buf_ptr = 0;
         s_current_phase_buf[thread_idx] = nullptr;
         wmb();
     } else {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!",
-            thread_idx);
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!", thread_idx);
     }
 
     wmb();

--- a/src/a2a3/platform/src/host/performance_collector.cpp
+++ b/src/a2a3/platform/src/host/performance_collector.cpp
@@ -52,7 +52,8 @@ void ProfMemoryManager::start(void* shared_mem_host,
     PerfRegisterCallback register_cb,
     PerfFreeCallback free_cb,
     void* user_data,
-    int device_id) {
+    int device_id,
+    PerfSetDeviceCallback set_device_cb) {
     shared_mem_host_ = shared_mem_host;
     num_cores_ = num_cores;
     num_phase_threads_ = num_phase_threads;
@@ -61,6 +62,7 @@ void ProfMemoryManager::start(void* shared_mem_host,
     free_cb_ = free_cb;
     user_data_ = user_data;
     device_id_ = device_id;
+    set_device_cb_ = set_device_cb;
 
     running_.store(true);
     mgmt_thread_ = std::thread(&ProfMemoryManager::mgmt_loop, this);
@@ -83,6 +85,16 @@ void ProfMemoryManager::stop() {
             free_buffer(info.dev_buffer_ptr);
         }
     }
+
+    // Free recycled buffers
+    for (void* ptr : recycled_perf_buffers_) {
+        free_buffer(ptr);
+    }
+    recycled_perf_buffers_.clear();
+    for (void* ptr : recycled_phase_buffers_) {
+        free_buffer(ptr);
+    }
+    recycled_phase_buffers_.clear();
 
     LOG_INFO("ProfMemoryManager stopped");
 }
@@ -115,7 +127,10 @@ void ProfMemoryManager::notify_copy_done(const CopyDoneInfo& info) {
 void* ProfMemoryManager::alloc_and_register(size_t size, void** host_ptr_out) {
     void* dev_ptr = alloc_cb_(size, user_data_);
     if (dev_ptr == nullptr) {
-        LOG_ERROR("ProfMemoryManager: alloc failed for %zu bytes", size);
+        const char* hint = (size == sizeof(PerfBuffer))
+                               ? "increase PLATFORM_PROF_BUFFERS_PER_CORE to reduce profiling data loss"
+                               : "increase PLATFORM_PROF_BUFFERS_PER_THREAD to reduce profiling data loss";
+        LOG_WARN("ProfMemoryManager: alloc failed for %zu bytes, %s", size, hint);
         *host_ptr_out = nullptr;
         return nullptr;
     }
@@ -175,30 +190,51 @@ void ProfMemoryManager::process_ready_entry(
 
         PhaseBufferState* state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
 
-        // Allocate new PhaseBuffer
-        void* host_ptr = nullptr;
-        void* new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
-        if (new_dev_ptr != nullptr) {
-            // Initialize new buffer
-            PhaseBuffer* new_buf = reinterpret_cast<PhaseBuffer*>(host_ptr);
-            new_buf->count = 0;
+        // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
+        // Source priority: recycled pool → drain done_queue → alloc (last resort).
+        rmb();
+        uint32_t head_val = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t available = tail - head_val;
 
-            // Push to free_queue (with overflow guard)
-            rmb();
-            uint32_t head_val = state->free_queue.head;
-            uint32_t tail = state->free_queue.tail;
-            if ((tail - head_val) >= PLATFORM_PROF_SLOT_COUNT) {
-                LOG_ERROR("ProfMemoryManager: phase free_queue overflow for thread %u", tidx);
-                free_buffer(new_dev_ptr);
-            } else {
-                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] =
-                    reinterpret_cast<uint64_t>(new_dev_ptr);
-                wmb();
-                state->free_queue.tail = tail + 1;
-                wmb();
+        int to_push = PLATFORM_PROF_SLOT_COUNT;
+        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
+            void* host_ptr = nullptr;
+            void* new_dev_ptr = nullptr;
+
+            if (!recycled_phase_buffers_.empty()) {
+                new_dev_ptr = recycled_phase_buffers_.back();
+                recycled_phase_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
             }
-        } else {
-            LOG_ERROR("ProfMemoryManager: phase buffer alloc failed, device may lose data");
+            if (new_dev_ptr == nullptr) {
+                std::lock_guard<std::mutex> lock(done_mutex_);
+                while (!done_queue_.empty()) {
+                    CopyDoneInfo dinfo = done_queue_.front();
+                    done_queue_.pop();
+                    if (dinfo.type == ProfBufferType::PERF_RECORD)
+                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else
+                        recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                }
+            }
+            if (new_dev_ptr == nullptr && !recycled_phase_buffers_.empty()) {
+                new_dev_ptr = recycled_phase_buffers_.back();
+                recycled_phase_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
+            }
+            if (new_dev_ptr == nullptr) break;
+
+            reinterpret_cast<PhaseBuffer*>(host_ptr)->count = 0;
+            uint32_t cur_tail = tail + p;
+            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
+                reinterpret_cast<uint64_t>(new_dev_ptr);
+            wmb();
+            state->free_queue.tail = cur_tail + 1;
+            wmb();
         }
 
         // Resolve host pointer of old buffer
@@ -233,29 +269,50 @@ void ProfMemoryManager::process_ready_entry(
 
         PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, core_index);
 
-        // Allocate new PerfBuffer
-        void* host_ptr = nullptr;
-        void* new_dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
-        if (new_dev_ptr != nullptr) {
-            PerfBuffer* new_buf = reinterpret_cast<PerfBuffer*>(host_ptr);
-            new_buf->count = 0;
+        // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
+        rmb();
+        uint32_t head_val = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t available = tail - head_val;
 
-            // Push to free_queue (with overflow guard)
-            rmb();
-            uint32_t head_val = state->free_queue.head;
-            uint32_t tail = state->free_queue.tail;
-            if ((tail - head_val) >= PLATFORM_PROF_SLOT_COUNT) {
-                LOG_ERROR("ProfMemoryManager: perf free_queue overflow for core %u", core_index);
-                free_buffer(new_dev_ptr);
-            } else {
-                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] =
-                    reinterpret_cast<uint64_t>(new_dev_ptr);
-                wmb();
-                state->free_queue.tail = tail + 1;
-                wmb();
+        int to_push = PLATFORM_PROF_SLOT_COUNT;
+        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
+            void* host_ptr = nullptr;
+            void* new_dev_ptr = nullptr;
+
+            if (!recycled_perf_buffers_.empty()) {
+                new_dev_ptr = recycled_perf_buffers_.back();
+                recycled_perf_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
             }
-        } else {
-            LOG_ERROR("ProfMemoryManager: perf buffer alloc failed, device may lose data");
+            if (new_dev_ptr == nullptr) {
+                std::lock_guard<std::mutex> lock(done_mutex_);
+                while (!done_queue_.empty()) {
+                    CopyDoneInfo dinfo = done_queue_.front();
+                    done_queue_.pop();
+                    if (dinfo.type == ProfBufferType::PERF_RECORD)
+                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else
+                        recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                }
+            }
+            if (new_dev_ptr == nullptr && !recycled_perf_buffers_.empty()) {
+                new_dev_ptr = recycled_perf_buffers_.back();
+                recycled_perf_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                new_dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
+            }
+            if (new_dev_ptr == nullptr) break;
+
+            reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+            uint32_t cur_tail = tail + p;
+            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
+                reinterpret_cast<uint64_t>(new_dev_ptr);
+            wmb();
+            state->free_queue.tail = cur_tail + 1;
+            wmb();
         }
 
         void* old_host_ptr = resolve_host_ptr(reinterpret_cast<void*>(old_dev_ptr));
@@ -282,16 +339,27 @@ void ProfMemoryManager::process_ready_entry(
 }
 
 void ProfMemoryManager::mgmt_loop() {
+    if (set_device_cb_ != nullptr) {
+        int rc = set_device_cb_(device_id_, user_data_);
+        if (rc != 0) {
+            LOG_ERROR("mgmt_loop: set_device_cb(%d) failed: %d", device_id_, rc);
+        }
+    }
+
     PerfDataHeader* header = get_perf_header(shared_mem_host_);
 
     while (running_.load()) {
-        // 1. Process done queue: free buffers that main thread has finished copying
+        // 1. Recycle done queue: move completed buffers to recycled pools for reuse
         {
             std::lock_guard<std::mutex> lock(done_mutex_);
             while (!done_queue_.empty()) {
                 CopyDoneInfo info = done_queue_.front();
                 done_queue_.pop();
-                free_buffer(info.dev_buffer_ptr);
+                if (info.type == ProfBufferType::PERF_RECORD) {
+                    recycled_perf_buffers_.push_back(info.dev_buffer_ptr);
+                } else {
+                    recycled_phase_buffers_.push_back(info.dev_buffer_ptr);
+                }
             }
         }
 
@@ -333,7 +401,71 @@ void ProfMemoryManager::mgmt_loop() {
             }
         }
 
-        // 3. If nothing found, yield briefly to avoid busy-spinning
+        // 3. Proactive replenishment: push buffers to cores/threads whose free_queue
+        //    is completely empty (avail == 0). Try recycled pool first, alloc as fallback.
+        if (!recycled_perf_buffers_.empty() || !recycled_phase_buffers_.empty()) {
+            for (int i = 0; i < num_cores_ && !recycled_perf_buffers_.empty(); i++) {
+                PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, i);
+                rmb();
+                uint32_t avail = state->free_queue.tail - state->free_queue.head;
+                if (avail == 0) {
+                    void* dev_ptr = recycled_perf_buffers_.back();
+                    recycled_perf_buffers_.pop_back();
+                    void* host_ptr = resolve_host_ptr(dev_ptr);
+                    if (host_ptr != nullptr) {
+                        reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+                        uint32_t t_val = state->free_queue.tail;
+                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                            reinterpret_cast<uint64_t>(dev_ptr);
+                        wmb();
+                        state->free_queue.tail = t_val + 1;
+                        wmb();
+                    }
+                }
+            }
+            for (int t = 0; t < num_phase_threads_ && !recycled_phase_buffers_.empty(); t++) {
+                PhaseBufferState* state = get_phase_buffer_state(shared_mem_host_, num_cores_, t);
+                rmb();
+                uint32_t avail = state->free_queue.tail - state->free_queue.head;
+                if (avail == 0) {
+                    void* dev_ptr = recycled_phase_buffers_.back();
+                    recycled_phase_buffers_.pop_back();
+                    void* host_ptr = resolve_host_ptr(dev_ptr);
+                    if (host_ptr != nullptr) {
+                        reinterpret_cast<PhaseBuffer*>(host_ptr)->count = 0;
+                        uint32_t t_val = state->free_queue.tail;
+                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                            reinterpret_cast<uint64_t>(dev_ptr);
+                        wmb();
+                        state->free_queue.tail = t_val + 1;
+                        wmb();
+                    }
+                }
+            }
+        }
+        // Alloc fallback: if recycled pools are both empty, scan for depleted cores and alloc.
+        // This only triggers when ALL pre-allocated buffers are in-flight (extreme workloads).
+        if (recycled_perf_buffers_.empty() && recycled_phase_buffers_.empty()) {
+            for (int i = 0; i < num_cores_; i++) {
+                PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, i);
+                rmb();
+                if (state->free_queue.tail - state->free_queue.head == 0) {
+                    void* host_ptr = nullptr;
+                    void* dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
+                    if (dev_ptr == nullptr) break;  // HBM exhausted, stop trying
+                    reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+                    uint32_t t_val = state->free_queue.tail;
+                    state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                        reinterpret_cast<uint64_t>(dev_ptr);
+                    wmb();
+                    state->free_queue.tail = t_val + 1;
+                    wmb();
+                    break;  // One alloc per iteration to limit rtMalloc frequency
+                }
+            }
+        }
+
+        // 4. If nothing found, yield briefly to avoid busy-spinning
         if (!found_any) {
             std::this_thread::sleep_for(std::chrono::microseconds(10));
         }
@@ -416,7 +548,8 @@ int PerformanceCollector::initialize(Runtime& runtime,
     PerfAllocCallback alloc_cb,
     PerfRegisterCallback register_cb,
     PerfFreeCallback free_cb,
-    void* user_data) {
+    void* user_data,
+    PerfSetDeviceCallback set_device_cb) {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
         return -1;
@@ -435,6 +568,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     register_cb_ = register_cb;
     free_cb_ = free_cb;
     user_data_ = user_data;
+    set_device_cb_ = set_device_cb;
 
     // Step 1: Calculate shared memory size (slot arrays only, no actual buffers)
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
@@ -491,7 +625,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("  buffer_capacity:  %d", PLATFORM_PROF_BUFFER_SIZE);
     LOG_DEBUG("  queue capacity:   %d", PLATFORM_PROF_READYQUEUE_SIZE);
 
-    // Step 5: Initialize PerfBufferStates and pre-fill free_queues
+    // Step 5: Initialize PerfBufferStates — 1 buffer per core in free_queue, rest to recycled pool
     for (int i = 0; i < num_aicore; i++) {
         PerfBufferState* state = get_perf_buffer_state(perf_host_ptr, i);
         memset(state, 0, sizeof(PerfBufferState));
@@ -501,29 +635,32 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->current_buf_ptr = 0;
         state->current_buf_seq = 0;
 
-        // Pre-fill free_queue with PLATFORM_PROF_SLOT_COUNT buffers
-        for (int s = 0; s < PLATFORM_PROF_SLOT_COUNT; s++) {
+        for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_CORE; s++) {
             void* host_buf_ptr = nullptr;
             void* dev_buf_ptr = alloc_single_buffer(sizeof(PerfBuffer), &host_buf_ptr);
             if (dev_buf_ptr == nullptr) {
                 LOG_ERROR("Failed to allocate PerfBuffer for core %d, buffer %d", i, s);
                 return -1;
             }
-            // Initialize buffer
             PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(host_buf_ptr);
             memset(buf, 0, sizeof(PerfBuffer));
             buf->count = 0;
 
-            // Push to free_queue
-            state->free_queue.buffer_ptrs[s] = reinterpret_cast<uint64_t>(dev_buf_ptr);
+            if (s == 0) {
+                state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
+            } else {
+                memory_manager_.recycled_perf_buffers_.push_back(dev_buf_ptr);
+            }
         }
         wmb();
-        state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
+        state->free_queue.tail = 1;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PerfBufferStates with %d buffers each", num_aicore, PLATFORM_PROF_SLOT_COUNT);
+    LOG_DEBUG("Initialized %d PerfBufferStates: 1 buffer/core, %d in recycled pool",
+        num_aicore,
+        num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1));
 
-    // Step 6: Initialize PhaseBufferStates and pre-fill free_queues
+    // Step 6: Initialize PhaseBufferStates — 1 buffer per thread in free_queue, rest to recycled pool
     for (int t = 0; t < num_phase_threads; t++) {
         PhaseBufferState* state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
         memset(state, 0, sizeof(PhaseBufferState));
@@ -533,8 +670,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->current_buf_ptr = 0;
         state->current_buf_seq = 0;
 
-        // Pre-fill free_queue with PLATFORM_PROF_SLOT_COUNT buffers
-        for (int s = 0; s < PLATFORM_PROF_SLOT_COUNT; s++) {
+        for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_THREAD; s++) {
             void* host_buf_ptr = nullptr;
             void* dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
             if (dev_buf_ptr == nullptr) {
@@ -545,14 +681,19 @@ int PerformanceCollector::initialize(Runtime& runtime,
             memset(buf, 0, sizeof(PhaseBuffer));
             buf->count = 0;
 
-            // Push to free_queue
-            state->free_queue.buffer_ptrs[s] = reinterpret_cast<uint64_t>(dev_buf_ptr);
+            if (s == 0) {
+                state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
+            } else {
+                memory_manager_.recycled_phase_buffers_.push_back(dev_buf_ptr);
+            }
         }
         wmb();
-        state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
+        state->free_queue.tail = 1;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PhaseBufferStates with %d buffers each", num_phase_threads, PLATFORM_PROF_SLOT_COUNT);
+    LOG_DEBUG("Initialized %d PhaseBufferStates: 1 buffer/thread, %d in recycled pool",
+        num_phase_threads,
+        num_phase_threads * (PLATFORM_PROF_BUFFERS_PER_THREAD - 1));
 
     wmb();
 
@@ -579,7 +720,8 @@ void PerformanceCollector::start_memory_manager() {
         register_cb_,
         free_cb_,
         user_data_,
-        device_id_);
+        device_id_,
+        set_device_cb_);
 }
 
 void PerformanceCollector::stop_memory_manager() {
@@ -588,10 +730,14 @@ void PerformanceCollector::stop_memory_manager() {
     }
 }
 
+void PerformanceCollector::signal_execution_complete() { execution_complete_.store(true); }
+
 void PerformanceCollector::poll_and_collect(int expected_tasks) {
     if (perf_shared_mem_host_ == nullptr) {
         return;
     }
+
+    execution_complete_.store(false);
 
     LOG_INFO("Collecting performance data");
 
@@ -599,6 +745,16 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
 
     const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);
     std::optional<std::chrono::steady_clock::time_point> idle_start;
+
+    // Initialize collection storage before the waiting loop so buffers
+    // can be processed immediately, preventing device memory leaks.
+    int total_records_collected = 0;
+    int buffers_processed = 0;
+
+    collected_perf_records_.clear();
+    collected_perf_records_.resize(num_aicore_);
+    collected_phase_records_.clear();
+    collected_phase_records_.resize(PLATFORM_MAX_AICPU_THREADS);
 
     if (expected_tasks <= 0) {
         LOG_INFO("Waiting for AICPU to write total_tasks in PerfDataHeader...");
@@ -621,24 +777,44 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 return;
             }
 
-            // Check for ready buffers while waiting
+            // Process ready buffers while waiting to free device memory
             ReadyBufferInfo info;
             if (memory_manager_.try_pop_ready(info)) {
-                // Process it (even before we know expected_tasks)
-                // Will be counted below
+                if (info.type == ProfBufferType::PERF_RECORD) {
+                    PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
+                    rmb();
+                    uint32_t count = buf->count;
+                    if (count > PLATFORM_PROF_BUFFER_SIZE) {
+                        count = PLATFORM_PROF_BUFFER_SIZE;
+                    }
+                    uint32_t core_index = info.index;
+                    if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                        for (uint32_t i = 0; i < count; i++) {
+                            collected_perf_records_[core_index].push_back(buf->records[i]);
+                        }
+                        total_records_collected += count;
+                    }
+                } else {
+                    PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
+                    rmb();
+                    uint32_t count = buf->count;
+                    if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                        count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                    }
+                    uint32_t tidx = info.index;
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_phase_records_[tidx].push_back(buf->records[i]);
+                    }
+                }
+                memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
+                buffers_processed++;
             }
         }
     }
 
     LOG_DEBUG("Initial expected tasks: %d", expected_tasks);
 
-    int total_records_collected = 0;
-    int buffers_processed = 0;
-
-    collected_perf_records_.clear();
-    collected_perf_records_.resize(num_aicore_);
-
-    // Pre-allocate phase record storage
+    // Check phase header for scheduler thread info
     AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
     int num_sched_for_poll = 0;
     if (phase_header->magic == AICPU_PHASE_MAGIC) {
@@ -646,8 +822,6 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
         if (num_sched_for_poll > PLATFORM_MAX_AICPU_THREADS) {
             num_sched_for_poll = PLATFORM_MAX_AICPU_THREADS;
         }
-        collected_phase_records_.clear();
-        collected_phase_records_.resize(PLATFORM_MAX_AICPU_THREADS);
     }
 
     idle_start.reset();
@@ -707,12 +881,47 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 LOG_DEBUG("Collected %u phase records from thread %u", count, tidx);
             }
 
-            // Notify memory manager to free old buffer
-            memory_manager_.notify_copy_done({info.dev_buffer_ptr});
+            // Notify memory manager to recycle old buffer
+            memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
             buffers_processed++;
 
         } else {
-            // Timeout on wait — check for overall timeout
+            // Timeout on wait — check for execution complete signal or overall timeout
+            if (execution_complete_.load()) {
+                // Device is done. Final non-blocking drain and exit.
+                ReadyBufferInfo drain_info;
+                while (memory_manager_.try_pop_ready(drain_info)) {
+                    if (drain_info.type == ProfBufferType::PERF_RECORD) {
+                        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(drain_info.host_buffer_ptr);
+                        rmb();
+                        uint32_t count = buf->count;
+                        if (count > PLATFORM_PROF_BUFFER_SIZE) count = PLATFORM_PROF_BUFFER_SIZE;
+                        uint32_t ci = drain_info.index;
+                        if (ci < static_cast<uint32_t>(num_aicore_)) {
+                            for (uint32_t i = 0; i < count; i++) {
+                                collected_perf_records_[ci].push_back(buf->records[i]);
+                            }
+                            total_records_collected += count;
+                        }
+                    } else {
+                        PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(drain_info.host_buffer_ptr);
+                        rmb();
+                        uint32_t count = buf->count;
+                        if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD))
+                            count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                        uint32_t tidx = drain_info.index;
+                        for (uint32_t i = 0; i < count; i++) {
+                            collected_phase_records_[tidx].push_back(buf->records[i]);
+                        }
+                    }
+                    memory_manager_.notify_copy_done({drain_info.dev_buffer_ptr, drain_info.type});
+                    buffers_processed++;
+                }
+                LOG_INFO("Execution complete signal received, exiting with %d/%d records",
+                    total_records_collected,
+                    expected_tasks);
+                break;
+            }
             if (!idle_start.has_value()) {
                 idle_start = std::chrono::steady_clock::now();
             }
@@ -785,7 +994,7 @@ void PerformanceCollector::drain_remaining_buffers() {
             drained_phase += count;
         }
 
-        memory_manager_.notify_copy_done({info.dev_buffer_ptr});
+        memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
     }
 
     if (drained_perf > 0 || drained_phase > 0) {
@@ -794,6 +1003,52 @@ void PerformanceCollector::drain_remaining_buffers() {
 
     if (drained_phase > 0) {
         has_phase_data_ = true;
+    }
+}
+
+void PerformanceCollector::scan_remaining_perf_buffers() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    rmb();
+
+    int total_recovered = 0;
+
+    for (int core_index = 0; core_index < num_aicore_; core_index++) {
+        PerfBufferState* state = get_perf_buffer_state(perf_shared_mem_host_, core_index);
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) {
+            continue;
+        }
+
+        void* host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void*>(buf_ptr));
+        if (host_ptr == nullptr) {
+            LOG_ERROR("scan_remaining_perf_buffers: no host mapping for dev_ptr=%p (core %d)",
+                reinterpret_cast<void*>(buf_ptr),
+                core_index);
+            continue;
+        }
+
+        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(host_ptr);
+        uint32_t count = buf->count;
+        if (count == 0) {
+            continue;
+        }
+        if (count > PLATFORM_PROF_BUFFER_SIZE) {
+            count = PLATFORM_PROF_BUFFER_SIZE;
+        }
+
+        for (uint32_t i = 0; i < count; i++) {
+            collected_perf_records_[core_index].push_back(buf->records[i]);
+        }
+        total_recovered += count;
+    }
+
+    if (total_recovered > 0) {
+        LOG_INFO("scan_remaining_perf_buffers: recovered %d records from active buffers", total_recovered);
     }
 }
 

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -1,10 +1,21 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
 #include <mutex>
 
 #include "aicpu/device_log.h"
 #include "aicpu/device_time.h"
-#include "spin_hint.h"
 #include "aicpu/performance_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "common/memory_barrier.h"
@@ -12,6 +23,7 @@
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "runtime.h"
+#include "spin_hint.h"
 
 constexpr int MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 constexpr int MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
@@ -36,8 +48,8 @@ struct AicpuExecutor {
     int thread_num_{0};
     int cores_total_num_{0};
     int thread_cores_num_[MAX_AICPU_THREADS]{};  // Total cores (AIC+AIV) assigned to each thread
-    int aic_per_thread_{0};  // Max AIC cores per thread (ceil), used as local queue cap
-    int aiv_per_thread_{0};  // Max AIV cores per thread (ceil), used as local queue cap
+    int aic_per_thread_{0};                      // Max AIC cores per thread (ceil), used as local queue cap
+    int aiv_per_thread_{0};                      // Max AIV cores per thread (ceil), used as local queue cap
     int core_assignments_[MAX_AICPU_THREADS][MAX_CORES_PER_THREAD];
 
     // Core discovery arrays (space-time tradeoff: avoid sorting)
@@ -85,8 +97,8 @@ struct AicpuExecutor {
     std::atomic<int> finished_count_{0};
 
     // ===== Performance profiling state =====
-    uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];  // Per-core AICPU dispatch timestamp
-    uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER]; // Per-core total dispatched task counter
+    uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];   // Per-core AICPU dispatch timestamp
+    uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER];  // Per-core total dispatched task counter
 
     // ===== Methods =====
     int init(Runtime* runtime);
@@ -296,7 +308,7 @@ int AicpuExecutor::init(Runtime* runtime) {
  * @return 0 on success, -1 on failure
  */
 int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
-    Handshake* all_handshakes = (Handshake*)runtime->workers;
+    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
     cores_total_num_ = runtime->worker_count;
 
     // Validate cores_total_num_ before using as array index
@@ -333,7 +345,9 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
             LOG_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                      i, physical_core_id, max_physical_cores_count);
+                i,
+                physical_core_id,
+                max_physical_cores_count);
             handshake_failed = true;
             continue;
         }
@@ -395,7 +409,11 @@ void AicpuExecutor::assign_cores_to_threads() {
     aiv_per_thread_ = (aiv_count_ + thread_num_ - 1) / thread_num_;
 
     LOG_INFO("Core Assignment: %d AIC cores, %d AIV cores across %d threads (max %d AIC/thread, %d AIV/thread)",
-        aic_count_, aiv_count_, thread_num_, aic_per_thread_, aiv_per_thread_);
+        aic_count_,
+        aiv_count_,
+        thread_num_,
+        aic_per_thread_,
+        aiv_per_thread_);
 
     for (int t = 0; t < thread_num_; t++) {
         int core_idx = 0;
@@ -537,14 +555,14 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime* runtime) {
  * Shutdown AICore - Send quit signal to all AICore kernels
  */
 int AicpuExecutor::shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores) {
-    Handshake* all_handshakes = (Handshake*)runtime->workers;
+    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
 
     LOG_INFO("Thread %d: Shutting down %d cores", thread_idx, thread_cores_num_[thread_idx]);
 
     for (int i = 0; i < thread_cores_num_[thread_idx]; i++) {
         int core_id = cur_thread_cores[i];
         Handshake* hank = &all_handshakes[core_id];
-        LOG_INFO("Thread %d: AICPU hank addr = 0x%lx", thread_idx, (uint64_t)hank);
+        LOG_INFO("Thread %d: AICPU hank addr = 0x%lx", thread_idx, reinterpret_cast<uint64_t>(hank));
 
         uint64_t reg_addr = core_id_to_reg_addr_[core_id];
         if (reg_addr != 0) {
@@ -561,7 +579,7 @@ int AicpuExecutor::shutdown_aicore(Runtime* runtime, int thread_idx, const int* 
  * Resolve dependencies and dispatch tasks using fast-path scheduling
  */
 int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
-    Handshake* hank = (Handshake*)runtime.workers;
+    Handshake* hank = reinterpret_cast<Handshake*>(runtime.workers);
 
     LOG_INFO("Thread %d: Starting execution with %d cores", thread_idx, core_num);
 
@@ -615,32 +633,61 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             int reg_state = EXTRACT_TASK_STATE(reg_val);
 
             // Case 1: Pending task finished directly
-            if (reg_task_id == pending_task_ids_[core_id] &&
-                reg_state == TASK_FIN_STATE) {
-
+            if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {
                 LOG_INFO("Thread %d: Core %d completed task %d (running_id=%d)",
-                         thread_idx, core_id, pending_task_ids_[core_id], running_task_ids_[core_id]);
-                
+                    thread_idx,
+                    core_id,
+                    pending_task_ids_[core_id],
+                    running_task_ids_[core_id]);
 
                 int completed_task_id = pending_task_ids_[core_id];
+                int prev_running_id = running_task_ids_[core_id];
 
-                // Profiling
+                // Profiling: when prev_running_id exists, its AICore record was
+                // written first (at records[count]), so complete it BEFORE the
+                // pending task's record to maintain buffer ordering.
                 if (profiling_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    PerfBuffer* perf_buf = (PerfBuffer*)h->perf_records_addr;
+                    PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
+
+                    if (prev_running_id != AICPU_TASK_INVALID) {
+                        Task* prev_task = &runtime.tasks[prev_running_id];
+                        uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
+                        for (int i = 0; i < prev_task->fanout_count; i++) {
+                            fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
+                        }
+                        if (perf_aicpu_complete_record(perf_buf,
+                                static_cast<uint32_t>(prev_running_id),
+                                static_cast<uint64_t>(prev_running_id),
+                                prev_task->func_id,
+                                h->core_type,
+                                dispatch_timestamps_[core_id],
+                                finish_ts,
+                                fanout_arr,
+                                prev_task->fanout_count) != 0) {
+                            DEV_ERROR("Core %d: perf_aicpu_complete_record failed for implicit task %d",
+                                core_id,
+                                prev_running_id);
+                        }
+                        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    }
+
+                    finish_ts = get_sys_cnt_aicpu();
                     Task* task = &runtime.tasks[completed_task_id];
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     for (int i = 0; i < task->fanout_count; i++) {
                         fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
                     }
                     if (perf_aicpu_complete_record(perf_buf,
-                        static_cast<uint32_t>(completed_task_id),
-                        static_cast<uint64_t>(completed_task_id),
-                        task->func_id, h->core_type,
-                        dispatch_timestamps_[core_id], finish_ts,
-                        fanout_arr, task->fanout_count) != 0) {
-                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d",
-                            core_id, completed_task_id);
+                            static_cast<uint32_t>(completed_task_id),
+                            static_cast<uint64_t>(completed_task_id),
+                            task->func_id,
+                            h->core_type,
+                            dispatch_timestamps_[core_id],
+                            finish_ts,
+                            fanout_arr,
+                            task->fanout_count) != 0) {
+                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d", core_id, completed_task_id);
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
@@ -648,7 +695,6 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 cur_thread_completed++;
                 completed_tasks_.fetch_add(1, std::memory_order_release);
 
-                int prev_running_id = running_task_ids_[core_id];
                 pending_task_ids_[core_id] = AICPU_TASK_INVALID;
                 running_task_ids_[core_id] = AICPU_TASK_INVALID;
 
@@ -695,8 +741,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         cur_aiv_tail,
                         cur_aiv_ready_count);
 
-                    LOG_INFO("Thread %d: Core %d resolved old running task %d",
-                             thread_idx, core_id, prev_running_id);
+                    LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
                 Task* task = runtime.get_task(completed_task_id);
@@ -715,14 +760,13 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 if (!dispatched && profiling_enabled) {
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
-            }
-
-            // Case 2: Pending task received ACK
-            else if (reg_task_id == pending_task_ids_[core_id] &&
-                     reg_state == TASK_ACK_STATE) {
-
+            } else if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_ACK_STATE) {
+                // Case 2: Pending task received ACK
                 LOG_INFO("Thread %d: Core %d ACKed task %d (running_id=%d)",
-                         thread_idx, core_id, pending_task_ids_[core_id], running_task_ids_[core_id]);
+                    thread_idx,
+                    core_id,
+                    pending_task_ids_[core_id],
+                    running_task_ids_[core_id]);
 
                 int prev_running_id = running_task_ids_[core_id];
 
@@ -735,6 +779,31 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 // completed (AICore overwrote COND before we could read its FIN).
                 // Count it here to avoid losing completion.
                 if (prev_running_id != AICPU_TASK_INVALID) {
+                    // Profiling: complete the implicit task's AICore record
+                    if (profiling_enabled) {
+                        uint64_t finish_ts = get_sys_cnt_aicpu();
+                        PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
+                        Task* prev_task = &runtime.tasks[prev_running_id];
+                        uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
+                        for (int i = 0; i < prev_task->fanout_count; i++) {
+                            fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
+                        }
+                        if (perf_aicpu_complete_record(perf_buf,
+                                static_cast<uint32_t>(prev_running_id),
+                                static_cast<uint64_t>(prev_running_id),
+                                prev_task->func_id,
+                                h->core_type,
+                                dispatch_timestamps_[core_id],
+                                finish_ts,
+                                fanout_arr,
+                                prev_task->fanout_count) != 0) {
+                            DEV_ERROR("Core %d: perf_aicpu_complete_record failed for implicit task %d",
+                                core_id,
+                                prev_running_id);
+                        }
+                        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    }
+
                     cur_thread_completed++;
                     completed_tasks_.fetch_add(1, std::memory_order_release);
 
@@ -748,39 +817,39 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         cur_aiv_tail,
                         cur_aiv_ready_count);
 
-                    LOG_INFO("Thread %d: Core %d resolved old running task %d",
-                             thread_idx, core_id, prev_running_id);
+                    LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
                 // Core can accept new task now (pipeline!)
                 // Continue to Case 4 to dispatch next task
-            }
-
-            // Case 3: Running task finished
-            else if (reg_task_id == running_task_ids_[core_id] &&
-                     reg_state == TASK_FIN_STATE) {
-
+            } else if (reg_task_id == running_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {
+                // Case 3: Running task finished
                 LOG_INFO("Thread %d: Core %d completed task %d (pending_id=%d)",
-                         thread_idx, core_id, running_task_ids_[core_id], pending_task_ids_[core_id]);
+                    thread_idx,
+                    core_id,
+                    running_task_ids_[core_id],
+                    pending_task_ids_[core_id]);
 
                 int completed_task_id = running_task_ids_[core_id];
 
                 if (profiling_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    PerfBuffer* perf_buf = (PerfBuffer*)h->perf_records_addr;
+                    PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
                     Task* task = &runtime.tasks[completed_task_id];
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     for (int i = 0; i < task->fanout_count; i++) {
                         fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
                     }
                     if (perf_aicpu_complete_record(perf_buf,
-                        static_cast<uint32_t>(completed_task_id),
-                        static_cast<uint64_t>(completed_task_id),
-                        task->func_id, h->core_type,
-                        dispatch_timestamps_[core_id], finish_ts,
-                        fanout_arr, task->fanout_count) != 0) {
-                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d",
-                            core_id, completed_task_id);
+                            static_cast<uint32_t>(completed_task_id),
+                            static_cast<uint64_t>(completed_task_id),
+                            task->func_id,
+                            h->core_type,
+                            dispatch_timestamps_[core_id],
+                            finish_ts,
+                            fanout_arr,
+                            task->fanout_count) != 0) {
+                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d", core_id, completed_task_id);
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
@@ -910,7 +979,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
 
             for (int i = 0; i < core_num; i++) {
                 int core_id = cur_thread_cores[i];
-                if (pending_task_ids_[core_id] != AICPU_TASK_INVALID || running_task_ids_[core_id] != AICPU_TASK_INVALID) {
+                if (pending_task_ids_[core_id] != AICPU_TASK_INVALID ||
+                    running_task_ids_[core_id] != AICPU_TASK_INVALID) {
                     all_cores_idle = false;
 
                     if (verification_warning_count == 0) {
@@ -1061,7 +1131,7 @@ void AicpuExecutor::deinit(Runtime* runtime) {
 
 void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
     LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    Handshake* all_handshakes = (Handshake*)runtime->workers;
+    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
     for (int i = 0; i < cores_total_num_; i++) {
         Handshake* hank = &all_handshakes[i];
         hank->aicpu_regs_ready = 1;

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * Runtime Class - Task Dependency Runtime Management
  *
@@ -15,8 +26,8 @@
  * and lightweight scheduling use cases.
  */
 
-#ifndef RUNTIME_H
-#define RUNTIME_H
+#ifndef SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_
+#define SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -45,7 +56,7 @@
 #endif
 
 #ifndef RUNTIME_MAX_FANOUT
-#define RUNTIME_MAX_FANOUT 512
+#define RUNTIME_MAX_FANOUT 128
 #endif
 
 #ifndef RUNTIME_MAX_WORKER
@@ -101,17 +112,17 @@
  * - physical_core_id: Written by AICPU, read by AICore (physical core ID)
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;          // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;          // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                 // Task pointer: 0=no task, non-zero=Task* address
-    volatile int32_t task_status;           // Task execution status: 0=idle, 1=busy
-    volatile int32_t control;               // Control signal: 0=execute, 1=quit
-    volatile CoreType core_type;            // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t perf_records_addr;    // Performance records address
-    volatile uint32_t perf_buffer_status;   // 0 = not full, 1 = full
-    volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t aicpu_ready;         // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;         // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                // Task pointer: 0=no task, non-zero=Task* address
+    volatile int32_t task_status;          // Task execution status: 0=idle, 1=busy
+    volatile int32_t control;              // Control signal: 0=execute, 1=quit
+    volatile CoreType core_type;           // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t perf_records_addr;   // Performance records address
+    volatile uint32_t perf_buffer_status;  // 0 = not full, 1 = full
+    volatile uint32_t physical_core_id;    // Physical core ID
     volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;   // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**
@@ -182,32 +193,32 @@ typedef struct {
  * Dependencies are managed manually via add_successor().
  */
 class Runtime {
-public:
+ public:
     // Handshake buffers for AICPU-AICore communication
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int sche_cpu_num;  // Number of AICPU threads for scheduling
+    int sche_cpu_num;     // Number of AICPU threads for scheduling
     int orch_thread_num;  // Number of orchestrator threads (unused, for API compatibility)
 
     // Profiling support
-    bool enable_profiling;                  // Enable profiling flag
-    uint64_t perf_data_base;                // Performance data shared memory base address (device-side)
+    bool enable_profiling;    // Enable profiling flag
+    uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
 
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
 
-private:
-    int next_task_id;               // Next available task ID
+ private:
+    int next_task_id;  // Next available task ID
 
     // Initial ready tasks (computed once, read-only after)
     int initial_ready_tasks[RUNTIME_MAX_TASKS];
     int initial_ready_count;
 
-  // Tensor pairs for host-device memory tracking
-  TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
-  int tensor_pair_count;
+    // Tensor pairs for host-device memory tracking
+    TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
+    int tensor_pair_count;
 
     // Function address mapping (for API compatibility with rt2)
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
@@ -216,7 +227,7 @@ private:
     int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
     int registered_kernel_count_;
 
-public:
+ public:
     /**
      * Constructor - zero-initialize all arrays
      */
@@ -235,7 +246,7 @@ public:
      * @param core_type Core type for this task (CoreType::AIC or CoreType::AIV)
      * @return Task ID (>= 0) on success, -1 on failure
      */
-    int add_task(uint64_t *args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
+    int add_task(uint64_t* args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
 
     /**
      * Add a dependency edge: from_task -> to_task
@@ -258,7 +269,7 @@ public:
      * @param task_id  Task ID to query
      * @return Pointer to task, or nullptr if invalid ID
      */
-    Task *get_task(int task_id);
+    Task* get_task(int task_id);
 
     /**
      * Get the total number of tasks in the runtime
@@ -278,7 +289,7 @@ public:
      * nullptr)
      * @return Number of initially ready tasks
      */
-    int get_initial_ready_tasks(int *ready_tasks);
+    int get_initial_ready_tasks(int* ready_tasks);
 
     // =========================================================================
     // Utility Methods
@@ -373,4 +384,4 @@ public:
     HostApi host_api;
 };
 
-#endif  // RUNTIME_H
+#endif  // SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_

--- a/src/a5/platform/include/common/perf_profiling.h
+++ b/src/a5/platform/include/common/perf_profiling.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file perf_profiling.h
  * @brief Performance profiling data structures
@@ -40,18 +51,18 @@
  * With phases = Base + sizeof(AicpuPhaseHeader) + num_threads * sizeof(PhaseBufferState)
  */
 
-#ifndef PLATFORM_COMMON_PERF_PROFILING_H_
-#define PLATFORM_COMMON_PERF_PROFILING_H_
+#ifndef SRC_A5_PLATFORM_INCLUDE_COMMON_PERF_PROFILING_H_
+#define SRC_A5_PLATFORM_INCLUDE_COMMON_PERF_PROFILING_H_
 
 #include <cstdint>
 #include <vector>
 
-#include "platform_config.h"
 #include "core_type.h"
+#include "platform_config.h"
 
 // Maximum number of successor tasks per PerfRecord (matches Task::fanout)
 #ifndef RUNTIME_MAX_FANOUT
-#define RUNTIME_MAX_FANOUT 512
+#define RUNTIME_MAX_FANOUT 128
 #endif
 
 // =============================================================================
@@ -63,29 +74,28 @@
  */
 struct PerfRecord {
     // Timing information (device clock timestamps)
-    uint64_t start_time;         // Task start timestamp (get_sys_cnt)
-    uint64_t end_time;           // Task end timestamp
-    uint64_t duration;           // Execution duration (end - start)
+    uint64_t start_time;  // Task start timestamp (get_sys_cnt)
+    uint64_t end_time;    // Task end timestamp
+    uint64_t duration;    // Execution duration (end - start)
 
     // AICPU-side timestamps (written by AICPU, not AICore)
-    uint64_t dispatch_time;      // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
-    uint64_t finish_time;        // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
+    uint64_t dispatch_time;  // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
+    uint64_t finish_time;    // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
 
     // AICore writes the register dispatch token (low 32 bits only) zero-extended into task_id.
     // For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), AICPU overwrites
     // with the full PTO2 encoding (ring_id << 32) | local_id after FIN/perf row match.
     // For host_build_graph, task_id stays as the plain integer task index (ring_id = 0).
     uint64_t task_id;
-    uint32_t func_id;         // Kernel function identifier
-    CoreType core_type;       // Core type (AIC/AIV)
+    uint32_t func_id;    // Kernel function identifier
+    CoreType core_type;  // Core type (AIC/AIV)
 
     // Dependency relationship (fanout only)
     uint64_t fanout[RUNTIME_MAX_FANOUT];  // Successor task task_id array
-    int32_t fanout_count;                  // Number of successor tasks
+    int32_t fanout_count;                 // Number of successor tasks
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfRecord) % 64 == 0,
-              "PerfRecord must be 64-byte aligned for optimal cache performance");
+static_assert(sizeof(PerfRecord) % 64 == 0, "PerfRecord must be 64-byte aligned for optimal cache performance");
 
 // =============================================================================
 // PerfBuffer - Fixed-Size Record Buffer
@@ -99,7 +109,7 @@ static_assert(sizeof(PerfRecord) % 64 == 0,
  */
 struct PerfBuffer {
     PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Record array
-    volatile uint32_t count;                         // Current record count
+    volatile uint32_t count;                        // Current record count
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -123,13 +133,12 @@ struct PerfBuffer {
  */
 struct PerfFreeQueue {
     volatile uint64_t buffer_ptrs[PLATFORM_PROF_SLOT_COUNT];  // Free buffer addresses
-    volatile uint32_t head;  // Consumer read position (Device increments)
-    volatile uint32_t tail;  // Producer write position (Host increments)
-    uint32_t pad[13];        // Pad to 128 bytes (aligned to cache line)
+    volatile uint32_t head;                                   // Consumer read position (Device increments)
+    volatile uint32_t tail;                                   // Producer write position (Host increments)
+    uint32_t pad[13];                                         // Pad to 128 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfFreeQueue) == 128,
-              "PerfFreeQueue must be 128 bytes for cache alignment");
+static_assert(sizeof(PerfFreeQueue) == 128, "PerfFreeQueue must be 128 bytes for cache alignment");
 
 // =============================================================================
 // PerfBufferState - Per-Core/Thread Buffer State (Unified for PerfRecord and Phase)
@@ -154,14 +163,13 @@ static_assert(sizeof(PerfFreeQueue) == 128,
  * - current_buf_seq: Device writes (monotonic counter)
  */
 struct PerfBufferState {
-    PerfFreeQueue free_queue;            // SPSC queue of free buffer addresses
-    volatile uint64_t current_buf_ptr;   // Current active buffer (0 = none)
-    volatile uint32_t current_buf_seq;   // Sequence number for ordering
-    uint32_t pad[13];                    // Pad to 192 bytes (aligned to cache line)
+    PerfFreeQueue free_queue;           // SPSC queue of free buffer addresses
+    volatile uint64_t current_buf_ptr;  // Current active buffer (0 = none)
+    volatile uint32_t current_buf_seq;  // Sequence number for ordering
+    uint32_t pad[13];                   // Pad to 192 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PerfBufferState) == 192,
-              "PerfBufferState must be 192 bytes for cache alignment");
+static_assert(sizeof(PerfBufferState) == 192, "PerfBufferState must be 192 bytes for cache alignment");
 
 // Type alias for semantic clarity in Phase profiling context
 using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
@@ -181,11 +189,11 @@ using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
  * - Phase entry:      core_index = thread_idx, is_phase = 1
  */
 struct ReadyQueueEntry {
-    uint32_t core_index;      // Core index (0 ~ num_cores-1), or thread_idx for phase entries
-    uint32_t is_phase;        // 0 = PerfRecord, 1 = Phase
-    uint64_t buffer_ptr;      // Device pointer to the full buffer
-    uint32_t buffer_seq;      // Sequence number for ordering
-    uint32_t pad;             // Alignment padding
+    uint32_t core_index;  // Core index (0 ~ num_cores-1), or thread_idx for phase entries
+    uint32_t is_phase;    // 0 = PerfRecord, 1 = Phase
+    uint64_t buffer_ptr;  // Device pointer to the full buffer
+    uint32_t buffer_seq;  // Sequence number for ordering
+    uint32_t pad;         // Alignment padding
 } __attribute__((aligned(32)));
 
 // =============================================================================
@@ -216,8 +224,8 @@ struct PerfDataHeader {
     volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // Producer write positions (AICPU modifies)
 
     // Metadata (Host initializes, Device read-only)
-    uint32_t num_cores;                              // Actual number of cores launched
-    volatile uint32_t total_tasks;                   // Total tasks (AICPU writes after orchestration)
+    uint32_t num_cores;             // Actual number of cores launched
+    volatile uint32_t total_tasks;  // Total tasks (AICPU writes after orchestration)
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -232,21 +240,21 @@ struct PerfDataHeader {
  */
 enum class AicpuPhaseId : uint32_t {
     // Scheduler phases (0-3)
-    SCHED_COMPLETE    = 0,  // Process completed tasks (fanout traversal)
-    SCHED_DISPATCH    = 1,  // Dispatch ready tasks to idle cores
-    SCHED_SCAN        = 2,  // Incremental scan for root tasks
-    SCHED_IDLE_WAIT   = 3,  // Idle/spinning (no progress)
+    SCHED_COMPLETE = 0,     // Process completed tasks (fanout traversal)
+    SCHED_DISPATCH = 1,     // Dispatch ready tasks to idle cores
+    SCHED_SCAN = 2,         // Incremental scan for root tasks
+    SCHED_IDLE_WAIT = 3,    // Idle/spinning (no progress)
     SCHED_PHASE_COUNT = 4,  // Sentinel: number of scheduler phases
     // Orchestrator phases (16-24)
-    ORCH_SYNC      = 16,  // tensormap sync
-    ORCH_ALLOC     = 17,  // task_ring_alloc
-    ORCH_PARAMS    = 18,  // param copy
-    ORCH_LOOKUP    = 19,  // tensormap lookup + dep
-    ORCH_HEAP      = 20,  // heap alloc
-    ORCH_INSERT    = 21,  // tensormap insert
-    ORCH_FANIN     = 22,  // fanin + early-ready
-    ORCH_FINALIZE  = 23,  // scheduler init + SM
-    ORCH_SCOPE_END = 24   // scope_end
+    ORCH_SYNC = 16,      // tensormap sync
+    ORCH_ALLOC = 17,     // task_ring_alloc
+    ORCH_PARAMS = 18,    // param copy
+    ORCH_LOOKUP = 19,    // tensormap lookup + dep
+    ORCH_HEAP = 20,      // heap alloc
+    ORCH_INSERT = 21,    // tensormap insert
+    ORCH_FANIN = 22,     // fanin + early-ready
+    ORCH_FINALIZE = 23,  // scheduler init + SM
+    ORCH_SCOPE_END = 24  // scope_end
 };
 
 /**
@@ -256,14 +264,14 @@ enum class AicpuPhaseId : uint32_t {
  * No thread_id field: identity is derived from array index (position = identity).
  */
 struct AicpuPhaseRecord {
-    uint64_t start_time;       // Phase start timestamp
-    uint64_t end_time;         // Phase end timestamp
-    uint32_t loop_iter;        // Loop iteration number
-    AicpuPhaseId phase_id;     // Phase type
+    uint64_t start_time;    // Phase start timestamp
+    uint64_t end_time;      // Phase end timestamp
+    uint32_t loop_iter;     // Loop iteration number
+    AicpuPhaseId phase_id;  // Phase type
     union {
-        uint64_t task_id;   // Multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph):
-                            // full PTO2 encoding (ring_id << 32) | local_id for cross-view correlation.
-        uint64_t tasks_processed; // Scheduler phases: number of tasks processed in this batch
+        uint64_t task_id;          // Multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph):
+                                   // full PTO2 encoding (ring_id << 32) | local_id for cross-view correlation.
+        uint64_t tasks_processed;  // Scheduler phases: number of tasks processed in this batch
     };
 };
 
@@ -284,12 +292,12 @@ struct AicpuOrchSummary {
     uint64_t insert_cycle;     // tensormap_insert phase
     uint64_t fanin_cycle;      // fanin+ready phase
     uint64_t scope_end_cycle;  // scope_end phase
-    int64_t  submit_count;     // Total tasks submitted
+    int64_t submit_count;      // Total tasks submitted
     uint32_t magic;            // Validation magic (AICPU_PHASE_MAGIC)
     uint32_t padding;          // Alignment padding
 } __attribute__((aligned(64)));
 
-constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"
+constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;        // "ACPH"
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per thread
 
 /**
@@ -310,12 +318,12 @@ struct PhaseBuffer {
  * Contains metadata and per-thread tracking.
  */
 struct AicpuPhaseHeader {
-    uint32_t magic;                  // Validation magic (AICPU_PHASE_MAGIC)
-    uint32_t num_sched_threads;      // Number of scheduler threads
-    uint32_t records_per_thread;     // Max records per PhaseBuffer
-    uint32_t num_cores;              // Total number of cores with valid assignments
+    uint32_t magic;                             // Validation magic (AICPU_PHASE_MAGIC)
+    uint32_t num_sched_threads;                 // Number of scheduler threads
+    uint32_t records_per_thread;                // Max records per PhaseBuffer
+    uint32_t num_cores;                         // Total number of cores with valid assignments
     int8_t core_to_thread[PLATFORM_MAX_CORES];  // core_id → scheduler thread index (-1 = unassigned)
-    AicpuOrchSummary orch_summary;   // Orchestrator cumulative data
+    AicpuOrchSummary orch_summary;              // Orchestrator cumulative data
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -345,9 +353,7 @@ inline size_t calc_perf_data_size(int num_cores) {
  * @param base_ptr Shared memory base address (device_ptr or host_ptr)
  * @return PerfDataHeader pointer
  */
-inline PerfDataHeader* get_perf_header(void* base_ptr) {
-    return (PerfDataHeader*)base_ptr;
-}
+inline PerfDataHeader* get_perf_header(void* base_ptr) { return reinterpret_cast<PerfDataHeader*>(base_ptr); }
 
 /**
  * Get PerfBufferState array start address
@@ -356,7 +362,7 @@ inline PerfDataHeader* get_perf_header(void* base_ptr) {
  * @return PerfBufferState array pointer
  */
 inline PerfBufferState* get_perf_buffer_states(void* base_ptr) {
-    return (PerfBufferState*)((char*)base_ptr + sizeof(PerfDataHeader));
+    return reinterpret_cast<PerfBufferState*>(reinterpret_cast<char*>(base_ptr) + sizeof(PerfDataHeader));
 }
 
 /**
@@ -378,9 +384,7 @@ inline PerfBufferState* get_perf_buffer_state(void* base_ptr, int core_index) {
  * @return Total bytes needed for header + all buffer states
  */
 inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threads) {
-    return calc_perf_data_size(num_cores)
-         + sizeof(AicpuPhaseHeader)
-         + num_sched_threads * sizeof(PhaseBufferState);
+    return calc_perf_data_size(num_cores) + sizeof(AicpuPhaseHeader) + num_sched_threads * sizeof(PhaseBufferState);
 }
 
 /**
@@ -391,7 +395,7 @@ inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threa
  * @return AicpuPhaseHeader pointer
  */
 inline AicpuPhaseHeader* get_phase_header(void* base_ptr, int num_cores) {
-    return (AicpuPhaseHeader*)((char*)base_ptr + calc_perf_data_size(num_cores));
+    return reinterpret_cast<AicpuPhaseHeader*>(reinterpret_cast<char*>(base_ptr) + calc_perf_data_size(num_cores));
 }
 
 /**
@@ -402,7 +406,8 @@ inline AicpuPhaseHeader* get_phase_header(void* base_ptr, int num_cores) {
  * @return PhaseBufferState array pointer
  */
 inline PhaseBufferState* get_phase_buffer_states(void* base_ptr, int num_cores) {
-    return (PhaseBufferState*)((char*)get_phase_header(base_ptr, num_cores) + sizeof(AicpuPhaseHeader));
+    return reinterpret_cast<PhaseBufferState*>(
+        reinterpret_cast<char*>(get_phase_header(base_ptr, num_cores)) + sizeof(AicpuPhaseHeader));
 }
 
 /**
@@ -421,4 +426,4 @@ inline PhaseBufferState* get_phase_buffer_state(void* base_ptr, int num_cores, i
 }
 #endif
 
-#endif  // PLATFORM_COMMON_PERF_PROFILING_H_
+#endif  // SRC_A5_PLATFORM_INCLUDE_COMMON_PERF_PROFILING_H_

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file platform_config.h
  * @brief Platform-specific configuration and architectural constraints
@@ -11,8 +22,8 @@
  * - Derived: All other limits calculated from base configuration
  */
 
-#ifndef PLATFORM_COMMON_PLATFORM_CONFIG_H_
-#define PLATFORM_COMMON_PLATFORM_CONFIG_H_
+#ifndef SRC_A5_PLATFORM_INCLUDE_COMMON_PLATFORM_CONFIG_H_
+#define SRC_A5_PLATFORM_INCLUDE_COMMON_PLATFORM_CONFIG_H_
 
 #include <cstdint>
 
@@ -60,14 +71,11 @@ constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 7;
  * - MAX_AIC_PER_THREAD = MAX_BLOCKDIM * AIC_CORES_PER_BLOCKDIM = 36 * 1 = 36
  * - MAX_AIV_PER_THREAD = MAX_BLOCKDIM * AIV_CORES_PER_BLOCKDIM = 36 * 2 = 72
  */
-constexpr int PLATFORM_MAX_AIC_PER_THREAD =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_AIC_CORES_PER_BLOCKDIM;  // 36
+constexpr int PLATFORM_MAX_AIC_PER_THREAD = PLATFORM_MAX_BLOCKDIM * PLATFORM_AIC_CORES_PER_BLOCKDIM;  // 36
 
-constexpr int PLATFORM_MAX_AIV_PER_THREAD =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_AIV_CORES_PER_BLOCKDIM;  // 72
+constexpr int PLATFORM_MAX_AIV_PER_THREAD = PLATFORM_MAX_BLOCKDIM * PLATFORM_AIV_CORES_PER_BLOCKDIM;  // 72
 
-constexpr int PLATFORM_MAX_CORES_PER_THREAD =
-    PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD;  // 108
+constexpr int PLATFORM_MAX_CORES_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD + PLATFORM_MAX_AIV_PER_THREAD;  // 108
 
 // =============================================================================
 // Performance Profiling Configuration
@@ -77,8 +85,7 @@ constexpr int PLATFORM_MAX_CORES_PER_THREAD =
  * Maximum number of cores that can be profiled simultaneously
  * Calculated as: MAX_BLOCKDIM * CORES_PER_BLOCKDIM = 36 * 3 = 108
  */
-constexpr int PLATFORM_MAX_CORES =
-    PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 108
+constexpr int PLATFORM_MAX_CORES = PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 108
 
 /**
  * Performance buffer capacity per buffer
@@ -90,21 +97,30 @@ constexpr int PLATFORM_PROF_BUFFER_SIZE = 1000;
  * Number of buffer slots per core/thread for dynamic profiling
  * Host dynamically allocates buffers and writes addresses into these slots.
  * Device reads slot addresses when switching buffers.
- * Using 8 slots (ring buffer) instead of 2 (double-buffer) to tolerate
- * Host-side latency in replacing full buffers.
+ * Using slots: provides full pipeline depth for buffer recycling.
+ * No runtime rtMalloc — all buffers are pre-allocated and recycled in a closed loop.
  */
-constexpr int PLATFORM_PROF_SLOT_COUNT = 8;
+constexpr int PLATFORM_PROF_SLOT_COUNT = 4;
+
+/**
+ * PerfBuffer pre-allocation count per AICore.
+ * 1 goes into the free_queue at init, the rest into the recycled pool.
+ */
+constexpr int PLATFORM_PROF_BUFFERS_PER_CORE = 8;
+
+/**
+ * PhaseBuffer pre-allocation count per AICPU thread.
+ * 1 goes into the free_queue at init, the rest into the recycled pool.
+ */
+constexpr int PLATFORM_PROF_BUFFERS_PER_THREAD = 16;
 
 /**
  * Ready queue capacity for performance data collection
  * Queue holds ReadyQueueEntry structs for buffers ready to be read by Host.
- * Includes both PerfRecord and PhaseRecord entries:
- *   PerfRecord: PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT
- *   Phase:      PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT
+ * Sized to match pre-allocation total across all cores and threads.
  */
 constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
-    PLATFORM_MAX_CORES * PLATFORM_PROF_SLOT_COUNT
-    + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_SLOT_COUNT;  // 872
+    PLATFORM_MAX_CORES * PLATFORM_PROF_BUFFERS_PER_CORE + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_BUFFERS_PER_THREAD;
 
 /**
  * System counter frequency (get_sys_cnt)
@@ -124,15 +140,15 @@ constexpr int PLATFORM_PROF_EMPTY_POLLS_CHECK_NUM = 1000;
 
 inline double cycles_to_us(uint64_t cycles) {
     return (static_cast<double>(cycles) / PLATFORM_PROF_SYS_CNT_FREQ) * 1000000.0;
-};
+}
 
 // =============================================================================
 // Register Communication Configuration
 // =============================================================================
 
 // Register offsets for AICore SPR access
-constexpr uint32_t REG_SPR_DATA_MAIN_BASE_OFFSET = 0xD0;    // Task dispatch (AICPU→AICore)
-constexpr uint32_t REG_SPR_COND_OFFSET = 0x5108;             // Status (AICore→AICPU): 0=IDLE, 1=BUSY
+constexpr uint32_t REG_SPR_DATA_MAIN_BASE_OFFSET = 0xD0;  // Task dispatch (AICPU→AICore)
+constexpr uint32_t REG_SPR_COND_OFFSET = 0x5108;          // Status (AICore→AICPU): 0=IDLE, 1=BUSY
 
 // Exit signal for AICore shutdown
 constexpr uint32_t AICORE_EXIT_SIGNAL = 0x7FFFFFF0;
@@ -144,8 +160,8 @@ constexpr uint32_t AICORE_COREID_MASK = 0x0FFF;
  * Register identifier for unified read_reg/write_reg interface
  */
 enum class RegId : uint32_t {
-    DATA_MAIN_BASE = 0,    // Task dispatch (AICPU→AICore)
-    COND = 1,              // Status (AICore→AICPU)
+    DATA_MAIN_BASE = 0,  // Task dispatch (AICPU→AICore)
+    COND = 1,            // Status (AICore→AICPU)
 };
 
 /**
@@ -153,8 +169,10 @@ enum class RegId : uint32_t {
  */
 constexpr uint32_t reg_offset(RegId reg) {
     switch (reg) {
-        case RegId::DATA_MAIN_BASE:  return REG_SPR_DATA_MAIN_BASE_OFFSET;
-        case RegId::COND:            return REG_SPR_COND_OFFSET;
+        case RegId::DATA_MAIN_BASE:
+            return REG_SPR_DATA_MAIN_BASE_OFFSET;
+        case RegId::COND:
+            return REG_SPR_COND_OFFSET;
     }
     return 0;  // unreachable: all RegId cases handled above
 }
@@ -234,26 +252,26 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = PLATFORM_NUM_DIES * PLATFORM_AI
  * State: ACK (0) = task received, FIN (1) = task completed
  */
 
-#define TASK_ID_MASK       0x7FFFFFFFU
-#define TASK_STATE_MASK    0x80000000U
+#define TASK_ID_MASK 0x7FFFFFFFU
+#define TASK_STATE_MASK 0x80000000U
 
-#define TASK_ACK_STATE     0
-#define TASK_FIN_STATE     1
+#define TASK_ACK_STATE 0
+#define TASK_FIN_STATE 1
 
-#define EXTRACT_TASK_ID(regval)    ((int)((regval) & TASK_ID_MASK))
-#define EXTRACT_TASK_STATE(regval) ((int)(((regval) & TASK_STATE_MASK) >> 31))
-#define MAKE_ACK_VALUE(task_id)    ((uint64_t)((task_id) & TASK_ID_MASK))
-#define MAKE_FIN_VALUE(task_id)    ((uint64_t)(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
+#define EXTRACT_TASK_ID(regval) (static_cast<int>((regval) & TASK_ID_MASK))
+#define EXTRACT_TASK_STATE(regval) (static_cast<int>(((regval) & TASK_STATE_MASK) >> 31))
+#define MAKE_ACK_VALUE(task_id) (static_cast<uint64_t>((task_id) & TASK_ID_MASK))
+#define MAKE_FIN_VALUE(task_id) (static_cast<uint64_t>(((task_id) & TASK_ID_MASK) | TASK_STATE_MASK))
 
 // These values are RESERVED and must never be used as real task IDs.
 // Valid task IDs: 0 to 0x7FFFFFEF (2147483631)
-#define AICORE_IDLE_TASK_ID        0x7FFFFFFFU
-#define AICORE_IDLE_VALUE          MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
+#define AICORE_IDLE_TASK_ID 0x7FFFFFFFU
+#define AICORE_IDLE_VALUE MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
 
-#define AICORE_EXIT_TASK_ID        0x7FFFFFFEU
-#define AICORE_EXITED_VALUE        MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
+#define AICORE_EXIT_TASK_ID 0x7FFFFFFEU
+#define AICORE_EXITED_VALUE MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
 
-#define AICPU_IDLE_TASK_ID         0x7FFFFFFDU
+#define AICPU_IDLE_TASK_ID 0x7FFFFFFDU
 
 // =============================================================================
 // Task State Constants
@@ -265,4 +283,4 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = PLATFORM_NUM_DIES * PLATFORM_AI
  */
 constexpr int AICPU_TASK_INVALID = -1;
 
-#endif  // PLATFORM_COMMON_PLATFORM_CONFIG_H_
+#endif  // SRC_A5_PLATFORM_INCLUDE_COMMON_PLATFORM_CONFIG_H_

--- a/src/a5/platform/include/host/performance_collector.h
+++ b/src/a5/platform/include/host/performance_collector.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file performance_collector.h
  * @brief Platform-agnostic performance data collector with dynamic memory management
@@ -11,8 +22,8 @@
  * Design Pattern: Dependency Injection via Callbacks for memory operations.
  */
 
-#ifndef PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_
-#define PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_
+#ifndef SRC_A5_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_
+#define SRC_A5_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_
 
 #include <atomic>
 #include <condition_variable>
@@ -46,8 +57,7 @@ using PerfAllocCallback = void* (*)(size_t size, void* user_data);
  * @param[out] host_ptr Host-mapped pointer
  * @return 0 on success, error code on failure
  */
-using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id,
-                                      void* user_data, void** host_ptr);
+using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id, void* user_data, void** host_ptr);
 
 /**
  * Memory unregister callback
@@ -82,18 +92,19 @@ enum class ProfBufferType { PERF_RECORD, PHASE };
  */
 struct ReadyBufferInfo {
     ProfBufferType type;
-    uint32_t index;           // core_index (PERF_RECORD) or thread_idx (PHASE)
-    uint32_t slot_idx;        // Reserved (unused in free queue design)
-    void* dev_buffer_ptr;     // Device address of the full buffer
-    void* host_buffer_ptr;    // Host-mapped address (sim: same as dev)
-    uint32_t buffer_seq;      // Sequence number for ordering
+    uint32_t index;         // core_index (PERF_RECORD) or thread_idx (PHASE)
+    uint32_t slot_idx;      // Reserved (unused in free queue design)
+    void* dev_buffer_ptr;   // Device address of the full buffer
+    void* host_buffer_ptr;  // Host-mapped address (sim: same as dev)
+    uint32_t buffer_seq;    // Sequence number for ordering
 };
 
 /**
  * Notification that a buffer has been copied and can be freed
  */
 struct CopyDoneInfo {
-    void* dev_buffer_ptr;     // Device buffer to free
+    void* dev_buffer_ptr;  // Device buffer to free
+    ProfBufferType type;   // Buffer type (for recycling)
 };
 
 /**
@@ -107,7 +118,7 @@ struct CopyDoneInfo {
  * 5. Frees device buffers after main thread confirms copy is done
  */
 class ProfMemoryManager {
-public:
+ public:
     ProfMemoryManager() = default;
     ~ProfMemoryManager();
 
@@ -130,9 +141,14 @@ public:
      * @param user_data User context for callbacks
      * @param device_id Device ID for registration
      */
-    void start(void* shared_mem_host, int num_cores, int num_phase_threads,
-               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-               PerfFreeCallback free_cb, void* user_data, int device_id);
+    void start(void* shared_mem_host,
+        int num_cores,
+        int num_phase_threads,
+        PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb,
+        void* user_data,
+        int device_id);
 
     /**
      * Stop the memory management thread
@@ -169,7 +185,7 @@ public:
      */
     bool is_running() const { return running_.load(); }
 
-private:
+ private:
     std::thread mgmt_thread_;
     std::atomic<bool> running_{false};
 
@@ -197,6 +213,10 @@ private:
     // Device-to-host pointer mapping (populated during alloc_and_register)
     std::unordered_map<void*, void*> dev_to_host_;
 
+    // Recycled buffer pools (avoids alloc/free churn in mgmt_loop)
+    std::vector<void*> recycled_perf_buffers_;
+    std::vector<void*> recycled_phase_buffers_;
+
     // Management thread main loop
     void mgmt_loop();
 
@@ -213,8 +233,7 @@ private:
     void register_mapping(void* dev_ptr, void* host_ptr);
 
     // Process one ReadyQueue entry
-    void process_ready_entry(PerfDataHeader* header, int thread_idx,
-                              const ReadyQueueEntry& entry);
+    void process_ready_entry(PerfDataHeader* header, int thread_idx, const ReadyQueueEntry& entry);
 };
 
 // =============================================================================
@@ -233,7 +252,7 @@ private:
  * Platform-agnostic: Memory management delegated to callbacks
  */
 class PerformanceCollector {
-public:
+ public:
     PerformanceCollector() = default;
     ~PerformanceCollector();
 
@@ -257,12 +276,12 @@ public:
      * @return 0 on success, error code on failure
      */
     int initialize(Runtime& runtime,
-                   int num_aicore,
-                   int device_id,
-                   PerfAllocCallback alloc_cb,
-                   PerfRegisterCallback register_cb,
-                   PerfFreeCallback free_cb,
-                   void* user_data);
+        int num_aicore,
+        int device_id,
+        PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb,
+        void* user_data);
 
     /**
      * Start the memory management thread
@@ -305,9 +324,7 @@ public:
      * @param user_data User-provided context pointer
      * @return 0 on success, error code on failure
      */
-    int finalize(PerfUnregisterCallback unregister_cb,
-                 PerfFreeCallback free_cb,
-                 void* user_data);
+    int finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data);
 
     /**
      * Check if collector is initialized
@@ -334,11 +351,27 @@ public:
     void collect_phase_data();
 
     /**
+     * Scan PerfBufferState::current_buf_ptr for all cores to recover
+     * partial records not delivered through the pipeline.
+     *
+     * Must be called after device execution completes and after
+     * stop_memory_manager(). Follows the same pattern as collect_phase_data()
+     * for PhaseBufferStates.
+     */
+    void scan_remaining_perf_buffers();
+
+    /**
+     * Signal that device execution is complete (streams synchronized).
+     * poll_and_collect() will drain remaining pipeline data and exit.
+     */
+    void signal_execution_complete();
+
+    /**
      * Get collected records (for testing)
      */
     const std::vector<std::vector<PerfRecord>>& get_records() const { return collected_perf_records_; }
 
-private:
+ private:
     // Shared memory pointers
     void* perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
     void* perf_shared_mem_host_{nullptr};  // Host-mapped pointer (slot arrays)
@@ -368,8 +401,11 @@ private:
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
     std::vector<int8_t> core_to_thread_;
 
+    // Signal from device_runner that execution is complete
+    std::atomic<bool> execution_complete_{false};
+
     // Allocate a single buffer (PerfBuffer or PhaseBuffer) and register it
     void* alloc_single_buffer(size_t size, void** host_ptr_out);
 };
 
-#endif  // PLATFORM_HOST_PERFORMANCE_COLLECTOR_H_
+#endif  // SRC_A5_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -482,12 +482,18 @@ int DeviceRunner::run(Runtime& runtime,
             LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
             return rc;
         }
+
+        // Signal collector that device execution is complete
+        if (runtime.enable_profiling) {
+            perf_collector_.signal_execution_complete();
+        }
     }
 
     // Stop memory management, drain remaining buffers, collect phase data, export
     if (runtime.enable_profiling) {
         perf_collector_.stop_memory_manager();
         perf_collector_.drain_remaining_buffers();
+        perf_collector_.scan_remaining_perf_buffers();
         perf_collector_.collect_phase_data();
         export_swimlane_json();
     }

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -342,6 +342,11 @@ int DeviceRunner::run(Runtime& runtime,
         t.join();
     }
 
+    // Signal collector that device execution is complete
+    if (runtime.enable_profiling) {
+        perf_collector_.signal_execution_complete();
+    }
+
     // Wait for collector thread if it was launched
     if (runtime.enable_profiling && collector_thread.joinable()) {
         collector_thread.join();
@@ -353,6 +358,7 @@ int DeviceRunner::run(Runtime& runtime,
     if (runtime.enable_profiling) {
         perf_collector_.stop_memory_manager();
         perf_collector_.drain_remaining_buffers();
+        perf_collector_.scan_remaining_perf_buffers();
         perf_collector_.collect_phase_data();
         export_swimlane_json();
     }

--- a/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file performance_collector_aicpu.cpp
  * @brief AICPU performance data collection implementation (SPSC free queue)
@@ -8,11 +19,13 @@
  */
 
 #include "aicpu/performance_collector_aicpu.h"
-#include "common/memory_barrier.h"
-#include "common/unified_log.h"
-#include "common/platform_config.h"
 
+#include <cinttypes>
 #include <cstring>
+
+#include "common/memory_barrier.h"
+#include "common/platform_config.h"
+#include "common/unified_log.h"
 
 // Cached pointers for hot-path access (set during init)
 static AicpuPhaseHeader* s_phase_header = nullptr;
@@ -64,7 +77,7 @@ static int enqueue_ready_buffer(PerfDataHeader* header,
 }
 
 void perf_aicpu_init_profiling(Runtime* runtime) {
-    void* perf_base = (void*)runtime->perf_data_base;
+    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize profiling");
         return;
@@ -97,7 +110,7 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
             state->current_buf_seq = 0;
             wmb();
 
-            PerfBuffer* buf = (PerfBuffer*)buf_ptr;
+            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(buf_ptr);
             buf->count = 0;
             h->perf_records_addr = buf_ptr;
 
@@ -115,14 +128,14 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
 }
 
 int perf_aicpu_complete_record(PerfBuffer* perf_buf,
-                                uint32_t expected_reg_task_id,
-                                uint64_t task_id,
-                                uint32_t func_id,
-                                CoreType core_type,
-                                uint64_t dispatch_time,
-                                uint64_t finish_time,
-                                const uint64_t* fanout,
-                                int32_t fanout_count) {
+    uint32_t expected_reg_task_id,
+    uint64_t task_id,
+    uint32_t func_id,
+    CoreType core_type,
+    uint64_t dispatch_time,
+    uint64_t finish_time,
+    const uint64_t* fanout,
+    int32_t fanout_count) {
     rmb();
     uint32_t count = perf_buf->count;
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
@@ -137,8 +150,7 @@ int perf_aicpu_complete_record(PerfBuffer* perf_buf,
     record->finish_time = finish_time;
 
     if (fanout != nullptr && fanout_count > 0) {
-        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT)
-                        ? RUNTIME_MAX_FANOUT : fanout_count;
+        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT) ? RUNTIME_MAX_FANOUT : fanout_count;
         for (int32_t i = 0; i < n; i++) {
             record->fanout[i] = fanout[i];
         }
@@ -153,7 +165,7 @@ int perf_aicpu_complete_record(PerfBuffer* perf_buf,
 }
 
 void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
-    void* perf_base = (void*)runtime->perf_data_base;
+    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
@@ -163,21 +175,31 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
         return;
     }
 
-    PerfBuffer* full_buf = (PerfBuffer*)state->current_buf_ptr;
+    PerfBuffer* full_buf = reinterpret_cast<PerfBuffer*>(state->current_buf_ptr);
     if (full_buf == nullptr) {
         return;
     }
 
-    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)",
-         thread_idx, core_id, full_buf->count);
+    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)", thread_idx, core_id, full_buf->count);
 
-    // Enqueue to ReadyQueue
+    // Check free_queue before committing the full buffer
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head == tail) {
+        // No replacement buffer available — overwrite current buffer to keep AICore alive
+        LOG_WARN("Thread %d: Core %d no free buffer, overwriting current buffer (data lost)", thread_idx, core_id);
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Enqueue full buffer to ReadyQueue
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
-        state->current_buf_ptr, seq, 0);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, state->current_buf_ptr, seq, 0);
     if (rc != 0) {
-        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
-             thread_idx, core_id);
+        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
         // Revert: discard data and keep writing
         full_buf->count = 0;
         wmb();
@@ -185,48 +207,30 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
     }
 
     // Pop next buffer from free_queue
+    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
     rmb();
-    uint32_t head = state->free_queue.head;
-    uint32_t tail = state->free_queue.tail;
+    state->free_queue.head = head + 1;
+    state->current_buf_ptr = new_buf_ptr;
+    state->current_buf_seq = seq + 1;
+    wmb();
 
-    if (head != tail) {
-        uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-        rmb();
-        state->free_queue.head = head + 1;
-        state->current_buf_ptr = new_buf_ptr;
-        state->current_buf_seq = seq + 1;
-        wmb();
+    PerfBuffer* new_buf = reinterpret_cast<PerfBuffer*>(new_buf_ptr);
+    new_buf->count = 0;
 
-        PerfBuffer* new_buf = (PerfBuffer*)new_buf_ptr;
-        new_buf->count = 0;
+    // Update handshake for AICore
+    Handshake* h = &runtime->workers[core_id];
+    h->perf_records_addr = new_buf_ptr;
+    wmb();
 
-        // Update handshake for AICore
-        Handshake* h = &runtime->workers[core_id];
-        h->perf_records_addr = new_buf_ptr;
-        wmb();
-
-        LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", 
-            thread_idx, core_id, new_buf_ptr);
-    } else {
-        // No free buffer available, stop profiling
-        LOG_WARN("Thread %d: Core %d no free buffer available, stopping profiling", 
-            thread_idx, core_id);
-        state->current_buf_ptr = 0;
-        Handshake* h = &runtime->workers[core_id];
-        h->perf_records_addr = 0;
-        wmb();
-    }
+    LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
 }
 
-void perf_aicpu_flush_buffers(Runtime* runtime, 
-    int thread_idx, 
-    const int* cur_thread_cores, 
-    int core_num) {
+void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
     if (!runtime->enable_profiling) {
         return;
     }
 
-    void* perf_base = (void*)runtime->perf_data_base;
+    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
@@ -249,34 +253,30 @@ void perf_aicpu_flush_buffers(Runtime* runtime,
             continue;
         }
 
-        PerfBuffer* buf = (PerfBuffer*)buf_ptr;
+        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(buf_ptr);
         if (buf->count == 0) {
             continue;
         }
 
         uint32_t seq = state->current_buf_seq;
-        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id,
-            buf_ptr, seq, 0);
+        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, buf_ptr, seq, 0);
         if (rc == 0) {
-            LOG_INFO("Thread %d: Core %d flushed buffer with %u records",
-                thread_idx, core_id, buf->count);
+            LOG_INFO("Thread %d: Core %d flushed buffer with %u records", thread_idx, core_id, buf->count);
             flushed_count++;
             state->current_buf_ptr = 0;
             wmb();
         } else {
-            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!",
-                thread_idx, core_id);
+            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
         }
     }
 
     wmb();
 
-    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", 
-        thread_idx, flushed_count);
+    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
 }
 
 void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
-    void* perf_base = (void*)runtime->perf_data_base;
+    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
@@ -287,7 +287,7 @@ void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
 }
 
 void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, int num_orch_threads) {
-    void* perf_base = (void*)runtime->perf_data_base;
+    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize phase profiling");
         return;
@@ -328,7 +328,7 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
             state->current_buf_seq = 0;
             wmb();
 
-            PhaseBuffer* buf = (PhaseBuffer*)buf_ptr;
+            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
             buf->count = 0;
             s_current_phase_buf[t] = buf;
 
@@ -349,7 +349,9 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
     wmb();
 
     LOG_INFO("Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread",
-        num_sched_threads, num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD);
+        num_sched_threads,
+        num_orch_threads,
+        PLATFORM_PHASE_RECORDS_PER_THREAD);
 }
 
 /**
@@ -366,16 +368,13 @@ static void switch_phase_buffer(int thread_idx) {
     PhaseBuffer* full_buf = s_current_phase_buf[thread_idx];
     if (full_buf == nullptr) return;
 
-    LOG_INFO("Thread %d: phase buffer is full (count=%u)",
-        thread_idx, full_buf->count);
+    LOG_INFO("Thread %d: phase buffer is full (count=%u)", thread_idx, full_buf->count);
 
     // Enqueue to ReadyQueue
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-        state->current_buf_ptr, seq, 1);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, state->current_buf_ptr, seq, 1);
     if (rc != 0) {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data",
-            thread_idx);
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data", thread_idx);
         full_buf->count = 0;
         wmb();
         return;
@@ -394,15 +393,14 @@ static void switch_phase_buffer(int thread_idx) {
         state->current_buf_seq = seq + 1;
         wmb();
 
-        PhaseBuffer* new_buf = (PhaseBuffer*)new_buf_ptr;
+        PhaseBuffer* new_buf = reinterpret_cast<PhaseBuffer*>(new_buf_ptr);
         new_buf->count = 0;
         s_current_phase_buf[thread_idx] = new_buf;
 
         LOG_INFO("Thread %d: switched to new phase buffer", thread_idx);
     } else {
         // No free buffer available, drop subsequent records
-        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up",
-            thread_idx);
+        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up", thread_idx);
         s_current_phase_buf[thread_idx] = nullptr;
         state->current_buf_ptr = 0;
         wmb();
@@ -411,8 +409,10 @@ static void switch_phase_buffer(int thread_idx) {
 
 void perf_aicpu_record_phase(int thread_idx,
     AicpuPhaseId phase_id,
-    uint64_t start_time, uint64_t end_time,
-    uint32_t loop_iter, uint64_t tasks_processed) {
+    uint64_t start_time,
+    uint64_t end_time,
+    uint32_t loop_iter,
+    uint64_t tasks_processed) {
     if (s_phase_header == nullptr) {
         return;
     }
@@ -436,7 +436,7 @@ void perf_aicpu_record_phase(int thread_idx,
             state->current_buf_seq = state->current_buf_seq + 1;
             wmb();
 
-            buf = (PhaseBuffer*)buf_ptr;
+            buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
             buf->count = 0;
             s_current_phase_buf[thread_idx] = buf;
 
@@ -481,18 +481,15 @@ void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src) {
 
     wmb();
 
-    LOG_INFO("Orchestrator summary written: %lld tasks, %.3fus",
-        (long long)src->submit_count,
+    LOG_INFO("Orchestrator summary written: %" PRId64 " tasks, %.3fus",
+        static_cast<int64_t>(src->submit_count),
         cycles_to_us(src->end_time - src->start_time));
 }
 
-void perf_aicpu_set_orch_thread_idx(int thread_idx) { 
-    s_orch_thread_idx = thread_idx; 
-}
+void perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }
 
-void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
-    uint64_t start_time, uint64_t end_time,
-    uint32_t submit_idx, uint64_t task_id) {
+void perf_aicpu_record_orch_phase(
+    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id) {
     if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
     perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
 }
@@ -512,23 +509,20 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
         return;
     }
 
-    PhaseBuffer* buf = (PhaseBuffer*)buf_ptr;
+    PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
     if (buf->count == 0) {
         return;
     }
 
     uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx,
-        buf_ptr, seq, 1);
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, buf_ptr, seq, 1);
     if (rc == 0) {
-        LOG_INFO("Thread %d: flushed phase buffer with %u records",
-            thread_idx, buf->count);
+        LOG_INFO("Thread %d: flushed phase buffer with %u records", thread_idx, buf->count);
         state->current_buf_ptr = 0;
         s_current_phase_buf[thread_idx] = nullptr;
         wmb();
     } else {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!",
-            thread_idx);
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!", thread_idx);
     }
 
     wmb();

--- a/src/a5/platform/src/host/performance_collector.cpp
+++ b/src/a5/platform/src/host/performance_collector.cpp
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * @file performance_collector.cpp
  * @brief Platform-agnostic performance data collector implementation
@@ -8,14 +19,18 @@
 
 #include "host/performance_collector.h"
 
+#include <sys/stat.h>
+#include <sys/types.h>
+
 #include <algorithm>
 #include <chrono>
+#include <cinttypes>
+#include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <optional>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <ctime>
+#include <string>
+#include <vector>
 
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
@@ -30,9 +45,14 @@ ProfMemoryManager::~ProfMemoryManager() {
     }
 }
 
-void ProfMemoryManager::start(void* shared_mem_host, int num_cores, int num_phase_threads,
-                               PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-                               PerfFreeCallback free_cb, void* user_data, int device_id) {
+void ProfMemoryManager::start(void* shared_mem_host,
+    int num_cores,
+    int num_phase_threads,
+    PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb,
+    void* user_data,
+    int device_id) {
     shared_mem_host_ = shared_mem_host;
     num_cores_ = num_cores;
     num_phase_threads_ = num_phase_threads;
@@ -64,6 +84,16 @@ void ProfMemoryManager::stop() {
         }
     }
 
+    // Free recycled buffers
+    for (void* ptr : recycled_perf_buffers_) {
+        free_buffer(ptr);
+    }
+    recycled_perf_buffers_.clear();
+    for (void* ptr : recycled_phase_buffers_) {
+        free_buffer(ptr);
+    }
+    recycled_phase_buffers_.clear();
+
     LOG_INFO("ProfMemoryManager stopped");
 }
 
@@ -79,7 +109,7 @@ bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo& info) {
 
 bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout) {
     std::unique_lock<std::mutex> lock(ready_mutex_);
-    if (ready_cv_.wait_for(lock, timeout, [this]{ return !ready_queue_.empty(); })) {
+    if (ready_cv_.wait_for(lock, timeout, [this] { return !ready_queue_.empty(); })) {
         info = ready_queue_.front();
         ready_queue_.pop();
         return true;
@@ -95,7 +125,10 @@ void ProfMemoryManager::notify_copy_done(const CopyDoneInfo& info) {
 void* ProfMemoryManager::alloc_and_register(size_t size, void** host_ptr_out) {
     void* dev_ptr = alloc_cb_(size, user_data_);
     if (dev_ptr == nullptr) {
-        LOG_ERROR("ProfMemoryManager: alloc failed for %zu bytes", size);
+        const char* hint = (size == sizeof(PerfBuffer))
+                               ? "increase PLATFORM_PROF_BUFFERS_PER_CORE to reduce profiling data loss"
+                               : "increase PLATFORM_PROF_BUFFERS_PER_THREAD to reduce profiling data loss";
+        LOG_WARN("ProfMemoryManager: alloc failed for %zu bytes, %s", size, hint);
         *host_ptr_out = nullptr;
         return nullptr;
     }
@@ -138,12 +171,10 @@ void* ProfMemoryManager::resolve_host_ptr(void* dev_ptr) {
     return nullptr;
 }
 
-void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) {
-    dev_to_host_[dev_ptr] = host_ptr;
-}
+void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
 
-void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*thread_idx*/,
-                                              const ReadyQueueEntry& entry) {
+void ProfMemoryManager::process_ready_entry(
+    PerfDataHeader* /*header*/, int /*thread_idx*/, const ReadyQueueEntry& entry) {
     bool is_phase = (entry.is_phase != 0);
     uint64_t old_dev_ptr = entry.buffer_ptr;
     uint32_t seq = entry.buffer_seq;
@@ -157,35 +188,57 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
 
         PhaseBufferState* state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
 
-        // Allocate new PhaseBuffer
-        void* host_ptr = nullptr;
-        void* new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
-        if (new_dev_ptr != nullptr) {
-            // Initialize new buffer
-            PhaseBuffer* new_buf = (PhaseBuffer*)host_ptr;
-            new_buf->count = 0;
+        // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
+        rmb();
+        uint32_t head_val = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t available = tail - head_val;
 
-            // Push to free_queue (with overflow guard)
-            rmb();
-            uint32_t head_val = state->free_queue.head;
-            uint32_t tail = state->free_queue.tail;
-            if ((tail - head_val) >= PLATFORM_PROF_SLOT_COUNT) {
-                LOG_ERROR("ProfMemoryManager: phase free_queue overflow for thread %u", tidx);
-                free_buffer(new_dev_ptr);
-            } else {
-                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] = (uint64_t)new_dev_ptr;
-                wmb();
-                state->free_queue.tail = tail + 1;
-                wmb();
+        int to_push = PLATFORM_PROF_SLOT_COUNT;
+        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
+            void* host_ptr = nullptr;
+            void* new_dev_ptr = nullptr;
+
+            if (!recycled_phase_buffers_.empty()) {
+                new_dev_ptr = recycled_phase_buffers_.back();
+                recycled_phase_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
             }
-        } else {
-            LOG_ERROR("ProfMemoryManager: phase buffer alloc failed, device may lose data");
+            if (new_dev_ptr == nullptr) {
+                std::lock_guard<std::mutex> lock(done_mutex_);
+                while (!done_queue_.empty()) {
+                    CopyDoneInfo dinfo = done_queue_.front();
+                    done_queue_.pop();
+                    if (dinfo.type == ProfBufferType::PERF_RECORD)
+                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else
+                        recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                }
+            }
+            if (new_dev_ptr == nullptr && !recycled_phase_buffers_.empty()) {
+                new_dev_ptr = recycled_phase_buffers_.back();
+                recycled_phase_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
+            }
+            if (new_dev_ptr == nullptr) break;
+
+            reinterpret_cast<PhaseBuffer*>(host_ptr)->count = 0;
+            uint32_t cur_tail = tail + p;
+            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
+                reinterpret_cast<uint64_t>(new_dev_ptr);
+            wmb();
+            state->free_queue.tail = cur_tail + 1;
+            wmb();
         }
 
         // Resolve host pointer of old buffer
-        void* old_host_ptr = resolve_host_ptr((void*)old_dev_ptr);
+        void* old_host_ptr = resolve_host_ptr(reinterpret_cast<void*>(old_dev_ptr));
         if (old_host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p", (void*)old_dev_ptr);
+            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p",
+                reinterpret_cast<void*>(old_dev_ptr));
             return;
         }
 
@@ -194,7 +247,7 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
         info.type = ProfBufferType::PHASE;
         info.index = tidx;
         info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = (void*)old_dev_ptr;
+        info.dev_buffer_ptr = reinterpret_cast<void*>(old_dev_ptr);
         info.host_buffer_ptr = old_host_ptr;
         info.buffer_seq = seq;
 
@@ -213,33 +266,56 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
 
         PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, core_index);
 
-        // Allocate new PerfBuffer
-        void* host_ptr = nullptr;
-        void* new_dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
-        if (new_dev_ptr != nullptr) {
-            PerfBuffer* new_buf = (PerfBuffer*)host_ptr;
-            new_buf->count = 0;
+        // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
+        rmb();
+        uint32_t head_val = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t available = tail - head_val;
 
-            // Push to free_queue (with overflow guard)
-            rmb();
-            uint32_t head_val = state->free_queue.head;
-            uint32_t tail = state->free_queue.tail;
-            if ((tail - head_val) >= PLATFORM_PROF_SLOT_COUNT) {
-                LOG_ERROR("ProfMemoryManager: perf free_queue overflow for core %u", core_index);
-                free_buffer(new_dev_ptr);
-            } else {
-                state->free_queue.buffer_ptrs[tail % PLATFORM_PROF_SLOT_COUNT] = (uint64_t)new_dev_ptr;
-                wmb();
-                state->free_queue.tail = tail + 1;
-                wmb();
+        int to_push = PLATFORM_PROF_SLOT_COUNT;
+        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
+            void* host_ptr = nullptr;
+            void* new_dev_ptr = nullptr;
+
+            if (!recycled_perf_buffers_.empty()) {
+                new_dev_ptr = recycled_perf_buffers_.back();
+                recycled_perf_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
             }
-        } else {
-            LOG_ERROR("ProfMemoryManager: perf buffer alloc failed, device may lose data");
+            if (new_dev_ptr == nullptr) {
+                std::lock_guard<std::mutex> lock(done_mutex_);
+                while (!done_queue_.empty()) {
+                    CopyDoneInfo dinfo = done_queue_.front();
+                    done_queue_.pop();
+                    if (dinfo.type == ProfBufferType::PERF_RECORD)
+                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else
+                        recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                }
+            }
+            if (new_dev_ptr == nullptr && !recycled_perf_buffers_.empty()) {
+                new_dev_ptr = recycled_perf_buffers_.back();
+                recycled_perf_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                new_dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
+            }
+            if (new_dev_ptr == nullptr) break;
+
+            reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+            uint32_t cur_tail = tail + p;
+            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
+                reinterpret_cast<uint64_t>(new_dev_ptr);
+            wmb();
+            state->free_queue.tail = cur_tail + 1;
+            wmb();
         }
 
-        void* old_host_ptr = resolve_host_ptr((void*)old_dev_ptr);
+        void* old_host_ptr = resolve_host_ptr(reinterpret_cast<void*>(old_dev_ptr));
         if (old_host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p", (void*)old_dev_ptr);
+            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p",
+                reinterpret_cast<void*>(old_dev_ptr));
             return;
         }
 
@@ -247,7 +323,7 @@ void ProfMemoryManager::process_ready_entry(PerfDataHeader* /*header*/, int /*th
         info.type = ProfBufferType::PERF_RECORD;
         info.index = core_index;
         info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = (void*)old_dev_ptr;
+        info.dev_buffer_ptr = reinterpret_cast<void*>(old_dev_ptr);
         info.host_buffer_ptr = old_host_ptr;
         info.buffer_seq = seq;
 
@@ -263,13 +339,17 @@ void ProfMemoryManager::mgmt_loop() {
     PerfDataHeader* header = get_perf_header(shared_mem_host_);
 
     while (running_.load()) {
-        // 1. Process done queue: free buffers that main thread has finished copying
+        // 1. Recycle done queue: move completed buffers to recycled pools for reuse
         {
             std::lock_guard<std::mutex> lock(done_mutex_);
             while (!done_queue_.empty()) {
                 CopyDoneInfo info = done_queue_.front();
                 done_queue_.pop();
-                free_buffer(info.dev_buffer_ptr);
+                if (info.type == ProfBufferType::PERF_RECORD) {
+                    recycled_perf_buffers_.push_back(info.dev_buffer_ptr);
+                } else {
+                    recycled_phase_buffers_.push_back(info.dev_buffer_ptr);
+                }
             }
         }
 
@@ -283,7 +363,10 @@ void ProfMemoryManager::mgmt_loop() {
             // Validate indices to prevent OOB access from corrupted shared memory
             if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
                 LOG_ERROR("mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)",
-                          t, head, tail, PLATFORM_PROF_READYQUEUE_SIZE);
+                    t,
+                    head,
+                    tail,
+                    PLATFORM_PROF_READYQUEUE_SIZE);
                 continue;
             }
 
@@ -308,7 +391,71 @@ void ProfMemoryManager::mgmt_loop() {
             }
         }
 
-        // 3. If nothing found, yield briefly to avoid busy-spinning
+        // 3. Proactive replenishment: push buffers to cores/threads whose free_queue
+        //    is completely empty (avail == 0). Try recycled pool first, alloc as fallback.
+        if (!recycled_perf_buffers_.empty() || !recycled_phase_buffers_.empty()) {
+            for (int i = 0; i < num_cores_ && !recycled_perf_buffers_.empty(); i++) {
+                PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, i);
+                rmb();
+                uint32_t avail = state->free_queue.tail - state->free_queue.head;
+                if (avail == 0) {
+                    void* dev_ptr = recycled_perf_buffers_.back();
+                    recycled_perf_buffers_.pop_back();
+                    void* host_ptr = resolve_host_ptr(dev_ptr);
+                    if (host_ptr != nullptr) {
+                        reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+                        uint32_t t_val = state->free_queue.tail;
+                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                            reinterpret_cast<uint64_t>(dev_ptr);
+                        wmb();
+                        state->free_queue.tail = t_val + 1;
+                        wmb();
+                    }
+                }
+            }
+            for (int t = 0; t < num_phase_threads_ && !recycled_phase_buffers_.empty(); t++) {
+                PhaseBufferState* state = get_phase_buffer_state(shared_mem_host_, num_cores_, t);
+                rmb();
+                uint32_t avail = state->free_queue.tail - state->free_queue.head;
+                if (avail == 0) {
+                    void* dev_ptr = recycled_phase_buffers_.back();
+                    recycled_phase_buffers_.pop_back();
+                    void* host_ptr = resolve_host_ptr(dev_ptr);
+                    if (host_ptr != nullptr) {
+                        reinterpret_cast<PhaseBuffer*>(host_ptr)->count = 0;
+                        uint32_t t_val = state->free_queue.tail;
+                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                            reinterpret_cast<uint64_t>(dev_ptr);
+                        wmb();
+                        state->free_queue.tail = t_val + 1;
+                        wmb();
+                    }
+                }
+            }
+        }
+        // Alloc fallback: if recycled pools are both empty, scan for depleted cores and alloc.
+        // This only triggers when ALL pre-allocated buffers are in-flight (extreme workloads).
+        if (recycled_perf_buffers_.empty() && recycled_phase_buffers_.empty()) {
+            for (int i = 0; i < num_cores_; i++) {
+                PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, i);
+                rmb();
+                if (state->free_queue.tail - state->free_queue.head == 0) {
+                    void* host_ptr = nullptr;
+                    void* dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
+                    if (dev_ptr == nullptr) break;
+                    reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+                    uint32_t t_val = state->free_queue.tail;
+                    state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                        reinterpret_cast<uint64_t>(dev_ptr);
+                    wmb();
+                    state->free_queue.tail = t_val + 1;
+                    wmb();
+                    break;
+                }
+            }
+        }
+
+        // 4. If nothing found, yield briefly to avoid busy-spinning
         if (!found_any) {
             std::this_thread::sleep_for(std::chrono::microseconds(10));
         }
@@ -321,8 +468,7 @@ void ProfMemoryManager::mgmt_loop() {
         uint32_t head = hdr->queue_heads[t];
         uint32_t tail = hdr->queue_tails[t];
         if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u",
-                      t, head, tail);
+            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u", t, head, tail);
             continue;
         }
         while (head != tail) {
@@ -387,12 +533,12 @@ void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out
 }
 
 int PerformanceCollector::initialize(Runtime& runtime,
-                                      int num_aicore,
-                                      int device_id,
-                                      PerfAllocCallback alloc_cb,
-                                      PerfRegisterCallback register_cb,
-                                      PerfFreeCallback free_cb,
-                                      void* user_data) {
+    int num_aicore,
+    int device_id,
+    PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb,
+    void* user_data) {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
         return -1;
@@ -421,8 +567,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("  Header size:          %zu bytes", sizeof(PerfDataHeader));
     LOG_DEBUG("  PerfBufferState size: %zu bytes each", sizeof(PerfBufferState));
     LOG_DEBUG("  PhaseBufferState size:%zu bytes each", sizeof(PhaseBufferState));
-    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)",
-              total_size, total_size / 1024);
+    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
 
     // Step 2: Allocate shared memory for slot arrays
     void* perf_dev_ptr = alloc_cb(total_size, user_data);
@@ -468,7 +613,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("  buffer_capacity:  %d", PLATFORM_PROF_BUFFER_SIZE);
     LOG_DEBUG("  queue capacity:   %d", PLATFORM_PROF_READYQUEUE_SIZE);
 
-    // Step 5: Initialize PerfBufferStates and pre-fill free_queues
+    // Step 5: Initialize PerfBufferStates — 1 buffer per core in free_queue, rest to recycled pool
     for (int i = 0; i < num_aicore; i++) {
         PerfBufferState* state = get_perf_buffer_state(perf_host_ptr, i);
         memset(state, 0, sizeof(PerfBufferState));
@@ -478,30 +623,32 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->current_buf_ptr = 0;
         state->current_buf_seq = 0;
 
-        // Pre-fill free_queue with PLATFORM_PROF_SLOT_COUNT buffers
-        for (int s = 0; s < PLATFORM_PROF_SLOT_COUNT; s++) {
+        for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_CORE; s++) {
             void* host_buf_ptr = nullptr;
             void* dev_buf_ptr = alloc_single_buffer(sizeof(PerfBuffer), &host_buf_ptr);
             if (dev_buf_ptr == nullptr) {
                 LOG_ERROR("Failed to allocate PerfBuffer for core %d, buffer %d", i, s);
                 return -1;
             }
-            // Initialize buffer
-            PerfBuffer* buf = (PerfBuffer*)host_buf_ptr;
+            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(host_buf_ptr);
             memset(buf, 0, sizeof(PerfBuffer));
             buf->count = 0;
 
-            // Push to free_queue
-            state->free_queue.buffer_ptrs[s] = (uint64_t)dev_buf_ptr;
+            if (s == 0) {
+                state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
+            } else {
+                memory_manager_.recycled_perf_buffers_.push_back(dev_buf_ptr);
+            }
         }
         wmb();
-        state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
+        state->free_queue.tail = 1;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PerfBufferStates with %d buffers each",
-              num_aicore, PLATFORM_PROF_SLOT_COUNT);
+    LOG_DEBUG("Initialized %d PerfBufferStates: 1 buffer/core, %d in recycled pool",
+        num_aicore,
+        num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1));
 
-    // Step 6: Initialize PhaseBufferStates and pre-fill free_queues
+    // Step 6: Initialize PhaseBufferStates — 1 buffer per thread in free_queue, rest to recycled pool
     for (int t = 0; t < num_phase_threads; t++) {
         PhaseBufferState* state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
         memset(state, 0, sizeof(PhaseBufferState));
@@ -511,32 +658,35 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->current_buf_ptr = 0;
         state->current_buf_seq = 0;
 
-        // Pre-fill free_queue with PLATFORM_PROF_SLOT_COUNT buffers
-        for (int s = 0; s < PLATFORM_PROF_SLOT_COUNT; s++) {
+        for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_THREAD; s++) {
             void* host_buf_ptr = nullptr;
             void* dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
             if (dev_buf_ptr == nullptr) {
                 LOG_ERROR("Failed to allocate PhaseBuffer for thread %d, buffer %d", t, s);
                 return -1;
             }
-            PhaseBuffer* buf = (PhaseBuffer*)host_buf_ptr;
+            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(host_buf_ptr);
             memset(buf, 0, sizeof(PhaseBuffer));
             buf->count = 0;
 
-            // Push to free_queue
-            state->free_queue.buffer_ptrs[s] = (uint64_t)dev_buf_ptr;
+            if (s == 0) {
+                state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
+            } else {
+                memory_manager_.recycled_phase_buffers_.push_back(dev_buf_ptr);
+            }
         }
         wmb();
-        state->free_queue.tail = PLATFORM_PROF_SLOT_COUNT;
+        state->free_queue.tail = 1;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PhaseBufferStates with %d buffers each",
-              num_phase_threads, PLATFORM_PROF_SLOT_COUNT);
+    LOG_DEBUG("Initialized %d PhaseBufferStates: 1 buffer/thread, %d in recycled pool",
+        num_phase_threads,
+        num_phase_threads * (PLATFORM_PROF_BUFFERS_PER_THREAD - 1));
 
     wmb();
 
     // Step 7: Pass base address to Runtime
-    runtime.perf_data_base = (uint64_t)perf_dev_ptr;
+    runtime.perf_data_base = reinterpret_cast<uint64_t>(perf_dev_ptr);
     LOG_DEBUG("Set runtime.perf_data_base = 0x%lx", runtime.perf_data_base);
 
     perf_shared_mem_dev_ = perf_dev_ptr;
@@ -551,10 +701,14 @@ void PerformanceCollector::start_memory_manager() {
         return;
     }
 
-    memory_manager_.start(perf_shared_mem_host_, num_aicore_,
-                           PLATFORM_MAX_AICPU_THREADS,
-                           alloc_cb_, register_cb_, free_cb_,
-                           user_data_, device_id_);
+    memory_manager_.start(perf_shared_mem_host_,
+        num_aicore_,
+        PLATFORM_MAX_AICPU_THREADS,
+        alloc_cb_,
+        register_cb_,
+        free_cb_,
+        user_data_,
+        device_id_);
 }
 
 void PerformanceCollector::stop_memory_manager() {
@@ -563,10 +717,14 @@ void PerformanceCollector::stop_memory_manager() {
     }
 }
 
+void PerformanceCollector::signal_execution_complete() { execution_complete_.store(true); }
+
 void PerformanceCollector::poll_and_collect(int expected_tasks) {
     if (perf_shared_mem_host_ == nullptr) {
         return;
     }
+
+    execution_complete_.store(false);
 
     LOG_INFO("Collecting performance data");
 
@@ -574,6 +732,16 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
 
     const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);
     std::optional<std::chrono::steady_clock::time_point> idle_start;
+
+    // Initialize collection storage before the waiting loop so buffers
+    // can be processed immediately, preventing device memory leaks.
+    int total_records_collected = 0;
+    int buffers_processed = 0;
+
+    collected_perf_records_.clear();
+    collected_perf_records_.resize(num_aicore_);
+    collected_phase_records_.clear();
+    collected_phase_records_.resize(PLATFORM_MAX_AICPU_THREADS);
 
     if (expected_tasks <= 0) {
         LOG_INFO("Waiting for AICPU to write total_tasks in PerfDataHeader...");
@@ -592,28 +760,48 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
                 LOG_ERROR("Timeout waiting for AICPU task count after %ld seconds",
-                         std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
                 return;
             }
 
-            // Check for ready buffers while waiting
+            // Process ready buffers while waiting to free device memory
             ReadyBufferInfo info;
             if (memory_manager_.try_pop_ready(info)) {
-                // Process it (even before we know expected_tasks)
-                // Will be counted below
+                if (info.type == ProfBufferType::PERF_RECORD) {
+                    PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
+                    rmb();
+                    uint32_t count = buf->count;
+                    if (count > PLATFORM_PROF_BUFFER_SIZE) {
+                        count = PLATFORM_PROF_BUFFER_SIZE;
+                    }
+                    uint32_t core_index = info.index;
+                    if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                        for (uint32_t i = 0; i < count; i++) {
+                            collected_perf_records_[core_index].push_back(buf->records[i]);
+                        }
+                        total_records_collected += count;
+                    }
+                } else {
+                    PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
+                    rmb();
+                    uint32_t count = buf->count;
+                    if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                        count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                    }
+                    uint32_t tidx = info.index;
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_phase_records_[tidx].push_back(buf->records[i]);
+                    }
+                }
+                memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
+                buffers_processed++;
             }
         }
     }
 
     LOG_DEBUG("Initial expected tasks: %d", expected_tasks);
 
-    int total_records_collected = 0;
-    int buffers_processed = 0;
-
-    collected_perf_records_.clear();
-    collected_perf_records_.resize(num_aicore_);
-
-    // Pre-allocate phase record storage
+    // Check phase header for scheduler thread info
     AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
     int num_sched_for_poll = 0;
     if (phase_header->magic == AICPU_PHASE_MAGIC) {
@@ -621,8 +809,6 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
         if (num_sched_for_poll > PLATFORM_MAX_AICPU_THREADS) {
             num_sched_for_poll = PLATFORM_MAX_AICPU_THREADS;
         }
-        collected_phase_records_.clear();
-        collected_phase_records_.resize(PLATFORM_MAX_AICPU_THREADS);
     }
 
     idle_start.reset();
@@ -645,7 +831,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             idle_start.reset();
 
             if (info.type == ProfBufferType::PERF_RECORD) {
-                PerfBuffer* buf = (PerfBuffer*)info.host_buffer_ptr;
+                PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
                 rmb();
                 uint32_t count = buf->count;
                 if (count > PLATFORM_PROF_BUFFER_SIZE) {
@@ -661,10 +847,13 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 }
 
                 LOG_DEBUG("Collected %u perf records from core %u (total: %d/%d)",
-                         count, core_index, total_records_collected, expected_tasks);
+                    count,
+                    core_index,
+                    total_records_collected,
+                    expected_tasks);
 
             } else {
-                PhaseBuffer* buf = (PhaseBuffer*)info.host_buffer_ptr;
+                PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
                 rmb();
                 uint32_t count = buf->count;
                 if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -679,21 +868,54 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 LOG_DEBUG("Collected %u phase records from thread %u", count, tidx);
             }
 
-            // Notify memory manager to free old buffer
-            memory_manager_.notify_copy_done({info.dev_buffer_ptr});
+            // Notify memory manager to recycle old buffer
+            memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
             buffers_processed++;
 
         } else {
-            // Timeout on wait — check for overall timeout
+            // Timeout on wait — check for execution complete signal or overall timeout
+            if (execution_complete_.load()) {
+                ReadyBufferInfo drain_info;
+                while (memory_manager_.try_pop_ready(drain_info)) {
+                    if (drain_info.type == ProfBufferType::PERF_RECORD) {
+                        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(drain_info.host_buffer_ptr);
+                        rmb();
+                        uint32_t count = buf->count;
+                        if (count > PLATFORM_PROF_BUFFER_SIZE) count = PLATFORM_PROF_BUFFER_SIZE;
+                        uint32_t ci = drain_info.index;
+                        if (ci < static_cast<uint32_t>(num_aicore_)) {
+                            for (uint32_t i = 0; i < count; i++) {
+                                collected_perf_records_[ci].push_back(buf->records[i]);
+                            }
+                            total_records_collected += count;
+                        }
+                    } else {
+                        PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(drain_info.host_buffer_ptr);
+                        rmb();
+                        uint32_t count = buf->count;
+                        if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD))
+                            count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                        uint32_t tidx = drain_info.index;
+                        for (uint32_t i = 0; i < count; i++) {
+                            collected_phase_records_[tidx].push_back(buf->records[i]);
+                        }
+                    }
+                    memory_manager_.notify_copy_done({drain_info.dev_buffer_ptr, drain_info.type});
+                    buffers_processed++;
+                }
+                LOG_INFO("Execution complete signal received, exiting with %d/%d records",
+                    total_records_collected,
+                    expected_tasks);
+                break;
+            }
             if (!idle_start.has_value()) {
                 idle_start = std::chrono::steady_clock::now();
             }
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
                 LOG_ERROR("Performance data collection idle timeout after %ld seconds",
-                         std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
-                LOG_ERROR("Collected %d / %d records before timeout",
-                         total_records_collected, expected_tasks);
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                LOG_ERROR("Collected %d / %d records before timeout", total_records_collected, expected_tasks);
                 break;
             }
         }
@@ -703,8 +925,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     LOG_INFO("Total records collected: %d", total_records_collected);
 
     if (total_records_collected < expected_tasks) {
-        LOG_WARN("Incomplete collection (%d / %d records)",
-                 total_records_collected, expected_tasks);
+        LOG_WARN("Incomplete collection (%d / %d records)", total_records_collected, expected_tasks);
     }
 
     LOG_INFO("Performance data collection complete");
@@ -732,7 +953,7 @@ void PerformanceCollector::drain_remaining_buffers() {
     ReadyBufferInfo info;
     while (memory_manager_.try_pop_ready(info)) {
         if (info.type == ProfBufferType::PERF_RECORD) {
-            PerfBuffer* buf = (PerfBuffer*)info.host_buffer_ptr;
+            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
             rmb();
             uint32_t count = buf->count;
             if (count > PLATFORM_PROF_BUFFER_SIZE) {
@@ -746,7 +967,7 @@ void PerformanceCollector::drain_remaining_buffers() {
                 drained_perf += count;
             }
         } else {
-            PhaseBuffer* buf = (PhaseBuffer*)info.host_buffer_ptr;
+            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
             rmb();
             uint32_t count = buf->count;
             if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -759,16 +980,61 @@ void PerformanceCollector::drain_remaining_buffers() {
             drained_phase += count;
         }
 
-        memory_manager_.notify_copy_done({info.dev_buffer_ptr});
+        memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
     }
 
     if (drained_perf > 0 || drained_phase > 0) {
-        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records",
-                 drained_perf, drained_phase);
+        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records", drained_perf, drained_phase);
     }
 
     if (drained_phase > 0) {
         has_phase_data_ = true;
+    }
+}
+
+void PerformanceCollector::scan_remaining_perf_buffers() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    rmb();
+
+    int total_recovered = 0;
+
+    for (int core_index = 0; core_index < num_aicore_; core_index++) {
+        PerfBufferState* state = get_perf_buffer_state(perf_shared_mem_host_, core_index);
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) {
+            continue;
+        }
+
+        void* host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void*>(buf_ptr));
+        if (host_ptr == nullptr) {
+            LOG_ERROR("scan_remaining_perf_buffers: no host mapping for dev_ptr=%p (core %d)",
+                reinterpret_cast<void*>(buf_ptr),
+                core_index);
+            continue;
+        }
+
+        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(host_ptr);
+        uint32_t count = buf->count;
+        if (count == 0) {
+            continue;
+        }
+        if (count > PLATFORM_PROF_BUFFER_SIZE) {
+            count = PLATFORM_PROF_BUFFER_SIZE;
+        }
+
+        for (uint32_t i = 0; i < count; i++) {
+            collected_perf_records_[core_index].push_back(buf->records[i]);
+        }
+        total_recovered += count;
+    }
+
+    if (total_recovered > 0) {
+        LOG_INFO("scan_remaining_perf_buffers: recovered %d records from active buffers", total_recovered);
     }
 }
 
@@ -783,15 +1049,15 @@ void PerformanceCollector::collect_phase_data() {
 
     // Validate magic
     if (phase_header->magic != AICPU_PHASE_MAGIC) {
-        LOG_INFO("No phase profiling data found (magic mismatch: 0x%x vs 0x%x)",
-                 phase_header->magic, AICPU_PHASE_MAGIC);
+        LOG_INFO(
+            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC);
         return;
     }
 
     int num_sched_threads = phase_header->num_sched_threads;
     if (num_sched_threads > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR("Invalid num_sched_threads %d from shared memory (max=%d)",
-                  num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
+        LOG_ERROR(
+            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
         return;
     }
     LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
@@ -809,13 +1075,14 @@ void PerformanceCollector::collect_phase_data() {
         rmb();
         uint64_t buf_ptr = state->current_buf_ptr;
         if (buf_ptr != 0) {
-            void* host_ptr = memory_manager_.resolve_host_ptr((void*)buf_ptr);
+            void* host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void*>(buf_ptr));
             if (host_ptr == nullptr) {
                 LOG_ERROR("collect_phase_data: no host mapping for dev_ptr=%p (thread %d)",
-                          (void*)buf_ptr, t);
+                    reinterpret_cast<void*>(buf_ptr),
+                    t);
                 continue;
             }
-            PhaseBuffer* pbuf = (PhaseBuffer*)host_ptr;
+            PhaseBuffer* pbuf = reinterpret_cast<PhaseBuffer*>(host_ptr);
             if (pbuf->count > 0) {
                 uint32_t count = pbuf->count;
                 if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -835,11 +1102,16 @@ void PerformanceCollector::collect_phase_data() {
         if (!collected_phase_records_[t].empty()) {
             size_t sched_count = 0, orch_count = 0;
             for (const auto& r : collected_phase_records_[t]) {
-                if (is_scheduler_phase(r.phase_id)) sched_count++;
-                else orch_count++;
+                if (is_scheduler_phase(r.phase_id))
+                    sched_count++;
+                else
+                    orch_count++;
             }
             LOG_INFO("  Thread %zu: %zu records (sched=%zu, orch=%zu)",
-                     t, collected_phase_records_[t].size(), sched_count, orch_count);
+                t,
+                collected_phase_records_[t].size(),
+                sched_count,
+                orch_count);
         }
     }
 
@@ -848,9 +1120,9 @@ void PerformanceCollector::collect_phase_data() {
     bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
 
     if (orch_valid) {
-        LOG_INFO("  Orchestrator: %lld tasks, %.3fus",
-                 (long long)collected_orch_summary_.submit_count,
-                 cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time));
+        LOG_INFO("  Orchestrator: %" PRId64 " tasks, %.3fus",
+            static_cast<int64_t>(collected_orch_summary_.submit_count),
+            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time));
     } else {
         LOG_INFO("  Orchestrator: no summary data");
     }
@@ -859,7 +1131,10 @@ void PerformanceCollector::collect_phase_data() {
     bool has_accumulated = has_phase_data_;
     if (!has_accumulated) {
         for (const auto& v : collected_phase_records_) {
-            if (!v.empty()) { has_accumulated = true; break; }
+            if (!v.empty()) {
+                has_accumulated = true;
+                break;
+            }
         }
     }
     has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
@@ -867,13 +1142,13 @@ void PerformanceCollector::collect_phase_data() {
     // Read core-to-thread mapping
     int num_cores = static_cast<int>(phase_header->num_cores);
     if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
-        core_to_thread_.assign(phase_header->core_to_thread,
-                                phase_header->core_to_thread + num_cores);
+        core_to_thread_.assign(phase_header->core_to_thread, phase_header->core_to_thread + num_cores);
         LOG_INFO("  Core-to-thread mapping: %d cores", num_cores);
     }
 
     LOG_INFO("Phase data collection complete: %d remaining records, orch_summary=%s",
-             total_phase_records, orch_valid ? "yes" : "no");
+        total_phase_records,
+        orch_valid ? "yes" : "no");
 }
 
 int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
@@ -917,10 +1192,9 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     }
 
     // Sort by canonical task_id (64-bit PTO2 raw)
-    std::sort(tagged_records.begin(), tagged_records.end(),
-              [](const TaggedRecord& a, const TaggedRecord& b) {
-                  return a.record->task_id < b.record->task_id;
-              });
+    std::sort(tagged_records.begin(), tagged_records.end(), [](const TaggedRecord& a, const TaggedRecord& b) {
+        return a.record->task_id < b.record->task_id;
+    });
 
     // Step 4: Calculate base time (minimum timestamp across all records)
     uint64_t base_time_cycles = UINT64_MAX;
@@ -942,8 +1216,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                 }
             }
         }
-        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC &&
-            collected_orch_summary_.start_time > 0 &&
+        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC && collected_orch_summary_.start_time > 0 &&
             collected_orch_summary_.start_time < base_time_cycles) {
             base_time_cycles = collected_orch_summary_.start_time;
         }
@@ -954,8 +1227,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     std::tm* timeinfo = std::localtime(&now);
     char time_buffer[32];
     std::strftime(time_buffer, sizeof(time_buffer), "%Y%m%d_%H%M%S", timeinfo);
-    std::string filepath = output_path + "/perf_swimlane_"
-                          + std::string(time_buffer) + ".json";
+    std::string filepath = output_path + "/perf_swimlane_" + std::string(time_buffer) + ".json";
 
     // Step 6: Open JSON file for writing
     std::ofstream outfile(filepath);
@@ -995,8 +1267,8 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         outfile << "      \"dispatch_time_us\": " << std::fixed << std::setprecision(3) << dispatch_us << ",\n";
         outfile << "      \"finish_time_us\": " << std::fixed << std::setprecision(3) << finish_us << ",\n";
         outfile << "      \"fanout\": [";
-        int safe_fanout_count = (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT)
-                                ? record.fanout_count : 0;
+        int safe_fanout_count =
+            (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT) ? record.fanout_count : 0;
         for (int j = 0; j < safe_fanout_count; ++j) {
             outfile << record.fanout[j];
             if (j < safe_fanout_count - 1) {
@@ -1017,26 +1289,41 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     if (has_phase_data_) {
         auto sched_phase_name = [](AicpuPhaseId id) -> const char* {
             switch (id) {
-                case AicpuPhaseId::SCHED_COMPLETE:    return "complete";
-                case AicpuPhaseId::SCHED_DISPATCH:    return "dispatch";
-                case AicpuPhaseId::SCHED_SCAN:        return "scan";
-                case AicpuPhaseId::SCHED_IDLE_WAIT:   return "idle";
-                default: return "unknown";
+                case AicpuPhaseId::SCHED_COMPLETE:
+                    return "complete";
+                case AicpuPhaseId::SCHED_DISPATCH:
+                    return "dispatch";
+                case AicpuPhaseId::SCHED_SCAN:
+                    return "scan";
+                case AicpuPhaseId::SCHED_IDLE_WAIT:
+                    return "idle";
+                default:
+                    return "unknown";
             }
         };
 
         auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
             switch (id) {
-                case AicpuPhaseId::ORCH_SYNC:      return "orch_sync";
-                case AicpuPhaseId::ORCH_ALLOC:     return "orch_alloc";
-                case AicpuPhaseId::ORCH_PARAMS:    return "orch_params";
-                case AicpuPhaseId::ORCH_LOOKUP:    return "orch_lookup";
-                case AicpuPhaseId::ORCH_HEAP:      return "orch_heap";
-                case AicpuPhaseId::ORCH_INSERT:    return "orch_insert";
-                case AicpuPhaseId::ORCH_FANIN:     return "orch_fanin";
-                case AicpuPhaseId::ORCH_FINALIZE:  return "orch_finalize";
-                case AicpuPhaseId::ORCH_SCOPE_END: return "orch_scope_end";
-                default: return "unknown";
+                case AicpuPhaseId::ORCH_SYNC:
+                    return "orch_sync";
+                case AicpuPhaseId::ORCH_ALLOC:
+                    return "orch_alloc";
+                case AicpuPhaseId::ORCH_PARAMS:
+                    return "orch_params";
+                case AicpuPhaseId::ORCH_LOOKUP:
+                    return "orch_lookup";
+                case AicpuPhaseId::ORCH_HEAP:
+                    return "orch_heap";
+                case AicpuPhaseId::ORCH_INSERT:
+                    return "orch_insert";
+                case AicpuPhaseId::ORCH_FANIN:
+                    return "orch_fanin";
+                case AicpuPhaseId::ORCH_FINALIZE:
+                    return "orch_finalize";
+                case AicpuPhaseId::ORCH_SCOPE_END:
+                    return "orch_scope_end";
+                default:
+                    return "unknown";
             }
         };
 
@@ -1051,10 +1338,9 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                 double end_us = cycles_to_us(pr.end_time - base_time_cycles);
                 if (!first) outfile << ",\n";
                 outfile << "      {\"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
-                        << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                        << ", \"phase\": \"" << sched_phase_name(pr.phase_id) << "\""
-                        << ", \"loop_iter\": " << pr.loop_iter
-                        << ", \"tasks_processed\": " << pr.tasks_processed
+                        << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us << ", \"phase\": \""
+                        << sched_phase_name(pr.phase_id) << "\""
+                        << ", \"loop_iter\": " << pr.loop_iter << ", \"tasks_processed\": " << pr.tasks_processed
                         << "}";
                 first = false;
             }
@@ -1075,14 +1361,22 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
             outfile << "    \"end_time_us\": " << std::fixed << std::setprecision(3) << orch_end_us << ",\n";
             outfile << "    \"submit_count\": " << collected_orch_summary_.submit_count << ",\n";
             outfile << "    \"phase_us\": {\n";
-            outfile << "      \"sync\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.sync_cycle) << ",\n";
-            outfile << "      \"alloc\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
-            outfile << "      \"params\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.params_cycle) << ",\n";
-            outfile << "      \"lookup\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
-            outfile << "      \"heap\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
-            outfile << "      \"insert\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
-            outfile << "      \"fanin\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
-            outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3) << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
+            outfile << "      \"sync\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.sync_cycle) << ",\n";
+            outfile << "      \"alloc\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
+            outfile << "      \"params\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.params_cycle) << ",\n";
+            outfile << "      \"lookup\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
+            outfile << "      \"heap\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
+            outfile << "      \"insert\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
+            outfile << "      \"fanin\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
+            outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3)
+                    << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
             outfile << "    }\n";
             outfile << "  }";
         }
@@ -1091,7 +1385,10 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         bool has_orch_phases = false;
         for (const auto& v : collected_phase_records_) {
             for (const auto& r : v) {
-                if (!is_scheduler_phase(r.phase_id)) { has_orch_phases = true; break; }
+                if (!is_scheduler_phase(r.phase_id)) {
+                    has_orch_phases = true;
+                    break;
+                }
             }
             if (has_orch_phases) break;
         }
@@ -1108,9 +1405,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
                     outfile << "      {\"phase\": \"" << orch_phase_name(pr.phase_id) << "\""
                             << ", \"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                             << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us
-                            << ", \"submit_idx\": " << pr.loop_iter
-                            << ", \"task_id\": " << pr.task_id
-                            << "}";
+                            << ", \"submit_idx\": " << pr.loop_iter << ", \"task_id\": " << pr.task_id << "}";
                     first = false;
                 }
                 if (!first) outfile << "\n";
@@ -1145,9 +1440,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     return 0;
 }
 
-int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
-                                    PerfFreeCallback free_cb,
-                                    void* user_data) {
+int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data) {
     if (perf_shared_mem_host_ == nullptr) {
         return 0;
     }
@@ -1166,7 +1459,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
 
         // Free current buffer if any
         if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            free_cb((void*)state->current_buf_ptr, user_data);
+            free_cb(reinterpret_cast<void*>(state->current_buf_ptr), user_data);
         }
 
         // Free all buffers in free_queue (limit iterations to max capacity)
@@ -1177,13 +1470,12 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
         while (head != tail && max_iters-- > 0) {
             uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
             if (buf_ptr != 0 && free_cb != nullptr) {
-                free_cb((void*)buf_ptr, user_data);
+                free_cb(reinterpret_cast<void*>(buf_ptr), user_data);
             }
             head++;
         }
         if (head != tail) {
-            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)",
-                     i, head, tail);
+            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)", i, head, tail);
         }
     }
 
@@ -1193,7 +1485,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
 
         // Free current buffer if any
         if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            free_cb((void*)state->current_buf_ptr, user_data);
+            free_cb(reinterpret_cast<void*>(state->current_buf_ptr), user_data);
         }
 
         // Free all buffers in free_queue (limit iterations to max capacity)
@@ -1204,13 +1496,12 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb,
         while (head != tail && max_iters-- > 0) {
             uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
             if (buf_ptr != 0 && free_cb != nullptr) {
-                free_cb((void*)buf_ptr, user_data);
+                free_cb(reinterpret_cast<void*>(buf_ptr), user_data);
             }
             head++;
         }
         if (head != tail) {
-            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)",
-                     t, head, tail);
+            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)", t, head, tail);
         }
     }
 

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 /**
  * Runtime Class - Task Dependency Runtime Management
  *
@@ -15,8 +26,8 @@
  * and lightweight scheduling use cases.
  */
 
-#ifndef RUNTIME_H
-#define RUNTIME_H
+#ifndef SRC_A5_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_
+#define SRC_A5_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -45,7 +56,7 @@
 #endif
 
 #ifndef RUNTIME_MAX_FANOUT
-#define RUNTIME_MAX_FANOUT 512
+#define RUNTIME_MAX_FANOUT 128
 #endif
 
 #ifndef RUNTIME_MAX_WORKER
@@ -101,17 +112,17 @@
  * - physical_core_id: Written by AICPU, read by AICore (physical core ID)
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;          // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;          // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                 // Task pointer: 0=no task, non-zero=Task* address
-    volatile int32_t task_status;           // Task execution status: 0=idle, 1=busy
-    volatile int32_t control;               // Control signal: 0=execute, 1=quit
-    volatile CoreType core_type;            // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t perf_records_addr;    // Performance records address
-    volatile uint32_t perf_buffer_status;   // 0 = not full, 1 = full
-    volatile uint32_t physical_core_id;     // Physical core ID
+    volatile uint32_t aicpu_ready;         // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;         // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                // Task pointer: 0=no task, non-zero=Task* address
+    volatile int32_t task_status;          // Task execution status: 0=idle, 1=busy
+    volatile int32_t control;              // Control signal: 0=execute, 1=quit
+    volatile CoreType core_type;           // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t perf_records_addr;   // Performance records address
+    volatile uint32_t perf_buffer_status;  // 0 = not full, 1 = full
+    volatile uint32_t physical_core_id;    // Physical core ID
     volatile uint32_t aicpu_regs_ready;    // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;   // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**
@@ -182,32 +193,32 @@ typedef struct {
  * Dependencies are managed manually via add_successor().
  */
 class Runtime {
-public:
+ public:
     // Handshake buffers for AICPU-AICore communication
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int sche_cpu_num;  // Number of AICPU threads for scheduling
+    int sche_cpu_num;     // Number of AICPU threads for scheduling
     int orch_thread_num;  // Number of orchestrator threads (unused, for API compatibility)
 
     // Profiling support
-    bool enable_profiling;                  // Enable profiling flag
-    uint64_t perf_data_base;                // Performance data shared memory base address (device-side)
+    bool enable_profiling;    // Enable profiling flag
+    uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
 
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
 
-private:
-    int next_task_id;               // Next available task ID
+ private:
+    int next_task_id;  // Next available task ID
 
     // Initial ready tasks (computed once, read-only after)
     int initial_ready_tasks[RUNTIME_MAX_TASKS];
     int initial_ready_count;
 
-  // Tensor pairs for host-device memory tracking
-  TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
-  int tensor_pair_count;
+    // Tensor pairs for host-device memory tracking
+    TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
+    int tensor_pair_count;
 
     // Function address mapping (for API compatibility with rt2)
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
@@ -216,7 +227,7 @@ private:
     int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
     int registered_kernel_count_;
 
-public:
+ public:
     /**
      * Constructor - zero-initialize all arrays
      */
@@ -235,7 +246,7 @@ public:
      * @param core_type Core type for this task (CoreType::AIC or CoreType::AIV)
      * @return Task ID (>= 0) on success, -1 on failure
      */
-    int add_task(uint64_t *args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
+    int add_task(uint64_t* args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
 
     /**
      * Add a dependency edge: from_task -> to_task
@@ -258,7 +269,7 @@ public:
      * @param task_id  Task ID to query
      * @return Pointer to task, or nullptr if invalid ID
      */
-    Task *get_task(int task_id);
+    Task* get_task(int task_id);
 
     /**
      * Get the total number of tasks in the runtime
@@ -278,7 +289,7 @@ public:
      * nullptr)
      * @return Number of initially ready tasks
      */
-    int get_initial_ready_tasks(int *ready_tasks);
+    int get_initial_ready_tasks(int* ready_tasks);
 
     // =========================================================================
     // Utility Methods
@@ -373,4 +384,4 @@ public:
     HostApi host_api;
 };
 
-#endif  // RUNTIME_H
+#endif  // SRC_A5_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_


### PR DESCRIPTION
Overhaul the profiling subsystem to fix buffer leaks, lost records, and excessive device memory allocation:

Buffer recycling (Host):
- Replace alloc/free-per-cycle with closed-loop buffer pools: completed buffers are recycled into per-type pools (recycled_perf_buffers_, recycled_phase_buffers_) instead of being freed
- Pre-allocate all PerfBuffers and PhaseBuffers at init time via PLATFORM_PROF_BUFFERS_PER_CORE and PLATFORM_PROF_BUFFERS_PER_THREAD, eliminating runtime rtMalloc calls entirely
- Reduce PLATFORM_PROF_SLOT_COUNT from 8 to 4 (sufficient with recycling)
- Process ready buffers during the expected_tasks wait phase to prevent device memory leaks when AICPU is slow to report total_tasks

Buffer recycling (AICPU):
- Replace per-cycle rtMalloc/rtFree with pre-allocated buffer arrays and free-list indices, matching the Host-side closed-loop design
- Pre-allocate phase buffers per thread and perf buffers per core at profiling init, recycling them on buffer switch

Implicit task profiling (AICPU):
- When pipelining two tasks on the same core, AICore may transition from FIN(task_A) to ACK(task_B) before AICPU reads the register. Both implicit completion paths (pending FIN and pending ACK) counted the old task but never called perf_aicpu_complete_record, losing its profiling record
- Add perf_aicpu_complete_record calls in both paths, completing the implicit task's record before the explicit task's to preserve buffer ordering

Other:
- Reduce RUNTIME_MAX_FANOUT from 512 to 128 to match actual usage
- Enable profiling setup in device_runner for both onboard and sim