### PR TITLE
Support: restructure C++ lint pipeline with clang-format/tidy/cpplint separation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,30 +6,131 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-BasedOnStyle: Google
-IndentWidth: 4
-DerivePointerAlignment: false
-PointerAlignment: Left
 
-# Max line width before auto-wrapping
+BasedOnStyle: LLVM
+Language: Cpp
+
+# --- Indentation ---
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
+IndentCaseLabels: false
+IndentPPDirectives: AfterHash
+NamespaceIndentation: None
+
+# --- Column limit ---
 ColumnLimit: 120
 
-# Continuation indent for wrapped lines (function args, etc.)
-ContinuationIndentWidth: 4
+# --- Pointer & reference ---
+DerivePointerAlignment: false
+PointerAlignment: Right
+ReferenceAlignment: Right
 
-# Alignment after open bracket: DontAlign avoids aligning to bracket
-# Options: Align, DontAlign, AlwaysBreak, BlockIndent
-AlignAfterOpenBracket: DontAlign
+# --- Braces ---
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
 
-# Allow all declaration parameters on the next line
+# --- Parameter packing & alignment ---
+AlignAfterOpenBracket: BlockIndent
+BinPackParameters: true
+BinPackArguments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-
-# Allow all call arguments on the next line
 AllowAllArgumentsOnNextLine: true
 
-# One parameter per line when wrapping is needed
-BinPackParameters: false
-BinPackArguments: false
+# --- Short statements ---
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLambdasOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
 
-# Access modifier offset: 1-space indent (matches Google cpplint expectation)
-AccessModifierOffset: -3
+# --- Alignment ---
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: false
+AlignTrailingComments: true
+AlignEscapedNewlines: Left
+AlignOperands: Align
+
+# --- Constructor initializers ---
+BreakConstructorInitializers: AfterColon
+PackConstructorInitializers: Never
+
+# --- Inheritance ---
+BreakInheritanceList: AfterComma
+
+# --- Template ---
+AlwaysBreakTemplateDeclarations: Yes
+
+# --- Binary & ternary operators ---
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+
+# --- Includes ---
+SortIncludes: Never
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^<.*>'
+    Priority: 3
+  - Regex: '^".*"'
+    Priority: 1
+
+# --- Namespace ---
+FixNamespaceComments: true
+CompactNamespaces: false
+
+# --- Spaces ---
+SpaceBeforeParens: ControlStatements
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: Never
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+# --- Empty lines ---
+MaxEmptyLinesToKeep: 1
+KeepEmptyLinesAtTheStartOfBlocks: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+
+# --- Access modifier ---
+AccessModifierOffset: -4
+
+# --- Other ---
+Cpp11BracedListStyle: true
+BreakStringLiterals: true
+ReflowComments: true
+SortUsingDeclarations: true
+InsertBraces: false
+AlwaysBreakAfterReturnType: None

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,21 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+Checks: >
+  -*,
+  bugprone-*,
+  performance-*,
+  modernize-*,
+  -modernize-use-trailing-return-type
+
+WarningsAsErrors: '*'
+
+HeaderFilterRegex: '(src|include)/.*'
+
+FormatStyle: file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,12 @@ repos:
           types_or: [c++, c]
           exclude: ^3rdparty/
 
+    - repo: https://github.com/pocc/pre-commit-hooks
+      rev: v1.3.5
+      hooks:
+        - id: clang-tidy
+          exclude: ^3rdparty/
+
     - repo: https://github.com/cpplint/cpplint
       rev:  2.0.0
       hooks:
@@ -49,7 +55,7 @@ repos:
           args:
             - --root=include
             - --linelength=120
-            - --filter=-whitespace/parens,-whitespace/indent_namespace,-runtime/references,-build/include_subdir
+            - --filter=-whitespace,-build,-legal,-runtime,-readability,+readability/todo
 
     # Markdown linting
     - repo: https://github.com/DavidAnson/markdownlint-cli2


### PR DESCRIPTION
- Replace Google-based .clang-format with LLVM-based custom config (right-aligned pointers, BlockIndent brackets, alignment rules)
- Add .clang-tidy with conservative checks (bugprone, performance, modernize)
- Narrow cpplint to readability/todo only; formatting and code quality checks are now handled by clang-format and clang-tidy respectively
- Add clang-tidy pre-commit hook via pocc/pre-commit-hooks