### PR TITLE
Refactor: apply clang-format to all C++ sources and add clang-tidy to clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,32 @@ Checks: >
   bugprone-*,
   performance-*,
   modernize-*,
-  -modernize-use-trailing-return-type
+  -modernize-use-trailing-return-type,
+  -modernize-avoid-c-arrays,
+  -modernize-use-nodiscard,
+  -modernize-macro-to-enum,
+  -modernize-deprecated-headers,
+  -modernize-use-auto,
+  -modernize-use-nullptr,
+  -modernize-use-using,
+  -modernize-loop-convert,
+  -modernize-use-default-member-init,
+  -modernize-use-equals-delete,
+  -modernize-use-bool-literals,
+  -modernize-raw-string-literal,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -bugprone-reserved-identifier,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-multi-level-implicit-pointer-conversion,
+  -bugprone-branch-clone,
+  -bugprone-empty-catch,
+  -bugprone-lambda-function-name,
+  -bugprone-macro-parentheses,
+  -bugprone-infinite-loop,
+  -bugprone-argument-comment,
+  -performance-no-int-to-ptr,
+  -performance-enum-size
 
 WarningsAsErrors: '*'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ---------- Python unit tests (no hardware) ----------
+  # ---------- Pre-commit hooks (format, lint, clang-tidy) ----------
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Install build and lint tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build g++ clang-tidy
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Python dependencies
+        run: pip install numpy ml_dtypes
+
+      - name: Cache cmake build directories
+        uses: actions/cache@v3
+        with:
+          path: build/cache
+          key: cmake-sim-${{ runner.os }}-${{ hashFiles('src/**/CMakeLists.txt', 'src/**/build_config.py', 'python/runtime_compiler.py') }}
+          restore-keys: |
+            cmake-sim-${{ runner.os }}-
+
+      - name: Build sim runtimes (generates per-target compile_commands.json)
+        run: python examples/scripts/build_runtimes.py --platforms a2a3sim a5sim
+
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
         with:
           extra_args: --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
 
+  # ---------- Python unit tests (no hardware) ----------
   ut-py:
     needs: pre-commit
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,13 +41,20 @@ repos:
           types_or: [c++, c]
           exclude: ^3rdparty/
 
-    # Temporarily disable clang-tidy while the runtime sources are not
-    # lintable without a local compilation database.
-    # - repo: https://github.com/pocc/pre-commit-hooks
-    #   rev: v1.3.5
-    #   hooks:
-    #     - id: clang-tidy
-    #       exclude: ^3rdparty/
+    - repo: local
+      hooks:
+        - id: clang-tidy
+          name: clang-tidy
+          entry: python tests/lint/clang_tidy.py
+          language: python
+          types_or: [c++, c]
+          exclude: |
+            (?x)^(
+              3rdparty/|
+              python/bindings/|
+              .*/kernels/|
+              .*/aicore/
+            )
 
     - repo: https://github.com/cpplint/cpplint
       rev:  2.0.0

--- a/examples/a2a3/aicpu_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/a2a3/aicpu_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Tile-based Matrix Multiplication Kernel (Cube Core)
  *
@@ -35,14 +45,13 @@ AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
     return (num_1 + num_2 - 1) / num_2 * num_2;
 }
 
-static __aicore__ void gemm_tile_impl(
-    __gm__ Tensor* input_a_tensor,
-    __gm__ Tensor* input_b_tensor,
-    __gm__ Tensor* output_tensor) {
-
-    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
-    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
-    __gm__ float* output  = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr)  + output_tensor->start_offset;
+static __aicore__ void
+gemm_tile_impl(__gm__ Tensor *input_a_tensor, __gm__ Tensor *input_b_tensor, __gm__ Tensor *output_tensor) {
+    __gm__ float *input_a =
+        reinterpret_cast<__gm__ float *>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
+    __gm__ float *input_b =
+        reinterpret_cast<__gm__ float *>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
+    __gm__ float *output = reinterpret_cast<__gm__ float *>(output_tensor->buffer.addr) + output_tensor->start_offset;
 
     constexpr int TILE = 64;
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
@@ -50,12 +59,12 @@ static __aicore__ void gemm_tile_impl(
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);
@@ -103,10 +112,10 @@ static __aicore__ void gemm_tile_impl(
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* input_a = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* input_b = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* output  = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_a = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *input_b = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *output = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
     gemm_tile_impl(input_a, input_b, output);
 }

--- a/examples/a2a3/aicpu_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/a2a3/aicpu_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Tile-based Element-wise Addition Kernel (Vector Core) - INOUT Pattern
  *
@@ -25,12 +35,12 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* c_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* p_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *c_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *p_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
 
-    __gm__ float* c_ptr = reinterpret_cast<__gm__ float*>(c_tensor->buffer.addr) + c_tensor->start_offset;
-    __gm__ float* p_ptr = reinterpret_cast<__gm__ float*>(p_tensor->buffer.addr) + p_tensor->start_offset;
+    __gm__ float *c_ptr = reinterpret_cast<__gm__ float *>(c_tensor->buffer.addr) + c_tensor->start_offset;
+    __gm__ float *p_ptr = reinterpret_cast<__gm__ float *>(p_tensor->buffer.addr) + p_tensor->start_offset;
 
     constexpr int TILE = 64;
 

--- a/examples/a2a3/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -54,8 +54,8 @@ static constexpr uint64_t TILE_BYTES = TILE_ELEMS * sizeof(float);
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
@@ -63,7 +63,8 @@ __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestrati
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    PTO2Runtime* rt, const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+    PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index
+) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 
@@ -80,7 +81,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
             for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
                 PTO2_SCOPE(rt) {
                     uint32_t c_elem_offset = (static_cast<uint32_t>(batch) * GRID_M * GRID_N +
-                                                 static_cast<uint32_t>(m_idx) * GRID_N + static_cast<uint32_t>(n_idx)) *
+                                              static_cast<uint32_t>(m_idx) * GRID_N + static_cast<uint32_t>(n_idx)) *
                                              TILE_ELEMS;
                     uint32_t c_view_offsets[1] = {c_elem_offset};
                     Tensor C_view = ext_C.view(tile_shapes, c_view_offsets);
@@ -91,11 +92,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     for (int k_idx = 0; k_idx < GRID_K; k_idx++) {
                         uint32_t a_elem_offset =
                             (static_cast<uint32_t>(batch) * GRID_M * GRID_K + static_cast<uint32_t>(m_idx) * GRID_K +
-                                static_cast<uint32_t>(k_idx)) *
+                             static_cast<uint32_t>(k_idx)) *
                             TILE_ELEMS;
                         uint32_t b_elem_offset =
                             (static_cast<uint32_t>(batch) * GRID_K * GRID_N + static_cast<uint32_t>(k_idx) * GRID_N +
-                                static_cast<uint32_t>(n_idx)) *
+                             static_cast<uint32_t>(n_idx)) *
                             TILE_ELEMS;
 
                         uint32_t a_view_offsets[1] = {a_elem_offset};
@@ -131,12 +132,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         }
     }
 
-    LOG_INFO(rt,
-        "[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each",
-        BATCH,
-        GRID_M,
-        GRID_N,
-        GRID_K);
+    LOG_INFO(
+        rt, "[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each", BATCH, GRID_M, GRID_N,
+        GRID_K
+    );
 }
 
 }  // extern "C"

--- a/examples/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_add.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Tensor Addition Kernel
  *
@@ -19,13 +29,13 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     constexpr int kTRows_ = 128;
     constexpr int kTCols_ = 128;

--- a/examples/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/examples/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Scalar Addition Kernel
  *
@@ -19,11 +29,11 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* src_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ float* src = reinterpret_cast<__gm__ float*>(src_tensor->buffer.addr) + src_tensor->start_offset;
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ float *src = reinterpret_cast<__gm__ float *>(src_tensor->buffer.addr) + src_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     union {
         uint64_t u64;

--- a/examples/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Tensor Multiplication Kernel
  *
@@ -19,13 +29,13 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     constexpr int kTRows_ = 128;
     constexpr int kTCols_ = 128;

--- a/examples/a2a3/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
+++ b/examples/a2a3/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
@@ -29,8 +29,8 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
@@ -38,7 +38,8 @@ __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestrati
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    PTO2Runtime* rt, const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+    PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index
+) {
     (void)orch_thread_num;
     (void)orch_thread_index;
 

--- a/examples/a2a3/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/a2a3/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Tile-based Matrix Multiplication Kernel (Cube Core)
  *
@@ -28,10 +38,10 @@ AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
     return (num_1 + num_2 - 1) / num_2 * num_2;
 }
 
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
-    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(args[0]);
-    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(args[1]);
-    __gm__ float* output = reinterpret_cast<__gm__ float*>(args[2]);
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ float *input_a = reinterpret_cast<__gm__ float *>(args[0]);
+    __gm__ float *input_b = reinterpret_cast<__gm__ float *>(args[1]);
+    __gm__ float *output = reinterpret_cast<__gm__ float *>(args[2]);
 
     constexpr int TILE = 64;
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
@@ -39,12 +49,12 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);

--- a/examples/a2a3/host_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/a2a3/host_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Tile-based Element-wise Addition Kernel (Vector Core)
  *
@@ -19,10 +29,10 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
-    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(args[0]);
-    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(args[1]);
-    __gm__ float* output = reinterpret_cast<__gm__ float*>(args[2]);
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ float *input_a = reinterpret_cast<__gm__ float *>(args[0]);
+    __gm__ float *input_b = reinterpret_cast<__gm__ float *>(args[1]);
+    __gm__ float *output = reinterpret_cast<__gm__ float *>(args[2]);
 
     constexpr int TILE = 64;
 

--- a/examples/a2a3/host_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/host_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -44,16 +44,16 @@ constexpr int BATCH = 1;
 
 constexpr size_t TILE_BYTES = TILE * TILE * sizeof(float);
 
-int build_bgemm_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
+int build_bgemm_graph(Runtime *runtime, const ChipStorageTaskArgs &orch_args) {
     // Expected orch_args: [A, B, C] — 3 tensors
     if (orch_args.tensor_count() < 3) {
         std::cerr << "build_bgemm_graph: Expected at least 3 tensors, got " << orch_args.tensor_count() << '\n';
         return -1;
     }
 
-    void* host_A = orch_args.tensor(0).data_as<void>();
-    void* host_B = orch_args.tensor(1).data_as<void>();
-    void* host_C = orch_args.tensor(2).data_as<void>();
+    void *host_A = orch_args.tensor(0).data_as<void>();
+    void *host_B = orch_args.tensor(1).data_as<void>();
+    void *host_C = orch_args.tensor(2).data_as<void>();
     size_t size_A = orch_args.tensor(0).nbytes();
     size_t size_B = orch_args.tensor(1).nbytes();
     size_t size_C = orch_args.tensor(2).nbytes();
@@ -62,18 +62,18 @@ int build_bgemm_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
     std::cout << "Grid: " << GRID_M << " x " << GRID_K << " x " << GRID_N << '\n';
 
     // Allocate device memory and copy inputs
-    void* dev_A = runtime->host_api.device_malloc(size_A);
+    void *dev_A = runtime->host_api.device_malloc(size_A);
     if (!dev_A) return -1;
     runtime->host_api.copy_to_device(dev_A, host_A, size_A);
 
-    void* dev_B = runtime->host_api.device_malloc(size_B);
+    void *dev_B = runtime->host_api.device_malloc(size_B);
     if (!dev_B) {
         runtime->host_api.device_free(dev_A);
         return -1;
     }
     runtime->host_api.copy_to_device(dev_B, host_B, size_B);
 
-    void* dev_C = runtime->host_api.device_malloc(size_C);
+    void *dev_C = runtime->host_api.device_malloc(size_C);
     if (!dev_C) {
         runtime->host_api.device_free(dev_A);
         runtime->host_api.device_free(dev_B);
@@ -84,7 +84,7 @@ int build_bgemm_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
 
     // Allocate intermediate P buffers (one per C tile)
     constexpr int NUM_P_BUFFERS = BATCH * GRID_M * GRID_N;
-    std::vector<void*> dev_P(NUM_P_BUFFERS, nullptr);
+    std::vector<void *> dev_P(NUM_P_BUFFERS, nullptr);
     for (int i = 0; i < NUM_P_BUFFERS; i++) {
         dev_P[i] = runtime->host_api.device_malloc(TILE_BYTES);
         if (!dev_P[i]) {
@@ -115,8 +115,8 @@ int build_bgemm_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
 
                     // Task 1: P = A[m,k] @ B[k,n] (gemm_tile on Cube core)
                     uint64_t args_gemm[6];
-                    args_gemm[0] = reinterpret_cast<uint64_t>(static_cast<char*>(dev_A) + A_offset);
-                    args_gemm[1] = reinterpret_cast<uint64_t>(static_cast<char*>(dev_B) + B_offset);
+                    args_gemm[0] = reinterpret_cast<uint64_t>(static_cast<char *>(dev_A) + A_offset);
+                    args_gemm[1] = reinterpret_cast<uint64_t>(static_cast<char *>(dev_B) + B_offset);
                     args_gemm[2] = reinterpret_cast<uint64_t>(dev_P[c_tile_idx]);
                     args_gemm[3] = TILE;
                     args_gemm[4] = TILE;
@@ -125,9 +125,9 @@ int build_bgemm_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
 
                     // Task 2: C[m,n] = C[m,n] + P (tile_add on Vector core)
                     uint64_t args_add[5];
-                    args_add[0] = reinterpret_cast<uint64_t>(static_cast<char*>(dev_C) + C_offset);
+                    args_add[0] = reinterpret_cast<uint64_t>(static_cast<char *>(dev_C) + C_offset);
                     args_add[1] = reinterpret_cast<uint64_t>(dev_P[c_tile_idx]);
-                    args_add[2] = reinterpret_cast<uint64_t>(static_cast<char*>(dev_C) + C_offset);
+                    args_add[2] = reinterpret_cast<uint64_t>(static_cast<char *>(dev_C) + C_offset);
                     args_add[3] = TILE;
                     args_add[4] = TILE;
                     int t_add = runtime->add_task(args_add, 5, 1, CoreType::AIV);

--- a/examples/a2a3/host_build_graph/matmul/kernels/aic/kernel_matmul.cpp
+++ b/examples/a2a3/host_build_graph/matmul/kernels/aic/kernel_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Matrix Multiplication Kernel (AIC)
  *
@@ -42,19 +52,19 @@ constexpr int N = 128;
  *              args[2] = out pointer (output matrix, MxN, float)
  *              args[3] = size (number of elements, unused for matmul)
  */
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     // Unpack arguments - half input, float output
-    __gm__ half* src0 = reinterpret_cast<__gm__ half*>(args[0]);
-    __gm__ half* src1 = reinterpret_cast<__gm__ half*>(args[1]);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(args[2]);
+    __gm__ half *src0 = reinterpret_cast<__gm__ half *>(args[0]);
+    __gm__ half *src1 = reinterpret_cast<__gm__ half *>(args[1]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(args[2]);
 
     // Global tensor types
-    using GlobalDataSrc0 = GlobalTensor<half, Shape<1, 1, 1, validM, validK>,
-        Stride<validM * validK, validM * validK, validM * validK, validK, 1>>;
-    using GlobalDataSrc1 = GlobalTensor<half, Shape<1, 1, 1, validK, validN>,
-        Stride<validK * validN, validK * validN, validK * validN, validN, 1>>;
-    using GlobalDataOut = GlobalTensor<float, Shape<1, 1, 1, validM, validN>,
-        Stride<validM * validN, validM * validN, validM * validN, validN, 1>>;
+    using GlobalDataSrc0 = GlobalTensor<
+        half, Shape<1, 1, 1, validM, validK>, Stride<validM * validK, validM * validK, validM * validK, validK, 1>>;
+    using GlobalDataSrc1 = GlobalTensor<
+        half, Shape<1, 1, 1, validK, validN>, Stride<validK * validN, validK * validN, validK * validN, validN, 1>>;
+    using GlobalDataOut = GlobalTensor<
+        float, Shape<1, 1, 1, validM, validN>, Stride<validM * validN, validM * validN, validM * validN, validN, 1>>;
 
     GlobalDataSrc0 src0Global(src0);
     GlobalDataSrc1 src1Global(src1);

--- a/examples/a2a3/host_build_graph/matmul/kernels/aiv/kernel_add_exp.cpp
+++ b/examples/a2a3/host_build_graph/matmul/kernels/aiv/kernel_add_exp.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Add then Exp Kernel
  *
@@ -30,11 +40,11 @@ using namespace pto;
  *              args[2] = out pointer (output tensor)
  *              args[3] = size (number of elements)
  */
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     // Unpack arguments
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(args[0]);
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(args[1]);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(args[2]);
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(args[0]);
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(args[1]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(args[2]);
     int size = static_cast<int>(args[3]);
 
     // Configuration: float, 128, 128, 128, 128

--- a/examples/a2a3/host_build_graph/matmul/kernels/aiv/kernel_log_sqrt.cpp
+++ b/examples/a2a3/host_build_graph/matmul/kernels/aiv/kernel_log_sqrt.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Log then Sqrt Kernel
  *
@@ -29,10 +39,10 @@ using namespace pto;
  *              args[1] = out pointer (output tensor, half)
  *              args[2] = size (number of elements)
  */
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     // Unpack arguments
-    __gm__ half* src = reinterpret_cast<__gm__ half*>(args[0]);
-    __gm__ half* out = reinterpret_cast<__gm__ half*>(args[1]);
+    __gm__ half *src = reinterpret_cast<__gm__ half *>(args[0]);
+    __gm__ half *out = reinterpret_cast<__gm__ half *>(args[1]);
     int size = static_cast<int>(args[2]);
 
     // Configuration

--- a/examples/a2a3/host_build_graph/matmul/kernels/orchestration/matmul_orch.cpp
+++ b/examples/a2a3/host_build_graph/matmul/kernels/orchestration/matmul_orch.cpp
@@ -36,7 +36,7 @@
 
 extern "C" {
 
-int build_matmul_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
+int build_matmul_graph(Runtime *runtime, const ChipStorageTaskArgs &orch_args) {
     // Validate argument count
     // Expected orch_args: [a, w1, w2, f] — 4 tensors
     if (orch_args.tensor_count() < 4) {
@@ -45,10 +45,10 @@ int build_matmul_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
     }
 
     // Extract host pointers and sizes from tensor metadata
-    void* host_a = orch_args.tensor(0).data_as<void>();
-    void* host_w1 = orch_args.tensor(1).data_as<void>();
-    void* host_w2 = orch_args.tensor(2).data_as<void>();
-    void* host_f = orch_args.tensor(3).data_as<void>();
+    void *host_a = orch_args.tensor(0).data_as<void>();
+    void *host_w1 = orch_args.tensor(1).data_as<void>();
+    void *host_w2 = orch_args.tensor(2).data_as<void>();
+    void *host_f = orch_args.tensor(3).data_as<void>();
     size_t size_a = orch_args.tensor(0).nbytes();
     size_t size_w1 = orch_args.tensor(1).nbytes();
     size_t size_w2 = orch_args.tensor(2).nbytes();
@@ -62,7 +62,7 @@ int build_matmul_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
     // Allocate device memory and copy inputs
     std::cout << "\n=== Allocating Device Memory ===" << '\n';
 
-    void* dev_a = runtime->host_api.device_malloc(size_a);
+    void *dev_a = runtime->host_api.device_malloc(size_a);
     if (!dev_a) {
         std::cerr << "Error: Failed to allocate device memory for A\n";
         return -1;
@@ -70,7 +70,7 @@ int build_matmul_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
     runtime->host_api.copy_to_device(dev_a, host_a, size_a);
     std::cout << "Tensor A: " << size_a << " bytes copied to device\n";
 
-    void* dev_w1 = runtime->host_api.device_malloc(size_w1);
+    void *dev_w1 = runtime->host_api.device_malloc(size_w1);
     if (!dev_w1) {
         std::cerr << "Error: Failed to allocate device memory for W1\n";
         runtime->host_api.device_free(dev_a);
@@ -79,7 +79,7 @@ int build_matmul_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
     runtime->host_api.copy_to_device(dev_w1, host_w1, size_w1);
     std::cout << "Tensor W1: " << size_w1 << " bytes copied to device\n";
 
-    void* dev_w2 = runtime->host_api.device_malloc(size_w2);
+    void *dev_w2 = runtime->host_api.device_malloc(size_w2);
     if (!dev_w2) {
         std::cerr << "Error: Failed to allocate device memory for W2\n";
         runtime->host_api.device_free(dev_a);
@@ -89,7 +89,7 @@ int build_matmul_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
     runtime->host_api.copy_to_device(dev_w2, host_w2, size_w2);
     std::cout << "Tensor W2: " << size_w2 << " bytes copied to device\n";
 
-    void* dev_f = runtime->host_api.device_malloc(size_f);
+    void *dev_f = runtime->host_api.device_malloc(size_f);
     if (!dev_f) {
         std::cerr << "Error: Failed to allocate device memory for F\n";
         runtime->host_api.device_free(dev_a);
@@ -106,9 +106,9 @@ int build_matmul_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
     // dev_c, dev_d are float precision (output of matmul kernels)
     size_t BYTES_HALF = SIZE * sizeof(uint16_t);                 // half = 2 bytes
     size_t BYTES_FLOAT = SIZE * sizeof(float);                   // float = 4 bytes
-    void* dev_b = runtime->host_api.device_malloc(BYTES_HALF);   // sqrt(log(A)) - half output
-    void* dev_c = runtime->host_api.device_malloc(BYTES_FLOAT);  // B @ W1 - float output
-    void* dev_d = runtime->host_api.device_malloc(BYTES_FLOAT);  // B @ W2 - float output
+    void *dev_b = runtime->host_api.device_malloc(BYTES_HALF);   // sqrt(log(A)) - half output
+    void *dev_c = runtime->host_api.device_malloc(BYTES_FLOAT);  // B @ W1 - float output
+    void *dev_d = runtime->host_api.device_malloc(BYTES_FLOAT);  // B @ W2 - float output
 
     if (!dev_b || !dev_c || !dev_d) {
         std::cerr << "Error: Failed to allocate intermediate tensors\n";

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Fixed tile size: (16, 16) @ (16, 16) -> (16, 16)
@@ -19,21 +29,20 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw)
-{
+static __aicore__ void pv_matmul_impl(__gm__ uint8_t *pij_raw, __gm__ uint8_t *vj_raw, __gm__ uint8_t *oi_raw) {
     constexpr int M = 16, K = 16, N = 16;
 
-    __gm__ half* pij = reinterpret_cast<__gm__ half*>(pij_raw);
-    __gm__ half* vj  = reinterpret_cast<__gm__ half*>(vj_raw);
-    __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ half *pij = reinterpret_cast<__gm__ half *>(pij_raw);
+    __gm__ half *vj = reinterpret_cast<__gm__ half *>(vj_raw);
+    __gm__ float *oi = reinterpret_cast<__gm__ float *>(oi_raw);
 
     // pij (M, K) fp16, vj (K, N) fp16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
-    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, N, 1>>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   pijGlobal(pij);
-    GlobalB   vjGlobal(vj);
+    GlobalA pijGlobal(pij);
+    GlobalB vjGlobal(vj);
     GlobalOut oiGlobal(oi);
 
     // L1 Mat tiles: standard ND pattern for both A and B
@@ -41,18 +50,18 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<half, M, K, M, K>;
+    using LeftTile = TileLeft<half, M, K, M, K>;
     using RightTile = TileRight<half, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -80,11 +89,10 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     TSTORE(oiGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* pij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* vj     = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *pij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *vj = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *oi_new = reinterpret_cast<__gm__ uint8_t *>(args[2]);
 
     pv_matmul_impl(pij, vj, oi_new);
 }

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Fixed tile size: (16, 16) @ (16, 16).T -> (16, 16)
@@ -19,22 +29,21 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw)
-{
+static __aicore__ void qk_matmul_impl(__gm__ uint8_t *qi_raw, __gm__ uint8_t *kj_raw, __gm__ uint8_t *sij_raw) {
     constexpr int M = 16, K = 16, N = 16;
 
-    __gm__ half* qi  = reinterpret_cast<__gm__ half*>(qi_raw);
-    __gm__ half* kj  = reinterpret_cast<__gm__ half*>(kj_raw);
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+    __gm__ half *qi = reinterpret_cast<__gm__ half *>(qi_raw);
+    __gm__ half *kj = reinterpret_cast<__gm__ half *>(kj_raw);
+    __gm__ float *sij = reinterpret_cast<__gm__ float *>(sij_raw);
 
     // qi (M, K) fp16 in ND (row-major) layout
-    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   qiGlobal(qi);
-    GlobalB   kjGlobal(kj);
+    GlobalA qiGlobal(qi);
+    GlobalB kjGlobal(kj);
     GlobalOut sijGlobal(sij);
 
     // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
@@ -42,18 +51,18 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<half, M, K, M, K>;
+    using LeftTile = TileLeft<half, M, K, M, K>;
     using RightTile = TileRight<half, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -81,11 +90,10 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     TSTORE(sijGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* qi  = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* kj  = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *qi = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *kj = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *sij = reinterpret_cast<__gm__ uint8_t *>(args[2]);
 
     qk_matmul_impl(qi, kj, sij);
 }

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Fixed tile size: oi/oi_new are (16, 16), mij/lij/mi/li are 16-element vectors
@@ -21,20 +31,19 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_t* lij_raw,
-                               __gm__ uint8_t* oi_new_raw, __gm__ uint8_t* mi_raw,
-                               __gm__ uint8_t* li_raw, __gm__ uint8_t* oi_raw,
-                               int is_first, int is_last, __gm__ uint8_t* dst_raw)
-{
+static __aicore__ void online_update_impl(
+    __gm__ uint8_t *mij_raw, __gm__ uint8_t *lij_raw, __gm__ uint8_t *oi_new_raw, __gm__ uint8_t *mi_raw,
+    __gm__ uint8_t *li_raw, __gm__ uint8_t *oi_raw, int is_first, int is_last, __gm__ uint8_t *dst_raw
+) {
     constexpr int M = 16, N = 16;
 
-    __gm__ float* mij_ptr    = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float* lij_ptr    = reinterpret_cast<__gm__ float*>(lij_raw);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new_raw);
-    __gm__ float* mi_ptr     = reinterpret_cast<__gm__ float*>(mi_raw);
-    __gm__ float* li_ptr     = reinterpret_cast<__gm__ float*>(li_raw);
-    __gm__ float* oi_ptr     = reinterpret_cast<__gm__ float*>(oi_raw);
-    __gm__ float* dst_ptr    = reinterpret_cast<__gm__ float*>(dst_raw);
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij_raw);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij_raw);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new_raw);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi_raw);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li_raw);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi_raw);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst_raw);
 
     // Scalar tile dimensions for RowMajor layout:
     // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
@@ -50,12 +59,11 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
 
     // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
-    using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
-                                        Stride<1, 1, 1, kScalarCols, 1>>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
 
     // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
-                                        Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -77,8 +85,8 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     // --- Tile types ---
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
-    using TileScalarND = Tile<TileType::Vec, float, kScalarRows, kScalarCols,
-                              BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     // --- UB memory layout ---
@@ -123,9 +131,9 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Passthrough to MTE3 (no V compute needed)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, mijND);     // mi = mij
-        TSTORE(liGlobalND, lijND);     // li = lij
-        TSTORE(oiGlobal, oiNewTile);   // oi = oi_new
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
 
         if (is_last) {
             // Single block: normalize dst = oi_new / lij
@@ -156,53 +164,53 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
         // pipe_barrier(PIPE_V) required between each dependent vector operation
         // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
+        TMAX(miNewND, miND, mijND);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
+        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
+        TEXP(alphaND, alphaND);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
+        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
+        TEXP(betaND, betaND);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(liND, alphaND, liND);           // li = alpha * li
+        TMUL(liND, alphaND, liND);  // li = alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
+        TMUL(tmpND, betaND, lijND);  // tmp = beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
+        TADD(liND, liND, tmpND);  // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
         // mi_new -> mi accumulator, li_new -> li accumulator
         // alpha -> mij buffer (reuse), beta -> lij buffer (reuse)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, miNewND);         // persist mi_new
-        TSTORE(liGlobalND, liND);            // persist li_new
-        TSTORE(mijGlobalND, alphaND);        // temp: alpha to mij buffer
-        TSTORE(lijGlobalND, betaND);         // temp: beta to lij buffer
+        TSTORE(miGlobalND, miNewND);   // persist mi_new
+        TSTORE(liGlobalND, liND);      // persist li_new
+        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
 
         // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        TLOAD(alphaDN, mijGlobalDN);         // alpha from mij buffer as DN
-        TLOAD(betaDN, lijGlobalDN);          // beta from lij buffer as DN
+        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
         if (is_last) {
-            TLOAD(liDN, liGlobalDN);         // li_new from li buffer as DN
+            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
         }
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
 
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
             pipe_barrier(PIPE_V);
-            TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
+            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             TSTORE(dstGlobal, oiTile);
@@ -215,16 +223,16 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* mij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* lij    = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mi     = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* li     = reinterpret_cast<__gm__ uint8_t*>(args[4]);
-    __gm__ uint8_t* oi     = reinterpret_cast<__gm__ uint8_t*>(args[5]);
-    int is_first  = static_cast<int>(args[6]);
-    int is_last   = static_cast<int>(args[7]);
-    __gm__ uint8_t* dst    = reinterpret_cast<__gm__ uint8_t*>(args[8]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *mij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *lij = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *oi_new = reinterpret_cast<__gm__ uint8_t *>(args[2]);
+    __gm__ uint8_t *mi = reinterpret_cast<__gm__ uint8_t *>(args[3]);
+    __gm__ uint8_t *li = reinterpret_cast<__gm__ uint8_t *>(args[4]);
+    __gm__ uint8_t *oi = reinterpret_cast<__gm__ uint8_t *>(args[5]);
+    int is_first = static_cast<int>(args[6]);
+    int is_last = static_cast<int>(args[7]);
+    __gm__ uint8_t *dst = reinterpret_cast<__gm__ uint8_t *>(args[8]);
 
     online_update_impl(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
 }

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Softmax Preparation Kernel (AIV)
 //
 // Fixed tile size: sij is (16, 16)
@@ -21,16 +31,16 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
-                                 __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
-                                 __gm__ uint8_t* lij_raw)
-{
+static __aicore__ void softmax_prepare_impl(
+    __gm__ uint8_t *sij_raw, float scale_value, __gm__ uint8_t *pij_raw, __gm__ uint8_t *mij_raw,
+    __gm__ uint8_t *lij_raw
+) {
     constexpr int M = 16, N = 16;
 
-    __gm__ float* sij = reinterpret_cast<__gm__ float*>(sij_raw);
-    __gm__ half*  pij = reinterpret_cast<__gm__ half*>(pij_raw);
-    __gm__ float* mij = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float* lij = reinterpret_cast<__gm__ float*>(lij_raw);
+    __gm__ float *sij = reinterpret_cast<__gm__ float *>(sij_raw);
+    __gm__ half *pij = reinterpret_cast<__gm__ half *>(pij_raw);
+    __gm__ float *mij = reinterpret_cast<__gm__ float *>(mij_raw);
+    __gm__ float *lij = reinterpret_cast<__gm__ float *>(lij_raw);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -81,14 +91,17 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
     TSTORE(pijGlobal, pijF16Tile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    union { uint64_t u; float f; } scale_conv;
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *sij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[1]);
     float scale_value = scale_conv.f;
-    __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mij = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[4]);
+    __gm__ uint8_t *pij = reinterpret_cast<__gm__ uint8_t *>(args[2]);
+    __gm__ uint8_t *mij = reinterpret_cast<__gm__ uint8_t *>(args[3]);
+    __gm__ uint8_t *lij = reinterpret_cast<__gm__ uint8_t *>(args[4]);
 
     softmax_prepare_impl(sij, scale_value, pij, mij, lij);
 }

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -37,19 +37,19 @@
 
 extern "C" {
 
-int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
+int build_paged_attention_graph(Runtime *runtime, const ChipStorageTaskArgs &orch_args) {
     if (orch_args.tensor_count() < 6) {
         std::cerr << "Expected at least 6 tensors, got " << orch_args.tensor_count() << '\n';
         return -1;
     }
 
     // Extract host pointers from tensor metadata
-    void* host_query = orch_args.tensor(0).data_as<void>();
-    void* host_key_cache = orch_args.tensor(1).data_as<void>();
-    void* host_value_cache = orch_args.tensor(2).data_as<void>();
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
-    void* host_out = orch_args.tensor(5).data_as<void>();
+    void *host_query = orch_args.tensor(0).data_as<void>();
+    void *host_key_cache = orch_args.tensor(1).data_as<void>();
+    void *host_value_cache = orch_args.tensor(2).data_as<void>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    void *host_out = orch_args.tensor(5).data_as<void>();
 
     // Extract sizes from tensor metadata
     size_t query_size = orch_args.tensor(0).nbytes();
@@ -83,10 +83,10 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
     std::cout << "q_tile_size=" << q_tile_size << ", num_head_tiles=" << num_head_tiles << '\n';
 
     // Allocate device memory for inputs/outputs
-    void* dev_query = runtime->host_api.device_malloc(query_size);
-    void* dev_key_cache = runtime->host_api.device_malloc(key_cache_size);
-    void* dev_value_cache = runtime->host_api.device_malloc(value_cache_size);
-    void* dev_out = runtime->host_api.device_malloc(out_size);
+    void *dev_query = runtime->host_api.device_malloc(query_size);
+    void *dev_key_cache = runtime->host_api.device_malloc(key_cache_size);
+    void *dev_value_cache = runtime->host_api.device_malloc(value_cache_size);
+    void *dev_out = runtime->host_api.device_malloc(out_size);
 
     if (!dev_query || !dev_key_cache || !dev_value_cache || !dev_out) {
         std::cerr << "Error: Failed to allocate device memory\n";
@@ -107,11 +107,11 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
     // Per-batch-per-block intermediate buffers
     uint32_t total_buffers = batch * max_num_blocks;
-    void** dev_sij_arr = new void*[total_buffers];
-    void** dev_pij_arr = new void*[total_buffers];
-    void** dev_mij_arr = new void*[total_buffers];
-    void** dev_lij_arr = new void*[total_buffers];
-    void** dev_oi_new_arr = new void*[total_buffers];
+    void **dev_sij_arr = new void *[total_buffers];
+    void **dev_pij_arr = new void *[total_buffers];
+    void **dev_mij_arr = new void *[total_buffers];
+    void **dev_lij_arr = new void *[total_buffers];
+    void **dev_oi_new_arr = new void *[total_buffers];
 
     for (uint32_t i = 0; i < total_buffers; i++) {
         dev_sij_arr[i] = runtime->host_api.device_malloc(sij_size);
@@ -127,9 +127,9 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
     size_t li_size = mi_size;
     size_t oi_size = static_cast<size_t>(q_tile_size) * head_dim * sizeof(float);
 
-    void** dev_mi_arr = new void*[total_accums];
-    void** dev_li_arr = new void*[total_accums];
-    void** dev_oi_arr = new void*[total_accums];
+    void **dev_mi_arr = new void *[total_accums];
+    void **dev_li_arr = new void *[total_accums];
+    void **dev_oi_arr = new void *[total_accums];
 
     for (uint32_t i = 0; i < total_accums; i++) {
         dev_mi_arr[i] = runtime->host_api.device_malloc(mi_size);
@@ -151,11 +151,11 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
             // Query: (batch, q_head_num, head_dim) fp16
             // qi points to heads [cur_offset .. cur_offset+q_tile_size) for batch b_idx
-            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query) +
+            uint8_t *qi_ptr = reinterpret_cast<uint8_t *>(dev_query) +
                               static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
 
             // Output: (batch * q_head_num, head_dim) float32
-            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out) +
+            uint8_t *out_ptr = reinterpret_cast<uint8_t *>(dev_out) +
                                static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
 
             // GQA: which kv_head this head tile maps to
@@ -163,9 +163,9 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
             // Per-(batch, head_tile) accumulators
             uint32_t accum_idx = b_idx * num_head_tiles + ht;
-            void* dev_mi = dev_mi_arr[accum_idx];
-            void* dev_li = dev_li_arr[accum_idx];
-            void* dev_oi = dev_oi_arr[accum_idx];
+            void *dev_mi = dev_mi_arr[accum_idx];
+            void *dev_li = dev_li_arr[accum_idx];
+            void *dev_oi = dev_oi_arr[accum_idx];
 
             int t_up_prev = -1;
 
@@ -173,50 +173,41 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
                 int cur_block_idx = host_block_table[b_idx * max_num_blocks + bn];
 
                 // Key: (total_blocks, block_size, kv_head_num, head_dim) fp16
-                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache) +
+                uint8_t *kj_ptr = reinterpret_cast<uint8_t *>(dev_key_cache) +
                                   (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
                                       head_dim * sizeof(uint16_t);
 
                 // Value: (total_blocks, block_size, kv_head_num, head_dim) fp16
-                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache) +
+                uint8_t *vj_ptr = reinterpret_cast<uint8_t *>(dev_value_cache) +
                                   (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
                                       head_dim * sizeof(uint16_t);
 
                 uint32_t buf_idx = b_idx * max_num_blocks + bn;
-                void* dev_sij = dev_sij_arr[buf_idx];
-                void* dev_pij = dev_pij_arr[buf_idx];
-                void* dev_mij = dev_mij_arr[buf_idx];
-                void* dev_lij = dev_lij_arr[buf_idx];
-                void* dev_oi_new = dev_oi_new_arr[buf_idx];
+                void *dev_sij = dev_sij_arr[buf_idx];
+                void *dev_pij = dev_pij_arr[buf_idx];
+                void *dev_mij = dev_mij_arr[buf_idx];
+                void *dev_lij = dev_lij_arr[buf_idx];
+                void *dev_oi_new = dev_oi_new_arr[buf_idx];
 
                 // QK: qi(M, K) @ kj.T(K, N) -> sij(M, N)
-                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),
-                    reinterpret_cast<uint64_t>(kj_ptr),
-                    reinterpret_cast<uint64_t>(dev_sij),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim),
-                    static_cast<uint64_t>(block_size)};
+                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),  reinterpret_cast<uint64_t>(kj_ptr),
+                                       reinterpret_cast<uint64_t>(dev_sij), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(head_dim),     static_cast<uint64_t>(block_size)};
                 int t_qk = runtime->add_task(qk_args, 6, FUNC_QK_MATMUL, CoreType::AIC);
                 total_tasks++;
 
                 // SF: scale, rowmax, exp, rowsum -> pij, mij, lij
-                uint64_t sf_args[7] = {reinterpret_cast<uint64_t>(dev_sij),
-                    scale_value_bits,
-                    reinterpret_cast<uint64_t>(dev_pij),
-                    reinterpret_cast<uint64_t>(dev_mij),
-                    reinterpret_cast<uint64_t>(dev_lij),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size)};
+                uint64_t sf_args[7] = {reinterpret_cast<uint64_t>(dev_sij), scale_value_bits,
+                                       reinterpret_cast<uint64_t>(dev_pij), reinterpret_cast<uint64_t>(dev_mij),
+                                       reinterpret_cast<uint64_t>(dev_lij), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(block_size)};
                 int t_sf = runtime->add_task(sf_args, 7, FUNC_SOFTMAX_PREPARE, CoreType::AIV);
                 total_tasks++;
 
                 // PV: pij(M, K') @ vj(K', N') -> oi_new(M, N')
-                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),
-                    reinterpret_cast<uint64_t>(vj_ptr),
-                    reinterpret_cast<uint64_t>(dev_oi_new),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(head_dim)};
+                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),    reinterpret_cast<uint64_t>(vj_ptr),
+                                       reinterpret_cast<uint64_t>(dev_oi_new), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(block_size),      static_cast<uint64_t>(head_dim)};
                 int t_pv = runtime->add_task(pv_args, 6, FUNC_PV_MATMUL, CoreType::AIC);
                 total_tasks++;
 
@@ -227,17 +218,12 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
                 int is_first = (bn == 0) ? 1 : 0;
                 int is_last = (bn == bn_this_batch - 1) ? 1 : 0;
 
-                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),
-                    reinterpret_cast<uint64_t>(dev_lij),
-                    reinterpret_cast<uint64_t>(dev_oi_new),
-                    reinterpret_cast<uint64_t>(dev_mi),
-                    reinterpret_cast<uint64_t>(dev_li),
-                    reinterpret_cast<uint64_t>(dev_oi),
-                    static_cast<uint64_t>(is_first),
-                    static_cast<uint64_t>(is_last),
-                    reinterpret_cast<uint64_t>(out_ptr),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim)};
+                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),    reinterpret_cast<uint64_t>(dev_lij),
+                                        reinterpret_cast<uint64_t>(dev_oi_new), reinterpret_cast<uint64_t>(dev_mi),
+                                        reinterpret_cast<uint64_t>(dev_li),     reinterpret_cast<uint64_t>(dev_oi),
+                                        static_cast<uint64_t>(is_first),        static_cast<uint64_t>(is_last),
+                                        reinterpret_cast<uint64_t>(out_ptr),    static_cast<uint64_t>(q_tile_size),
+                                        static_cast<uint64_t>(head_dim)};
                 int t_up = runtime->add_task(up_args, 11, FUNC_ONLINE_UPDATE, CoreType::AIV);
                 total_tasks++;
 

--- a/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Tensor Addition Kernel
  *
@@ -32,11 +42,11 @@ using namespace pto;
  *              args[2] = out pointer (output tensor)
  *              args[3] = size (number of elements)
  */
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     // Unpack arguments (order matches runtimemaker.cpp)
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(args[0]);
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(args[1]);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(args[2]);
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(args[0]);
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(args[1]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(args[2]);
     int size = static_cast<int>(args[3]);
 
     // Configuration: float, 128, 128, 128, 128

--- a/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Scalar Addition Kernel
  *
@@ -32,9 +42,9 @@ using namespace pto;
  *              args[2] = out pointer (output tensor)
  *              args[3] = size (number of elements)
  */
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     // Unpack arguments
-    __gm__ float* src = reinterpret_cast<__gm__ float*>(args[0]);
+    __gm__ float *src = reinterpret_cast<__gm__ float *>(args[0]);
 
     // Convert scalar from uint64_t to float
     union {
@@ -44,7 +54,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     converter.u64 = args[1];
     float scalar = converter.f32;
 
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(args[2]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(args[2]);
     int size = static_cast<int>(args[3]);
 
     // Configuration: float, 128, 128, 128, 128

--- a/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Tensor Multiplication Kernel
  *
@@ -32,11 +42,11 @@ using namespace pto;
  *              args[2] = out pointer (output tensor)
  *              args[3] = size (number of elements)
  */
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     // Unpack arguments (order matches runtimemaker.cpp)
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(args[0]);
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(args[1]);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(args[2]);
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(args[0]);
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(args[1]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(args[2]);
     int size = static_cast<int>(args[3]);
 
     // Configuration: float, 128, 128, 128, 128

--- a/examples/a2a3/host_build_graph/vector_example/kernels/orchestration/example_orch.cpp
+++ b/examples/a2a3/host_build_graph/vector_example/kernels/orchestration/example_orch.cpp
@@ -28,7 +28,7 @@
 
 extern "C" {
 
-int build_example_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
+int build_example_graph(Runtime *runtime, const ChipStorageTaskArgs &orch_args) {
     // Validate argument count
     // Expected orch_args: [a, b, f] — 3 tensors
     if (orch_args.tensor_count() < 3) {
@@ -37,9 +37,9 @@ int build_example_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) 
     }
 
     // Extract host pointers, sizes, and element count from tensor metadata
-    void* host_a = orch_args.tensor(0).data_as<void>();
-    void* host_b = orch_args.tensor(1).data_as<void>();
-    void* host_f = orch_args.tensor(2).data_as<void>();
+    void *host_a = orch_args.tensor(0).data_as<void>();
+    void *host_b = orch_args.tensor(1).data_as<void>();
+    void *host_f = orch_args.tensor(2).data_as<void>();
     size_t size_a = orch_args.tensor(0).nbytes();
     size_t size_b = orch_args.tensor(1).nbytes();
     size_t size_f = orch_args.tensor(2).nbytes();
@@ -52,7 +52,7 @@ int build_example_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) 
     // Allocate device memory and copy inputs
     std::cout << "\n=== Allocating Device Memory ===" << '\n';
 
-    void* dev_a = runtime->host_api.device_malloc(size_a);
+    void *dev_a = runtime->host_api.device_malloc(size_a);
     if (!dev_a) {
         std::cerr << "Error: Failed to allocate device memory for a\n";
         return -1;
@@ -60,7 +60,7 @@ int build_example_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) 
     runtime->host_api.copy_to_device(dev_a, host_a, size_a);
     std::cout << "Tensor a: " << size_a << " bytes copied to device\n";
 
-    void* dev_b = runtime->host_api.device_malloc(size_b);
+    void *dev_b = runtime->host_api.device_malloc(size_b);
     if (!dev_b) {
         std::cerr << "Error: Failed to allocate device memory for b\n";
         runtime->host_api.device_free(dev_a);
@@ -69,7 +69,7 @@ int build_example_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) 
     runtime->host_api.copy_to_device(dev_b, host_b, size_b);
     std::cout << "Tensor b: " << size_b << " bytes copied to device\n";
 
-    void* dev_f = runtime->host_api.device_malloc(size_f);
+    void *dev_f = runtime->host_api.device_malloc(size_f);
     if (!dev_f) {
         std::cerr << "Error: Failed to allocate device memory for f\n";
         runtime->host_api.device_free(dev_a);
@@ -82,9 +82,9 @@ int build_example_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) 
 
     // Allocate intermediate tensors (c, d, e)
     size_t BYTES = SIZE * sizeof(float);
-    void* dev_c = runtime->host_api.device_malloc(BYTES);
-    void* dev_d = runtime->host_api.device_malloc(BYTES);
-    void* dev_e = runtime->host_api.device_malloc(BYTES);
+    void *dev_c = runtime->host_api.device_malloc(BYTES);
+    void *dev_d = runtime->host_api.device_malloc(BYTES);
+    void *dev_e = runtime->host_api.device_malloc(BYTES);
 
     if (!dev_c || !dev_d || !dev_e) {
         std::cerr << "Error: Failed to allocate intermediate tensors\n";

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_hub.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -11,4 +21,4 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Batched PV Matmul Kernel: for each batch b, pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -22,20 +32,14 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void pv_matmul_batch_impl(
-    __gm__ Tensor* pij_batch,
-    __gm__ Tensor* value_cache,
-    __gm__ Tensor* oi_new_batch,
-    uint64_t block_table_ptr,
-    uint64_t batch_count,
-    uint64_t block_idx,
-    uint64_t block_num,
-    uint64_t batch_start) {
-
-    __gm__ half* pij_base = reinterpret_cast<__gm__ half*>(pij_batch->buffer.addr);
-    __gm__ half* val_base = reinterpret_cast<__gm__ half*>(value_cache->buffer.addr);
-    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new_batch->buffer.addr);
+    __gm__ Tensor *pij_batch, __gm__ Tensor *value_cache, __gm__ Tensor *oi_new_batch, uint64_t block_table_ptr,
+    uint64_t batch_count, uint64_t block_idx, uint64_t block_num, uint64_t batch_start
+) {
+    __gm__ half *pij_base = reinterpret_cast<__gm__ half *>(pij_batch->buffer.addr);
+    __gm__ half *val_base = reinterpret_cast<__gm__ half *>(value_cache->buffer.addr);
+    __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_new_batch->buffer.addr);
     // Block table values are always non-negative (physical block indices)
-    __gm__ int32_t* bt = reinterpret_cast<__gm__ int32_t*>(block_table_ptr);
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_ptr);
 
     using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
@@ -61,10 +65,10 @@ static __aicore__ void pv_matmul_batch_impl(
     TASSIGN(cTile, 0x0);
 
     for (uint64_t b = 0; b < batch_count; b++) {
-        __gm__ half* pij_addr = pij_base + b * M * K;
+        __gm__ half *pij_addr = pij_base + b * M * K;
         int32_t phys_block = bt[(batch_start + b) * block_num + block_idx];
-        __gm__ half* vj_addr = val_base + (uint64_t)phys_block * K * N;
-        __gm__ float* oi_addr = oi_base + b * M * N;
+        __gm__ half *vj_addr = val_base + (uint64_t)phys_block * K * N;
+        __gm__ float *oi_addr = oi_base + b * M * N;
 
         GlobalA pijGlobal(pij_addr);
         GlobalB vjGlobal(vj_addr);
@@ -95,10 +99,10 @@ static __aicore__ void pv_matmul_batch_impl(
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* pij_batch = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* value_cache = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new_batch = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *pij_batch = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *value_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t block_table_ptr = static_cast<uint64_t>(args[3]);
     uint64_t batch_count = static_cast<uint64_t>(args[4]);
     uint64_t block_idx = static_cast<uint64_t>(args[5]);
@@ -106,6 +110,6 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t batch_start = static_cast<uint64_t>(args[7]);
 
     pv_matmul_batch_impl<16, 16, 16>(
-        pij_batch, value_cache, oi_new_batch,
-        block_table_ptr, batch_count, block_idx, block_num, batch_start);
+        pij_batch, value_cache, oi_new_batch, block_table_ptr, batch_count, block_idx, block_num, batch_start
+    );
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Batched QK Matmul Kernel: for each batch b, qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -22,22 +32,15 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void qk_matmul_batch_impl(
-    __gm__ Tensor* query,
-    __gm__ Tensor* key_cache,
-    __gm__ Tensor* sij_batch,
-    uint64_t block_table_ptr,
-    uint64_t batch_count,
-    uint64_t block_idx,
-    uint64_t q_offset,
-    uint64_t block_num,
-    uint64_t num_heads,
-    uint64_t batch_start) {
-
-    __gm__ half* query_base = reinterpret_cast<__gm__ half*>(query->buffer.addr);
-    __gm__ half* key_base = reinterpret_cast<__gm__ half*>(key_cache->buffer.addr);
-    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_batch->buffer.addr);
+    __gm__ Tensor *query, __gm__ Tensor *key_cache, __gm__ Tensor *sij_batch, uint64_t block_table_ptr,
+    uint64_t batch_count, uint64_t block_idx, uint64_t q_offset, uint64_t block_num, uint64_t num_heads,
+    uint64_t batch_start
+) {
+    __gm__ half *query_base = reinterpret_cast<__gm__ half *>(query->buffer.addr);
+    __gm__ half *key_base = reinterpret_cast<__gm__ half *>(key_cache->buffer.addr);
+    __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_batch->buffer.addr);
     // Block table values are always non-negative (physical block indices)
-    __gm__ int32_t* bt = reinterpret_cast<__gm__ int32_t*>(block_table_ptr);
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_ptr);
 
     using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
@@ -63,10 +66,10 @@ static __aicore__ void qk_matmul_batch_impl(
     TASSIGN(cTile, 0x0);
 
     for (uint64_t b = 0; b < batch_count; b++) {
-        __gm__ half* qi_addr = query_base + ((batch_start + b) * num_heads + q_offset) * K;
+        __gm__ half *qi_addr = query_base + ((batch_start + b) * num_heads + q_offset) * K;
         int32_t phys_block = bt[(batch_start + b) * block_num + block_idx];
-        __gm__ half* kj_addr = key_base + (uint64_t)phys_block * N * K;
-        __gm__ float* sij_addr = sij_base + b * M * N;
+        __gm__ half *kj_addr = key_base + (uint64_t)phys_block * N * K;
+        __gm__ float *sij_addr = sij_base + b * M * N;
 
         GlobalA qiGlobal(qi_addr);
         GlobalB kjGlobal(kj_addr);
@@ -97,10 +100,10 @@ static __aicore__ void qk_matmul_batch_impl(
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* query = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* key_cache = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* sij_batch = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *query = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *key_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *sij_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t block_table_ptr = static_cast<uint64_t>(args[3]);
     uint64_t batch_count = static_cast<uint64_t>(args[4]);
     uint64_t block_idx = static_cast<uint64_t>(args[5]);
@@ -110,7 +113,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t batch_start = static_cast<uint64_t>(args[9]);
 
     qk_matmul_batch_impl<16, 16, 16>(
-        query, key_cache, sij_batch,
-        block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
-        batch_start);
+        query, key_cache, sij_batch, block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
+        batch_start
+    );
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_hub.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -11,4 +21,4 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Batched Online Softmax Update + Normalize Kernel (AIV)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -27,27 +37,17 @@ using namespace pto;
 
 template <int M, int N>
 static __aicore__ void online_update_batch_impl(
-    __gm__ Tensor* mij_batch,
-    __gm__ Tensor* lij_batch,
-    __gm__ Tensor* oi_new_batch,
-    __gm__ Tensor* mi_batch,
-    __gm__ Tensor* li_batch,
-    __gm__ Tensor* oi_batch,
-    __gm__ Tensor* out,
-    uint64_t is_first,
-    uint64_t is_last,
-    uint64_t batch_count,
-    uint64_t q_offset,
-    uint64_t num_heads,
-    uint64_t batch_start) {
-
-    __gm__ float* mij_base = reinterpret_cast<__gm__ float*>(mij_batch->buffer.addr);
-    __gm__ float* lij_base = reinterpret_cast<__gm__ float*>(lij_batch->buffer.addr);
-    __gm__ float* oi_new_base = reinterpret_cast<__gm__ float*>(oi_new_batch->buffer.addr);
-    __gm__ float* mi_base = reinterpret_cast<__gm__ float*>(mi_batch->buffer.addr);
-    __gm__ float* li_base = reinterpret_cast<__gm__ float*>(li_batch->buffer.addr);
-    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_batch->buffer.addr);
-    __gm__ float* out_base = reinterpret_cast<__gm__ float*>(out->buffer.addr);
+    __gm__ Tensor *mij_batch, __gm__ Tensor *lij_batch, __gm__ Tensor *oi_new_batch, __gm__ Tensor *mi_batch,
+    __gm__ Tensor *li_batch, __gm__ Tensor *oi_batch, __gm__ Tensor *out, uint64_t is_first, uint64_t is_last,
+    uint64_t batch_count, uint64_t q_offset, uint64_t num_heads, uint64_t batch_start
+) {
+    __gm__ float *mij_base = reinterpret_cast<__gm__ float *>(mij_batch->buffer.addr);
+    __gm__ float *lij_base = reinterpret_cast<__gm__ float *>(lij_batch->buffer.addr);
+    __gm__ float *oi_new_base = reinterpret_cast<__gm__ float *>(oi_new_batch->buffer.addr);
+    __gm__ float *mi_base = reinterpret_cast<__gm__ float *>(mi_batch->buffer.addr);
+    __gm__ float *li_base = reinterpret_cast<__gm__ float *>(li_batch->buffer.addr);
+    __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_batch->buffer.addr);
+    __gm__ float *out_base = reinterpret_cast<__gm__ float *>(out->buffer.addr);
 
     constexpr int kScalarCols = 32 / sizeof(float);
     constexpr int kScalarRows = M / kScalarCols;
@@ -90,13 +90,13 @@ static __aicore__ void online_update_batch_impl(
     TASSIGN(liDN, 2 * kDataBytes + 8 * kScalarNDBytes + 2 * kScalarDNBytes);
 
     for (uint64_t b = 0; b < batch_count; b++) {
-        __gm__ float* mij_ptr = mij_base + b * M;
-        __gm__ float* lij_ptr = lij_base + b * M;
-        __gm__ float* oi_new_ptr = oi_new_base + b * M * N;
-        __gm__ float* mi_ptr = mi_base + b * M;
-        __gm__ float* li_ptr = li_base + b * M;
-        __gm__ float* oi_ptr = oi_base + b * M * N;
-        __gm__ float* dst_ptr = out_base + ((batch_start + b) * num_heads + q_offset) * N;
+        __gm__ float *mij_ptr = mij_base + b * M;
+        __gm__ float *lij_ptr = lij_base + b * M;
+        __gm__ float *oi_new_ptr = oi_new_base + b * M * N;
+        __gm__ float *mi_ptr = mi_base + b * M;
+        __gm__ float *li_ptr = li_base + b * M;
+        __gm__ float *oi_ptr = oi_base + b * M * N;
+        __gm__ float *dst_ptr = out_base + ((batch_start + b) * num_heads + q_offset) * N;
 
         GlobalDataMxN oiNewGlobal(oi_new_ptr);
         GlobalDataMxN oiGlobal(oi_ptr);
@@ -202,14 +202,14 @@ static __aicore__ void online_update_batch_impl(
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* mij_batch = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* lij_batch = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new_batch = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mi_batch = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* li_batch = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* oi_batch = reinterpret_cast<__gm__ Tensor*>(args[5]);
-    __gm__ Tensor* out = reinterpret_cast<__gm__ Tensor*>(args[6]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mij_batch = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *lij_batch = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mi_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *li_batch = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *oi_batch = reinterpret_cast<__gm__ Tensor *>(args[5]);
+    __gm__ Tensor *out = reinterpret_cast<__gm__ Tensor *>(args[6]);
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t batch_count = static_cast<uint64_t>(args[9]);
@@ -218,7 +218,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t batch_start = static_cast<uint64_t>(args[12]);
 
     online_update_batch_impl<16, 16>(
-        mij_batch, lij_batch, oi_new_batch,
-        mi_batch, li_batch, oi_batch, out,
-        is_first, is_last, batch_count, q_offset, num_heads, batch_start);
+        mij_batch, lij_batch, oi_new_batch, mi_batch, li_batch, oi_batch, out, is_first, is_last, batch_count, q_offset,
+        num_heads, batch_start
+    );
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -37,20 +37,15 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_batch_impl(__gm__ Tensor* sij_batch,
-    __gm__ Tensor* pij_batch,
-    __gm__ Tensor* mij_batch,
-    __gm__ Tensor* lij_batch,
-    float scale_value,
-    uint64_t context_lens_ptr,
-    uint64_t batch_count,
-    uint64_t block_idx,
-    uint64_t batch_start) {
-    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_batch->buffer.addr);
-    __gm__ half* pij_base = reinterpret_cast<__gm__ half*>(pij_batch->buffer.addr);
-    __gm__ float* mij_base = reinterpret_cast<__gm__ float*>(mij_batch->buffer.addr);
-    __gm__ float* lij_base = reinterpret_cast<__gm__ float*>(lij_batch->buffer.addr);
-    __gm__ int32_t* ctx_lens = reinterpret_cast<__gm__ int32_t*>(context_lens_ptr);
+static __aicore__ void softmax_prepare_batch_impl(
+    __gm__ Tensor *sij_batch, __gm__ Tensor *pij_batch, __gm__ Tensor *mij_batch, __gm__ Tensor *lij_batch,
+    float scale_value, uint64_t context_lens_ptr, uint64_t batch_count, uint64_t block_idx, uint64_t batch_start
+) {
+    __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_batch->buffer.addr);
+    __gm__ half *pij_base = reinterpret_cast<__gm__ half *>(pij_batch->buffer.addr);
+    __gm__ float *mij_base = reinterpret_cast<__gm__ float *>(mij_batch->buffer.addr);
+    __gm__ float *lij_base = reinterpret_cast<__gm__ float *>(lij_batch->buffer.addr);
+    __gm__ int32_t *ctx_lens = reinterpret_cast<__gm__ int32_t *>(context_lens_ptr);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -90,10 +85,10 @@ static __aicore__ void softmax_prepare_batch_impl(__gm__ Tensor* sij_batch,
             valid_len = (remaining < N) ? remaining : N;
         }
 
-        __gm__ float* sij_addr = sij_base + b * M * N;
-        __gm__ half* pij_addr = pij_base + b * M * N;
-        __gm__ float* mij_addr = mij_base + b * M;
-        __gm__ float* lij_addr = lij_base + b * M;
+        __gm__ float *sij_addr = sij_base + b * M * N;
+        __gm__ half *pij_addr = pij_base + b * M * N;
+        __gm__ float *mij_addr = mij_base + b * M;
+        __gm__ float *lij_addr = lij_base + b * M;
 
         GlobalDataMxN sijGlobal(sij_addr);
         GlobalDataMxN_f16 pijGlobal(pij_addr);
@@ -156,11 +151,11 @@ static __aicore__ void softmax_prepare_batch_impl(__gm__ Tensor* sij_batch,
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* sij_batch = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* pij_batch = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* mij_batch = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* lij_batch = reinterpret_cast<__gm__ Tensor*>(args[3]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *sij_batch = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *pij_batch = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *mij_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *lij_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
     float scale_value = from_u64<float>(static_cast<uint64_t>(args[4]));
     uint64_t context_lens_ptr = static_cast<uint64_t>(args[5]);
     uint64_t batch_count = static_cast<uint64_t>(args[6]);
@@ -168,5 +163,6 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t batch_start = static_cast<uint64_t>(args[8]);
 
     softmax_prepare_batch_impl<16, 16>(
-        sij_batch, pij_batch, mij_batch, lij_batch, scale_value, context_lens_ptr, batch_count, block_idx, batch_start);
+        sij_batch, pij_batch, mij_batch, lij_batch, scale_value, context_lens_ptr, batch_count, block_idx, batch_start
+    );
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -37,16 +37,16 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     // Read dimensions from tensor metadata
     uint64_t batch = orch_args.tensor(0).shapes[0];
     uint64_t num_heads = orch_args.tensor(0).shapes[1];
@@ -64,8 +64,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
     LOG_INFO("batch_paged_attention: batch=%" PRIu64 ", num_heads=%" PRIu64, batch, num_heads);
 
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
 
     uint64_t max_bn = 0;
     for (uint64_t b = 0; b < batch; b++) {
@@ -75,10 +75,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     }
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void* query_ptr = orch_args.tensor(0).data_as<void>();
-    void* kc_ptr = orch_args.tensor(1).data_as<void>();
-    void* vc_ptr = orch_args.tensor(2).data_as<void>();
-    void* out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).data_as<void>();
+    void *out_ptr = orch_args.tensor(5).data_as<void>();
 
     uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
     uint64_t kv_total_rows = total_blocks_count * block_size;
@@ -121,9 +121,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 params_hub.add_output(scalar_ci);
                 params_hub.add_output(scalar_ci);
                 TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, params_hub);
-                const Tensor& oi_batch = hub_outs.get_ref(0);
-                const Tensor& li_batch = hub_outs.get_ref(1);
-                const Tensor& mi_batch = hub_outs.get_ref(2);
+                const Tensor &oi_batch = hub_outs.get_ref(0);
+                const Tensor &li_batch = hub_outs.get_ref(1);
+                const Tensor &mi_batch = hub_outs.get_ref(2);
 
                 for (uint64_t bn = 0; bn < max_bn; bn++) {
                     Arg params_qk;
@@ -138,7 +138,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_qk.add_scalar(num_heads);
                     params_qk.add_scalar(batch_start);
                     TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
-                    const Tensor& sij_b = qk_outs.get_ref(0);
+                    const Tensor &sij_b = qk_outs.get_ref(0);
 
                     Arg params_sf;
                     params_sf.add_input(sij_b);
@@ -151,9 +151,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_sf.add_scalar(bn);
                     params_sf.add_scalar(batch_start);
                     TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
-                    const Tensor& pij_b = sf_outs.get_ref(0);
-                    const Tensor& mij_b = sf_outs.get_ref(1);
-                    const Tensor& lij_b = sf_outs.get_ref(2);
+                    const Tensor &pij_b = sf_outs.get_ref(0);
+                    const Tensor &mij_b = sf_outs.get_ref(1);
+                    const Tensor &lij_b = sf_outs.get_ref(2);
 
                     Arg params_pv;
                     params_pv.add_input(pij_b);
@@ -165,7 +165,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_pv.add_scalar(block_num);
                     params_pv.add_scalar(batch_start);
                     TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
-                    const Tensor& oi_new_b = pv_outs.get_ref(0);
+                    const Tensor &oi_new_b = pv_outs.get_ref(0);
 
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn == max_bn - 1) ? 1 : 0;
@@ -189,13 +189,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         }
     }
 
-    LOG_INFO("batch_paged_attention: %" PRIu64 " tasks (batch=%" PRIu64 ", max_bn=%" PRIu64 ", chunks=%" PRIu64
-             ", IN_CORE_BATCH=%" PRIu64 ")",
-        static_cast<uint64_t>(num_chunks * (1 + max_bn * 4)),
-        batch,
-        max_bn,
-        num_chunks,
-        IN_CORE_BATCH);
+    LOG_INFO(
+        "batch_paged_attention: %" PRIu64 " tasks (batch=%" PRIu64 ", max_bn=%" PRIu64 ", chunks=%" PRIu64
+        ", IN_CORE_BATCH=%" PRIu64 ")",
+        static_cast<uint64_t>(num_chunks * (1 + max_bn * 4)), batch, max_bn, num_chunks, IN_CORE_BATCH
+    );
 }
 
 }  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Tile-based Matrix Multiplication Kernel (Cube Core)
  *
@@ -35,14 +45,13 @@ AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
     return (num_1 + num_2 - 1) / num_2 * num_2;
 }
 
-static __aicore__ void gemm_tile_impl(
-    __gm__ Tensor* input_a_tensor,
-    __gm__ Tensor* input_b_tensor,
-    __gm__ Tensor* output_tensor) {
-
-    __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
-    __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
-    __gm__ float* output  = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr)  + output_tensor->start_offset;
+static __aicore__ void
+gemm_tile_impl(__gm__ Tensor *input_a_tensor, __gm__ Tensor *input_b_tensor, __gm__ Tensor *output_tensor) {
+    __gm__ float *input_a =
+        reinterpret_cast<__gm__ float *>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
+    __gm__ float *input_b =
+        reinterpret_cast<__gm__ float *>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
+    __gm__ float *output = reinterpret_cast<__gm__ float *>(output_tensor->buffer.addr) + output_tensor->start_offset;
 
     constexpr int TILE = 64;
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
@@ -50,12 +59,12 @@ static __aicore__ void gemm_tile_impl(
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);
@@ -103,10 +112,10 @@ static __aicore__ void gemm_tile_impl(
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* input_a = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* input_b = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* output  = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_a = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *input_b = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *output = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
     gemm_tile_impl(input_a, input_b, output);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Tile-based Element-wise Addition Kernel (Vector Core) - INOUT Pattern
  *
@@ -25,12 +35,12 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* c_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* p_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *c_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *p_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
 
-    __gm__ float* c_ptr = reinterpret_cast<__gm__ float*>(c_tensor->buffer.addr) + c_tensor->start_offset;
-    __gm__ float* p_ptr = reinterpret_cast<__gm__ float*>(p_tensor->buffer.addr) + p_tensor->start_offset;
+    __gm__ float *c_ptr = reinterpret_cast<__gm__ float *>(c_tensor->buffer.addr) + c_tensor->start_offset;
+    __gm__ float *p_ptr = reinterpret_cast<__gm__ float *>(p_tensor->buffer.addr) + p_tensor->start_offset;
 
     constexpr int TILE = 64;
 

--- a/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -52,16 +52,16 @@ static constexpr uint32_t TILE_ELEMS = TILE * TILE;  // 4096 elements
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 
@@ -80,7 +80,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
             for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
                 PTO2_SCOPE() {
                     uint32_t c_elem_offset = (static_cast<uint32_t>(batch) * GRID_M * GRID_N +
-                                                 static_cast<uint32_t>(m_idx) * GRID_N + static_cast<uint32_t>(n_idx)) *
+                                              static_cast<uint32_t>(m_idx) * GRID_N + static_cast<uint32_t>(n_idx)) *
                                              TILE_ELEMS;
                     uint32_t c_view_offsets[1] = {c_elem_offset};
                     Tensor C_view = ext_C.view(tile_shapes, c_view_offsets);
@@ -88,11 +88,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     for (int k_idx = 0; k_idx < GRID_K; k_idx++) {
                         uint32_t a_elem_offset =
                             (static_cast<uint32_t>(batch) * GRID_M * GRID_K + static_cast<uint32_t>(m_idx) * GRID_K +
-                                static_cast<uint32_t>(k_idx)) *
+                             static_cast<uint32_t>(k_idx)) *
                             TILE_ELEMS;
                         uint32_t b_elem_offset =
                             (static_cast<uint32_t>(batch) * GRID_K * GRID_N + static_cast<uint32_t>(k_idx) * GRID_N +
-                                static_cast<uint32_t>(n_idx)) *
+                             static_cast<uint32_t>(n_idx)) *
                             TILE_ELEMS;
 
                         uint32_t a_view_offsets[1] = {a_elem_offset};
@@ -105,25 +105,24 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                         params_gemm.add_input(B_view);
                         params_gemm.add_output(tile_ci);
                         TaskOutputTensors gemm_outs = pto2_rt_submit_aic_task(FUNC_GEMM_TILE,
-                            params_gemm);  // gemm
+                                                                              params_gemm);  // gemm
 
                         // C[m,n] += P
                         Arg params_add;
                         params_add.add_inout(C_view);
                         params_add.add_input(gemm_outs.get_ref(0));
                         pto2_rt_submit_aiv_task(FUNC_TILE_ADD,
-                            params_add);  // add
+                                                params_add);  // add
                     }
                 }
             }
         }
     }
 
-    LOG_INFO("[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each",
-        BATCH,
-        GRID_M,
-        GRID_N,
-        GRID_K);
+    LOG_INFO(
+        "[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each", BATCH, GRID_M, GRID_N,
+        GRID_K
+    );
 }
 
 }  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Matrix Multiplication Kernel (Cube Core)
  *
@@ -35,28 +45,24 @@ AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
     return (num_1 + num_2 - 1) / num_2 * num_2;
 }
 
-static __aicore__ inline int get_num_tiles(__gm__ Tensor* tensor, uint64_t tile_elems) {
+static __aicore__ inline int get_num_tiles(__gm__ Tensor *tensor, uint64_t tile_elems) {
     uint64_t total_elems = tensor->shapes[0];
     return static_cast<int>(total_elems / tile_elems);
 }
 
 template <int TILE>
-static __aicore__ void matmul_impl(
-    __gm__ float* input_a,
-    __gm__ float* input_b,
-    __gm__ float* output) {
-
+static __aicore__ void matmul_impl(__gm__ float *input_a, __gm__ float *input_b, __gm__ float *output) {
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
     constexpr int M = CeilAlign<int>(TILE, 16);
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA = GlobalTensor<
+        float, Shape<1, 1, 1, TILE, TILE>, pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB = GlobalTensor<
+        float, Shape<1, 1, 1, TILE, TILE>, pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC = GlobalTensor<
+        float, Shape<1, 1, 1, TILE, TILE>, pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);
@@ -104,22 +110,22 @@ static __aicore__ void matmul_impl(
     wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* input_a = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* input_b = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* output  = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_a = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *input_b = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *output = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
     constexpr uint64_t TILE_ELEMS = 128 * 128;
     int num_tiles = get_num_tiles(input_a, TILE_ELEMS);
 
-    __gm__ float* base_a = reinterpret_cast<__gm__ float*>(input_a->buffer.addr) + input_a->start_offset;
-    __gm__ float* base_b = reinterpret_cast<__gm__ float*>(input_b->buffer.addr) + input_b->start_offset;
-    __gm__ float* base_c = reinterpret_cast<__gm__ float*>(output->buffer.addr) + output->start_offset;
+    __gm__ float *base_a = reinterpret_cast<__gm__ float *>(input_a->buffer.addr) + input_a->start_offset;
+    __gm__ float *base_b = reinterpret_cast<__gm__ float *>(input_b->buffer.addr) + input_b->start_offset;
+    __gm__ float *base_c = reinterpret_cast<__gm__ float *>(output->buffer.addr) + output->start_offset;
 
     for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
-        __gm__ float* a_ptr = base_a + (tile_idx * TILE_ELEMS);
-        __gm__ float* b_ptr = base_b + (tile_idx * TILE_ELEMS);
-        __gm__ float* c_ptr = base_c + (tile_idx * TILE_ELEMS);
+        __gm__ float *a_ptr = base_a + (tile_idx * TILE_ELEMS);
+        __gm__ float *b_ptr = base_b + (tile_idx * TILE_ELEMS);
+        __gm__ float *c_ptr = base_c + (tile_idx * TILE_ELEMS);
 
         matmul_impl<128>(a_ptr, b_ptr, c_ptr);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Tensor Addition Kernel (for mixed task)
  *
@@ -28,17 +38,13 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ inline int get_num_tiles(__gm__ Tensor* tensor, uint64_t tile_elems) {
+static __aicore__ inline int get_num_tiles(__gm__ Tensor *tensor, uint64_t tile_elems) {
     uint64_t total_elems = tensor->shapes[0];
     return static_cast<int>(total_elems / tile_elems);
 }
 
 template <int ROWS, int COLS>
-static __aicore__ void add_impl(
-    __gm__ float* src0,
-    __gm__ float* src1,
-    __gm__ float* out) {
-
+static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ float *out) {
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
@@ -67,22 +73,22 @@ static __aicore__ void add_impl(
     wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[5]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[5]);
 
     constexpr uint64_t TILE_ELEMS = 128 * 128;
     int num_tiles = get_num_tiles(src0_tensor, TILE_ELEMS);
 
-    __gm__ float* base_src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* base_src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* base_out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    __gm__ float *base_src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *base_src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *base_out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
-        __gm__ float* src0_ptr = base_src0 + (tile_idx * TILE_ELEMS);
-        __gm__ float* src1_ptr = base_src1 + (tile_idx * TILE_ELEMS);
-        __gm__ float* out_ptr = base_out + (tile_idx * TILE_ELEMS);
+        __gm__ float *src0_ptr = base_src0 + (tile_idx * TILE_ELEMS);
+        __gm__ float *src1_ptr = base_src1 + (tile_idx * TILE_ELEMS);
+        __gm__ float *out_ptr = base_out + (tile_idx * TILE_ELEMS);
 
         add_impl<128, 128>(src0_ptr, src1_ptr, out_ptr);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Standalone Element-wise Addition Kernel
  *
@@ -28,11 +38,7 @@ using namespace pto;
 #endif
 
 template <int ROWS, int COLS>
-static __aicore__ void add_impl(
-    __gm__ float* src0,
-    __gm__ float* src1,
-    __gm__ float* out) {
-
+static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ float *out) {
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
@@ -61,14 +67,14 @@ static __aicore__ void add_impl(
     wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     add_impl<128, 128>(src0, src1, out);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Tensor Multiplication Kernel (for mixed task, AIV1 slot)
  *
@@ -29,17 +39,13 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ inline int get_num_tiles(__gm__ Tensor* tensor, uint64_t tile_elems) {
+static __aicore__ inline int get_num_tiles(__gm__ Tensor *tensor, uint64_t tile_elems) {
     uint64_t total_elems = tensor->shapes[0];
     return static_cast<int>(total_elems / tile_elems);
 }
 
 template <int ROWS, int COLS>
-static __aicore__ void mul_impl(
-    __gm__ float* src0,
-    __gm__ float* src1,
-    __gm__ float* out) {
-
+static __aicore__ void mul_impl(__gm__ float *src0, __gm__ float *src1, __gm__ float *out) {
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
@@ -68,22 +74,22 @@ static __aicore__ void mul_impl(
     wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[6]);
-    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[7]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[8]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[6]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[7]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[8]);
 
     constexpr uint64_t TILE_ELEMS = 128 * 128;
     int num_tiles = get_num_tiles(src0_tensor, TILE_ELEMS);
 
-    __gm__ float* base_src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* base_src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* base_out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    __gm__ float *base_src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *base_src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *base_out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
-        __gm__ float* src0_ptr = base_src0 + (tile_idx * TILE_ELEMS);
-        __gm__ float* src1_ptr = base_src1 + (tile_idx * TILE_ELEMS);
-        __gm__ float* out_ptr = base_out + (tile_idx * TILE_ELEMS);
+        __gm__ float *src0_ptr = base_src0 + (tile_idx * TILE_ELEMS);
+        __gm__ float *src1_ptr = base_src1 + (tile_idx * TILE_ELEMS);
+        __gm__ float *out_ptr = base_out + (tile_idx * TILE_ELEMS);
 
         mul_impl<128, 128>(src0_ptr, src1_ptr, out_ptr);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Standalone Element-wise Multiplication Kernel (AIV1 slot)
  *
@@ -28,11 +38,7 @@ using namespace pto;
 #endif
 
 template <int ROWS, int COLS>
-static __aicore__ void mul_impl(
-    __gm__ float* src0,
-    __gm__ float* src1,
-    __gm__ float* out) {
-
+static __aicore__ void mul_impl(__gm__ float *src0, __gm__ float *src1, __gm__ float *out) {
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
@@ -61,14 +67,14 @@ static __aicore__ void mul_impl(
     wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[5]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[5]);
 
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     mul_impl<128, 128>(src0, src1, out);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -40,16 +40,16 @@ static constexpr uint32_t TILE_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 15,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_hub.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Fixed tile size: (16, 16) @ (16, 16) -> (16, 16)
@@ -22,10 +32,10 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __gm__ Tensor* oi) {
-    __gm__ half* pij_addr = reinterpret_cast<__gm__ half*>(pij->buffer.addr);
-    __gm__ half* vj_addr = reinterpret_cast<__gm__ half*>(vj->buffer.addr);
-    __gm__ float* oi_addr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
+static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __gm__ Tensor *oi) {
+    __gm__ half *pij_addr = reinterpret_cast<__gm__ half *>(pij->buffer.addr);
+    __gm__ half *vj_addr = reinterpret_cast<__gm__ half *>(vj->buffer.addr);
+    __gm__ float *oi_addr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
 
     // pij (M, K) fp16, vj (K, N) fp16 in ND (row-major), oi_new (M, N) fp32
     using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
@@ -83,10 +93,10 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* vj = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *vj = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
     pv_matmul_impl<16, 16, 16>(pij, vj, oi_new);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Fixed tile size: (16, 16) @ (16, 16).T -> (16, 16)
@@ -22,10 +32,10 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm__ Tensor* sij) {
-    __gm__ half* qi_addr = reinterpret_cast<__gm__ half*>(qi->buffer.addr);
-    __gm__ half* kj_addr = reinterpret_cast<__gm__ half*>(kj->buffer.addr);
-    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
+static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm__ Tensor *sij) {
+    __gm__ half *qi_addr = reinterpret_cast<__gm__ half *>(qi->buffer.addr);
+    __gm__ half *kj_addr = reinterpret_cast<__gm__ half *>(kj->buffer.addr);
+    __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
 
     // qi (M, K) fp16 in ND (row-major) layout
     using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
@@ -84,10 +94,10 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* qi = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* kj = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *qi = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *kj = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *sij = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
     qk_matmul_impl<16, 16, 16>(qi, kj, sij);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_hub.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Fixed tile size: oi/oi_new are (16, 16), mij/lij/mi/li are 16-element vectors
@@ -24,22 +34,17 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ Tensor* mij,
-    __gm__ Tensor* lij,
-    __gm__ Tensor* oi_new,
-    __gm__ Tensor* mi,
-    __gm__ Tensor* li,
-    __gm__ Tensor* oi,
-    uint64_t is_first,
-    uint64_t is_last,
-    __gm__ Tensor* dst) {
-    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
-    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
-    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
-    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
-    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+static __aicore__ void online_update_impl(
+    __gm__ Tensor *mij, __gm__ Tensor *lij, __gm__ Tensor *oi_new, __gm__ Tensor *mi, __gm__ Tensor *li,
+    __gm__ Tensor *oi, uint64_t is_first, uint64_t is_last, __gm__ Tensor *dst
+) {
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi->buffer.addr);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li->buffer.addr);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst->buffer.addr);
 
     // Scalar tile dimensions for RowMajor layout:
     // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
@@ -221,14 +226,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mi = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* li = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* oi = reinterpret_cast<__gm__ Tensor*>(args[5]);
-    __gm__ Tensor* dst = reinterpret_cast<__gm__ Tensor*>(args[6]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mi = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *li = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *oi = reinterpret_cast<__gm__ Tensor *>(args[5]);
+    __gm__ Tensor *dst = reinterpret_cast<__gm__ Tensor *>(args[6]);
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -42,12 +42,13 @@ using namespace pto;
 
 template <int M, int N>
 static __aicore__ void softmax_prepare_impl(
-    __gm__ Tensor* sij, float scale_value, __gm__ Tensor* pij, __gm__ Tensor* mij, __gm__ Tensor* lij) {
+    __gm__ Tensor *sij, float scale_value, __gm__ Tensor *pij, __gm__ Tensor *mij, __gm__ Tensor *lij
+) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
-    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
-    __gm__ half* pij_addr = reinterpret_cast<__gm__ half*>(pij->buffer.addr);
-    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
+    __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
+    __gm__ half *pij_addr = reinterpret_cast<__gm__ half *>(pij->buffer.addr);
+    __gm__ float *mij_addr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_addr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -118,11 +119,11 @@ static __aicore__ void softmax_prepare_impl(
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[3]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *sij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[3]);
     float scale_value = from_u64<float>(static_cast<uint64_t>(args[4]));
 
     softmax_prepare_impl<16, 16>(sij, scale_value, pij, mij, lij);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -39,16 +39,16 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     // Read dimensions from tensor metadata
     // query: shape=[batch, num_heads, head_dim]
     uint64_t batch = orch_args.tensor(0).shapes[0];
@@ -74,18 +74,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     uint64_t b_start = batch * orch_thread_index / orch_thread_num;
     uint64_t b_end = batch * (orch_thread_index + 1) / orch_thread_num;
 
-    LOG_INFO("orch_idx=%d/%d batch=%" PRIu64 " b_range=[%" PRIu64 ",%" PRIu64 ")",
-        orch_thread_index,
-        orch_thread_num,
-        batch,
-        b_start,
-        b_end);
+    LOG_INFO(
+        "orch_idx=%d/%d batch=%" PRIu64 " b_range=[%" PRIu64 ",%" PRIu64 ")", orch_thread_index, orch_thread_num, batch,
+        b_start, b_end
+    );
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void* query_ptr = orch_args.tensor(0).data_as<void>();
-    void* kc_ptr = orch_args.tensor(1).data_as<void>();
-    void* vc_ptr = orch_args.tensor(2).data_as<void>();
-    void* out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).data_as<void>();
+    void *out_ptr = orch_args.tensor(5).data_as<void>();
 
     // Compute kv_total_rows from key_cache tensor metadata
     uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
@@ -104,8 +102,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     LOG_DEBUG("value_cache=%s", value_cache.dump().c_str());
     LOG_DEBUG("out=%s", out.dump().c_str());
 
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -133,9 +131,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 params_inplace.add_output(scalar_ci);
                 params_inplace.add_output(scalar_ci);
                 TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, params_inplace);
-                const Tensor& oi = hub_outs.get_ref(0);
-                const Tensor& li_update = hub_outs.get_ref(1);
-                const Tensor& mi_update = hub_outs.get_ref(2);
+                const Tensor &oi = hub_outs.get_ref(0);
+                const Tensor &li_update = hub_outs.get_ref(1);
+                const Tensor &mi_update = hub_outs.get_ref(2);
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
                     uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
@@ -151,7 +149,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_qk.add_input(kj);
                     params_qk.add_output(sij_ci);
                     TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
-                    const Tensor& sij = qk_outs.get_ref(0);
+                    const Tensor &sij = qk_outs.get_ref(0);
 
                     uint32_t sij_valid_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(valid_len)};
                     uint32_t sij_valid_offsets[2] = {0, 0};
@@ -163,16 +161,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_sf.add_output(scalar_ci);
                     params_sf.add_scalar(scale_value);
                     TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
-                    const Tensor& pij_f16 = sf_outs.get_ref(0);
-                    const Tensor& mi = sf_outs.get_ref(1);
-                    const Tensor& li = sf_outs.get_ref(2);
+                    const Tensor &pij_f16 = sf_outs.get_ref(0);
+                    const Tensor &mi = sf_outs.get_ref(1);
+                    const Tensor &li = sf_outs.get_ref(2);
 
                     Arg params_pv;
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
                     TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
-                    const Tensor& oi_tmp = pv_outs.get_ref(0);
+                    const Tensor &oi_tmp = pv_outs.get_ref(0);
 
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
@@ -193,11 +191,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         }
     }
 
-    LOG_INFO("orch_idx=%d: tasks submitted for batch=[%" PRIu64 ",%" PRIu64 "), num_heads=%" PRIu64,
-        orch_thread_index,
-        b_start,
-        b_end,
-        num_heads);
+    LOG_INFO(
+        "orch_idx=%d: tasks submitted for batch=[%" PRIu64 ",%" PRIu64 "), num_heads=%" PRIu64, orch_thread_index,
+        b_start, b_end, num_heads
+    );
 }
 
 }  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/aic/kernel_spmd_read.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/aic/kernel_spmd_read.cpp
@@ -51,9 +51,9 @@ static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
 #define CACHELINE_OUT 0
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     // AIC writes at fixed cache line 0 (no sub_block_id needed)
     out[0] = static_cast<float>(get_block_idx(args));

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/aiv/kernel_spmd_read.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/aiv/kernel_spmd_read.cpp
@@ -52,9 +52,9 @@ static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
 #define CACHELINE_OUT 0
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     int32_t sub_block_id = get_sub_block_id(args);
     // AIV writes at cache line (1 + sub_block_id), skipping AIC's cache line 0

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -30,16 +30,16 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;  // NOLINT(readability/casting)
     if (orch_thread_index != 0) return;
 

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/aiv/kernel_spmd_write.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/aiv/kernel_spmd_write.cpp
@@ -51,9 +51,9 @@ static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
 #define CACHELINE_OUT 0
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     int32_t base_cl = static_cast<int32_t>(args[1]);
     int32_t block_idx = get_block_idx(args);

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -32,15 +32,15 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_spmd_aiv(int32_t kernel_id, Tensor& out, int16_t block_num, int64_t base_cl) {
+static void submit_spmd_aiv(int32_t kernel_id, Tensor &out, int16_t block_num, int64_t base_cl) {
     Arg args;
     args.add_inout(out);
     args.add_scalar(base_cl);
@@ -48,8 +48,8 @@ static void submit_spmd_aiv(int32_t kernel_id, Tensor& out, int16_t block_num, i
     pto2_rt_submit_aiv_task(kernel_id, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;  // NOLINT(readability/casting)
     if (orch_thread_index != 0) return;
 

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp
@@ -49,9 +49,9 @@ static constexpr int32_t SLOTS_PER_BLOCK = 3;
 #define CACHELINE_OUT 0
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     int32_t base_cl = static_cast<int32_t>(args[1]);
     int32_t block_idx = get_block_idx(args);

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp
@@ -51,9 +51,9 @@ static constexpr int32_t SLOTS_PER_BLOCK = 3;
 #define CACHELINE_OUT 0
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     int32_t base_cl = static_cast<int32_t>(args[1]);
     int32_t block_idx = get_block_idx(args);

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -34,16 +34,16 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_spmd_mix(
-    int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, Tensor& out, int16_t block_num, int64_t base_cl) {
+static void
+submit_spmd_mix(int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, Tensor &out, int16_t block_num, int64_t base_cl) {
     MixedKernels mk;
     mk.aic_kernel_id = aic_id;
     mk.aiv0_kernel_id = aiv0_id;
@@ -56,8 +56,8 @@ static void submit_spmd_mix(
     pto2_rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;  // NOLINT(readability/casting)
     if (orch_thread_index != 0) return;
 

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Tensor Addition Kernel
  *
@@ -34,14 +44,14 @@ using namespace pto;
  *              args[2] = out pointer (output tensor)
  *              args[3] = size (number of elements)
  */
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     // Unpack arguments (Tensor* pointers from runtime)
-    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     // Configuration: float, 128, 128, 128, 128
     constexpr int kTRows_ = 128;
@@ -73,7 +83,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    
+
     set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -46,12 +46,12 @@ using namespace pto;
  *              args[2] = scalar value (as uint64_t, needs conversion to float)
  *              args[3] = size (number of elements)
  */
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     // Unpack arguments (Tensor* pointers from runtime)
-    __gm__ Tensor* src_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ float* src = reinterpret_cast<__gm__ float*>(src_tensor->buffer.addr) + src_tensor->start_offset;
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    __gm__ Tensor *src_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ float *src = reinterpret_cast<__gm__ float *>(src_tensor->buffer.addr) + src_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     // Convert scalar from uint64_t to float
     float scalar = from_u64<float>(static_cast<uint64_t>(args[2]));

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_mul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Tensor Multiplication Kernel
  *
@@ -34,14 +44,14 @@ using namespace pto;
  *              args[2] = out pointer (output tensor)
  *              args[3] = size (number of elements)
  */
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     // Unpack arguments (Tensor* pointers from runtime)
-    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     // Configuration: float, 128, 128, 128, 128
     constexpr int kTRows_ = 128;
@@ -73,7 +83,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    
+
     set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -39,8 +39,8 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
@@ -52,8 +52,8 @@ __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestrati
  * The executor wraps this call in PTO2_SCOPE, so we are already inside
  * the outer scope on entry.
  */
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 
@@ -74,7 +74,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     params_t0.add_input(ext_b);
     params_t0.add_output(inter_ci);
     TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);  // kernel_add
-    const Tensor& c = outs_t0.get_ref(0);
+    const Tensor &c = outs_t0.get_ref(0);
 
     // Inner scope: owns t1, t2, t3, t4; intermediates d, e, g release on scope end.
     // c flows in from outer scope (outer-scope tensors are visible to inner scopes).
@@ -86,7 +86,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         params_t1.add_scalar(to_u64(1.0f));
         params_t1.add_scalar(static_cast<uint64_t>(3));
         TaskOutputTensors outs_t1 = pto2_rt_submit_aiv_task(1, params_t1);  // kernel_add_scalar
-        const Tensor& d = outs_t1.get_ref(0);
+        const Tensor &d = outs_t1.get_ref(0);
 
         // t2: e = c + 2 (kernel_id=1, kernel_add_scalar)
         Arg params_t2;
@@ -95,7 +95,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         params_t2.add_scalar(to_u64(2.0f));
         params_t2.add_scalar(static_cast<uint64_t>(3));
         TaskOutputTensors outs_t2 = pto2_rt_submit_aiv_task(1, params_t2);  // kernel_add_scalar
-        const Tensor& e = outs_t2.get_ref(0);
+        const Tensor &e = outs_t2.get_ref(0);
 
         // t3: g = d * e (kernel_id=2, kernel_mul)
         Arg params_t3;
@@ -104,7 +104,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         params_t3.add_output(inter_ci);
         params_t3.add_scalar(static_cast<uint64_t>(3));
         TaskOutputTensors outs_t3 = pto2_rt_submit_aiv_task(2, params_t3);  // kernel_mul
-        const Tensor& g = outs_t3.get_ref(0);
+        const Tensor &g = outs_t3.get_ref(0);
 
         // t4: f = g + c (kernel_id=0, kernel_add)
         Arg params_t4;

--- a/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Fixed tile size: (16, 16) @ (16, 16) -> (16, 16)
@@ -19,21 +29,20 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw)
-{
+static __aicore__ void pv_matmul_impl(__gm__ uint8_t *pij_raw, __gm__ uint8_t *vj_raw, __gm__ uint8_t *oi_raw) {
     constexpr int M = 16, K = 16, N = 16;
 
-    __gm__ half* pij = reinterpret_cast<__gm__ half*>(pij_raw);
-    __gm__ half* vj  = reinterpret_cast<__gm__ half*>(vj_raw);
-    __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
+    __gm__ half *pij = reinterpret_cast<__gm__ half *>(pij_raw);
+    __gm__ half *vj = reinterpret_cast<__gm__ half *>(vj_raw);
+    __gm__ float *oi = reinterpret_cast<__gm__ float *>(oi_raw);
 
     // pij (M, K) fp16, vj (K, N) fp16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, pto::Stride<M*K, M*K, M*K, K, 1>>;
-    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, pto::Stride<K*N, K*N, K*N, N, 1>>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   pijGlobal(pij);
-    GlobalB   vjGlobal(vj);
+    GlobalA pijGlobal(pij);
+    GlobalB vjGlobal(vj);
     GlobalOut oiGlobal(oi);
 
     // L1 Mat tiles: standard ND pattern for both A and B
@@ -41,18 +50,18 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<half, M, K, M, K>;
+    using LeftTile = TileLeft<half, M, K, M, K>;
     using RightTile = TileRight<half, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -80,11 +89,10 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     TSTORE(oiGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* pij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* vj     = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *pij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *vj = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *oi_new = reinterpret_cast<__gm__ uint8_t *>(args[2]);
 
     pv_matmul_impl(pij, vj, oi_new);
 }

--- a/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Fixed tile size: (16, 16) @ (16, 16).T -> (16, 16)
@@ -19,22 +29,21 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw)
-{
+static __aicore__ void qk_matmul_impl(__gm__ uint8_t *qi_raw, __gm__ uint8_t *kj_raw, __gm__ uint8_t *sij_raw) {
     constexpr int M = 16, K = 16, N = 16;
 
-    __gm__ half* qi  = reinterpret_cast<__gm__ half*>(qi_raw);
-    __gm__ half* kj  = reinterpret_cast<__gm__ half*>(kj_raw);
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+    __gm__ half *qi = reinterpret_cast<__gm__ half *>(qi_raw);
+    __gm__ half *kj = reinterpret_cast<__gm__ half *>(kj_raw);
+    __gm__ float *sij = reinterpret_cast<__gm__ float *>(sij_raw);
 
     // qi (M, K) fp16 in ND (row-major) layout
-    using GlobalA   = GlobalTensor<half, Shape<1, 1, 1, M, K>, pto::Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB   = GlobalTensor<half, Shape<1, 1, 1, K, N>, pto::Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   qiGlobal(qi);
-    GlobalB   kjGlobal(kj);
+    GlobalA qiGlobal(qi);
+    GlobalB kjGlobal(kj);
     GlobalOut sijGlobal(sij);
 
     // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
@@ -42,18 +51,18 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<half, M, K, M, K>;
+    using LeftTile = TileLeft<half, M, K, M, K>;
     using RightTile = TileRight<half, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -81,11 +90,10 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     TSTORE(sijGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* qi  = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* kj  = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *qi = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *kj = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *sij = reinterpret_cast<__gm__ uint8_t *>(args[2]);
 
     qk_matmul_impl(qi, kj, sij);
 }

--- a/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Fixed tile size: oi/oi_new are (16, 16), mij/lij/mi/li are 16-element vectors
@@ -21,20 +31,19 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_t* lij_raw,
-                               __gm__ uint8_t* oi_new_raw, __gm__ uint8_t* mi_raw,
-                               __gm__ uint8_t* li_raw, __gm__ uint8_t* oi_raw,
-                               int is_first, int is_last, __gm__ uint8_t* dst_raw)
-{
+static __aicore__ void online_update_impl(
+    __gm__ uint8_t *mij_raw, __gm__ uint8_t *lij_raw, __gm__ uint8_t *oi_new_raw, __gm__ uint8_t *mi_raw,
+    __gm__ uint8_t *li_raw, __gm__ uint8_t *oi_raw, int is_first, int is_last, __gm__ uint8_t *dst_raw
+) {
     constexpr int M = 16, N = 16;
 
-    __gm__ float* mij_ptr    = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float* lij_ptr    = reinterpret_cast<__gm__ float*>(lij_raw);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new_raw);
-    __gm__ float* mi_ptr     = reinterpret_cast<__gm__ float*>(mi_raw);
-    __gm__ float* li_ptr     = reinterpret_cast<__gm__ float*>(li_raw);
-    __gm__ float* oi_ptr     = reinterpret_cast<__gm__ float*>(oi_raw);
-    __gm__ float* dst_ptr    = reinterpret_cast<__gm__ float*>(dst_raw);
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij_raw);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij_raw);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new_raw);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi_raw);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li_raw);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi_raw);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst_raw);
 
     // Scalar tile dimensions for RowMajor layout:
     // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
@@ -50,12 +59,11 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<1, 1, 1, N, 1>>;
 
     // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
-    using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
-                                        pto::Stride<1, 1, 1, kScalarCols, 1>>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, pto::Stride<1, 1, 1, kScalarCols, 1>>;
 
     // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
-                                        pto::Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, pto::Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -77,8 +85,8 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     // --- Tile types ---
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
-    using TileScalarND = Tile<TileType::Vec, float, kScalarRows, kScalarCols,
-                              BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     // --- UB memory layout ---
@@ -123,9 +131,9 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Passthrough to MTE3 (no V compute needed)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, mijND);     // mi = mij
-        TSTORE(liGlobalND, lijND);     // li = lij
-        TSTORE(oiGlobal, oiNewTile);   // oi = oi_new
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
 
         if (is_last) {
             // Single block: normalize dst = oi_new / lij
@@ -154,44 +162,44 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
-        TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
-        TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
-        TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
-        TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
-        TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
-        TMUL(liND, alphaND, liND);           // li = alpha * li
-        TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
-        TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
+        TMAX(miNewND, miND, mijND);    // mi_new = max(mi, mij)
+        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
+        TEXP(alphaND, alphaND);        // alpha = exp(mi - mi_new)
+        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
+        TEXP(betaND, betaND);          // beta = exp(mij - mi_new)
+        TMUL(liND, alphaND, liND);     // li = alpha * li
+        TMUL(tmpND, betaND, lijND);    // tmp = beta * lij
+        TADD(liND, liND, tmpND);       // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
         // mi_new -> mi accumulator, li_new -> li accumulator
         // alpha -> mij buffer (reuse), beta -> lij buffer (reuse)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, miNewND);         // persist mi_new
-        TSTORE(liGlobalND, liND);            // persist li_new
-        TSTORE(mijGlobalND, alphaND);        // temp: alpha to mij buffer
-        TSTORE(lijGlobalND, betaND);         // temp: beta to lij buffer
+        TSTORE(miGlobalND, miNewND);   // persist mi_new
+        TSTORE(liGlobalND, liND);      // persist li_new
+        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
 
         // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        TLOAD(alphaDN, mijGlobalDN);         // alpha from mij buffer as DN
-        TLOAD(betaDN, lijGlobalDN);          // beta from lij buffer as DN
+        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
         if (is_last) {
-            TLOAD(liDN, liGlobalDN);         // li_new from li buffer as DN
+            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
         }
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
 
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
-        TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
+        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
-            TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
+            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             TSTORE(dstGlobal, oiTile);
@@ -204,16 +212,16 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* mij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* lij    = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mi     = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* li     = reinterpret_cast<__gm__ uint8_t*>(args[4]);
-    __gm__ uint8_t* oi     = reinterpret_cast<__gm__ uint8_t*>(args[5]);
-    int is_first  = static_cast<int>(args[6]);
-    int is_last   = static_cast<int>(args[7]);
-    __gm__ uint8_t* dst    = reinterpret_cast<__gm__ uint8_t*>(args[8]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *mij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *lij = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *oi_new = reinterpret_cast<__gm__ uint8_t *>(args[2]);
+    __gm__ uint8_t *mi = reinterpret_cast<__gm__ uint8_t *>(args[3]);
+    __gm__ uint8_t *li = reinterpret_cast<__gm__ uint8_t *>(args[4]);
+    __gm__ uint8_t *oi = reinterpret_cast<__gm__ uint8_t *>(args[5]);
+    int is_first = static_cast<int>(args[6]);
+    int is_last = static_cast<int>(args[7]);
+    __gm__ uint8_t *dst = reinterpret_cast<__gm__ uint8_t *>(args[8]);
 
     online_update_impl(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
 }

--- a/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Softmax Preparation Kernel (AIV)
 //
 // Fixed tile size: sij is (16, 16)
@@ -21,16 +31,16 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
-                                 __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
-                                 __gm__ uint8_t* lij_raw)
-{
+static __aicore__ void softmax_prepare_impl(
+    __gm__ uint8_t *sij_raw, float scale_value, __gm__ uint8_t *pij_raw, __gm__ uint8_t *mij_raw,
+    __gm__ uint8_t *lij_raw
+) {
     constexpr int M = 16, N = 16;
 
-    __gm__ float* sij = reinterpret_cast<__gm__ float*>(sij_raw);
-    __gm__ half*  pij = reinterpret_cast<__gm__ half*>(pij_raw);
-    __gm__ float* mij = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float* lij = reinterpret_cast<__gm__ float*>(lij_raw);
+    __gm__ float *sij = reinterpret_cast<__gm__ float *>(sij_raw);
+    __gm__ half *pij = reinterpret_cast<__gm__ half *>(pij_raw);
+    __gm__ float *mij = reinterpret_cast<__gm__ float *>(mij_raw);
+    __gm__ float *lij = reinterpret_cast<__gm__ float *>(lij_raw);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -81,14 +91,17 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
     TSTORE(pijGlobal, pijF16Tile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    union { uint64_t u; float f; } scale_conv;
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *sij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[1]);
     float scale_value = scale_conv.f;
-    __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mij = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[4]);
+    __gm__ uint8_t *pij = reinterpret_cast<__gm__ uint8_t *>(args[2]);
+    __gm__ uint8_t *mij = reinterpret_cast<__gm__ uint8_t *>(args[3]);
+    __gm__ uint8_t *lij = reinterpret_cast<__gm__ uint8_t *>(args[4]);
 
     softmax_prepare_impl(sij, scale_value, pij, mij, lij);
 }

--- a/examples/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -37,19 +37,19 @@
 
 extern "C" {
 
-int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
+int build_paged_attention_graph(Runtime *runtime, const ChipStorageTaskArgs &orch_args) {
     if (orch_args.tensor_count() < 6) {
         std::cerr << "Expected at least 6 tensors, got " << orch_args.tensor_count() << '\n';
         return -1;
     }
 
     // Extract host pointers from tensor metadata
-    void* host_query = orch_args.tensor(0).data_as<void>();
-    void* host_key_cache = orch_args.tensor(1).data_as<void>();
-    void* host_value_cache = orch_args.tensor(2).data_as<void>();
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
-    void* host_out = orch_args.tensor(5).data_as<void>();
+    void *host_query = orch_args.tensor(0).data_as<void>();
+    void *host_key_cache = orch_args.tensor(1).data_as<void>();
+    void *host_value_cache = orch_args.tensor(2).data_as<void>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    void *host_out = orch_args.tensor(5).data_as<void>();
 
     // Extract sizes from tensor metadata
     size_t query_size = orch_args.tensor(0).nbytes();
@@ -83,10 +83,10 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
     std::cout << "q_tile_size=" << q_tile_size << ", num_head_tiles=" << num_head_tiles << '\n';
 
     // Allocate device memory for inputs/outputs
-    void* dev_query = runtime->host_api.device_malloc(query_size);
-    void* dev_key_cache = runtime->host_api.device_malloc(key_cache_size);
-    void* dev_value_cache = runtime->host_api.device_malloc(value_cache_size);
-    void* dev_out = runtime->host_api.device_malloc(out_size);
+    void *dev_query = runtime->host_api.device_malloc(query_size);
+    void *dev_key_cache = runtime->host_api.device_malloc(key_cache_size);
+    void *dev_value_cache = runtime->host_api.device_malloc(value_cache_size);
+    void *dev_out = runtime->host_api.device_malloc(out_size);
 
     if (!dev_query || !dev_key_cache || !dev_value_cache || !dev_out) {
         std::cerr << "Error: Failed to allocate device memory\n";
@@ -107,11 +107,11 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
     // Per-batch-per-block intermediate buffers
     uint32_t total_buffers = batch * max_num_blocks;
-    void** dev_sij_arr = new void*[total_buffers];
-    void** dev_pij_arr = new void*[total_buffers];
-    void** dev_mij_arr = new void*[total_buffers];
-    void** dev_lij_arr = new void*[total_buffers];
-    void** dev_oi_new_arr = new void*[total_buffers];
+    void **dev_sij_arr = new void *[total_buffers];
+    void **dev_pij_arr = new void *[total_buffers];
+    void **dev_mij_arr = new void *[total_buffers];
+    void **dev_lij_arr = new void *[total_buffers];
+    void **dev_oi_new_arr = new void *[total_buffers];
 
     for (uint32_t i = 0; i < total_buffers; i++) {
         dev_sij_arr[i] = runtime->host_api.device_malloc(sij_size);
@@ -127,9 +127,9 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
     size_t li_size = mi_size;
     size_t oi_size = static_cast<size_t>(q_tile_size) * head_dim * sizeof(float);
 
-    void** dev_mi_arr = new void*[total_accums];
-    void** dev_li_arr = new void*[total_accums];
-    void** dev_oi_arr = new void*[total_accums];
+    void **dev_mi_arr = new void *[total_accums];
+    void **dev_li_arr = new void *[total_accums];
+    void **dev_oi_arr = new void *[total_accums];
 
     for (uint32_t i = 0; i < total_accums; i++) {
         dev_mi_arr[i] = runtime->host_api.device_malloc(mi_size);
@@ -151,11 +151,11 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
             // Query: (batch, q_head_num, head_dim) fp16
             // qi points to heads [cur_offset .. cur_offset+q_tile_size) for batch b_idx
-            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query) +
+            uint8_t *qi_ptr = reinterpret_cast<uint8_t *>(dev_query) +
                               static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
 
             // Output: (batch * q_head_num, head_dim) float32
-            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out) +
+            uint8_t *out_ptr = reinterpret_cast<uint8_t *>(dev_out) +
                                static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
 
             // GQA: which kv_head this head tile maps to
@@ -163,9 +163,9 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
             // Per-(batch, head_tile) accumulators
             uint32_t accum_idx = b_idx * num_head_tiles + ht;
-            void* dev_mi = dev_mi_arr[accum_idx];
-            void* dev_li = dev_li_arr[accum_idx];
-            void* dev_oi = dev_oi_arr[accum_idx];
+            void *dev_mi = dev_mi_arr[accum_idx];
+            void *dev_li = dev_li_arr[accum_idx];
+            void *dev_oi = dev_oi_arr[accum_idx];
 
             int t_up_prev = -1;
 
@@ -173,50 +173,41 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
                 int cur_block_idx = host_block_table[b_idx * max_num_blocks + bn];
 
                 // Key: (total_blocks, block_size, kv_head_num, head_dim) fp16
-                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache) +
+                uint8_t *kj_ptr = reinterpret_cast<uint8_t *>(dev_key_cache) +
                                   (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
                                       head_dim * sizeof(uint16_t);
 
                 // Value: (total_blocks, block_size, kv_head_num, head_dim) fp16
-                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache) +
+                uint8_t *vj_ptr = reinterpret_cast<uint8_t *>(dev_value_cache) +
                                   (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
                                       head_dim * sizeof(uint16_t);
 
                 uint32_t buf_idx = b_idx * max_num_blocks + bn;
-                void* dev_sij = dev_sij_arr[buf_idx];
-                void* dev_pij = dev_pij_arr[buf_idx];
-                void* dev_mij = dev_mij_arr[buf_idx];
-                void* dev_lij = dev_lij_arr[buf_idx];
-                void* dev_oi_new = dev_oi_new_arr[buf_idx];
+                void *dev_sij = dev_sij_arr[buf_idx];
+                void *dev_pij = dev_pij_arr[buf_idx];
+                void *dev_mij = dev_mij_arr[buf_idx];
+                void *dev_lij = dev_lij_arr[buf_idx];
+                void *dev_oi_new = dev_oi_new_arr[buf_idx];
 
                 // QK: qi(M, K) @ kj.T(K, N) -> sij(M, N)
-                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),
-                    reinterpret_cast<uint64_t>(kj_ptr),
-                    reinterpret_cast<uint64_t>(dev_sij),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim),
-                    static_cast<uint64_t>(block_size)};
+                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),  reinterpret_cast<uint64_t>(kj_ptr),
+                                       reinterpret_cast<uint64_t>(dev_sij), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(head_dim),     static_cast<uint64_t>(block_size)};
                 int t_qk = runtime->add_task(qk_args, 6, FUNC_QK_MATMUL, CoreType::AIC);
                 total_tasks++;
 
                 // SF: scale, rowmax, exp, rowsum -> pij, mij, lij
-                uint64_t sf_args[7] = {reinterpret_cast<uint64_t>(dev_sij),
-                    scale_value_bits,
-                    reinterpret_cast<uint64_t>(dev_pij),
-                    reinterpret_cast<uint64_t>(dev_mij),
-                    reinterpret_cast<uint64_t>(dev_lij),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size)};
+                uint64_t sf_args[7] = {reinterpret_cast<uint64_t>(dev_sij), scale_value_bits,
+                                       reinterpret_cast<uint64_t>(dev_pij), reinterpret_cast<uint64_t>(dev_mij),
+                                       reinterpret_cast<uint64_t>(dev_lij), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(block_size)};
                 int t_sf = runtime->add_task(sf_args, 7, FUNC_SOFTMAX_PREPARE, CoreType::AIV);
                 total_tasks++;
 
                 // PV: pij(M, K') @ vj(K', N') -> oi_new(M, N')
-                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),
-                    reinterpret_cast<uint64_t>(vj_ptr),
-                    reinterpret_cast<uint64_t>(dev_oi_new),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(head_dim)};
+                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),    reinterpret_cast<uint64_t>(vj_ptr),
+                                       reinterpret_cast<uint64_t>(dev_oi_new), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(block_size),      static_cast<uint64_t>(head_dim)};
                 int t_pv = runtime->add_task(pv_args, 6, FUNC_PV_MATMUL, CoreType::AIC);
                 total_tasks++;
 
@@ -227,17 +218,12 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
                 int is_first = (bn == 0) ? 1 : 0;
                 int is_last = (bn == bn_this_batch - 1) ? 1 : 0;
 
-                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),
-                    reinterpret_cast<uint64_t>(dev_lij),
-                    reinterpret_cast<uint64_t>(dev_oi_new),
-                    reinterpret_cast<uint64_t>(dev_mi),
-                    reinterpret_cast<uint64_t>(dev_li),
-                    reinterpret_cast<uint64_t>(dev_oi),
-                    static_cast<uint64_t>(is_first),
-                    static_cast<uint64_t>(is_last),
-                    reinterpret_cast<uint64_t>(out_ptr),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim)};
+                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),    reinterpret_cast<uint64_t>(dev_lij),
+                                        reinterpret_cast<uint64_t>(dev_oi_new), reinterpret_cast<uint64_t>(dev_mi),
+                                        reinterpret_cast<uint64_t>(dev_li),     reinterpret_cast<uint64_t>(dev_oi),
+                                        static_cast<uint64_t>(is_first),        static_cast<uint64_t>(is_last),
+                                        reinterpret_cast<uint64_t>(out_ptr),    static_cast<uint64_t>(q_tile_size),
+                                        static_cast<uint64_t>(head_dim)};
                 int t_up = runtime->add_task(up_args, 11, FUNC_ONLINE_UPDATE, CoreType::AIV);
                 total_tasks++;
 

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_hub.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Fixed tile size: (16, 16) @ (16, 16) -> (16, 16)
@@ -22,10 +32,10 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __gm__ Tensor* oi) {
-    __gm__ half* pij_addr = reinterpret_cast<__gm__ half*>(pij->buffer.addr);
-    __gm__ half* vj_addr = reinterpret_cast<__gm__ half*>(vj->buffer.addr);
-    __gm__ float* oi_addr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
+static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __gm__ Tensor *oi) {
+    __gm__ half *pij_addr = reinterpret_cast<__gm__ half *>(pij->buffer.addr);
+    __gm__ half *vj_addr = reinterpret_cast<__gm__ half *>(vj->buffer.addr);
+    __gm__ float *oi_addr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
 
     // pij (M, K) fp16, vj (K, N) fp16 in ND (row-major), oi_new (M, N) fp32
     using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
@@ -78,13 +88,12 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(oiGlobal, cTile);
-
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* vj = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *vj = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
     pv_matmul_impl<16, 16, 16>(pij, vj, oi_new);
 }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Fixed tile size: (16, 16) @ (16, 16).T -> (16, 16)
@@ -22,10 +32,10 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm__ Tensor* sij) {
-    __gm__ half* qi_addr = reinterpret_cast<__gm__ half*>(qi->buffer.addr);
-    __gm__ half* kj_addr = reinterpret_cast<__gm__ half*>(kj->buffer.addr);
-    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
+static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm__ Tensor *sij) {
+    __gm__ half *qi_addr = reinterpret_cast<__gm__ half *>(qi->buffer.addr);
+    __gm__ half *kj_addr = reinterpret_cast<__gm__ half *>(kj->buffer.addr);
+    __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
 
     // qi (M, K) fp16 in ND (row-major) layout
     using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
@@ -79,13 +89,12 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(sijGlobal, cTile);
-
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* qi = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* kj = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *qi = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *kj = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *sij = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
     qk_matmul_impl<16, 16, 16>(qi, kj, sij);
 }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_hub.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Fixed tile size: oi/oi_new are (16, 16), mij/lij/mi/li are 16-element vectors
@@ -24,22 +34,17 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ Tensor* mij,
-    __gm__ Tensor* lij,
-    __gm__ Tensor* oi_new,
-    __gm__ Tensor* mi,
-    __gm__ Tensor* li,
-    __gm__ Tensor* oi,
-    uint64_t is_first,
-    uint64_t is_last,
-    __gm__ Tensor* dst) {
-    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
-    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
-    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
-    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
-    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+static __aicore__ void online_update_impl(
+    __gm__ Tensor *mij, __gm__ Tensor *lij, __gm__ Tensor *oi_new, __gm__ Tensor *mi, __gm__ Tensor *li,
+    __gm__ Tensor *oi, uint64_t is_first, uint64_t is_last, __gm__ Tensor *dst
+) {
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi->buffer.addr);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li->buffer.addr);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst->buffer.addr);
 
     // Scalar tile dimensions for RowMajor layout:
     // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
@@ -159,14 +164,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
 
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
         // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);  // mi_new = max(mi, mij)
+        TMAX(miNewND, miND, mijND);    // mi_new = max(mi, mij)
         TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
-        TEXP(alphaND, alphaND);  // alpha = exp(mi - mi_new)
+        TEXP(alphaND, alphaND);        // alpha = exp(mi - mi_new)
         TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
-        TEXP(betaND, betaND);  // beta = exp(mij - mi_new)
-        TMUL(liND, alphaND, liND);  // li = alpha * li
-        TMUL(tmpND, betaND, lijND);  // tmp = beta * lij
-        TADD(liND, liND, tmpND);  // li = alpha * li + beta * lij (= li_new)
+        TEXP(betaND, betaND);          // beta = exp(mij - mi_new)
+        TMUL(liND, alphaND, liND);     // li = alpha * li
+        TMUL(tmpND, betaND, lijND);    // tmp = beta * lij
+        TADD(liND, liND, tmpND);       // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
         // mi_new -> mi accumulator, li_new -> li accumulator
@@ -192,7 +197,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
         TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
-        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
@@ -209,14 +214,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mi = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* li = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* oi = reinterpret_cast<__gm__ Tensor*>(args[5]);
-    __gm__ Tensor* dst = reinterpret_cast<__gm__ Tensor*>(args[6]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mi = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *li = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *oi = reinterpret_cast<__gm__ Tensor *>(args[5]);
+    __gm__ Tensor *dst = reinterpret_cast<__gm__ Tensor *>(args[6]);
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
 

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Softmax Preparation Kernel (AIV) with partial block masking
 //
 // Fixed tile size: sij is (16, 16)
@@ -29,16 +39,14 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
-    float scale_value,
-    __gm__ Tensor* pij,
-    __gm__ Tensor* mij,
-    __gm__ Tensor* lij) {
+static __aicore__ void softmax_prepare_impl(
+    __gm__ Tensor *sij, float scale_value, __gm__ Tensor *pij, __gm__ Tensor *mij, __gm__ Tensor *lij
+) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
-    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
-    __gm__ half* pij_addr = reinterpret_cast<__gm__ half*>(pij->buffer.addr);
-    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
+    __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
+    __gm__ half *pij_addr = reinterpret_cast<__gm__ half *>(pij->buffer.addr);
+    __gm__ float *mij_addr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_addr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -100,14 +108,13 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     TSTORE(mijGlobal, maxTile);
     TSTORE(lijGlobal, sumTile);
     TSTORE(pijGlobal, pijF16Tile);
-
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[3]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *sij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[3]);
     union {
         uint64_t u;
         float f;

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -39,16 +39,16 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     // Read dimensions from tensor metadata
     // query: shape=[batch, num_heads, head_dim]
     uint64_t batch = orch_args.tensor(0).shapes[0];
@@ -74,18 +74,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     uint64_t b_start = batch * orch_thread_index / orch_thread_num;
     uint64_t b_end = batch * (orch_thread_index + 1) / orch_thread_num;
 
-    LOG_INFO("orch_idx=%d/%d batch=%" PRIu64 " b_range=[%" PRIu64 ",%" PRIu64 ")",
-        orch_thread_index,
-        orch_thread_num,
-        batch,
-        b_start,
-        b_end);
+    LOG_INFO(
+        "orch_idx=%d/%d batch=%" PRIu64 " b_range=[%" PRIu64 ",%" PRIu64 ")", orch_thread_index, orch_thread_num, batch,
+        b_start, b_end
+    );
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void* query_ptr = orch_args.tensor(0).data_as<void>();
-    void* kc_ptr = orch_args.tensor(1).data_as<void>();
-    void* vc_ptr = orch_args.tensor(2).data_as<void>();
-    void* out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).data_as<void>();
+    void *out_ptr = orch_args.tensor(5).data_as<void>();
 
     // Compute kv_total_rows from key_cache tensor metadata
     uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
@@ -104,8 +102,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     LOG_DEBUG("value_cache=%s", value_cache.dump().c_str());
     LOG_DEBUG("out=%s", out.dump().c_str());
 
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -133,9 +131,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 args_inplace.add_output(scalar_ci);
                 args_inplace.add_output(scalar_ci);
                 TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, args_inplace);
-                const Tensor& oi = hub_outs.get_ref(0);
-                const Tensor& li_update = hub_outs.get_ref(1);
-                const Tensor& mi_update = hub_outs.get_ref(2);
+                const Tensor &oi = hub_outs.get_ref(0);
+                const Tensor &li_update = hub_outs.get_ref(1);
+                const Tensor &mi_update = hub_outs.get_ref(2);
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
                     uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
@@ -151,7 +149,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     args_qk.add_input(kj);
                     args_qk.add_output(sij_ci);
                     TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, args_qk);
-                    const Tensor& sij = qk_outs.get_ref(0);
+                    const Tensor &sij = qk_outs.get_ref(0);
 
                     uint32_t sij_valid_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(valid_len)};
                     uint32_t sij_valid_offsets[2] = {0, 0};
@@ -163,16 +161,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     args_sf.add_output(scalar_ci);
                     args_sf.add_scalar(scale_value);
                     TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, args_sf);
-                    const Tensor& pij_f16 = sf_outs.get_ref(0);
-                    const Tensor& mi = sf_outs.get_ref(1);
-                    const Tensor& li = sf_outs.get_ref(2);
+                    const Tensor &pij_f16 = sf_outs.get_ref(0);
+                    const Tensor &mi = sf_outs.get_ref(1);
+                    const Tensor &li = sf_outs.get_ref(2);
 
                     Arg args_pv;
                     args_pv.add_input(pij_f16);
                     args_pv.add_input(vj);
                     args_pv.add_output(tile2d_ci);
                     TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, args_pv);
-                    const Tensor& oi_tmp = pv_outs.get_ref(0);
+                    const Tensor &oi_tmp = pv_outs.get_ref(0);
 
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
@@ -193,11 +191,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         }
     }
 
-    LOG_INFO("orch_idx=%d: tasks submitted for batch=[%" PRIu64 ",%" PRIu64 "), num_heads=%" PRIu64,
-        orch_thread_index,
-        b_start,
-        b_end,
-        num_heads);
+    LOG_INFO(
+        "orch_idx=%d: tasks submitted for batch=[%" PRIu64 ",%" PRIu64 "), num_heads=%" PRIu64, orch_thread_index,
+        b_start, b_end, num_heads
+    );
 }
 
 }  // extern "C"

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -58,16 +58,18 @@ NB_MODULE(_task_interface, m) {
         .value("UINT64", DataType::UINT64);
 
     // --- Free functions ---
-    m.def("get_element_size",
-        &get_element_size,
-        nb::arg("dtype"),
-        "Return the byte size of a single element of the given DataType.");
+    m.def(
+        "get_element_size", &get_element_size, nb::arg("dtype"),
+        "Return the byte size of a single element of the given DataType."
+    );
 
     m.def(
         "get_dtype_name",
-        [](DataType dt) -> std::string { return get_dtype_name(dt); },
-        nb::arg("dtype"),
-        "Return the string name of a DataType.");
+        [](DataType dt) -> std::string {
+            return get_dtype_name(dt);
+        },
+        nb::arg("dtype"), "Return the string name of a DataType."
+    );
 
     // --- Constants ---
     m.attr("CONTINUOUS_TENSOR_MAX_DIMS") = CONTINUOUS_TENSOR_MAX_DIMS;
@@ -86,53 +88,76 @@ NB_MODULE(_task_interface, m) {
                 arg.data = data;
                 arg.dtype = dtype;
                 arg.ndims = static_cast<uint32_t>(n);
-                for (size_t i = 0; i < n; ++i) arg.shapes[i] = nb::cast<uint32_t>(shapes[i]);
+                for (size_t i = 0; i < n; ++i)
+                    arg.shapes[i] = nb::cast<uint32_t>(shapes[i]);
                 return arg;
             },
-            nb::arg("data"),
-            nb::arg("shapes"),
-            nb::arg("dtype"),
-            "Create a ContinuousTensor from a data pointer, shape tuple, and dtype.")
+            nb::arg("data"), nb::arg("shapes"), nb::arg("dtype"),
+            "Create a ContinuousTensor from a data pointer, shape tuple, and dtype."
+        )
 
         .def_prop_rw(
             "data",
-            [](const ContinuousTensor& self) -> uint64_t { return self.data; },
-            [](ContinuousTensor& self, uint64_t v) { self.data = v; })
+            [](const ContinuousTensor &self) -> uint64_t {
+                return self.data;
+            },
+            [](ContinuousTensor &self, uint64_t v) {
+                self.data = v;
+            }
+        )
 
         .def_prop_rw(
             "shapes",
-            [](const ContinuousTensor& self) -> nb::tuple {
+            [](const ContinuousTensor &self) -> nb::tuple {
                 uint32_t n = self.ndims;
                 if (n > CONTINUOUS_TENSOR_MAX_DIMS) n = CONTINUOUS_TENSOR_MAX_DIMS;
                 nb::list lst;
-                for (uint32_t i = 0; i < n; ++i) lst.append(self.shapes[i]);
+                for (uint32_t i = 0; i < n; ++i)
+                    lst.append(self.shapes[i]);
                 return nb::tuple(lst);
             },
-            [](ContinuousTensor& self, nb::tuple t) {
+            [](ContinuousTensor &self, nb::tuple t) {
                 size_t n = nb::len(t);
                 if (n > CONTINUOUS_TENSOR_MAX_DIMS)
-                    throw std::invalid_argument("shapes tuple length exceeds CONTINUOUS_TENSOR_MAX_DIMS (" +
-                                                std::to_string(CONTINUOUS_TENSOR_MAX_DIMS) + ")");
-                for (size_t i = 0; i < n; ++i) self.shapes[i] = nb::cast<uint32_t>(t[i]);
+                    throw std::invalid_argument(
+                        "shapes tuple length exceeds CONTINUOUS_TENSOR_MAX_DIMS (" +
+                        std::to_string(CONTINUOUS_TENSOR_MAX_DIMS) + ")"
+                    );
+                for (size_t i = 0; i < n; ++i)
+                    self.shapes[i] = nb::cast<uint32_t>(t[i]);
                 self.ndims = static_cast<uint32_t>(n);
-            })
+            }
+        )
 
         .def_prop_rw(
             "ndims",
-            [](const ContinuousTensor& self) -> uint32_t { return self.ndims; },
-            [](ContinuousTensor& self, uint32_t v) { self.ndims = v; })
+            [](const ContinuousTensor &self) -> uint32_t {
+                return self.ndims;
+            },
+            [](ContinuousTensor &self, uint32_t v) {
+                self.ndims = v;
+            }
+        )
 
         .def_prop_rw(
             "dtype",
-            [](const ContinuousTensor& self) -> DataType { return self.dtype; },
-            [](ContinuousTensor& self, DataType dt) { self.dtype = dt; })
+            [](const ContinuousTensor &self) -> DataType {
+                return self.dtype;
+            },
+            [](ContinuousTensor &self, DataType dt) {
+                self.dtype = dt;
+            }
+        )
 
         .def(
             "nbytes",
-            [](const ContinuousTensor& self) -> uint64_t { return self.nbytes(); },
-            "Compute total bytes (product of shapes * element_size).")
+            [](const ContinuousTensor &self) -> uint64_t {
+                return self.nbytes();
+            },
+            "Compute total bytes (product of shapes * element_size)."
+        )
 
-        .def("__repr__", [](const ContinuousTensor& self) -> std::string {
+        .def("__repr__", [](const ContinuousTensor &self) -> std::string {
             std::ostringstream os;
             os << "ContinuousTensor(data=0x" << std::hex << self.data << std::dec << ", shapes=(";
             for (uint32_t i = 0; i < self.ndims; ++i) {
@@ -147,36 +172,35 @@ NB_MODULE(_task_interface, m) {
     nb::class_<ChipStorageTaskArgs>(m, "ChipStorageTaskArgs")
         .def(nb::init<>())
 
-        .def("add_tensor",
-            &ChipStorageTaskArgs::add_tensor,
-            nb::arg("t"),
-            "Add a ContinuousTensor. Must be called before any add_scalar().")
+        .def(
+            "add_tensor", &ChipStorageTaskArgs::add_tensor, nb::arg("t"),
+            "Add a ContinuousTensor. Must be called before any add_scalar()."
+        )
 
-        .def("add_scalar",
-            &ChipStorageTaskArgs::add_scalar,
-            nb::arg("s"),
-            "Add a uint64_t scalar. After this, add_tensor() is no longer allowed.")
+        .def(
+            "add_scalar", &ChipStorageTaskArgs::add_scalar, nb::arg("s"),
+            "Add a uint64_t scalar. After this, add_tensor() is no longer allowed."
+        )
 
         .def(
             "tensor",
-            [](const ChipStorageTaskArgs& self, int32_t i) -> const ContinuousTensor& {
+            [](const ChipStorageTaskArgs &self, int32_t i) -> const ContinuousTensor & {
                 if (i < 0 || i >= self.tensor_count())
                     throw std::out_of_range("ChipStorageTaskArgs tensor index out of range");
                 return self.tensor(i);
             },
-            nb::arg("i"),
-            nb::rv_policy::reference_internal,
-            "Return the ContinuousTensor at index i.")
+            nb::arg("i"), nb::rv_policy::reference_internal, "Return the ContinuousTensor at index i."
+        )
 
         .def(
             "scalar",
-            [](const ChipStorageTaskArgs& self, int32_t i) -> uint64_t {
+            [](const ChipStorageTaskArgs &self, int32_t i) -> uint64_t {
                 if (i < 0 || i >= self.scalar_count())
                     throw std::out_of_range("ChipStorageTaskArgs scalar index out of range");
                 return self.scalar(i);
             },
-            nb::arg("i"),
-            "Return the scalar at index i.")
+            nb::arg("i"), "Return the scalar at index i."
+        )
 
         .def("tensor_count", &ChipStorageTaskArgs::tensor_count)
         .def("scalar_count", &ChipStorageTaskArgs::scalar_count)
@@ -185,13 +209,19 @@ NB_MODULE(_task_interface, m) {
 
         .def(
             "__len__",
-            [](const ChipStorageTaskArgs& self) { return self.tensor_count() + self.scalar_count(); },
-            "Return total number of arguments (tensors + scalars).")
+            [](const ChipStorageTaskArgs &self) {
+                return self.tensor_count() + self.scalar_count();
+            },
+            "Return total number of arguments (tensors + scalars)."
+        )
 
         .def(
             "__ptr__",
-            [](const ChipStorageTaskArgs& self) -> uint64_t { return reinterpret_cast<uint64_t>(&self); },
-            "Return the memory address of the underlying C++ object.");
+            [](const ChipStorageTaskArgs &self) -> uint64_t {
+                return reinterpret_cast<uint64_t>(&self);
+            },
+            "Return the memory address of the underlying C++ object."
+        );
 
     // --- TensorArgType enum ---
     nb::enum_<TensorArgType>(m, "TensorArgType")
@@ -203,36 +233,35 @@ NB_MODULE(_task_interface, m) {
     nb::class_<DynamicTaskArgs>(m, "DynamicTaskArgs")
         .def(nb::init<>())
 
-        .def("add_tensor",
-            &DynamicTaskArgs::add_tensor,
-            nb::arg("t"),
-            "Add a ContinuousTensor. Must be called before any add_scalar().")
+        .def(
+            "add_tensor", &DynamicTaskArgs::add_tensor, nb::arg("t"),
+            "Add a ContinuousTensor. Must be called before any add_scalar()."
+        )
 
-        .def("add_scalar",
-            &DynamicTaskArgs::add_scalar,
-            nb::arg("s"),
-            "Add a uint64_t scalar. After this, add_tensor() is no longer allowed.")
+        .def(
+            "add_scalar", &DynamicTaskArgs::add_scalar, nb::arg("s"),
+            "Add a uint64_t scalar. After this, add_tensor() is no longer allowed."
+        )
 
         .def(
             "tensor",
-            [](const DynamicTaskArgs& self, int32_t i) -> const ContinuousTensor& {
+            [](const DynamicTaskArgs &self, int32_t i) -> const ContinuousTensor & {
                 if (i < 0 || i >= self.tensor_count())
                     throw std::out_of_range("DynamicTaskArgs tensor index out of range");
                 return self.tensor(i);
             },
-            nb::arg("i"),
-            nb::rv_policy::reference_internal,
-            "Return the ContinuousTensor at index i.")
+            nb::arg("i"), nb::rv_policy::reference_internal, "Return the ContinuousTensor at index i."
+        )
 
         .def(
             "scalar",
-            [](const DynamicTaskArgs& self, int32_t i) -> uint64_t {
+            [](const DynamicTaskArgs &self, int32_t i) -> uint64_t {
                 if (i < 0 || i >= self.scalar_count())
                     throw std::out_of_range("DynamicTaskArgs scalar index out of range");
                 return self.scalar(i);
             },
-            nb::arg("i"),
-            "Return the scalar at index i.")
+            nb::arg("i"), "Return the scalar at index i."
+        )
 
         .def("tensor_count", &DynamicTaskArgs::tensor_count)
         .def("scalar_count", &DynamicTaskArgs::scalar_count)
@@ -241,8 +270,11 @@ NB_MODULE(_task_interface, m) {
 
         .def(
             "__len__",
-            [](const DynamicTaskArgs& self) { return self.tensor_count() + self.scalar_count(); },
-            "Return total number of arguments (tensors + scalars).");
+            [](const DynamicTaskArgs &self) {
+                return self.tensor_count() + self.scalar_count();
+            },
+            "Return total number of arguments (tensors + scalars)."
+        );
 
     // --- TaggedTaskArgs (fixed-size with per-tensor TensorArgType tags) ---
     nb::class_<TaggedTaskArgs>(m, "TaggedTaskArgs")
@@ -250,59 +282,57 @@ NB_MODULE(_task_interface, m) {
 
         .def(
             "add_tensor",
-            [](TaggedTaskArgs& self, const ContinuousTensor& t, TensorArgType tag) {
+            [](TaggedTaskArgs &self, const ContinuousTensor &t, TensorArgType tag) {
                 self.add_tensor(t);
                 self.tag(self.tensor_count() - 1) = tag;
             },
-            nb::arg("t"),
-            nb::arg("tag") = TensorArgType::INPUT,
-            "Add a ContinuousTensor with an optional TensorArgType tag (default INPUT).")
+            nb::arg("t"), nb::arg("tag") = TensorArgType::INPUT,
+            "Add a ContinuousTensor with an optional TensorArgType tag (default INPUT)."
+        )
 
-        .def("add_scalar",
-            &TaggedTaskArgs::add_scalar,
-            nb::arg("s"),
-            "Add a uint64_t scalar. After this, add_tensor() is no longer allowed.")
+        .def(
+            "add_scalar", &TaggedTaskArgs::add_scalar, nb::arg("s"),
+            "Add a uint64_t scalar. After this, add_tensor() is no longer allowed."
+        )
 
         .def(
             "tensor",
-            [](const TaggedTaskArgs& self, int32_t i) -> const ContinuousTensor& {
+            [](const TaggedTaskArgs &self, int32_t i) -> const ContinuousTensor & {
                 if (i < 0 || i >= self.tensor_count())
                     throw std::out_of_range("TaggedTaskArgs tensor index out of range");
                 return self.tensor(i);
             },
-            nb::arg("i"),
-            nb::rv_policy::reference_internal,
-            "Return the ContinuousTensor at index i.")
+            nb::arg("i"), nb::rv_policy::reference_internal, "Return the ContinuousTensor at index i."
+        )
 
         .def(
             "scalar",
-            [](const TaggedTaskArgs& self, int32_t i) -> uint64_t {
+            [](const TaggedTaskArgs &self, int32_t i) -> uint64_t {
                 if (i < 0 || i >= self.scalar_count())
                     throw std::out_of_range("TaggedTaskArgs scalar index out of range");
                 return self.scalar(i);
             },
-            nb::arg("i"),
-            "Return the scalar at index i.")
+            nb::arg("i"), "Return the scalar at index i."
+        )
 
         .def(
             "tag",
-            [](const TaggedTaskArgs& self, int32_t i) -> TensorArgType {
+            [](const TaggedTaskArgs &self, int32_t i) -> TensorArgType {
                 if (i < 0 || i >= self.tensor_count()) throw std::out_of_range("TaggedTaskArgs tag index out of range");
                 return self.tag(i);
             },
-            nb::arg("i"),
-            "Return the TensorArgType tag for the tensor at index i.")
+            nb::arg("i"), "Return the TensorArgType tag for the tensor at index i."
+        )
 
         .def(
             "set_tag",
-            [](TaggedTaskArgs& self, int32_t i, TensorArgType tag) {
+            [](TaggedTaskArgs &self, int32_t i, TensorArgType tag) {
                 if (i < 0 || i >= self.tensor_count())
                     throw std::out_of_range("TaggedTaskArgs set_tag index out of range");
                 self.tag(i) = tag;
             },
-            nb::arg("i"),
-            nb::arg("tag"),
-            "Set the TensorArgType tag for the tensor at index i.")
+            nb::arg("i"), nb::arg("tag"), "Set the TensorArgType tag for the tensor at index i."
+        )
 
         .def("tensor_count", &TaggedTaskArgs::tensor_count)
         .def("scalar_count", &TaggedTaskArgs::scalar_count)
@@ -311,8 +341,11 @@ NB_MODULE(_task_interface, m) {
 
         .def(
             "__len__",
-            [](const TaggedTaskArgs& self) { return self.tensor_count() + self.scalar_count(); },
-            "Return total number of arguments (tensors + scalars).");
+            [](const TaggedTaskArgs &self) {
+                return self.tensor_count() + self.scalar_count();
+            },
+            "Return total number of arguments (tensors + scalars)."
+        );
 
     // --- ArgDirection enum ---
     nb::enum_<ArgDirection>(m, "ArgDirection")
@@ -323,58 +356,74 @@ NB_MODULE(_task_interface, m) {
 
     m.def(
         "arg_direction_name",
-        [](ArgDirection d) -> std::string { return arg_direction_name(d); },
-        nb::arg("direction"),
-        "Return the string name of an ArgDirection.");
+        [](ArgDirection d) -> std::string {
+            return arg_direction_name(d);
+        },
+        nb::arg("direction"), "Return the string name of an ArgDirection."
+    );
 
     // --- PyCoreCallable wrapper ---
     struct PyCoreCallable {
         std::vector<uint8_t> buffer_;
-        const CoreCallable& get() const { return *reinterpret_cast<const CoreCallable*>(buffer_.data()); }
+        const CoreCallable &get() const { return *reinterpret_cast<const CoreCallable *>(buffer_.data()); }
     };
 
     nb::class_<PyCoreCallable>(m, "CoreCallable")
         .def_static(
             "build",
             [](std::vector<ArgDirection> signature, nb::bytes binary) -> PyCoreCallable {
-                auto bin_ptr = reinterpret_cast<const void*>(binary.c_str());
+                auto bin_ptr = reinterpret_cast<const void *>(binary.c_str());
                 auto bin_size = static_cast<uint32_t>(binary.size());
                 auto buf = make_callable<CORE_MAX_TENSOR_ARGS>(
-                    signature.data(), static_cast<int32_t>(signature.size()), bin_ptr, bin_size);
+                    signature.data(), static_cast<int32_t>(signature.size()), bin_ptr, bin_size
+                );
                 return PyCoreCallable{std::move(buf)};
             },
-            nb::arg("signature"),
-            nb::arg("binary"),
-            "Build a CoreCallable from a signature list and binary bytes.")
+            nb::arg("signature"), nb::arg("binary"), "Build a CoreCallable from a signature list and binary bytes."
+        )
 
         .def(
             "sig",
-            [](const PyCoreCallable& self, int32_t i) -> ArgDirection { return self.get().sig(i); },
-            nb::arg("i"),
-            "Return the ArgDirection at signature index i.")
+            [](const PyCoreCallable &self, int32_t i) -> ArgDirection {
+                return self.get().sig(i);
+            },
+            nb::arg("i"), "Return the ArgDirection at signature index i."
+        )
 
         .def_prop_ro(
             "sig_count",
-            [](const PyCoreCallable& self) -> int32_t { return self.get().sig_count(); },
-            "Number of signature entries.")
+            [](const PyCoreCallable &self) -> int32_t {
+                return self.get().sig_count();
+            },
+            "Number of signature entries."
+        )
 
         .def_prop_ro(
             "binary_size",
-            [](const PyCoreCallable& self) -> uint32_t { return self.get().binary_size(); },
-            "Size of the binary payload in bytes.")
+            [](const PyCoreCallable &self) -> uint32_t {
+                return self.get().binary_size();
+            },
+            "Size of the binary payload in bytes."
+        )
 
         .def(
             "buffer_ptr",
-            [](const PyCoreCallable& self) -> uint64_t { return reinterpret_cast<uint64_t>(self.buffer_.data()); },
-            "Return the memory address of the underlying buffer.")
+            [](const PyCoreCallable &self) -> uint64_t {
+                return reinterpret_cast<uint64_t>(self.buffer_.data());
+            },
+            "Return the memory address of the underlying buffer."
+        )
 
         .def(
             "buffer_size",
-            [](const PyCoreCallable& self) -> size_t { return self.buffer_.size(); },
-            "Return the total size of the underlying buffer in bytes.")
+            [](const PyCoreCallable &self) -> size_t {
+                return self.buffer_.size();
+            },
+            "Return the total size of the underlying buffer in bytes."
+        )
 
-        .def("__repr__", [](const PyCoreCallable& self) -> std::string {
-            const auto& c = self.get();
+        .def("__repr__", [](const PyCoreCallable &self) -> std::string {
+            const auto &c = self.get();
             std::ostringstream os;
             os << "CoreCallable(sig_count=" << c.sig_count() << ", binary_size=" << c.binary_size() << ")";
             return os.str();
@@ -383,17 +432,15 @@ NB_MODULE(_task_interface, m) {
     // --- PyChipCallable wrapper ---
     struct PyChipCallable {
         std::vector<uint8_t> buffer_;
-        const ChipCallable& get() const { return *reinterpret_cast<const ChipCallable*>(buffer_.data()); }
+        const ChipCallable &get() const { return *reinterpret_cast<const ChipCallable *>(buffer_.data()); }
     };
 
     nb::class_<PyChipCallable>(m, "ChipCallable")
         .def_static(
             "build",
-            [](std::vector<ArgDirection> signature,
-                std::string func_name,
-                nb::bytes binary,
-                std::vector<std::tuple<int32_t, PyCoreCallable>> children) -> PyChipCallable {
-                auto bin_ptr = reinterpret_cast<const void*>(binary.c_str());
+            [](std::vector<ArgDirection> signature, std::string func_name, nb::bytes binary,
+               std::vector<std::tuple<int32_t, PyCoreCallable>> children) -> PyChipCallable {
+                auto bin_ptr = reinterpret_cast<const void *>(binary.c_str());
                 auto bin_size = static_cast<uint32_t>(binary.size());
                 auto child_count = static_cast<int32_t>(children.size());
 
@@ -404,65 +451,73 @@ NB_MODULE(_task_interface, m) {
                     child_bufs[i] = std::get<1>(children[i]).buffer_;
                 }
 
-                auto buf = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 32>(signature.data(),
-                    static_cast<int32_t>(signature.size()),
-                    func_name.c_str(),
-                    bin_ptr,
-                    bin_size,
-                    func_ids.data(),
-                    child_bufs.data(),
-                    child_count);
+                auto buf = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 32>(
+                    signature.data(), static_cast<int32_t>(signature.size()), func_name.c_str(), bin_ptr, bin_size,
+                    func_ids.data(), child_bufs.data(), child_count
+                );
                 return PyChipCallable{std::move(buf)};
             },
-            nb::arg("signature"),
-            nb::arg("func_name"),
-            nb::arg("binary"),
-            nb::arg("children"),
-            "Build a ChipCallable from signature, func_name, binary, and list of (func_id, CoreCallable) children.")
+            nb::arg("signature"), nb::arg("func_name"), nb::arg("binary"), nb::arg("children"),
+            "Build a ChipCallable from signature, func_name, binary, and list of (func_id, CoreCallable) children."
+        )
 
         .def(
             "sig",
-            [](const PyChipCallable& self, int32_t i) -> ArgDirection { return self.get().sig(i); },
-            nb::arg("i"),
-            "Return the ArgDirection at signature index i.")
+            [](const PyChipCallable &self, int32_t i) -> ArgDirection {
+                return self.get().sig(i);
+            },
+            nb::arg("i"), "Return the ArgDirection at signature index i."
+        )
 
         .def_prop_ro(
             "sig_count",
-            [](const PyChipCallable& self) -> int32_t { return self.get().sig_count(); },
-            "Number of signature entries.")
+            [](const PyChipCallable &self) -> int32_t {
+                return self.get().sig_count();
+            },
+            "Number of signature entries."
+        )
 
         .def_prop_ro(
             "binary_size",
-            [](const PyChipCallable& self) -> uint32_t { return self.get().binary_size(); },
-            "Size of the binary payload in bytes.")
+            [](const PyChipCallable &self) -> uint32_t {
+                return self.get().binary_size();
+            },
+            "Size of the binary payload in bytes."
+        )
 
         .def_prop_ro(
             "func_name",
-            [](const PyChipCallable& self) -> std::string {
-                const auto& c = self.get();
+            [](const PyChipCallable &self) -> std::string {
+                const auto &c = self.get();
                 return std::string(c.func_name(), c.func_name_len());
             },
-            "The orchestration function name.")
+            "The orchestration function name."
+        )
 
         .def_prop_ro(
             "child_count",
-            [](const PyChipCallable& self) -> int32_t { return self.get().child_count(); },
-            "Number of child callables.")
+            [](const PyChipCallable &self) -> int32_t {
+                return self.get().child_count();
+            },
+            "Number of child callables."
+        )
 
         .def(
             "child_func_id",
-            [](const PyChipCallable& self, int32_t i) -> int32_t { return self.get().child_func_id(i); },
-            nb::arg("i"),
-            "Return the func_id for child at index i.")
+            [](const PyChipCallable &self, int32_t i) -> int32_t {
+                return self.get().child_func_id(i);
+            },
+            nb::arg("i"), "Return the func_id for child at index i."
+        )
 
         .def(
             "child",
-            [](const PyChipCallable& self, int32_t i) -> PyCoreCallable {
-                const auto& parent = self.get();
-                const auto& c = parent.child(i);
+            [](const PyChipCallable &self, int32_t i) -> PyCoreCallable {
+                const auto &parent = self.get();
+                const auto &c = parent.child(i);
                 // Reconstruct a PyCoreCallable by copying the child's raw bytes
                 auto offset = parent.child_offset(i);
-                const uint8_t* child_start = reinterpret_cast<const uint8_t*>(parent.storage_ + offset);
+                const uint8_t *child_start = reinterpret_cast<const uint8_t *>(parent.storage_ + offset);
                 // Determine child size: from offset to next child or end of buffer
                 size_t child_size;
                 if (i + 1 < parent.child_count()) {
@@ -474,27 +529,35 @@ NB_MODULE(_task_interface, m) {
                 std::vector<uint8_t> child_buf(child_start, child_start + child_size);
                 return PyCoreCallable{std::move(child_buf)};
             },
-            nb::arg("i"),
-            "Return the CoreCallable child at index i.")
+            nb::arg("i"), "Return the CoreCallable child at index i."
+        )
 
         .def(
             "child_offset",
-            [](const PyChipCallable& self, int32_t i) -> uint32_t { return self.get().child_offset(i); },
-            nb::arg("i"),
-            "Return the byte offset of child i within storage (must be multiple of 64).")
+            [](const PyChipCallable &self, int32_t i) -> uint32_t {
+                return self.get().child_offset(i);
+            },
+            nb::arg("i"), "Return the byte offset of child i within storage (must be multiple of 64)."
+        )
 
         .def(
             "buffer_ptr",
-            [](const PyChipCallable& self) -> uint64_t { return reinterpret_cast<uint64_t>(self.buffer_.data()); },
-            "Return the memory address of the underlying buffer.")
+            [](const PyChipCallable &self) -> uint64_t {
+                return reinterpret_cast<uint64_t>(self.buffer_.data());
+            },
+            "Return the memory address of the underlying buffer."
+        )
 
         .def(
             "buffer_size",
-            [](const PyChipCallable& self) -> size_t { return self.buffer_.size(); },
-            "Return the total size of the underlying buffer in bytes.")
+            [](const PyChipCallable &self) -> size_t {
+                return self.buffer_.size();
+            },
+            "Return the total size of the underlying buffer in bytes."
+        )
 
-        .def("__repr__", [](const PyChipCallable& self) -> std::string {
-            const auto& c = self.get();
+        .def("__repr__", [](const PyChipCallable &self) -> std::string {
+            const auto &c = self.get();
             std::ostringstream os;
             os << "ChipCallable(func_name=\"" << std::string(c.func_name(), c.func_name_len())
                << "\", sig_count=" << c.sig_count() << ", binary_size=" << c.binary_size()
@@ -509,7 +572,7 @@ NB_MODULE(_task_interface, m) {
         .def_rw("aicpu_thread_num", &CallConfig::aicpu_thread_num)
         .def_rw("orch_thread_num", &CallConfig::orch_thread_num)
         .def_rw("enable_profiling", &CallConfig::enable_profiling)
-        .def("__repr__", [](const CallConfig& self) -> std::string {
+        .def("__repr__", [](const CallConfig &self) -> std::string {
             std::ostringstream os;
             os << "CallConfig(block_dim=" << self.block_dim << ", aicpu_thread_num=" << self.aicpu_thread_num
                << ", orch_thread_num=" << self.orch_thread_num
@@ -522,26 +585,21 @@ NB_MODULE(_task_interface, m) {
         .def(nb::init<>())
         .def(
             "init",
-            [](ChipWorker& self, int device_id, const std::string& host_lib_path, nb::bytes aicpu, nb::bytes aicore) {
-                self.init(device_id,
-                    host_lib_path,
-                    reinterpret_cast<const uint8_t*>(aicpu.c_str()),
-                    aicpu.size(),
-                    reinterpret_cast<const uint8_t*>(aicore.c_str()),
-                    aicore.size());
+            [](ChipWorker &self, int device_id, const std::string &host_lib_path, nb::bytes aicpu, nb::bytes aicore) {
+                self.init(
+                    device_id, host_lib_path, reinterpret_cast<const uint8_t *>(aicpu.c_str()), aicpu.size(),
+                    reinterpret_cast<const uint8_t *>(aicore.c_str()), aicore.size()
+                );
             },
-            nb::arg("device_id"),
-            nb::arg("host_lib_path"),
-            nb::arg("aicpu_binary"),
-            nb::arg("aicore_binary"))
+            nb::arg("device_id"), nb::arg("host_lib_path"), nb::arg("aicpu_binary"), nb::arg("aicore_binary")
+        )
         .def(
             "run",
-            [](ChipWorker& self, const PyChipCallable& callable, ChipStorageTaskArgs& args, const CallConfig& config) {
+            [](ChipWorker &self, const PyChipCallable &callable, ChipStorageTaskArgs &args, const CallConfig &config) {
                 self.run(callable.buffer_.data(), &args, config);
             },
-            nb::arg("callable"),
-            nb::arg("args"),
-            nb::arg("config"))
+            nb::arg("callable"), nb::arg("args"), nb::arg("config")
+        )
         .def("reset", &ChipWorker::reset)
         .def_prop_ro("device_id", &ChipWorker::device_id)
         .def_prop_ro("initialized", &ChipWorker::initialized);

--- a/src/a2a3/platform/include/aicore/performance_collector_aicore.h
+++ b/src/a2a3/platform/include/aicore/performance_collector_aicore.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file performance_collector_aicore.h
  * @brief AICore performance data collection interface
@@ -36,18 +46,13 @@
  * @param start_time Start timestamp
  * @param end_time End timestamp
  */
-__aicore__ __attribute__((always_inline))
-static inline void perf_aicore_record_task(
-    __gm__ PerfBuffer* perf_buf,
-    uint32_t task_id,
-    uint64_t start_time,
-    uint64_t end_time) {
-
+__aicore__ __attribute__((always_inline)) static inline void
+perf_aicore_record_task(__gm__ PerfBuffer *perf_buf, uint32_t task_id, uint64_t start_time, uint64_t end_time) {
     // Read current buffer count (AICPU owns the count, AICore reads only)
     dcci(&perf_buf->count, SINGLE_CACHE_LINE);
     uint32_t idx = perf_buf->count;
 
-    __gm__ PerfRecord* record = &perf_buf->records[idx];
+    __gm__ PerfRecord *record = &perf_buf->records[idx];
 
     // Write record data (func_id, core_type, and count filled by AICPU at completion)
     record->start_time = start_time;

--- a/src/a2a3/platform/include/aicpu/device_log.h
+++ b/src/a2a3/platform/include/aicpu/device_log.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file device_log.h
  * @brief Unified Device Logging Interface for AICPU
@@ -40,58 +50,58 @@ extern bool g_is_log_enable_warn;
 extern bool g_is_log_enable_error;
 
 // Platform constant (defined in platform-specific device_log.cpp)
-extern const char* TILE_FWK_DEVICE_MACHINE;
+extern const char *TILE_FWK_DEVICE_MACHINE;
 
 // =============================================================================
 // Platform-Specific Logging Functions (Low-Level Layer)
 // =============================================================================
 
 // Platform-specific logging functions (implemented in device_log.cpp)
-void dev_log_debug(const char* func, const char* fmt, ...);
-void dev_log_info(const char* func, const char* fmt, ...);
-void dev_log_warn(const char* func, const char* fmt, ...);
-void dev_log_error(const char* func, const char* fmt, ...);
-void dev_log_always(const char* func, const char* fmt, ...);
+void dev_log_debug(const char *func, const char *fmt, ...);
+void dev_log_info(const char *func, const char *fmt, ...);
+void dev_log_warn(const char *func, const char *fmt, ...);
+void dev_log_error(const char *func, const char *fmt, ...);
+void dev_log_always(const char *func, const char *fmt, ...);
 
 // =============================================================================
 // High-Level Logging Macros (Platform-Independent Layer)
 // =============================================================================
 
-#define D_DEV_LOGD(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_debug()) { \
+#define D_DEV_LOGD(MODE_NAME, fmt, ...)                      \
+    do {                                                     \
+        if (is_log_enable_debug()) {                         \
             dev_log_debug(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                    \
+    } while (0)
 
-#define D_DEV_LOGI(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_info()) { \
+#define D_DEV_LOGI(MODE_NAME, fmt, ...)                     \
+    do {                                                    \
+        if (is_log_enable_info()) {                         \
             dev_log_info(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                   \
+    } while (0)
 
-#define D_DEV_LOGW(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_warn()) { \
+#define D_DEV_LOGW(MODE_NAME, fmt, ...)                     \
+    do {                                                    \
+        if (is_log_enable_warn()) {                         \
             dev_log_warn(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                   \
+    } while (0)
 
-#define D_DEV_LOGE(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_error()) { \
+#define D_DEV_LOGE(MODE_NAME, fmt, ...)                      \
+    do {                                                     \
+        if (is_log_enable_error()) {                         \
             dev_log_error(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                    \
+    } while (0)
 
 // =============================================================================
 // Convenience Macros
 // =============================================================================
 
 #define DEV_DEBUG(fmt, args...) D_DEV_LOGD(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_INFO(fmt, args...)  D_DEV_LOGI(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_WARN(fmt, args...)  D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
+#define DEV_INFO(fmt, args...) D_DEV_LOGI(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
+#define DEV_WARN(fmt, args...) D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
 #define DEV_ERROR(fmt, args...) D_DEV_LOGE(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
 #define DEV_ALWAYS(fmt, args...) dev_log_always(__FUNCTION__, fmt, ##args)
 
@@ -110,32 +120,32 @@ void dev_log_always(const char* func, const char* fmt, ...);
 // Conditional Check Macros
 // =============================================================================
 
-#define DEV_CHECK_COND_RETURN_VOID(cond, fmt, ...)          \
-    do {                                                    \
-        if (!(cond)) {                                      \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return;                                         \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_COND_RETURN_VOID(cond, fmt, ...) \
+    do {                                           \
+        if (!(cond)) {                             \
+            DEV_ERROR(fmt, ##__VA_ARGS__);         \
+            DEV_ASSERT(0);                         \
+            return;                                \
+        }                                          \
+    } while (0)
 
-#define DEV_CHECK_COND_RETURN(cond, retval, fmt, ...)       \
-    do {                                                    \
-        if (!(cond)) {                                      \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return (retval);                                \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_COND_RETURN(cond, retval, fmt, ...) \
+    do {                                              \
+        if (!(cond)) {                                \
+            DEV_ERROR(fmt, ##__VA_ARGS__);            \
+            DEV_ASSERT(0);                            \
+            return (retval);                          \
+        }                                             \
+    } while (0)
 
-#define DEV_CHECK_POINTER_NULL_RETURN_VOID(ptr, fmt, ...)   \
-    do {                                                    \
-        if ((ptr) == nullptr) {                             \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return;                                         \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_POINTER_NULL_RETURN_VOID(ptr, fmt, ...) \
+    do {                                                  \
+        if ((ptr) == nullptr) {                           \
+            DEV_ERROR(fmt, ##__VA_ARGS__);                \
+            DEV_ASSERT(0);                                \
+            return;                                       \
+        }                                                 \
+    } while (0)
 
 // =============================================================================
 // Helper Functions
@@ -143,8 +153,8 @@ void dev_log_always(const char* func, const char* fmt, ...);
 
 // Check if log level is enabled (inline for efficiency)
 inline bool is_log_enable_debug() { return g_is_log_enable_debug; }
-inline bool is_log_enable_info()  { return g_is_log_enable_info; }
-inline bool is_log_enable_warn()  { return g_is_log_enable_warn; }
+inline bool is_log_enable_info() { return g_is_log_enable_info; }
+inline bool is_log_enable_warn() { return g_is_log_enable_warn; }
 inline bool is_log_enable_error() { return g_is_log_enable_error; }
 
 // Initialize log switch (platform-specific implementation)

--- a/src/a2a3/platform/include/aicpu/device_malloc.h
+++ b/src/a2a3/platform/include/aicpu/device_malloc.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file device_malloc.h
  * @brief Device Memory Allocation Interface for AICPU
@@ -29,7 +39,7 @@
  * @param size  Number of bytes to allocate
  * @return Pointer to allocated memory, or nullptr on failure
  */
-void* aicpu_device_malloc(size_t size);
+void *aicpu_device_malloc(size_t size);
 
 /**
  * Free device memory previously allocated by aicpu_device_malloc().
@@ -38,6 +48,6 @@ void* aicpu_device_malloc(size_t size);
  *
  * @param ptr  Pointer to free (may be nullptr)
  */
-void aicpu_device_free(void* ptr);
+void aicpu_device_free(void *ptr);
 
 #endif  // PLATFORM_DEVICE_MALLOC_H_

--- a/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file performance_collector_aicpu.h
  * @brief AICPU performance data collection interface
@@ -26,7 +36,7 @@
  *
  * @param runtime Runtime instance pointer
  */
-void perf_aicpu_init_profiling(Runtime* runtime);
+void perf_aicpu_init_profiling(Runtime *runtime);
 
 /**
  * Complete a PerfRecord with AICPU-side metadata after AICore task completion
@@ -45,15 +55,10 @@ void perf_aicpu_init_profiling(Runtime* runtime);
  * @param fanout                Pre-extracted successor task ID array (nullptr if none)
  * @param fanout_count          Number of entries in fanout array (0 if none)
  */
-int perf_aicpu_complete_record(PerfBuffer* perf_buf,
-                                uint32_t expected_reg_task_id,
-                                uint64_t task_id,
-                                uint32_t func_id,
-                                CoreType core_type,
-                                uint64_t dispatch_time,
-                                uint64_t finish_time,
-                                const uint64_t* fanout,
-                                int32_t fanout_count);
+int perf_aicpu_complete_record(
+    PerfBuffer *perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
+    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
+);
 
 /**
  * Switch performance buffer when current buffer is full
@@ -64,7 +69,7 @@ int perf_aicpu_complete_record(PerfBuffer* perf_buf,
  * @param core_id Core ID
  * @param thread_idx Thread index
  */
-void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx);
+void perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx);
 
 /**
  * Flush remaining performance data
@@ -76,10 +81,7 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx);
  * @param cur_thread_cores Array of core IDs managed by this thread
  * @param core_num Number of cores managed by this thread
  */
-void perf_aicpu_flush_buffers(Runtime* runtime,
-                               int thread_idx,
-                               const int* cur_thread_cores,
-                               int core_num);
+void perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cur_thread_cores, int core_num);
 
 /**
  * Update total task count in performance header
@@ -90,7 +92,7 @@ void perf_aicpu_flush_buffers(Runtime* runtime,
  * @param runtime Runtime instance pointer
  * @param total_tasks Current total task count
  */
-void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks);
+void perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks);
 
 /**
  * Initialize AICPU phase profiling
@@ -102,7 +104,7 @@ void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks);
  * @param num_sched_threads Number of scheduler threads
  * @param num_orch_threads Number of orchestrator threads (may become schedulers after transition)
  */
-void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, int num_orch_threads = 1);
+void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, int num_orch_threads = 1);
 
 /**
  * Record a single scheduler phase
@@ -119,10 +121,10 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
  *                        full PTO2 task_id encoding (ring_id << 32) | local_id (orchestrator
  *                        phases in multi-ring runtimes: tensormap_and_ringbuffer, aicpu_build_graph)
  */
-void perf_aicpu_record_phase(int thread_idx,
-                              AicpuPhaseId phase_id,
-                              uint64_t start_time, uint64_t end_time,
-                              uint32_t loop_iter, uint64_t tasks_processed);
+void perf_aicpu_record_phase(
+    int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
+    uint64_t tasks_processed
+);
 
 /**
  * Write orchestrator cumulative summary
@@ -132,7 +134,7 @@ void perf_aicpu_record_phase(int thread_idx,
  *
  * @param src Pointer to populated AicpuOrchSummary (magic field is set internally)
  */
-void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src);
+void perf_aicpu_write_orch_summary(const AicpuOrchSummary *src);
 
 /**
  * Set orchestrator thread index for per-task phase recording
@@ -154,13 +156,13 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx);
  * @param start_time Phase start timestamp
  * @param end_time Phase end timestamp
  * @param submit_idx Task submission index (acts as loop_iter)
- * @param task_id Task identifier. For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), this is the full PTO2 encoding:
- *               (ring_id << 32) | local_id, enabling cross-view correlation between orchestrator
- *               and scheduler swimlanes.
+ * @param task_id Task identifier. For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), this is the
+ * full PTO2 encoding: (ring_id << 32) | local_id, enabling cross-view correlation between orchestrator and scheduler
+ * swimlanes.
  */
-void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
-                                   uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx, uint64_t task_id);
+void perf_aicpu_record_orch_phase(
+    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id
+);
 
 /**
  * Write core-to-thread assignment mapping to shared memory
@@ -173,10 +175,10 @@ void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
  * @param num_threads Number of scheduler threads
  * @param total_cores Total number of cores
  */
-void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
-                                        const int* core_counts,
-                                        int num_threads,
-                                        int total_cores);
+void perf_aicpu_write_core_assignments(
+    const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
+    int total_cores
+);
 
 /**
  * Flush remaining phase records for a thread

--- a/src/a2a3/platform/include/aicpu/platform_regs.h
+++ b/src/a2a3/platform/include/aicpu/platform_regs.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file platform_regs.h
  * @brief Platform-level register access interface for AICPU
@@ -106,6 +116,6 @@ uint32_t platform_get_physical_cores_count();
  * @param addr  Start address of the memory range
  * @param size  Size of the memory range in bytes
  */
-void cache_invalidate_range(const void* addr, size_t size);
+void cache_invalidate_range(const void *addr, size_t size);
 
 #endif  // PLATFORM_AICPU_PLATFORM_REGS_H_

--- a/src/a2a3/platform/include/common/compile_strategy.h
+++ b/src/a2a3/platform/include/common/compile_strategy.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Compile Strategy - Toolchain Type Definitions
  *
@@ -16,10 +26,10 @@
 #define COMPILE_STRATEGY_H
 
 typedef enum {
-    TOOLCHAIN_CCEC = 0,          // ccec (Ascend AICore compiler)
-    TOOLCHAIN_HOST_GXX_15 = 1,   // g++-15 (host, simulation kernels)
-    TOOLCHAIN_HOST_GXX = 2,      // g++ (host, orchestration .so)
-    TOOLCHAIN_AARCH64_GXX = 3,   // aarch64-target-linux-gnu-g++ (cross-compile)
+    TOOLCHAIN_CCEC = 0,         // ccec (Ascend AICore compiler)
+    TOOLCHAIN_HOST_GXX_15 = 1,  // g++-15 (host, simulation kernels)
+    TOOLCHAIN_HOST_GXX = 2,     // g++ (host, orchestration .so)
+    TOOLCHAIN_AARCH64_GXX = 3,  // aarch64-target-linux-gnu-g++ (cross-compile)
 } ToolchainType;
 
 #endif /* COMPILE_STRATEGY_H */

--- a/src/a2a3/platform/include/common/core_type.h
+++ b/src/a2a3/platform/include/common/core_type.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file core_type.h
  * @brief Core type enumeration and utilities for AICore platform
@@ -32,7 +42,7 @@ enum class CoreType : int32_t {
  * @param type_str  String representation ("aic" or "aiv", case-insensitive)
  * @return Core type enum value, or CoreType::AIC if invalid
  */
-inline CoreType core_type_from_string(const char* type_str) {
+inline CoreType core_type_from_string(const char *type_str) {
     if (type_str == nullptr) {
         return CoreType::AIC;
     }
@@ -51,11 +61,14 @@ inline CoreType core_type_from_string(const char* type_str) {
  * @param core_type  Core type enum value
  * @return String representation ("AIC", "AIV", or "UNKNOWN")
  */
-inline const char* core_type_to_string(CoreType core_type) {
+inline const char *core_type_to_string(CoreType core_type) {
     switch (core_type) {
-        case CoreType::AIC: return "AIC";
-        case CoreType::AIV: return "AIV";
-        default: return "UNKNOWN";
+    case CoreType::AIC:
+        return "AIC";
+    case CoreType::AIV:
+        return "AIV";
+    default:
+        return "UNKNOWN";
     }
 }
 

--- a/src/a2a3/platform/include/common/kernel_args.h
+++ b/src/a2a3/platform/include/common/kernel_args.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file kernel_args.h
  * @brief KernelArgs Structure - Shared between Host, AICPU, and AICore
@@ -56,8 +66,8 @@ extern "C" {
  */
 struct KernelArgs {
     uint64_t unused[5] = {0};          // Alignment padding (required by CANN runtime offset)
-    DeviceArgs* device_args{nullptr};  // Device arguments (AICPU reads, contains SO info)
-    Runtime* runtime_args{nullptr};    // Task runtime in device memory
+    DeviceArgs *device_args{nullptr};  // Device arguments (AICPU reads, contains SO info)
+    Runtime *runtime_args{nullptr};    // Task runtime in device memory
     uint64_t regs{0};                  // Per-core register base address array (platform-specific)
 };
 

--- a/src/a2a3/platform/include/common/perf_profiling.h
+++ b/src/a2a3/platform/include/common/perf_profiling.h
@@ -353,7 +353,7 @@ inline size_t calc_perf_data_size(int num_cores) {
  * @param base_ptr Shared memory base address (device_ptr or host_ptr)
  * @return PerfDataHeader pointer
  */
-inline PerfDataHeader* get_perf_header(void* base_ptr) { return reinterpret_cast<PerfDataHeader*>(base_ptr); }
+inline PerfDataHeader *get_perf_header(void *base_ptr) { return reinterpret_cast<PerfDataHeader *>(base_ptr); }
 
 /**
  * Get PerfBufferState array start address
@@ -361,8 +361,8 @@ inline PerfDataHeader* get_perf_header(void* base_ptr) { return reinterpret_cast
  * @param base_ptr Shared memory base address
  * @return PerfBufferState array pointer
  */
-inline PerfBufferState* get_perf_buffer_states(void* base_ptr) {
-    return reinterpret_cast<PerfBufferState*>(reinterpret_cast<char*>(base_ptr) + sizeof(PerfDataHeader));
+inline PerfBufferState *get_perf_buffer_states(void *base_ptr) {
+    return reinterpret_cast<PerfBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(PerfDataHeader));
 }
 
 /**
@@ -372,7 +372,7 @@ inline PerfBufferState* get_perf_buffer_states(void* base_ptr) {
  * @param core_index Core index (0 ~ num_cores-1)
  * @return PerfBufferState pointer
  */
-inline PerfBufferState* get_perf_buffer_state(void* base_ptr, int core_index) {
+inline PerfBufferState *get_perf_buffer_state(void *base_ptr, int core_index) {
     return &get_perf_buffer_states(base_ptr)[core_index];
 }
 
@@ -394,8 +394,8 @@ inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threa
  * @param num_cores Number of AICore instances
  * @return AicpuPhaseHeader pointer
  */
-inline AicpuPhaseHeader* get_phase_header(void* base_ptr, int num_cores) {
-    return reinterpret_cast<AicpuPhaseHeader*>(reinterpret_cast<char*>(base_ptr) + calc_perf_data_size(num_cores));
+inline AicpuPhaseHeader *get_phase_header(void *base_ptr, int num_cores) {
+    return reinterpret_cast<AicpuPhaseHeader *>(reinterpret_cast<char *>(base_ptr) + calc_perf_data_size(num_cores));
 }
 
 /**
@@ -405,9 +405,10 @@ inline AicpuPhaseHeader* get_phase_header(void* base_ptr, int num_cores) {
  * @param num_cores Number of AICore instances
  * @return PhaseBufferState array pointer
  */
-inline PhaseBufferState* get_phase_buffer_states(void* base_ptr, int num_cores) {
-    return reinterpret_cast<PhaseBufferState*>(
-        reinterpret_cast<char*>(get_phase_header(base_ptr, num_cores)) + sizeof(AicpuPhaseHeader));
+inline PhaseBufferState *get_phase_buffer_states(void *base_ptr, int num_cores) {
+    return reinterpret_cast<PhaseBufferState *>(
+        reinterpret_cast<char *>(get_phase_header(base_ptr, num_cores)) + sizeof(AicpuPhaseHeader)
+    );
 }
 
 /**
@@ -418,7 +419,7 @@ inline PhaseBufferState* get_phase_buffer_states(void* base_ptr, int num_cores) 
  * @param thread_idx Thread index
  * @return PhaseBufferState pointer
  */
-inline PhaseBufferState* get_phase_buffer_state(void* base_ptr, int num_cores, int thread_idx) {
+inline PhaseBufferState *get_phase_buffer_state(void *base_ptr, int num_cores, int thread_idx) {
     return &get_phase_buffer_states(base_ptr, num_cores)[thread_idx];
 }
 

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -164,7 +164,7 @@ constexpr uint32_t AICORE_COREID_MASK = 0x0FFF;
 /**
  * Register identifier for unified read_reg/write_reg interface
  */
-enum class RegId : uint32_t {
+enum class RegId : uint8_t {
     DATA_MAIN_BASE = 0,    // Task dispatch (AICPU→AICore)
     COND = 1,              // Status (AICore→AICPU)
     FAST_PATH_ENABLE = 2,  // Fast path control
@@ -175,12 +175,12 @@ enum class RegId : uint32_t {
  */
 constexpr uint32_t reg_offset(RegId reg) {
     switch (reg) {
-        case RegId::DATA_MAIN_BASE:
-            return REG_SPR_DATA_MAIN_BASE_OFFSET;
-        case RegId::COND:
-            return REG_SPR_COND_OFFSET;
-        case RegId::FAST_PATH_ENABLE:
-            return REG_SPR_FAST_PATH_ENABLE_OFFSET;
+    case RegId::DATA_MAIN_BASE:
+        return REG_SPR_DATA_MAIN_BASE_OFFSET;
+    case RegId::COND:
+        return REG_SPR_COND_OFFSET;
+    case RegId::FAST_PATH_ENABLE:
+        return REG_SPR_FAST_PATH_ENABLE_OFFSET;
     }
     return 0;  // unreachable: all RegId cases handled above
 }
@@ -219,8 +219,7 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = 25;
 #define TASK_ID_MASK 0x7FFFFFFFU
 #define TASK_STATE_MASK 0x80000000U
 
-#define TASK_ACK_STATE 0
-#define TASK_FIN_STATE 1
+enum : uint8_t { TASK_ACK_STATE = 0, TASK_FIN_STATE = 1 };
 
 #define EXTRACT_TASK_ID(regval) (static_cast<int>((regval) & TASK_ID_MASK))
 #define EXTRACT_TASK_STATE(regval) (static_cast<int>(((regval) & TASK_STATE_MASK) >> 31))
@@ -229,13 +228,14 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = 25;
 
 // These values are RESERVED and must never be used as real task IDs.
 // Valid task IDs: 0 to 0x7FFFFFEF (2147483631)
-#define AICORE_IDLE_TASK_ID 0x7FFFFFFFU
+enum : uint32_t {
+    AICORE_IDLE_TASK_ID = 0x7FFFFFFFU,
+    AICORE_EXIT_TASK_ID = 0x7FFFFFFEU,
+    AICPU_IDLE_TASK_ID = 0x7FFFFFFDU,
+};
 #define AICORE_IDLE_VALUE MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
 
-#define AICORE_EXIT_TASK_ID 0x7FFFFFFEU
 #define AICORE_EXITED_VALUE MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
-
-#define AICPU_IDLE_TASK_ID 0x7FFFFFFDU
 
 // =============================================================================
 // Task State Constants

--- a/src/a2a3/platform/include/common/qualifier.h
+++ b/src/a2a3/platform/include/common/qualifier.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file qualifier.h
  * @brief Memory qualifier fallbacks for non-AICore builds

--- a/src/a2a3/platform/include/common/unified_log.h
+++ b/src/a2a3/platform/include/common/unified_log.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file unified_log.h
  * @brief Unified logging interface using link-time polymorphism
@@ -18,11 +28,11 @@ extern "C" {
 #endif
 
 // Unified logging functions
-void unified_log_error(const char* func, const char* fmt, ...);
-void unified_log_warn(const char* func, const char* fmt, ...);
-void unified_log_info(const char* func, const char* fmt, ...);
-void unified_log_debug(const char* func, const char* fmt, ...);
-void unified_log_always(const char* func, const char* fmt, ...);
+void unified_log_error(const char *func, const char *fmt, ...);
+void unified_log_warn(const char *func, const char *fmt, ...);
+void unified_log_info(const char *func, const char *fmt, ...);
+void unified_log_debug(const char *func, const char *fmt, ...);
+void unified_log_always(const char *func, const char *fmt, ...);
 
 #ifdef __cplusplus
 }
@@ -32,10 +42,9 @@ void unified_log_always(const char* func, const char* fmt, ...);
 
 // Convenience macros (automatically capture function name)
 #define LOG_ERROR(fmt, ...) unified_log_error(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
-#define LOG_WARN(fmt, ...)  unified_log_warn(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
-#define LOG_INFO(fmt, ...)  unified_log_info(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) unified_log_warn(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...) unified_log_info(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 #define LOG_DEBUG(fmt, ...) unified_log_debug(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 #define LOG_ALWAYS(fmt, ...) unified_log_always(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 
 #endif  // PLATFORM_UNIFIED_LOG_H_
-

--- a/src/a2a3/platform/include/host/function_cache.h
+++ b/src/a2a3/platform/include/host/function_cache.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file function_cache.h
  * @brief Function Cache Structures for Kernel Binary Management
@@ -77,29 +87,27 @@ struct CoreFunctionBinCache {
      * Get offset array pointer
      * @return Pointer to array of offsets
      */
-    uint64_t* get_offsets() {
-        return reinterpret_cast<uint64_t*>(reinterpret_cast<uint8_t*>(this) + sizeof(CoreFunctionBinCache));
+    uint64_t *get_offsets() {
+        return reinterpret_cast<uint64_t *>(reinterpret_cast<uint8_t *>(this) + sizeof(CoreFunctionBinCache));
     }
 
     /**
      * Get pointer to binary data region
      * @return Pointer to start of binary data
      */
-    uint8_t* get_binary_data() {
-        return reinterpret_cast<uint8_t*>(get_offsets()) + num_kernels * sizeof(uint64_t);
-    }
+    uint8_t *get_binary_data() { return reinterpret_cast<uint8_t *>(get_offsets()) + num_kernels * sizeof(uint64_t); }
 
     /**
      * Get CoreFunctionBin by index
      * @param index  Kernel index
      * @return Pointer to CoreFunctionBin structure, nullptr if invalid index
      */
-    CoreFunctionBin* get_kernel(uint64_t index) {
+    CoreFunctionBin *get_kernel(uint64_t index) {
         if (index >= num_kernels) {
             return nullptr;
         }
         uint64_t offset = get_offsets()[index];
-        return reinterpret_cast<CoreFunctionBin*>(get_binary_data() + offset);
+        return reinterpret_cast<CoreFunctionBin *>(get_binary_data() + offset);
     }
 
     /**

--- a/src/a2a3/platform/include/host/host_regs.h
+++ b/src/a2a3/platform/include/host/host_regs.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file host_regs.h
  * @brief AICore register address retrieval via CANN HAL APIs
@@ -32,9 +42,6 @@ constexpr uint8_t PLATFORM_AICORE_MAP_BUFF_LEN = 2;
  * @param allocator Memory allocator for device memory
  * @return 0 on success, negative on failure
  */
-int init_aicore_register_addresses(
-    uint64_t* runtime_regs_ptr,
-    uint64_t device_id,
-    MemoryAllocator& allocator);
+int init_aicore_register_addresses(uint64_t *runtime_regs_ptr, uint64_t device_id, MemoryAllocator &allocator);
 
 #endif  // PLATFORM_HOST_HOST_REGS_H_

--- a/src/a2a3/platform/include/host/memory_allocator.h
+++ b/src/a2a3/platform/include/host/memory_allocator.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file memory_allocator.h
  * @brief Memory Allocator - Centralized Memory Management
@@ -38,8 +48,8 @@ public:
     ~MemoryAllocator();
 
     // Prevent copying
-    MemoryAllocator(const MemoryAllocator&) = delete;
-    MemoryAllocator& operator=(const MemoryAllocator&) = delete;
+    MemoryAllocator(const MemoryAllocator &) = delete;
+    MemoryAllocator &operator=(const MemoryAllocator &) = delete;
 
     /**
      * Allocate memory and track the pointer
@@ -51,7 +61,7 @@ public:
      * @param size  Size in bytes to allocate
      * @return Memory pointer on success, nullptr on failure
      */
-    void* alloc(size_t size);
+    void *alloc(size_t size);
 
     /**
      * Free memory if tracked
@@ -67,7 +77,7 @@ public:
      * @param ptr  Memory pointer to free
      * @return 0 on success, error code on failure, 0 if ptr not tracked
      */
-    int free(void* ptr);
+    int free(void *ptr);
 
     /**
      * Free all remaining tracked allocations
@@ -88,7 +98,7 @@ public:
     size_t get_allocation_count() const { return ptr_set_.size(); }
 
 private:
-    std::set<void*> ptr_set_;
+    std::set<void *> ptr_set_;
     bool finalized_{false};
 };
 

--- a/src/a2a3/platform/include/host/performance_collector.h
+++ b/src/a2a3/platform/include/host/performance_collector.h
@@ -45,7 +45,7 @@
  * @param user_data User-provided context pointer
  * @return Allocated device memory pointer, or nullptr on failure
  */
-using PerfAllocCallback = void* (*)(size_t size, void* user_data);
+using PerfAllocCallback = void *(*)(size_t size, void *user_data);
 
 /**
  * Memory registration callback (for Host-Device shared memory)
@@ -57,7 +57,7 @@ using PerfAllocCallback = void* (*)(size_t size, void* user_data);
  * @param[out] host_ptr Host-mapped pointer
  * @return 0 on success, error code on failure
  */
-using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id, void* user_data, void** host_ptr);
+using PerfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void *user_data, void **host_ptr);
 
 /**
  * Memory unregister callback
@@ -67,7 +67,7 @@ using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id, 
  * @param user_data User-provided context pointer
  * @return 0 on success, error code on failure
  */
-using PerfUnregisterCallback = int (*)(void* dev_ptr, int device_id, void* user_data);
+using PerfUnregisterCallback = int (*)(void *dev_ptr, int device_id, void *user_data);
 
 /**
  * Memory free callback
@@ -76,7 +76,7 @@ using PerfUnregisterCallback = int (*)(void* dev_ptr, int device_id, void* user_
  * @param user_data User-provided context pointer
  * @return 0 on success, error code on failure
  */
-using PerfFreeCallback = int (*)(void* dev_ptr, void* user_data);
+using PerfFreeCallback = int (*)(void *dev_ptr, void *user_data);
 
 /**
  * Device context setup callback (called once on mgmt thread startup)
@@ -85,7 +85,7 @@ using PerfFreeCallback = int (*)(void* dev_ptr, void* user_data);
  * @param user_data User-provided context pointer
  * @return 0 on success, error code on failure
  */
-using PerfSetDeviceCallback = int (*)(int device_id, void* user_data);
+using PerfSetDeviceCallback = int (*)(int device_id, void *user_data);
 
 // =============================================================================
 // ProfMemoryManager - Dynamic Buffer Memory Management Thread
@@ -103,8 +103,8 @@ struct ReadyBufferInfo {
     ProfBufferType type;
     uint32_t index;         // core_index (PERF_RECORD) or thread_idx (PHASE)
     uint32_t slot_idx;      // Reserved (unused in free queue design)
-    void* dev_buffer_ptr;   // Device address of the full buffer
-    void* host_buffer_ptr;  // Host-mapped address (sim: same as dev)
+    void *dev_buffer_ptr;   // Device address of the full buffer
+    void *host_buffer_ptr;  // Host-mapped address (sim: same as dev)
     uint32_t buffer_seq;    // Sequence number for ordering
 };
 
@@ -112,7 +112,7 @@ struct ReadyBufferInfo {
  * Notification that a buffer has been copied and can be freed
  */
 struct CopyDoneInfo {
-    void* dev_buffer_ptr;  // Device buffer to free
+    void *dev_buffer_ptr;  // Device buffer to free
     ProfBufferType type;   // Buffer type (for recycling)
 };
 
@@ -127,13 +127,13 @@ struct CopyDoneInfo {
  * 5. Frees device buffers after main thread confirms copy is done
  */
 class ProfMemoryManager {
- public:
+public:
     ProfMemoryManager() = default;
     ~ProfMemoryManager();
 
     // Disable copy
-    ProfMemoryManager(const ProfMemoryManager&) = delete;
-    ProfMemoryManager& operator=(const ProfMemoryManager&) = delete;
+    ProfMemoryManager(const ProfMemoryManager &) = delete;
+    ProfMemoryManager &operator=(const ProfMemoryManager &) = delete;
 
     // Allow PerformanceCollector to register initial buffer mappings
     friend class PerformanceCollector;
@@ -151,15 +151,11 @@ class ProfMemoryManager {
      * @param device_id Device ID for registration
      * @param set_device_cb Device context setup callback (nullptr to skip)
      */
-    void start(void* shared_mem_host,
-        int num_cores,
-        int num_phase_threads,
-        PerfAllocCallback alloc_cb,
-        PerfRegisterCallback register_cb,
-        PerfFreeCallback free_cb,
-        void* user_data,
-        int device_id,
-        PerfSetDeviceCallback set_device_cb = nullptr);
+    void start(
+        void *shared_mem_host, int num_cores, int num_phase_threads, PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb, PerfFreeCallback free_cb, void *user_data, int device_id,
+        PerfSetDeviceCallback set_device_cb = nullptr
+    );
 
     /**
      * Stop the memory management thread
@@ -173,7 +169,7 @@ class ProfMemoryManager {
      * @param[out] info Ready buffer info
      * @return true if an item was available, false otherwise
      */
-    bool try_pop_ready(ReadyBufferInfo& info);
+    bool try_pop_ready(ReadyBufferInfo &info);
 
     /**
      * Wait for a ready buffer info with timeout
@@ -182,26 +178,26 @@ class ProfMemoryManager {
      * @param timeout Maximum wait time
      * @return true if an item was available, false on timeout
      */
-    bool wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout);
+    bool wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout);
 
     /**
      * Notify that a buffer has been copied and can be freed
      *
      * @param info Copy done notification
      */
-    void notify_copy_done(const CopyDoneInfo& info);
+    void notify_copy_done(const CopyDoneInfo &info);
 
     /**
      * Check if the manager thread is running
      */
     bool is_running() const { return running_.load(); }
 
- private:
+private:
     std::thread mgmt_thread_;
     std::atomic<bool> running_{false};
 
     // Shared memory references
-    void* shared_mem_host_{nullptr};
+    void *shared_mem_host_{nullptr};
     int num_cores_{0};
     int num_phase_threads_{0};
 
@@ -210,7 +206,7 @@ class ProfMemoryManager {
     PerfRegisterCallback register_cb_{nullptr};
     PerfFreeCallback free_cb_{nullptr};
     PerfSetDeviceCallback set_device_cb_{nullptr};
-    void* user_data_{nullptr};
+    void *user_data_{nullptr};
     int device_id_{-1};
 
     // Management thread → main thread (ready buffers)
@@ -223,29 +219,29 @@ class ProfMemoryManager {
     std::queue<CopyDoneInfo> done_queue_;
 
     // Device-to-host pointer mapping (populated during alloc_and_register)
-    std::unordered_map<void*, void*> dev_to_host_;
+    std::unordered_map<void *, void *> dev_to_host_;
 
     // Recycled buffer pools (avoids alloc/free churn in mgmt_loop)
-    std::vector<void*> recycled_perf_buffers_;
-    std::vector<void*> recycled_phase_buffers_;
+    std::vector<void *> recycled_perf_buffers_;
+    std::vector<void *> recycled_phase_buffers_;
 
     // Management thread main loop
     void mgmt_loop();
 
     // Allocate a new buffer and optionally register for host access
-    void* alloc_and_register(size_t size, void** host_ptr_out);
+    void *alloc_and_register(size_t size, void **host_ptr_out);
 
     // Free a previously allocated buffer
-    void free_buffer(void* dev_ptr);
+    void free_buffer(void *dev_ptr);
 
     // Resolve device pointer to host pointer
-    void* resolve_host_ptr(void* dev_ptr);
+    void *resolve_host_ptr(void *dev_ptr);
 
     // Register an external dev→host mapping (for initial buffers)
-    void register_mapping(void* dev_ptr, void* host_ptr);
+    void register_mapping(void *dev_ptr, void *host_ptr);
 
     // Process one ReadyQueue entry
-    void process_ready_entry(PerfDataHeader* header, int thread_idx, const ReadyQueueEntry& entry);
+    void process_ready_entry(PerfDataHeader *header, int thread_idx, const ReadyQueueEntry &entry);
 };
 
 // =============================================================================
@@ -264,13 +260,13 @@ class ProfMemoryManager {
  * Platform-agnostic: Memory management delegated to callbacks
  */
 class PerformanceCollector {
- public:
+public:
     PerformanceCollector() = default;
     ~PerformanceCollector();
 
     // Disable copy and move
-    PerformanceCollector(const PerformanceCollector&) = delete;
-    PerformanceCollector& operator=(const PerformanceCollector&) = delete;
+    PerformanceCollector(const PerformanceCollector &) = delete;
+    PerformanceCollector &operator=(const PerformanceCollector &) = delete;
 
     /**
      * Initialize performance profiling
@@ -288,14 +284,10 @@ class PerformanceCollector {
      * @param set_device_cb Device context setup callback (nullptr to skip)
      * @return 0 on success, error code on failure
      */
-    int initialize(Runtime& runtime,
-        int num_aicore,
-        int device_id,
-        PerfAllocCallback alloc_cb,
-        PerfRegisterCallback register_cb,
-        PerfFreeCallback free_cb,
-        void* user_data,
-        PerfSetDeviceCallback set_device_cb = nullptr);
+    int initialize(
+        Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb, void *user_data, PerfSetDeviceCallback set_device_cb = nullptr
+    );
 
     /**
      * Start the memory management thread
@@ -321,7 +313,7 @@ class PerformanceCollector {
      * @param output_path Output directory path
      * @return 0 on success, error code on failure
      */
-    int export_swimlane_json(const std::string& output_path = "outputs");
+    int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
      * Stop the memory management thread and clean up remaining data
@@ -338,7 +330,7 @@ class PerformanceCollector {
      * @param user_data User-provided context pointer
      * @return 0 on success, error code on failure
      */
-    int finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data);
+    int finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void *user_data);
 
     /**
      * Check if collector is initialized
@@ -383,12 +375,12 @@ class PerformanceCollector {
     /**
      * Get collected records (for testing)
      */
-    const std::vector<std::vector<PerfRecord>>& get_records() const { return collected_perf_records_; }
+    const std::vector<std::vector<PerfRecord>> &get_records() const { return collected_perf_records_; }
 
- private:
+private:
     // Shared memory pointers
-    void* perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
-    void* perf_shared_mem_host_{nullptr};  // Host-mapped pointer (slot arrays)
+    void *perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
+    void *perf_shared_mem_host_{nullptr};  // Host-mapped pointer (slot arrays)
     bool was_registered_{false};           // True if register_cb was called successfully
     int device_id_{-1};
 
@@ -400,7 +392,7 @@ class PerformanceCollector {
     PerfRegisterCallback register_cb_{nullptr};
     PerfFreeCallback free_cb_{nullptr};
     PerfSetDeviceCallback set_device_cb_{nullptr};
-    void* user_data_{nullptr};
+    void *user_data_{nullptr};
 
     // Memory manager
     ProfMemoryManager memory_manager_;
@@ -420,7 +412,7 @@ class PerformanceCollector {
     std::atomic<bool> execution_complete_{false};
 
     // Allocate a single buffer (PerfBuffer or PhaseBuffer) and register it
-    void* alloc_single_buffer(size_t size, void** host_ptr_out);
+    void *alloc_single_buffer(size_t size, void **host_ptr_out);
 };
 
 #endif  // SRC_A2A3_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_

--- a/src/a2a3/platform/include/host/platform_compile_info.h
+++ b/src/a2a3/platform/include/host/platform_compile_info.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Platform Compile Info Interface
  *
@@ -18,7 +28,7 @@ extern "C" {
  *
  * @return Platform identifier string (e.g., "a2a3", "a2a3sim")
  */
-const char* get_platform(void);
+const char *get_platform(void);
 
 #ifdef __cplusplus
 }

--- a/src/a2a3/platform/include/host/pto_runtime_c_api.h
+++ b/src/a2a3/platform/include/host/pto_runtime_c_api.h
@@ -52,7 +52,7 @@ extern "C" {
  * Opaque pointer types for C interface.
  * These hide the C++ class implementations.
  */
-typedef void* RuntimeHandle;
+typedef void *RuntimeHandle;
 
 /* ===========================================================================
  * Runtime API
@@ -84,7 +84,7 @@ size_t get_runtime_size(void);
  * @param orch_args Separated tensor/scalar arguments for orchestration
  * @return 0 on success, -1 on failure
  */
-int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args);
+int init_runtime(RuntimeHandle runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args);
 
 /* ===========================================================================
  * Device Memory API (for use by orchestration functions)
@@ -97,14 +97,14 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
  * @param size  Size in bytes to allocate
  * @return Device pointer on success, NULL on failure
  */
-void* device_malloc(size_t size);
+void *device_malloc(size_t size);
 
 /**
  * Free device memory.
  *
  * @param dev_ptr  Device pointer to free
  */
-void device_free(void* dev_ptr);
+void device_free(void *dev_ptr);
 
 /**
  * Copy data from host to device.
@@ -114,7 +114,7 @@ void device_free(void* dev_ptr);
  * @param size     Size in bytes to copy
  * @return 0 on success, error code on failure
  */
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
+int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size);
 
 /**
  * Copy data from device to host.
@@ -124,7 +124,7 @@ int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
  * @param size     Size in bytes to copy
  * @return 0 on success, error code on failure
  */
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
+int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size);
 
 /**
  * Execute a runtime on the device.
@@ -144,15 +144,10 @@ int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
  * @param orch_thread_num  Number of orchestrator threads (default 1)
  * @return 0 on success, error code on failure
  */
-int launch_runtime(RuntimeHandle runtime,
-    int aicpu_thread_num,
-    int block_dim,
-    int device_id,
-    const uint8_t* aicpu_binary,
-    size_t aicpu_size,
-    const uint8_t* aicore_binary,
-    size_t aicore_size,
-    int orch_thread_num);
+int launch_runtime(
+    RuntimeHandle runtime, int aicpu_thread_num, int block_dim, int device_id, const uint8_t *aicpu_binary,
+    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size, int orch_thread_num
+);
 
 /**
  * Finalize and cleanup a runtime instance.
@@ -197,7 +192,7 @@ int set_device(int device_id);
  * @param dev_ptr   Device memory pointer
  * @param size      Size of tensor in bytes
  */
-void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size);
+void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, size_t size);
 
 /**
  * Enable or disable performance profiling for swimlane visualization.

--- a/src/a2a3/platform/include/host/raii_scope_guard.h
+++ b/src/a2a3/platform/include/host/raii_scope_guard.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #ifndef PLATFORM_RAII_SCOPE_GUARD_H_
 #define PLATFORM_RAII_SCOPE_GUARD_H_
 
@@ -17,8 +27,9 @@
 template <typename F>
 class RAIIScopeGuard {
 public:
-    explicit RAIIScopeGuard(F fn)
-        : fn_(std::move(fn)), active_(true) {}
+    explicit RAIIScopeGuard(F fn) :
+        fn_(std::move(fn)),
+        active_(true) {}
 
     ~RAIIScopeGuard() {
         if (active_) {
@@ -26,17 +37,16 @@ public:
         }
     }
 
-    RAIIScopeGuard(RAIIScopeGuard&& other) noexcept
-        : fn_(std::move(other.fn_)), active_(other.active_) {
+    RAIIScopeGuard(RAIIScopeGuard &&other) noexcept :
+        fn_(std::move(other.fn_)),
+        active_(other.active_) {
         other.active_ = false;
     }
 
-    RAIIScopeGuard(const RAIIScopeGuard&) = delete;
-    RAIIScopeGuard& operator=(const RAIIScopeGuard&) = delete;
+    RAIIScopeGuard(const RAIIScopeGuard &) = delete;
+    RAIIScopeGuard &operator=(const RAIIScopeGuard &) = delete;
 
-    void dismiss() noexcept {
-        active_ = false;
-    }
+    void dismiss() noexcept { active_ = false; }
 
 private:
     F fn_;

--- a/src/a2a3/platform/onboard/aicore/inner_kernel.h
+++ b/src/a2a3/platform/onboard/aicore/inner_kernel.h
@@ -54,14 +54,14 @@
  */
 __aicore__ inline uint64_t read_reg(RegId reg) {
     switch (reg) {
-        case RegId::DATA_MAIN_BASE: {
-            uint32_t val;
-            __asm__ volatile("MOV %0, DATA_MAIN_BASE\n" : "=l"(val));
-            return static_cast<uint64_t>(val);
-        }
-        case RegId::COND:
-        case RegId::FAST_PATH_ENABLE:
-            return 0;
+    case RegId::DATA_MAIN_BASE: {
+        uint32_t val;
+        __asm__ volatile("MOV %0, DATA_MAIN_BASE\n" : "=l"(val));
+        return static_cast<uint64_t>(val);
+    }
+    case RegId::COND:
+    case RegId::FAST_PATH_ENABLE:
+        return 0;
     }
 }
 
@@ -73,12 +73,12 @@ __aicore__ inline uint64_t read_reg(RegId reg) {
  */
 __aicore__ inline void write_reg(RegId reg, uint64_t value) {
     switch (reg) {
-        case RegId::COND:
-            set_cond(static_cast<uint32_t>(value));
-            break;
-        case RegId::DATA_MAIN_BASE:
-        case RegId::FAST_PATH_ENABLE:
-            break;
+    case RegId::COND:
+        set_cond(static_cast<uint32_t>(value));
+        break;
+    case RegId::DATA_MAIN_BASE:
+    case RegId::FAST_PATH_ENABLE:
+        break;
     }
 }
 

--- a/src/a2a3/platform/onboard/aicore/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicore/kernel.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Minimal AICore Kernel
  */
@@ -8,7 +18,7 @@ class Runtime;
 
 #ifdef __DAV_VEC__
 #define KERNEL_ENTRY(x) \
-    x##_0_mix_aiv  // 动态生成函数名 KERNEL_ENTRY(my_kernel) ->
+    x##_0_mix_aiv  // Dynamically generate function name: KERNEL_ENTRY(my_kernel) ->
                    // my_kernel_0_mix_aiv
 #define block_idx block_idx_aiv
 #define core_type core_type_aiv
@@ -21,7 +31,7 @@ class Runtime;
 [[block_local]] int block_idx;
 [[block_local]] CoreType core_type;
 
-extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
+extern __aicore__ void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type);
 
 /**
  * Kernel entry point with control loop
@@ -38,7 +48,7 @@ extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, Co
  *
  * @param runtime Address of Runtime structure in device memory
  */
-extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime* runtime) {
+extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime *runtime) {
     // Calculate block_idx for this core
 #ifdef __DAV_VEC__
     block_idx = get_block_idx() * get_subblockdim() + get_subblockid() + get_block_num();

--- a/src/a2a3/platform/onboard/aicpu/cache_ops.cpp
+++ b/src/a2a3/platform/onboard/aicpu/cache_ops.cpp
@@ -1,17 +1,27 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstddef>
 #include <cstdint>
 
 #include "aicpu/platform_regs.h"
 
-void cache_invalidate_range(const void* addr, size_t size) {
+void cache_invalidate_range(const void *addr, size_t size) {
     if (size == 0) {
         return;
     }
     const size_t kCacheLineSize = 64;
     uintptr_t start = (uintptr_t)addr & ~(kCacheLineSize - 1);
-    uintptr_t end   = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    uintptr_t end = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
     for (uintptr_t p = start; p < end; p += kCacheLineSize) {
-        __asm__ __volatile__("dc civac, %0" :: "r"(p) : "memory");
+        __asm__ __volatile__("dc civac, %0" ::"r"(p) : "memory");
     }
     __asm__ __volatile__("dsb sy" ::: "memory");
     __asm__ __volatile__("isb" ::: "memory");

--- a/src/a2a3/platform/onboard/aicpu/device_log.cpp
+++ b/src/a2a3/platform/onboard/aicpu/device_log.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Device logging implementation for AICPU kernel
  */
@@ -12,7 +22,7 @@ bool g_is_log_enable_info = false;
 bool g_is_log_enable_warn = false;
 bool g_is_log_enable_error = false;
 
-const char* TILE_FWK_DEVICE_MACHINE = "AI_CPU";
+const char *TILE_FWK_DEVICE_MACHINE = "AI_CPU";
 
 void init_log_switch() {
     g_is_log_enable_debug = CheckLogLevel(AICPU, DLOG_DEBUG);
@@ -25,7 +35,7 @@ void init_log_switch() {
 // Platform-Specific Logging Functions (Real Hardware: use CANN dlog API)
 // =============================================================================
 
-void dev_log_debug(const char* func, const char* fmt, ...) {
+void dev_log_debug(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];
@@ -35,7 +45,7 @@ void dev_log_debug(const char* func, const char* fmt, ...) {
     dlog_debug(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
 }
 
-void dev_log_info(const char* func, const char* fmt, ...) {
+void dev_log_info(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];
@@ -44,7 +54,7 @@ void dev_log_info(const char* func, const char* fmt, ...) {
     dlog_info(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
 }
 
-void dev_log_warn(const char* func, const char* fmt, ...) {
+void dev_log_warn(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];
@@ -53,7 +63,7 @@ void dev_log_warn(const char* func, const char* fmt, ...) {
     dlog_warn(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
 }
 
-void dev_log_error(const char* func, const char* fmt, ...) {
+void dev_log_error(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];
@@ -62,7 +72,7 @@ void dev_log_error(const char* func, const char* fmt, ...) {
     dlog_error(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
 }
 
-void dev_log_always(const char* func, const char* fmt, ...) {
+void dev_log_always(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];

--- a/src/a2a3/platform/onboard/aicpu/device_malloc.cpp
+++ b/src/a2a3/platform/onboard/aicpu/device_malloc.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file device_malloc.cpp
  * @brief Device Memory Allocation for Real Hardware (a2a3)
@@ -13,8 +23,8 @@
 #include <dlfcn.h>
 #include <cstdlib>
 
-using HalMemAllocFn = int (*)(void** pp, unsigned long long size, unsigned long long flag);
-using HalMemFreeFn = int (*)(void* pp);
+using HalMemAllocFn = int (*)(void **pp, unsigned long long size, unsigned long long flag);
+using HalMemFreeFn = int (*)(void *pp);
 
 static HalMemAllocFn g_halMemAlloc = nullptr;
 static HalMemFreeFn g_halMemFree = nullptr;
@@ -34,7 +44,7 @@ static void resolve_hal_mem_functions() {
     g_hal_resolved = true;
 }
 
-void* aicpu_device_malloc(size_t size) {
+void *aicpu_device_malloc(size_t size) {
     resolve_hal_mem_functions();
 
     if (g_halMemAlloc == nullptr) {
@@ -42,7 +52,7 @@ void* aicpu_device_malloc(size_t size) {
         return nullptr;
     }
 
-    void* ptr = nullptr;
+    void *ptr = nullptr;
     // halMemAlloc flag layout (ascend_hal_define.h):
     //   bit0~9:   devid (0 for local device)
     //   bit10~13: virt mem type (MEM_SVM=0x0 << 10)
@@ -57,7 +67,7 @@ void* aicpu_device_malloc(size_t size) {
     return ptr;
 }
 
-void aicpu_device_free(void* ptr) {
+void aicpu_device_free(void *ptr) {
     if (ptr == nullptr) {
         return;
     }

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdio>
 
 #include "common/unified_log.h"
@@ -72,8 +82,7 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_platform_regs(k_args->regs);
 
     // Affinity gate: drop excess threads before entering runtime
-    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num,
-                                      PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
+    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
         LOG_INFO("Thread dropped by cluster affinity");
         return 0;
     }

--- a/src/a2a3/platform/onboard/aicpu/platform_aicpu_affinity.cpp
+++ b/src/a2a3/platform/onboard/aicpu/platform_aicpu_affinity.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "aicpu/platform_aicpu_affinity.h"
 
 #include <atomic>
@@ -21,9 +31,7 @@ static std::atomic<int32_t> s_gate_ready{0};
 static int32_t s_thread_cpu[MAX_GATE_THREADS];
 static bool s_thread_survive[MAX_GATE_THREADS];
 
-static inline int32_t popcount64(uint64_t v) {
-    return __builtin_popcountll(static_cast<unsigned long long>(v));
-}
+static inline int32_t popcount64(uint64_t v) { return __builtin_popcountll(static_cast<unsigned long long>(v)); }
 
 bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched) {
     if (logical_count >= total_launched) {
@@ -55,13 +63,11 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
 
     // Barrier: wait until all total_launched threads have reported
     while (popcount64(s_cpumask.load(std::memory_order_acquire)) < total_launched &&
-           s_reported.load(std::memory_order_acquire) < total_launched) {
-    }
+           s_reported.load(std::memory_order_acquire) < total_launched) {}
 
     // CAS winner does cluster classification
     int32_t expected = 0;
-    if (s_gate_init.compare_exchange_strong(expected, 1,
-            std::memory_order_acq_rel, std::memory_order_acquire)) {
+    if (s_gate_init.compare_exchange_strong(expected, 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
         // Initialize survive flags
         for (int32_t i = 0; i < total_launched; ++i) {
             s_thread_survive[i] = false;
@@ -78,7 +84,7 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
             if (c < 0) continue;
             int32_t cluster_id = c / CPUS_PER_CLUSTER;
             if (cluster_id < 0 || cluster_id >= MAX_CLUSTERS) continue;
-            ClusterInfo& info = clusters[cluster_id];
+            ClusterInfo &info = clusters[cluster_id];
             if (info.count < MAX_GATE_THREADS) info.tids[info.count++] = tid;
         }
 
@@ -87,8 +93,10 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
         int32_t major_cnt = clusters[major_id].count;
         int32_t minor_cnt = clusters[minor_id].count;
 
-        LOG_INFO("AICPU affinity gate: major=%d(cnt=%d) minor=%d(cnt=%d) logical=%d",
-                 major_id, major_cnt, minor_id, minor_cnt, logical_count);
+        LOG_INFO(
+            "AICPU affinity gate: major=%d(cnt=%d) minor=%d(cnt=%d) logical=%d", major_id, major_cnt, minor_id,
+            minor_cnt, logical_count
+        );
 
         if (major_cnt == logical_count && minor_cnt == (total_launched - logical_count)) {
             // Expected topology: major cluster threads survive
@@ -97,9 +105,11 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
             }
         } else {
             // Unexpected topology: fall back to first logical_count threads
-            LOG_WARN("AICPU affinity gate: unexpected topology (major=%d minor=%d), "
-                     "falling back to index-based cutoff",
-                     major_cnt, minor_cnt);
+            LOG_WARN(
+                "AICPU affinity gate: unexpected topology (major=%d minor=%d), "
+                "falling back to index-based cutoff",
+                major_cnt, minor_cnt
+            );
             for (int32_t i = 0; i < logical_count && i < total_launched; ++i) {
                 s_thread_survive[i] = true;
             }
@@ -109,8 +119,7 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
     }
 
     // Wait for classification to complete
-    while (s_gate_ready.load(std::memory_order_acquire) == 0) {
-    }
+    while (s_gate_ready.load(std::memory_order_acquire) == 0) {}
 
     bool survive = (idx < total_launched) ? s_thread_survive[idx] : false;
 

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -35,10 +35,10 @@
 // =============================================================================
 
 namespace {
-void* g_hal_handle = nullptr;
+void *g_hal_handle = nullptr;
 
-using HalHostRegisterFn = int (*)(void* dev_ptr, size_t size, unsigned int flags, int device_id, void** host_ptr);
-using HalHostUnregisterFn = int (*)(void* host_ptr, int device_id);
+using HalHostRegisterFn = int (*)(void *dev_ptr, size_t size, unsigned int flags, int device_id, void **host_ptr);
+using HalHostUnregisterFn = int (*)(void *host_ptr, int device_id);
 
 int load_hal_if_needed() {
     if (g_hal_handle != nullptr) {
@@ -71,18 +71,18 @@ HalHostUnregisterFn get_halHostUnregister() {
 // KernelArgsHelper Implementation
 // =============================================================================
 
-int KernelArgsHelper::init_device_args(const DeviceArgs& host_device_args, MemoryAllocator& allocator) {
+int KernelArgsHelper::init_device_args(const DeviceArgs &host_device_args, MemoryAllocator &allocator) {
     allocator_ = &allocator;
 
     // Allocate device memory for device_args
     if (args.device_args == nullptr) {
         uint64_t device_args_size = sizeof(DeviceArgs);
-        void* device_args_dev = allocator_->alloc(device_args_size);
+        void *device_args_dev = allocator_->alloc(device_args_size);
         if (device_args_dev == nullptr) {
             LOG_ERROR("Alloc for device_args failed");
             return -1;
         }
-        args.device_args = reinterpret_cast<DeviceArgs*>(device_args_dev);
+        args.device_args = reinterpret_cast<DeviceArgs *>(device_args_dev);
     }
     // Copy host_device_args to device memory via device_args
     int rc =
@@ -105,17 +105,17 @@ int KernelArgsHelper::finalize_device_args() {
     return 0;
 }
 
-int KernelArgsHelper::init_runtime_args(const Runtime& host_runtime, MemoryAllocator& allocator) {
+int KernelArgsHelper::init_runtime_args(const Runtime &host_runtime, MemoryAllocator &allocator) {
     allocator_ = &allocator;
 
     if (args.runtime_args == nullptr) {
         uint64_t runtime_size = sizeof(Runtime);
-        void* runtime_dev = allocator_->alloc(runtime_size);
+        void *runtime_dev = allocator_->alloc(runtime_size);
         if (runtime_dev == nullptr) {
             LOG_ERROR("Alloc for runtime_args failed");
             return -1;
         }
-        args.runtime_args = reinterpret_cast<Runtime*>(runtime_dev);
+        args.runtime_args = reinterpret_cast<Runtime *>(runtime_dev);
     }
     int rc = rtMemcpy(args.runtime_args, sizeof(Runtime), &host_runtime, sizeof(Runtime), RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
@@ -140,7 +140,7 @@ int KernelArgsHelper::finalize_runtime_args() {
 // AicpuSoInfo Implementation
 // =============================================================================
 
-int AicpuSoInfo::init(const std::vector<uint8_t>& aicpu_so_binary, MemoryAllocator& allocator) {
+int AicpuSoInfo::init(const std::vector<uint8_t> &aicpu_so_binary, MemoryAllocator &allocator) {
     allocator_ = &allocator;
 
     if (aicpu_so_binary.empty()) {
@@ -149,7 +149,7 @@ int AicpuSoInfo::init(const std::vector<uint8_t>& aicpu_so_binary, MemoryAllocat
     }
 
     size_t file_size = aicpu_so_binary.size();
-    void* d_aicpu_data = allocator_->alloc(file_size);
+    void *d_aicpu_data = allocator_->alloc(file_size);
     if (d_aicpu_data == nullptr) {
         LOG_ERROR("Alloc failed for AICPU SO");
         return -1;
@@ -170,7 +170,7 @@ int AicpuSoInfo::init(const std::vector<uint8_t>& aicpu_so_binary, MemoryAllocat
 
 int AicpuSoInfo::finalize() {
     if (aicpu_so_bin != 0 && allocator_ != nullptr) {
-        int rc = allocator_->free(reinterpret_cast<void*>(aicpu_so_bin));
+        int rc = allocator_->free(reinterpret_cast<void *>(aicpu_so_bin));
         aicpu_so_bin = 0;
         return rc;
     }
@@ -181,7 +181,7 @@ int AicpuSoInfo::finalize() {
 // DeviceRunner Implementation
 // =============================================================================
 
-DeviceRunner& DeviceRunner::get() {
+DeviceRunner &DeviceRunner::get() {
     static DeviceRunner runner;
     return runner;
 }
@@ -189,7 +189,8 @@ DeviceRunner& DeviceRunner::get() {
 DeviceRunner::~DeviceRunner() { finalize(); }
 
 int DeviceRunner::ensure_device_initialized(
-    int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
+    int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+) {
     // First ensure device is set and streams are created
     int rc = ensure_device_set(device_id);
     if (rc != 0) {
@@ -235,7 +236,8 @@ int DeviceRunner::ensure_device_set(int device_id) {
 }
 
 int DeviceRunner::ensure_binaries_loaded(
-    const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
+    const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+) {
     // Check if already loaded
     if (binaries_loaded_) {
         // Just update kernel binary if different
@@ -275,28 +277,26 @@ int DeviceRunner::ensure_binaries_loaded(
     return 0;
 }
 
-void* DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
+void *DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
 
-void DeviceRunner::free_tensor(void* dev_ptr) {
+void DeviceRunner::free_tensor(void *dev_ptr) {
     if (dev_ptr != nullptr) {
         mem_alloc_.free(dev_ptr);
     }
 }
 
-int DeviceRunner::copy_to_device(void* dev_ptr, const void* host_ptr, size_t bytes) {
+int DeviceRunner::copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes) {
     return rtMemcpy(dev_ptr, bytes, host_ptr, bytes, RT_MEMCPY_HOST_TO_DEVICE);
 }
 
-int DeviceRunner::copy_from_device(void* host_ptr, const void* dev_ptr, size_t bytes) {
+int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes) {
     return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
-int DeviceRunner::run(Runtime& runtime,
-    int block_dim,
-    int device_id,
-    const std::vector<uint8_t>& aicpu_so_binary,
-    const std::vector<uint8_t>& aicore_kernel_binary,
-    int launch_aicpu_num) {
+int DeviceRunner::run(
+    Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
+) {
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -314,7 +314,8 @@ int DeviceRunner::run(Runtime& runtime,
 
     if (runtime.orch_thread_num > launch_aicpu_num) {
         LOG_ERROR(
-            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num);
+            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num
+        );
         return -1;
     }
 
@@ -322,19 +323,21 @@ int DeviceRunner::run(Runtime& runtime,
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
             LOG_ERROR(
-                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num);
+                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num
+            );
             return -1;
         }
     } else {
         LOG_INFO(
-            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num);
+            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num
+        );
         // Post-transition: all threads become schedulers
         if (block_dim % launch_aicpu_num != 0) {
             LOG_WARN(
                 "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
                 "some threads will have different core counts after transition",
-                block_dim,
-                launch_aicpu_num);
+                block_dim, launch_aicpu_num
+            );
         }
     }
 
@@ -385,7 +388,7 @@ int DeviceRunner::run(Runtime& runtime,
     // device address; compute binary code address using compile-time offset
     LOG_DEBUG("Setting function_bin_addr for Tasks");
     for (int i = 0; i < runtime.get_task_count(); i++) {
-        Task* task = runtime.get_task(i);
+        Task *task = runtime.get_task(i);
         if (task != nullptr) {
             uint64_t callable_addr = runtime.get_function_bin_addr(task->func_id);
             task->function_bin_addr = callable_addr + CoreCallable::binary_data_offset();
@@ -397,12 +400,14 @@ int DeviceRunner::run(Runtime& runtime,
     // Scope guards for cleanup on all exit paths
     auto regs_cleanup = RAIIScopeGuard([this]() {
         if (kernel_args_.args.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.regs));
             kernel_args_.args.regs = 0;
         }
     });
 
-    auto runtime_args_cleanup = RAIIScopeGuard([this]() { kernel_args_.finalize_runtime_args(); });
+    auto runtime_args_cleanup = RAIIScopeGuard([this]() {
+        kernel_args_.finalize_runtime_args();
+    });
 
     // Initialize performance profiling if enabled
     if (runtime.enable_profiling) {
@@ -441,7 +446,8 @@ int DeviceRunner::run(Runtime& runtime,
     std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServer===" << '\n';
     // Launch AICPU main kernel (over-launch for affinity gate)
     rc = launch_aicpu_kernel(
-        stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
+        stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
+    );
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
         return rc;
@@ -459,8 +465,9 @@ int DeviceRunner::run(Runtime& runtime,
         // Poll and collect performance data in a separate collector thread
         std::thread collector_thread;
         if (runtime.enable_profiling) {
-            collector_thread =
-                std::thread([this, &runtime]() { poll_and_collect_performance_data(runtime.get_task_count()); });
+            collector_thread = std::thread([this, &runtime]() {
+                poll_and_collect_performance_data(runtime.get_task_count());
+            });
         }
         auto thread_guard = RAIIScopeGuard([&]() {
             if (runtime.enable_profiling && collector_thread.joinable()) {
@@ -516,12 +523,10 @@ void DeviceRunner::print_handshake_results() {
 
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
-        LOG_DEBUG("  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d",
-            i,
-            workers[i].aicore_done,
-            workers[i].aicpu_ready,
-            workers[i].control,
-            workers[i].task);
+        LOG_DEBUG(
+            "  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d", i, workers[i].aicore_done,
+            workers[i].aicpu_ready, workers[i].control, workers[i].task
+        );
     }
 }
 
@@ -540,8 +545,8 @@ int DeviceRunner::finalize() {
     if (!func_id_to_addr_.empty()) {
         LOG_ERROR("finalize() called with %zu kernel binaries still cached (memory leak)", func_id_to_addr_.size());
         // Cleanup leaked binaries to prevent memory leaks
-        for (const auto& pair : func_id_to_addr_) {
-            void* gm_addr = reinterpret_cast<void*>(pair.second);
+        for (const auto &pair : func_id_to_addr_) {
+            void *gm_addr = reinterpret_cast<void *>(pair.second);
             mem_alloc_.free(gm_addr);
             LOG_DEBUG("Freed leaked kernel binary: func_id=%d, addr=0x%lx", pair.first, pair.second);
         }
@@ -561,7 +566,7 @@ int DeviceRunner::finalize() {
 
     // Cleanup performance profiling
     if (perf_collector_.is_initialized()) {
-        auto unregister_cb = [](void* dev_ptr, int device_id, void* user_data) -> int {
+        auto unregister_cb = [](void *dev_ptr, int device_id, void *user_data) -> int {
             (void)user_data;
             HalHostUnregisterFn fn = get_halHostUnregister();
             if (fn != nullptr) {
@@ -570,8 +575,8 @@ int DeviceRunner::finalize() {
             return 0;
         };
 
-        auto free_cb = [](void* dev_ptr, void* user_data) -> int {
-            auto* allocator = static_cast<MemoryAllocator*>(user_data);
+        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+            auto *allocator = static_cast<MemoryAllocator *>(user_data);
             return allocator->free(dev_ptr);
         };
 
@@ -589,7 +594,7 @@ int DeviceRunner::finalize() {
     return 0;
 }
 
-int DeviceRunner::launch_aicpu_kernel(rtStream_t stream, KernelArgs* k_args, const char* kernel_name, int aicpu_num) {
+int DeviceRunner::launch_aicpu_kernel(rtStream_t stream, KernelArgs *k_args, const char *kernel_name, int aicpu_num) {
     struct Args {
         KernelArgs k_args;
         char kernel_name[32];
@@ -609,17 +614,18 @@ int DeviceRunner::launch_aicpu_kernel(rtStream_t stream, KernelArgs* k_args, con
     rt_args.soNameAddrOffset = offsetof(struct Args, so_name);
 
     return rtAicpuKernelLaunchExWithArgs(
-        rtKernelType_t::KERNEL_TYPE_AICPU_KFC, "AST_DYN_AICPU", aicpu_num, &rt_args, nullptr, stream, 0);
+        rtKernelType_t::KERNEL_TYPE_AICPU_KFC, "AST_DYN_AICPU", aicpu_num, &rt_args, nullptr, stream, 0
+    );
 }
 
-int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime* runtime) {
+int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime *runtime) {
     if (aicore_kernel_binary_.empty()) {
         LOG_ERROR("AICore kernel binary is empty");
         return -1;
     }
 
     size_t bin_size = aicore_kernel_binary_.size();
-    const void* bin_data = aicore_kernel_binary_.data();
+    const void *bin_data = aicore_kernel_binary_.data();
 
     rtDevBinary_t binary;
     std::memset(&binary, 0, sizeof(binary));
@@ -627,7 +633,7 @@ int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime* runtime) {
     binary.version = 0;
     binary.data = bin_data;
     binary.length = bin_size;
-    void* bin_handle = nullptr;
+    void *bin_handle = nullptr;
     int rc = rtRegisterAllKernel(&binary, &bin_handle);
     if (rc != RT_ERROR_NONE) {
         LOG_ERROR("rtRegisterAllKernel failed: %d", rc);
@@ -635,7 +641,7 @@ int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime* runtime) {
     }
 
     struct Args {
-        Runtime* runtime;
+        Runtime *runtime;
     };
     // Pass device address of Runtime to AICore
     Args args = {runtime};
@@ -660,7 +666,7 @@ int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime* runtime) {
 // Kernel Binary Upload (returns device address for caller to store in Runtime)
 // =============================================================================
 
-uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data, size_t bin_size) {
+uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size) {
     if (bin_data == nullptr || bin_size == 0) {
         LOG_ERROR("Invalid kernel binary data");
         return 0;
@@ -682,7 +688,7 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     LOG_DEBUG("Uploading kernel binary: func_id=%d, size=%zu bytes", func_id, bin_size);
 
     // Allocate device GM memory for kernel binary
-    void* gm_addr = mem_alloc_.alloc(bin_size);
+    void *gm_addr = mem_alloc_.alloc(bin_size);
     if (gm_addr == nullptr) {
         LOG_ERROR("Failed to allocate device GM memory for kernel func_id=%d", func_id);
         return 0;
@@ -694,7 +700,7 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     assert((callable_addr & (CALLABLE_ALIGN - 1)) == 0 && "device alloc must be CALLABLE_ALIGN-byte aligned");
     uint64_t binary_code_addr = callable_addr + CoreCallable::binary_data_offset();
     // Write resolved_addr_ into the host-side buffer (the field lives at a fixed offset)
-    CoreCallable* host_callable = reinterpret_cast<CoreCallable*>(const_cast<uint8_t*>(bin_data));
+    CoreCallable *host_callable = reinterpret_cast<CoreCallable *>(const_cast<uint8_t *>(bin_data));
     host_callable->set_resolved_addr(binary_code_addr);
 
     // Copy the full CoreCallable (header + binary) to device
@@ -719,7 +725,7 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
     }
 
     uint64_t function_bin_addr = it->second;
-    void* gm_addr = reinterpret_cast<void*>(function_bin_addr);
+    void *gm_addr = reinterpret_cast<void *>(function_bin_addr);
 
     mem_alloc_.free(gm_addr);
     func_id_to_addr_.erase(it);
@@ -727,15 +733,15 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
     LOG_DEBUG("Removed kernel binary: func_id=%d, addr=0x%lx", func_id, function_bin_addr);
 }
 
-int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, int device_id) {
+int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, int device_id) {
     // Define allocation callback (a2a3: use MemoryAllocator)
-    auto alloc_cb = [](size_t size, void* user_data) -> void* {
-        auto* allocator = static_cast<MemoryAllocator*>(user_data);
+    auto alloc_cb = [](size_t size, void *user_data) -> void * {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
         return allocator->alloc(size);
     };
 
     // Define registration callback (a2a3: use halHostRegister for shared memory)
-    auto register_cb = [](void* dev_ptr, size_t size, int device_id, void* user_data, void** host_ptr) -> int {
+    auto register_cb = [](void *dev_ptr, size_t size, int device_id, void *user_data, void **host_ptr) -> int {
         (void)user_data;  // Not needed for registration
         if (load_hal_if_needed() != 0) {
             LOG_ERROR("Failed to load ascend_hal for profiling: %s", dlerror());
@@ -749,21 +755,24 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
 
-    auto free_cb = [](void* dev_ptr, void* user_data) -> int {
-        auto* allocator = static_cast<MemoryAllocator*>(user_data);
+    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
         return allocator->free(dev_ptr);
     };
 
-    auto set_device_cb = [](int device_id, void* /*user_data*/) -> int { return rtSetDevice(device_id); };
+    auto set_device_cb = [](int device_id, void * /*user_data*/) -> int {
+        return rtSetDevice(device_id);
+    };
 
     return perf_collector_.initialize(
-        runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_, set_device_cb);
+        runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_, set_device_cb
+    );
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
     perf_collector_.poll_and_collect(expected_tasks);
 }
 
-int DeviceRunner::export_swimlane_json(const std::string& output_path) {
+int DeviceRunner::export_swimlane_json(const std::string &output_path) {
     return perf_collector_.export_swimlane_json(output_path);
 }

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Device Runner - Ascend Device Execution Utilities
  *
@@ -59,7 +69,7 @@ struct DeviceArgs {
  */
 struct KernelArgsHelper {
     KernelArgs args;
-    MemoryAllocator* allocator_{nullptr};
+    MemoryAllocator *allocator_{nullptr};
 
     /**
      * Initialize device arguments by allocating device memory and copying data
@@ -68,7 +78,7 @@ struct KernelArgsHelper {
      * @param allocator       Memory allocator to use
      * @return 0 on success, error code on failure
      */
-    int init_device_args(const DeviceArgs& host_device_args, MemoryAllocator& allocator);
+    int init_device_args(const DeviceArgs &host_device_args, MemoryAllocator &allocator);
 
     /**
      * Free device memory allocated for device arguments
@@ -84,7 +94,7 @@ struct KernelArgsHelper {
      * @param allocator  Memory allocator to use
      * @return 0 on success, error code on failure
      */
-    int init_runtime_args(const Runtime& host_runtime, MemoryAllocator& allocator);
+    int init_runtime_args(const Runtime &host_runtime, MemoryAllocator &allocator);
 
     /**
      * Free device memory allocated for runtime arguments
@@ -100,8 +110,8 @@ struct KernelArgsHelper {
      * is expected, enabling transparent device memory management while
      * maintaining API compatibility.
      */
-    operator KernelArgs*() { return &args; }
-    KernelArgs* operator&() { return &args; }
+    operator KernelArgs *() { return &args; }
+    KernelArgs *operator&() { return &args; }
 };
 
 /**
@@ -113,7 +123,7 @@ struct KernelArgsHelper {
 struct AicpuSoInfo {
     uint64_t aicpu_so_bin{0};
     uint64_t aicpu_so_len{0};
-    MemoryAllocator* allocator_{nullptr};
+    MemoryAllocator *allocator_{nullptr};
 
     /**
      * Load shared object binary data and copy to device memory
@@ -122,7 +132,7 @@ struct AicpuSoInfo {
      * @param allocator      Memory allocator to use
      * @return 0 on success, error code on failure
      */
-    int init(const std::vector<uint8_t>& aicpu_so_binary, MemoryAllocator& allocator);
+    int init(const std::vector<uint8_t> &aicpu_so_binary, MemoryAllocator &allocator);
 
     /**
      * Free device memory allocated for shared object
@@ -151,7 +161,7 @@ public:
      *
      * @return Reference to the singleton DeviceRunner instance
      */
-    static DeviceRunner& get();
+    static DeviceRunner &get();
 
     /**
      * Allocate device tensor memory
@@ -159,14 +169,14 @@ public:
      * @param bytes  Size of tensor in bytes
      * @return Device pointer on success, nullptr on failure
      */
-    void* allocate_tensor(size_t bytes);
+    void *allocate_tensor(size_t bytes);
 
     /**
      * Free device tensor memory
      *
      * @param dev_ptr  Device pointer to free
      */
-    void free_tensor(void* dev_ptr);
+    void free_tensor(void *dev_ptr);
 
     /**
      * Copy data from host to device
@@ -176,7 +186,7 @@ public:
      * @param bytes    Number of bytes to copy
      * @return 0 on success, error code on failure
      */
-    int copy_to_device(void* dev_ptr, const void* host_ptr, size_t bytes);
+    int copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes);
 
     /**
      * Copy data from device to host
@@ -186,7 +196,7 @@ public:
      * @param bytes    Number of bytes to copy
      * @return 0 on success, error code on failure
      */
-    int copy_from_device(void* host_ptr, const void* dev_ptr, size_t bytes);
+    int copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes);
 
     /**
      * Execute a runtime
@@ -210,12 +220,9 @@ public:
      * @param launch_aicpu_num      Number of AICPU instances (default: 1)
      * @return 0 on success, error code on failure
      */
-    int run(Runtime& runtime,
-        int block_dim,
-        int device_id,
-        const std::vector<uint8_t>& aicpu_so_binary,
-        const std::vector<uint8_t>& aicore_kernel_binary,
-        int launch_aicpu_num = 1);
+    int
+    run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
 
     /**
      * Print handshake results from device
@@ -246,7 +253,7 @@ public:
      * @param output_path Path to output directory (default: "outputs")
      * @return 0 on success, error code on failure
      */
-    int export_swimlane_json(const std::string& output_path = "outputs");
+    int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
      * Cleanup all resources
@@ -270,7 +277,7 @@ public:
      * @param aicpu_num    Number of AICPU instances to launch
      * @return 0 on success, error code on failure
      */
-    int launch_aicpu_kernel(rtStream_t stream, KernelArgs* k_args, const char* kernel_name, int aicpu_num);
+    int launch_aicpu_kernel(rtStream_t stream, KernelArgs *k_args, const char *kernel_name, int aicpu_num);
 
     /**
      * Launch an AICore kernel
@@ -282,7 +289,7 @@ public:
      * @param runtime   Pointer to device runtime
      * @return 0 on success, error code on failure
      */
-    int launch_aicore_kernel(rtStream_t stream, Runtime* runtime);
+    int launch_aicore_kernel(rtStream_t stream, Runtime *runtime);
 
     /**
      * Upload a kernel binary to device memory
@@ -303,7 +310,7 @@ public:
      * @param bin_size  Size of binary data in bytes
      * @return Device GM address of kernel on success, 0 on error
      */
-    uint64_t upload_kernel_binary(int func_id, const uint8_t* bin_data, size_t bin_size);
+    uint64_t upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size);
 
     /**
      * Remove a kernel binary from device memory
@@ -350,7 +357,7 @@ private:
     DeviceArgs device_args_;
 
     // Kernel binary management
-    bool binaries_loaded_{false};            // true after AICPU SO loaded
+    bool binaries_loaded_{false};              // true after AICPU SO loaded
     std::map<int, uint64_t> func_id_to_addr_;  // func_id -> function_bin_addr (device GM)
 
     // Performance profiling
@@ -370,9 +377,9 @@ private:
      * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int ensure_device_initialized(int device_id,
-                                const std::vector<uint8_t>& aicpu_so_binary,
-                                const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_device_initialized(
+        int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+    );
 
     /**
      * Load AICPU SO and initialize device args
@@ -385,7 +392,9 @@ private:
      * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_binaries_loaded(
+        const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+    );
 
     /**
      * Initialize performance profiling shared memory
@@ -398,7 +407,7 @@ private:
      * @param device_id Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_performance_profiling(Runtime& runtime, int num_aicore, int device_id);
+    int init_performance_profiling(Runtime &runtime, int num_aicore, int device_id);
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a2a3/platform/onboard/host/host_regs.cpp
+++ b/src/a2a3/platform/onboard/host/host_regs.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file host_regs.cpp
  * @brief Host-side AICore register address retrieval implementation
@@ -15,24 +25,22 @@
 /**
  * Query valid AICore cores via HAL API
  */
-static bool get_pg_mask(uint64_t& valid, int64_t device_id) {
+static bool get_pg_mask(uint64_t &valid, int64_t device_id) {
     uint64_t aicore_bitmap[PLATFORM_AICORE_MAP_BUFF_LEN] = {0};
     int32_t size_n = static_cast<int32_t>(sizeof(uint64_t)) * PLATFORM_AICORE_MAP_BUFF_LEN;
 
-    auto halFuncDevInfo =
-        (int (*)(uint64_t deviceId, int32_t moduleType, int32_t infoType, void* buf, int32_t* size))dlsym(
-            nullptr, "halGetDeviceInfoByBuff");
+    auto halFuncDevInfo = (int (*)(uint64_t deviceId, int32_t moduleType, int32_t infoType, void *buf, int32_t *size))
+        dlsym(nullptr, "halGetDeviceInfoByBuff");
 
     if (halFuncDevInfo == nullptr) {
         LOG_WARN("halGetDeviceInfoByBuff not found, assuming all cores valid");
         return false;
     }
 
-    auto ret = halFuncDevInfo(static_cast<uint32_t>(device_id),
-        MODULE_TYPE_AICORE,
-        INFO_TYPE_OCCUPY,
-        reinterpret_cast<void*>(&aicore_bitmap[0]),
-        &size_n);
+    auto ret = halFuncDevInfo(
+        static_cast<uint32_t>(device_id), MODULE_TYPE_AICORE, INFO_TYPE_OCCUPY,
+        reinterpret_cast<void *>(&aicore_bitmap[0]), &size_n
+    );
 
     if (ret != 0) {
         LOG_ERROR("halGetDeviceInfoByBuff failed with rc=%d", ret);
@@ -46,8 +54,8 @@ static bool get_pg_mask(uint64_t& valid, int64_t device_id) {
 /**
  * Retrieve AICore register base addresses via HAL API
  */
-static int get_aicore_reg_info(std::vector<int64_t>& aic, std::vector<int64_t>& aiv,
-                           const int& addr_type, int64_t device_id) {
+static int
+get_aicore_reg_info(std::vector<int64_t> &aic, std::vector<int64_t> &aiv, const int &addr_type, int64_t device_id) {
     uint64_t valid = 0;
     if (!get_pg_mask(valid, device_id)) {
         // If can't get mask, assume all cores valid
@@ -62,9 +70,8 @@ static int get_aicore_reg_info(std::vector<int64_t>& aic, std::vector<int64_t>& 
         return (valid & (1ULL << id)) != 0;
     };
 
-    auto halFunc =
-        (int (*)(int type, void* paramValue, size_t paramValueSize, void* outValue, size_t* outSizeRet))dlsym(
-            nullptr, "halMemCtl");
+    auto halFunc = (int (*)(int type, void *paramValue, size_t paramValueSize, void *outValue, size_t *outSizeRet))
+        dlsym(nullptr, "halMemCtl");
 
     if (halFunc == nullptr) {
         LOG_ERROR("halMemCtl not found in symbol table");
@@ -76,11 +83,10 @@ static int get_aicore_reg_info(std::vector<int64_t>& aic, std::vector<int64_t>& 
     in_map_para.devid = device_id;
     in_map_para.addr_type = addr_type;
 
-    auto ret = halFunc(0,
-        reinterpret_cast<void*>(&in_map_para),
-        sizeof(struct AddrMapInPara),
-        reinterpret_cast<void*>(&out_map_para),
-        nullptr);
+    auto ret = halFunc(
+        0, reinterpret_cast<void *>(&in_map_para), sizeof(struct AddrMapInPara),
+        reinterpret_cast<void *>(&out_map_para), nullptr
+    );
 
     if (ret != 0) {
         LOG_ERROR("halMemCtl failed with rc=%d", ret);
@@ -107,7 +113,7 @@ static int get_aicore_reg_info(std::vector<int64_t>& aic, std::vector<int64_t>& 
     return 0;
 }
 
-static void get_aicore_regs(std::vector<int64_t>& regs, uint64_t device_id) {
+static void get_aicore_regs(std::vector<int64_t> &regs, uint64_t device_id) {
     std::vector<int64_t> aiv;
     std::vector<int64_t> aic;
 
@@ -127,15 +133,10 @@ static void get_aicore_regs(std::vector<int64_t>& regs, uint64_t device_id) {
     regs.insert(regs.end(), aic.begin(), aic.end());
     regs.insert(regs.end(), aiv.begin(), aiv.end());
 
-    LOG_INFO("get_aicore_regs: Retrieved %zu AIC and %zu AIV register addresses",
-             aic.size(), aiv.size());
+    LOG_INFO("get_aicore_regs: Retrieved %zu AIC and %zu AIV register addresses", aic.size(), aiv.size());
 }
 
-int init_aicore_register_addresses(
-    uint64_t* runtime_regs_ptr,
-    uint64_t device_id,
-    MemoryAllocator& allocator) {
-
+int init_aicore_register_addresses(uint64_t *runtime_regs_ptr, uint64_t device_id, MemoryAllocator &allocator) {
     if (runtime_regs_ptr == nullptr) {
         LOG_ERROR("init_aicore_register_addresses: Invalid parameters");
         return -1;
@@ -154,7 +155,7 @@ int init_aicore_register_addresses(
 
     // Step 2: Allocate device memory for register address array
     size_t regs_size = host_regs.size() * sizeof(int64_t);
-    void* reg_ptr = allocator.alloc(regs_size);
+    void *reg_ptr = allocator.alloc(regs_size);
     if (reg_ptr == nullptr) {
         LOG_ERROR("Failed to allocate device memory for register addresses");
         return -1;
@@ -171,8 +172,10 @@ int init_aicore_register_addresses(
     // Step 4: Store device pointer in output regs field
     *runtime_regs_ptr = reinterpret_cast<uint64_t>(reg_ptr);
 
-    LOG_INFO("Successfully initialized register addresses: %zu addresses at device 0x%llx",
-             host_regs.size(), *runtime_regs_ptr);
+    LOG_INFO(
+        "Successfully initialized register addresses: %zu addresses at device 0x%llx", host_regs.size(),
+        *runtime_regs_ptr
+    );
 
     return 0;
 }

--- a/src/a2a3/platform/onboard/host/memory_allocator.cpp
+++ b/src/a2a3/platform/onboard/host/memory_allocator.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Memory Allocator Implementation
  *
@@ -13,8 +23,8 @@
 
 MemoryAllocator::~MemoryAllocator() { finalize(); }
 
-void* MemoryAllocator::alloc(size_t size) {
-    void* ptr = nullptr;
+void *MemoryAllocator::alloc(size_t size) {
+    void *ptr = nullptr;
     int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
     if (rc != 0) {
         LOG_ERROR("rtMalloc failed: %d (size=%zu)", rc, size);
@@ -26,7 +36,7 @@ void* MemoryAllocator::alloc(size_t size) {
     return ptr;
 }
 
-int MemoryAllocator::free(void* ptr) {
+int MemoryAllocator::free(void *ptr) {
     if (ptr == nullptr) {
         return 0;
     }
@@ -59,7 +69,7 @@ int MemoryAllocator::finalize() {
     int last_error = 0;
 
     // Free all remaining tracked pointers
-    for (void* ptr : ptr_set_) {
+    for (void *ptr : ptr_set_) {
         int rc = rtFree(ptr);
         if (rc != 0) {
             LOG_ERROR("rtFree failed during Finalize: %d", rc);

--- a/src/a2a3/platform/onboard/host/platform_compile_info.cpp
+++ b/src/a2a3/platform/onboard/host/platform_compile_info.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "host/platform_compile_info.h"
 
-extern "C" const char* get_platform(void) { return "a2a3"; }
+extern "C" const char *get_platform(void) { return "a2a3"; }

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -30,15 +30,15 @@ extern "C" {
 /* Runtime Implementation Functions (defined in runtimemaker.cpp) */
 /* ===========================================================================
  */
-int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args);
-int validate_runtime_impl(Runtime* runtime);
+int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args);
+int validate_runtime_impl(Runtime *runtime);
 
 /* Forward declarations for device memory functions used in init_runtime */
-void* device_malloc(size_t size);
-void device_free(void* dev_ptr);
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
+void *device_malloc(size_t size);
+void device_free(void *dev_ptr);
+int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size);
+int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size);
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size);
 void remove_kernel_binary_wrapper(int func_id);
 
 /* ===========================================================================
@@ -49,7 +49,7 @@ void remove_kernel_binary_wrapper(int func_id);
 
 size_t get_runtime_size(void) { return sizeof(Runtime); }
 
-int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args) {
+int init_runtime(RuntimeHandle runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args) {
     if (runtime == NULL) {
         return -1;
     }
@@ -58,7 +58,7 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
 
     try {
         // Placement new to construct Runtime in user-allocated memory
-        Runtime* r = new (runtime) Runtime();
+        Runtime *r = new (runtime) Runtime();
 
         // Initialize host API function pointers (host-only, not available on device)
         r->host_api.device_malloc = device_malloc;
@@ -68,7 +68,7 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
         r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
         r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
 
-        LOG_DEBUG("About to call init_runtime_impl, r=%p", (void*)r);
+        LOG_DEBUG("About to call init_runtime_impl, r=%p", (void *)r);
 
         // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
         int result = init_runtime_impl(r, callable, orch_args);
@@ -96,54 +96,54 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
 /* ===========================================================================
  */
 
-void* device_malloc(size_t size) {
+void *device_malloc(size_t size) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.allocate_tensor(size);
     } catch (...) {
         return NULL;
     }
 }
 
-void device_free(void* dev_ptr) {
+void device_free(void *dev_ptr) {
     if (dev_ptr == NULL) {
         return;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         runner.free_tensor(dev_ptr);
     } catch (...) {
         // Ignore errors during free
     }
 }
 
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size) {
+int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size) {
     if (dev_ptr == NULL || host_ptr == NULL) {
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.copy_to_device(dev_ptr, host_ptr, size);
     } catch (...) {
         return -1;
     }
 }
 
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size) {
+int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     if (host_ptr == NULL || dev_ptr == NULL) {
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.copy_from_device(host_ptr, dev_ptr, size);
     } catch (...) {
         return -1;
     }
 }
 
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size) {
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.upload_kernel_binary(func_id, bin_data, bin_size);
     } catch (...) {
         return 0;
@@ -152,22 +152,17 @@ uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size
 
 void remove_kernel_binary_wrapper(int func_id) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         runner.remove_kernel_binary(func_id);
     } catch (...) {
         // Ignore errors during cleanup
     }
 }
 
-int launch_runtime(RuntimeHandle runtime,
-    int aicpu_thread_num,
-    int block_dim,
-    int device_id,
-    const uint8_t* aicpu_binary,
-    size_t aicpu_size,
-    const uint8_t* aicore_binary,
-    size_t aicore_size,
-    int orch_thread_num) {
+int launch_runtime(
+    RuntimeHandle runtime, int aicpu_thread_num, int block_dim, int device_id, const uint8_t *aicpu_binary,
+    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size, int orch_thread_num
+) {
     if (runtime == NULL) {
         return -1;
     }
@@ -175,14 +170,14 @@ int launch_runtime(RuntimeHandle runtime,
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
 
         // Convert to vectors for run()
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
 
         // Run the runtime (device initialization is handled internally)
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         r->orch_thread_num = orch_thread_num;
         return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
@@ -195,7 +190,7 @@ int finalize_runtime(RuntimeHandle runtime) {
         return -1;
     }
     try {
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         int rc = validate_runtime_impl(r);
 
         // Call destructor (user will call free())
@@ -208,7 +203,7 @@ int finalize_runtime(RuntimeHandle runtime) {
 
 int set_device(int device_id) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.ensure_device_set(device_id);
     } catch (...) {
         return -1;
@@ -220,11 +215,11 @@ int set_device(int device_id) {
  * registration and stores addresses in Runtime's func_id_to_addr_[] array.
  */
 
-void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size) {
+void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, size_t size) {
     if (runtime == NULL) {
         return;
     }
-    Runtime* r = static_cast<Runtime*>(runtime);
+    Runtime *r = static_cast<Runtime *>(runtime);
     r->record_tensor_pair(host_ptr, dev_ptr, size);
 }
 
@@ -233,7 +228,7 @@ int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
         return -1;
     }
     try {
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         r->enable_profiling = (enabled != 0);
         return 0;
     } catch (...) {

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -142,7 +142,7 @@ inline uint64_t get_sys_cnt_aicore() {
  * Set by the kernel wrapper before calling aicore_execute().
  * Points to a SIM_REG_BLOCK_SIZE-byte block allocated by DeviceRunner.
  */
-extern thread_local volatile uint8_t* g_sim_reg_base;
+extern thread_local volatile uint8_t *g_sim_reg_base;
 
 /**
  * Per-thread simulated physical core ID.
@@ -158,7 +158,7 @@ extern thread_local uint32_t g_sim_physical_core_id;
  */
 inline uint64_t read_reg(RegId reg) {
     uint32_t offset = reg_offset(reg);
-    uint64_t val = static_cast<uint64_t>(*reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset));
+    uint64_t val = static_cast<uint64_t>(*reinterpret_cast<volatile uint32_t *>(g_sim_reg_base + offset));
     OUT_OF_ORDER_LOAD_BARRIER();
     return val;
 }
@@ -171,7 +171,7 @@ inline uint64_t read_reg(RegId reg) {
  */
 inline void write_reg(RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
-    *reinterpret_cast<volatile uint32_t*>(g_sim_reg_base + offset) = static_cast<uint32_t>(value);
+    *reinterpret_cast<volatile uint32_t *>(g_sim_reg_base + offset) = static_cast<uint32_t>(value);
     OUT_OF_ORDER_STORE_BARRIER();
 }
 

--- a/src/a2a3/platform/sim/aicore/kernel.cpp
+++ b/src/a2a3/platform/sim/aicore/kernel.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * AICore Kernel Wrapper for Simulation
  *
@@ -12,23 +22,25 @@
 #include "runtime.h"
 
 // Thread-local simulated register base (declared in inner_kernel.h)
-thread_local volatile uint8_t* g_sim_reg_base = nullptr;
+thread_local volatile uint8_t *g_sim_reg_base = nullptr;
 
 // Thread-local simulated physical core ID (declared in inner_kernel.h)
 thread_local uint32_t g_sim_physical_core_id = 0;
 
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
-void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
+void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type);
 
 // Wrapper with extern "C" for dlsym lookup
 // NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
-extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs) {
+extern "C" void aicore_execute_wrapper(
+    __gm__ Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs
+) {
     // Set up simulated register base for this thread.
     // regs points to an array of uint64_t base addresses (one per core).
     // physical_core_id indexes into it to get this core's register block.
     if (regs != 0) {
-        uint64_t* regs_array = reinterpret_cast<uint64_t*>(regs);
-        g_sim_reg_base = reinterpret_cast<volatile uint8_t*>(regs_array[physical_core_id]);
+        uint64_t *regs_array = reinterpret_cast<uint64_t *>(regs);
+        g_sim_reg_base = reinterpret_cast<volatile uint8_t *>(regs_array[physical_core_id]);
     }
 
     g_sim_physical_core_id = physical_core_id;

--- a/src/a2a3/platform/sim/aicpu/cache_ops.cpp
+++ b/src/a2a3/platform/sim/aicpu/cache_ops.cpp
@@ -1,7 +1,17 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstddef>
 
 #include "aicpu/platform_regs.h"
 
-void cache_invalidate_range(const void* /* addr */, size_t /* size */) {
+void cache_invalidate_range(const void * /* addr */, size_t /* size */) {
     // No-op on simulation: no hardware cache to invalidate
 }

--- a/src/a2a3/platform/sim/aicpu/device_log.cpp
+++ b/src/a2a3/platform/sim/aicpu/device_log.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file device_log.cpp
  * @brief Simulation Platform Log Implementation
@@ -26,7 +36,7 @@ bool g_is_log_enable_error = true;
 // Platform Constant
 // =============================================================================
 
-const char* TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
+const char *TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
 
 // =============================================================================
 // Log Initialization (Read from PTO_LOG_LEVEL environment variable)
@@ -34,18 +44,18 @@ const char* TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
 
 void init_log_switch() {
     // Read PTO_LOG_LEVEL environment variable
-    const char* level_str = std::getenv("PTO_LOG_LEVEL");
-    
+    const char *level_str = std::getenv("PTO_LOG_LEVEL");
+
     if (level_str != nullptr) {
         // Convert to lowercase for comparison
         char level[64];
         strncpy(level, level_str, sizeof(level) - 1);
         level[sizeof(level) - 1] = '\0';
-        
-        for (char* p = level; *p; ++p) {
+
+        for (char *p = level; *p; ++p) {
             *p = tolower(*p);
         }
-        
+
         // Parse log level
         if (strcmp(level, "silent") == 0 || strcmp(level, "error") == 0) {
             // Silent/Error: only errors
@@ -85,7 +95,7 @@ void init_log_switch() {
 // Platform-Specific Logging Functions (Simulation: use printf)
 // =============================================================================
 
-void dev_log_debug(const char* func, const char* fmt, ...) {
+void dev_log_debug(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     printf("[DEBUG] %s: ", func);
@@ -94,7 +104,7 @@ void dev_log_debug(const char* func, const char* fmt, ...) {
     va_end(args);
 }
 
-void dev_log_info(const char* func, const char* fmt, ...) {
+void dev_log_info(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     printf("[INFO] %s: ", func);
@@ -103,7 +113,7 @@ void dev_log_info(const char* func, const char* fmt, ...) {
     va_end(args);
 }
 
-void dev_log_warn(const char* func, const char* fmt, ...) {
+void dev_log_warn(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     printf("[WARN] %s: ", func);
@@ -112,7 +122,7 @@ void dev_log_warn(const char* func, const char* fmt, ...) {
     va_end(args);
 }
 
-void dev_log_error(const char* func, const char* fmt, ...) {
+void dev_log_error(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     printf("[ERROR] %s: ", func);
@@ -121,7 +131,7 @@ void dev_log_error(const char* func, const char* fmt, ...) {
     va_end(args);
 }
 
-void dev_log_always(const char* func, const char* fmt, ...) {
+void dev_log_always(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     printf("[ALWAYS] %s: ", func);

--- a/src/a2a3/platform/sim/aicpu/device_malloc.cpp
+++ b/src/a2a3/platform/sim/aicpu/device_malloc.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file device_malloc.cpp
  * @brief Device Memory Allocation for Simulation (a2a3sim)
@@ -10,10 +20,6 @@
 
 #include <cstdlib>
 
-void* aicpu_device_malloc(size_t size) {
-    return malloc(size);
-}
+void *aicpu_device_malloc(size_t size) { return malloc(size); }
 
-void aicpu_device_free(void* ptr) {
-    free(ptr);
-}
+void aicpu_device_free(void *ptr) { free(ptr); }

--- a/src/a2a3/platform/sim/aicpu/device_time.cpp
+++ b/src/a2a3/platform/sim/aicpu/device_time.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "aicpu/device_time.h"
 
 #include <chrono>
@@ -6,13 +16,10 @@
 
 uint64_t get_sys_cnt_aicpu() {
     auto now = std::chrono::high_resolution_clock::now();
-    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        now.time_since_epoch()
-    ).count();
+    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
     constexpr uint64_t kNsPerSec = std::nano::den;
     uint64_t seconds = elapsed_ns / kNsPerSec;
     uint64_t remaining_ns = elapsed_ns % kNsPerSec;
-    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ +
-                     (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
+    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
     return ticks;
 }

--- a/src/a2a3/platform/sim/aicpu/platform_aicpu_affinity.cpp
+++ b/src/a2a3/platform/sim/aicpu/platform_aicpu_affinity.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "aicpu/platform_aicpu_affinity.h"
 
 #include <atomic>
@@ -17,8 +27,10 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
     bool survive = (idx < logical_count);
 
     if (!survive) {
-        LOG_INFO("AICPU affinity gate (sim): thread idx=%d DROPPED (logical=%d, launched=%d)",
-                 idx, logical_count, total_launched);
+        LOG_INFO(
+            "AICPU affinity gate (sim): thread idx=%d DROPPED (logical=%d, launched=%d)", idx, logical_count,
+            total_launched
+        );
     }
 
     // Last thread resets state for next invocation

--- a/src/a2a3/platform/sim/aicpu/spin_hint.h
+++ b/src/a2a3/platform/sim/aicpu/spin_hint.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file spin_hint.h
  * @brief Platform-specific spin-wait hint for AICPU (simulation)
@@ -19,9 +29,17 @@
 #include <sched.h>
 
 #if defined(__aarch64__)
-#define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()                        \
+    do {                                        \
+        __asm__ volatile("yield" ::: "memory"); \
+        sched_yield();                          \
+    } while (0)
 #elif defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()        \
+    do {                        \
+        __builtin_ia32_pause(); \
+        sched_yield();          \
+    } while (0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -35,16 +35,17 @@
 #include "host/raii_scope_guard.h"
 
 // Function pointer types for dynamically loaded executors
-typedef int (*aicpu_execute_func_t)(Runtime* runtime);
+typedef int (*aicpu_execute_func_t)(Runtime *runtime);
 typedef void (*aicore_execute_func_t)(
-    Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs);
+    Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs
+);
 typedef void (*set_platform_regs_func_t)(uint64_t regs);
 
 // =============================================================================
 // DeviceRunner Implementation
 // =============================================================================
 
-DeviceRunner& DeviceRunner::get() {
+DeviceRunner &DeviceRunner::get() {
     static DeviceRunner runner;
     return runner;
 }
@@ -52,13 +53,15 @@ DeviceRunner& DeviceRunner::get() {
 DeviceRunner::~DeviceRunner() { finalize(); }
 
 int DeviceRunner::ensure_device_initialized(
-    int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
+    int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+) {
     device_id_ = device_id;
     return ensure_binaries_loaded(aicpu_so_binary, aicore_kernel_binary);
 }
 
 int DeviceRunner::ensure_binaries_loaded(
-    const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
+    const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+) {
     // Close any previously loaded binaries before reloading
     unload_executor_binaries();
 
@@ -70,7 +73,7 @@ int DeviceRunner::ensure_binaries_loaded(
             LOG_ERROR("Failed to create temp file for AICPU SO: %s", aicpu_so_path_.c_str());
             return -1;
         }
-        ofs.write(reinterpret_cast<const char*>(aicpu_so_binary.data()), aicpu_so_binary.size());
+        ofs.write(reinterpret_cast<const char *>(aicpu_so_binary.data()), aicpu_so_binary.size());
         ofs.close();
 
         aicpu_so_handle_ = dlopen(aicpu_so_path_.c_str(), RTLD_NOW | RTLD_GLOBAL);
@@ -79,7 +82,7 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
-        aicpu_execute_func_ = reinterpret_cast<int (*)(Runtime*)>(dlsym(aicpu_so_handle_, "aicpu_execute"));
+        aicpu_execute_func_ = reinterpret_cast<int (*)(Runtime *)>(dlsym(aicpu_so_handle_, "aicpu_execute"));
         if (aicpu_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicpu_execute: %s", dlerror());
             return -1;
@@ -102,7 +105,7 @@ int DeviceRunner::ensure_binaries_loaded(
             LOG_ERROR("Failed to create temp file for AICore SO: %s", aicore_so_path_.c_str());
             return -1;
         }
-        ofs.write(reinterpret_cast<const char*>(aicore_kernel_binary.data()), aicore_kernel_binary.size());
+        ofs.write(reinterpret_cast<const char *>(aicore_kernel_binary.data()), aicore_kernel_binary.size());
         ofs.close();
 
         aicore_so_handle_ = dlopen(aicore_so_path_.c_str(), RTLD_NOW | RTLD_GLOBAL);
@@ -111,8 +114,9 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
-        aicore_execute_func_ = reinterpret_cast<void (*)(Runtime*, int, CoreType, uint32_t, uint64_t)>(
-            dlsym(aicore_so_handle_, "aicore_execute_wrapper"));
+        aicore_execute_func_ = reinterpret_cast<void (*)(Runtime *, int, CoreType, uint32_t, uint64_t)>(
+            dlsym(aicore_so_handle_, "aicore_execute_wrapper")
+        );
         if (aicore_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicore_execute_wrapper: %s", dlerror());
             return -1;
@@ -123,32 +127,30 @@ int DeviceRunner::ensure_binaries_loaded(
     return 0;
 }
 
-void* DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
+void *DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
 
-void DeviceRunner::free_tensor(void* dev_ptr) {
+void DeviceRunner::free_tensor(void *dev_ptr) {
     if (dev_ptr != nullptr) {
         mem_alloc_.free(dev_ptr);
     }
 }
 
-int DeviceRunner::copy_to_device(void* dev_ptr, const void* host_ptr, size_t bytes) {
+int DeviceRunner::copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes) {
     // In simulation, this is just a memcpy
     std::memcpy(dev_ptr, host_ptr, bytes);
     return 0;
 }
 
-int DeviceRunner::copy_from_device(void* host_ptr, const void* dev_ptr, size_t bytes) {
+int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes) {
     // In simulation, this is just a memcpy
     std::memcpy(host_ptr, dev_ptr, bytes);
     return 0;
 }
 
-int DeviceRunner::run(Runtime& runtime,
-    int block_dim,
-    int device_id,
-    const std::vector<uint8_t>& aicpu_so_binary,
-    const std::vector<uint8_t>& aicore_kernel_binary,
-    int launch_aicpu_num) {
+int DeviceRunner::run(
+    Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
+) {
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -166,7 +168,8 @@ int DeviceRunner::run(Runtime& runtime,
 
     if (runtime.orch_thread_num > launch_aicpu_num) {
         LOG_ERROR(
-            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num);
+            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num
+        );
         return -1;
     }
 
@@ -174,19 +177,21 @@ int DeviceRunner::run(Runtime& runtime,
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
             LOG_ERROR(
-                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num);
+                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num
+            );
             return -1;
         }
     } else {
         LOG_INFO(
-            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num);
+            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num
+        );
         // Post-transition: all threads become schedulers
         if (block_dim % launch_aicpu_num != 0) {
             LOG_WARN(
                 "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
                 "some threads will have different core counts after transition",
-                block_dim,
-                launch_aicpu_num);
+                block_dim, launch_aicpu_num
+            );
         }
     }
 
@@ -228,10 +233,10 @@ int DeviceRunner::run(Runtime& runtime,
     // host address; dereference resolved_addr_ for the dlsym function pointer
     LOG_DEBUG("Setting function_bin_addr for Tasks (Simulation)");
     for (int i = 0; i < runtime.get_task_count(); i++) {
-        Task* task = runtime.get_task(i);
+        Task *task = runtime.get_task(i);
         if (task != nullptr) {
             uint64_t callable_addr = runtime.get_function_bin_addr(task->func_id);
-            const CoreCallable* c = reinterpret_cast<const CoreCallable*>(callable_addr);
+            const CoreCallable *c = reinterpret_cast<const CoreCallable *>(callable_addr);
             task->function_bin_addr = c->resolved_addr();
             LOG_DEBUG("Task %d (func_id=%d) -> function_bin_addr=0x%lx", i, task->func_id, task->function_bin_addr);
         }
@@ -260,30 +265,32 @@ int DeviceRunner::run(Runtime& runtime,
 
     // Allocate simulated register blocks for all AICore cores
     size_t total_reg_size = num_aicore * SIM_REG_BLOCK_SIZE;
-    void* reg_blocks = mem_alloc_.alloc(total_reg_size);
+    void *reg_blocks = mem_alloc_.alloc(total_reg_size);
     if (reg_blocks == nullptr) {
         LOG_ERROR("Failed to allocate simulated register memory (%zu bytes)", total_reg_size);
         return -1;
     }
     std::memset(reg_blocks, 0, total_reg_size);
 
-    auto reg_blocks_cleanup = RAIIScopeGuard([this, reg_blocks]() { mem_alloc_.free(reg_blocks); });
+    auto reg_blocks_cleanup = RAIIScopeGuard([this, reg_blocks]() {
+        mem_alloc_.free(reg_blocks);
+    });
 
     // Build array of per-core register base addresses
     size_t regs_array_size = num_aicore * sizeof(uint64_t);
-    uint64_t* regs_array = reinterpret_cast<uint64_t*>(mem_alloc_.alloc(regs_array_size));
+    uint64_t *regs_array = reinterpret_cast<uint64_t *>(mem_alloc_.alloc(regs_array_size));
     if (regs_array == nullptr) {
         LOG_ERROR("Failed to allocate register address array");
         return -1;
     }
     for (int i = 0; i < num_aicore; i++) {
-        regs_array[i] = reinterpret_cast<uint64_t>(static_cast<uint8_t*>(reg_blocks) + i * SIM_REG_BLOCK_SIZE);
+        regs_array[i] = reinterpret_cast<uint64_t>(static_cast<uint8_t *>(reg_blocks) + i * SIM_REG_BLOCK_SIZE);
     }
     kernel_args_.regs = reinterpret_cast<uint64_t>(regs_array);
 
     auto regs_array_cleanup = RAIIScopeGuard([this]() {
         if (kernel_args_.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.regs));
+            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.regs));
             kernel_args_.regs = 0;
         }
     });
@@ -303,6 +310,7 @@ int DeviceRunner::run(Runtime& runtime,
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
     LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
     std::vector<std::thread> aicpu_threads;
+    aicpu_threads.reserve(over_launch);
     for (int i = 0; i < over_launch; i++) {
         aicpu_threads.emplace_back([this, &runtime, launch_aicpu_num, over_launch]() {
             if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
@@ -326,16 +334,17 @@ int DeviceRunner::run(Runtime& runtime,
     // Poll and collect performance data during execution (if enabled)
     std::thread collector_thread;
     if (runtime.enable_profiling) {
-        collector_thread =
-            std::thread([this, &runtime]() { poll_and_collect_performance_data(runtime.get_task_count()); });
+        collector_thread = std::thread([this, &runtime]() {
+            poll_and_collect_performance_data(runtime.get_task_count());
+        });
     }
 
     // Wait for all threads to complete
     LOG_INFO("Waiting for threads to complete");
-    for (auto& t : aicpu_threads) {
+    for (auto &t : aicpu_threads) {
         t.join();
     }
-    for (auto& t : aicore_threads) {
+    for (auto &t : aicore_threads) {
         t.join();
     }
 
@@ -379,12 +388,10 @@ void DeviceRunner::print_handshake_results() {
 
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
-        LOG_DEBUG("  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d",
-            i,
-            last_runtime_->workers[i].aicore_done,
-            last_runtime_->workers[i].aicpu_ready,
-            last_runtime_->workers[i].control,
-            last_runtime_->workers[i].task);
+        LOG_DEBUG(
+            "  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d", i, last_runtime_->workers[i].aicore_done,
+            last_runtime_->workers[i].aicpu_ready, last_runtime_->workers[i].control, last_runtime_->workers[i].task
+        );
     }
 }
 
@@ -419,7 +426,7 @@ int DeviceRunner::finalize() {
 
     // Cleanup performance profiling
     if (perf_collector_.is_initialized()) {
-        auto free_cb = [](void* dev_ptr, void* user_data) -> int {
+        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
             (void)user_data;
             free(dev_ptr);
             return 0;
@@ -432,8 +439,8 @@ int DeviceRunner::finalize() {
     if (!func_id_to_addr_.empty()) {
         LOG_ERROR("finalize() called with %zu kernel binaries still cached", func_id_to_addr_.size());
         // Cleanup leaked handles and host copies
-        for (auto& pair : func_id_to_addr_) {
-            MappedKernel& kernel = pair.second;
+        for (auto &pair : func_id_to_addr_) {
+            MappedKernel &kernel = pair.second;
             if (kernel.dl_handle != nullptr) {
                 dlclose(kernel.dl_handle);
                 LOG_DEBUG("Closed leaked kernel: func_id=%d", pair.first);
@@ -461,7 +468,7 @@ int DeviceRunner::finalize() {
 // Kernel Binary Upload (returns function address for caller to store in Runtime)
 // =============================================================================
 
-uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data, size_t bin_size) {
+uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size) {
     if (bin_data == nullptr || bin_size == 0) {
         LOG_ERROR("Invalid kernel data");
         return 0;
@@ -475,8 +482,8 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     }
 
     // Extract binary from CoreCallable envelope
-    const CoreCallable* callable = reinterpret_cast<const CoreCallable*>(bin_data);
-    const void* kernel_binary = callable->binary_data();
+    const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(bin_data);
+    const void *kernel_binary = callable->binary_data();
     size_t kernel_size = callable->binary_size();
 
     // 1. Generate temp file path
@@ -489,13 +496,13 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
         LOG_ERROR("Failed to create temp file: %s", tmpfile);
         return 0;
     }
-    ofs.write(reinterpret_cast<const char*>(kernel_binary), kernel_size);
+    ofs.write(reinterpret_cast<const char *>(kernel_binary), kernel_size);
     ofs.close();
 
     LOG_DEBUG("Uploading kernel .so: %s (size=%zu bytes)", tmpfile, kernel_size);
 
     // 3. dlopen to load .so (RTLD_NOW ensures all symbols resolved immediately)
-    void* handle = dlopen(tmpfile, RTLD_NOW | RTLD_LOCAL);
+    void *handle = dlopen(tmpfile, RTLD_NOW | RTLD_LOCAL);
 
     // 4. Remove temp file immediately (.so is already in memory)
     std::remove(tmpfile);
@@ -506,7 +513,7 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     }
 
     // 5. dlsym to get kernel function address (unified entry point: "kernel_entry")
-    void* func = dlsym(handle, "kernel_entry");
+    void *func = dlsym(handle, "kernel_entry");
     if (!func) {
         LOG_ERROR("dlsym failed for 'kernel_entry': %s", dlerror());
         dlclose(handle);
@@ -514,9 +521,9 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     }
 
     // 6. Create host-memory copy of CoreCallable with resolved_addr_ = func_ptr
-    uint8_t* copy = new uint8_t[bin_size];
+    uint8_t *copy = new uint8_t[bin_size];
     std::memcpy(copy, bin_data, bin_size);
-    CoreCallable* callable_copy = reinterpret_cast<CoreCallable*>(copy);
+    CoreCallable *callable_copy = reinterpret_cast<CoreCallable *>(copy);
     callable_copy->set_resolved_addr(reinterpret_cast<uint64_t>(func));
 
     // 7. Store mapping info for cleanup
@@ -525,11 +532,10 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     kernel.callable_buf = copy;
     func_id_to_addr_[func_id] = kernel;
 
-    LOG_DEBUG("Registered kernel (dlopen): func_id=%d -> callable=0x%lx, func_addr=0x%lx, handle=%p",
-        func_id,
-        reinterpret_cast<uint64_t>(copy),
-        reinterpret_cast<uint64_t>(func),
-        handle);
+    LOG_DEBUG(
+        "Registered kernel (dlopen): func_id=%d -> callable=0x%lx, func_addr=0x%lx, handle=%p", func_id,
+        reinterpret_cast<uint64_t>(copy), reinterpret_cast<uint64_t>(func), handle
+    );
 
     return reinterpret_cast<uint64_t>(copy);
 }
@@ -540,7 +546,7 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
         return;
     }
 
-    MappedKernel& kernel = it->second;
+    MappedKernel &kernel = it->second;
     if (kernel.dl_handle != nullptr) {
         dlclose(kernel.dl_handle);
         LOG_DEBUG("Removed kernel binary (dlclose): func_id=%d, handle=%p", func_id, kernel.dl_handle);
@@ -554,15 +560,15 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
 // Performance Profiling Implementation
 // =============================================================================
 
-int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, int device_id) {
+int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, int device_id) {
     // Define allocation callback (a2a3sim: use malloc)
-    auto alloc_cb = [](size_t size, void* user_data) -> void* {
+    auto alloc_cb = [](size_t size, void *user_data) -> void * {
         (void)user_data;  // Not needed for malloc
         return malloc(size);
     };
 
     // Define free callback (a2a3sim: use free)
-    auto free_cb = [](void* dev_ptr, void* user_data) -> int {
+    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
         (void)user_data;  // Not needed for free
         free(dev_ptr);
         return 0;
@@ -576,6 +582,6 @@ void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
     perf_collector_.poll_and_collect(expected_tasks);
 }
 
-int DeviceRunner::export_swimlane_json(const std::string& output_path) {
+int DeviceRunner::export_swimlane_json(const std::string &output_path) {
     return perf_collector_.export_swimlane_json(output_path);
 }

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -56,8 +56,8 @@
  * proper handling of external symbols (e.g., std::exp) via PLT/GOT.
  */
 struct MappedKernel {
-    void* dl_handle{nullptr};        // dlopen handle
-    uint8_t* callable_buf{nullptr};  // host-memory copy of CoreCallable (owns memory)
+    void *dl_handle{nullptr};        // dlopen handle
+    uint8_t *callable_buf{nullptr};  // host-memory copy of CoreCallable (owns memory)
 };
 
 /**
@@ -73,11 +73,11 @@ struct MappedKernel {
  * - Kernel .text binaries are loaded into mmap'd executable memory
  */
 class DeviceRunner {
- public:
+public:
     /**
      * Get singleton instance
      */
-    static DeviceRunner& get();
+    static DeviceRunner &get();
 
     /**
      * Allocate tensor memory (host memory in simulation)
@@ -85,14 +85,14 @@ class DeviceRunner {
      * @param bytes  Size of tensor in bytes
      * @return Pointer on success, nullptr on failure
      */
-    void* allocate_tensor(size_t bytes);
+    void *allocate_tensor(size_t bytes);
 
     /**
      * Free tensor memory
      *
      * @param dev_ptr  Pointer to free
      */
-    void free_tensor(void* dev_ptr);
+    void free_tensor(void *dev_ptr);
 
     /**
      * Copy data (memcpy in simulation)
@@ -102,7 +102,7 @@ class DeviceRunner {
      * @param bytes     Number of bytes to copy
      * @return 0 on success
      */
-    int copy_to_device(void* dev_ptr, const void* host_ptr, size_t bytes);
+    int copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes);
 
     /**
      * Copy data (memcpy in simulation)
@@ -112,7 +112,7 @@ class DeviceRunner {
      * @param bytes     Number of bytes to copy
      * @return 0 on success
      */
-    int copy_from_device(void* host_ptr, const void* dev_ptr, size_t bytes);
+    int copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes);
 
     /**
      * Execute a runtime using threads
@@ -132,12 +132,9 @@ class DeviceRunner {
      * @param launch_aicpu_num     Number of AICPU threads
      * @return 0 on success
      */
-    int run(Runtime& runtime,
-        int block_dim,
-        int device_id,
-        const std::vector<uint8_t>& aicpu_so_binary,
-        const std::vector<uint8_t>& aicore_kernel_binary,
-        int launch_aicpu_num = 1);
+    int
+    run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
 
     /**
      * Print handshake results
@@ -165,7 +162,7 @@ class DeviceRunner {
      * @param output_path Path to output directory (default: "outputs")
      * @return 0 on success, error code on failure
      */
-    int export_swimlane_json(const std::string& output_path = "outputs");
+    int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
      * Cleanup all resources
@@ -191,7 +188,7 @@ class DeviceRunner {
      * @param bin_size     Size of binary data in bytes
      * @return Function pointer address on success, 0 on error
      */
-    uint64_t upload_kernel_binary(int func_id, const uint8_t* bin_data, size_t bin_size);
+    uint64_t upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size);
 
     /**
      * Remove a kernel binary from memory
@@ -203,7 +200,7 @@ class DeviceRunner {
      */
     void remove_kernel_binary(int func_id);
 
- private:
+private:
     DeviceRunner() = default;
     ~DeviceRunner();
 
@@ -223,14 +220,14 @@ class DeviceRunner {
     std::map<int, MappedKernel> func_id_to_addr_;
 
     // Runtime pointer for print_handshake_results
-    Runtime* last_runtime_{nullptr};
+    Runtime *last_runtime_{nullptr};
 
     // Dynamically loaded executor libraries and function pointers
-    void* aicpu_so_handle_{nullptr};
-    void* aicore_so_handle_{nullptr};
-    int (*aicpu_execute_func_)(Runtime*){nullptr};                                       // NOLINT(readability/braces)
-    void (*aicore_execute_func_)(Runtime*, int, CoreType, uint32_t, uint64_t){nullptr};  // NOLINT(readability/braces)
-    void (*set_platform_regs_func_)(uint64_t){nullptr};                                  // NOLINT(readability/braces)
+    void *aicpu_so_handle_{nullptr};
+    void *aicore_so_handle_{nullptr};
+    int (*aicpu_execute_func_)(Runtime *){nullptr};                                       // NOLINT(readability/braces)
+    void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t){nullptr};  // NOLINT(readability/braces)
+    void (*set_platform_regs_func_)(uint64_t){nullptr};                                   // NOLINT(readability/braces)
     std::string aicpu_so_path_;
     std::string aicore_so_path_;
 
@@ -239,9 +236,11 @@ class DeviceRunner {
 
     // Private helper methods
     int ensure_device_initialized(
-        int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
+        int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+    );
     int ensure_binaries_loaded(
-        const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
+        const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+    );
     void unload_executor_binaries();
 
     /**
@@ -254,7 +253,7 @@ class DeviceRunner {
      * @param device_id Device ID (ignored in simulation)
      * @return 0 on success, error code on failure
      */
-    int init_performance_profiling(Runtime& runtime, int num_aicore, int device_id);
+    int init_performance_profiling(Runtime &runtime, int num_aicore, int device_id);
 };
 
 #endif  // SRC_A2A3_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a2a3/platform/sim/host/memory_allocator.cpp
+++ b/src/a2a3/platform/sim/host/memory_allocator.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Memory Allocator Implementation (Simulation)
  *
@@ -9,12 +19,10 @@
 #include <cstdlib>
 #include "common/unified_log.h"
 
-MemoryAllocator::~MemoryAllocator() {
-    finalize();
-}
+MemoryAllocator::~MemoryAllocator() { finalize(); }
 
-void* MemoryAllocator::alloc(size_t size) {
-    void* ptr = std::malloc(size);
+void *MemoryAllocator::alloc(size_t size) {
+    void *ptr = std::malloc(size);
     if (ptr == nullptr) {
         LOG_ERROR("malloc failed (size=%zu)", size);
         return nullptr;
@@ -25,7 +33,7 @@ void* MemoryAllocator::alloc(size_t size) {
     return ptr;
 }
 
-int MemoryAllocator::free(void* ptr) {
+int MemoryAllocator::free(void *ptr) {
     if (ptr == nullptr) {
         return 0;
     }
@@ -52,7 +60,7 @@ int MemoryAllocator::finalize() {
     }
 
     // Free all remaining tracked pointers
-    for (void* ptr : ptr_set_) {
+    for (void *ptr : ptr_set_) {
         std::free(ptr);
     }
 

--- a/src/a2a3/platform/sim/host/platform_compile_info.cpp
+++ b/src/a2a3/platform/sim/host/platform_compile_info.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "host/platform_compile_info.h"
 
-extern "C" const char* get_platform(void) { return "a2a3sim"; }
+extern "C" const char *get_platform(void) { return "a2a3sim"; }

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -31,15 +31,15 @@ extern "C" {
  * Runtime Implementation Functions (defined in runtimemaker.cpp)
  * ===========================================================================
  */
-int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args);
-int validate_runtime_impl(Runtime* runtime);
+int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args);
+int validate_runtime_impl(Runtime *runtime);
 
 /* Forward declarations */
-void* device_malloc(size_t size);
-void device_free(void* dev_ptr);
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
+void *device_malloc(size_t size);
+void device_free(void *dev_ptr);
+int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size);
+int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size);
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size);
 void remove_kernel_binary_wrapper(int func_id);
 
 /* ===========================================================================
@@ -49,7 +49,7 @@ void remove_kernel_binary_wrapper(int func_id);
 
 size_t get_runtime_size(void) { return sizeof(Runtime); }
 
-int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args) {
+int init_runtime(RuntimeHandle runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args) {
     if (runtime == NULL) {
         return -1;
     }
@@ -58,7 +58,7 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
 
     try {
         // Placement new to construct Runtime in user-allocated memory
-        Runtime* r = new (runtime) Runtime();
+        Runtime *r = new (runtime) Runtime();
 
         // Initialize host API function pointers
         r->host_api.device_malloc = device_malloc;
@@ -91,54 +91,54 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
  * ===========================================================================
  */
 
-void* device_malloc(size_t size) {
+void *device_malloc(size_t size) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.allocate_tensor(size);
     } catch (...) {
         return NULL;
     }
 }
 
-void device_free(void* dev_ptr) {
+void device_free(void *dev_ptr) {
     if (dev_ptr == NULL) {
         return;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         runner.free_tensor(dev_ptr);
     } catch (...) {
         // Ignore errors during free
     }
 }
 
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size) {
+int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size) {
     if (dev_ptr == NULL || host_ptr == NULL) {
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.copy_to_device(dev_ptr, host_ptr, size);
     } catch (...) {
         return -1;
     }
 }
 
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size) {
+int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     if (host_ptr == NULL || dev_ptr == NULL) {
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.copy_from_device(host_ptr, dev_ptr, size);
     } catch (...) {
         return -1;
     }
 }
 
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size) {
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.upload_kernel_binary(func_id, bin_data, bin_size);
     } catch (...) {
         return 0;
@@ -147,28 +147,23 @@ uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size
 
 void remove_kernel_binary_wrapper(int func_id) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         runner.remove_kernel_binary(func_id);
     } catch (...) {
         // Ignore errors during cleanup
     }
 }
 
-int launch_runtime(RuntimeHandle runtime,
-    int aicpu_thread_num,
-    int block_dim,
-    int device_id,
-    const uint8_t* aicpu_binary,
-    size_t aicpu_size,
-    const uint8_t* aicore_binary,
-    size_t aicore_size,
-    int orch_thread_num) {
+int launch_runtime(
+    RuntimeHandle runtime, int aicpu_thread_num, int block_dim, int device_id, const uint8_t *aicpu_binary,
+    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size, int orch_thread_num
+) {
     if (runtime == NULL) {
         return -1;
     }
 
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
 
         // In simulation, binaries are ignored
         std::vector<uint8_t> aicpu_vec;
@@ -181,7 +176,7 @@ int launch_runtime(RuntimeHandle runtime,
             aicore_vec.assign(aicore_binary, aicore_binary + aicore_size);
         }
 
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         r->orch_thread_num = orch_thread_num;
         return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
@@ -194,7 +189,7 @@ int finalize_runtime(RuntimeHandle runtime) {
         return -1;
     }
     try {
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         int rc = validate_runtime_impl(r);
 
         // Call destructor (user will call free())
@@ -215,7 +210,7 @@ int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
         return -1;
     }
     try {
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         r->enable_profiling = (enabled != 0);
         return 0;
     } catch (...) {
@@ -228,11 +223,11 @@ int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
  * registration and stores addresses in Runtime's func_id_to_addr_[] array.
  */
 
-void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size) {
+void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, size_t size) {
     if (runtime == NULL) {
         return;
     }
-    Runtime* r = static_cast<Runtime*>(runtime);
+    Runtime *r = static_cast<Runtime *>(runtime);
     r->record_tensor_pair(host_ptr, dev_ptr, size);
 }
 

--- a/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -28,15 +28,15 @@
 #include "common/unified_log.h"
 
 // Cached pointers for hot-path access (set during init)
-static AicpuPhaseHeader* s_phase_header = nullptr;
-static PerfDataHeader* s_perf_header = nullptr;
+static AicpuPhaseHeader *s_phase_header = nullptr;
+static PerfDataHeader *s_perf_header = nullptr;
 
 // Per-core PerfBufferState cache
-static PerfBufferState* s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
+static PerfBufferState *s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
 
 // Per-thread PhaseBufferState cache
-static PhaseBufferState* s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
-static PhaseBuffer* s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
+static PhaseBufferState *s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
+static PhaseBuffer *s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
 static __thread int s_orch_thread_idx = -1;
 
@@ -51,12 +51,10 @@ static __thread int s_orch_thread_idx = -1;
  * @param is_phase 0 = PerfRecord, 1 = Phase
  * @return 0 on success, -1 if queue full
  */
-static int enqueue_ready_buffer(PerfDataHeader* header,
-    int thread_idx,
-    uint32_t core_index,
-    uint64_t buffer_ptr,
-    uint32_t buffer_seq,
-    uint32_t is_phase) {
+static int enqueue_ready_buffer(
+    PerfDataHeader *header, int thread_idx, uint32_t core_index, uint64_t buffer_ptr, uint32_t buffer_seq,
+    uint32_t is_phase
+) {
     uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
     uint32_t current_tail = header->queue_tails[thread_idx];
     uint32_t current_head = header->queue_heads[thread_idx];
@@ -76,8 +74,8 @@ static int enqueue_ready_buffer(PerfDataHeader* header,
     return 0;
 }
 
-void perf_aicpu_init_profiling(Runtime* runtime) {
-    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
+void perf_aicpu_init_profiling(Runtime *runtime) {
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize profiling");
         return;
@@ -92,8 +90,8 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
 
     // Pop first buffer from free_queue for each core
     for (int i = 0; i < runtime->worker_count; i++) {
-        Handshake* h = &runtime->workers[i];
-        PerfBufferState* state = get_perf_buffer_state(perf_base, i);
+        Handshake *h = &runtime->workers[i];
+        PerfBufferState *state = get_perf_buffer_state(perf_base, i);
 
         s_perf_buffer_states[i] = state;
 
@@ -110,7 +108,7 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
             state->current_buf_seq = 0;
             wmb();
 
-            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(buf_ptr);
+            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(buf_ptr);
             buf->count = 0;
             h->perf_records_addr = buf_ptr;
 
@@ -127,20 +125,15 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
     LOG_INFO("Performance profiling initialized for %d cores", runtime->worker_count);
 }
 
-int perf_aicpu_complete_record(PerfBuffer* perf_buf,
-    uint32_t expected_reg_task_id,
-    uint64_t task_id,
-    uint32_t func_id,
-    CoreType core_type,
-    uint64_t dispatch_time,
-    uint64_t finish_time,
-    const uint64_t* fanout,
-    int32_t fanout_count) {
+int perf_aicpu_complete_record(
+    PerfBuffer *perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
+    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
+) {
     rmb();
     uint32_t count = perf_buf->count;
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
 
-    PerfRecord* record = &perf_buf->records[count];
+    PerfRecord *record = &perf_buf->records[count];
     if (static_cast<uint32_t>(record->task_id) != expected_reg_task_id) return -1;
 
     record->task_id = task_id;
@@ -164,18 +157,18 @@ int perf_aicpu_complete_record(PerfBuffer* perf_buf,
     return 0;
 }
 
-void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
-    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
+void perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx) {
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
 
-    PerfBufferState* state = s_perf_buffer_states[core_id];
+    PerfBufferState *state = s_perf_buffer_states[core_id];
     if (state == nullptr) {
         return;
     }
 
-    PerfBuffer* full_buf = reinterpret_cast<PerfBuffer*>(state->current_buf_ptr);
+    PerfBuffer *full_buf = reinterpret_cast<PerfBuffer *>(state->current_buf_ptr);
     if (full_buf == nullptr) {
         return;
     }
@@ -214,23 +207,23 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
     state->current_buf_seq = seq + 1;
     wmb();
 
-    PerfBuffer* new_buf = reinterpret_cast<PerfBuffer*>(new_buf_ptr);
+    PerfBuffer *new_buf = reinterpret_cast<PerfBuffer *>(new_buf_ptr);
     new_buf->count = 0;
 
     // Update handshake for AICore
-    Handshake* h = &runtime->workers[core_id];
+    Handshake *h = &runtime->workers[core_id];
     h->perf_records_addr = new_buf_ptr;
     wmb();
 
     LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
 }
 
-void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
+void perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cur_thread_cores, int core_num) {
     if (!runtime->enable_profiling) {
         return;
     }
 
-    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
@@ -243,7 +236,7 @@ void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_t
 
     for (int i = 0; i < core_num; i++) {
         int core_id = cur_thread_cores[i];
-        PerfBufferState* state = s_perf_buffer_states[core_id];
+        PerfBufferState *state = s_perf_buffer_states[core_id];
         if (state == nullptr) continue;
 
         rmb();
@@ -253,7 +246,7 @@ void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_t
             continue;
         }
 
-        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(buf_ptr);
+        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(buf_ptr);
         if (buf->count == 0) {
             continue;
         }
@@ -275,19 +268,19 @@ void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_t
     LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
 }
 
-void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
-    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
+void perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks) {
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
 
-    PerfDataHeader* header = get_perf_header(perf_base);
+    PerfDataHeader *header = get_perf_header(perf_base);
     header->total_tasks = total_tasks;
     wmb();
 }
 
-void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, int num_orch_threads) {
-    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
+void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, int num_orch_threads) {
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize phase profiling");
         return;
@@ -311,7 +304,7 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
         total_threads = PLATFORM_MAX_AICPU_THREADS;
     }
     for (int t = 0; t < total_threads; t++) {
-        PhaseBufferState* state = get_phase_buffer_state(perf_base, runtime->worker_count, t);
+        PhaseBufferState *state = get_phase_buffer_state(perf_base, runtime->worker_count, t);
 
         s_phase_buffer_states[t] = state;
 
@@ -328,7 +321,7 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
             state->current_buf_seq = 0;
             wmb();
 
-            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
             buf->count = 0;
             s_current_phase_buf[t] = buf;
 
@@ -348,10 +341,10 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
 
     wmb();
 
-    LOG_INFO("Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread",
-        num_sched_threads,
-        num_orch_threads,
-        PLATFORM_PHASE_RECORDS_PER_THREAD);
+    LOG_INFO(
+        "Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread", num_sched_threads,
+        num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD
+    );
 }
 
 /**
@@ -362,10 +355,10 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
  * records are dropped (preserving already-enqueued data).
  */
 static void switch_phase_buffer(int thread_idx) {
-    PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
     if (state == nullptr) return;
 
-    PhaseBuffer* full_buf = s_current_phase_buf[thread_idx];
+    PhaseBuffer *full_buf = s_current_phase_buf[thread_idx];
     if (full_buf == nullptr) return;
 
     LOG_INFO("Thread %d: phase buffer is full (count=%u)", thread_idx, full_buf->count);
@@ -393,7 +386,7 @@ static void switch_phase_buffer(int thread_idx) {
         state->current_buf_seq = seq + 1;
         wmb();
 
-        PhaseBuffer* new_buf = reinterpret_cast<PhaseBuffer*>(new_buf_ptr);
+        PhaseBuffer *new_buf = reinterpret_cast<PhaseBuffer *>(new_buf_ptr);
         new_buf->count = 0;
         s_current_phase_buf[thread_idx] = new_buf;
 
@@ -407,21 +400,19 @@ static void switch_phase_buffer(int thread_idx) {
     }
 }
 
-void perf_aicpu_record_phase(int thread_idx,
-    AicpuPhaseId phase_id,
-    uint64_t start_time,
-    uint64_t end_time,
-    uint32_t loop_iter,
-    uint64_t tasks_processed) {
+void perf_aicpu_record_phase(
+    int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
+    uint64_t tasks_processed
+) {
     if (s_phase_header == nullptr) {
         return;
     }
 
-    PhaseBuffer* buf = s_current_phase_buf[thread_idx];
+    PhaseBuffer *buf = s_current_phase_buf[thread_idx];
 
     // Try to recover from nullptr (no buffer was available on previous switch)
     if (buf == nullptr) {
-        PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+        PhaseBufferState *state = s_phase_buffer_states[thread_idx];
         if (state == nullptr) return;
 
         rmb();
@@ -436,7 +427,7 @@ void perf_aicpu_record_phase(int thread_idx,
             state->current_buf_seq = state->current_buf_seq + 1;
             wmb();
 
-            buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
+            buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
             buf->count = 0;
             s_current_phase_buf[thread_idx] = buf;
 
@@ -458,7 +449,7 @@ void perf_aicpu_record_phase(int thread_idx,
         }
     }
 
-    AicpuPhaseRecord* record = &buf->records[idx];
+    AicpuPhaseRecord *record = &buf->records[idx];
     record->start_time = start_time;
     record->end_time = end_time;
     record->loop_iter = loop_iter;
@@ -468,12 +459,12 @@ void perf_aicpu_record_phase(int thread_idx,
     buf->count = idx + 1;
 }
 
-void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src) {
+void perf_aicpu_write_orch_summary(const AicpuOrchSummary *src) {
     if (s_phase_header == nullptr) {
         return;
     }
 
-    AicpuOrchSummary* dst = &s_phase_header->orch_summary;
+    AicpuOrchSummary *dst = &s_phase_header->orch_summary;
 
     memcpy(dst, src, sizeof(AicpuOrchSummary));
     dst->magic = AICPU_PHASE_MAGIC;
@@ -481,15 +472,17 @@ void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src) {
 
     wmb();
 
-    LOG_INFO("Orchestrator summary written: %" PRId64 " tasks, %.3fus",
-        static_cast<int64_t>(src->submit_count),
-        cycles_to_us(src->end_time - src->start_time));
+    LOG_INFO(
+        "Orchestrator summary written: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(src->submit_count),
+        cycles_to_us(src->end_time - src->start_time)
+    );
 }
 
 void perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }
 
 void perf_aicpu_record_orch_phase(
-    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id) {
+    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id
+) {
     if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
     perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
 }
@@ -499,7 +492,7 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
         return;
     }
 
-    PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
     if (state == nullptr) return;
 
     rmb();
@@ -509,7 +502,7 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
         return;
     }
 
-    PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
+    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
     if (buf->count == 0) {
         return;
     }
@@ -528,10 +521,10 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
     wmb();
 }
 
-void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
-    const int* core_counts,
-    int num_threads,
-    int total_cores) {
+void perf_aicpu_write_core_assignments(
+    const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
+    int total_cores
+) {
     if (s_phase_header == nullptr) {
         return;
     }

--- a/src/a2a3/platform/src/aicpu/platform_regs.cpp
+++ b/src/a2a3/platform/src/aicpu/platform_regs.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file platform_regs.cpp
  * @brief Platform-level register access implementation for AICPU
@@ -22,17 +32,12 @@
 
 static uint64_t g_platform_regs = 0;
 
-void set_platform_regs(uint64_t regs) {
-    g_platform_regs = regs;
-}
+void set_platform_regs(uint64_t regs) { g_platform_regs = regs; }
 
-uint64_t get_platform_regs() {
-    return g_platform_regs;
-}
+uint64_t get_platform_regs() { return g_platform_regs; }
 
 uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        reg_base_addr + reg_offset(reg));
+    volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(reg_base_addr + reg_offset(reg));
 
     __sync_synchronize();
 
@@ -45,8 +50,7 @@ uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
 }
 
 void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        reg_base_addr + reg_offset(reg));
+    volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(reg_base_addr + reg_offset(reg));
 
     __sync_synchronize();
 
@@ -69,8 +73,7 @@ void platform_deinit_aicore_regs(uint64_t reg_addr) {
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
 
     // Wait for AICore to acknowledge exit by writing AICORE_EXITED_VALUE to COND
-    while (read_reg(reg_addr, RegId::COND) != AICORE_EXITED_VALUE) {
-    }
+    while (read_reg(reg_addr, RegId::COND) != AICORE_EXITED_VALUE) {}
 
     // Initialize task dispatch register to idle state
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);

--- a/src/a2a3/platform/src/aicpu/unified_log_device.cpp
+++ b/src/a2a3/platform/src/aicpu/unified_log_device.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file unified_log_device.cpp
  * @brief Unified logging - Device implementation
@@ -8,7 +18,7 @@
 
 #include <cstdarg>
 
-void unified_log_error(const char* func, const char* fmt, ...) {
+void unified_log_error(const char *func, const char *fmt, ...) {
     if (!is_log_enable_error()) {
         return;
     }
@@ -20,52 +30,52 @@ void unified_log_error(const char* func, const char* fmt, ...) {
     dev_log_error(func, "%s", buffer);
 }
 
-void unified_log_warn(const char* func, const char* fmt, ...) {
+void unified_log_warn(const char *func, const char *fmt, ...) {
     if (!is_log_enable_warn()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_warn(func, "%s", buffer);
 }
 
-void unified_log_info(const char* func, const char* fmt, ...) {
+void unified_log_info(const char *func, const char *fmt, ...) {
     if (!is_log_enable_info()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_info(func, "%s", buffer);
 }
 
-void unified_log_debug(const char* func, const char* fmt, ...) {
+void unified_log_debug(const char *func, const char *fmt, ...) {
     if (!is_log_enable_debug()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_debug(func, "%s", buffer);
 }
 
-void unified_log_always(const char* func, const char* fmt, ...) {
+void unified_log_always(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];

--- a/src/a2a3/platform/src/host/host_log.cpp
+++ b/src/a2a3/platform/src/host/host_log.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file host_log.cpp
  * @brief Implementation of Unified Host Logging System
@@ -13,24 +23,22 @@
 // HostLogger Implementation
 // =============================================================================
 
-HostLogger& HostLogger::get_instance() {
+HostLogger &HostLogger::get_instance() {
     static HostLogger instance;
     return instance;
 }
 
-HostLogger::HostLogger() 
-    : current_level_(HostLogLevel::INFO),
-      log_file_path_(""),
-      log_file_handle_(nullptr),
-      initialized_(false) {
+HostLogger::HostLogger() :
+    current_level_(HostLogLevel::INFO),
+    log_file_path_(""),
+    log_file_handle_(nullptr),
+    initialized_(false) {
     init_from_env();
 }
 
 HostLogger::~HostLogger() {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (log_file_handle_ != nullptr && 
-        log_file_handle_ != stdout && 
-        log_file_handle_ != stderr) {
+    if (log_file_handle_ != nullptr && log_file_handle_ != stdout && log_file_handle_ != stderr) {
         fclose(log_file_handle_);
         log_file_handle_ = nullptr;
     }
@@ -38,17 +46,17 @@ HostLogger::~HostLogger() {
 
 void HostLogger::init_from_env() {
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     // Parse PTO_LOG_LEVEL environment variable
-    const char* level_str = std::getenv("PTO_LOG_LEVEL");
+    const char *level_str = std::getenv("PTO_LOG_LEVEL");
     if (level_str != nullptr) {
         std::string level(level_str);
-        
+
         // Convert to lowercase for comparison
-        for (char& c : level) {
+        for (char &c : level) {
             c = std::tolower(c);
         }
-        
+
         // Map log level strings to enum values (1-to-1 mapping)
         if (level == "error") {
             current_level_ = HostLogLevel::ERROR;
@@ -66,19 +74,17 @@ void HostLogger::init_from_env() {
         // Default to INFO
         current_level_ = HostLogLevel::INFO;
     }
-    
+
     // Parse PTO_LOG_FILE environment variable
-    const char* file_path = std::getenv("PTO_LOG_FILE");
+    const char *file_path = std::getenv("PTO_LOG_FILE");
     if (file_path != nullptr && strlen(file_path) > 0) {
         log_file_path_ = file_path;
-        
+
         // Close previous file handle if it exists
-        if (log_file_handle_ != nullptr && 
-            log_file_handle_ != stdout && 
-            log_file_handle_ != stderr) {
+        if (log_file_handle_ != nullptr && log_file_handle_ != stdout && log_file_handle_ != stderr) {
             fclose(log_file_handle_);
         }
-        
+
         // Open log file in append mode
         log_file_handle_ = fopen(log_file_path_.c_str(), "a");
         if (log_file_handle_ == nullptr) {
@@ -88,7 +94,7 @@ void HostLogger::init_from_env() {
             log_file_path_.clear();
         }
     }
-    
+
     initialized_ = true;
 }
 
@@ -101,29 +107,29 @@ bool HostLogger::is_enabled(HostLogLevel level) const {
     return static_cast<int>(level) <= static_cast<int>(current_level_);
 }
 
-const char* HostLogger::get_level_name(HostLogLevel level) const {
+const char *HostLogger::get_level_name(HostLogLevel level) const {
     switch (level) {
-        case HostLogLevel::ERROR:
-            return "ERROR";
-        case HostLogLevel::WARN:
-            return "WARN";
-        case HostLogLevel::INFO:
-            return "INFO";
-        case HostLogLevel::DEBUG:
-            return "DEBUG";
-        case HostLogLevel::ALWAYS:
-            return "ALWAYS";
-        default:
-            return "UNKNOWN";
+    case HostLogLevel::ERROR:
+        return "ERROR";
+    case HostLogLevel::WARN:
+        return "WARN";
+    case HostLogLevel::INFO:
+        return "INFO";
+    case HostLogLevel::DEBUG:
+        return "DEBUG";
+    case HostLogLevel::ALWAYS:
+        return "ALWAYS";
+    default:
+        return "UNKNOWN";
     }
 }
 
-FILE* HostLogger::get_output_file(HostLogLevel level) {
+FILE *HostLogger::get_output_file(HostLogLevel level) {
     // If log file is configured, use it for all levels
     if (log_file_handle_ != nullptr) {
         return log_file_handle_;
     }
-    
+
     // Otherwise, use stderr for ERROR/WARN, stdout for INFO/DEBUG
     if (level == HostLogLevel::ERROR || level == HostLogLevel::WARN) {
         return stderr;
@@ -132,35 +138,34 @@ FILE* HostLogger::get_output_file(HostLogLevel level) {
     }
 }
 
-void HostLogger::log(HostLogLevel level, const char* format, ...) {
+void HostLogger::log(HostLogLevel level, const char *format, ...) {
     // Check if this level is enabled
     if (!is_enabled(level)) {
         return;
     }
-    
+
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     // Get output file
-    FILE* output = get_output_file(level);
+    FILE *output = get_output_file(level);
     if (output == nullptr) {
         return;
     }
-    
+
     // Print log level prefix (matching Python format)
     fprintf(output, "[%s] ", get_level_name(level));
-    
+
     // Print formatted message
     va_list args;
     va_start(args, format);
     vfprintf(output, format, args);
     va_end(args);
-    
+
     // Add newline if not already present
     if (format[strlen(format) - 1] != '\n') {
         fprintf(output, "\n");
     }
-    
+
     // Flush to ensure immediate output
     fflush(output);
 }
-

--- a/src/a2a3/platform/src/host/host_log.h
+++ b/src/a2a3/platform/src/host/host_log.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file host_log.h
  * @brief Unified Host Logging System
@@ -30,11 +40,11 @@
 // =============================================================================
 
 enum class HostLogLevel {
-    ALWAYS = -1, // always logging
-    ERROR = 0,   // error level only
-    WARN = 1,    // warn level and above
-    INFO = 2,    // info level and above (default)
-    DEBUG = 3    // debug level (all messages)
+    ALWAYS = -1,  // always logging
+    ERROR = 0,    // error level only
+    WARN = 1,     // warn level and above
+    INFO = 2,     // info level and above (default)
+    DEBUG = 3     // debug level (all messages)
 };
 
 // =============================================================================
@@ -44,11 +54,11 @@ enum class HostLogLevel {
 class HostLogger {
 public:
     // Get singleton instance
-    static HostLogger& get_instance();
+    static HostLogger &get_instance();
 
     // Log a message with specified level
-    void log(HostLogLevel level, const char* format, ...);
-    
+    void log(HostLogLevel level, const char *format, ...);
+
     // Check if a log level is enabled
     bool is_enabled(HostLogLevel level) const;
 
@@ -58,26 +68,26 @@ public:
 private:
     HostLogger();
     ~HostLogger();
-    
+
     // Delete copy/move constructors
-    HostLogger(const HostLogger&) = delete;
-    HostLogger& operator=(const HostLogger&) = delete;
-    HostLogger(HostLogger&&) = delete;
-    HostLogger& operator=(HostLogger&&) = delete;
+    HostLogger(const HostLogger &) = delete;
+    HostLogger &operator=(const HostLogger &) = delete;
+    HostLogger(HostLogger &&) = delete;
+    HostLogger &operator=(HostLogger &&) = delete;
 
     // Initialize from environment variables
     void init_from_env();
-    
+
     // Get level name string
-    const char* get_level_name(HostLogLevel level) const;
-    
+    const char *get_level_name(HostLogLevel level) const;
+
     // Get output file handle (FILE* for stdout/stderr or file)
-    FILE* get_output_file(HostLogLevel level);
+    FILE *get_output_file(HostLogLevel level);
 
     // Member variables
     HostLogLevel current_level_;
     std::string log_file_path_;
-    FILE* log_file_handle_;
+    FILE *log_file_handle_;
     std::mutex mutex_;
     bool initialized_;
 };
@@ -86,29 +96,28 @@ private:
 // Logging Macros (High-Level Interface)
 // =============================================================================
 
-#define HOST_LOG_ERROR(fmt, ...) \
-    do { \
+#define HOST_LOG_ERROR(fmt, ...)                                                 \
+    do {                                                                         \
         HostLogger::get_instance().log(HostLogLevel::ERROR, fmt, ##__VA_ARGS__); \
-    } while(0)
+    } while (0)
 
-#define HOST_LOG_WARN(fmt, ...) \
-    do { \
+#define HOST_LOG_WARN(fmt, ...)                                                 \
+    do {                                                                        \
         HostLogger::get_instance().log(HostLogLevel::WARN, fmt, ##__VA_ARGS__); \
-    } while(0)
+    } while (0)
 
-#define HOST_LOG_INFO(fmt, ...) \
-    do { \
-        if (HostLogger::get_instance().is_enabled(HostLogLevel::INFO)) { \
+#define HOST_LOG_INFO(fmt, ...)                                                     \
+    do {                                                                            \
+        if (HostLogger::get_instance().is_enabled(HostLogLevel::INFO)) {            \
             HostLogger::get_instance().log(HostLogLevel::INFO, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                                           \
+    } while (0)
 
-#define HOST_LOG_DEBUG(fmt, ...) \
-    do { \
-        if (HostLogger::get_instance().is_enabled(HostLogLevel::DEBUG)) { \
+#define HOST_LOG_DEBUG(fmt, ...)                                                     \
+    do {                                                                             \
+        if (HostLogger::get_instance().is_enabled(HostLogLevel::DEBUG)) {            \
             HostLogger::get_instance().log(HostLogLevel::DEBUG, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                                            \
+    } while (0)
 
-#endif // PLATFORM_HOST_LOG_H_
-
+#endif  // PLATFORM_HOST_LOG_H_

--- a/src/a2a3/platform/src/host/performance_collector.cpp
+++ b/src/a2a3/platform/src/host/performance_collector.cpp
@@ -45,15 +45,11 @@ ProfMemoryManager::~ProfMemoryManager() {
     }
 }
 
-void ProfMemoryManager::start(void* shared_mem_host,
-    int num_cores,
-    int num_phase_threads,
-    PerfAllocCallback alloc_cb,
-    PerfRegisterCallback register_cb,
-    PerfFreeCallback free_cb,
-    void* user_data,
-    int device_id,
-    PerfSetDeviceCallback set_device_cb) {
+void ProfMemoryManager::start(
+    void *shared_mem_host, int num_cores, int num_phase_threads, PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb, PerfFreeCallback free_cb, void *user_data, int device_id,
+    PerfSetDeviceCallback set_device_cb
+) {
     shared_mem_host_ = shared_mem_host;
     num_cores_ = num_cores;
     num_phase_threads_ = num_phase_threads;
@@ -87,11 +83,11 @@ void ProfMemoryManager::stop() {
     }
 
     // Free recycled buffers
-    for (void* ptr : recycled_perf_buffers_) {
+    for (void *ptr : recycled_perf_buffers_) {
         free_buffer(ptr);
     }
     recycled_perf_buffers_.clear();
-    for (void* ptr : recycled_phase_buffers_) {
+    for (void *ptr : recycled_phase_buffers_) {
         free_buffer(ptr);
     }
     recycled_phase_buffers_.clear();
@@ -99,7 +95,7 @@ void ProfMemoryManager::stop() {
     LOG_INFO("ProfMemoryManager stopped");
 }
 
-bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo& info) {
+bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo &info) {
     std::lock_guard<std::mutex> lock(ready_mutex_);
     if (ready_queue_.empty()) {
         return false;
@@ -109,9 +105,11 @@ bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo& info) {
     return true;
 }
 
-bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout) {
+bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout) {
     std::unique_lock<std::mutex> lock(ready_mutex_);
-    if (ready_cv_.wait_for(lock, timeout, [this] { return !ready_queue_.empty(); })) {
+    if (ready_cv_.wait_for(lock, timeout, [this] {
+            return !ready_queue_.empty();
+        })) {
         info = ready_queue_.front();
         ready_queue_.pop();
         return true;
@@ -119,24 +117,24 @@ bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo& info, std::chrono::milli
     return false;
 }
 
-void ProfMemoryManager::notify_copy_done(const CopyDoneInfo& info) {
+void ProfMemoryManager::notify_copy_done(const CopyDoneInfo &info) {
     std::lock_guard<std::mutex> lock(done_mutex_);
     done_queue_.push(info);
 }
 
-void* ProfMemoryManager::alloc_and_register(size_t size, void** host_ptr_out) {
-    void* dev_ptr = alloc_cb_(size, user_data_);
+void *ProfMemoryManager::alloc_and_register(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size, user_data_);
     if (dev_ptr == nullptr) {
-        const char* hint = (size == sizeof(PerfBuffer))
-                               ? "increase PLATFORM_PROF_BUFFERS_PER_CORE to reduce profiling data loss"
-                               : "increase PLATFORM_PROF_BUFFERS_PER_THREAD to reduce profiling data loss";
+        const char *hint = (size == sizeof(PerfBuffer)) ?
+                               "increase PLATFORM_PROF_BUFFERS_PER_CORE to reduce profiling data loss" :
+                               "increase PLATFORM_PROF_BUFFERS_PER_THREAD to reduce profiling data loss";
         LOG_WARN("ProfMemoryManager: alloc failed for %zu bytes, %s", size, hint);
         *host_ptr_out = nullptr;
         return nullptr;
     }
 
     if (register_cb_ != nullptr) {
-        void* host_ptr = nullptr;
+        void *host_ptr = nullptr;
         int rc = register_cb_(dev_ptr, size, device_id_, user_data_, &host_ptr);
         if (rc != 0 || host_ptr == nullptr) {
             LOG_ERROR("ProfMemoryManager: register failed: %d", rc);
@@ -154,14 +152,14 @@ void* ProfMemoryManager::alloc_and_register(size_t size, void** host_ptr_out) {
     return dev_ptr;
 }
 
-void ProfMemoryManager::free_buffer(void* dev_ptr) {
+void ProfMemoryManager::free_buffer(void *dev_ptr) {
     if (dev_ptr != nullptr && free_cb_ != nullptr) {
         dev_to_host_.erase(dev_ptr);
         free_cb_(dev_ptr, user_data_);
     }
 }
 
-void* ProfMemoryManager::resolve_host_ptr(void* dev_ptr) {
+void *ProfMemoryManager::resolve_host_ptr(void *dev_ptr) {
     if (register_cb_ == nullptr) {
         return dev_ptr;  // Simulation mode: dev_ptr == host_ptr
     }
@@ -173,10 +171,11 @@ void* ProfMemoryManager::resolve_host_ptr(void* dev_ptr) {
     return nullptr;
 }
 
-void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
+void ProfMemoryManager::register_mapping(void *dev_ptr, void *host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
 
 void ProfMemoryManager::process_ready_entry(
-    PerfDataHeader* /*header*/, int /*thread_idx*/, const ReadyQueueEntry& entry) {
+    PerfDataHeader * /*header*/, int /*thread_idx*/, const ReadyQueueEntry &entry
+) {
     bool is_phase = (entry.is_phase != 0);
     uint64_t old_dev_ptr = entry.buffer_ptr;
     uint32_t seq = entry.buffer_seq;
@@ -188,7 +187,7 @@ void ProfMemoryManager::process_ready_entry(
             return;
         }
 
-        PhaseBufferState* state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
+        PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
 
         // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
         // Source priority: recycled pool → drain done_queue → alloc (last resort).
@@ -199,8 +198,8 @@ void ProfMemoryManager::process_ready_entry(
 
         int to_push = PLATFORM_PROF_SLOT_COUNT;
         for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
-            void* host_ptr = nullptr;
-            void* new_dev_ptr = nullptr;
+            void *host_ptr = nullptr;
+            void *new_dev_ptr = nullptr;
 
             if (!recycled_phase_buffers_.empty()) {
                 new_dev_ptr = recycled_phase_buffers_.back();
@@ -214,8 +213,7 @@ void ProfMemoryManager::process_ready_entry(
                     done_queue_.pop();
                     if (dinfo.type == ProfBufferType::PERF_RECORD)
                         recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
-                    else
-                        recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
                 }
             }
             if (new_dev_ptr == nullptr && !recycled_phase_buffers_.empty()) {
@@ -228,7 +226,7 @@ void ProfMemoryManager::process_ready_entry(
             }
             if (new_dev_ptr == nullptr) break;
 
-            reinterpret_cast<PhaseBuffer*>(host_ptr)->count = 0;
+            reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
             uint32_t cur_tail = tail + p;
             state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
                 reinterpret_cast<uint64_t>(new_dev_ptr);
@@ -238,10 +236,12 @@ void ProfMemoryManager::process_ready_entry(
         }
 
         // Resolve host pointer of old buffer
-        void* old_host_ptr = resolve_host_ptr(reinterpret_cast<void*>(old_dev_ptr));
+        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
         if (old_host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p",
-                reinterpret_cast<void*>(old_dev_ptr));
+            LOG_ERROR(
+                "ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p",
+                reinterpret_cast<void *>(old_dev_ptr)
+            );
             return;
         }
 
@@ -250,7 +250,7 @@ void ProfMemoryManager::process_ready_entry(
         info.type = ProfBufferType::PHASE;
         info.index = tidx;
         info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = reinterpret_cast<void*>(old_dev_ptr);
+        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
         info.host_buffer_ptr = old_host_ptr;
         info.buffer_seq = seq;
 
@@ -267,7 +267,7 @@ void ProfMemoryManager::process_ready_entry(
             return;
         }
 
-        PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, core_index);
+        PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, core_index);
 
         // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
         rmb();
@@ -277,8 +277,8 @@ void ProfMemoryManager::process_ready_entry(
 
         int to_push = PLATFORM_PROF_SLOT_COUNT;
         for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
-            void* host_ptr = nullptr;
-            void* new_dev_ptr = nullptr;
+            void *host_ptr = nullptr;
+            void *new_dev_ptr = nullptr;
 
             if (!recycled_perf_buffers_.empty()) {
                 new_dev_ptr = recycled_perf_buffers_.back();
@@ -292,8 +292,7 @@ void ProfMemoryManager::process_ready_entry(
                     done_queue_.pop();
                     if (dinfo.type == ProfBufferType::PERF_RECORD)
                         recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
-                    else
-                        recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
                 }
             }
             if (new_dev_ptr == nullptr && !recycled_perf_buffers_.empty()) {
@@ -306,7 +305,7 @@ void ProfMemoryManager::process_ready_entry(
             }
             if (new_dev_ptr == nullptr) break;
 
-            reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+            reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
             uint32_t cur_tail = tail + p;
             state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
                 reinterpret_cast<uint64_t>(new_dev_ptr);
@@ -315,10 +314,12 @@ void ProfMemoryManager::process_ready_entry(
             wmb();
         }
 
-        void* old_host_ptr = resolve_host_ptr(reinterpret_cast<void*>(old_dev_ptr));
+        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
         if (old_host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p",
-                reinterpret_cast<void*>(old_dev_ptr));
+            LOG_ERROR(
+                "ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p",
+                reinterpret_cast<void *>(old_dev_ptr)
+            );
             return;
         }
 
@@ -326,7 +327,7 @@ void ProfMemoryManager::process_ready_entry(
         info.type = ProfBufferType::PERF_RECORD;
         info.index = core_index;
         info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = reinterpret_cast<void*>(old_dev_ptr);
+        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
         info.host_buffer_ptr = old_host_ptr;
         info.buffer_seq = seq;
 
@@ -346,7 +347,7 @@ void ProfMemoryManager::mgmt_loop() {
         }
     }
 
-    PerfDataHeader* header = get_perf_header(shared_mem_host_);
+    PerfDataHeader *header = get_perf_header(shared_mem_host_);
 
     while (running_.load()) {
         // 1. Recycle done queue: move completed buffers to recycled pools for reuse
@@ -372,11 +373,10 @@ void ProfMemoryManager::mgmt_loop() {
 
             // Validate indices to prevent OOB access from corrupted shared memory
             if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-                LOG_ERROR("mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)",
-                    t,
-                    head,
-                    tail,
-                    PLATFORM_PROF_READYQUEUE_SIZE);
+                LOG_ERROR(
+                    "mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)", t, head, tail,
+                    PLATFORM_PROF_READYQUEUE_SIZE
+                );
                 continue;
             }
 
@@ -405,15 +405,15 @@ void ProfMemoryManager::mgmt_loop() {
         //    is completely empty (avail == 0). Try recycled pool first, alloc as fallback.
         if (!recycled_perf_buffers_.empty() || !recycled_phase_buffers_.empty()) {
             for (int i = 0; i < num_cores_ && !recycled_perf_buffers_.empty(); i++) {
-                PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, i);
+                PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
                 rmb();
                 uint32_t avail = state->free_queue.tail - state->free_queue.head;
                 if (avail == 0) {
-                    void* dev_ptr = recycled_perf_buffers_.back();
+                    void *dev_ptr = recycled_perf_buffers_.back();
                     recycled_perf_buffers_.pop_back();
-                    void* host_ptr = resolve_host_ptr(dev_ptr);
+                    void *host_ptr = resolve_host_ptr(dev_ptr);
                     if (host_ptr != nullptr) {
-                        reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+                        reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
                         uint32_t t_val = state->free_queue.tail;
                         state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
                             reinterpret_cast<uint64_t>(dev_ptr);
@@ -424,15 +424,15 @@ void ProfMemoryManager::mgmt_loop() {
                 }
             }
             for (int t = 0; t < num_phase_threads_ && !recycled_phase_buffers_.empty(); t++) {
-                PhaseBufferState* state = get_phase_buffer_state(shared_mem_host_, num_cores_, t);
+                PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, t);
                 rmb();
                 uint32_t avail = state->free_queue.tail - state->free_queue.head;
                 if (avail == 0) {
-                    void* dev_ptr = recycled_phase_buffers_.back();
+                    void *dev_ptr = recycled_phase_buffers_.back();
                     recycled_phase_buffers_.pop_back();
-                    void* host_ptr = resolve_host_ptr(dev_ptr);
+                    void *host_ptr = resolve_host_ptr(dev_ptr);
                     if (host_ptr != nullptr) {
-                        reinterpret_cast<PhaseBuffer*>(host_ptr)->count = 0;
+                        reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
                         uint32_t t_val = state->free_queue.tail;
                         state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
                             reinterpret_cast<uint64_t>(dev_ptr);
@@ -447,13 +447,13 @@ void ProfMemoryManager::mgmt_loop() {
         // This only triggers when ALL pre-allocated buffers are in-flight (extreme workloads).
         if (recycled_perf_buffers_.empty() && recycled_phase_buffers_.empty()) {
             for (int i = 0; i < num_cores_; i++) {
-                PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, i);
+                PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
                 rmb();
                 if (state->free_queue.tail - state->free_queue.head == 0) {
-                    void* host_ptr = nullptr;
-                    void* dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
+                    void *host_ptr = nullptr;
+                    void *dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
                     if (dev_ptr == nullptr) break;  // HBM exhausted, stop trying
-                    reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+                    reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
                     uint32_t t_val = state->free_queue.tail;
                     state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
                         reinterpret_cast<uint64_t>(dev_ptr);
@@ -472,7 +472,7 @@ void ProfMemoryManager::mgmt_loop() {
     }
 
     // Final drain: process any remaining entries
-    PerfDataHeader* hdr = get_perf_header(shared_mem_host_);
+    PerfDataHeader *hdr = get_perf_header(shared_mem_host_);
     for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
         rmb();
         uint32_t head = hdr->queue_heads[t];
@@ -516,8 +516,8 @@ PerformanceCollector::~PerformanceCollector() {
     }
 }
 
-void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out) {
-    void* dev_ptr = alloc_cb_(size, user_data_);
+void *PerformanceCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size, user_data_);
     if (dev_ptr == nullptr) {
         LOG_ERROR("Failed to allocate buffer (%zu bytes)", size);
         *host_ptr_out = nullptr;
@@ -525,7 +525,7 @@ void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out
     }
 
     if (register_cb_ != nullptr) {
-        void* host_ptr = nullptr;
+        void *host_ptr = nullptr;
         int rc = register_cb_(dev_ptr, size, device_id_, user_data_, &host_ptr);
         if (rc != 0 || host_ptr == nullptr) {
             LOG_ERROR("Buffer registration failed: %d", rc);
@@ -542,14 +542,10 @@ void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out
     return dev_ptr;
 }
 
-int PerformanceCollector::initialize(Runtime& runtime,
-    int num_aicore,
-    int device_id,
-    PerfAllocCallback alloc_cb,
-    PerfRegisterCallback register_cb,
-    PerfFreeCallback free_cb,
-    void* user_data,
-    PerfSetDeviceCallback set_device_cb) {
+int PerformanceCollector::initialize(
+    Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb, void *user_data, PerfSetDeviceCallback set_device_cb
+) {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
         return -1;
@@ -582,7 +578,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
 
     // Step 2: Allocate shared memory for slot arrays
-    void* perf_dev_ptr = alloc_cb(total_size, user_data);
+    void *perf_dev_ptr = alloc_cb(total_size, user_data);
     if (perf_dev_ptr == nullptr) {
         LOG_ERROR("Failed to allocate shared memory (%zu bytes)", total_size);
         return -1;
@@ -590,7 +586,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("Allocated shared memory: %p", perf_dev_ptr);
 
     // Step 3: Register to host mapping (optional)
-    void* perf_host_ptr = nullptr;
+    void *perf_host_ptr = nullptr;
     if (register_cb != nullptr) {
         int rc = register_cb(perf_dev_ptr, total_size, device_id, user_data, &perf_host_ptr);
         if (rc != 0) {
@@ -609,7 +605,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     }
 
     // Step 4: Initialize header
-    PerfDataHeader* header = get_perf_header(perf_host_ptr);
+    PerfDataHeader *header = get_perf_header(perf_host_ptr);
 
     for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
         memset(header->queues[t], 0, sizeof(header->queues[t]));
@@ -627,7 +623,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
 
     // Step 5: Initialize PerfBufferStates — 1 buffer per core in free_queue, rest to recycled pool
     for (int i = 0; i < num_aicore; i++) {
-        PerfBufferState* state = get_perf_buffer_state(perf_host_ptr, i);
+        PerfBufferState *state = get_perf_buffer_state(perf_host_ptr, i);
         memset(state, 0, sizeof(PerfBufferState));
 
         state->free_queue.head = 0;
@@ -636,13 +632,13 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->current_buf_seq = 0;
 
         for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_CORE; s++) {
-            void* host_buf_ptr = nullptr;
-            void* dev_buf_ptr = alloc_single_buffer(sizeof(PerfBuffer), &host_buf_ptr);
+            void *host_buf_ptr = nullptr;
+            void *dev_buf_ptr = alloc_single_buffer(sizeof(PerfBuffer), &host_buf_ptr);
             if (dev_buf_ptr == nullptr) {
                 LOG_ERROR("Failed to allocate PerfBuffer for core %d, buffer %d", i, s);
                 return -1;
             }
-            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(host_buf_ptr);
+            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(host_buf_ptr);
             memset(buf, 0, sizeof(PerfBuffer));
             buf->count = 0;
 
@@ -656,13 +652,14 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->free_queue.tail = 1;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PerfBufferStates: 1 buffer/core, %d in recycled pool",
-        num_aicore,
-        num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1));
+    LOG_DEBUG(
+        "Initialized %d PerfBufferStates: 1 buffer/core, %d in recycled pool", num_aicore,
+        num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1)
+    );
 
     // Step 6: Initialize PhaseBufferStates — 1 buffer per thread in free_queue, rest to recycled pool
     for (int t = 0; t < num_phase_threads; t++) {
-        PhaseBufferState* state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
+        PhaseBufferState *state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
         memset(state, 0, sizeof(PhaseBufferState));
 
         state->free_queue.head = 0;
@@ -671,13 +668,13 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->current_buf_seq = 0;
 
         for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_THREAD; s++) {
-            void* host_buf_ptr = nullptr;
-            void* dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
+            void *host_buf_ptr = nullptr;
+            void *dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
             if (dev_buf_ptr == nullptr) {
                 LOG_ERROR("Failed to allocate PhaseBuffer for thread %d, buffer %d", t, s);
                 return -1;
             }
-            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(host_buf_ptr);
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(host_buf_ptr);
             memset(buf, 0, sizeof(PhaseBuffer));
             buf->count = 0;
 
@@ -691,9 +688,10 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->free_queue.tail = 1;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PhaseBufferStates: 1 buffer/thread, %d in recycled pool",
-        num_phase_threads,
-        num_phase_threads * (PLATFORM_PROF_BUFFERS_PER_THREAD - 1));
+    LOG_DEBUG(
+        "Initialized %d PhaseBufferStates: 1 buffer/thread, %d in recycled pool", num_phase_threads,
+        num_phase_threads * (PLATFORM_PROF_BUFFERS_PER_THREAD - 1)
+    );
 
     wmb();
 
@@ -713,15 +711,10 @@ void PerformanceCollector::start_memory_manager() {
         return;
     }
 
-    memory_manager_.start(perf_shared_mem_host_,
-        num_aicore_,
-        PLATFORM_MAX_AICPU_THREADS,
-        alloc_cb_,
-        register_cb_,
-        free_cb_,
-        user_data_,
-        device_id_,
-        set_device_cb_);
+    memory_manager_.start(
+        perf_shared_mem_host_, num_aicore_, PLATFORM_MAX_AICPU_THREADS, alloc_cb_, register_cb_, free_cb_, user_data_,
+        device_id_, set_device_cb_
+    );
 }
 
 void PerformanceCollector::stop_memory_manager() {
@@ -741,7 +734,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
 
     LOG_INFO("Collecting performance data");
 
-    PerfDataHeader* header = get_perf_header(perf_shared_mem_host_);
+    PerfDataHeader *header = get_perf_header(perf_shared_mem_host_);
 
     const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);
     std::optional<std::chrono::steady_clock::time_point> idle_start;
@@ -772,8 +765,10 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
 
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
-                LOG_ERROR("Timeout waiting for AICPU task count after %ld seconds",
-                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                LOG_ERROR(
+                    "Timeout waiting for AICPU task count after %ld seconds",
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
+                );
                 return;
             }
 
@@ -781,7 +776,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             ReadyBufferInfo info;
             if (memory_manager_.try_pop_ready(info)) {
                 if (info.type == ProfBufferType::PERF_RECORD) {
-                    PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
+                    PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
                     rmb();
                     uint32_t count = buf->count;
                     if (count > PLATFORM_PROF_BUFFER_SIZE) {
@@ -795,7 +790,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                         total_records_collected += count;
                     }
                 } else {
-                    PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
+                    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
                     rmb();
                     uint32_t count = buf->count;
                     if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -815,7 +810,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     LOG_DEBUG("Initial expected tasks: %d", expected_tasks);
 
     // Check phase header for scheduler thread info
-    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
     int num_sched_for_poll = 0;
     if (phase_header->magic == AICPU_PHASE_MAGIC) {
         num_sched_for_poll = phase_header->num_sched_threads;
@@ -844,7 +839,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             idle_start.reset();
 
             if (info.type == ProfBufferType::PERF_RECORD) {
-                PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
+                PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
                 rmb();
                 uint32_t count = buf->count;
                 if (count > PLATFORM_PROF_BUFFER_SIZE) {
@@ -859,14 +854,13 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                     total_records_collected += count;
                 }
 
-                LOG_DEBUG("Collected %u perf records from core %u (total: %d/%d)",
-                    count,
-                    core_index,
-                    total_records_collected,
-                    expected_tasks);
+                LOG_DEBUG(
+                    "Collected %u perf records from core %u (total: %d/%d)", count, core_index, total_records_collected,
+                    expected_tasks
+                );
 
             } else {
-                PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
+                PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
                 rmb();
                 uint32_t count = buf->count;
                 if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -892,7 +886,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 ReadyBufferInfo drain_info;
                 while (memory_manager_.try_pop_ready(drain_info)) {
                     if (drain_info.type == ProfBufferType::PERF_RECORD) {
-                        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(drain_info.host_buffer_ptr);
+                        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(drain_info.host_buffer_ptr);
                         rmb();
                         uint32_t count = buf->count;
                         if (count > PLATFORM_PROF_BUFFER_SIZE) count = PLATFORM_PROF_BUFFER_SIZE;
@@ -904,7 +898,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                             total_records_collected += count;
                         }
                     } else {
-                        PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(drain_info.host_buffer_ptr);
+                        PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(drain_info.host_buffer_ptr);
                         rmb();
                         uint32_t count = buf->count;
                         if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD))
@@ -917,9 +911,10 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                     memory_manager_.notify_copy_done({drain_info.dev_buffer_ptr, drain_info.type});
                     buffers_processed++;
                 }
-                LOG_INFO("Execution complete signal received, exiting with %d/%d records",
-                    total_records_collected,
-                    expected_tasks);
+                LOG_INFO(
+                    "Execution complete signal received, exiting with %d/%d records", total_records_collected,
+                    expected_tasks
+                );
                 break;
             }
             if (!idle_start.has_value()) {
@@ -927,8 +922,10 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             }
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
-                LOG_ERROR("Performance data collection idle timeout after %ld seconds",
-                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                LOG_ERROR(
+                    "Performance data collection idle timeout after %ld seconds",
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
+                );
                 LOG_ERROR("Collected %d / %d records before timeout", total_records_collected, expected_tasks);
                 break;
             }
@@ -951,7 +948,7 @@ void PerformanceCollector::drain_remaining_buffers() {
     }
 
     // Ensure phase record storage is initialized
-    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
     rmb();
     int num_sched = 0;
     if (phase_header->magic == AICPU_PHASE_MAGIC) {
@@ -967,7 +964,7 @@ void PerformanceCollector::drain_remaining_buffers() {
     ReadyBufferInfo info;
     while (memory_manager_.try_pop_ready(info)) {
         if (info.type == ProfBufferType::PERF_RECORD) {
-            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
+            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
             rmb();
             uint32_t count = buf->count;
             if (count > PLATFORM_PROF_BUFFER_SIZE) {
@@ -981,7 +978,7 @@ void PerformanceCollector::drain_remaining_buffers() {
                 drained_perf += count;
             }
         } else {
-            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
             rmb();
             uint32_t count = buf->count;
             if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -1016,7 +1013,7 @@ void PerformanceCollector::scan_remaining_perf_buffers() {
     int total_recovered = 0;
 
     for (int core_index = 0; core_index < num_aicore_; core_index++) {
-        PerfBufferState* state = get_perf_buffer_state(perf_shared_mem_host_, core_index);
+        PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, core_index);
 
         rmb();
         uint64_t buf_ptr = state->current_buf_ptr;
@@ -1024,15 +1021,16 @@ void PerformanceCollector::scan_remaining_perf_buffers() {
             continue;
         }
 
-        void* host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void*>(buf_ptr));
+        void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
         if (host_ptr == nullptr) {
-            LOG_ERROR("scan_remaining_perf_buffers: no host mapping for dev_ptr=%p (core %d)",
-                reinterpret_cast<void*>(buf_ptr),
-                core_index);
+            LOG_ERROR(
+                "scan_remaining_perf_buffers: no host mapping for dev_ptr=%p (core %d)",
+                reinterpret_cast<void *>(buf_ptr), core_index
+            );
             continue;
         }
 
-        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(host_ptr);
+        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(host_ptr);
         uint32_t count = buf->count;
         if (count == 0) {
             continue;
@@ -1059,19 +1057,21 @@ void PerformanceCollector::collect_phase_data() {
 
     rmb();
 
-    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
 
     // Validate magic
     if (phase_header->magic != AICPU_PHASE_MAGIC) {
         LOG_INFO(
-            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC);
+            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC
+        );
         return;
     }
 
     int num_sched_threads = phase_header->num_sched_threads;
     if (num_sched_threads > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR(
-            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
+            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS
+        );
         return;
     }
     LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
@@ -1084,19 +1084,20 @@ void PerformanceCollector::collect_phase_data() {
     // contains partial data that was never enqueued (the active buffer when execution ended).
     int total_phase_records = 0;
     for (int t = 0; t < total_slots; t++) {
-        PhaseBufferState* state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
 
         rmb();
         uint64_t buf_ptr = state->current_buf_ptr;
         if (buf_ptr != 0) {
-            void* host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void*>(buf_ptr));
+            void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
             if (host_ptr == nullptr) {
-                LOG_ERROR("collect_phase_data: no host mapping for dev_ptr=%p (thread %d)",
-                    reinterpret_cast<void*>(buf_ptr),
-                    t);
+                LOG_ERROR(
+                    "collect_phase_data: no host mapping for dev_ptr=%p (thread %d)", reinterpret_cast<void *>(buf_ptr),
+                    t
+                );
                 continue;
             }
-            PhaseBuffer* pbuf = reinterpret_cast<PhaseBuffer*>(host_ptr);
+            PhaseBuffer *pbuf = reinterpret_cast<PhaseBuffer *>(host_ptr);
             if (pbuf->count > 0) {
                 uint32_t count = pbuf->count;
                 if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -1115,17 +1116,14 @@ void PerformanceCollector::collect_phase_data() {
     for (size_t t = 0; t < collected_phase_records_.size(); t++) {
         if (!collected_phase_records_[t].empty()) {
             size_t sched_count = 0, orch_count = 0;
-            for (const auto& r : collected_phase_records_[t]) {
-                if (is_scheduler_phase(r.phase_id))
-                    sched_count++;
-                else
-                    orch_count++;
+            for (const auto &r : collected_phase_records_[t]) {
+                if (is_scheduler_phase(r.phase_id)) sched_count++;
+                else orch_count++;
             }
-            LOG_INFO("  Thread %zu: %zu records (sched=%zu, orch=%zu)",
-                t,
-                collected_phase_records_[t].size(),
-                sched_count,
-                orch_count);
+            LOG_INFO(
+                "  Thread %zu: %zu records (sched=%zu, orch=%zu)", t, collected_phase_records_[t].size(), sched_count,
+                orch_count
+            );
         }
     }
 
@@ -1134,9 +1132,10 @@ void PerformanceCollector::collect_phase_data() {
     bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
 
     if (orch_valid) {
-        LOG_INFO("  Orchestrator: %" PRId64 " tasks, %.3fus",
-            static_cast<int64_t>(collected_orch_summary_.submit_count),
-            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time));
+        LOG_INFO(
+            "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
+            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time)
+        );
     } else {
         LOG_INFO("  Orchestrator: no summary data");
     }
@@ -1144,7 +1143,7 @@ void PerformanceCollector::collect_phase_data() {
     // Check if drain_remaining_buffers() already accumulated some Phase records
     bool has_accumulated = has_phase_data_;
     if (!has_accumulated) {
-        for (const auto& v : collected_phase_records_) {
+        for (const auto &v : collected_phase_records_) {
             if (!v.empty()) {
                 has_accumulated = true;
                 break;
@@ -1160,15 +1159,16 @@ void PerformanceCollector::collect_phase_data() {
         LOG_INFO("  Core-to-thread mapping: %d cores", num_cores);
     }
 
-    LOG_INFO("Phase data collection complete: %d remaining records, orch_summary=%s",
-        total_phase_records,
-        orch_valid ? "yes" : "no");
+    LOG_INFO(
+        "Phase data collection complete: %d remaining records, orch_summary=%s", total_phase_records,
+        orch_valid ? "yes" : "no"
+    );
 }
 
-int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
+int PerformanceCollector::export_swimlane_json(const std::string &output_path) {
     // Step 1: Validate collected data
     bool has_any_records = false;
-    for (const auto& core_records : collected_perf_records_) {
+    for (const auto &core_records : collected_perf_records_) {
         if (!core_records.empty()) {
             has_any_records = true;
             break;
@@ -1190,29 +1190,29 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
     // Step 3: Flatten per-core vectors into tagged records with core_id derived from index
     struct TaggedRecord {
-        const PerfRecord* record;
+        const PerfRecord *record;
         uint32_t core_id;
     };
     std::vector<TaggedRecord> tagged_records;
     size_t total_records = 0;
-    for (const auto& core_records : collected_perf_records_) {
+    for (const auto &core_records : collected_perf_records_) {
         total_records += core_records.size();
     }
     tagged_records.reserve(total_records);
     for (size_t core_idx = 0; core_idx < collected_perf_records_.size(); core_idx++) {
-        for (const auto& record : collected_perf_records_[core_idx]) {
+        for (const auto &record : collected_perf_records_[core_idx]) {
             tagged_records.push_back({&record, static_cast<uint32_t>(core_idx)});
         }
     }
 
     // Sort by canonical task_id (64-bit PTO2 raw)
-    std::sort(tagged_records.begin(), tagged_records.end(), [](const TaggedRecord& a, const TaggedRecord& b) {
+    std::sort(tagged_records.begin(), tagged_records.end(), [](const TaggedRecord &a, const TaggedRecord &b) {
         return a.record->task_id < b.record->task_id;
     });
 
     // Step 4: Calculate base time (minimum timestamp across all records)
     uint64_t base_time_cycles = UINT64_MAX;
-    for (const auto& tagged : tagged_records) {
+    for (const auto &tagged : tagged_records) {
         if (tagged.record->start_time < base_time_cycles) {
             base_time_cycles = tagged.record->start_time;
         }
@@ -1223,8 +1223,8 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
     // Include phase record timestamps in base_time calculation
     if (has_phase_data_) {
-        for (const auto& thread_records : collected_phase_records_) {
-            for (const auto& pr : thread_records) {
+        for (const auto &thread_records : collected_phase_records_) {
+            for (const auto &pr : thread_records) {
                 if (pr.start_time > 0 && pr.start_time < base_time_cycles) {
                     base_time_cycles = pr.start_time;
                 }
@@ -1238,7 +1238,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
     // Step 5: Generate filename with timestamp (YYYYMMDD_HHMMSS)
     std::time_t now = time(nullptr);
-    std::tm* timeinfo = std::localtime(&now);
+    std::tm *timeinfo = std::localtime(&now);
     char time_buffer[32];
     std::strftime(time_buffer, sizeof(time_buffer), "%Y%m%d_%H%M%S", timeinfo);
     std::string filepath = output_path + "/perf_swimlane_" + std::string(time_buffer) + ".json";
@@ -1257,8 +1257,8 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     outfile << "  \"tasks\": [\n";
 
     for (size_t i = 0; i < tagged_records.size(); ++i) {
-        const auto& tagged = tagged_records[i];
-        const auto& record = *tagged.record;
+        const auto &tagged = tagged_records[i];
+        const auto &record = *tagged.record;
 
         // Convert times to microseconds
         double start_us = cycles_to_us(record.start_time - base_time_cycles);
@@ -1267,7 +1267,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         double dispatch_us = (record.dispatch_time > 0) ? cycles_to_us(record.dispatch_time - base_time_cycles) : 0.0;
         double finish_us = (record.finish_time > 0) ? cycles_to_us(record.finish_time - base_time_cycles) : 0.0;
 
-        const char* core_type_str = (record.core_type == CoreType::AIC) ? "aic" : "aiv";
+        const char *core_type_str = (record.core_type == CoreType::AIC) ? "aic" : "aiv";
 
         outfile << "    {\n";
         outfile << "      \"task_id\": " << record.task_id << ",\n";
@@ -1301,43 +1301,43 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
     // Step 8: Write phase profiling data (version 2)
     if (has_phase_data_) {
-        auto sched_phase_name = [](AicpuPhaseId id) -> const char* {
+        auto sched_phase_name = [](AicpuPhaseId id) -> const char * {
             switch (id) {
-                case AicpuPhaseId::SCHED_COMPLETE:
-                    return "complete";
-                case AicpuPhaseId::SCHED_DISPATCH:
-                    return "dispatch";
-                case AicpuPhaseId::SCHED_SCAN:
-                    return "scan";
-                case AicpuPhaseId::SCHED_IDLE_WAIT:
-                    return "idle";
-                default:
-                    return "unknown";
+            case AicpuPhaseId::SCHED_COMPLETE:
+                return "complete";
+            case AicpuPhaseId::SCHED_DISPATCH:
+                return "dispatch";
+            case AicpuPhaseId::SCHED_SCAN:
+                return "scan";
+            case AicpuPhaseId::SCHED_IDLE_WAIT:
+                return "idle";
+            default:
+                return "unknown";
             }
         };
 
-        auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
+        auto orch_phase_name = [](AicpuPhaseId id) -> const char * {
             switch (id) {
-                case AicpuPhaseId::ORCH_SYNC:
-                    return "orch_sync";
-                case AicpuPhaseId::ORCH_ALLOC:
-                    return "orch_alloc";
-                case AicpuPhaseId::ORCH_PARAMS:
-                    return "orch_params";
-                case AicpuPhaseId::ORCH_LOOKUP:
-                    return "orch_lookup";
-                case AicpuPhaseId::ORCH_HEAP:
-                    return "orch_heap";
-                case AicpuPhaseId::ORCH_INSERT:
-                    return "orch_insert";
-                case AicpuPhaseId::ORCH_FANIN:
-                    return "orch_fanin";
-                case AicpuPhaseId::ORCH_FINALIZE:
-                    return "orch_finalize";
-                case AicpuPhaseId::ORCH_SCOPE_END:
-                    return "orch_scope_end";
-                default:
-                    return "unknown";
+            case AicpuPhaseId::ORCH_SYNC:
+                return "orch_sync";
+            case AicpuPhaseId::ORCH_ALLOC:
+                return "orch_alloc";
+            case AicpuPhaseId::ORCH_PARAMS:
+                return "orch_params";
+            case AicpuPhaseId::ORCH_LOOKUP:
+                return "orch_lookup";
+            case AicpuPhaseId::ORCH_HEAP:
+                return "orch_heap";
+            case AicpuPhaseId::ORCH_INSERT:
+                return "orch_insert";
+            case AicpuPhaseId::ORCH_FANIN:
+                return "orch_fanin";
+            case AicpuPhaseId::ORCH_FINALIZE:
+                return "orch_finalize";
+            case AicpuPhaseId::ORCH_SCOPE_END:
+                return "orch_scope_end";
+            default:
+                return "unknown";
             }
         };
 
@@ -1346,7 +1346,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         for (size_t t = 0; t < collected_phase_records_.size(); t++) {
             outfile << "    [\n";
             bool first = true;
-            for (const auto& pr : collected_phase_records_[t]) {
+            for (const auto &pr : collected_phase_records_[t]) {
                 if (!is_scheduler_phase(pr.phase_id)) continue;
                 double start_us = cycles_to_us(pr.start_time - base_time_cycles);
                 double end_us = cycles_to_us(pr.end_time - base_time_cycles);
@@ -1397,8 +1397,8 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
         // Per-task orchestrator phase records (filtered from unified collected_phase_records_)
         bool has_orch_phases = false;
-        for (const auto& v : collected_phase_records_) {
-            for (const auto& r : v) {
+        for (const auto &v : collected_phase_records_) {
+            for (const auto &r : v) {
                 if (!is_scheduler_phase(r.phase_id)) {
                     has_orch_phases = true;
                     break;
@@ -1411,7 +1411,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
             for (size_t t = 0; t < collected_phase_records_.size(); t++) {
                 outfile << "    [\n";
                 bool first = true;
-                for (const auto& pr : collected_phase_records_[t]) {
+                for (const auto &pr : collected_phase_records_[t]) {
                     if (is_scheduler_phase(pr.phase_id)) continue;
                     double start_us = cycles_to_us(pr.start_time - base_time_cycles);
                     double end_us = cycles_to_us(pr.end_time - base_time_cycles);
@@ -1454,7 +1454,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     return 0;
 }
 
-int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data) {
+int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void *user_data) {
     if (perf_shared_mem_host_ == nullptr) {
         return 0;
     }
@@ -1469,11 +1469,11 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFre
     // The memory manager frees old buffers after copy; initial buffers in free_queues remain.
     // Free all buffers in the free_queues and current_buf_ptr.
     for (int i = 0; i < num_aicore_; i++) {
-        PerfBufferState* state = get_perf_buffer_state(perf_shared_mem_host_, i);
+        PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, i);
 
         // Free current buffer if any
         if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            free_cb(reinterpret_cast<void*>(state->current_buf_ptr), user_data);
+            free_cb(reinterpret_cast<void *>(state->current_buf_ptr), user_data);
         }
 
         // Free all buffers in free_queue (limit iterations to max capacity)
@@ -1484,7 +1484,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFre
         while (head != tail && max_iters-- > 0) {
             uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
             if (buf_ptr != 0 && free_cb != nullptr) {
-                free_cb(reinterpret_cast<void*>(buf_ptr), user_data);
+                free_cb(reinterpret_cast<void *>(buf_ptr), user_data);
             }
             head++;
         }
@@ -1495,11 +1495,11 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFre
 
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
     for (int t = 0; t < num_phase_threads; t++) {
-        PhaseBufferState* state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
 
         // Free current buffer if any
         if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            free_cb(reinterpret_cast<void*>(state->current_buf_ptr), user_data);
+            free_cb(reinterpret_cast<void *>(state->current_buf_ptr), user_data);
         }
 
         // Free all buffers in free_queue (limit iterations to max capacity)
@@ -1510,7 +1510,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFre
         while (head != tail && max_iters-- > 0) {
             uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
             if (buf_ptr != 0 && free_cb != nullptr) {
-                free_cb(reinterpret_cast<void*>(buf_ptr), user_data);
+                free_cb(reinterpret_cast<void *>(buf_ptr), user_data);
             }
             head++;
         }

--- a/src/a2a3/platform/src/host/unified_log_host.cpp
+++ b/src/a2a3/platform/src/host/unified_log_host.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file unified_log_host.cpp
  * @brief Unified logging - Host implementation
@@ -9,7 +19,7 @@
 #include <cstdarg>
 #include <cstdio>
 
-void unified_log_error(const char* func, const char* fmt, ...) {
+void unified_log_error(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];
@@ -18,18 +28,18 @@ void unified_log_error(const char* func, const char* fmt, ...) {
     HostLogger::get_instance().log(HostLogLevel::ERROR, "%s: %s", func, buffer);
 }
 
-void unified_log_warn(const char* func, const char* fmt, ...) {
+void unified_log_warn(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     HostLogger::get_instance().log(HostLogLevel::WARN, "%s: %s", func, buffer);
 }
 
-void unified_log_info(const char* func, const char* fmt, ...) {
+void unified_log_info(const char *func, const char *fmt, ...) {
     if (!HostLogger::get_instance().is_enabled(HostLogLevel::INFO)) {
         return;
     }
@@ -41,7 +51,7 @@ void unified_log_info(const char* func, const char* fmt, ...) {
     HostLogger::get_instance().log(HostLogLevel::INFO, "%s: %s", func, buffer);
 }
 
-void unified_log_debug(const char* func, const char* fmt, ...) {
+void unified_log_debug(const char *func, const char *fmt, ...) {
     if (!HostLogger::get_instance().is_enabled(HostLogLevel::DEBUG)) {
         return;
     }
@@ -53,7 +63,7 @@ void unified_log_debug(const char* func, const char* fmt, ...) {
     HostLogger::get_instance().log(HostLogLevel::DEBUG, "%s: %s", func, buffer);
 }
 
-void unified_log_always(const char* func, const char* fmt, ...) {
+void unified_log_always(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];

--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -22,7 +22,7 @@
  * All kernels follow the same signature: void kernel(__gm__ int64_t* args)
  * This enables simple, switch-free dispatch.
  */
-typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
+typedef void (*UnifiedKernelFunc)(__gm__ int64_t *);
 
 /**
  * Execute task from PTO2DispatchPayload.
@@ -31,13 +31,13 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload *payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
 
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
-    kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
+    kernel(reinterpret_cast<__gm__ int64_t *>(payload->args));
     OUT_OF_ORDER_STORE_BARRIER();
 }
 
@@ -56,8 +56,8 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * @param block_idx Block index (core ID)
  * @param core_type Core type (AIC or AIV)
  */
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
-    __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type) {
+    __gm__ Handshake *my_hank = (__gm__ Handshake *)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
@@ -83,7 +83,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     // Cache payload address (set once by AICPU during initialization, never changes)
-    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+    __gm__ PTO2DispatchPayload *payload = reinterpret_cast<__gm__ PTO2DispatchPayload *>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
 
@@ -124,7 +124,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             // (func_id and core_type are filled by AICPU at completion time)
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
-                __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
+                __gm__ PerfBuffer *perf_buf = (__gm__ PerfBuffer *)my_hank->perf_records_addr;
                 perf_aicore_record_task(perf_buf, task_id, start_time, end_time);
             }
 

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -68,14 +68,14 @@
 // The orchestration .so receives a PTO2Runtime* (with ops table populated)
 // instead of a raw shared-memory pointer.
 typedef void (*DeviceOrchestrationFunc)(
-    PTO2Runtime* rt, const ChipStorageTaskArgs& orch_args, int32_t orch_thread_num, int32_t orch_thread_index);
+    PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args, int32_t orch_thread_num, int32_t orch_thread_index
+);
 
 // Config function exported by orchestration .so
-typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs& orch_args);
+typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs &orch_args);
 
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 constexpr int32_t MAX_AIC_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD;
-constexpr int32_t MAX_AIV_PER_THREAD = PLATFORM_MAX_AIV_PER_THREAD;
 constexpr int32_t MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 
 constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
@@ -87,7 +87,7 @@ constexpr int32_t STALL_DUMP_CORE_MAX = 8;
 constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
 constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
 
-static PTO2Runtime* rt{nullptr};
+static PTO2Runtime *rt{nullptr};
 
 // Per-core dispatch payload storage (one per physical core)
 static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
@@ -134,35 +134,34 @@ struct CoreStateTracker {
     Cluster clusters[MAX_AIC_PER_THREAD];
     int32_t cluster_count;
 
-    CoreTypeTracker& aic() { return by_type[0]; }
-    CoreTypeTracker& aiv() { return by_type[1]; }
+    CoreTypeTracker &aic() { return by_type[0]; }
+    CoreTypeTracker &aiv() { return by_type[1]; }
 
     template <CoreType CT>
-    CoreTypeTracker& get() {
+    CoreTypeTracker &get() {
         return by_type[static_cast<int32_t>(CT)];
     }
 
-    int32_t find_cluster_for_shape(PTO2ResourceShape shape, bool* core_idle) {
+    int32_t find_cluster_for_shape(PTO2ResourceShape shape, bool *core_idle) {
         for (int32_t i = 0; i < cluster_count; i++) {
-            Cluster& c = clusters[i];
+            Cluster &c = clusters[i];
             switch (shape) {
-                case PTO2ResourceShape::AIC_ONLY:
-                    if (core_idle[c.aic_core_id]) return i;
-                    break;
-                case PTO2ResourceShape::AIV_X1:
-                    if (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]]) return i;
-                    break;
-                case PTO2ResourceShape::AIV_X2:
-                    if (core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]]) return i;
-                    break;
-                case PTO2ResourceShape::AIC_AIV_X1:
-                    if (core_idle[c.aic_core_id] && (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]]))
-                        return i;
-                    break;
-                case PTO2ResourceShape::AIC_AIV_X2:
-                    if (core_idle[c.aic_core_id] && core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]])
-                        return i;
-                    break;
+            case PTO2ResourceShape::AIC_ONLY:
+                if (core_idle[c.aic_core_id]) return i;
+                break;
+            case PTO2ResourceShape::AIV_X1:
+                if (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]]) return i;
+                break;
+            case PTO2ResourceShape::AIV_X2:
+                if (core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]]) return i;
+                break;
+            case PTO2ResourceShape::AIC_AIV_X1:
+                if (core_idle[c.aic_core_id] && (core_idle[c.aiv_core_ids[0]] || core_idle[c.aiv_core_ids[1]]))
+                    return i;
+                break;
+            case PTO2ResourceShape::AIC_AIV_X2:
+                if (core_idle[c.aic_core_id] && core_idle[c.aiv_core_ids[0]] && core_idle[c.aiv_core_ids[1]]) return i;
+                break;
             }
         }
         return -1;
@@ -207,7 +206,7 @@ struct AicpuExecutor {
     PTO2SubtaskSlot executing_subslot_by_core_[RUNTIME_MAX_WORKER]{};
 
     // Per-core slot state tracking (PTO2TaskSlotState* for the running task on each core)
-    PTO2TaskSlotState* executing_slot_state_by_core_[RUNTIME_MAX_WORKER]{};
+    PTO2TaskSlotState *executing_slot_state_by_core_[RUNTIME_MAX_WORKER]{};
 
     // Platform register base address array (set via get_platform_regs())
     uint64_t regs_{0};
@@ -240,43 +239,44 @@ struct AicpuExecutor {
     std::atomic<bool> completed_{false};
 
     // Orchestration SO handle - defer dlclose until all tasks complete
-    void* orch_so_handle_{nullptr};
+    void *orch_so_handle_{nullptr};
     char orch_so_path_[256]{};  // Path to orchestration SO file for cleanup
 
     // Shared orchestration function pointer (loaded by first orch thread, used by all)
     DeviceOrchestrationFunc orch_func_{nullptr};
-    const ChipStorageTaskArgs* orch_args_cached_{nullptr};
+    const ChipStorageTaskArgs *orch_args_cached_{nullptr};
 
     // ===== Performance profiling state =====
     uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];  // Per-core AICPU dispatch timestamp
     uint32_t
         core_dispatch_counts_[RUNTIME_MAX_WORKER];  // Per-core total dispatched task counter (for buffer management)
 
-    uint64_t* func_id_to_addr_;
+    uint64_t *func_id_to_addr_;
     uint64_t get_function_bin_addr(int func_id) const {
         if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
         return func_id_to_addr_[func_id];
     }
 
     // ===== Methods =====
-    int32_t init(Runtime* runtime);
-    int32_t handshake_all_cores(Runtime* runtime);
+    int32_t init(Runtime *runtime);
+    int32_t handshake_all_cores(Runtime *runtime);
     void assign_cores_to_threads();
     void reassign_cores_for_all_threads();
-    int32_t resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx);
-    int32_t shutdown_aicore(Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num);
-    int32_t run(Runtime* runtime);
-    void deinit(Runtime* runtime);
-    void emergency_shutdown(Runtime* runtime);
+    int32_t resolve_and_dispatch_pto2(Runtime *runtime, int32_t thread_idx);
+    int32_t shutdown_aicore(Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num);
+    int32_t run(Runtime *runtime);
+    void deinit(Runtime *runtime);
+    void emergency_shutdown(Runtime *runtime);
     void diagnose_stuck_state(
-        Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank);
+        Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
+    );
 
     // Build slim PTO2DispatchPayload: only function_bin_addr + args.
     // Metadata (task_id, subslot, kernel_id, core_type) stays in TaskDescriptor.
     // Dispatch order: tensor args first, then scalar args.
-    void build_pto2_payload(PTO2DispatchPayload& out, int32_t kernel_id, PTO2TaskPayload& task_pl) {
+    void build_pto2_payload(PTO2DispatchPayload &out, int32_t kernel_id, PTO2TaskPayload &task_pl) {
         uint64_t callable_addr = get_function_bin_addr(kernel_id);
-        const CoreCallable* callable = reinterpret_cast<const CoreCallable*>(callable_addr);
+        const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
         out.function_bin_addr = callable->resolved_addr();
         int32_t n = 0;
         for (int32_t i = 0; i < task_pl.tensor_count; i++) {
@@ -290,30 +290,19 @@ struct AicpuExecutor {
 
     // Template methods for Phase 1 and Phase 2
     template <CoreType CT>
-    void check_running_cores_for_completion(int32_t thread_idx,
-        CoreTypeTracker& ct,
-        Handshake* hank,
-        int32_t& completed_this_turn,
-        int32_t& cur_thread_completed,
-        bool& made_progress,
-        PTO2TaskSlotState* deferred_release_slot_states[],
-        int32_t& deferred_release_count,
-        PTO2LocalReadyBuffer* local_bufs
+    void check_running_cores_for_completion(
+        int32_t thread_idx, CoreTypeTracker &ct, Handshake *hank, int32_t &completed_this_turn,
+        int32_t &cur_thread_completed, bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[],
+        int32_t &deferred_release_count, PTO2LocalReadyBuffer *local_bufs
 #if PTO2_PROFILING
         ,
-        bool profiling_enabled,
-        uint32_t& phase_complete_count
+        bool profiling_enabled, uint32_t &phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
         ,
-        uint64_t& complete_probe_count,
-        uint64_t& complete_hit_count,
-        uint64_t& notify_edges_total,
-        int32_t& notify_max_degree,
-        uint64_t& notify_tasks_enqueued,
-        uint64_t& fanin_edges_total,
-        int32_t& fanin_max_degree,
-        uint64_t& sched_complete_perf_cycle
+        uint64_t &complete_probe_count, uint64_t &complete_hit_count, uint64_t &notify_edges_total,
+        int32_t &notify_max_degree, uint64_t &notify_tasks_enqueued, uint64_t &fanin_edges_total,
+        int32_t &fanin_max_degree, uint64_t &sched_complete_perf_cycle
 #endif
     ) {
         for (int32_t i = ct.running_count - 1; i >= 0; i--) {
@@ -337,7 +326,7 @@ struct AicpuExecutor {
             if (done) {
                 executing_reg_task_ids_[core_id] = AICPU_TASK_INVALID;
                 PTO2SubtaskSlot subslot = executing_subslot_by_core_[core_id];
-                PTO2TaskSlotState& slot_state = *executing_slot_state_by_core_[core_id];
+                PTO2TaskSlotState &slot_state = *executing_slot_state_by_core_[core_id];
 
                 // Two-stage completion: mark subtask done, then handle mixed-task completion
                 bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state, subslot);
@@ -362,7 +351,8 @@ struct AicpuExecutor {
                         while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
                             int32_t fe = rt->scheduler.on_task_release(
-                                *deferred_release_slot_states[--deferred_release_count], thread_idx);
+                                *deferred_release_slot_states[--deferred_release_count], thread_idx
+                            );
 #else
                             int32_t fe =
                                 rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
@@ -383,32 +373,29 @@ struct AicpuExecutor {
 #if PTO2_SCHED_PROFILING
                     uint64_t t_perf_start = get_sys_cnt_aicpu();
 #endif
-                    Handshake* h = &hank[core_id];
+                    Handshake *h = &hank[core_id];
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
+                    PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
 
                     // Pre-extract fanout (platform layer cannot depend on PTO2DepListEntry)
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     int32_t fanout_n = 0;
-                    PTO2DepListEntry* cur = slot_state.fanout_head;
+                    PTO2DepListEntry *cur = slot_state.fanout_head;
                     while (cur != nullptr && fanout_n < RUNTIME_MAX_FANOUT) {
                         fanout_arr[fanout_n++] = cur->slot_state->task->task_id.raw;
                         cur = cur->next;
                     }
 
                     int32_t perf_slot_idx = static_cast<int32_t>(executing_subslot_by_core_[core_id]);
-                    if (perf_aicpu_complete_record(perf_buf,
-                            static_cast<uint32_t>(expected_reg_task_id),
-                            slot_state.task->task_id.raw,
-                            slot_state.task->kernel_id[perf_slot_idx],
-                            CT,
-                            dispatch_timestamps_[core_id],
-                            finish_ts,
-                            fanout_arr,
-                            fanout_n) != 0) {
-                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task 0x%" PRIx64,
-                            core_id,
-                            static_cast<uint64_t>(slot_state.task->task_id.raw));
+                    if (perf_aicpu_complete_record(
+                            perf_buf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
+                            slot_state.task->kernel_id[perf_slot_idx], CT, dispatch_timestamps_[core_id], finish_ts,
+                            fanout_arr, fanout_n
+                        ) != 0) {
+                        DEV_ERROR(
+                            "Core %d: perf_aicpu_complete_record failed for task 0x%" PRIx64, core_id,
+                            static_cast<uint64_t>(slot_state.task->task_id.raw)
+                        );
                     }
 #if PTO2_SCHED_PROFILING
                     sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
@@ -416,12 +403,10 @@ struct AicpuExecutor {
                 }
 #endif
 
-                DEV_DEBUG("Thread %d: %s core %d completed PTO2 task %d (mixed_complete=%d)",
-                    thread_idx,
-                    CT == CoreType::AIC ? "AIC" : "AIV",
-                    core_id,
-                    expected_reg_task_id,
-                    mixed_complete ? 1 : 0);
+                DEV_DEBUG(
+                    "Thread %d: %s core %d completed PTO2 task %d (mixed_complete=%d)", thread_idx,
+                    CT == CoreType::AIC ? "AIC" : "AIV", core_id, expected_reg_task_id, mixed_complete ? 1 : 0
+                );
                 cur_thread_completed++;
                 if (mixed_complete) {
                     completed_this_turn++;
@@ -431,18 +416,18 @@ struct AicpuExecutor {
         }
     }
 
-    static const char* shape_name(PTO2ResourceShape shape) {
+    static const char *shape_name(PTO2ResourceShape shape) {
         switch (shape) {
-            case PTO2ResourceShape::AIC_ONLY:
-                return "AIC_ONLY";
-            case PTO2ResourceShape::AIV_X1:
-                return "AIV_X1";
-            case PTO2ResourceShape::AIV_X2:
-                return "AIV_X2";
-            case PTO2ResourceShape::AIC_AIV_X1:
-                return "AIC_AIV_X1";
-            case PTO2ResourceShape::AIC_AIV_X2:
-                return "AIC_AIV_X2";
+        case PTO2ResourceShape::AIC_ONLY:
+            return "AIC_ONLY";
+        case PTO2ResourceShape::AIV_X1:
+            return "AIV_X1";
+        case PTO2ResourceShape::AIV_X2:
+            return "AIV_X2";
+        case PTO2ResourceShape::AIC_AIV_X1:
+            return "AIC_AIV_X1";
+        case PTO2ResourceShape::AIC_AIV_X2:
+            return "AIC_AIV_X2";
         }
         return "UNKNOWN";
     }
@@ -469,44 +454,37 @@ struct AicpuExecutor {
      * Even/odd threads use different fallback orders (AIC-first vs AIV-first)
      * to reduce contention on the same ready queue across adjacent threads.
      */
-    static const PTO2ResourceShape* get_dispatch_order(int32_t thread_idx) {
+    static const PTO2ResourceShape *get_dispatch_order(int32_t thread_idx) {
         // Even threads: AIC-first fallback after widest
         static constexpr PTO2ResourceShape kEvenOrder[PTO2_NUM_RESOURCE_SHAPES] = {
-            PTO2ResourceShape::AIC_AIV_X2,
-            PTO2ResourceShape::AIC_AIV_X1,
-            PTO2ResourceShape::AIC_ONLY,
-            PTO2ResourceShape::AIV_X2,
-            PTO2ResourceShape::AIV_X1,
+            PTO2ResourceShape::AIC_AIV_X2, PTO2ResourceShape::AIC_AIV_X1, PTO2ResourceShape::AIC_ONLY,
+            PTO2ResourceShape::AIV_X2,     PTO2ResourceShape::AIV_X1,
         };
         // Odd threads: AIV-first fallback after widest
         static constexpr PTO2ResourceShape kOddOrder[PTO2_NUM_RESOURCE_SHAPES] = {
-            PTO2ResourceShape::AIC_AIV_X2,
-            PTO2ResourceShape::AIV_X2,
-            PTO2ResourceShape::AIC_AIV_X1,
-            PTO2ResourceShape::AIV_X1,
-            PTO2ResourceShape::AIC_ONLY,
+            PTO2ResourceShape::AIC_AIV_X2, PTO2ResourceShape::AIV_X2,   PTO2ResourceShape::AIC_AIV_X1,
+            PTO2ResourceShape::AIV_X1,     PTO2ResourceShape::AIC_ONLY,
         };
         return (thread_idx % 2 == 0) ? kEvenOrder : kOddOrder;
     }
 
-    PTO2TaskSlotState* pop_ready_task(PTO2ResourceShape shape,
-        int32_t thread_idx
+    PTO2TaskSlotState *pop_ready_task(
+        PTO2ResourceShape shape, int32_t thread_idx
 #if PTO2_SCHED_PROFILING
         ,
-        uint64_t& pop_hit,
-        uint64_t& pop_miss,
-        uint64_t& sched_dispatch_pop_cycle
+        uint64_t &pop_hit, uint64_t &pop_miss, uint64_t &sched_dispatch_pop_cycle
 #endif
     ) {
         (void)thread_idx;  // NOLINT(readability/casting)
 #if PTO2_SCHED_PROFILING
         extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
         uint64_t t_pop_start = get_sys_cnt_aicpu();
-        PTO2TaskSlotState* slot_state = rt->scheduler.get_ready_task(
-            shape, g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]);
+        PTO2TaskSlotState *slot_state = rt->scheduler.get_ready_task(
+            shape, g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx]
+        );
         sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
 #else
-        PTO2TaskSlotState* slot_state = rt->scheduler.get_ready_task(shape);
+        PTO2TaskSlotState *slot_state = rt->scheduler.get_ready_task(shape);
 #endif
         if (slot_state) {
 #if PTO2_SCHED_PROFILING
@@ -520,20 +498,16 @@ struct AicpuExecutor {
         return slot_state;
     }
 
-    void dispatch_subtask_to_core(Runtime* runtime,
-        CoreStateTracker& tracker,
-        int32_t core_id,
-        CoreType core_type,
-        PTO2TaskSlotState& slot_state,
+    void dispatch_subtask_to_core(
+        Runtime *runtime, CoreStateTracker &tracker, int32_t core_id, CoreType core_type, PTO2TaskSlotState &slot_state,
         PTO2SubtaskSlot subslot
 #if PTO2_PROFILING
         ,
-        bool profiling_enabled,
-        int32_t thread_idx
+        bool profiling_enabled, int32_t thread_idx
 #endif
     ) {
-        PTO2DispatchPayload& payload = s_pto2_payload_per_core[core_id];
-        PTO2TaskDescriptor& task = *slot_state.task;
+        PTO2DispatchPayload &payload = s_pto2_payload_per_core[core_id];
+        PTO2TaskDescriptor &task = *slot_state.task;
         int32_t slot_idx = static_cast<int32_t>(subslot);
         build_pto2_payload(payload, task.kernel_id[slot_idx], *slot_state.payload);
         executing_subslot_by_core_[core_id] = subslot;
@@ -563,7 +537,7 @@ struct AicpuExecutor {
         }
         write_reg(core_id_to_reg_addr_[core_id], RegId::DATA_MAIN_BASE, static_cast<uint64_t>(reg_task_id));
 
-        CoreTypeTracker& ct = tracker.by_type[static_cast<int32_t>(core_type)];
+        CoreTypeTracker &ct = tracker.by_type[static_cast<int32_t>(core_type)];
         int32_t idle_idx = ct.find_idle_index(core_id);
         ct.move_idle_to_running(idle_idx);
         core_idle_[core_id] = false;
@@ -579,8 +553,8 @@ static AicpuExecutor g_aicpu_executor;
  * Handshake with all cores and discover their types
  * Sets up register addresses for fast dispatch.
  */
-int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+int32_t AicpuExecutor::handshake_all_cores(Runtime *runtime) {
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     cores_total_num_ = runtime->worker_count;
 
     // Validate cores_total_num_ before using as array index
@@ -609,33 +583,31 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     // Step 2: Wait for all cores to respond, collect core type and register addresses
     bool handshake_failed = false;
     for (int32_t i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_handshakes[i];
+        Handshake *hank = &all_handshakes[i];
 
-        while (hank->aicore_regs_ready == 0) {
-        }
+        while (hank->aicore_regs_ready == 0) {}
 
         uint32_t physical_core_id = hank->physical_core_id;
 
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
-            DEV_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                i,
-                physical_core_id,
-                max_physical_cores_count);
+            DEV_ERROR(
+                "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
+                max_physical_cores_count
+            );
             handshake_failed = true;
             continue;
         }
 
         // Get register address using physical_core_id
-        uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
+        uint64_t *regs = reinterpret_cast<uint64_t *>(regs_);
         uint64_t reg_addr = regs[physical_core_id];
 
         // Initialize AICore registers after discovery (first round)
         platform_init_aicore_regs(reg_addr);
         hank->aicpu_regs_ready = 1;
 
-        while (hank->aicore_done == 0) {
-        }
+        while (hank->aicore_done == 0) {}
 
         CoreType type = hank->core_type;
 
@@ -677,11 +649,10 @@ void AicpuExecutor::assign_cores_to_threads() {
     int32_t divisor = (sched_thread_num_ > 0) ? sched_thread_num_ : thread_num_;
     int32_t cluster_count = aic_count_;
 
-    DEV_INFO("Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)",
-        cluster_count,
-        divisor,
-        aic_count_,
-        aiv_count_);
+    DEV_INFO(
+        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count, divisor,
+        aic_count_, aiv_count_
+    );
 
     memset(core_idle_, true, sizeof(core_idle_));
     for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
@@ -706,8 +677,8 @@ void AicpuExecutor::assign_cores_to_threads() {
 
     for (int32_t ci = 0; ci < cluster_count; ci++) {
         int32_t t = ci % divisor;
-        CoreStateTracker& tracker = trackers_[t];
-        int32_t& idx = core_idx[t];
+        CoreStateTracker &tracker = trackers_[t];
+        int32_t &idx = core_idx[t];
 
         int32_t aic_wid = aic_cores_[ci].worker_id;
         int32_t aiv0_wid = aiv_cores_[2 * ci].worker_id;
@@ -770,7 +741,7 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
     }
 
     // Restore a single core's running/idle state into its new thread's tracker
-    auto reassign_core = [&](int32_t worker_id, CoreTypeTracker& type_tracker, int32_t thread_idx) {
+    auto reassign_core = [&](int32_t worker_id, CoreTypeTracker &type_tracker, int32_t thread_idx) {
         core_assignments_[thread_idx][core_count_per_thread_[thread_idx]++] = worker_id;
         if (running_cores[worker_id]) {
             type_tracker.running[type_tracker.running_count++] = worker_id;
@@ -782,7 +753,7 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
     // Assign whole clusters round-robin across all threads
     for (int32_t ci = 0; ci < aic_count_; ci++) {
         int32_t t = ci % thread_num_;
-        CoreStateTracker& tracker = trackers_[t];
+        CoreStateTracker &tracker = trackers_[t];
 
         int32_t aic_wid = aic_cores_[ci].worker_id;
         int32_t aiv0_wid = aiv_cores_[2 * ci].worker_id;
@@ -798,18 +769,15 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
     // Log final distribution for verification
     DEV_INFO("Core reassignment complete:");
     for (int32_t t = 0; t < thread_num_; t++) {
-        DEV_INFO("  Thread %d: %d cores, %d clusters (AIC: running=%d idle=%d, AIV: running=%d idle=%d)",
-            t,
-            core_count_per_thread_[t],
-            trackers_[t].cluster_count,
-            trackers_[t].aic().running_count,
-            trackers_[t].aic().idle_count,
-            trackers_[t].aiv().running_count,
-            trackers_[t].aiv().idle_count);
+        DEV_INFO(
+            "  Thread %d: %d cores, %d clusters (AIC: running=%d idle=%d, AIV: running=%d idle=%d)", t,
+            core_count_per_thread_[t], trackers_[t].cluster_count, trackers_[t].aic().running_count,
+            trackers_[t].aic().idle_count, trackers_[t].aiv().running_count, trackers_[t].aiv().idle_count
+        );
     }
 }
 
-int32_t AicpuExecutor::init(Runtime* runtime) {
+int32_t AicpuExecutor::init(Runtime *runtime) {
     bool expected = false;
     if (!initialized_.compare_exchange_strong(expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
         return 0;
@@ -835,7 +803,8 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
     if (!orch_to_sched_ && sched_thread_num_ == 0) {
         DEV_ERROR(
             "no scheduler and orch not trans to schedulers when finished, maybe you need set env PTO2_ORCH_TO_SCHED=1 "
-            "or scale down orch number.");
+            "or scale down orch number."
+        );
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -867,7 +836,7 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
     // Initialize runtime execution state
     // Task count comes from PTO2 shared memory
     if (runtime->get_pto2_gm_sm_ptr()) {
-        auto* header = static_cast<PTO2SharedMemoryHeader*>(runtime->get_pto2_gm_sm_ptr());
+        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_pto2_gm_sm_ptr());
         int32_t pto2_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
@@ -909,7 +878,8 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
 int32_t AicpuExecutor::shutdown_aicore(
-    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num) {
+    Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num
+) {
     (void)runtime;  // NOLINT(readability/casting)
     if (core_num == 0) return 0;
 
@@ -928,30 +898,30 @@ int32_t AicpuExecutor::shutdown_aicore(
     return 0;
 }
 
-int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx) {
-    int32_t& core_num = core_count_per_thread_[thread_idx];
-    CoreStateTracker& tracker = trackers_[thread_idx];
+int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t thread_idx) {
+    int32_t &core_num = core_count_per_thread_[thread_idx];
+    CoreStateTracker &tracker = trackers_[thread_idx];
     DEV_INFO("Thread %d: resolve_and_dispatch_pto2 entry", thread_idx);
 
-    void* sm_base = runtime->get_pto2_gm_sm_ptr();
+    void *sm_base = runtime->get_pto2_gm_sm_ptr();
     if (!sm_base) {
         DEV_ERROR("PTO2 dispatch: sm_base is null");
         return -1;
     }
     DEV_INFO("Thread %d: sm_base=%p", thread_idx, sm_base);
 
-    PTO2SharedMemoryHeader* header = static_cast<PTO2SharedMemoryHeader*>(sm_base);
-    DEV_INFO("Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu",
-        thread_idx,
-        static_cast<void*>(header),
+    PTO2SharedMemoryHeader *header = static_cast<PTO2SharedMemoryHeader *>(sm_base);
+    DEV_INFO(
+        "Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu", thread_idx, static_cast<void *>(header),
         static_cast<uint64_t>(header->rings[0].task_descriptors_offset),
-        static_cast<uint64_t>(header->rings[0].task_window_size));
+        static_cast<uint64_t>(header->rings[0].task_window_size)
+    );
 
-    Handshake* hank = static_cast<Handshake*>(runtime->workers);
-    DEV_INFO("Thread %d: hank=%p, window_size=%lu",
-        thread_idx,
-        static_cast<void*>(hank),
-        static_cast<uint64_t>(header->rings[0].task_window_size));
+    Handshake *hank = static_cast<Handshake *>(runtime->workers);
+    DEV_INFO(
+        "Thread %d: hank=%p, window_size=%lu", thread_idx, static_cast<void *>(hank),
+        static_cast<uint64_t>(header->rings[0].task_window_size)
+    );
 
     // One-time init: assign perf buffers (one thread does it; others wait)
     if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
@@ -1014,12 +984,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     // Local-first dispatch buffers (stack-allocated, one per CoreType per scheduling thread).
     // Initialized once; must be empty at the start of each iteration.
     constexpr int LOCAL_READY_CAP_PER_TYPE = 256;
-    PTO2TaskSlotState* local_aic_ptrs[LOCAL_READY_CAP_PER_TYPE];
-    PTO2TaskSlotState* local_aiv_ptrs[LOCAL_READY_CAP_PER_TYPE];
+    PTO2TaskSlotState *local_aic_ptrs[LOCAL_READY_CAP_PER_TYPE];
+    PTO2TaskSlotState *local_aiv_ptrs[LOCAL_READY_CAP_PER_TYPE];
     PTO2LocalReadyBuffer local_bufs[PTO2_LOCAL_DISPATCH_TYPE_NUM];  // [0]=AIC, [1]=AIV
     local_bufs[0].reset(local_aic_ptrs, LOCAL_READY_CAP_PER_TYPE);
     local_bufs[1].reset(local_aiv_ptrs, LOCAL_READY_CAP_PER_TYPE);
-    PTO2TaskSlotState* deferred_release_slot_states[256];
+    PTO2TaskSlotState *deferred_release_slot_states[256];
     int32_t deferred_release_count = 0;
 
     bool cores_released = false;
@@ -1041,10 +1011,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     DEV_ERROR(
                         "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
                         "completed_tasks=%d, total_tasks=%d",
-                        thread_idx,
-                        orch_err,
-                        completed_tasks_.load(std::memory_order_relaxed),
-                        total_tasks_);
+                        thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
+                    );
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1054,10 +1022,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 task_count = total_tasks_;
                 if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
                     completed_.store(true, std::memory_order_release);
-                    DEV_INFO("Thread %d: PTO2 completed tasks %d/%d",
-                        thread_idx,
-                        completed_tasks_.load(std::memory_order_relaxed),
-                        task_count);
+                    DEV_INFO(
+                        "Thread %d: PTO2 completed tasks %d/%d", thread_idx,
+                        completed_tasks_.load(std::memory_order_relaxed), task_count
+                    );
                     break;
                 }
             }
@@ -1094,33 +1062,21 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Check AIC running cores
         bool try_completed = false;
         always_assert(
-            local_bufs[0].count == 0 && local_bufs[1].count == 0);  // Invariant: previous iteration fully consumed
+            local_bufs[0].count == 0 && local_bufs[1].count == 0
+        );  // Invariant: previous iteration fully consumed
         if (tracker.aic().running_count > 0) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIC>(thread_idx,
-                tracker.aic(),
-                hank,
-                completed_this_turn,
-                cur_thread_completed,
-                made_progress,
-                deferred_release_slot_states,
-                deferred_release_count,
-                local_bufs
+            check_running_cores_for_completion<CoreType::AIC>(
+                thread_idx, tracker.aic(), hank, completed_this_turn, cur_thread_completed, made_progress,
+                deferred_release_slot_states, deferred_release_count, local_bufs
 #if PTO2_PROFILING
                 ,
-                profiling_enabled,
-                phase_complete_count
+                profiling_enabled, phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
                 ,
-                complete_probe_count,
-                complete_hit_count,
-                notify_edges_total,
-                notify_max_degree,
-                notify_tasks_enqueued,
-                fanin_edges_total,
-                fanin_max_degree,
-                sched_complete_perf_cycle
+                complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
 #endif
             );
         }
@@ -1128,30 +1084,17 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Check AIV running cores
         if (tracker.aiv().running_count > 0) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIV>(thread_idx,
-                tracker.aiv(),
-                hank,
-                completed_this_turn,
-                cur_thread_completed,
-                made_progress,
-                deferred_release_slot_states,
-                deferred_release_count,
-                local_bufs
+            check_running_cores_for_completion<CoreType::AIV>(
+                thread_idx, tracker.aiv(), hank, completed_this_turn, cur_thread_completed, made_progress,
+                deferred_release_slot_states, deferred_release_count, local_bufs
 #if PTO2_PROFILING
                 ,
-                profiling_enabled,
-                phase_complete_count
+                profiling_enabled, phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
                 ,
-                complete_probe_count,
-                complete_hit_count,
-                notify_edges_total,
-                notify_max_degree,
-                notify_tasks_enqueued,
-                fanin_edges_total,
-                fanin_max_degree,
-                sched_complete_perf_cycle
+                complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
 #endif
             );
         }
@@ -1165,10 +1108,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             if (thread_idx == 0 && task_count > 0) {
                 if (new_total <= PROGRESS_VERBOSE_THRESHOLD ||
                     new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL || new_total >= task_count) {
-                    DEV_ALWAYS("PTO2 progress: completed=%d total=%d (%.1f%%)",
-                        new_total,
-                        task_count,
-                        100.0 * new_total / task_count);
+                    DEV_ALWAYS(
+                        "PTO2 progress: completed=%d total=%d (%.1f%%)", new_total, task_count,
+                        100.0 * new_total / task_count
+                    );
                 }
             }
         }
@@ -1180,7 +1123,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             CYCLE_COUNT_LAP(sched_complete_cycle);
             if (profiling_enabled && phase_complete_count > 0) {
                 perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, sched_loop_count, phase_complete_count);
+                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, sched_loop_count, phase_complete_count
+                );
                 _t0_phase = _t1;
                 phase_complete_count = 0;
             }
@@ -1192,62 +1136,47 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         bool try_pushed = false;
 
         // Local dispatch: drain both per-CoreType local_bufs, match to idle clusters by shape
-        PTO2TaskSlotState* overflow_ptrs[LOCAL_READY_CAP_PER_TYPE * PTO2_LOCAL_DISPATCH_TYPE_NUM];
+        PTO2TaskSlotState *overflow_ptrs[LOCAL_READY_CAP_PER_TYPE * PTO2_LOCAL_DISPATCH_TYPE_NUM];
         int overflow_count = 0;
         for (int bi = 0; bi < PTO2_LOCAL_DISPATCH_TYPE_NUM; bi++) {
             while (local_bufs[bi].count > 0) {
-                PTO2TaskSlotState* slot_state = local_bufs[bi].pop();
+                PTO2TaskSlotState *slot_state = local_bufs[bi].pop();
                 PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state->active_mask);
                 int32_t ci = tracker.find_cluster_for_shape(shape, core_idle_);
 
                 if (ci >= 0) {
                     try_pushed = true;
-                    Cluster& c = tracker.clusters[ci];
+                    Cluster &c = tracker.clusters[ci];
 #if PTO2_SCHED_PROFILING
                     uint64_t t_setup_start = get_sys_cnt_aicpu();
 #endif
                     ResourceCount rc = shape_resource_count(shape);
 
                     if (rc.aic) {
-                        dispatch_subtask_to_core(runtime,
-                            tracker,
-                            c.aic_core_id,
-                            CoreType::AIC,
-                            *slot_state,
-                            PTO2SubtaskSlot::AIC
+                        dispatch_subtask_to_core(
+                            runtime, tracker, c.aic_core_id, CoreType::AIC, *slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                             ,
-                            profiling_enabled,
-                            thread_idx
+                            profiling_enabled, thread_idx
 #endif
                         );
                     }
                     if (rc.aiv >= 1) {
                         int32_t aiv0 = core_idle_[c.aiv_core_ids[0]] ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
-                        dispatch_subtask_to_core(runtime,
-                            tracker,
-                            aiv0,
-                            CoreType::AIV,
-                            *slot_state,
-                            PTO2SubtaskSlot::AIV0
+                        dispatch_subtask_to_core(
+                            runtime, tracker, aiv0, CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                             ,
-                            profiling_enabled,
-                            thread_idx
+                            profiling_enabled, thread_idx
 #endif
                         );
                     }
                     if (rc.aiv >= 2) {
-                        dispatch_subtask_to_core(runtime,
-                            tracker,
-                            c.aiv_core_ids[1],
-                            CoreType::AIV,
-                            *slot_state,
-                            PTO2SubtaskSlot::AIV1
+                        dispatch_subtask_to_core(
+                            runtime, tracker, c.aiv_core_ids[1], CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
                             ,
-                            profiling_enabled,
-                            thread_idx
+                            profiling_enabled, thread_idx
 #endif
                         );
                     }
@@ -1260,11 +1189,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
                     made_progress = true;
-                    DEV_DEBUG("Thread %d: Dispatching %s task %" PRId64 " to cluster %d (local)",
-                        thread_idx,
-                        shape_name(shape),
-                        static_cast<int64_t>(slot_state->task->task_id.raw),
-                        ci);
+                    DEV_DEBUG(
+                        "Thread %d: Dispatching %s task %" PRId64 " to cluster %d (local)", thread_idx,
+                        shape_name(shape), static_cast<int64_t>(slot_state->task->task_id.raw), ci
+                    );
                 } else {
                     overflow_ptrs[overflow_count++] = slot_state;
 #if PTO2_SCHED_PROFILING
@@ -1280,7 +1208,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         }
 
         // Phase 3: Global dispatch — fill remaining idle cores from global readyQ (cluster-based)
-        const PTO2ResourceShape* dispatch_order = get_dispatch_order(thread_idx);
+        const PTO2ResourceShape *dispatch_order = get_dispatch_order(thread_idx);
 
         for (int32_t si = 0; si < PTO2_NUM_RESOURCE_SHAPES; si++) {
             PTO2ResourceShape shape = dispatch_order[si];
@@ -1290,13 +1218,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 int32_t ci = tracker.find_cluster_for_shape(shape, core_idle_);
                 if (ci < 0) break;
 
-                PTO2TaskSlotState* slot_state = pop_ready_task(shape,
-                    thread_idx
+                PTO2TaskSlotState *slot_state = pop_ready_task(
+                    shape, thread_idx
 #if PTO2_SCHED_PROFILING
                     ,
-                    pop_hit,
-                    pop_miss,
-                    sched_dispatch_pop_cycle
+                    pop_hit, pop_miss, sched_dispatch_pop_cycle
 #endif
                 );
                 if (!slot_state) break;
@@ -1308,49 +1234,34 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_SCHED_PROFILING
                 uint64_t t_setup_start = get_sys_cnt_aicpu();
 #endif
-                Cluster& c = tracker.clusters[ci];
+                Cluster &c = tracker.clusters[ci];
                 ResourceCount rc = shape_resource_count(shape);
 
                 if (rc.aic) {
-                    dispatch_subtask_to_core(runtime,
-                        tracker,
-                        c.aic_core_id,
-                        CoreType::AIC,
-                        *slot_state,
-                        PTO2SubtaskSlot::AIC
+                    dispatch_subtask_to_core(
+                        runtime, tracker, c.aic_core_id, CoreType::AIC, *slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                         ,
-                        profiling_enabled,
-                        thread_idx
+                        profiling_enabled, thread_idx
 #endif
                     );
                 }
                 if (rc.aiv >= 1) {
                     int32_t aiv_id = core_idle_[c.aiv_core_ids[0]] ? c.aiv_core_ids[0] : c.aiv_core_ids[1];
-                    dispatch_subtask_to_core(runtime,
-                        tracker,
-                        aiv_id,
-                        CoreType::AIV,
-                        *slot_state,
-                        PTO2SubtaskSlot::AIV0
+                    dispatch_subtask_to_core(
+                        runtime, tracker, aiv_id, CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                         ,
-                        profiling_enabled,
-                        thread_idx
+                        profiling_enabled, thread_idx
 #endif
                     );
                 }
                 if (rc.aiv >= 2) {
-                    dispatch_subtask_to_core(runtime,
-                        tracker,
-                        c.aiv_core_ids[1],
-                        CoreType::AIV,
-                        *slot_state,
-                        PTO2SubtaskSlot::AIV1
+                    dispatch_subtask_to_core(
+                        runtime, tracker, c.aiv_core_ids[1], CoreType::AIV, *slot_state, PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
                         ,
-                        profiling_enabled,
-                        thread_idx
+                        profiling_enabled, thread_idx
 #endif
                     );
                 }
@@ -1358,11 +1269,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_SCHED_PROFILING
                 sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
-                DEV_DEBUG("Thread %d: Dispatching %s task %" PRId64 " to cluster %d",
-                    thread_idx,
-                    shape_name(shape),
-                    static_cast<int64_t>(slot_state->task->task_id.raw),
-                    ci);
+                DEV_DEBUG(
+                    "Thread %d: Dispatching %s task %" PRId64 " to cluster %d", thread_idx, shape_name(shape),
+                    static_cast<int64_t>(slot_state->task->task_id.raw), ci
+                );
             }
         }
 
@@ -1373,7 +1283,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             CYCLE_COUNT_LAP(sched_dispatch_cycle);
             if (profiling_enabled && phase_dispatch_count > 0) {
                 perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, sched_loop_count, phase_dispatch_count);
+                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, sched_loop_count, phase_dispatch_count
+                );
                 _t0_phase = _t1;
                 phase_dispatch_count = 0;
             }
@@ -1407,9 +1318,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
                 int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
                 if (orch_err != PTO2_ERROR_NONE) {
-                    DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores",
-                        thread_idx,
-                        orch_err);
+                    DEV_ERROR(
+                        "Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx,
+                        orch_err
+                    );
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1418,20 +1330,19 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
             if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
                 int32_t c = completed_tasks_.load(std::memory_order_relaxed);
-                DEV_ALWAYS("PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
-                    idle_iterations,
-                    c,
-                    task_count,
-                    last_progress_count);
+                DEV_ALWAYS(
+                    "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
+                    idle_iterations, c, task_count, last_progress_count
+                );
                 // Scan all task slots to find truly stuck tasks using scheduler state
-                PTO2SchedulerState* sched = &rt->scheduler;
-                PTO2SharedMemoryHeader* sm_header_diag = static_cast<PTO2SharedMemoryHeader*>(sm_base);
+                PTO2SchedulerState *sched = &rt->scheduler;
+                PTO2SharedMemoryHeader *sm_header_diag = static_cast<PTO2SharedMemoryHeader *>(sm_base);
                 int32_t cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
                     int32_t ring_task_count =
                         sm_header_diag->rings[r].fc.current_task_index.load(std::memory_order_relaxed);
                     for (int32_t si = 0; si < ring_task_count; si++) {
-                        PTO2TaskSlotState& slot_state = sched->get_slot_state(r, si);
+                        PTO2TaskSlotState &slot_state = sched->get_slot_state(r, si);
                         PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
                         int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
                         int32_t fi = slot_state.fanin_count;
@@ -1449,12 +1360,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                                 DEV_ALWAYS(
                                     "  STUCK-READY  ring=%d task_id=%" PRId64
                                     " kernel_id=%d refcount=%d fanin=%d state=%d",  // NOLINT(whitespace/line_length)
-                                    r,
-                                    static_cast<int64_t>(slot_state.task->task_id.raw),
-                                    kid,
-                                    rc,
-                                    fi,
-                                    static_cast<int32_t>(st));
+                                    r, static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi,
+                                    static_cast<int32_t>(st)
+                                );
                             }
                         } else {
                             cnt_waiting++;
@@ -1462,32 +1370,24 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                                 DEV_ALWAYS(
                                     "  STUCK-WAIT   ring=%d task_id=%" PRId64
                                     " kernel_id=%d refcount=%d fanin=%d state=%d",  // NOLINT(whitespace/line_length)
-                                    r,
-                                    static_cast<int64_t>(slot_state.task->task_id.raw),
-                                    kid,
-                                    rc,
-                                    fi,
-                                    static_cast<int32_t>(st));
+                                    r, static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi,
+                                    static_cast<int32_t>(st)
+                                );
                             }
                         }
                     }
                 }
-                DEV_ALWAYS("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d",
-                    cnt_ready,
-                    cnt_waiting,
-                    cnt_inflight);
+                DEV_ALWAYS(
+                    "  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight
+                );
                 // Log this thread's dispatch state
                 int32_t total_idle = tracker.aic().idle_count + tracker.aiv().idle_count;
                 int32_t total_running = tracker.aic().running_count + tracker.aiv().running_count;
-                DEV_ALWAYS("  thread=%d idle_cores=%d (AIC=%d AIV=%d) running_cores=%d (AIC=%d AIV=%d) core_num=%d",
-                    thread_idx,
-                    total_idle,
-                    tracker.aic().idle_count,
-                    tracker.aiv().idle_count,
-                    total_running,
-                    tracker.aic().running_count,
-                    tracker.aiv().running_count,
-                    core_num);
+                DEV_ALWAYS(
+                    "  thread=%d idle_cores=%d (AIC=%d AIV=%d) running_cores=%d (AIC=%d AIV=%d) core_num=%d",
+                    thread_idx, total_idle, tracker.aic().idle_count, tracker.aiv().idle_count, total_running,
+                    tracker.aic().running_count, tracker.aiv().running_count, core_num
+                );
                 // Dump AIC running cores
                 for (int32_t ci = 0; ci < tracker.aic().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
                     int32_t cid = tracker.aic().running[ci];
@@ -1498,13 +1398,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         hw_kernel = executing_slot_state_by_core_[cid]->task->kernel_id[diag_slot];
                     }
                     uint64_t cond_reg = read_reg(core_id_to_reg_addr_[cid], RegId::COND);
-                    DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
-                        cid,
-                        static_cast<unsigned>(cond_reg),
-                        EXTRACT_TASK_STATE(cond_reg),
-                        EXTRACT_TASK_ID(cond_reg),
-                        sw_tid,
-                        hw_kernel);
+                    DEV_ALWAYS(
+                        "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid,
+                        static_cast<unsigned>(cond_reg), EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
+                        sw_tid, hw_kernel
+                    );
                 }
                 // Dump AIV running cores
                 for (int32_t ci = 0; ci < tracker.aiv().running_count && ci < STALL_DUMP_CORE_MAX; ci++) {
@@ -1516,25 +1414,21 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         hw_kernel = executing_slot_state_by_core_[cid]->task->kernel_id[diag_slot];
                     }
                     uint64_t cond_reg = read_reg(core_id_to_reg_addr_[cid], RegId::COND);
-                    DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
-                        cid,
-                        static_cast<unsigned>(cond_reg),
-                        EXTRACT_TASK_STATE(cond_reg),
-                        EXTRACT_TASK_ID(cond_reg),
-                        sw_tid,
-                        hw_kernel);
+                    DEV_ALWAYS(
+                        "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid,
+                        static_cast<unsigned>(cond_reg), EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
+                        sw_tid, hw_kernel
+                    );
                 }
                 // Dump cluster state
                 for (int32_t cli = 0; cli < tracker.cluster_count && cli < STALL_DUMP_CORE_MAX; cli++) {
-                    Cluster& cl = tracker.clusters[cli];
-                    DEV_ALWAYS("    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)",
-                        cli,
-                        cl.aic_core_id,
-                        core_idle_[cl.aic_core_id] ? "idle" : "busy",
-                        cl.aiv_core_ids[0],
-                        core_idle_[cl.aiv_core_ids[0]] ? "idle" : "busy",
-                        cl.aiv_core_ids[1],
-                        core_idle_[cl.aiv_core_ids[1]] ? "idle" : "busy");
+                    Cluster &cl = tracker.clusters[cli];
+                    DEV_ALWAYS(
+                        "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, cl.aic_core_id,
+                        core_idle_[cl.aic_core_id] ? "idle" : "busy", cl.aiv_core_ids[0],
+                        core_idle_[cl.aiv_core_ids[0]] ? "idle" : "busy", cl.aiv_core_ids[1],
+                        core_idle_[cl.aiv_core_ids[1]] ? "idle" : "busy"
+                    );
                 }
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
@@ -1563,143 +1457,131 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     {
         PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
         uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
-        uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle)
-                                     ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle)
-                                     : 0;
-        uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle)
-                                     ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle)
-                                     : 0;
+        uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle) ?
+                                     (sched_complete_cycle - otc_total - sched_complete_perf_cycle) :
+                                     0;
+        uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle) ?
+                                     (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) :
+                                     0;
 
-        DEV_ALWAYS("Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===",
-            thread_idx,
-            cycles_to_us(sched_total),
-            cur_thread_completed);
+        DEV_ALWAYS(
+            "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
+            cycles_to_us(sched_total), cur_thread_completed
+        );
 
         // Level 1: complete
         double notify_avg =
             cur_thread_completed > 0 ? static_cast<double>(notify_edges_total) / cur_thread_completed : 0.0;
         double fanin_avg =
             cur_thread_completed > 0 ? static_cast<double>(fanin_edges_total) / cur_thread_completed : 0.0;
-        DEV_ALWAYS("Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
-                   ", max_degree=%d, avg=%.1f]  [fanin: "  // NOLINT(whitespace/line_length)
-                   "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
-            thread_idx,
-            cycles_to_us(sched_complete_cycle),
-            sched_complete_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(notify_edges_total),
-            notify_max_degree,
-            notify_avg,
-            static_cast<uint64_t>(fanin_edges_total),
-            fanin_max_degree,
-            fanin_avg);
+        DEV_ALWAYS(
+            "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
+            ", max_degree=%d, avg=%.1f]  [fanin: "  // NOLINT(whitespace/line_length)
+            "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
+            thread_idx, cycles_to_us(sched_complete_cycle), sched_complete_cycle * 100.0 / sched_total,
+            static_cast<uint64_t>(notify_edges_total), notify_max_degree, notify_avg,
+            static_cast<uint64_t>(fanin_edges_total), fanin_max_degree, fanin_avg
+        );
 
         // Level 2: complete sub-phases (percentage relative to complete)
         uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
         uint64_t complete_miss_count =
             (complete_probe_count > complete_hit_count) ? (complete_probe_count - complete_hit_count) : 0;
         double complete_hit_rate = complete_probe_count > 0 ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
-        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
-            thread_idx,
-            cycles_to_us(complete_poll),
-            complete_poll * 100.0 / c_parent,
-            static_cast<uint64_t>(complete_hit_count),
-            static_cast<uint64_t>(complete_miss_count),
-            complete_hit_rate);
-        DEV_ALWAYS("Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.lock_cycle),
-            sp.lock_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle),
-            cycles_to_us(sp.lock_wait_cycle),
-            static_cast<uint64_t>(sp.lock_atomic_count));
-        DEV_ALWAYS("Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.fanout_cycle),
-            sp.fanout_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle),
-            cycles_to_us(sp.push_wait_cycle),
-            static_cast<uint64_t>(sp.fanout_atomic_count));
-        DEV_ALWAYS("Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.fanin_cycle),
-            sp.fanin_cycle * 100.0 / c_parent,
-            static_cast<uint64_t>(sp.fanin_atomic_count));
-        DEV_ALWAYS("Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.self_consumed_cycle),
-            sp.self_consumed_cycle * 100.0 / c_parent,
-            static_cast<uint64_t>(sp.self_atomic_count));
-        DEV_ALWAYS("Thread %d:     perf         : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_complete_perf_cycle),
-            sched_complete_perf_cycle * 100.0 / c_parent);
+        DEV_ALWAYS(
+            "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
+            thread_idx, cycles_to_us(complete_poll), complete_poll * 100.0 / c_parent,
+            static_cast<uint64_t>(complete_hit_count), static_cast<uint64_t>(complete_miss_count), complete_hit_rate
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
+            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
+            static_cast<uint64_t>(sp.lock_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
+            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
+            static_cast<uint64_t>(sp.fanout_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.fanin_cycle), sp.fanin_cycle * 100.0 / c_parent,
+            static_cast<uint64_t>(sp.fanin_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.self_consumed_cycle), sp.self_consumed_cycle * 100.0 / c_parent,
+            static_cast<uint64_t>(sp.self_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_complete_perf_cycle),
+            sched_complete_perf_cycle * 100.0 / c_parent
+        );
 
         // Level 1: dispatch
         uint64_t pop_total = pop_hit + pop_miss;
         double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
-        DEV_ALWAYS("Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64
-                   ", hit_rate=%.1f%%]",  // NOLINT(whitespace/line_length)
-            thread_idx,
-            cycles_to_us(sched_dispatch_cycle),
-            sched_dispatch_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(pop_hit),
-            static_cast<uint64_t>(pop_miss),
-            pop_hit_rate);
+        DEV_ALWAYS(
+            "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64
+            ", hit_rate=%.1f%%]",  // NOLINT(whitespace/line_length)
+            thread_idx, cycles_to_us(sched_dispatch_cycle), sched_dispatch_cycle * 100.0 / sched_total,
+            static_cast<uint64_t>(pop_hit), static_cast<uint64_t>(pop_miss), pop_hit_rate
+        );
         uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
         uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
         double local_hit_rate = total_dispatched > 0 ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
-        DEV_ALWAYS("Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
-                   ", local_rate=%.1f%%",  // NOLINT(whitespace/line_length)
-            thread_idx,
-            static_cast<uint64_t>(local_dispatch_count),
-            static_cast<uint64_t>(global_dispatch_count),
-            static_cast<uint64_t>(local_overflow_count),
-            local_hit_rate);
+        DEV_ALWAYS(
+            "Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
+            ", local_rate=%.1f%%",  // NOLINT(whitespace/line_length)
+            thread_idx, static_cast<uint64_t>(local_dispatch_count), static_cast<uint64_t>(global_dispatch_count),
+            static_cast<uint64_t>(local_overflow_count), local_hit_rate
+        );
 
         // Level 2: dispatch sub-phases (percentage relative to dispatch)
         uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
-        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(dispatch_poll),
-            dispatch_poll * 100.0 / d_parent);
-        DEV_ALWAYS("Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sched_dispatch_pop_cycle),
-            sched_dispatch_pop_cycle * 100.0 / d_parent,
-            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle),
-            cycles_to_us(sp.pop_wait_cycle),
-            static_cast<uint64_t>(sp.pop_atomic_count));
-        DEV_ALWAYS("Thread %d:     setup        : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_dispatch_setup_cycle),
-            sched_dispatch_setup_cycle * 100.0 / d_parent);
+        DEV_ALWAYS(
+            "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
+            dispatch_poll * 100.0 / d_parent
+        );
+        DEV_ALWAYS(
+            "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sched_dispatch_pop_cycle), sched_dispatch_pop_cycle * 100.0 / d_parent,
+            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+            static_cast<uint64_t>(sp.pop_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
+            sched_dispatch_setup_cycle * 100.0 / d_parent
+        );
 
         // Level 1: scan
-        DEV_ALWAYS("Thread %d:   scan           : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_scan_cycle),
-            sched_scan_cycle * 100.0 / sched_total);
+        DEV_ALWAYS(
+            "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_scan_cycle),
+            sched_scan_cycle * 100.0 / sched_total
+        );
 
         // Level 1: idle
-        DEV_ALWAYS("Thread %d:   idle           : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_idle_cycle),
-            sched_idle_cycle * 100.0 / sched_total);
+        DEV_ALWAYS(
+            "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_idle_cycle),
+            sched_idle_cycle * 100.0 / sched_total
+        );
 
         // Average per completion
         if (cur_thread_completed > 0) {
-            DEV_ALWAYS("Thread %d:   avg/complete   : %.3fus",
-                thread_idx,
-                cycles_to_us(sched_complete_cycle) / cur_thread_completed);
+            DEV_ALWAYS(
+                "Thread %d:   avg/complete   : %.3fus", thread_idx,
+                cycles_to_us(sched_complete_cycle) / cur_thread_completed
+            );
         }
     }
 #endif
     // Summary line (always print when PTO2_PROFILING=1)
-    DEV_ALWAYS("Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d",
-        thread_idx,
-        cycles_to_us(sched_total),
-        static_cast<uint64_t>(sched_loop_count),
-        cur_thread_completed);
+    DEV_ALWAYS(
+        "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
+        cycles_to_us(sched_total), static_cast<uint64_t>(sched_loop_count), cur_thread_completed
+    );
 #endif
 
 #if PTO2_PROFILING
@@ -1713,7 +1595,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     return cur_thread_completed;
 }
 
-int32_t AicpuExecutor::run(Runtime* runtime) {
+int32_t AicpuExecutor::run(Runtime *runtime) {
     int32_t thread_idx = thread_idx_++;
 
     DEV_ALWAYS("Thread %d: Start", thread_idx);
@@ -1728,7 +1610,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             if (orch_idx == 0) {
                 DEV_INFO("Thread %d: Primary orchestrator, loading SO via dlopen", thread_idx);
 
-                const void* so_data = runtime->get_device_orch_so_data();
+                const void *so_data = runtime->get_device_orch_so_data();
                 size_t so_size = runtime->get_device_orch_so_size();
 
                 if (so_data == nullptr || so_size == 0) {
@@ -1739,27 +1621,26 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 // Try multiple paths that may allow execution on AICPU
                 char so_path[256];
                 bool file_created = false;
-                const char* candidate_dirs[] = {
-                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"};
+                const char *candidate_dirs[] = {
+                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
+                };
                 const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
 
                 for (int32_t i = 0; i < num_candidates && !file_created; i++) {
                     snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
                     int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
                     if (fd < 0) {
-                        DEV_INFO("Thread %d: Cannot create SO at %s (errno=%d), trying next path",
-                            thread_idx,
-                            so_path,
-                            errno);
+                        DEV_INFO(
+                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
                         continue;
                     }
                     ssize_t written = write(fd, so_data, so_size);
                     close(fd);
                     if (written != static_cast<ssize_t>(so_size)) {
-                        DEV_INFO("Thread %d: Cannot write SO to %s (errno=%d), trying next path",
-                            thread_idx,
-                            so_path,
-                            errno);
+                        DEV_INFO(
+                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
                         unlink(so_path);
                         continue;
                     }
@@ -1773,8 +1654,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 }
 
                 dlerror();
-                void* handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
-                const char* dlopen_err = dlerror();
+                void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+                const char *dlopen_err = dlerror();
                 if (handle == nullptr) {
                     DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
                     unlink(so_path);
@@ -1789,7 +1670,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 dlerror();
                 DeviceOrchestrationFunc orch_func =
                     reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
-                const char* dlsym_error = dlerror();
+                const char *dlsym_error = dlerror();
                 if (dlsym_error != nullptr) {
                     DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
                     dlclose(handle);
@@ -1803,23 +1684,21 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     return -1;
                 }
 
-                const ChipStorageTaskArgs& args = runtime->get_orch_args();
+                const ChipStorageTaskArgs &args = runtime->get_orch_args();
                 int32_t arg_count = args.tensor_count() + args.scalar_count();
                 DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
                 for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
-                    const ContinuousTensor& t = args.tensor(i);
-                    DEV_INFO("Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)",
-                        thread_idx,
-                        i,
-                        static_cast<uint64_t>(t.data),
-                        t.ndims,
-                        static_cast<unsigned>(t.dtype));
+                    const ContinuousTensor &t = args.tensor(i);
+                    DEV_INFO(
+                        "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
+                        static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
+                    );
                 }
                 for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
-                    DEV_INFO("Thread %d: orch_args[%d] = SCALAR(0x%lx)",
-                        thread_idx,
-                        args.tensor_count() + i,
-                        static_cast<uint64_t>(args.scalar(i)));
+                    DEV_INFO(
+                        "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
+                        static_cast<uint64_t>(args.scalar(i))
+                    );
                 }
 
                 uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
@@ -1850,17 +1729,16 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 if (runtime->pto2_dep_pool_size > 0) {
                     dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
                 }
-                DEV_INFO("Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d",
-                    thread_idx,
-                    static_cast<uint64_t>(task_window_size),
-                    static_cast<uint64_t>(heap_size),
-                    dep_pool_capacity);
+                DEV_INFO(
+                    "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
+                    static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
+                );
 
-                void* sm_ptr = runtime->get_pto2_gm_sm_ptr();
-                void* gm_heap = runtime->get_pto2_gm_heap_ptr();
+                void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
+                void *gm_heap = runtime->get_pto2_gm_heap_ptr();
 
                 uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
-                PTO2SharedMemoryHandle* sm_handle =
+                PTO2SharedMemoryHandle *sm_handle =
                     pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
                 if (!sm_handle) {
                     DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
@@ -1870,7 +1748,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 }
 
                 rt = pto2_runtime_create_from_sm(
-                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity);
+                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity
+                );
                 if (!rt) {
                     DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                     pto2_sm_destroy(sm_handle);
@@ -1932,21 +1811,20 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 #endif
 
             // Call orchestration function wrapped in an outer scope
-            DEV_ALWAYS("Thread %d: Calling aicpu_orchestration_entry from SO (orch_idx=%d/(0~%d))",
-                thread_idx,
-                orch_idx,
-                orch_thread_num_ - 1);
+            DEV_ALWAYS(
+                "Thread %d: Calling aicpu_orchestration_entry from SO (orch_idx=%d/(0~%d))", thread_idx, orch_idx,
+                orch_thread_num_ - 1
+            );
 #if PTO2_PROFILING
             uint64_t orch_cycle_start = get_sys_cnt_aicpu();
 #endif
             PTO2_SCOPE(rt) { orch_func_(rt, *orch_args_cached_, orch_thread_num_, orch_idx); }
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
-            DEV_ALWAYS("Thread %d: orch_start=%" PRIu64 " orch_func_cost=%.3fus (orch_idx=%d)",
-                thread_idx,
-                static_cast<uint64_t>(orch_cycle_start),
-                cycles_to_us(orch_cycle_end - orch_cycle_start),
-                orch_idx);
+            DEV_ALWAYS(
+                "Thread %d: orch_start=%" PRIu64 " orch_func_cost=%.3fus (orch_idx=%d)", thread_idx,
+                static_cast<uint64_t>(orch_cycle_start), cycles_to_us(orch_cycle_end - orch_cycle_start), orch_idx
+            );
 #endif
 
             // Print orchestrator profiling data
@@ -1954,39 +1832,37 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
             uint64_t total = p.alloc_cycle + p.params_cycle + p.heap_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
-            DEV_ALWAYS("Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===",
-                thread_idx,
-                static_cast<int64_t>(p.submit_count),
-                cycles_to_us(total));
-            DEV_ALWAYS("Thread %d:   task_ring_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-                thread_idx,
-                cycles_to_us(p.alloc_cycle),
-                p.alloc_cycle * 100.0 / total,
-                cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle),
-                cycles_to_us(p.alloc_wait_cycle),
-                static_cast<uint64_t>(p.alloc_atomic_count));
-            DEV_ALWAYS("Thread %d:   heap_alloc     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-                thread_idx,
-                cycles_to_us(p.heap_cycle),
-                p.heap_cycle * 100.0 / total,
-                cycles_to_us(p.heap_cycle - p.heap_wait_cycle),
-                cycles_to_us(p.heap_wait_cycle),
-                static_cast<uint64_t>(p.heap_atomic_count));
-            DEV_ALWAYS("Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "",
-                thread_idx,
-                cycles_to_us(p.params_cycle),
-                p.params_cycle * 100.0 / total,
-                static_cast<uint64_t>(p.params_atomic_count));
-            DEV_ALWAYS("Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-                thread_idx,
-                cycles_to_us(p.fanin_cycle),
-                p.fanin_cycle * 100.0 / total,
-                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle),
-                cycles_to_us(p.fanin_wait_cycle),
-                static_cast<uint64_t>(p.fanin_atomic_count));
-            DEV_ALWAYS("Thread %d:   avg/task       : %.3fus",
-                thread_idx,
-                p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0);
+            DEV_ALWAYS(
+                "Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===", thread_idx,
+                static_cast<int64_t>(p.submit_count), cycles_to_us(total)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   task_ring_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(p.alloc_cycle), p.alloc_cycle * 100.0 / total,
+                cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle), cycles_to_us(p.alloc_wait_cycle),
+                static_cast<uint64_t>(p.alloc_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   heap_alloc     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(p.heap_cycle), p.heap_cycle * 100.0 / total,
+                cycles_to_us(p.heap_cycle - p.heap_wait_cycle), cycles_to_us(p.heap_wait_cycle),
+                static_cast<uint64_t>(p.heap_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+                cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total,
+                static_cast<uint64_t>(p.params_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
+                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
+                static_cast<uint64_t>(p.fanin_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   avg/task       : %.3fus", thread_idx,
+                p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0
+            );
 
 #if PTO2_PROFILING
             // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
@@ -2012,7 +1888,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             // Write core-to-thread mapping (one-time, after orchestration)
             if (runtime->enable_profiling) {
                 perf_aicpu_write_core_assignments(
-                    core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_);
+                    core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
+                );
                 // Flush orchestrator's phase record buffer
                 perf_aicpu_flush_phase_buffers(thread_idx);
             }
@@ -2024,8 +1901,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 // Last orchestrator: signal completion and trigger core transition
                 pto2_rt_orchestration_done(rt);
 
-                void* sm = runtime->get_pto2_gm_sm_ptr();
-                PTO2SharedMemoryHeader* sm_header = static_cast<PTO2SharedMemoryHeader*>(sm);
+                void *sm = runtime->get_pto2_gm_sm_ptr();
+                PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
                 int32_t pto2_task_count = 0;
                 if (sm_header) {
                     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -2033,9 +1910,10 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     }
                 }
 #if PTO2_PROFILING
-                DEV_ALWAYS("PTO2 total submitted tasks = %d, already executed %d tasks",
-                    pto2_task_count,
-                    completed_tasks_.load(std::memory_order_acquire));
+                DEV_ALWAYS(
+                    "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_task_count,
+                    completed_tasks_.load(std::memory_order_acquire)
+                );
 #endif
                 total_tasks_ = pto2_task_count;
                 if (runtime->enable_profiling && pto2_task_count > 0) {
@@ -2044,10 +1922,10 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 orchestrator_done_ = true;
                 {
                     int32_t orch_err = 0;
-                    void* sm = runtime->get_pto2_gm_sm_ptr();
+                    void *sm = runtime->get_pto2_gm_sm_ptr();
                     if (sm) {
                         orch_err =
-                            static_cast<PTO2SharedMemoryHeader*>(sm)->orch_error_code.load(std::memory_order_relaxed);
+                            static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
                     }
 
                     // Fatal error: shutdown AICore immediately before core transition.
@@ -2075,7 +1953,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     transition_requested_.store(true, std::memory_order_release);
 #if PTO2_PROFILING
                     DEV_ALWAYS(
-                        "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts));
+                        "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
+                    );
 #endif
 
                     // Wait for scheduler threads to acknowledge transition request
@@ -2096,10 +1975,10 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 
 #if PTO2_ORCH_PROFILING
                 uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
-                DEV_ALWAYS("Thread %d: reassign, cost %.3fus (orch_idx=%d)",
-                    thread_idx,
-                    cycles_to_us(reassign_cycle_end - reassign_cycle_start),
-                    orch_idx);
+                DEV_ALWAYS(
+                    "Thread %d: reassign, cost %.3fus (orch_idx=%d)", thread_idx,
+                    cycles_to_us(reassign_cycle_end - reassign_cycle_start), orch_idx
+                );
 #endif
             } else {
                 // Non-last orchestrator: wait for last orchestrator to finish setup
@@ -2137,7 +2016,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     // platform_deinit_aicore_regs is idempotent; orchestrator threads have
     // core_count_per_thread_ == 0 so they skip the loop harmlessly.
     {
-        const int32_t* shutdown_cores = core_assignments_[thread_idx];
+        const int32_t *shutdown_cores = core_assignments_[thread_idx];
         int32_t shutdown_count = core_count_per_thread_[thread_idx];
 #if PTO2_PROFILING
         if (shutdown_count > 0) {
@@ -2171,7 +2050,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     return 0;
 }
 
-void AicpuExecutor::deinit(Runtime* runtime) {
+void AicpuExecutor::deinit(Runtime *runtime) {
     // 1. Invalidate AICPU cache for Runtime address range.
     //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
     //    bypasses this cache. Invalidating now ensures next round reads from HBM.
@@ -2229,11 +2108,11 @@ void AicpuExecutor::deinit(Runtime* runtime) {
     DEV_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
+void AicpuExecutor::emergency_shutdown(Runtime *runtime) {
     DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     for (int32_t i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_handshakes[i];
+        Handshake *hank = &all_handshakes[i];
         OUT_OF_ORDER_STORE_BARRIER();
         hank->aicpu_regs_ready = 1;
         if (core_id_to_reg_addr_[i] != 0) {
@@ -2245,9 +2124,10 @@ void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
 }
 
 void AicpuExecutor::diagnose_stuck_state(
-    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank) {
+    Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
+) {
     (void)runtime;  // NOLINT(readability/casting)
-    PTO2SchedulerState* sched = &rt->scheduler;
+    PTO2SchedulerState *sched = &rt->scheduler;
     DEV_ALWAYS("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
 
     int32_t completed = completed_tasks_.load(std::memory_order_acquire);
@@ -2262,12 +2142,10 @@ void AicpuExecutor::diagnose_stuck_state(
         mixed_x1_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC_AIV_X1)].size();
         mixed_x2_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC_AIV_X2)].size();
     }
-    DEV_ALWAYS("Ready Queues: AIC=%lu, AIV=%lu, AIV_X2=%lu, AIC_AIV_X1=%lu, AIC_AIV_X2=%lu",
-        aic_ready,
-        aiv_ready,
-        aiv_x2_ready,
-        mixed_x1_ready,
-        mixed_x2_ready);
+    DEV_ALWAYS(
+        "Ready Queues: AIC=%lu, AIV=%lu, AIV_X2=%lu, AIC_AIV_X1=%lu, AIC_AIV_X2=%lu", aic_ready, aiv_ready,
+        aiv_x2_ready, mixed_x1_ready, mixed_x2_ready
+    );
 
     int32_t busy_cores = 0;
     int32_t idle_cores = 0;
@@ -2275,8 +2153,8 @@ void AicpuExecutor::diagnose_stuck_state(
     DEV_ALWAYS("Core Status:");
     for (int32_t i = 0; i < core_num; i++) {
         int32_t core_id = cur_thread_cores[i];
-        Handshake* h = &hank[core_id];
-        const char* core_type_str = core_type_to_string(h->core_type);
+        Handshake *h = &hank[core_id];
+        const char *core_type_str = core_type_to_string(h->core_type);
 
         uint64_t reg_addr = core_id_to_reg_addr_[core_id];
         uint64_t reg_val = read_reg(reg_addr, RegId::COND);
@@ -2295,20 +2173,14 @@ void AicpuExecutor::diagnose_stuck_state(
                 DEV_ALWAYS(
                     "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_reg_task_id=%d, "
                     "kernel_id=%d",
-                    core_id,
-                    core_type_str,
-                    reg_val,
-                    reg_task_id,
-                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
-                    task_id,
-                    kernel_id);
+                    core_id, core_type_str, reg_val, reg_task_id, reg_state == TASK_FIN_STATE ? "FIN" : "ACK", task_id,
+                    kernel_id
+                );
             } else {
-                DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked",
-                    core_id,
-                    core_type_str,
-                    reg_val,
-                    reg_task_id,
-                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK");
+                DEV_ALWAYS(
+                    "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked", core_id,
+                    core_type_str, reg_val, reg_task_id, reg_state == TASK_FIN_STATE ? "FIN" : "ACK"
+                );
             }
         } else {
             idle_cores++;
@@ -2345,7 +2217,7 @@ void AicpuExecutor::diagnose_stuck_state(
  * @param runtime Pointer to Runtime structure
  * @return 0 on success, non-zero on error
  */
-extern "C" int32_t aicpu_execute(Runtime* runtime) {
+extern "C" int32_t aicpu_execute(Runtime *runtime) {
     if (runtime == nullptr) {
         DEV_ERROR("%s", "Invalid argument: null Runtime pointer");
         return -1;

--- a/src/a2a3/runtime/aicpu_build_graph/host/runtime_compile_info.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/host/runtime_compile_info.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "host/platform_compile_info.h"
 #include "host/runtime_compile_info.h"
 #include <string.h>
@@ -14,5 +24,4 @@ ToolchainType get_orchestration_compiler(void) {
     if (strcmp(get_platform(), "a2a3") == 0) return TOOLCHAIN_AARCH64_GXX;
     return TOOLCHAIN_HOST_GXX;
 }
-
 }

--- a/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
@@ -52,10 +52,10 @@ static int64_t _now_ms() {
  * Parse an environment variable as uint64_t with optional power-of-2 constraint.
  * Returns the parsed value on success, or 0 if unset or validation fails.
  */
-static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool require_power_of_2) {
-    const char* env = std::getenv(name);
+static uint64_t parse_env_uint64(const char *name, uint64_t min_val, bool require_power_of_2) {
+    const char *env = std::getenv(name);
     if (!env) return 0;
-    char* endptr;
+    char *endptr;
     errno = 0;
     uint64_t val = strtoull(env, &endptr, 10);
     if (errno == ERANGE || endptr == env || *endptr != '\0' || val < min_val) {
@@ -85,7 +85,7 @@ static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool requir
  * @param orch_args Separated tensor/scalar arguments
  * @return 0 on success, -1 on failure
  */
-extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args) {
+extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args) {
     // Validate inputs
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -97,10 +97,11 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", callable->child_count());
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
-            const auto& kernel = callable->child(i);
-            uint64_t addr = runtime->host_api.upload_kernel_binary(func_id,
-                reinterpret_cast<const uint8_t*>(&kernel),
-                CoreCallable::binary_data_offset() + kernel.binary_size());
+            const auto &kernel = callable->child(i);
+            uint64_t addr = runtime->host_api.upload_kernel_binary(
+                func_id, reinterpret_cast<const uint8_t *>(&kernel),
+                CoreCallable::binary_data_offset() + kernel.binary_size()
+            );
             if (addr == 0) {
                 LOG_ERROR("Failed to upload kernel binary for func_id=%d", func_id);
                 return -1;
@@ -109,7 +110,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
         }
     }
 
-    const uint8_t* orch_so_binary = static_cast<const uint8_t*>(callable->binary_data());
+    const uint8_t *orch_so_binary = static_cast<const uint8_t *>(callable->binary_data());
     size_t orch_so_size = callable->binary_size();
 
     if (orch_so_binary == nullptr || orch_so_size == 0) {
@@ -135,10 +136,10 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
     for (int i = 0; i < tensor_count; i++) {
         ContinuousTensor t = orch_args->tensor(i);
 
-        void* host_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(t.data));
+        void *host_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(t.data));
         size_t size = static_cast<size_t>(t.nbytes());
 
-        void* dev_ptr = runtime->host_api.device_malloc(size);
+        void *dev_ptr = runtime->host_api.device_malloc(size);
         if (dev_ptr == nullptr) {
             LOG_ERROR("Failed to allocate device memory for tensor %d", i);
             return -1;
@@ -163,7 +164,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
 
     // Copy orchestration SO to device memory (AICPU cannot access host memory)
     int64_t t_so_start = _now_ms();
-    void* dev_so = runtime->host_api.device_malloc(orch_so_size);
+    void *dev_so = runtime->host_api.device_malloc(orch_so_size);
     if (dev_so == nullptr) {
         LOG_ERROR("Failed to allocate device memory for orchestration SO");
         return -1;
@@ -184,17 +185,17 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
 
     // Read ready queue shard count from environment for AICPU scheduler
     {
-        const char* env_shards = std::getenv("PTO2_READY_QUEUE_SHARDS");
+        const char *env_shards = std::getenv("PTO2_READY_QUEUE_SHARDS");
         if (env_shards) {
-            char* endptr;
+            char *endptr;
             int64_t val = strtol(env_shards, &endptr, 10);
             if (endptr != env_shards && *endptr == '\0' && val >= 1 && val <= PLATFORM_MAX_AICPU_THREADS) {
                 runtime->ready_queue_shards = static_cast<int>(val);
             } else {
-                LOG_WARN("PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d",
-                    env_shards,
-                    PLATFORM_MAX_AICPU_THREADS,
-                    RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
+                LOG_WARN(
+                    "PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d", env_shards,
+                    PLATFORM_MAX_AICPU_THREADS, RUNTIME_DEFAULT_READY_QUEUE_SHARDS
+                );
                 runtime->ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
             }
         }
@@ -203,7 +204,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
 
     // Read orchestrator-to-scheduler transition flag from environment
     {
-        const char* env_val = std::getenv("PTO2_ORCH_TO_SCHED");
+        const char *env_val = std::getenv("PTO2_ORCH_TO_SCHED");
         if (env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T')) {
             runtime->orch_to_sched = true;
         }
@@ -216,13 +217,16 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
         runtime->pto2_heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
         runtime->pto2_dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
         if (runtime->pto2_task_window_size || runtime->pto2_heap_size || runtime->pto2_dep_pool_size) {
-            LOG_INFO("Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
+            LOG_INFO(
+                "Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
                 static_cast<uint64_t>(
-                    runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE),
+                    runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE
+                ),
                 static_cast<uint64_t>(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
-                static_cast<uint64_t>(runtime->pto2_dep_pool_size
-                                          ? runtime->pto2_dep_pool_size
-                                          : PTO2_DEP_LIST_POOL_SIZE));  // NOLINT(whitespace/line_length)
+                static_cast<uint64_t>(
+                    runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE
+                )
+            );  // NOLINT(whitespace/line_length)
         }
     }
 
@@ -234,7 +238,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
     // Allocate GM heap for orchestrator output buffers (all rings combined)
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
     int64_t t_heap_start = _now_ms();
-    void* gm_heap = runtime->host_api.device_malloc(total_heap_size);
+    void *gm_heap = runtime->host_api.device_malloc(total_heap_size);
     int64_t t_heap_end = _now_ms();
     if (gm_heap == nullptr) {
         LOG_ERROR("Failed to allocate GM heap");
@@ -246,7 +250,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
     // Allocate PTO2 shared memory
     int64_t t_sm_start = _now_ms();
     uint64_t sm_size = pto2_sm_calculate_size(eff_task_window_size);
-    void* sm_ptr = runtime->host_api.device_malloc(sm_size);
+    void *sm_ptr = runtime->host_api.device_malloc(sm_size);
     int64_t t_sm_end = _now_ms();
     if (sm_ptr == nullptr) {
         LOG_ERROR("Failed to allocate PTO2 shared memory");
@@ -282,7 +286,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime* runtime) {
+extern "C" int validate_runtime_impl(Runtime *runtime) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -293,13 +297,13 @@ extern "C" int validate_runtime_impl(Runtime* runtime) {
     LOG_INFO("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair* tensor_pairs = runtime->get_tensor_pairs();
+    TensorPair *tensor_pairs = runtime->get_tensor_pairs();
     int tensor_pair_count = runtime->get_tensor_pair_count();
 
     LOG_INFO("Tensor pairs to process: %d", tensor_pair_count);
 
     // PTO2 (device orchestration): graph output may be in packed buffer
-    void* pto2_sm = runtime->get_pto2_gm_sm_ptr();
+    void *pto2_sm = runtime->get_pto2_gm_sm_ptr();
     uint64_t graph_out_ptr = 0;
     uint64_t graph_out_size = 0;
 
@@ -320,7 +324,7 @@ extern "C" int validate_runtime_impl(Runtime* runtime) {
 
     bool first_output_tensor = true;
     for (int i = 0; i < tensor_pair_count; i++) {
-        const TensorPair& pair = tensor_pairs[i];
+        const TensorPair &pair = tensor_pairs[i];
 
         // Skip if device pointer is null
         if (pair.dev_ptr == nullptr) {
@@ -334,12 +338,12 @@ extern "C" int validate_runtime_impl(Runtime* runtime) {
             continue;
         }
 
-        void* src_ptr = pair.dev_ptr;
+        void *src_ptr = pair.dev_ptr;
         size_t copy_size = pair.size;
 
         // Use graph_output_ptr for the first output tensor if available
         if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
-            src_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(graph_out_ptr));
+            src_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(graph_out_ptr));
             copy_size = static_cast<size_t>(graph_out_size);
             LOG_INFO("Using packed output buffer for tensor %d", i);
             first_output_tensor = false;

--- a/src/a2a3/runtime/aicpu_build_graph/orchestration/common.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/orchestration/common.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "common.h"
 
 #ifdef __linux__
@@ -12,20 +22,19 @@
 #endif
 
 /**
- * 使用 addr2line 将地址转换为 文件:行号 信息
- * 使用 -i 标志展开内联，返回第一行（最内层实际代码位置）
- * 如果存在内联，同时通过 inline_chain 返回外层调用链
+ * Use addr2line to convert an address to file:line information.
+ * Uses the -i flag to expand inlines; returns the first line (innermost actual code location).
+ * If inlining is present, also returns the outer call chain via inline_chain.
  */
 #ifdef __linux__
-static std::string addr_to_line(const char* executable, void* addr,
-                                std::string* inline_chain = nullptr) {
+static std::string addr_to_line(const char *executable, void *addr, std::string *inline_chain = nullptr) {
     char cmd[512];
     snprintf(cmd, sizeof(cmd), "addr2line -e %s -f -C -p -i %p 2>/dev/null", executable, addr);
 
     std::array<char, 256> buffer;
     std::string raw_output;
 
-    FILE* pipe = popen(cmd, "r");
+    FILE *pipe = popen(cmd, "r");
     if (pipe) {
         while (fgets(buffer.data(), buffer.size(), pipe) != nullptr) {
             raw_output += buffer.data();
@@ -37,21 +46,22 @@ static std::string addr_to_line(const char* executable, void* addr,
         return "";
     }
 
-    // 按行分割
+    // Split by lines
     std::vector<std::string> lines;
     size_t pos = 0;
     while (pos < raw_output.size()) {
         size_t nl = raw_output.find('\n', pos);
         if (nl == std::string::npos) nl = raw_output.size();
         std::string line = raw_output.substr(pos, nl - pos);
-        while (!line.empty() && line.back() == '\r') line.pop_back();
+        while (!line.empty() && line.back() == '\r')
+            line.pop_back();
         if (!line.empty()) lines.push_back(line);
         pos = nl + 1;
     }
 
     if (lines.empty()) return "";
 
-    // 第一行是最内层的实际代码位置，后续行是外层内联调用者
+    // First line is the innermost actual code location; subsequent lines are outer inline callers
     if (inline_chain && lines.size() > 1) {
         *inline_chain = "";
         for (size_t j = 1; j < lines.size(); j++) {
@@ -64,29 +74,29 @@ static std::string addr_to_line(const char* executable, void* addr,
 #endif
 
 /**
- * 获取当前调用栈信息（包含文件路径和行号）
- * 通过 dladdr 定位每个栈帧所在的共享库，并用相对地址调用 addr2line
+ * Get current stack trace information (including file paths and line numbers).
+ * Uses dladdr to locate the shared library for each stack frame, then calls addr2line with relative addresses.
  */
 std::string get_stacktrace(int skip_frames) {
     (void)skip_frames;  // May be unused on non-Linux platforms
     std::string result;
 #ifdef __linux__
     const int max_frames = 64;
-    void* buffer[max_frames];
+    void *buffer[max_frames];
     int nframes = backtrace(buffer, max_frames);
-    char** symbols = backtrace_symbols(buffer, nframes);
+    char **symbols = backtrace_symbols(buffer, nframes);
 
     if (symbols) {
-        result = "调用栈:\n";
+        result = "Stack trace:\n";
         for (int i = skip_frames; i < nframes; i++) {
             std::string frame_info;
 
-            void* addr = (void*)((char*)buffer[i] - 1);
+            void *addr = (void *)((char *)buffer[i] - 1);
 
             Dl_info dl_info;
             std::string inline_chain;
             if (dladdr(addr, &dl_info) && dl_info.dli_fname) {
-                void* rel_addr = (void*)((char*)addr - (char*)dl_info.dli_fbase);
+                void *rel_addr = (void *)((char *)addr - (char *)dl_info.dli_fbase);
                 std::string addr2line_result = addr_to_line(dl_info.dli_fname, rel_addr, &inline_chain);
 
                 if (addr2line_result.empty()) {
@@ -106,7 +116,7 @@ std::string get_stacktrace(int skip_frames) {
                 if (start != std::string::npos && end != std::string::npos) {
                     std::string mangled = frame.substr(start + 1, end - start - 1);
                     int status;
-                    char* demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &status);
+                    char *demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &status);
                     if (status == 0 && demangled) {
                         frame = frame.substr(0, start + 1) + demangled + frame.substr(end);
                         free(demangled);
@@ -125,27 +135,29 @@ std::string get_stacktrace(int skip_frames) {
         free(symbols);
     }
 #else
-    result = "(调用栈仅在 Linux 上可用)\n";
+    result = "(Stack trace is only available on Linux)\n";
 #endif
     return result;
 }
 
-// AssertionError 构造函数
-static std::string build_assert_message(const char* condition, const char* file, int line) {
-    std::string msg = "断言失败: " + std::string(condition) + "\n";
-    msg += "  位置: " + std::string(file) + ":" + std::to_string(line) + "\n";
+// AssertionError constructor
+static std::string build_assert_message(const char *condition, const char *file, int line) {
+    std::string msg = "Assertion failed: " + std::string(condition) + "\n";
+    msg += "  Location: " + std::string(file) + ":" + std::to_string(line) + "\n";
     msg += get_stacktrace(3);
     return msg;
 }
 
-AssertionError::AssertionError(const char* condition, const char* file, int line)
-    : std::runtime_error(build_assert_message(condition, file, line)),
-      condition_(condition), file_(file), line_(line) {}
+AssertionError::AssertionError(const char *condition, const char *file, int line) :
+    std::runtime_error(build_assert_message(condition, file, line)),
+    condition_(condition),
+    file_(file),
+    line_(line) {}
 
-[[noreturn]] void assert_impl(const char* condition, const char* file, int line) {
+[[noreturn]] void assert_impl(const char *condition, const char *file, int line) {
     fprintf(stderr, "\n========================================\n");
-    fprintf(stderr, "断言失败: %s\n", condition);
-    fprintf(stderr, "位置: %s:%d\n", file, line);
+    fprintf(stderr, "Assertion failed: %s\n", condition);
+    fprintf(stderr, "Location: %s:%d\n", file, line);
     fprintf(stderr, "%s", get_stacktrace(2).c_str());
     fprintf(stderr, "========================================\n\n");
     fflush(stderr);

--- a/src/a2a3/runtime/aicpu_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/aicpu_build_graph/orchestration/pto_orchestration_api.h
@@ -40,10 +40,12 @@
 
 // Convert ContinuousTensor to Tensor (needs make_tensor_external from tensor.h)
 static_assert(
-    CONTINUOUS_TENSOR_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "ContinuousTensor and runtime max dims must match");
-inline Tensor from_tensor_arg(const ContinuousTensor& t, bool manual_dep = false, int32_t version = 0) {
+    CONTINUOUS_TENSOR_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "ContinuousTensor and runtime max dims must match"
+);
+inline Tensor from_tensor_arg(const ContinuousTensor &t, bool manual_dep = false, int32_t version = 0) {
     return make_tensor_external(
-        reinterpret_cast<void*>(static_cast<uintptr_t>(t.data)), t.shapes, t.ndims, t.dtype, manual_dep, version);
+        reinterpret_cast<void *>(static_cast<uintptr_t>(t.data)), t.shapes, t.ndims, t.dtype, manual_dep, version
+    );
 }
 
 // =============================================================================
@@ -62,19 +64,19 @@ typedef struct PTO2Runtime PTO2Runtime;
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
 typedef struct PTO2RuntimeOps {
-    SubmitResult (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const Arg& args);
-    void (*add_dependency)(PTO2Runtime* rt, PTO2TaskId producer, PTO2TaskId consumer);
-    void (*scope_begin)(PTO2Runtime* rt);
-    void (*scope_end)(PTO2Runtime* rt);
-    void (*orchestration_done)(PTO2Runtime* rt);
-    bool (*is_fatal)(PTO2Runtime* rt);
+    SubmitResult (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    void (*add_dependency)(PTO2Runtime *rt, PTO2TaskId producer, PTO2TaskId consumer);
+    void (*scope_begin)(PTO2Runtime *rt);
+    void (*scope_end)(PTO2Runtime *rt);
+    void (*orchestration_done)(PTO2Runtime *rt);
+    bool (*is_fatal)(PTO2Runtime *rt);
 
     // Logging (populated by runtime, called by orchestration)
-    void (*log_error)(const char* func, const char* fmt, ...);
-    void (*log_warn)(const char* func, const char* fmt, ...);
-    void (*log_info)(const char* func, const char* fmt, ...);
-    void (*log_debug)(const char* func, const char* fmt, ...);
-    void (*log_always)(const char* func, const char* fmt, ...);
+    void (*log_error)(const char *func, const char *fmt, ...);
+    void (*log_warn)(const char *func, const char *fmt, ...);
+    void (*log_info)(const char *func, const char *fmt, ...);
+    void (*log_debug)(const char *func, const char *fmt, ...);
+    void (*log_always)(const char *func, const char *fmt, ...);
 } PTO2RuntimeOps;
 
 /**
@@ -85,21 +87,21 @@ typedef struct PTO2RuntimeOps {
  * is well-defined (C struct layout guarantee).
  */
 struct PTO2Runtime {
-    const PTO2RuntimeOps* ops;
+    const PTO2RuntimeOps *ops;
 };
 
 // =============================================================================
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline SubmitResult pto2_rt_submit_task(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const Arg& args) {
+static inline SubmitResult pto2_rt_submit_task(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
     return rt->ops->submit_task(rt, mixed_kernels, args);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
-static inline SubmitResult pto2_rt_submit_aic_task(PTO2Runtime* rt, int32_t kernel_id, const Arg& args) {
+static inline SubmitResult pto2_rt_submit_aic_task(PTO2Runtime *rt, int32_t kernel_id, const Arg &args) {
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
@@ -108,7 +110,7 @@ static inline SubmitResult pto2_rt_submit_aic_task(PTO2Runtime* rt, int32_t kern
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
-static inline SubmitResult pto2_rt_submit_aiv_task(PTO2Runtime* rt, int32_t kernel_id, const Arg& args) {
+static inline SubmitResult pto2_rt_submit_aiv_task(PTO2Runtime *rt, int32_t kernel_id, const Arg &args) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
@@ -117,17 +119,17 @@ static inline SubmitResult pto2_rt_submit_aiv_task(PTO2Runtime* rt, int32_t kern
 /**
  * Add an explicit dependency: consumer waits for producer to complete.
  */
-static inline void pto2_rt_add_dependency(PTO2Runtime* rt, PTO2TaskId producer, PTO2TaskId consumer) {
+static inline void pto2_rt_add_dependency(PTO2Runtime *rt, PTO2TaskId producer, PTO2TaskId consumer) {
     rt->ops->add_dependency(rt, producer, consumer);
 }
 
-static inline void pto2_rt_scope_begin(PTO2Runtime* rt) { rt->ops->scope_begin(rt); }
+static inline void pto2_rt_scope_begin(PTO2Runtime *rt) { rt->ops->scope_begin(rt); }
 
-static inline void pto2_rt_scope_end(PTO2Runtime* rt) { rt->ops->scope_end(rt); }
+static inline void pto2_rt_scope_end(PTO2Runtime *rt) { rt->ops->scope_end(rt); }
 
-static inline void pto2_rt_orchestration_done(PTO2Runtime* rt) { rt->ops->orchestration_done(rt); }
+static inline void pto2_rt_orchestration_done(PTO2Runtime *rt) { rt->ops->orchestration_done(rt); }
 
-static inline bool pto2_rt_is_fatal(PTO2Runtime* rt) { return rt->ops->is_fatal(rt); }
+static inline bool pto2_rt_is_fatal(PTO2Runtime *rt) { return rt->ops->is_fatal(rt); }
 
 // =============================================================================
 // Logging Macros for Orchestration (call through ops table)
@@ -148,11 +150,14 @@ static inline bool pto2_rt_is_fatal(PTO2Runtime* rt) { return rt->ops->is_fatal(
  */
 class PTO2ScopeGuard {
 public:  // NOLINT(whitespace/indent)
-    explicit PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) { rt_->ops->scope_begin(rt_); }
+    explicit PTO2ScopeGuard(PTO2Runtime *rt) :
+        rt_(rt) {
+        rt_->ops->scope_begin(rt_);
+    }
     ~PTO2ScopeGuard() { rt_->ops->scope_end(rt_); }
 
 private:  // NOLINT(whitespace/indent)
-    PTO2Runtime* rt_;
+    PTO2Runtime *rt_;
 };
 
 #define _PTO2_CONCATENATE_IMPL(x, y) x##y

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/common.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/common.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #pragma once
 
 #include <stdio.h>
@@ -6,37 +16,37 @@
 #include <string>
 
 /**
- * 获取当前调用栈信息（包含文件路径和行号）
- * 实现在 common.cpp 中
+ * Get current stack trace information (including file paths and line numbers).
+ * Implemented in common.cpp.
  */
 std::string get_stacktrace(int skip_frames = 1);
 
 /**
- * 断言失败异常，包含文件、行号、条件和调用栈信息
+ * Assertion failure exception, containing file, line number, condition, and stack trace information.
  */
 class AssertionError : public std::runtime_error {
 public:
-    AssertionError(const char* condition, const char* file, int line);
+    AssertionError(const char *condition, const char *file, int line);
 
-    const char* condition() const { return condition_; }
-    const char* file() const { return file_; }
+    const char *condition() const { return condition_; }
+    const char *file() const { return file_; }
     int line() const { return line_; }
 
 private:
-    const char* condition_;
-    const char* file_;
+    const char *condition_;
+    const char *file_;
     int line_;
 };
 
 /**
- * 断言失败时的处理函数
- * 实现在 common.cpp 中
+ * Handler function for assertion failures.
+ * Implemented in common.cpp.
  */
-[[noreturn]] void assert_impl(const char* condition, const char* file, int line);
+[[noreturn]] void assert_impl(const char *condition, const char *file, int line);
 
 /**
- * debug_assert 宏 - 在 debug 模式下检查条件，失败时抛出异常并打印调用栈
- * 在 release 模式 (NDEBUG) 下为空操作
+ * debug_assert macro - checks condition in debug mode; throws exception and prints stack trace on failure.
+ * No-op in release mode (NDEBUG).
  */
 #ifdef NDEBUG
 #define debug_assert(cond) ((void)0)
@@ -50,7 +60,7 @@ private:
 #endif
 
 /**
- * always_assert 宏 - 无论 debug 还是 release 模式都检查条件
+ * always_assert macro - checks condition in both debug and release modes.
  */
 #define always_assert(cond)                         \
     do {                                            \

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto2_dispatch_payload.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file pto2_dispatch_payload.h
  * @brief Minimal dispatch payload for AICore kernel execution
@@ -26,7 +36,7 @@
  * AICore reads function_bin_addr, casts to UnifiedKernelFunc, calls with args.
  */
 struct PTO2DispatchPayload {
-    uint64_t function_bin_addr; /**< Kernel entry in GM: (UnifiedKernelFunc)function_bin_addr */
+    uint64_t function_bin_addr;            /**< Kernel entry in GM: (UnifiedKernelFunc)function_bin_addr */
     uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers + scalars) */
 };
 

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.cpp
@@ -43,8 +43,8 @@
 #include "aicpu/performance_collector_aicpu.h"
 // Weak fallback for builds that don't link device_time.cpp (e.g. host).
 __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
-__attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
+__attribute__((weak, visibility("hidden"))) void
+perf_aicpu_record_orch_phase(AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 static uint64_t g_orch_alloc_cycle = 0;
 static uint64_t g_orch_args_cycle = 0;
 static uint64_t g_orch_heap_cycle = 0;
@@ -78,8 +78,8 @@ uint64_t g_orch_scope_end_atomic_count = 0;
 #include "aicpu/device_time.h"
 #include "aicpu/performance_collector_aicpu.h"
 __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
-__attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
+__attribute__((weak, visibility("hidden"))) void
+perf_aicpu_record_orch_phase(AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 static uint32_t g_orch_submit_idx = 0;
 #define CYCLE_COUNT_START()                     \
     bool _prof_active = orch->enable_profiling; \
@@ -105,11 +105,10 @@ static uint32_t g_orch_submit_idx = 0;
 // Orchestrator Initialization
 // =============================================================================
 
-bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
-    PTO2SharedMemoryHandle* sm_handle,
-    void* gm_heap,
-    uint64_t heap_size,
-    int32_t dep_pool_capacity) {
+bool pto2_orchestrator_init(
+    PTO2OrchestratorState *orch, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
+    int32_t dep_pool_capacity
+) {
     *orch = PTO2OrchestratorState{};
 
     orch->sm_handle = sm_handle;
@@ -119,21 +118,20 @@ bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
 
     // Initialize per-ring resources
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        void* ring_heap_base = reinterpret_cast<char*>(gm_heap) + r * heap_size;
-        auto& fc = sm_handle->header->rings[r].fc;
+        void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + r * heap_size;
+        auto &fc = sm_handle->header->rings[r].fc;
 
         pto2_heap_ring_init(&orch->rings[r].heap_ring, ring_heap_base, heap_size, &fc.heap_tail, &fc.heap_top);
         orch->rings[r].heap_ring.error_code_ptr = &sm_handle->header->orch_error_code;
 
-        pto2_task_ring_init(&orch->rings[r].task_ring,
-            sm_handle->task_descriptors[r],
-            sm_handle->header->rings[r].task_window_size,
-            &fc.last_task_alive,
-            &fc.current_task_index);
+        pto2_task_ring_init(
+            &orch->rings[r].task_ring, sm_handle->task_descriptors[r], sm_handle->header->rings[r].task_window_size,
+            &fc.last_task_alive, &fc.current_task_index
+        );
         orch->rings[r].task_ring.error_code_ptr = &sm_handle->header->orch_error_code;
 
-        PTO2DepListEntry* dep_entries =
-            reinterpret_cast<PTO2DepListEntry*>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
+        PTO2DepListEntry *dep_entries =
+            reinterpret_cast<PTO2DepListEntry *>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
         if (!dep_entries) {
             for (int j = 0; j < r; j++) {
                 free(orch->rings[j].dep_pool.base);
@@ -146,8 +144,8 @@ bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
     // Initialize scope stack
     uint64_t max_depth = PTO2_MAX_SCOPE_DEPTH;
     int32_t init_cap = PTO2_SCOPE_TASKS_INIT_CAP;
-    orch->scope_tasks = reinterpret_cast<PTO2TaskSlotState**>(malloc(init_cap * sizeof(PTO2TaskSlotState*)));
-    orch->scope_begins = reinterpret_cast<int32_t*>(malloc(max_depth * sizeof(int32_t)));
+    orch->scope_tasks = reinterpret_cast<PTO2TaskSlotState **>(malloc(init_cap * sizeof(PTO2TaskSlotState *)));
+    orch->scope_begins = reinterpret_cast<int32_t *>(malloc(max_depth * sizeof(int32_t)));
     if (!orch->scope_tasks || !orch->scope_begins) {
         free(orch->scope_tasks);
         free(orch->scope_begins);
@@ -164,7 +162,7 @@ bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
     return true;
 }
 
-void pto2_orchestrator_destroy(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_destroy(PTO2OrchestratorState *orch) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         free(orch->rings[r].dep_pool.base);
         orch->rings[r].dep_pool.base = NULL;
@@ -176,7 +174,7 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState* orch) {
     orch->scope_begins = NULL;
 }
 
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler) {
+void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler) {
     orch->scheduler = scheduler;
 }
 
@@ -184,11 +182,11 @@ void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerS
 // Scope Management
 // =============================================================================
 
-static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState* task_slot_state) {
+static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         int32_t new_cap = orch->scope_tasks_capacity * 2;
-        PTO2TaskSlotState** new_buf =
-            reinterpret_cast<PTO2TaskSlotState**>(realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState*)));
+        PTO2TaskSlotState **new_buf =
+            reinterpret_cast<PTO2TaskSlotState **>(realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState *)));
         assert(new_buf && "Failed to grow scope task buffer");
         orch->scope_tasks = new_buf;
         orch->scope_tasks_capacity = new_cap;
@@ -196,7 +194,7 @@ static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState* tas
     orch->scope_tasks[orch->scope_tasks_size++] = task_slot_state;
 }
 
-void pto2_scope_begin(PTO2OrchestratorState* orch) {
+void pto2_scope_begin(PTO2OrchestratorState *orch) {
     if (orch->fatal) {
         return;
     }
@@ -206,7 +204,7 @@ void pto2_scope_begin(PTO2OrchestratorState* orch) {
     orch->scope_begins[orch->scope_stack_top] = orch->scope_tasks_size;
 }
 
-void pto2_scope_end(PTO2OrchestratorState* orch) {
+void pto2_scope_end(PTO2OrchestratorState *orch) {
     if (orch->fatal) {
         return;
     }
@@ -220,13 +218,13 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
     int32_t count = orch->scope_tasks_size - begin;
 
     if (orch->scheduler && count > 0) {
-        PTO2TaskSlotState** tasks = &orch->scope_tasks[begin];
+        PTO2TaskSlotState **tasks = &orch->scope_tasks[begin];
 
         // Batch publish: release the "+1 redundance" in fanin for each task.
         // Tasks whose fanin is fully satisfied become READY and are pushed
         // to the scheduler's ready queues.
         for (int32_t i = 0; i < count; i++) {
-            PTO2TaskSlotState* slot = tasks[i];
+            PTO2TaskSlotState *slot = tasks[i];
             if (!slot) continue;
 
             // task_state is already PENDING from submit_task (defensive store)
@@ -256,7 +254,7 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
 // =============================================================================
 // Task Submission (3-step: alloc, heap, write — no TensorMap)
 // =============================================================================
-SubmitResult pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const Arg& args) {
+SubmitResult pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args) {
     CYCLE_COUNT_START();
 
     SubmitResult result;
@@ -279,8 +277,8 @@ SubmitResult pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKern
     }
 
     uint8_t ring_id = orch->current_ring_id();
-    auto& task_ring = orch->rings[ring_id].task_ring;
-    PTO2SchedulerState* sched = orch->scheduler;
+    auto &task_ring = orch->rings[ring_id].task_ring;
+    PTO2SchedulerState *sched = orch->scheduler;
 
     // Validate submit inputs
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
@@ -332,25 +330,25 @@ SubmitResult pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKern
     int32_t slot = task_ring.get_task_slot(local_id);
     PTO2TaskId task_id = pto2_make_task_id(ring_id, static_cast<uint32_t>(local_id));
 
-    PTO2TaskDescriptor& task = task_ring.get_task_by_slot(slot);
-    PTO2TaskPayload* payload = &orch->sm_handle->task_payloads[ring_id][slot];
+    PTO2TaskDescriptor &task = task_ring.get_task_by_slot(slot);
+    PTO2TaskPayload *payload = &orch->sm_handle->task_payloads[ring_id][slot];
 
     // Prefetch payload cache lines for write
     for (int32_t i = 0; i < args.tensor_count(); i++) {
         __builtin_prefetch(&payload->tensors[i], 1, 3);
-        __builtin_prefetch(reinterpret_cast<char*>(&payload->tensors[i]) + 64, 1, 3);
+        __builtin_prefetch(reinterpret_cast<char *>(&payload->tensors[i]) + 64, 1, 3);
     }
     for (int32_t i = 0; i < args.scalar_count(); i += 8) {
         __builtin_prefetch(&payload->scalars[i], 1, 3);
     }
     __builtin_prefetch(payload, 1, 3);
-    __builtin_prefetch(reinterpret_cast<char*>(payload) + 64, 1, 3);
-    __builtin_prefetch(reinterpret_cast<char*>(payload) + 128, 1, 3);
+    __builtin_prefetch(reinterpret_cast<char *>(payload) + 64, 1, 3);
+    __builtin_prefetch(reinterpret_cast<char *>(payload) + 128, 1, 3);
 
     // Initialize slot state
     if (sched) {
-        auto& rs = sched->ring_sched_states[ring_id];
-        PTO2TaskSlotState& slot_state = rs.get_slot_state_by_slot(slot);
+        auto &rs = sched->ring_sched_states[ring_id];
+        PTO2TaskSlotState &slot_state = rs.get_slot_state_by_slot(slot);
         // fanin_count starts at 1: the "+1 redundance" released at scope_end
         slot_state.fanin_count = 1;
         slot_state.fanout_head = nullptr;
@@ -384,26 +382,26 @@ SubmitResult pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKern
         }
     }
 
-    void* local_packed_base = nullptr;
-    void* local_packed_end = nullptr;
+    void *local_packed_base = nullptr;
+    void *local_packed_end = nullptr;
     if (total_output_size > 0) {
         local_packed_base = orch->pto2_alloc_packed_buffer(total_output_size);
         if (!local_packed_base) {
             orch->fatal = true;
             return result;
         }
-        local_packed_end = reinterpret_cast<char*>(local_packed_base) + total_output_size;
+        local_packed_end = reinterpret_cast<char *>(local_packed_base) + total_output_size;
     }
 
     // Materialize OUTPUT tensors into TaskOutputTensors
     int32_t offset = 0;
     for (int i = 0; i < args.tensor_count(); i++) {
         if (args.tag(i) == TensorArgType::OUTPUT) {
-            const TensorCreateInfo& ci = args.tensor(i).create_info;
+            const TensorCreateInfo &ci = args.tensor(i).create_info;
             uint64_t buffer_size = ci.buffer_size_bytes();
-            uint64_t alloc_addr = reinterpret_cast<uint64_t>(reinterpret_cast<char*>(local_packed_base) + offset);
+            uint64_t alloc_addr = reinterpret_cast<uint64_t>(reinterpret_cast<char *>(local_packed_base) + offset);
             offset += PTO2_ALIGN_UP(buffer_size, PTO2_PACKED_OUTPUT_ALIGN);
-            result.outputs.materialize_output(ci, reinterpret_cast<void*>(alloc_addr), /*version=*/0);
+            result.outputs.materialize_output(ci, reinterpret_cast<void *>(alloc_addr), /*version=*/0);
         }
     }
 
@@ -431,8 +429,8 @@ SubmitResult pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKern
 
     // Record dep pool watermark
     if (sched) {
-        auto& rs = sched->ring_sched_states[ring_id];
-        PTO2TaskSlotState& slot_state = rs.get_slot_state_by_slot(slot);
+        auto &rs = sched->ring_sched_states[ring_id];
+        PTO2TaskSlotState &slot_state = rs.get_slot_state_by_slot(slot);
         slot_state.dep_pool_mark = orch->rings[ring_id].dep_pool.top;
     }
 
@@ -452,10 +450,10 @@ SubmitResult pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKern
 // Explicit Dependency Management
 // =============================================================================
 
-void pto2_add_dependency(PTO2OrchestratorState* orch, PTO2TaskId producer_id, PTO2TaskId consumer_id) {
+void pto2_add_dependency(PTO2OrchestratorState *orch, PTO2TaskId producer_id, PTO2TaskId consumer_id) {
     if (orch->fatal) return;
 
-    PTO2SchedulerState* sched = orch->scheduler;
+    PTO2SchedulerState *sched = orch->scheduler;
     if (!sched) return;
 
     uint8_t prod_ring = producer_id.ring();
@@ -463,17 +461,17 @@ void pto2_add_dependency(PTO2OrchestratorState* orch, PTO2TaskId producer_id, PT
     uint8_t cons_ring = consumer_id.ring();
     uint32_t cons_local = consumer_id.local();
 
-    auto& prod_rs = sched->ring_sched_states[prod_ring];
-    auto& cons_rs = sched->ring_sched_states[cons_ring];
+    auto &prod_rs = sched->ring_sched_states[prod_ring];
+    auto &cons_rs = sched->ring_sched_states[cons_ring];
 
-    PTO2TaskSlotState& prod_state = prod_rs.get_slot_state_by_task_id(prod_local);
-    PTO2TaskSlotState& cons_state = cons_rs.get_slot_state_by_task_id(cons_local);
+    PTO2TaskSlotState &prod_state = prod_rs.get_slot_state_by_task_id(prod_local);
+    PTO2TaskSlotState &cons_state = cons_rs.get_slot_state_by_task_id(cons_local);
 
     // Increment consumer's fanin_count (+1 for this dependency)
     cons_state.fanin_count += 1;
 
     // Record producer in consumer's payload for DFX/debugging
-    PTO2TaskPayload* cons_payload = cons_state.payload;
+    PTO2TaskPayload *cons_payload = cons_state.payload;
     if (cons_payload->fanin_actual_count < PTO2_MAX_INPUTS) {
         cons_payload->fanin_slot_states[cons_payload->fanin_actual_count] = &prod_state;
         cons_payload->fanin_actual_count++;
@@ -482,7 +480,7 @@ void pto2_add_dependency(PTO2OrchestratorState* orch, PTO2TaskId producer_id, PT
     // Wire the fanout edge from producer to consumer.
     // Always use fanout_lock: the producer may be from a previous scope
     // and already visible to the scheduler.
-    auto& dep_pool = orch->rings[cons_ring].dep_pool;
+    auto &dep_pool = orch->rings[cons_ring].dep_pool;
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
     pto2_fanout_lock(prod_state, g_orch_fanin_atomic_count, g_orch_fanin_wait_cycle);
@@ -512,21 +510,18 @@ void pto2_add_dependency(PTO2OrchestratorState* orch, PTO2TaskId producer_id, PT
 // Flow Control
 // =============================================================================
 
-void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         int32_t total_tasks = orch->rings[r].task_ring.current_index_ptr->load(std::memory_order_acquire);
         if (total_tasks > 0) {
             LOG_INFO("=== [Orchestrator] ring %d: total_tasks=%d ===", r, total_tasks);
         }
-        auto& pool = orch->rings[r].dep_pool;
+        auto &pool = orch->rings[r].dep_pool;
         if (pool.top > 0) {
-            LOG_INFO("=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===",
-                r,
-                pool.top,
-                pool.tail,
-                pool.top - pool.tail,
-                pool.high_water,
-                pool.capacity);
+            LOG_INFO(
+                "=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===", r, pool.top, pool.tail,
+                pool.top - pool.tail, pool.high_water, pool.capacity
+            );
         }
     }
     orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
@@ -539,7 +534,7 @@ void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
 // Debug Utilities
 // =============================================================================
 
-void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch) {
     LOG_INFO("=== Orchestrator Statistics ===");
 #if PTO2_PROFILING
     LOG_INFO("Tasks submitted:     %" PRId64, orch->tasks_submitted);
@@ -551,18 +546,19 @@ void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
         int32_t active = pto2_task_ring_active_count(&orch->rings[r].task_ring);
         if (active > 0) {
             LOG_INFO("Ring %d task active:  %d", r, active);
-            LOG_INFO("Ring %d heap used:    %" PRIu64 " / %" PRIu64,
-                r,
-                orch->rings[r].heap_ring.top_ptr->load(std::memory_order_relaxed),
-                orch->rings[r].heap_ring.size);
             LOG_INFO(
-                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity);
+                "Ring %d heap used:    %" PRIu64 " / %" PRIu64, r,
+                orch->rings[r].heap_ring.top_ptr->load(std::memory_order_relaxed), orch->rings[r].heap_ring.size
+            );
+            LOG_INFO(
+                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity
+            );
         }
     }
     LOG_INFO("===============================");
 }
 
-void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState *orch) {
     LOG_INFO("=== Scope Stack ===");
     LOG_INFO("Depth: %d", orch->scope_stack_top + 1);
 

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.h
@@ -47,7 +47,7 @@
  */
 struct PTO2OrchestratorState {
     // === SHARED MEMORY ACCESS ===
-    PTO2SharedMemoryHandle* sm_handle;
+    PTO2SharedMemoryHandle *sm_handle;
 
     // === PER-RING RESOURCES ===
     PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
@@ -56,24 +56,24 @@ struct PTO2OrchestratorState {
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    PTO2TaskSlotState** scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
+    PTO2TaskSlotState **scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
     int32_t scope_tasks_size;         // Number of task IDs currently in the buffer
     int32_t scope_tasks_capacity;     // Allocated capacity of scope_tasks
-    int32_t* scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
+    int32_t *scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
     int32_t scope_stack_top;          // Current top of stack (-1 = no scope open)
     uint64_t scope_stack_capacity;    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
 
     // === SCHEDULER REFERENCE ===
     // Note: In simulated mode, orchestrator and scheduler share address space
     // In real mode, they communicate via shared memory only
-    PTO2SchedulerState* scheduler;  // For simulated mode only
+    PTO2SchedulerState *scheduler;  // For simulated mode only
 #if PTO2_PROFILING
     // Runtime profiling switch copied from Runtime::enable_profiling.
     bool enable_profiling;
 #endif
 
     // === GM HEAP (for output buffers) ===
-    void* gm_heap_base;     // Base address of GM heap
+    void *gm_heap_base;     // Base address of GM heap
     uint64_t gm_heap_size;  // Total size of GM heap (all rings)
 
     // === FATAL ERROR ===
@@ -101,13 +101,13 @@ struct PTO2OrchestratorState {
     /**
      * Allocate packed output buffer from current ring's heap
      */
-    void* pto2_alloc_packed_buffer(int32_t total_size) {
+    void *pto2_alloc_packed_buffer(int32_t total_size) {
         if (total_size <= 0) {
             return NULL;
         }
 
         uint8_t rid = current_ring_id();
-        void* buffer = rings[rid].heap_ring.pto2_heap_ring_alloc(total_size);
+        void *buffer = rings[rid].heap_ring.pto2_heap_ring_alloc(total_size);
 
 #if PTO2_PROFILING
         buffers_allocated++;
@@ -131,21 +131,20 @@ struct PTO2OrchestratorState {
  * @param heap_size  Size of GM heap
  * @return true on success
  */
-bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
-    PTO2SharedMemoryHandle* sm_handle,
-    void* gm_heap,
-    uint64_t heap_size,
-    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+bool pto2_orchestrator_init(
+    PTO2OrchestratorState *orch, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 
 /**
  * Destroy orchestrator state and free resources
  */
-void pto2_orchestrator_destroy(PTO2OrchestratorState* orch);
+void pto2_orchestrator_destroy(PTO2OrchestratorState *orch);
 
 /**
  * Set scheduler reference (for simulated mode)
  */
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler);
+void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler);
 
 // =============================================================================
 // Scope Management
@@ -158,7 +157,7 @@ void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerS
  * Tasks submitted while this scope is at the top of the stack are
  * owned by it and have their fanout_count initialized to 1.
  */
-void pto2_scope_begin(PTO2OrchestratorState* orch);
+void pto2_scope_begin(PTO2OrchestratorState *orch);
 
 /**
  * End current scope
@@ -171,7 +170,7 @@ void pto2_scope_begin(PTO2OrchestratorState* orch);
  * This is the scope-end batch publish mechanism: tasks are invisible
  * to the scheduler until this point.
  */
-void pto2_scope_end(PTO2OrchestratorState* orch);
+void pto2_scope_end(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Task Submission
@@ -194,7 +193,7 @@ void pto2_scope_end(PTO2OrchestratorState* orch);
  * @param args      Aggregated tensor and scalar parameters
  * @return PTO2TaskId for use in pto2_add_dependency()
  */
-SubmitResult pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const Arg& args);
+SubmitResult pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args);
 
 // =============================================================================
 // Explicit Dependency Management
@@ -215,7 +214,7 @@ SubmitResult pto2_submit_mixed_task(PTO2OrchestratorState* orch, const MixedKern
  * @param producer  Producer task ID (must complete before consumer starts)
  * @param consumer  Consumer task ID (depends on producer)
  */
-void pto2_add_dependency(PTO2OrchestratorState* orch, PTO2TaskId producer, PTO2TaskId consumer);
+void pto2_add_dependency(PTO2OrchestratorState *orch, PTO2TaskId producer, PTO2TaskId consumer);
 
 // =============================================================================
 // Flow Control
@@ -226,7 +225,7 @@ void pto2_add_dependency(PTO2OrchestratorState* orch, PTO2TaskId producer, PTO2T
  *
  * Signals to scheduler that no more tasks will be submitted.
  */
-void pto2_orchestrator_done(PTO2OrchestratorState* orch);
+void pto2_orchestrator_done(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Debug Utilities
@@ -235,12 +234,12 @@ void pto2_orchestrator_done(PTO2OrchestratorState* orch);
 /**
  * Print orchestrator statistics
  */
-void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch);
+void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch);
 
 /**
  * Print scope stack state
  */
-void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch);
+void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Orchestrator Profiling Data

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Ring Buffer Implementation
  *
@@ -18,9 +28,9 @@
 // Heap Ring Buffer Implementation
 // =============================================================================
 
-void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
-                          std::atomic<uint64_t>* tail_ptr,
-                          std::atomic<uint64_t>* top_ptr) {
+void pto2_heap_ring_init(
+    PTO2HeapRing *ring, void *base, uint64_t size, std::atomic<uint64_t> *tail_ptr, std::atomic<uint64_t> *top_ptr
+) {
     ring->base = base;
     ring->size = size;
     ring->top_ptr = top_ptr;
@@ -31,9 +41,10 @@ void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
 // Task Ring Buffer Implementation
 // =============================================================================
 
-void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
-                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr,
-                          std::atomic<int32_t>* current_index_ptr) {
+void pto2_task_ring_init(
+    PTO2TaskRing *ring, PTO2TaskDescriptor *descriptors, int32_t window_size, std::atomic<int32_t> *last_alive_ptr,
+    std::atomic<int32_t> *current_index_ptr
+) {
     ring->descriptors = descriptors;
     ring->window_size = window_size;
     ring->current_index_ptr = current_index_ptr;
@@ -43,7 +54,7 @@ void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
 // =============================================================================
 // Dependency List Pool Implementation
 // =============================================================================
-void PTO2DepListPool::reclaim(PTO2SchedulerState& sched, uint8_t ring_id, int32_t sm_last_task_alive) {
+void PTO2DepListPool::reclaim(PTO2SchedulerState &sched, uint8_t ring_id, int32_t sm_last_task_alive) {
     if (sm_last_task_alive >= last_reclaimed + PTO2_DEP_POOL_CLEANUP_INTERVAL && sm_last_task_alive > 0) {
         int32_t mark = sched.ring_sched_states[ring_id].get_slot_state_by_task_id(sm_last_task_alive - 1).dep_pool_mark;
         if (mark > 0) {
@@ -54,7 +65,8 @@ void PTO2DepListPool::reclaim(PTO2SchedulerState& sched, uint8_t ring_id, int32_
 }
 
 void PTO2DepListPool::ensure_space(
-    PTO2SchedulerState& sched, PTO2RingFlowControl& fc, uint8_t ring_id, int32_t needed) {
+    PTO2SchedulerState &sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed
+) {
     if (available() >= needed) return;
 
     int spin_count = 0;
@@ -78,10 +90,10 @@ void PTO2DepListPool::ensure_space(
             LOG_ERROR("FATAL: Dependency Pool Deadlock Detected! (ring %d)", ring_id);
             LOG_ERROR("========================================");
             LOG_ERROR("DepListPool cannot reclaim space after %d spins (no progress).", spin_count);
-            LOG_ERROR("  - Pool used:     %d / %d (%.1f%%)",
-                used(),
-                capacity,
-                (capacity > 0) ? (100.0 * used() / capacity) : 0.0);
+            LOG_ERROR(
+                "  - Pool used:     %d / %d (%.1f%%)", used(), capacity,
+                (capacity > 0) ? (100.0 * used() / capacity) : 0.0
+            );
             LOG_ERROR("  - Pool top:      %d (linear)", top);
             LOG_ERROR("  - Pool tail:     %d (linear)", tail);
             LOG_ERROR("  - High water:    %d", high_water);

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.h
@@ -1,25 +1,35 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Ring Buffer Data Structures
- * 
+ *
  * Implements ring buffer designs for zero-overhead memory management:
- * 
+ *
  * 1. HeapRing - Output buffer allocation from GM Heap
  *    - O(1) bump allocation
  *    - Wrap-around at end, skip to beginning if buffer doesn't fit
  *    - Implicit reclamation via heap_tail advancement
  *    - Back-pressure: stalls when no space available
- * 
+ *
  * 2. TaskRing - Task slot allocation
  *    - Fixed window size (TASK_WINDOW_SIZE)
  *    - Wrap-around modulo window size
  *    - Implicit reclamation via last_task_alive advancement
  *    - Back-pressure: stalls when window is full
- * 
+ *
  * 3. DepListPool - Dependency list entry allocation
  *    - Ring buffer for linked list entries
  *    - O(1) prepend operation
  *    - Implicit reclamation with task ring
- * 
+ *
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
@@ -40,15 +50,15 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 #endif
 
 // Block notification interval (in spin counts)
-#define PTO2_BLOCK_NOTIFY_INTERVAL  10000
+#define PTO2_BLOCK_NOTIFY_INTERVAL 10000
 // Heap ring spin limit - after this, report deadlock and exit
-#define PTO2_HEAP_SPIN_LIMIT        100000
+#define PTO2_HEAP_SPIN_LIMIT 100000
 
 // Flow control spin limit - if exceeded, likely deadlock due to scope/fanout_count
-#define PTO2_FLOW_CONTROL_SPIN_LIMIT  100000
+#define PTO2_FLOW_CONTROL_SPIN_LIMIT 100000
 
 // Dep pool spin limit - if exceeded, dep pool capacity too small for workload
-#define PTO2_DEP_POOL_SPIN_LIMIT      100000
+#define PTO2_DEP_POOL_SPIN_LIMIT 100000
 
 // =============================================================================
 // Heap Ring Buffer
@@ -56,20 +66,20 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 
 /**
  * Heap ring buffer structure
- * 
+ *
  * Allocates output buffers from a contiguous GM Heap.
  * Wrap-around design with implicit reclamation.
  */
 struct PTO2HeapRing {
-    void*    base;        // GM_Heap_Base pointer
-    uint64_t size;        // GM_Heap_Size (total heap size in bytes)
-    std::atomic<uint64_t>* top_ptr;  // Allocation pointer (shared atomic in SM header)
+    void *base;                      // GM_Heap_Base pointer
+    uint64_t size;                   // GM_Heap_Size (total heap size in bytes)
+    std::atomic<uint64_t> *top_ptr;  // Allocation pointer (shared atomic in SM header)
 
     // Reference to shared memory tail (for back-pressure)
-    std::atomic<uint64_t>* tail_ptr;  // Points to header->heap_tail
+    std::atomic<uint64_t> *tail_ptr;  // Points to header->heap_tail
 
     // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
-    std::atomic<int32_t>* error_code_ptr = nullptr;
+    std::atomic<int32_t> *error_code_ptr = nullptr;
 
     /**
      * Allocate memory from heap ring
@@ -81,7 +91,7 @@ struct PTO2HeapRing {
      * @param size  Requested size in bytes
      * @return Pointer to allocated memory, or nullptr on fatal error
      */
-    void* pto2_heap_ring_alloc(uint64_t size) {
+    void *pto2_heap_ring_alloc(uint64_t size) {
         // Align size for DMA efficiency
         size = PTO2_ALIGN_UP(size, PTO2_ALIGN_SIZE);
 
@@ -97,7 +107,7 @@ struct PTO2HeapRing {
 #endif
 
         while (1) {
-            void* ptr = pto2_heap_ring_try_alloc(size);
+            void *ptr = pto2_heap_ring_try_alloc(size);
             if (ptr != NULL) {
 #if PTO2_SPIN_VERBOSE_LOGGING
                 if (notified) {
@@ -111,7 +121,8 @@ struct PTO2HeapRing {
                 }
                 {
                     extern uint64_t g_orch_heap_atomic_count;
-                    g_orch_heap_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
+                    g_orch_heap_atomic_count +=
+                        spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
                 }
 #endif
                 return ptr;
@@ -120,15 +131,20 @@ struct PTO2HeapRing {
             // No space available, spin-wait
             spin_count++;
 #if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+            if (!waiting) {
+                wait_start = get_sys_cnt_aicpu();
+                waiting = true;
+            }
 #endif
 
             // Progress detection: reset spin counter if heap_tail advances
             uint64_t cur_tail = tail_ptr->load(std::memory_order_acquire);
             if (cur_tail != prev_tail) {
 #if PTO2_SPIN_VERBOSE_LOGGING
-                LOG_INFO("[HeapRing] Progress: tail %" PRIu64 " -> %" PRIu64 " (reset spin_count=%d)",
-                         prev_tail, cur_tail, spin_count);
+                LOG_INFO(
+                    "[HeapRing] Progress: tail %" PRIu64 " -> %" PRIu64 " (reset spin_count=%d)", prev_tail, cur_tail,
+                    spin_count
+                );
 #endif
                 spin_count = 0;
                 prev_tail = cur_tail;
@@ -138,9 +154,11 @@ struct PTO2HeapRing {
             // Periodic block notification
             if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 && spin_count < PTO2_HEAP_SPIN_LIMIT) {
                 uint64_t top = top_ptr->load(std::memory_order_acquire);
-                LOG_WARN("[HeapRing] BLOCKED: requesting %" PRIu64 " bytes"
-                     ", top=%" PRIu64 ", tail=%" PRIu64 ", spins=%d",
-                     size, top, cur_tail, spin_count);
+                LOG_WARN(
+                    "[HeapRing] BLOCKED: requesting %" PRIu64 " bytes"
+                    ", top=%" PRIu64 ", tail=%" PRIu64 ", spins=%d",
+                    size, top, cur_tail, spin_count
+                );
                 notified = true;
             }
 #endif
@@ -161,8 +179,9 @@ struct PTO2HeapRing {
                 LOG_ERROR("  is stuck. Check TaskRing diagnostics for root cause.");
                 LOG_ERROR("Solution: Increase heap size or investigate task stall.");
                 LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
-                LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %lu)",
-                          (unsigned long)(this->size * 2));
+                LOG_ERROR(
+                    "  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %lu)", (unsigned long)(this->size * 2)
+                );
                 LOG_ERROR("========================================");
                 if (error_code_ptr) {
                     error_code_ptr->store(PTO2_ERROR_HEAP_RING_DEADLOCK, std::memory_order_release);
@@ -180,7 +199,7 @@ struct PTO2HeapRing {
      * @param size  Requested size in bytes
      * @return Pointer to allocated memory, or NULL if no space
      */
-    void* pto2_heap_ring_try_alloc(uint64_t alloc_size) {
+    void *pto2_heap_ring_try_alloc(uint64_t alloc_size) {
         // Align size for DMA efficiency
         alloc_size = PTO2_ALIGN_UP(alloc_size, PTO2_ALIGN_SIZE);
 
@@ -189,7 +208,7 @@ struct PTO2HeapRing {
             // Read latest tail from shared memory (Scheduler updates this)
             uint64_t tail = tail_ptr->load(std::memory_order_acquire);
             uint64_t new_top;
-            void* result;
+            void *result;
 
             if (top >= tail) {
                 // Case 1: top is at or ahead of tail (normal case)
@@ -197,7 +216,7 @@ struct PTO2HeapRing {
 
                 if (space_at_end >= alloc_size) {
                     new_top = top + alloc_size;
-                    result = (char*)base + top;
+                    result = (char *)base + top;
                 } else if (tail > alloc_size) {
                     // Wrap to beginning
                     new_top = alloc_size;
@@ -210,14 +229,13 @@ struct PTO2HeapRing {
                 uint64_t gap = tail - top;
                 if (gap >= alloc_size) {
                     new_top = top + alloc_size;
-                    result = (char*)base + top;
+                    result = (char *)base + top;
                 } else {
                     return NULL;
                 }
             }
 
-            if (top_ptr->compare_exchange_weak(top, new_top,
-                    std::memory_order_acq_rel, std::memory_order_acquire)) {
+            if (top_ptr->compare_exchange_weak(top, new_top, std::memory_order_acq_rel, std::memory_order_acquire)) {
                 return result;
             }
             // CAS failed, retry with updated top
@@ -243,15 +261,15 @@ struct PTO2HeapRing {
 
 /**
  * Initialize heap ring buffer
- * 
+ *
  * @param ring      Heap ring to initialize
  * @param base      Base address of heap memory
  * @param size      Total heap size in bytes
  * @param tail_ptr  Pointer to shared memory heap_tail
  */
-void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
-                          std::atomic<uint64_t>* tail_ptr,
-                          std::atomic<uint64_t>* top_ptr);
+void pto2_heap_ring_init(
+    PTO2HeapRing *ring, void *base, uint64_t size, std::atomic<uint64_t> *tail_ptr, std::atomic<uint64_t> *top_ptr
+);
 
 // =============================================================================
 // Task Ring Buffer
@@ -259,20 +277,20 @@ void pto2_heap_ring_init(PTO2HeapRing* ring, void* base, uint64_t size,
 
 /**
  * Task ring buffer structure
- * 
+ *
  * Fixed-size sliding window for task management.
  * Provides back-pressure when window is full.
  */
 struct PTO2TaskRing {
-    PTO2TaskDescriptor* descriptors;  // Task descriptor array (from shared memory)
-    int32_t window_size;              // Window size (power of 2)
-    std::atomic<int32_t>* current_index_ptr;  // Shared atomic in SM header
+    PTO2TaskDescriptor *descriptors;          // Task descriptor array (from shared memory)
+    int32_t window_size;                      // Window size (power of 2)
+    std::atomic<int32_t> *current_index_ptr;  // Shared atomic in SM header
 
     // Reference to shared memory last_task_alive (for back-pressure)
-    std::atomic<int32_t>* last_alive_ptr;  // Points to header->last_task_alive
+    std::atomic<int32_t> *last_alive_ptr;  // Points to header->last_task_alive
 
     // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
-    std::atomic<int32_t>* error_code_ptr = nullptr;
+    std::atomic<int32_t> *error_code_ptr = nullptr;
 
     /**
      * Allocate a task slot from task ring
@@ -309,7 +327,8 @@ struct PTO2TaskRing {
                 }
                 {
                     extern uint64_t g_orch_alloc_atomic_count;
-                    g_orch_alloc_atomic_count += spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
+                    g_orch_alloc_atomic_count +=
+                        spin_count + 1;  // spin_count retries + 1 success (each try_alloc = 1 load)
                 }
 #endif
                 return task_id;
@@ -318,15 +337,20 @@ struct PTO2TaskRing {
             // Window is full, spin-wait (with yield to prevent CPU starvation)
             spin_count++;
 #if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+            if (!waiting) {
+                wait_start = get_sys_cnt_aicpu();
+                waiting = true;
+            }
 #endif
 
             // Progress detection: reset spin counter if last_task_alive advances
             int32_t cur_last_alive = last_alive_ptr->load(std::memory_order_acquire);
             if (cur_last_alive > prev_last_alive) {
 #if PTO2_SPIN_VERBOSE_LOGGING
-                LOG_INFO("[TaskRing] Progress: last_alive %d -> %d (reset spin_count=%d)",
-                         prev_last_alive, cur_last_alive, spin_count);
+                LOG_INFO(
+                    "[TaskRing] Progress: last_alive %d -> %d (reset spin_count=%d)", prev_last_alive, cur_last_alive,
+                    spin_count
+                );
 #endif
                 spin_count = 0;
                 prev_last_alive = cur_last_alive;
@@ -334,13 +358,15 @@ struct PTO2TaskRing {
 
 #if PTO2_SPIN_VERBOSE_LOGGING
             // Periodic block notification
-            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 && spin_count < PTO2_FLOW_CONTROL_SPIN_LIMIT) {
+            if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0 && spin_count > 0 &&
+                spin_count < PTO2_FLOW_CONTROL_SPIN_LIMIT) {
                 int32_t current = current_index_ptr->load(std::memory_order_acquire);
                 int32_t active_count = current - cur_last_alive;
-                LOG_WARN("[TaskRing] BLOCKED (Flow Control): current=%d, last_alive=%d, "
-                     "active=%d/%d (%.1f%%), spins=%d",
-                     current, cur_last_alive, active_count, window_size,
-                     100.0 * active_count / window_size, spin_count);
+                LOG_WARN(
+                    "[TaskRing] BLOCKED (Flow Control): current=%d, last_alive=%d, "
+                    "active=%d/%d (%.1f%%), spins=%d",
+                    current, cur_last_alive, active_count, window_size, 100.0 * active_count / window_size, spin_count
+                );
                 notified = true;
             }
 #endif
@@ -359,8 +385,7 @@ struct PTO2TaskRing {
                 LOG_ERROR("  - Active tasks:        %d / %d", active_count, window_size);
                 LOG_ERROR("  - Window utilization:  %.1f%%", 100.0 * active_count / window_size);
                 LOG_ERROR("Diagnosis:");
-                LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d",
-                          cur_last_alive, cur_last_alive);
+                LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d", cur_last_alive, cur_last_alive);
                 LOG_ERROR("  cannot transition to CONSUMED. Possible causes:");
                 LOG_ERROR("  1. Task %d still executing (subtasks not complete)", cur_last_alive);
                 LOG_ERROR("  2. Task %d fanout not fully released (downstream not done)", cur_last_alive);
@@ -405,32 +430,33 @@ struct PTO2TaskRing {
     int32_t get_task_slot(int32_t task_id) const { return task_id & (window_size - 1); }
 
     /**
-    * Get task descriptor by ID
-    */
-    PTO2TaskDescriptor& get_task(int32_t task_id) { return descriptors[task_id & (window_size - 1)]; }
+     * Get task descriptor by ID
+     */
+    PTO2TaskDescriptor &get_task(int32_t task_id) { return descriptors[task_id & (window_size - 1)]; }
 
     /**
-    * Get task descriptor by task slot
-    */
-    PTO2TaskDescriptor& get_task_by_slot(int32_t task_slot) { return descriptors[task_slot]; }
+     * Get task descriptor by task slot
+     */
+    PTO2TaskDescriptor &get_task_by_slot(int32_t task_slot) { return descriptors[task_slot]; }
 };
 
 /**
  * Initialize task ring buffer
- * 
+ *
  * @param ring            Task ring to initialize
  * @param descriptors     Task descriptor array from shared memory
  * @param window_size     Window size (must be power of 2)
  * @param last_alive_ptr  Pointer to shared memory last_task_alive
  */
-void pto2_task_ring_init(PTO2TaskRing* ring, PTO2TaskDescriptor* descriptors,
-                          int32_t window_size, std::atomic<int32_t>* last_alive_ptr,
-                          std::atomic<int32_t>* current_index_ptr);
+void pto2_task_ring_init(
+    PTO2TaskRing *ring, PTO2TaskDescriptor *descriptors, int32_t window_size, std::atomic<int32_t> *last_alive_ptr,
+    std::atomic<int32_t> *current_index_ptr
+);
 
 /**
  * Get number of active tasks in window
  */
-static inline int32_t pto2_task_ring_active_count(PTO2TaskRing* ring) {
+static inline int32_t pto2_task_ring_active_count(PTO2TaskRing *ring) {
     int32_t last_alive = ring->last_alive_ptr->load(std::memory_order_acquire);
     return ring->current_index_ptr->load(std::memory_order_acquire) - last_alive;
 }
@@ -438,7 +464,7 @@ static inline int32_t pto2_task_ring_active_count(PTO2TaskRing* ring) {
 /**
  * Check if task ring has space for more tasks
  */
-static inline bool pto2_task_ring_has_space(PTO2TaskRing* ring) {
+static inline bool pto2_task_ring_has_space(PTO2TaskRing *ring) {
     int32_t active = pto2_task_ring_active_count(ring);
     return active < ring->window_size - 1;
 }
@@ -446,7 +472,7 @@ static inline bool pto2_task_ring_has_space(PTO2TaskRing* ring) {
 /**
  * Get task descriptor by ID
  */
-static inline PTO2TaskDescriptor* pto2_task_ring_get(PTO2TaskRing* ring, int32_t task_id) {
+static inline PTO2TaskDescriptor *pto2_task_ring_get(PTO2TaskRing *ring, int32_t task_id) {
     return &ring->descriptors[task_id & (ring->window_size - 1)];
 }
 
@@ -465,15 +491,15 @@ static inline PTO2TaskDescriptor* pto2_task_ring_get(PTO2TaskRing* ring, int32_t
  * is obtained via modulo: base[linear_index % capacity].
  */
 struct PTO2DepListPool {
-    PTO2DepListEntry* base;   // Pool base address
-    int32_t capacity;         // Total number of entries
-    int32_t top;              // Linear next-allocation counter (starts from 1)
-    int32_t tail;             // Linear first-alive counter (entries before this are dead)
-    int32_t high_water;       // Peak concurrent usage (top - tail)
-    int32_t last_reclaimed{0}; // last_task_alive at last successful reclamation
+    PTO2DepListEntry *base;     // Pool base address
+    int32_t capacity;           // Total number of entries
+    int32_t top;                // Linear next-allocation counter (starts from 1)
+    int32_t tail;               // Linear first-alive counter (entries before this are dead)
+    int32_t high_water;         // Peak concurrent usage (top - tail)
+    int32_t last_reclaimed{0};  // last_task_alive at last successful reclamation
 
     // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
-    std::atomic<int32_t>* error_code_ptr = nullptr;
+    std::atomic<int32_t> *error_code_ptr = nullptr;
 
     /**
      * Initialize dependency list pool
@@ -481,7 +507,7 @@ struct PTO2DepListPool {
      * @param base      Pool base address from shared memory
      * @param capacity  Total number of entries
      */
-    void init(PTO2DepListEntry* in_base, int32_t in_capacity, std::atomic<int32_t>* in_error_code_ptr) {
+    void init(PTO2DepListEntry *in_base, int32_t in_capacity, std::atomic<int32_t> *in_error_code_ptr) {
         base = in_base;
         capacity = in_capacity;
         top = 1;   // Start from 1, 0 means NULL/empty
@@ -504,20 +530,20 @@ struct PTO2DepListPool {
      * @param ring_id            Ring layer index
      * @param sm_last_task_alive Current last_task_alive from shared memory
      */
-    void reclaim(PTO2SchedulerState& sched, uint8_t ring_id, int32_t sm_last_task_alive);
+    void reclaim(PTO2SchedulerState &sched, uint8_t ring_id, int32_t sm_last_task_alive);
 
     /**
      * Ensure dep pool for a specific ring has at least `needed` entries available.
      * Spin-waits for reclamation if under pressure. Detects deadlock if no progress.
      */
-    void ensure_space(PTO2SchedulerState& sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed);
+    void ensure_space(PTO2SchedulerState &sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed);
 
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)
      *
      * @return Pointer to allocated entry, or nullptr on fatal error
      */
-    PTO2DepListEntry* alloc() {
+    PTO2DepListEntry *alloc() {
         int32_t used = top - tail;
         if (used >= capacity) {
             LOG_ERROR("========================================");
@@ -563,8 +589,8 @@ struct PTO2DepListPool {
      * @param task_slot     Task slot to prepend
      * @return New head offset
      */
-    PTO2DepListEntry* prepend(PTO2DepListEntry* cur, PTO2TaskSlotState* slot_state) {
-        PTO2DepListEntry* new_entry = alloc();
+    PTO2DepListEntry *prepend(PTO2DepListEntry *cur, PTO2TaskSlotState *slot_state) {
+        PTO2DepListEntry *new_entry = alloc();
         if (!new_entry) return nullptr;
         new_entry->slot_state = slot_state;
         new_entry->next = cur;
@@ -572,20 +598,16 @@ struct PTO2DepListPool {
     }
 
     /**
-    * Get entry by offset
-    */
-    PTO2DepListEntry* pto2_dep_pool_get(int32_t offset) {
+     * Get entry by offset
+     */
+    PTO2DepListEntry *pto2_dep_pool_get(int32_t offset) {
         if (offset <= 0) return NULL;
         return &base[offset];
     }
 
-    int32_t used() const {
-        return top - tail;
-    }
+    int32_t used() const { return top - tail; }
 
-    int32_t available() const {
-        return capacity - used();
-    }
+    int32_t available() const { return capacity - used(); }
 };
 
 // =============================================================================
@@ -597,9 +619,9 @@ struct PTO2DepListPool {
  * PTO2_MAX_RING_DEPTH instances provide independent reclamation per scope depth.
  */
 struct PTO2RingSet {
-    PTO2HeapRing    heap_ring;
-    PTO2TaskRing    task_ring;
+    PTO2HeapRing heap_ring;
+    PTO2TaskRing task_ring;
     PTO2DepListPool dep_pool;
 };
 
-#endif // PTO_RING_BUFFER_H
+#endif  // PTO_RING_BUFFER_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.cpp
@@ -37,21 +37,21 @@ void pto2_set_orch_thread_idx(int idx) { pto2_current_orch_idx = idx; }
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
-static SubmitResult submit_task_impl(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const Arg& args) {
+static SubmitResult submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
     return pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels, args);
 }
 
-static void add_dependency_impl(PTO2Runtime* rt, PTO2TaskId producer, PTO2TaskId consumer) {
+static void add_dependency_impl(PTO2Runtime *rt, PTO2TaskId producer, PTO2TaskId consumer) {
     pto2_add_dependency(&rt->orchestrators[pto2_current_orch_idx], producer, consumer);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime* rt) { pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]); }
+void pto2_rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_scope_end(PTO2Runtime* rt) { pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]); }
+void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_orchestration_done(PTO2Runtime* rt) { pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]); }
+void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]); }
 
-static bool is_fatal_impl(PTO2Runtime* rt) { return rt->orchestrators[pto2_current_orch_idx].fatal; }
+static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrators[pto2_current_orch_idx].fatal; }
 
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
@@ -71,14 +71,15 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // Runtime Creation and Destruction
 // =============================================================================
 
-PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode) {
+PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode) {
     return pto2_runtime_create_custom(mode, PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
 }
 
-PTO2Runtime* pto2_runtime_create_custom(
-    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity) {
+PTO2Runtime *pto2_runtime_create_custom(
+    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity
+) {
     // Allocate runtime context
-    PTO2Runtime* rt = reinterpret_cast<PTO2Runtime*>(calloc(1, sizeof(PTO2Runtime)));
+    PTO2Runtime *rt = reinterpret_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) {
         return NULL;
     }
@@ -134,17 +135,15 @@ PTO2Runtime* pto2_runtime_create_custom(
     return rt;
 }
 
-PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-    PTO2SharedMemoryHandle* sm_handle,
-    void* gm_heap,
-    uint64_t heap_size,
-    int orch_count,
-    int32_t dep_pool_capacity) {
+PTO2Runtime *pto2_runtime_create_from_sm(
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count,
+    int32_t dep_pool_capacity
+) {
     if (!sm_handle) return NULL;
     if (orch_count < 1) orch_count = 1;
     if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
 
-    PTO2Runtime* rt = reinterpret_cast<PTO2Runtime*>(calloc(1, sizeof(PTO2Runtime)));
+    PTO2Runtime *rt = reinterpret_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) return NULL;
 
     rt->ops = &s_runtime_ops;
@@ -183,7 +182,7 @@ PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
     return rt;
 }
 
-void pto2_runtime_destroy(PTO2Runtime* rt) {
+void pto2_runtime_destroy(PTO2Runtime *rt) {
     if (!rt) return;
 
     pto2_scheduler_destroy(&rt->scheduler);
@@ -202,7 +201,7 @@ void pto2_runtime_destroy(PTO2Runtime* rt) {
     free(rt);
 }
 
-void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode) {
+void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;
     }

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.h
@@ -69,19 +69,19 @@ enum PTO2RuntimeMode {
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
-    SubmitResult (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const Arg& args);
-    void (*add_dependency)(PTO2Runtime* rt, PTO2TaskId producer, PTO2TaskId consumer);
-    void (*scope_begin)(PTO2Runtime* rt);
-    void (*scope_end)(PTO2Runtime* rt);
-    void (*orchestration_done)(PTO2Runtime* rt);
-    bool (*is_fatal)(PTO2Runtime* rt);
+    SubmitResult (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    void (*add_dependency)(PTO2Runtime *rt, PTO2TaskId producer, PTO2TaskId consumer);
+    void (*scope_begin)(PTO2Runtime *rt);
+    void (*scope_end)(PTO2Runtime *rt);
+    void (*orchestration_done)(PTO2Runtime *rt);
+    bool (*is_fatal)(PTO2Runtime *rt);
 
     // Logging (populated by runtime, called by orchestration)
-    void (*log_error)(const char* func, const char* fmt, ...);
-    void (*log_warn)(const char* func, const char* fmt, ...);
-    void (*log_info)(const char* func, const char* fmt, ...);
-    void (*log_debug)(const char* func, const char* fmt, ...);
-    void (*log_always)(const char* func, const char* fmt, ...);
+    void (*log_error)(const char *func, const char *fmt, ...);
+    void (*log_warn)(const char *func, const char *fmt, ...);
+    void (*log_info)(const char *func, const char *fmt, ...);
+    void (*log_debug)(const char *func, const char *fmt, ...);
+    void (*log_always)(const char *func, const char *fmt, ...);
 };
 
 /**
@@ -92,16 +92,16 @@ struct PTO2RuntimeOps {
  */
 struct PTO2Runtime {
     // Ops table (first field — used by orchestration .so via function pointers)
-    const PTO2RuntimeOps* ops;
+    const PTO2RuntimeOps *ops;
 
     // Components
-    PTO2SharedMemoryHandle* sm_handle;
+    PTO2SharedMemoryHandle *sm_handle;
     PTO2OrchestratorState orchestrators[PTO2_MAX_ORCH_THREADS];
     int orch_count;  // Number of active orchestrator states
     PTO2SchedulerState scheduler;
 
     // GM Heap for output buffers
-    void* gm_heap;
+    void *gm_heap;
     uint64_t gm_heap_size;
     bool gm_heap_owned;  // True if we allocated it
 
@@ -122,7 +122,7 @@ struct PTO2Runtime {
  * @param mode Execution mode
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode);
+PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode);
 
 /**
  * Create runtime with custom sizes
@@ -132,10 +132,10 @@ PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode);
  * @param heap_size        Size of GM heap
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
-    uint64_t task_window_size,
-    uint64_t heap_size,
-    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+PTO2Runtime *pto2_runtime_create_custom(
+    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 
 /**
  * Create runtime from existing shared memory and GM heap (e.g. on device).
@@ -147,22 +147,20 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
  * @param heap_size GM heap size in bytes
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-    PTO2SharedMemoryHandle* sm_handle,
-    void* gm_heap,
-    uint64_t heap_size,
-    int orch_count = 1,
-    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+PTO2Runtime *pto2_runtime_create_from_sm(
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count = 1,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 
 /**
  * Destroy runtime and free all resources
  */
-void pto2_runtime_destroy(PTO2Runtime* rt);
+void pto2_runtime_destroy(PTO2Runtime *rt);
 
 /**
  * Set execution mode
  */
-void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode);
+void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
 
 /**
  * Set the orchestrator index for the current thread.
@@ -181,7 +179,7 @@ void pto2_set_orch_thread_idx(int idx);
  * bounded by the scope. When scope_end() is called, the scope
  * releases its reference to all enclosed tasks.
  */
-void pto2_rt_scope_begin(PTO2Runtime* rt);
+void pto2_rt_scope_begin(PTO2Runtime *rt);
 
 /**
  * End current scope
@@ -189,14 +187,14 @@ void pto2_rt_scope_begin(PTO2Runtime* rt);
  * Releases scope reference for all tasks submitted since scope_begin().
  * Tasks whose refcount reaches zero will have their buffers released.
  */
-void pto2_rt_scope_end(PTO2Runtime* rt);
+void pto2_rt_scope_end(PTO2Runtime *rt);
 
 /**
  * Mark orchestration as complete
  *
  * Signals that no more tasks will be submitted.
  */
-void pto2_rt_orchestration_done(PTO2Runtime* rt);
+void pto2_rt_orchestration_done(PTO2Runtime *rt);
 
 /**
  * Scope helper macros for C
@@ -245,11 +243,14 @@ void pto2_rt_orchestration_done(PTO2Runtime* rt);
  */
 class PTO2ScopeGuard {
 public:  // NOLINT(whitespace/indent)
-    explicit PTO2ScopeGuard(PTO2Runtime* rt) : rt_(rt) { pto2_rt_scope_begin(rt_); }
+    explicit PTO2ScopeGuard(PTO2Runtime *rt) :
+        rt_(rt) {
+        pto2_rt_scope_begin(rt_);
+    }
     ~PTO2ScopeGuard() { pto2_rt_scope_end(rt_); }
 
 private:  // NOLINT(whitespace/indent)
-    PTO2Runtime* rt_;
+    PTO2Runtime *rt_;
 };
 
 /**

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2_types.h
@@ -121,14 +121,16 @@
 struct PTO2TaskId {
     uint64_t raw;
 
-    constexpr PTO2TaskId() : raw(0) {}
-    constexpr explicit PTO2TaskId(uint64_t v) : raw(v) {}
+    constexpr PTO2TaskId() :
+        raw(0) {}
+    constexpr explicit PTO2TaskId(uint64_t v) :
+        raw(v) {}
 
     constexpr uint8_t ring() const { return static_cast<uint8_t>(raw >> 32); }
     constexpr uint32_t local() const { return static_cast<uint32_t>(raw & 0xFFFFFFFFu); }
 
-    constexpr bool operator==(const PTO2TaskId& other) const { return raw == other.raw; }
-    constexpr bool operator!=(const PTO2TaskId& other) const { return raw != other.raw; }
+    constexpr bool operator==(const PTO2TaskId &other) const { return raw == other.raw; }
+    constexpr bool operator!=(const PTO2TaskId &other) const { return raw != other.raw; }
 };
 
 static_assert(sizeof(PTO2TaskId) == 8, "PTO2TaskId must stay 8 bytes (shared memory ABI)");
@@ -203,8 +205,8 @@ typedef enum {
  */
 struct PTO2TaskSlotState;  // Forward declaration
 struct PTO2DepListEntry {
-    PTO2TaskSlotState* slot_state;  // Consumer slot state (direct pointer)
-    PTO2DepListEntry* next;         // next entry
+    PTO2TaskSlotState *slot_state;  // Consumer slot state (direct pointer)
+    PTO2DepListEntry *next;         // next entry
 };
 
 // =============================================================================
@@ -228,8 +230,8 @@ struct PTO2TaskDescriptor {
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];
 
     // Packed output buffer (all outputs packed into single contiguous buffer)
-    void* packed_buffer_base;  // Start of packed buffer in GM Heap
-    void* packed_buffer_end;   // End of packed buffer (for heap reclamation)
+    void *packed_buffer_base;  // Start of packed buffer in GM Heap
+    void *packed_buffer_end;   // End of packed buffer (for heap reclamation)
 };
 
 // =============================================================================
@@ -250,18 +252,18 @@ struct PTO2TaskPayload {
     int32_t scalar_count{0};
     int32_t fanin_actual_count{0};  // Actual fanin count (without the +1 redundance)
     int32_t _reserved{0};           // Reserved (dep_pool_mark moved to SlotState for local access)
-    PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
+    PTO2TaskSlotState *fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
     // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
     // === Cache lines 35-50 (1024B) — scalars ===
     uint64_t scalars[MAX_SCALAR_ARGS];
 
-    void init(const Arg& args, const TaskOutputTensors& materialized_outputs) {
+    void init(const Arg &args, const TaskOutputTensors &materialized_outputs) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
         int32_t out_idx = 0;
         for (int32_t i = 0; i < args.tensor_count(); i++) {
-            const Tensor* src;
+            const Tensor *src;
             if (args.tag(i) == TensorArgType::OUTPUT) {
                 src = materialized_outputs.output_ptr(out_idx++);
             } else {
@@ -292,7 +294,7 @@ struct alignas(64) PTO2TaskSlotState {
     std::atomic<int32_t> fanout_lock;  // Per-task spinlock (0=unlocked, 1=locked)
     int32_t fanout_count;              // 1 (owning scope) + number of consumers
 
-    PTO2DepListEntry* fanout_head;  // Pointer to first fanout entry (nullptr = empty)
+    PTO2DepListEntry *fanout_head;  // Pointer to first fanout entry (nullptr = empty)
 
     // Task state (completion, consumed check, ready check)
     std::atomic<PTO2TaskState> task_state;  // PENDING/READY/RUNNING/COMPLETED/CONSUMED
@@ -304,9 +306,9 @@ struct alignas(64) PTO2TaskSlotState {
     // Fanout refcount (accessed with fanout_count in check_and_handle_consumed)
     std::atomic<int32_t> fanout_refcount;  // Dynamic: counts released references
 
-    PTO2TaskPayload* payload;
+    PTO2TaskPayload *payload;
 
-    PTO2TaskDescriptor* task;
+    PTO2TaskDescriptor *task;
 
     // Hot-path completion fields (moved from TaskDescriptor to avoid cross-struct access)
     uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
@@ -325,7 +327,7 @@ static_assert(sizeof(PTO2TaskSlotState) == 64);
  * Cycle cost function pointer type
  * Returns estimated cycle count for the InCore function
  */
-typedef int64_t (*PTO2CycleCostFunc)(void** args, int32_t num_args);
+typedef int64_t (*PTO2CycleCostFunc)(void **args, int32_t num_args);
 
 // =============================================================================
 // InCore Function Type
@@ -335,7 +337,7 @@ typedef int64_t (*PTO2CycleCostFunc)(void** args, int32_t num_args);
  * InCore function signature
  * All InCore functions must match this signature
  */
-typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
+typedef void (*PTO2InCoreFunc)(void **args, int32_t num_args);
 
 // =============================================================================
 // Utility Macros
@@ -380,7 +382,7 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 #endif
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& atomic_count, uint64_t& wait_cycle) {
+static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
     uint64_t t0 = get_sys_cnt_aicpu();
     bool contended = false;
     uint32_t atomic_ops = 0;
@@ -393,7 +395,8 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& ato
         }
         int32_t expected = 0;
         if (slot_state.fanout_lock.compare_exchange_weak(
-                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             atomic_ops++;  // successful CAS = 1 atomic
             atomic_count += atomic_ops;
             if (contended) {
@@ -407,20 +410,21 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& ato
 }
 #endif
 
-static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state) {
+static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state) {
     for (;;) {
         while (slot_state.fanout_lock.load(std::memory_order_acquire) != 0) {
             SPIN_WAIT_HINT();
         }
         int32_t expected = 0;
         if (slot_state.fanout_lock.compare_exchange_weak(
-                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             return;
         }
     }
 }
 
-static inline void pto2_fanout_unlock(PTO2TaskSlotState& slot_state) {
+static inline void pto2_fanout_unlock(PTO2TaskSlotState &slot_state) {
     slot_state.fanout_lock.store(0, std::memory_order_release);
 }
 

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_scheduler.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Scheduler Implementation
  *
@@ -57,14 +67,20 @@ PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
 // Task State Names
 // =============================================================================
 
-const char* pto2_task_state_name(PTO2TaskState state) {
+const char *pto2_task_state_name(PTO2TaskState state) {
     switch (state) {
-        case PTO2_TASK_PENDING:   return "PENDING";
-        case PTO2_TASK_READY:     return "READY";
-        case PTO2_TASK_RUNNING:   return "RUNNING";
-        case PTO2_TASK_COMPLETED: return "COMPLETED";
-        case PTO2_TASK_CONSUMED:  return "CONSUMED";
-        default:                  return "UNKNOWN";
+    case PTO2_TASK_PENDING:
+        return "PENDING";
+    case PTO2_TASK_READY:
+        return "READY";
+    case PTO2_TASK_RUNNING:
+        return "RUNNING";
+    case PTO2_TASK_COMPLETED:
+        return "COMPLETED";
+    case PTO2_TASK_CONSUMED:
+        return "CONSUMED";
+    default:
+        return "UNKNOWN";
     }
 }
 
@@ -72,8 +88,8 @@ const char* pto2_task_state_name(PTO2TaskState state) {
 // Ready Queue Implementation
 // =============================================================================
 
-bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity) {
-    queue->slots = (PTO2ReadyQueueSlot*)malloc(capacity * sizeof(PTO2ReadyQueueSlot));
+bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity) {
+    queue->slots = (PTO2ReadyQueueSlot *)malloc(capacity * sizeof(PTO2ReadyQueueSlot));
     if (!queue->slots) {
         return false;
     }
@@ -91,7 +107,7 @@ bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity) {
     return true;
 }
 
-void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
+void pto2_ready_queue_destroy(PTO2ReadyQueue *queue) {
     if (queue->slots) {
         free(queue->slots);
         queue->slots = NULL;
@@ -103,10 +119,10 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
 // =============================================================================
 
 bool PTO2SchedulerState::RingSchedState::init(
-    PTO2SharedMemoryHandle* sm_handle, int32_t ring_id,
-    void* gm_heap_base, uint64_t per_ring_heap_size) {
+    PTO2SharedMemoryHandle *sm_handle, int32_t ring_id, void *gm_heap_base, uint64_t per_ring_heap_size
+) {
     task_descriptors = sm_handle->task_descriptors[ring_id];
-    heap_base = (char*)gm_heap_base + ring_id * per_ring_heap_size;
+    heap_base = (char *)gm_heap_base + ring_id * per_ring_heap_size;
     task_window_size = sm_handle->header->rings[ring_id].task_window_size;
     task_window_mask = static_cast<int32_t>(task_window_size - 1);
     last_task_alive = 0;
@@ -146,9 +162,9 @@ void PTO2SchedulerState::RingSchedState::destroy() {
     slot_states = nullptr;
 }
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle,
-                          void* gm_heap_base, uint64_t per_ring_heap_size) {
+bool pto2_scheduler_init(
+    PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle, void *gm_heap_base, uint64_t per_ring_heap_size
+) {
     sched->sm_handle = sm_handle;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -182,7 +198,7 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
     return true;
 }
 
-void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
+void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].destroy();
     }
@@ -196,11 +212,10 @@ void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
 // Debug Utilities
 // =============================================================================
 
-void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
+void pto2_scheduler_print_stats(PTO2SchedulerState *sched) {
     LOG_INFO("=== Scheduler Statistics ===");
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (sched->ring_sched_states[r].last_task_alive > 0 ||
-            sched->ring_sched_states[r].heap_tail > 0) {
+        if (sched->ring_sched_states[r].last_task_alive > 0 || sched->ring_sched_states[r].heap_tail > 0) {
             LOG_INFO("Ring %d:", r);
             LOG_INFO("  last_task_alive: %d", sched->ring_sched_states[r].last_task_alive);
             LOG_INFO("  heap_tail:       %" PRIu64, sched->ring_sched_states[r].heap_tail);
@@ -213,14 +228,13 @@ void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
     LOG_INFO("============================");
 }
 
-void pto2_scheduler_print_queues(PTO2SchedulerState* sched) {
+void pto2_scheduler_print_queues(PTO2SchedulerState *sched) {
     LOG_INFO("=== Ready Queues ===");
 
-    const char* shape_names[] = {"AIC_ONLY", "AIV_X1", "AIV_X2", "AIC_AIV_X1", "AIC_AIV_X2"};
+    const char *shape_names[] = {"AIC_ONLY", "AIV_X1", "AIV_X2", "AIC_AIV_X1", "AIC_AIV_X2"};
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        LOG_INFO("  %s: count=%" PRIu64, shape_names[i],
-                 sched->ready_queues[i].size());
+        LOG_INFO("  %s: count=%" PRIu64, shape_names[i], sched->ready_queues[i].size());
     }
 
     LOG_INFO("====================");

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_scheduler.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Scheduler Interface
  *
@@ -30,7 +40,12 @@
 #if PTO2_SCHED_PROFILING
 #include "aicpu/device_time.h"
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
-#define PTO2_SCHED_CYCLE_LAP(acc) do { _st1 = get_sys_cnt_aicpu(); acc += (_st1 - _st0); _st0 = _st1; } while(0)
+#define PTO2_SCHED_CYCLE_LAP(acc)   \
+    do {                            \
+        _st1 = get_sys_cnt_aicpu(); \
+        acc += (_st1 - _st0);       \
+        _st0 = _st1;                \
+    } while (0)
 #endif
 
 // =============================================================================
@@ -42,7 +57,7 @@
  */
 struct PTO2ReadyQueueSlot {
     std::atomic<int64_t> sequence;
-    PTO2TaskSlotState* slot_state;
+    PTO2TaskSlotState *slot_state;
 };
 
 /**
@@ -60,17 +75,17 @@ struct PTO2ReadyQueueSlot {
 static constexpr int PTO2_LOCAL_DISPATCH_TYPE_NUM = 2;
 
 struct PTO2LocalReadyBuffer {
-    PTO2TaskSlotState** slot_states = nullptr;
+    PTO2TaskSlotState **slot_states = nullptr;
     int count = 0;
     int capacity = 0;
 
-    void reset(PTO2TaskSlotState** buf, int cap) {
+    void reset(PTO2TaskSlotState **buf, int cap) {
         slot_states = buf;
         count = 0;
         capacity = cap;
     }
 
-    bool try_push(PTO2TaskSlotState* s) {
+    bool try_push(PTO2TaskSlotState *s) {
         if (slot_states && count < capacity) {
             slot_states[count++] = s;
             return true;
@@ -78,9 +93,7 @@ struct PTO2LocalReadyBuffer {
         return false;
     }
 
-    PTO2TaskSlotState* pop() {
-        return (count > 0) ? slot_states[--count] : nullptr;
-    }
+    PTO2TaskSlotState *pop() { return (count > 0) ? slot_states[--count] : nullptr; }
 };
 
 /**
@@ -94,16 +107,16 @@ struct PTO2LocalReadyBuffer {
  *   consumers only touch dequeue_pos
  */
 struct alignas(64) PTO2ReadyQueue {
-    PTO2ReadyQueueSlot* slots;
+    PTO2ReadyQueueSlot *slots;
     uint64_t capacity;
-    uint64_t mask;                          // capacity - 1
-    char _pad0[64 - 24];                   // Pad to own cache line
+    uint64_t mask;        // capacity - 1
+    char _pad0[64 - 24];  // Pad to own cache line
 
     std::atomic<uint64_t> enqueue_pos;
-    char _pad1[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad1[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     std::atomic<uint64_t> dequeue_pos;
-    char _pad2[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad2[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     uint64_t size() {
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -111,17 +124,18 @@ struct alignas(64) PTO2ReadyQueue {
         return (e >= d) ? (e - d) : 0;
     }
 
-    bool push(PTO2TaskSlotState* slot_state) {
+    bool push(PTO2TaskSlotState *slot_state) {
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         while (true) {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)pos;
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    )) {
                     break;
                 }
             } else if (diff < 0) {
@@ -135,9 +149,9 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    bool push(PTO2TaskSlotState* slot_state, uint64_t& atomic_count, uint64_t& wait_cycle) {
+    bool push(PTO2TaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         uint64_t t0 = get_sys_cnt_aicpu();
         bool contended = false;
         uint32_t atomic_ops = 0;
@@ -148,8 +162,9 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - (int64_t)pos;
             atomic_ops += 2;  // enqueue_pos.load + sequence.load
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    )) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -173,7 +188,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 #endif
 
-    PTO2TaskSlotState* pop() {
+    PTO2TaskSlotState *pop() {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -182,28 +197,29 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         while (true) {
             pos = dequeue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)(pos + 1);
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed))
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    ))
                     break;
             } else if (diff < 0) {
                 return nullptr;  // Queue empty
             }
         }
 
-        PTO2TaskSlotState* result = slot->slot_state;
+        PTO2TaskSlotState *result = slot->slot_state;
         slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
         return result;
     }
 
 #if PTO2_SCHED_PROFILING
-    PTO2TaskSlotState* pop(uint64_t& atomic_count, uint64_t& wait_cycle) {
+    PTO2TaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -213,7 +229,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         uint64_t t0 = get_sys_cnt_aicpu();
         bool contended = false;
         uint32_t atomic_ops = 0;
@@ -224,8 +240,9 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - (int64_t)(pos + 1);
             atomic_ops += 2;  // dequeue_pos.load + sequence.load
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    )) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -244,7 +261,7 @@ struct alignas(64) PTO2ReadyQueue {
             wait_cycle += (get_sys_cnt_aicpu() - t0);
         }
 
-        PTO2TaskSlotState* result = slot->slot_state;
+        PTO2TaskSlotState *result = slot->slot_state;
         slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
         return result;
     }
@@ -252,8 +269,8 @@ struct alignas(64) PTO2ReadyQueue {
 };
 
 // Cold-path ready queue operations (defined in pto_scheduler.cpp)
-bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity);
-void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
+bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity);
+void pto2_ready_queue_destroy(PTO2ReadyQueue *queue);
 
 // =============================================================================
 // Scheduler State
@@ -263,10 +280,10 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
  * Statistics returned by mixed-task completion processing
  */
 struct PTO2CompletionStats {
-    int32_t fanout_edges;      // Number of fanout edges traversed (notify consumers)
-    int32_t tasks_enqueued;    // Number of consumers that became READY
-    int32_t fanin_edges;       // Number of fanin edges traversed (release producers)
-    bool mixed_task_completed; // True only when this callback completed a mixed task
+    int32_t fanout_edges;       // Number of fanout edges traversed (notify consumers)
+    int32_t tasks_enqueued;     // Number of consumers that became READY
+    int32_t fanin_edges;        // Number of fanin edges traversed (release producers)
+    bool mixed_task_completed;  // True only when this callback completed a mixed task
 };
 
 /**
@@ -278,42 +295,39 @@ struct PTO2CompletionStats {
  */
 struct PTO2SchedulerState {
     // Shared memory access
-    PTO2SharedMemoryHandle* sm_handle;
+    PTO2SharedMemoryHandle *sm_handle;
 
     // Per-ring state
     struct RingSchedState {
-        PTO2TaskDescriptor* task_descriptors;
-        PTO2TaskSlotState* slot_states;
+        PTO2TaskDescriptor *task_descriptors;
+        PTO2TaskSlotState *slot_states;
         int32_t last_task_alive;
         int32_t last_heap_consumed;
         uint64_t heap_tail;
-        void* heap_base;
+        void *heap_base;
         int32_t task_window_mask;
         uint64_t task_window_size;
         // Try-lock used to advance this ring's pointers (CONSUMED scanning + heap tail update).
         std::atomic<int32_t> advance_lock;
 
-        bool init(PTO2SharedMemoryHandle* sm_handle, int32_t ring_id,
-                  void* gm_heap_base, uint64_t per_ring_heap_size);
+        bool init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id, void *gm_heap_base, uint64_t per_ring_heap_size);
         void destroy();
 
-        PTO2TaskSlotState& get_slot_state_by_task_id(int32_t local_id) {
+        PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
             return slot_states[local_id & task_window_mask];
         }
-        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) {
-            return slot_states[slot];
-        }
+        PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
-        void sync_to_sm(PTO2SharedMemoryRingHeader& ring) {
+        void sync_to_sm(PTO2SharedMemoryRingHeader &ring) {
             ring.fc.last_task_alive.store(last_task_alive, std::memory_order_release);
             ring.fc.heap_tail.store(heap_tail, std::memory_order_release);
         }
 
-        void advance_ring_pointers(PTO2SharedMemoryRingHeader& ring) {
+        void advance_ring_pointers(PTO2SharedMemoryRingHeader &ring) {
             int32_t current_task_index = ring.fc.current_task_index.load(std::memory_order_acquire);
 
             while (last_task_alive < current_task_index) {
-                PTO2TaskSlotState& slot_state = get_slot_state_by_task_id(last_task_alive);
+                PTO2TaskSlotState &slot_state = get_slot_state_by_task_id(last_task_alive);
                 if (slot_state.task_state.load(std::memory_order_acquire) != PTO2_TASK_CONSUMED) {
                     break;
                 }
@@ -322,10 +336,10 @@ struct PTO2SchedulerState {
 
             if (last_task_alive > 0) {
                 int32_t last_consumed_id = last_task_alive - 1;
-                PTO2TaskSlotState& slot_state = get_slot_state_by_task_id(last_consumed_id);
-                PTO2TaskDescriptor& task = *slot_state.task;
+                PTO2TaskSlotState &slot_state = get_slot_state_by_task_id(last_consumed_id);
+                PTO2TaskDescriptor &task = *slot_state.task;
                 if (task.packed_buffer_end != NULL) {
-                    heap_tail = (uint64_t)((char*)task.packed_buffer_end - (char*)heap_base);
+                    heap_tail = (uint64_t)((char *)task.packed_buffer_end - (char *)heap_base);
                 }
             }
 
@@ -344,19 +358,20 @@ struct PTO2SchedulerState {
     // =========================================================================
     // Inline hot-path methods
     // =========================================================================
-    PTO2TaskSlotState& get_slot_state(int32_t ring_id, int32_t local_id) {
+    PTO2TaskSlotState &get_slot_state(int32_t ring_id, int32_t local_id) {
         return ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
     }
-    PTO2TaskSlotState& get_slot_state_by_slot(int32_t ring_id, int32_t slot) {
+    PTO2TaskSlotState &get_slot_state_by_slot(int32_t ring_id, int32_t slot) {
         return ring_sched_states[ring_id].get_slot_state_by_slot(slot);
     }
 
-    void check_and_handle_consumed(PTO2TaskSlotState& slot_state) {
+    void check_and_handle_consumed(PTO2TaskSlotState &slot_state) {
         if (slot_state.fanout_refcount.load(std::memory_order_acquire) != slot_state.fanout_count) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
             return;
         }
 
@@ -367,15 +382,16 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
         }
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    void check_and_handle_consumed(PTO2TaskSlotState& slot_state, uint64_t& atomic_count) {
+    void check_and_handle_consumed(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
         int32_t fc = slot_state.fanout_count;
         int32_t rc = slot_state.fanout_refcount.load(std::memory_order_acquire);
 
@@ -384,8 +400,9 @@ struct PTO2SchedulerState {
         if (rc != fc) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
             atomic_count += 1;  // failed CAS
             return;
         }
@@ -399,8 +416,9 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
             atomic_count += 2;  // try-lock CAS + unlock store
@@ -410,21 +428,20 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    void release_producer(PTO2TaskSlotState& slot_state) {
+    void release_producer(PTO2TaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         check_and_handle_consumed(slot_state);
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    void release_producer(PTO2TaskSlotState& slot_state, uint64_t& atomic_count) {
+    void release_producer(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         atomic_count += 1;  // fanout_refcount.fetch_add
         check_and_handle_consumed(slot_state, atomic_count);
     }
 #endif
 
-    bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state,
-                                        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+    bool release_fanin_and_check_ready(PTO2TaskSlotState &slot_state, PTO2LocalReadyBuffer *local_bufs = nullptr) {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
         // init release, making fanin_count visible — plain load suffices.
@@ -448,16 +465,18 @@ struct PTO2SchedulerState {
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state,
-                                        uint64_t& atomic_count, uint64_t& push_wait,
-                                        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+    bool release_fanin_and_check_ready(
+        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
+        PTO2LocalReadyBuffer *local_bufs = nullptr
+    ) {
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
         atomic_count += 1;  // fanin_refcount.fetch_add
 
         if (new_refcount == slot_state.fanin_count) {
             PTO2TaskState expected = PTO2_TASK_PENDING;
             if (slot_state.task_state.compare_exchange_strong(
-                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
+                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire
+                )) {
                 atomic_count += 1;  // CAS(task_state PENDING→READY)
                 // Local-first: try per-CoreType thread-local buffer before global queue
                 PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state.active_mask);
@@ -476,12 +495,12 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    PTO2TaskSlotState* get_ready_task(PTO2ResourceShape shape) {
+    PTO2TaskSlotState *get_ready_task(PTO2ResourceShape shape) {
         return ready_queues[static_cast<int32_t>(shape)].pop();
     }
 
-    template<CoreType CT>
-    PTO2TaskSlotState* get_ready_task(PTO2LocalReadyBuffer* local_bufs) {
+    template <CoreType CT>
+    PTO2TaskSlotState *get_ready_task(PTO2LocalReadyBuffer *local_bufs) {
         constexpr int ct = static_cast<int>(CT);
         if (local_bufs && local_bufs[ct].count > 0) {
             return local_bufs[ct].pop();
@@ -490,13 +509,12 @@ struct PTO2SchedulerState {
     }
 
 #if PTO2_SCHED_PROFILING
-    PTO2TaskSlotState* get_ready_task(PTO2ResourceShape shape, uint64_t& atomic_count, uint64_t& wait_cycle) {
+    PTO2TaskSlotState *get_ready_task(PTO2ResourceShape shape, uint64_t &atomic_count, uint64_t &wait_cycle) {
         return ready_queues[static_cast<int32_t>(shape)].pop(atomic_count, wait_cycle);
     }
 
-    template<CoreType CT>
-    PTO2TaskSlotState* get_ready_task(PTO2LocalReadyBuffer* local_bufs,
-                           uint64_t& atomic_count, uint64_t& wait_cycle) {
+    template <CoreType CT>
+    PTO2TaskSlotState *get_ready_task(PTO2LocalReadyBuffer *local_bufs, uint64_t &atomic_count, uint64_t &wait_cycle) {
         constexpr int ct = static_cast<int>(CT);
         if (local_bufs && local_bufs[ct].count > 0) {
             return local_bufs[ct].pop();
@@ -509,12 +527,12 @@ struct PTO2SchedulerState {
      * Requeue a ready task that could not be dispatched (no suitable cluster).
      * Pushes the task back into its shape-based queue.
      */
-    void requeue_ready_task(PTO2TaskSlotState& slot_state) {
+    void requeue_ready_task(PTO2TaskSlotState &slot_state) {
         PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state.active_mask);
         ready_queues[static_cast<int32_t>(shape)].push(&slot_state);
     }
 
-    void on_scope_end(PTO2TaskSlotState** task_slot_states, int32_t count) {
+    void on_scope_end(PTO2TaskSlotState **task_slot_states, int32_t count) {
 #if PTO2_ORCH_PROFILING
         extern uint64_t g_orch_scope_end_atomic_count;
         for (int32_t i = 0; i < count; i++) {
@@ -534,7 +552,7 @@ struct PTO2SchedulerState {
      *
      * @return true if this subtask was the last one, completing the mixed task.
      */
-    bool on_subtask_complete(PTO2TaskSlotState& slot_state, PTO2SubtaskSlot subslot) {
+    bool on_subtask_complete(PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot) {
         uint8_t done_bit = (1u << static_cast<uint8_t>(subslot));
         uint8_t prev_mask = slot_state.subtask_done_mask.fetch_or(done_bit, std::memory_order_acq_rel);
         uint8_t new_mask = prev_mask | done_bit;
@@ -553,12 +571,14 @@ struct PTO2SchedulerState {
 #else
     void
 #endif
-    on_mixed_task_complete(PTO2TaskSlotState& slot_state, 
+    on_mixed_task_complete(
+        PTO2TaskSlotState &slot_state,
 #if PTO2_SCHED_PROFILING
         int thread_idx,
 #endif
 
-        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+        PTO2LocalReadyBuffer *local_bufs = nullptr
+    ) {
 #if PTO2_SCHED_PROFILING
         PTO2CompletionStats stats = {0, 0, 0, true};
 #endif
@@ -576,7 +596,7 @@ struct PTO2SchedulerState {
         pto2_fanout_lock(slot_state);
 #endif
         slot_state.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
-        PTO2DepListEntry* current = slot_state.fanout_head;  // Protected by fanout_lock
+        PTO2DepListEntry *current = slot_state.fanout_head;  // Protected by fanout_lock
         pto2_fanout_unlock(slot_state);
 
 #if PTO2_SCHED_PROFILING
@@ -591,11 +611,10 @@ struct PTO2SchedulerState {
         uint64_t fanout_atomics = 0, push_wait = 0;
 #endif
         while (current != nullptr) {
-            PTO2TaskSlotState& consumer_slot = *current->slot_state;
+            PTO2TaskSlotState &consumer_slot = *current->slot_state;
 #if PTO2_SCHED_PROFILING
             stats.fanout_edges++;
-            if (release_fanin_and_check_ready(consumer_slot,
-                                               fanout_atomics, push_wait, local_bufs)) {
+            if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait, local_bufs)) {
                 stats.tasks_enqueued++;
             }
 #else
@@ -618,7 +637,7 @@ struct PTO2SchedulerState {
      */
 
 #if PTO2_SCHED_PROFILING
-    int32_t on_task_release(PTO2TaskSlotState& slot_state, int32_t thread_idx) {
+    int32_t on_task_release(PTO2TaskSlotState &slot_state, int32_t thread_idx) {
         PTO2_SCHED_CYCLE_START();
         extern uint64_t g_sched_fanin_cycle[], g_sched_fanin_atomic_count[];
         extern uint64_t g_sched_self_atomic_count[];
@@ -626,9 +645,9 @@ struct PTO2SchedulerState {
         extern uint64_t g_sched_complete_count[];
         uint64_t fanin_atomics = 0;
 #else
-    int32_t on_task_release(PTO2TaskSlotState& slot_state) {
+    int32_t on_task_release(PTO2TaskSlotState &slot_state) {
 #endif
-        PTO2TaskPayload* payload = slot_state.payload;
+        PTO2TaskPayload *payload = slot_state.payload;
         int32_t fanin_edges = payload->fanin_actual_count;
         for (int32_t i = 0; i < fanin_edges; i++) {
 #if PTO2_SCHED_PROFILING
@@ -660,18 +679,18 @@ struct PTO2SchedulerState {
 // Scheduler API (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle,
-                          void* gm_heap_base, uint64_t per_ring_heap_size);
-void pto2_scheduler_destroy(PTO2SchedulerState* sched);
+bool pto2_scheduler_init(
+    PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle, void *gm_heap_base, uint64_t per_ring_heap_size
+);
+void pto2_scheduler_destroy(PTO2SchedulerState *sched);
 
 // =============================================================================
 // Debug Utilities (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-void pto2_scheduler_print_stats(PTO2SchedulerState* sched);
-void pto2_scheduler_print_queues(PTO2SchedulerState* sched);
-const char* pto2_task_state_name(PTO2TaskState state);
+void pto2_scheduler_print_stats(PTO2SchedulerState *sched);
+void pto2_scheduler_print_queues(PTO2SchedulerState *sched);
+const char *pto2_task_state_name(PTO2TaskState state);
 
 // =============================================================================
 // Scheduler Profiling Data
@@ -686,9 +705,9 @@ struct PTO2SchedProfilingData {
     uint64_t self_consumed_cycle;  // self check_and_handle_consumed
 
     // Wait times
-    uint64_t lock_wait_cycle;      // spin-wait in fanout_lock
-    uint64_t push_wait_cycle;      // CAS contention in push()
-    uint64_t pop_wait_cycle;       // CAS contention in pop()
+    uint64_t lock_wait_cycle;  // spin-wait in fanout_lock
+    uint64_t push_wait_cycle;  // CAS contention in push()
+    uint64_t pop_wait_cycle;   // CAS contention in pop()
 
     // Atomic counts per sub-phase
     uint64_t lock_atomic_count;
@@ -697,7 +716,7 @@ struct PTO2SchedProfilingData {
     uint64_t self_atomic_count;
     uint64_t pop_atomic_count;
 
-    int64_t  complete_count;
+    int64_t complete_count;
 };
 
 /**
@@ -707,4 +726,4 @@ struct PTO2SchedProfilingData {
 PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
 #endif
 
-#endif // PTO_SCHEDULER_H
+#endif  // PTO_SCHEDULER_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_shared_memory.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Shared Memory Implementation
  *
@@ -44,26 +54,25 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
 // Creation and Destruction
 // =============================================================================
 
-static void pto2_sm_setup_pointers_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
-    char* ptr = (char*)handle->sm_base;
+static void
+pto2_sm_setup_pointers_per_ring(PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+    char *ptr = (char *)handle->sm_base;
 
     // Header
-    handle->header = (PTO2SharedMemoryHeader*)ptr;
+    handle->header = (PTO2SharedMemoryHeader *)ptr;
     ptr += PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
 
     // Per-ring task descriptors and payloads
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        handle->task_descriptors[r] = (PTO2TaskDescriptor*)ptr;
+        handle->task_descriptors[r] = (PTO2TaskDescriptor *)ptr;
         ptr += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
 
-        handle->task_payloads[r] = (PTO2TaskPayload*)ptr;
+        handle->task_payloads[r] = (PTO2TaskPayload *)ptr;
         ptr += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
     }
 }
 
-static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle* handle, uint64_t task_window_size) {
+static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle *handle, uint64_t task_window_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
@@ -71,10 +80,9 @@ static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle* handle, uint64_t task
     pto2_sm_setup_pointers_per_ring(handle, task_window_sizes);
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size) {
+PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_size) {
     // Allocate handle
-    PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
+    PTO2SharedMemoryHandle *handle = (PTO2SharedMemoryHandle *)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) {
         return NULL;
     }
@@ -82,19 +90,19 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     // Calculate total size
     uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
 
-    // Allocate shared memory (aligned for DMA efficiency)
-    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-        if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
-            free(handle);
-            return NULL;
-        }
-    #else
-        handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
-        if (!handle->sm_base) {
-            free(handle);
-            return NULL;
-        }
-    #endif
+// Allocate shared memory (aligned for DMA efficiency)
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+    if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
+        free(handle);
+        return NULL;
+    }
+#else
+    handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
+    if (!handle->sm_base) {
+        free(handle);
+        return NULL;
+    }
+#endif
 
     handle->sm_size = sm_size;
     handle->is_owner = true;
@@ -111,21 +119,16 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     return handle;
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create_default(void) {
-    return pto2_sm_create(PTO2_TASK_WINDOW_SIZE,
-                          PTO2_HEAP_SIZE);
-}
+PTO2SharedMemoryHandle *pto2_sm_create_default(void) { return pto2_sm_create(PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE); }
 
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size) {
+PTO2SharedMemoryHandle *
+pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size) {
     if (!sm_base || sm_size == 0) return NULL;
 
     uint64_t required = pto2_sm_calculate_size(task_window_size);
     if (sm_size < required) return NULL;
 
-    PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
+    PTO2SharedMemoryHandle *handle = (PTO2SharedMemoryHandle *)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) return NULL;
 
     handle->sm_base = sm_base;
@@ -138,7 +141,7 @@ PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
     return handle;
 }
 
-void pto2_sm_destroy(PTO2SharedMemoryHandle* handle) {
+void pto2_sm_destroy(PTO2SharedMemoryHandle *handle) {
     if (!handle) return;
 
     if (handle->is_owner && handle->sm_base) {
@@ -153,9 +156,7 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle* handle) {
 // =============================================================================
 //
 // no need init data in pool, init pool data when used
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size) {
+void pto2_sm_init_header(PTO2SharedMemoryHandle *handle, uint64_t task_window_size, uint64_t heap_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -166,10 +167,10 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
 }
 
 void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]) {
-    PTO2SharedMemoryHeader* header = handle->header;
+    PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+) {
+    PTO2SharedMemoryHeader *header = handle->header;
 
     // Per-ring flow control (start at 0)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -203,10 +204,10 @@ void pto2_sm_init_header_per_ring(
 // Debug Utilities
 // =============================================================================
 
-void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
+void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle) {
     if (!handle || !handle->header) return;
 
-    PTO2SharedMemoryHeader* h = handle->header;
+    PTO2SharedMemoryHeader *h = handle->header;
 
     LOG_INFO("=== PTO2 Shared Memory Layout ===");
     LOG_INFO("Base address:       %p", handle->sm_base);
@@ -216,8 +217,10 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
         LOG_INFO("Ring %d:", r);
         LOG_INFO("  task_window_size: %" PRIu64, h->rings[r].task_window_size);
         LOG_INFO("  heap_size:        %" PRIu64 " bytes", h->rings[r].heap_size);
-        LOG_INFO("  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")",
-                 h->rings[r].task_descriptors_offset, h->rings[r].task_descriptors_offset);
+        LOG_INFO(
+            "  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")", h->rings[r].task_descriptors_offset,
+            h->rings[r].task_descriptors_offset
+        );
         LOG_INFO("  heap_top:         %" PRIu64, h->rings[r].fc.heap_top.load(std::memory_order_acquire));
         LOG_INFO("  heap_tail:        %" PRIu64, h->rings[r].fc.heap_tail.load(std::memory_order_acquire));
         LOG_INFO("  current_task_idx: %d", h->rings[r].fc.current_task_index.load(std::memory_order_acquire));
@@ -232,12 +235,12 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
     LOG_INFO("================================");
 }
 
-bool pto2_sm_validate(PTO2SharedMemoryHandle* handle) {
+bool pto2_sm_validate(PTO2SharedMemoryHandle *handle) {
     if (!handle) return false;
     if (!handle->sm_base) return false;
     if (!handle->header) return false;
 
-    PTO2SharedMemoryHeader* h = handle->header;
+    PTO2SharedMemoryHeader *h = handle->header;
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         if (!h->rings[r].fc.validate(handle, r)) return false;
@@ -246,12 +249,12 @@ bool pto2_sm_validate(PTO2SharedMemoryHandle* handle) {
     return true;
 }
 
-bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle* handle, int32_t ring_id) const {
+bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const {
     if (!handle) return false;
     if (!handle->header) return false;
     if (ring_id < 0 || ring_id >= PTO2_MAX_RING_DEPTH) return false;
 
-    const PTO2SharedMemoryHeader* h = handle->header;
+    const PTO2SharedMemoryHeader *h = handle->header;
 
     // Check that offsets are within bounds
     if (h->rings[ring_id].task_descriptors_offset >= h->total_size) return false;

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_shared_memory.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Shared Memory Layout
  *
@@ -50,9 +60,9 @@ struct PTO2RingFlowControl {
     int32_t _pad0;                            // Alignment padding
 
     // Written by Scheduler, Read by Orchestrator (for back-pressure)
-    std::atomic<uint64_t> heap_tail;          // Heap ring free pointer
-    std::atomic<int32_t> last_task_alive;     // Task ring tail (oldest active task)
-    int32_t _pad1;                            // Alignment padding
+    std::atomic<uint64_t> heap_tail;       // Heap ring free pointer
+    std::atomic<int32_t> last_task_alive;  // Task ring tail (oldest active task)
+    int32_t _pad1;                         // Alignment padding
 
     void init() {
         heap_top.store(0, std::memory_order_relaxed);
@@ -61,7 +71,7 @@ struct PTO2RingFlowControl {
         last_task_alive.store(0, std::memory_order_relaxed);
     }
 
-    bool validate(PTO2SharedMemoryHandle* handle, int32_t ring_id) const;
+    bool validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const;
 };
 
 /**
@@ -86,7 +96,7 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
 
     // === GLOBAL FIELDS ===
-    std::atomic<int32_t> orchestrator_done;   // Flag: orchestration complete
+    std::atomic<int32_t> orchestrator_done;  // Flag: orchestration complete
 
     // Total shared memory size (for validation)
     uint64_t total_size;
@@ -104,13 +114,15 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
 
     // Scheduler error state (Scheduler → Host, independent of orchestrator)
     // Written by scheduler threads on timeout; read by orchestrator and host.
-    std::atomic<int32_t> sched_error_bitmap;   // Bit X set = thread X had error
-    std::atomic<int32_t> sched_error_code;     // Last scheduler error code (last-writer-wins)
-    std::atomic<int32_t> sched_error_thread;   // Thread index of last error writer
+    std::atomic<int32_t> sched_error_bitmap;  // Bit X set = thread X had error
+    std::atomic<int32_t> sched_error_code;    // Last scheduler error code (last-writer-wins)
+    std::atomic<int32_t> sched_error_thread;  // Thread index of last error writer
 };
 
-static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
-              "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)");
+static_assert(
+    sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
+    "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)"
+);
 
 // =============================================================================
 // Shared Memory Handle
@@ -121,17 +133,16 @@ static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
  * Provides both Orchestrator and Scheduler views of the same memory
  */
 struct PTO2SharedMemoryHandle {
-    void*   sm_base;              // Base address of shared memory
-    uint64_t sm_size;             // Total size of shared memory
+    void *sm_base;     // Base address of shared memory
+    uint64_t sm_size;  // Total size of shared memory
 
     // Quick pointers into shared memory regions (per-ring)
-    PTO2SharedMemoryHeader* header;
-    PTO2TaskDescriptor*     task_descriptors[PTO2_MAX_RING_DEPTH];
-    PTO2TaskPayload*        task_payloads[PTO2_MAX_RING_DEPTH];
+    PTO2SharedMemoryHeader *header;
+    PTO2TaskDescriptor *task_descriptors[PTO2_MAX_RING_DEPTH];
+    PTO2TaskPayload *task_payloads[PTO2_MAX_RING_DEPTH];
 
     // Ownership flag
-    bool    is_owner;             // True if this handle allocated the memory
-
+    bool is_owner;  // True if this handle allocated the memory
 };
 
 // =============================================================================
@@ -161,13 +172,12 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
  * @param heap_size         Heap size per ring for output buffers
  * @return Handle with both views, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size);
+PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Create shared memory with default sizes
  */
-PTO2SharedMemoryHandle* pto2_sm_create_default(void);
+PTO2SharedMemoryHandle *pto2_sm_create_default(void);
 
 /**
  * Wrap an existing buffer as shared memory (e.g. device GM buffer).
@@ -179,31 +189,27 @@ PTO2SharedMemoryHandle* pto2_sm_create_default(void);
  * @param heap_size          Heap size per ring (for layout; buffer has no heap region)
  * @return Handle, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size);
+PTO2SharedMemoryHandle *
+pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Destroy shared memory and free resources
  */
-void pto2_sm_destroy(PTO2SharedMemoryHandle* handle);
+void pto2_sm_destroy(PTO2SharedMemoryHandle *handle);
 
 /**
  * Initialize shared memory header with layout information
  * Called after memory is allocated
  */
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size);
+void pto2_sm_init_header(PTO2SharedMemoryHandle *handle, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Initialize shared memory header with per-ring layout information.
  */
 void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]);
+    PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+);
 
 // =============================================================================
 // Debug Utilities
@@ -212,16 +218,16 @@ void pto2_sm_init_header_per_ring(
 /**
  * Print shared memory layout info
  */
-void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle);
+void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle);
 
 /**
  * Validate shared memory integrity
  * @return true if valid, false if corrupted
  */
-bool pto2_sm_validate(PTO2SharedMemoryHandle* handle);
+bool pto2_sm_validate(PTO2SharedMemoryHandle *handle);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // PTO_SHARED_MEMORY_H
+#endif  // PTO_SHARED_MEMORY_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_submit_types.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Submit Types - Shared submit-contract definitions
  *
@@ -21,7 +31,7 @@ inline constexpr int32_t PTO2_SUBTASK_SLOT_COUNT = 3;
  * Subtask slot indices
  */
 enum class PTO2SubtaskSlot : uint8_t {
-    AIC  = 0,
+    AIC = 0,
     AIV0 = 1,
     AIV1 = 2,
 };
@@ -29,7 +39,7 @@ enum class PTO2SubtaskSlot : uint8_t {
 /**
  * Subtask mask bits (for active_mask / subtask_done_mask)
  */
-inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC  = (1u << 0);  // 0x1
+inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC = (1u << 0);   // 0x1
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV0 = (1u << 1);  // 0x2
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV1 = (1u << 2);  // 0x4
 
@@ -56,11 +66,11 @@ struct MixedKernels {
  * Resource shape — classifies a MixedKernels into one of 5 queue buckets.
  */
 enum class PTO2ResourceShape : uint8_t {
-    AIC_ONLY    = 0,   // AIC only
-    AIV_X1      = 1,   // One AIV slot
-    AIV_X2      = 2,   // Both AIV slots
-    AIC_AIV_X1  = 3,   // AIC + one AIV
-    AIC_AIV_X2  = 4,   // AIC + both AIV
+    AIC_ONLY = 0,    // AIC only
+    AIV_X1 = 1,      // One AIV slot
+    AIV_X2 = 2,      // Both AIV slots
+    AIC_AIV_X1 = 3,  // AIC + one AIV
+    AIC_AIV_X2 = 4,  // AIC + both AIV
 };
 
 inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 5;
@@ -71,8 +81,7 @@ inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 5;
  */
 static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
     bool has_aic = (active_mask & PTO2_SUBTASK_MASK_AIC) != 0;
-    int aiv_count = ((active_mask & PTO2_SUBTASK_MASK_AIV0) != 0)
-                  + ((active_mask & PTO2_SUBTASK_MASK_AIV1) != 0);
+    int aiv_count = ((active_mask & PTO2_SUBTASK_MASK_AIV0) != 0) + ((active_mask & PTO2_SUBTASK_MASK_AIV1) != 0);
 
     if (has_aic) {
         if (aiv_count == 0) return PTO2ResourceShape::AIC_ONLY;
@@ -86,12 +95,12 @@ static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
 /**
  * Compute active_mask from MixedKernels.
  */
-static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels& mk) {
+static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels &mk) {
     uint8_t mask = 0;
-    if (mk.aic_kernel_id  != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
+    if (mk.aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
     if (mk.aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
     if (mk.aiv1_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV1;
     return mask;
 }
 
-#endif // PTO_SUBMIT_TYPES_H
+#endif  // PTO_SUBMIT_TYPES_H

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_types.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_types.h
@@ -66,31 +66,32 @@ struct PTO2TaskId;
  */
 class TaskOutputTensors {
 public:  // NOLINT(whitespace/indent)
-    TaskOutputTensors() : output_count_(0) {}
+    TaskOutputTensors() :
+        output_count_(0) {}
 
     bool empty() const { return output_count_ == 0; }
     uint32_t size() const { return output_count_; }
 
     /// Borrow a materialized output tensor by index (lvalue only).
-    const Tensor& get_ref(uint32_t index) const& {
+    const Tensor &get_ref(uint32_t index) const & {
         always_assert(index < output_count_);
-        return *reinterpret_cast<const Tensor*>(_storage + index * sizeof(Tensor));
+        return *reinterpret_cast<const Tensor *>(_storage + index * sizeof(Tensor));
     }
-    const Tensor& get_ref(uint32_t index) const&& = delete;
+    const Tensor &get_ref(uint32_t index) const && = delete;
 
     /// Runtime-internal: append one materialized output Tensor.
-    Tensor& materialize_output(const TensorCreateInfo& ci, void* addr, int32_t version) {
+    Tensor &materialize_output(const TensorCreateInfo &ci, void *addr, int32_t version) {
         always_assert(output_count_ < PTO2_MAX_OUTPUTS);
-        Tensor* out = output_ptr(output_count_);
+        Tensor *out = output_ptr(output_count_);
         out->init_from_create_info(ci, addr, version);
         output_count_++;
         return *out;
     }
 
     /// Runtime-internal: writable pointer for materialization.
-    Tensor* output_ptr(uint32_t index) { return reinterpret_cast<Tensor*>(_storage + index * sizeof(Tensor)); }
-    const Tensor* output_ptr(uint32_t index) const {
-        return reinterpret_cast<const Tensor*>(_storage + index * sizeof(Tensor));
+    Tensor *output_ptr(uint32_t index) { return reinterpret_cast<Tensor *>(_storage + index * sizeof(Tensor)); }
+    const Tensor *output_ptr(uint32_t index) const {
+        return reinterpret_cast<const Tensor *>(_storage + index * sizeof(Tensor));
     }
 
 private:  // NOLINT(whitespace/indent)
@@ -109,9 +110,10 @@ private:  // NOLINT(whitespace/indent)
  * The active member is determined by TensorArgType (OUTPUT → create_info, else → ptr).
  */
 union TensorRef {
-    const Tensor* ptr;
+    const Tensor *ptr;
     TensorCreateInfo create_info;
-    TensorRef() : ptr(nullptr) {}
+    TensorRef() :
+        ptr(nullptr) {}
 };
 
 /**
@@ -138,7 +140,7 @@ union TensorRef {
  */
 struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType> {
     bool has_error{false};
-    const char* error_msg{nullptr};
+    const char *error_msg{nullptr};
 
     void reset() {
         clear();
@@ -146,7 +148,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         error_msg = nullptr;
     }
 
-    void set_error(const char* msg) {
+    void set_error(const char *msg) {
         if (!has_error) {
             has_error = true;
             error_msg = msg;
@@ -157,7 +159,8 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         if (scalar_count_ != 0) {
             set_error(
                 "add_input/add_output/add_inout called after add_scalar: "
-                "all tensors must be added before any scalars");
+                "all tensors must be added before any scalars"
+            );
             return false;
         }
         if (tensor_count_ >= MAX_TENSOR_ARGS) {
@@ -167,7 +170,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         return true;
     }
 
-    void add_input(const Tensor& t) {
+    void add_input(const Tensor &t) {
         if (!check_add_tensor_valid()) {
             return;
         }
@@ -178,7 +181,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
 
     /// Standard future-output path: runtime allocates buffer from heap,
     /// materializes Tensor into TaskOutputTensors.
-    void add_output(const TensorCreateInfo& ci) {
+    void add_output(const TensorCreateInfo &ci) {
         if (!check_add_tensor_valid()) {
             return;
         }
@@ -187,7 +190,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         tensor_count_++;
     }
 
-    void add_inout(const Tensor& t) {
+    void add_inout(const Tensor &t) {
         if (!check_add_tensor_valid()) {
             return;
         }
@@ -204,7 +207,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         scalars_[scalar_count_++] = v;
     }
 
-    void add_scalars(const uint64_t* values, int count) {
+    void add_scalars(const uint64_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
             return;
@@ -219,16 +222,16 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
      * (e.g., -1 → 0x00000000FFFFFFFF, not 0xFFFFFFFFFFFFFFFF).
      * Uses NEON to process 4 elements per iteration on aarch64.
      */
-    void add_scalars_i32(const int32_t* values, int count) {
+    void add_scalars_i32(const int32_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
             return;
         }
-        uint64_t* dst = &scalars_[scalar_count_];
+        uint64_t *dst = &scalars_[scalar_count_];
 #if defined(__aarch64__)
         int i = 0;
         for (; i + 4 <= count; i += 4) {
-            uint32x4_t v = vld1q_u32(reinterpret_cast<const uint32_t*>(values + i));
+            uint32x4_t v = vld1q_u32(reinterpret_cast<const uint32_t *>(values + i));
             uint64x2_t lo = vmovl_u32(vget_low_u32(v));
             uint64x2_t hi = vmovl_u32(vget_high_u32(v));
             vst1q_u64(dst + i, lo);
@@ -249,7 +252,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
      * Copy scalars from another Arg's scalar array.
      * Useful when multiple tasks share the same scalar data (e.g., block indices).
      */
-    void copy_scalars_from(const Arg& src, int src_offset, int count) {
+    void copy_scalars_from(const Arg &src, int src_offset, int count) {
         if (src_offset + count > src.scalar_count_) {
             set_error("Source scalar range out of bounds in copy_scalars_from");
             return;

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
@@ -66,7 +66,7 @@ Runtime::Runtime() {
 // Tensor Pair Management
 // =============================================================================
 
-void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
+void Runtime::record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size) {
     if (tensor_pair_count >= RUNTIME_MAX_TENSOR_PAIRS) {
         LOG_ERROR("[Runtime] Tensor pairs full (max=%d)", RUNTIME_MAX_TENSOR_PAIRS);
         return;
@@ -78,7 +78,7 @@ void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
     LOG_INFO("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
 }
 
-TensorPair* Runtime::get_tensor_pairs() { return tensor_pairs; }
+TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
 
 int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
@@ -89,18 +89,18 @@ void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 // =============================================================================
 
 bool Runtime::get_orch_built_on_host() const { return orch_built_on_host_; }
-void* Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
-void* Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
-const ChipStorageTaskArgs& Runtime::get_orch_args() const { return orch_args_storage_; }
+void *Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
+void *Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
+const ChipStorageTaskArgs &Runtime::get_orch_args() const { return orch_args_storage_; }
 void Runtime::set_orch_built_on_host(bool v) { orch_built_on_host_ = v; }
-void Runtime::set_pto2_gm_sm_ptr(void* p) { pto2_gm_sm_ptr_ = p; }
-void Runtime::set_pto2_gm_heap(void* p) { pto2_gm_heap_ptr_ = p; }
-void Runtime::set_pto2_slot_states_ptr(void* p) { pto2_slot_states_ptr_ = p; }
-void Runtime::set_orch_args(const ChipStorageTaskArgs& args) { orch_args_storage_ = args; }
+void Runtime::set_pto2_gm_sm_ptr(void *p) { pto2_gm_sm_ptr_ = p; }
+void Runtime::set_pto2_gm_heap(void *p) { pto2_gm_heap_ptr_ = p; }
+void Runtime::set_pto2_slot_states_ptr(void *p) { pto2_slot_states_ptr_ = p; }
+void Runtime::set_orch_args(const ChipStorageTaskArgs &args) { orch_args_storage_ = args; }
 
 // Device orchestration SO binary (for dlopen on AICPU thread 3)
 // Copies data to internal storage to avoid lifetime issues with Python ctypes arrays
-void Runtime::set_device_orch_so(const void* data, size_t size) {
+void Runtime::set_device_orch_so(const void *data, size_t size) {
     if (data == nullptr || size == 0) {
         device_orch_so_size_ = 0;
         return;
@@ -114,7 +114,7 @@ void Runtime::set_device_orch_so(const void* data, size_t size) {
     device_orch_so_size_ = size;
 }
 
-const void* Runtime::get_device_orch_so_data() const {
+const void *Runtime::get_device_orch_so_data() const {
     return device_orch_so_size_ > 0 ? device_orch_so_storage_ : nullptr;
 }
 

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
@@ -106,8 +106,8 @@ struct Handshake {
  * Used for copy-back during finalize.
  */
 struct TensorPair {
-    void* host_ptr;
-    void* dev_ptr;
+    void *host_ptr;
+    void *dev_ptr;
     size_t size;
 };
 
@@ -116,11 +116,11 @@ struct TensorPair {
  * Allows runtime to use pluggable device memory backends.
  */
 struct HostApi {
-    void* (*device_malloc)(size_t size);
-    void (*device_free)(void* dev_ptr);
-    int (*copy_to_device)(void* dev_ptr, const void* host_ptr, size_t size);
-    int (*copy_from_device)(void* host_ptr, const void* dev_ptr, size_t size);
-    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t* bin_data, size_t bin_size);
+    void *(*device_malloc)(size_t size);
+    void (*device_free)(void *dev_ptr);
+    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
+    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t *bin_data, size_t bin_size);
     void (*remove_kernel_binary)(int func_id);
 };
 
@@ -188,9 +188,9 @@ private:  // NOLINT(whitespace/indent)
 
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
-    void* pto2_gm_sm_ptr_;                   // GM pointer to PTO2 shared memory (device)
-    void* pto2_gm_heap_ptr_;                 // GM heap for orchestrator output buffers (device)
-    void* pto2_slot_states_ptr_;             // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
+    void *pto2_gm_sm_ptr_;                   // GM pointer to PTO2 shared memory (device)
+    void *pto2_gm_heap_ptr_;                 // GM heap for orchestrator output buffers (device)
+    void *pto2_slot_states_ptr_;             // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
     ChipStorageTaskArgs orch_args_storage_;  // Copy of args for device
 
     // Device orchestration SO binary (for dlopen on AICPU thread 3)
@@ -211,12 +211,12 @@ public:  // NOLINT(whitespace/indent)
     /**
      * Record a host-device tensor pair for copy-back during finalize.
      */
-    void record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size);
+    void record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size);
 
     /**
      * Get pointer to tensor pairs array.
      */
-    TensorPair* get_tensor_pairs();
+    TensorPair *get_tensor_pairs();
 
     /**
      * Get number of recorded tensor pairs.
@@ -237,18 +237,18 @@ public:  // NOLINT(whitespace/indent)
     // =========================================================================
 
     bool get_orch_built_on_host() const;
-    void* get_pto2_gm_sm_ptr() const;
-    void* get_pto2_gm_heap_ptr() const;
-    const ChipStorageTaskArgs& get_orch_args() const;
+    void *get_pto2_gm_sm_ptr() const;
+    void *get_pto2_gm_heap_ptr() const;
+    const ChipStorageTaskArgs &get_orch_args() const;
     void set_orch_built_on_host(bool v);
-    void set_pto2_gm_sm_ptr(void* p);
-    void set_pto2_gm_heap(void* p);
-    void set_pto2_slot_states_ptr(void* p);
-    void set_orch_args(const ChipStorageTaskArgs& args);
+    void set_pto2_gm_sm_ptr(void *p);
+    void set_pto2_gm_heap(void *p);
+    void set_pto2_slot_states_ptr(void *p);
+    void set_orch_args(const ChipStorageTaskArgs &args);
 
     // Device orchestration SO binary (for dlopen on AICPU thread 3)
-    void set_device_orch_so(const void* data, size_t size);
-    const void* get_device_orch_so_data() const;
+    void set_device_orch_so(const void *data, size_t size);
+    const void *get_device_orch_so_data() const;
     size_t get_device_orch_so_size() const;
 
     uint64_t get_function_bin_addr(int func_id) const;
@@ -267,7 +267,7 @@ public:  // NOLINT(whitespace/indent)
     int get_task_count() const { return 0; }
 
     /** @deprecated RT2 uses PTO2DispatchPayload, not Task. Always returns nullptr. */
-    Task* get_task(int) { return nullptr; }
+    Task *get_task(int) { return nullptr; }
 
     /** @deprecated Use PTO2 dispatch mode */
     bool get_use_pto2_dispatch() const { return true; }

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/tensor.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/tensor.h
@@ -45,8 +45,8 @@ struct Segment {
     uint64_t begin;
     uint64_t end;
 
-    bool line_segment_intersection(const Segment& other) const { return end > other.begin && other.end > begin; }
-    bool contains(const Segment& other) const { return begin <= other.begin && other.end <= end; }
+    bool line_segment_intersection(const Segment &other) const { return end > other.begin && other.end > begin; }
+    bool contains(const Segment &other) const { return begin <= other.begin && other.end <= end; }
 };
 
 /**
@@ -65,8 +65,13 @@ struct TensorCreateInfo {
     uint64_t initial_value;
 
     TensorCreateInfo(
-        const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false)
-        : dtype(dtype), ndims(ndims), manual_dep(manual_dep), has_initial_value(false), initial_value(0) {
+        const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false
+    ) :
+        dtype(dtype),
+        ndims(ndims),
+        manual_dep(manual_dep),
+        has_initial_value(false),
+        initial_value(0) {
         for (uint32_t i = 0; i < ndims; i++) {
             raw_shapes[i] = shapes[i];
         }
@@ -126,52 +131,33 @@ struct alignas(64) Tensor {
     uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
 
     Tensor() = default;
-    Tensor(const Tensor&) = default;
-    Tensor& operator=(const Tensor&) = default;
-    Tensor(Tensor&&) = default;
-    Tensor& operator=(Tensor&&) = default;
+    Tensor(const Tensor &) = default;
+    Tensor &operator=(const Tensor &) = default;
+    Tensor(Tensor &&) = default;
+    Tensor &operator=(Tensor &&) = default;
     ~Tensor() = default;
 
     /// Return the effective raw_shapes pointer (shapes[] when is_raw_eq_shapes).
     /// Avoids cache line 2 access for the common case.
-    const uint32_t* get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
+    const uint32_t *get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
 
-    Tensor(void* addr,
-        uint64_t buffer_size_bytes,
-        const uint32_t raw_shapes[],
-        const uint32_t shapes[],
-        const uint32_t offsets[],
-        uint32_t ndims,
-        DataType dtype,
-        int32_t version,
-        bool is_all_offset_zero = false,
-        bool is_raw_eq_shapes = false,
-        bool manual_dep = false) {
-        init(addr,
-            buffer_size_bytes,
-            raw_shapes,
-            shapes,
-            offsets,
-            ndims,
-            dtype,
-            version,
-            is_all_offset_zero,
-            is_raw_eq_shapes,
-            manual_dep);
+    Tensor(
+        void *addr, uint64_t buffer_size_bytes, const uint32_t raw_shapes[], const uint32_t shapes[],
+        const uint32_t offsets[], uint32_t ndims, DataType dtype, int32_t version, bool is_all_offset_zero = false,
+        bool is_raw_eq_shapes = false, bool manual_dep = false
+    ) {
+        init(
+            addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version, is_all_offset_zero,
+            is_raw_eq_shapes, manual_dep
+        );
     }
 
     // --- Initialization ---
-    void init(void* addr,
-        uint64_t buffer_size_bytes,
-        const uint32_t in_raw_shapes[],
-        const uint32_t in_shapes[],
-        const uint32_t in_offsets[],
-        uint32_t in_ndims,
-        DataType in_dtype,
-        int32_t in_version,
-        bool in_is_all_offset_zero = false,
-        bool in_is_raw_eq_shapes = false,
-        bool in_manual_dep = false) {
+    void init(
+        void *addr, uint64_t buffer_size_bytes, const uint32_t in_raw_shapes[], const uint32_t in_shapes[],
+        const uint32_t in_offsets[], uint32_t in_ndims, DataType in_dtype, int32_t in_version,
+        bool in_is_all_offset_zero = false, bool in_is_raw_eq_shapes = false, bool in_manual_dep = false
+    ) {
         buffer = {reinterpret_cast<uint64_t>(addr), buffer_size_bytes};
         ndims = in_ndims;
         dtype = in_dtype;
@@ -194,7 +180,7 @@ struct alignas(64) Tensor {
         }
     }
 
-    void init(const Tensor& other) {
+    void init(const Tensor &other) {
         memcpy(this, &other, 64);  // fast copy cache line 1
         if (!other.is_raw_eq_shapes) {
             for (uint32_t i = 0; i < ndims; i++) {
@@ -209,7 +195,8 @@ struct alignas(64) Tensor {
     }
 
     void init_with_view(
-        const Tensor& other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) {
+        const Tensor &other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false
+    ) {
         buffer = other.buffer;
         ndims = other.ndims;
         dtype = other.dtype;
@@ -218,7 +205,7 @@ struct alignas(64) Tensor {
         // view always diverges shapes from raw_shapes, so is_raw_eq_shapes = false.
         // Read parent's effective raw_shapes (avoids parent cache line 2 when parent is_raw_eq_shapes).
         is_raw_eq_shapes = false;
-        const uint32_t* parent_raw = other.get_raw_shapes();
+        const uint32_t *parent_raw = other.get_raw_shapes();
         for (uint32_t i = 0; i < ndims; i++) {
             raw_shapes[i] = parent_raw[i];
             shapes[i] = view_shapes[i];
@@ -252,7 +239,7 @@ struct alignas(64) Tensor {
             start_offset = 0;
             return;
         }
-        const uint32_t* rs = get_raw_shapes();
+        const uint32_t *rs = get_raw_shapes();
         uint64_t result = 0;
         uint64_t stride = 1;
         for (int i = static_cast<int>(ndims) - 1; i >= 0; i--) {
@@ -262,7 +249,7 @@ struct alignas(64) Tensor {
         start_offset = result;
     }
 
-    void copy(const Tensor& other) { init(other); }
+    void copy(const Tensor &other) { init(other); }
 
     Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
         Tensor result;
@@ -335,34 +322,28 @@ struct alignas(64) Tensor {
         return total;
     }
 
-    bool is_same_memref(const Tensor& other) const { return buffer.addr == other.buffer.addr; }
+    bool is_same_memref(const Tensor &other) const { return buffer.addr == other.buffer.addr; }
 
     /// Materialize a TensorCreateInfo into this Tensor (fresh contiguous output).
-    void init_from_create_info(const struct TensorCreateInfo& ci, void* addr, int32_t version_val) {
-        init(addr,
-            ci.buffer_size_bytes(),
-            ci.raw_shapes,
-            ci.raw_shapes,
-            nullptr,
-            ci.ndims,
-            ci.dtype,
-            version_val,
+    void init_from_create_info(const struct TensorCreateInfo &ci, void *addr, int32_t version_val) {
+        init(
+            addr, ci.buffer_size_bytes(), ci.raw_shapes, ci.raw_shapes, nullptr, ci.ndims, ci.dtype, version_val,
             /*is_all_offset_zero=*/true,
-            /*is_raw_eq_shapes=*/true,
-            ci.manual_dep);
+            /*is_raw_eq_shapes=*/true, ci.manual_dep
+        );
     }
 
     std::string dump() const {
         std::stringstream ss;
         std::string indent = "    ";
-        ss << "{" << std::endl;
-        ss << indent << "buffer.addr: " << buffer.addr << std::endl;
-        ss << indent << "buffer.size: " << buffer.size << " bytes" << std::endl;
-        ss << indent << "dtype: " << get_dtype_name(dtype) << std::endl;
-        ss << indent << "ndims: " << ndims << std::endl;
-        ss << indent << "version: " << version << std::endl;
+        ss << "{" << '\n';
+        ss << indent << "buffer.addr: " << buffer.addr << '\n';
+        ss << indent << "buffer.size: " << buffer.size << " bytes" << '\n';
+        ss << indent << "dtype: " << get_dtype_name(dtype) << '\n';
+        ss << indent << "ndims: " << ndims << '\n';
+        ss << indent << "version: " << version << '\n';
 
-        const uint32_t* rs = get_raw_shapes();
+        const uint32_t *rs = get_raw_shapes();
         ss << indent << "raw_shapes: [";
         for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
@@ -370,7 +351,7 @@ struct alignas(64) Tensor {
             }
             ss << rs[i];
         }
-        ss << "]" << std::endl;
+        ss << "]" << '\n';
         ss << indent << "shapes: [";
         for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
@@ -378,7 +359,7 @@ struct alignas(64) Tensor {
             }
             ss << shapes[i];
         }
-        ss << "]" << std::endl;
+        ss << "]" << '\n';
         ss << indent << "offsets: [";
         for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
@@ -386,8 +367,8 @@ struct alignas(64) Tensor {
             }
             ss << (is_all_offset_zero ? 0u : offsets[i]);
         }
-        ss << "]" << std::endl;
-        ss << "}" << std::endl;
+        ss << "]" << '\n';
+        ss << "}" << '\n';
         return ss.str();
     }
 };
@@ -403,18 +384,17 @@ using TensorData = Tensor;
 /**
  * Create a Tensor for pre-allocated external memory.
  */
-static inline Tensor make_tensor_external(void* addr,
-    const uint32_t shapes[],
-    uint32_t ndims,
-    DataType dtype = DataType::FLOAT32,
-    bool manual_dep = false,
-    int32_t version = 0) {
+static inline Tensor make_tensor_external(
+    void *addr, const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false,
+    int32_t version = 0
+) {
     static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
     uint64_t total = 1;
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(addr,
+    return {
+        addr,
         total * get_element_size(dtype),
         shapes,
         shapes,
@@ -424,5 +404,6 @@ static inline Tensor make_tensor_external(void* addr,
         version,
         /*is_all_offset_zero=*/true,
         /*is_raw_eq_shapes=*/true,
-        manual_dep);
+        manual_dep
+    };
 }

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -15,19 +15,19 @@
 #include "common/platform_config.h"  // Platform configuration (C/C++ compatible)
 #include "runtime.h"                 // NOLINT(build/include_subdir)
 
-typedef void (*KernelFunc)(__gm__ int64_t*);
+typedef void (*KernelFunc)(__gm__ int64_t *);
 
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task *task) {
     if (task->function_bin_addr == 0) {
         return;
     }
     KernelFunc kernel = (KernelFunc)task->function_bin_addr;
-    kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
+    kernel(reinterpret_cast<__gm__ int64_t *>(task->args));
     OUT_OF_ORDER_STORE_BARRIER();
 }
 
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
-    __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type) {
+    __gm__ Handshake *my_hank = (__gm__ Handshake *)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
@@ -74,14 +74,14 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             uint32_t actual_task_id = task_id;
             write_reg(RegId::COND, MAKE_ACK_VALUE(actual_task_id));
 
-            __gm__ Task* task_ptr = &(runtime->tasks[actual_task_id]);
+            __gm__ Task *task_ptr = &(runtime->tasks[actual_task_id]);
             uint64_t start_time = get_sys_cnt_aicore();
 
             execute_task(task_ptr);
 
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
-                __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
+                __gm__ PerfBuffer *perf_buf = (__gm__ PerfBuffer *)my_hank->perf_records_addr;
                 perf_aicore_record_task(perf_buf, actual_task_id, start_time, end_time);
             }
 

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -101,37 +101,28 @@ struct AicpuExecutor {
     uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER];  // Per-core total dispatched task counter
 
     // ===== Methods =====
-    int init(Runtime* runtime);
-    int handshake_all_cores(Runtime* runtime);
+    int init(Runtime *runtime);
+    int handshake_all_cores(Runtime *runtime);
     void assign_cores_to_threads();
-    void classify_and_distribute_initial_tasks(Runtime* runtime);
-    int resolve_and_dispatch(Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num);
-    int shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores);
-    int run(Runtime* runtime);
-    void deinit(Runtime* runtime);
-    void emergency_shutdown(Runtime* runtime);
-    void diagnose_stuck_state(
-        Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num, Handshake* hank);
+    void classify_and_distribute_initial_tasks(Runtime *runtime);
+    int resolve_and_dispatch(Runtime &runtime, int thread_idx, const int *cur_thread_cores, int core_num);
+    int shutdown_aicore(Runtime *runtime, int thread_idx, const int *cur_thread_cores);
+    int run(Runtime *runtime);
+    void deinit(Runtime *runtime);
+    void emergency_shutdown(Runtime *runtime);
+    void
+    diagnose_stuck_state(Runtime &runtime, int thread_idx, const int *cur_thread_cores, int core_num, Handshake *hank);
 
     // Helper functions (inline to avoid linker issues, not always_inline to preserve barriers)
-    inline void resolve_task_dependencies(Task* task,
-        Runtime& runtime,
-        int* cur_ready_queue_aic,
-        int& cur_aic_tail,
-        int& cur_aic_ready_count,
-        int* cur_ready_queue_aiv,
-        int& cur_aiv_tail,
-        int& cur_aiv_ready_count);
+    inline void resolve_task_dependencies(
+        Task *task, Runtime &runtime, int *cur_ready_queue_aic, int &cur_aic_tail, int &cur_aic_ready_count,
+        int *cur_ready_queue_aiv, int &cur_aiv_tail, int &cur_aiv_ready_count
+    );
 
-    inline bool try_dispatch_task(int core_id,
-        uint64_t reg_addr,
-        CoreType core_type,
-        int thread_idx,
-        int* local_queue,
-        int& head,
-        int& ready_count,
-        bool profiling_enabled,
-        Runtime& runtime);
+    inline bool try_dispatch_task(
+        int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head,
+        int &ready_count, bool profiling_enabled, Runtime &runtime
+    );
 };
 
 static AicpuExecutor g_aicpu_executor;
@@ -139,17 +130,13 @@ static AicpuExecutor g_aicpu_executor;
 // ===== Helper Function Implementations =====
 
 // Resolve dependencies: decrement fanin and enqueue newly ready tasks
-inline void AicpuExecutor::resolve_task_dependencies(Task* task,
-    Runtime& runtime,
-    int* cur_ready_queue_aic,
-    int& cur_aic_tail,
-    int& cur_aic_ready_count,
-    int* cur_ready_queue_aiv,
-    int& cur_aiv_tail,
-    int& cur_aiv_ready_count) {
+inline void AicpuExecutor::resolve_task_dependencies(
+    Task *task, Runtime &runtime, int *cur_ready_queue_aic, int &cur_aic_tail, int &cur_aic_ready_count,
+    int *cur_ready_queue_aiv, int &cur_aiv_tail, int &cur_aiv_ready_count
+) {
     for (int j = 0; j < task->fanout_count; j++) {
         int dep_id = task->fanout[j];
-        Task* dep = runtime.get_task(dep_id);
+        Task *dep = runtime.get_task(dep_id);
         int prev_fanin = dep->fanin.fetch_sub(1, std::memory_order_acq_rel);
 
         if (prev_fanin == 1) {
@@ -181,15 +168,10 @@ inline void AicpuExecutor::resolve_task_dependencies(Task* task,
 }
 
 // Try to dispatch a task from thread-local queue to a core
-inline bool AicpuExecutor::try_dispatch_task(int core_id,
-    uint64_t reg_addr,
-    CoreType core_type,
-    int thread_idx,
-    int* local_queue,
-    int& head,
-    int& ready_count,
-    bool profiling_enabled,
-    Runtime& runtime) {
+inline bool AicpuExecutor::try_dispatch_task(
+    int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head, int &ready_count,
+    bool profiling_enabled, Runtime &runtime
+) {
     if (ready_count <= 0) {
         return false;
     }
@@ -208,13 +190,11 @@ inline bool AicpuExecutor::try_dispatch_task(int core_id,
         }
     }
 
-    const char* core_type_str = (core_type == CoreType::AIC) ? "AIC" : "AIV";
-    LOG_INFO("Thread %d: Dispatching %s task %d to core %d (running_id=%d)",
-        thread_idx,
-        core_type_str,
-        task_id,
-        core_id,
-        running_task_ids_[core_id]);
+    const char *core_type_str = (core_type == CoreType::AIC) ? "AIC" : "AIV";
+    LOG_INFO(
+        "Thread %d: Dispatching %s task %d to core %d (running_id=%d)", thread_idx, core_type_str, task_id, core_id,
+        running_task_ids_[core_id]
+    );
 
     // Set state before writing register to avoid race with AICore ACK
     pending_task_ids_[core_id] = task_id;
@@ -226,7 +206,7 @@ inline bool AicpuExecutor::try_dispatch_task(int core_id,
 
 // ===== AicpuExecutor Method Implementations =====
 
-int AicpuExecutor::init(Runtime* runtime) {
+int AicpuExecutor::init(Runtime *runtime) {
     bool expected = false;
     if (!initialized_.compare_exchange_strong(expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
         return 0;
@@ -307,8 +287,8 @@ int AicpuExecutor::init(Runtime* runtime) {
  * @param runtime Runtime pointer
  * @return 0 on success, -1 on failure
  */
-int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+int AicpuExecutor::handshake_all_cores(Runtime *runtime) {
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     cores_total_num_ = runtime->worker_count;
 
     // Validate cores_total_num_ before using as array index
@@ -333,7 +313,7 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     // Step 2: Wait for all cores to respond and collect core type information
     bool handshake_failed = false;
     for (int i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_handshakes[i];
+        Handshake *hank = &all_handshakes[i];
 
         // Wait for aicore_regs_ready signal
         while (hank->aicore_regs_ready == 0) {
@@ -344,24 +324,23 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
 
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
-            LOG_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                i,
-                physical_core_id,
-                max_physical_cores_count);
+            LOG_ERROR(
+                "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
+                max_physical_cores_count
+            );
             handshake_failed = true;
             continue;
         }
 
         // Get register address using physical_core_id
-        uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
+        uint64_t *regs = reinterpret_cast<uint64_t *>(regs_);
         uint64_t reg_addr = regs[physical_core_id];
 
         // Initialize AICore registers after discovery (first round)
         platform_init_aicore_regs(reg_addr);
         hank->aicpu_regs_ready = 1;
 
-        while (hank->aicore_done == 0) {
-        }
+        while (hank->aicore_done == 0) {}
 
         CoreType type = hank->core_type;
 
@@ -384,11 +363,10 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
 
         core_id_to_reg_addr_[i] = reg_addr;
 
-        LOG_INFO("  Core %d: type=%s, physical_id=%u, reg_addr=0x%lx",
-            i,
-            core_type_to_string(type),
-            physical_core_id,
-            reg_addr);
+        LOG_INFO(
+            "  Core %d: type=%s, physical_id=%u, reg_addr=0x%lx", i, core_type_to_string(type), physical_core_id,
+            reg_addr
+        );
     }
 
     if (handshake_failed) {
@@ -408,12 +386,10 @@ void AicpuExecutor::assign_cores_to_threads() {
     aic_per_thread_ = (aic_count_ + thread_num_ - 1) / thread_num_;
     aiv_per_thread_ = (aiv_count_ + thread_num_ - 1) / thread_num_;
 
-    LOG_INFO("Core Assignment: %d AIC cores, %d AIV cores across %d threads (max %d AIC/thread, %d AIV/thread)",
-        aic_count_,
-        aiv_count_,
-        thread_num_,
-        aic_per_thread_,
-        aiv_per_thread_);
+    LOG_INFO(
+        "Core Assignment: %d AIC cores, %d AIV cores across %d threads (max %d AIC/thread, %d AIV/thread)", aic_count_,
+        aiv_count_, thread_num_, aic_per_thread_, aiv_per_thread_
+    );
 
     for (int t = 0; t < thread_num_; t++) {
         int core_idx = 0;
@@ -434,7 +410,8 @@ void AicpuExecutor::assign_cores_to_threads() {
         int offset = 0;
 
         offset += snprintf(
-            log_buffer + offset, sizeof(log_buffer) - offset, "Thread %d: assigned %d cores - AIC[", t, core_idx);
+            log_buffer + offset, sizeof(log_buffer) - offset, "Thread %d: assigned %d cores - AIC[", t, core_idx
+        );
 
         for (int k = 0, i = t; i < aic_count_; i += thread_num_, k++) {
             if (k > 0) offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, ",");
@@ -455,7 +432,7 @@ void AicpuExecutor::assign_cores_to_threads() {
 }
 
 // Classify and distribute initial ready tasks to thread-local and shared queues
-void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime* runtime) {
+void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime *runtime) {
     ready_queue_aic_head_ = 0;
     ready_queue_aic_tail_ = 0;
     ready_queue_aiv_head_ = 0;
@@ -472,7 +449,7 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime* runtime) {
     int initial_aiv_count = 0;
 
     for (int i = 0; i < initial_count; i++) {
-        Task* task = runtime->get_task(initial_ready[i]);
+        Task *task = runtime->get_task(initial_ready[i]);
         if (task->core_type == CoreType::AIC) {
             initial_aic[initial_aic_count++] = initial_ready[i];
         } else {
@@ -535,12 +512,14 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime* runtime) {
     }
     ready_count_aiv_.store(aiv_shared_count, std::memory_order_release);
 
-    LOG_INFO("Init: Task distribution complete - AIC: %d in local queues, %d in shared queue",
-        initial_aic_count - aic_shared_count,
-        aic_shared_count);
-    LOG_INFO("Init: Task distribution complete - AIV: %d in local queues, %d in shared queue",
-        initial_aiv_count - aiv_shared_count,
-        aiv_shared_count);
+    LOG_INFO(
+        "Init: Task distribution complete - AIC: %d in local queues, %d in shared queue",
+        initial_aic_count - aic_shared_count, aic_shared_count
+    );
+    LOG_INFO(
+        "Init: Task distribution complete - AIV: %d in local queues, %d in shared queue",
+        initial_aiv_count - aiv_shared_count, aiv_shared_count
+    );
 
     for (int t = 0; t < thread_num_; t++) {
         int aic_size =
@@ -554,14 +533,14 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime* runtime) {
 /**
  * Shutdown AICore - Send quit signal to all AICore kernels
  */
-int AicpuExecutor::shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores) {
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+int AicpuExecutor::shutdown_aicore(Runtime *runtime, int thread_idx, const int *cur_thread_cores) {
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
 
     LOG_INFO("Thread %d: Shutting down %d cores", thread_idx, thread_cores_num_[thread_idx]);
 
     for (int i = 0; i < thread_cores_num_[thread_idx]; i++) {
         int core_id = cur_thread_cores[i];
-        Handshake* hank = &all_handshakes[core_id];
+        Handshake *hank = &all_handshakes[core_id];
         LOG_INFO("Thread %d: AICPU hank addr = 0x%lx", thread_idx, reinterpret_cast<uint64_t>(hank));
 
         uint64_t reg_addr = core_id_to_reg_addr_[core_id];
@@ -578,8 +557,8 @@ int AicpuExecutor::shutdown_aicore(Runtime* runtime, int thread_idx, const int* 
 /**
  * Resolve dependencies and dispatch tasks using fast-path scheduling
  */
-int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
-    Handshake* hank = reinterpret_cast<Handshake*>(runtime.workers);
+int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const int *cur_thread_cores, int core_num) {
+    Handshake *hank = reinterpret_cast<Handshake *>(runtime.workers);
 
     LOG_INFO("Thread %d: Starting execution with %d cores", thread_idx, core_num);
 
@@ -597,8 +576,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
     bool profiling_enabled = runtime.enable_profiling;
 
     // Extract array pointers as local variables for better readability and performance
-    int* cur_ready_queue_aic = cur_ready_queue_aic_[thread_idx];
-    int* cur_ready_queue_aiv = cur_ready_queue_aiv_[thread_idx];
+    int *cur_ready_queue_aic = cur_ready_queue_aic_[thread_idx];
+    int *cur_ready_queue_aiv = cur_ready_queue_aiv_[thread_idx];
 
     // Initialize local circular queue pointers from member variables (set by init())
     // After this point, only use local variables for lock-free performance
@@ -612,7 +591,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
     int cur_aiv_ready_count = (cur_aiv_tail - cur_aiv_head + MAX_CORES_PER_THREAD) % MAX_CORES_PER_THREAD;
 
     LOG_INFO(
-        "Thread %d: Initial state - local queue: %d AIC, %d AIV", thread_idx, cur_aic_ready_count, cur_aiv_ready_count);
+        "Thread %d: Initial state - local queue: %d AIC, %d AIV", thread_idx, cur_aic_ready_count, cur_aiv_ready_count
+    );
 
     // Initialize dispatch timestamps for all cores
     uint64_t dispatch_start_time = get_sys_cnt_aicpu();
@@ -626,7 +606,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
         for (int i = 0; i < core_num; i++) {
             int core_id = cur_thread_cores[i];
             uint64_t reg_addr = core_id_to_reg_addr_[core_id];
-            Handshake* h = &hank[core_id];
+            Handshake *h = &hank[core_id];
 
             uint64_t reg_val = read_reg(reg_addr, RegId::COND);
             int reg_task_id = EXTRACT_TASK_ID(reg_val);
@@ -634,11 +614,10 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
 
             // Case 1: Pending task finished directly
             if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {
-                LOG_INFO("Thread %d: Core %d completed task %d (running_id=%d)",
-                    thread_idx,
-                    core_id,
-                    pending_task_ids_[core_id],
-                    running_task_ids_[core_id]);
+                LOG_INFO(
+                    "Thread %d: Core %d completed task %d (running_id=%d)", thread_idx, core_id,
+                    pending_task_ids_[core_id], running_task_ids_[core_id]
+                );
 
                 int completed_task_id = pending_task_ids_[core_id];
                 int prev_running_id = running_task_ids_[core_id];
@@ -648,45 +627,38 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 // pending task's record to maintain buffer ordering.
                 if (profiling_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
+                    PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
 
                     if (prev_running_id != AICPU_TASK_INVALID) {
-                        Task* prev_task = &runtime.tasks[prev_running_id];
+                        Task *prev_task = &runtime.tasks[prev_running_id];
                         uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                         for (int i = 0; i < prev_task->fanout_count; i++) {
                             fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
                         }
-                        if (perf_aicpu_complete_record(perf_buf,
-                                static_cast<uint32_t>(prev_running_id),
-                                static_cast<uint64_t>(prev_running_id),
-                                prev_task->func_id,
-                                h->core_type,
-                                dispatch_timestamps_[core_id],
-                                finish_ts,
-                                fanout_arr,
-                                prev_task->fanout_count) != 0) {
-                            DEV_ERROR("Core %d: perf_aicpu_complete_record failed for implicit task %d",
-                                core_id,
-                                prev_running_id);
+                        if (perf_aicpu_complete_record(
+                                perf_buf, static_cast<uint32_t>(prev_running_id),
+                                static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
+                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                            ) != 0) {
+                            DEV_ERROR(
+                                "Core %d: perf_aicpu_complete_record failed for implicit task %d", core_id,
+                                prev_running_id
+                            );
                         }
                         dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                     }
 
                     finish_ts = get_sys_cnt_aicpu();
-                    Task* task = &runtime.tasks[completed_task_id];
+                    Task *task = &runtime.tasks[completed_task_id];
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     for (int i = 0; i < task->fanout_count; i++) {
                         fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
                     }
-                    if (perf_aicpu_complete_record(perf_buf,
-                            static_cast<uint32_t>(completed_task_id),
-                            static_cast<uint64_t>(completed_task_id),
-                            task->func_id,
-                            h->core_type,
-                            dispatch_timestamps_[core_id],
-                            finish_ts,
-                            fanout_arr,
-                            task->fanout_count) != 0) {
+                    if (perf_aicpu_complete_record(
+                            perf_buf, static_cast<uint32_t>(completed_task_id),
+                            static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
+                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                        ) != 0) {
                         DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d", core_id, completed_task_id);
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
@@ -702,25 +674,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 // This allows the core to start next task immediately
                 bool dispatched = false;
                 if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
-                    dispatched = try_dispatch_task(core_id,
-                        reg_addr,
-                        CoreType::AIC,
-                        thread_idx,
-                        cur_ready_queue_aic,
-                        cur_aic_head,
-                        cur_aic_ready_count,
-                        profiling_enabled,
-                        runtime);
+                    dispatched = try_dispatch_task(
+                        core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
+                        cur_aic_ready_count, profiling_enabled, runtime
+                    );
                 } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
-                    dispatched = try_dispatch_task(core_id,
-                        reg_addr,
-                        CoreType::AIV,
-                        thread_idx,
-                        cur_ready_queue_aiv,
-                        cur_aiv_head,
-                        cur_aiv_ready_count,
-                        profiling_enabled,
-                        runtime);
+                    dispatched = try_dispatch_task(
+                        core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
+                        cur_aiv_ready_count, profiling_enabled, runtime
+                    );
                 }
 
                 // Resolve old running task dependencies (if exists)
@@ -731,28 +693,20 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     cur_thread_completed++;
                     completed_tasks_.fetch_add(1, std::memory_order_release);
 
-                    Task* prev_running_task = runtime.get_task(prev_running_id);
-                    resolve_task_dependencies(prev_running_task,
-                        runtime,
-                        cur_ready_queue_aic,
-                        cur_aic_tail,
-                        cur_aic_ready_count,
-                        cur_ready_queue_aiv,
-                        cur_aiv_tail,
-                        cur_aiv_ready_count);
+                    Task *prev_running_task = runtime.get_task(prev_running_id);
+                    resolve_task_dependencies(
+                        prev_running_task, runtime, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
+                        cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                    );
 
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
-                Task* task = runtime.get_task(completed_task_id);
-                resolve_task_dependencies(task,
-                    runtime,
-                    cur_ready_queue_aic,
-                    cur_aic_tail,
-                    cur_aic_ready_count,
-                    cur_ready_queue_aiv,
-                    cur_aiv_tail,
-                    cur_aiv_ready_count);
+                Task *task = runtime.get_task(completed_task_id);
+                resolve_task_dependencies(
+                    task, runtime, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count, cur_ready_queue_aiv,
+                    cur_aiv_tail, cur_aiv_ready_count
+                );
 
                 made_progress = true;
 
@@ -762,11 +716,10 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 }
             } else if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_ACK_STATE) {
                 // Case 2: Pending task received ACK
-                LOG_INFO("Thread %d: Core %d ACKed task %d (running_id=%d)",
-                    thread_idx,
-                    core_id,
-                    pending_task_ids_[core_id],
-                    running_task_ids_[core_id]);
+                LOG_INFO(
+                    "Thread %d: Core %d ACKed task %d (running_id=%d)", thread_idx, core_id, pending_task_ids_[core_id],
+                    running_task_ids_[core_id]
+                );
 
                 int prev_running_id = running_task_ids_[core_id];
 
@@ -782,24 +735,21 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     // Profiling: complete the implicit task's AICore record
                     if (profiling_enabled) {
                         uint64_t finish_ts = get_sys_cnt_aicpu();
-                        PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
-                        Task* prev_task = &runtime.tasks[prev_running_id];
+                        PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
+                        Task *prev_task = &runtime.tasks[prev_running_id];
                         uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                         for (int i = 0; i < prev_task->fanout_count; i++) {
                             fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
                         }
-                        if (perf_aicpu_complete_record(perf_buf,
-                                static_cast<uint32_t>(prev_running_id),
-                                static_cast<uint64_t>(prev_running_id),
-                                prev_task->func_id,
-                                h->core_type,
-                                dispatch_timestamps_[core_id],
-                                finish_ts,
-                                fanout_arr,
-                                prev_task->fanout_count) != 0) {
-                            DEV_ERROR("Core %d: perf_aicpu_complete_record failed for implicit task %d",
-                                core_id,
-                                prev_running_id);
+                        if (perf_aicpu_complete_record(
+                                perf_buf, static_cast<uint32_t>(prev_running_id),
+                                static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
+                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                            ) != 0) {
+                            DEV_ERROR(
+                                "Core %d: perf_aicpu_complete_record failed for implicit task %d", core_id,
+                                prev_running_id
+                            );
                         }
                         dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                     }
@@ -807,15 +757,11 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     cur_thread_completed++;
                     completed_tasks_.fetch_add(1, std::memory_order_release);
 
-                    Task* prev_running_task = runtime.get_task(prev_running_id);
-                    resolve_task_dependencies(prev_running_task,
-                        runtime,
-                        cur_ready_queue_aic,
-                        cur_aic_tail,
-                        cur_aic_ready_count,
-                        cur_ready_queue_aiv,
-                        cur_aiv_tail,
-                        cur_aiv_ready_count);
+                    Task *prev_running_task = runtime.get_task(prev_running_id);
+                    resolve_task_dependencies(
+                        prev_running_task, runtime, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
+                        cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                    );
 
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
@@ -824,31 +770,26 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 // Continue to Case 4 to dispatch next task
             } else if (reg_task_id == running_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {
                 // Case 3: Running task finished
-                LOG_INFO("Thread %d: Core %d completed task %d (pending_id=%d)",
-                    thread_idx,
-                    core_id,
-                    running_task_ids_[core_id],
-                    pending_task_ids_[core_id]);
+                LOG_INFO(
+                    "Thread %d: Core %d completed task %d (pending_id=%d)", thread_idx, core_id,
+                    running_task_ids_[core_id], pending_task_ids_[core_id]
+                );
 
                 int completed_task_id = running_task_ids_[core_id];
 
                 if (profiling_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
-                    Task* task = &runtime.tasks[completed_task_id];
+                    PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
+                    Task *task = &runtime.tasks[completed_task_id];
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     for (int i = 0; i < task->fanout_count; i++) {
                         fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
                     }
-                    if (perf_aicpu_complete_record(perf_buf,
-                            static_cast<uint32_t>(completed_task_id),
-                            static_cast<uint64_t>(completed_task_id),
-                            task->func_id,
-                            h->core_type,
-                            dispatch_timestamps_[core_id],
-                            finish_ts,
-                            fanout_arr,
-                            task->fanout_count) != 0) {
+                    if (perf_aicpu_complete_record(
+                            perf_buf, static_cast<uint32_t>(completed_task_id),
+                            static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
+                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                        ) != 0) {
                         DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d", core_id, completed_task_id);
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
@@ -862,37 +803,23 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 bool dispatched = false;
                 if (pending_task_ids_[core_id] == AICPU_TASK_INVALID) {
                     if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
-                        dispatched = try_dispatch_task(core_id,
-                            reg_addr,
-                            CoreType::AIC,
-                            thread_idx,
-                            cur_ready_queue_aic,
-                            cur_aic_head,
-                            cur_aic_ready_count,
-                            profiling_enabled,
-                            runtime);
+                        dispatched = try_dispatch_task(
+                            core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
+                            cur_aic_ready_count, profiling_enabled, runtime
+                        );
                     } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
-                        dispatched = try_dispatch_task(core_id,
-                            reg_addr,
-                            CoreType::AIV,
-                            thread_idx,
-                            cur_ready_queue_aiv,
-                            cur_aiv_head,
-                            cur_aiv_ready_count,
-                            profiling_enabled,
-                            runtime);
+                        dispatched = try_dispatch_task(
+                            core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
+                            cur_aiv_ready_count, profiling_enabled, runtime
+                        );
                     }
                 }
 
-                Task* task = runtime.get_task(completed_task_id);
-                resolve_task_dependencies(task,
-                    runtime,
-                    cur_ready_queue_aic,
-                    cur_aic_tail,
-                    cur_aic_ready_count,
-                    cur_ready_queue_aiv,
-                    cur_aiv_tail,
-                    cur_aiv_ready_count);
+                Task *task = runtime.get_task(completed_task_id);
+                resolve_task_dependencies(
+                    task, runtime, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count, cur_ready_queue_aiv,
+                    cur_aiv_tail, cur_aiv_ready_count
+                );
 
                 made_progress = true;
 
@@ -905,27 +832,17 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             // Case 4: Dispatch new task if pending slot is available
             if (pending_task_ids_[core_id] == AICPU_TASK_INVALID) {
                 if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
-                    if (try_dispatch_task(core_id,
-                            reg_addr,
-                            CoreType::AIC,
-                            thread_idx,
-                            cur_ready_queue_aic,
-                            cur_aic_head,
-                            cur_aic_ready_count,
-                            profiling_enabled,
-                            runtime)) {
+                    if (try_dispatch_task(
+                            core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
+                            cur_aic_ready_count, profiling_enabled, runtime
+                        )) {
                         made_progress = true;
                     }
                 } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
-                    if (try_dispatch_task(core_id,
-                            reg_addr,
-                            CoreType::AIV,
-                            thread_idx,
-                            cur_ready_queue_aiv,
-                            cur_aiv_head,
-                            cur_aiv_ready_count,
-                            profiling_enabled,
-                            runtime)) {
+                    if (try_dispatch_task(
+                            core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
+                            cur_aiv_ready_count, profiling_enabled, runtime
+                        )) {
                         made_progress = true;
                     }
                 }
@@ -949,7 +866,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 cur_aic_ready_count += to_grab;
 
                 LOG_INFO(
-                    "Thread %d: Grabbed %d AIC tasks from shared queue (available=%d)", thread_idx, to_grab, available);
+                    "Thread %d: Grabbed %d AIC tasks from shared queue (available=%d)", thread_idx, to_grab, available
+                );
             }
         }
 
@@ -969,7 +887,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 cur_aiv_ready_count += to_grab;
 
                 LOG_INFO(
-                    "Thread %d: Grabbed %d AIV tasks from shared queue (available=%d)", thread_idx, to_grab, available);
+                    "Thread %d: Grabbed %d AIV tasks from shared queue (available=%d)", thread_idx, to_grab, available
+                );
             }
         }
 
@@ -989,13 +908,9 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         LOG_WARN(
                             "Thread %d: Counter reached %d/%d but core %d still has work (COND=0x%lx, pending_id=%d, "
                             "running_id=%d)",
-                            thread_idx,
-                            completed_tasks_.load(std::memory_order_acquire),
-                            task_count,
-                            core_id,
-                            reg_val,
-                            pending_task_ids_[core_id],
-                            running_task_ids_[core_id]);
+                            thread_idx, completed_tasks_.load(std::memory_order_acquire), task_count, core_id, reg_val,
+                            pending_task_ids_[core_id], running_task_ids_[core_id]
+                        );
                     }
                     break;
                 }
@@ -1006,19 +921,20 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 int aic_remaining = ready_count_aic_.load(std::memory_order_acquire);
                 int aiv_remaining = ready_count_aiv_.load(std::memory_order_acquire);
                 if (aic_remaining > 0 || aiv_remaining > 0) {
-                    LOG_WARN("Thread %d: Queues not empty after completion! AIC=%d, AIV=%d",
-                        thread_idx,
-                        aic_remaining,
-                        aiv_remaining);
+                    LOG_WARN(
+                        "Thread %d: Queues not empty after completion! AIC=%d, AIV=%d", thread_idx, aic_remaining,
+                        aiv_remaining
+                    );
                 }
                 break;  // Exit main loop
             }
 
             verification_warning_count++;
             if (verification_warning_count > MAX_VERIFICATION_WARNINGS) {
-                LOG_ERROR("Thread %d: Counter reached but cores still working after %d checks!",
-                    thread_idx,
-                    verification_warning_count);
+                LOG_ERROR(
+                    "Thread %d: Counter reached but cores still working after %d checks!", thread_idx,
+                    verification_warning_count
+                );
                 diagnose_stuck_state(runtime, thread_idx, cur_thread_cores, core_num, hank);
                 return -1;
             }
@@ -1029,11 +945,10 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             idle_iterations++;
             if (idle_iterations % WARN_INTERVAL == 0) {
                 int current = completed_tasks_.load(std::memory_order_acquire);
-                LOG_WARN("Thread %d: %d idle iterations, progress %d/%d tasks",
-                    thread_idx,
-                    idle_iterations,
-                    current,
-                    task_count);
+                LOG_WARN(
+                    "Thread %d: %d idle iterations, progress %d/%d tasks", thread_idx, idle_iterations, current,
+                    task_count
+                );
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
                 LOG_ERROR("Thread %d: Timeout after %d idle iterations!", thread_idx, idle_iterations);
@@ -1052,12 +967,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
     return cur_thread_completed;
 }
 
-int AicpuExecutor::run(Runtime* runtime) {
+int AicpuExecutor::run(Runtime *runtime) {
     int thread_idx = thread_idx_++;
 
     LOG_INFO("Thread %d: Start", thread_idx);
 
-    const int* cur_thread_cores = core_assignments_[thread_idx];
+    const int *cur_thread_cores = core_assignments_[thread_idx];
 
     LOG_INFO("Thread %d: Runtime has %d tasks", thread_idx, runtime->get_task_count());
     int completed = resolve_and_dispatch(*runtime, thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
@@ -1084,7 +999,7 @@ int AicpuExecutor::run(Runtime* runtime) {
     return 0;
 }
 
-void AicpuExecutor::deinit(Runtime* runtime) {
+void AicpuExecutor::deinit(Runtime *runtime) {
     // === Exit cleanup: reset all inter-round state ===
 
     // 1. Invalidate AICPU cache for Runtime address range.
@@ -1129,11 +1044,11 @@ void AicpuExecutor::deinit(Runtime* runtime) {
     LOG_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
+void AicpuExecutor::emergency_shutdown(Runtime *runtime) {
     LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     for (int i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_handshakes[i];
+        Handshake *hank = &all_handshakes[i];
         OUT_OF_ORDER_STORE_BARRIER();
         hank->aicpu_regs_ready = 1;
         if (core_id_to_reg_addr_[i] != 0) {
@@ -1145,7 +1060,8 @@ void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
 }
 
 void AicpuExecutor::diagnose_stuck_state(
-    Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num, Handshake* hank) {
+    Runtime &runtime, int thread_idx, const int *cur_thread_cores, int core_num, Handshake *hank
+) {
     LOG_ERROR("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
 
     int completed = completed_tasks_.load(std::memory_order_acquire);
@@ -1162,9 +1078,9 @@ void AicpuExecutor::diagnose_stuck_state(
     LOG_ERROR("Core Status:");
     for (int i = 0; i < core_num; i++) {
         int core_id = cur_thread_cores[i];
-        Handshake* h = &hank[core_id];
+        Handshake *h = &hank[core_id];
 
-        const char* core_type_str = core_type_to_string(h->core_type);
+        const char *core_type_str = core_type_to_string(h->core_type);
 
         uint64_t reg_addr = core_id_to_reg_addr_[core_id];
         uint64_t reg_val = read_reg(reg_addr, RegId::COND);
@@ -1178,34 +1094,22 @@ void AicpuExecutor::diagnose_stuck_state(
             busy_cores++;
 
             if (pending_id != AICPU_TASK_INVALID) {
-                Task* task = runtime.get_task(pending_id);
+                Task *task = runtime.get_task(pending_id);
                 LOG_ERROR(
                     "  Core %d [%s, PENDING]: COND=0x%lx (reg_task_id=%d, reg_state=%d), pending_id=%d, func_id=%d, "
                     "fanin=%d, fanout=%d",
-                    core_id,
-                    core_type_str,
-                    reg_val,
-                    reg_task_id,
-                    reg_state,
-                    task->task_id,
-                    task->func_id,
-                    task->fanin.load(std::memory_order_acquire),
-                    task->fanout_count);
+                    core_id, core_type_str, reg_val, reg_task_id, reg_state, task->task_id, task->func_id,
+                    task->fanin.load(std::memory_order_acquire), task->fanout_count
+                );
             }
             if (running_id != AICPU_TASK_INVALID) {
-                Task* task = runtime.get_task(running_id);
+                Task *task = runtime.get_task(running_id);
                 LOG_ERROR(
                     "  Core %d [%s, RUNNING]: COND=0x%lx (reg_task_id=%d, reg_state=%d), running_id=%d, func_id=%d, "
                     "fanin=%d, fanout=%d",
-                    core_id,
-                    core_type_str,
-                    reg_val,
-                    reg_task_id,
-                    reg_state,
-                    task->task_id,
-                    task->func_id,
-                    task->fanin.load(std::memory_order_acquire),
-                    task->fanout_count);
+                    core_id, core_type_str, reg_val, reg_task_id, reg_state, task->task_id, task->func_id,
+                    task->fanin.load(std::memory_order_acquire), task->fanout_count
+                );
             }
         } else {
             idle_cores++;
@@ -1222,7 +1126,7 @@ void AicpuExecutor::diagnose_stuck_state(
         LOG_ERROR("Tasks with fanin > 0:");
         int stuck_count = 0;
         for (int tid = 0; tid < total && stuck_count < 10; tid++) {
-            Task* t = runtime.get_task(tid);
+            Task *t = runtime.get_task(tid);
             int fanin = t->fanin.load(std::memory_order_acquire);
             if (fanin > 0) {
                 LOG_ERROR("  Task %d: fanin=%d (waiting for dependencies)", tid, fanin);
@@ -1255,10 +1159,12 @@ void AicpuExecutor::diagnose_stuck_state(
  * @param runtime Pointer to Runtime structure
  * @return 0 on success, non-zero on error
  */
-extern "C" int aicpu_execute(Runtime* runtime) {
+extern "C" int aicpu_execute(Runtime *runtime) {
     // Initialize log switches (only once, thread-safe)
     static std::once_flag log_init_flag;
-    std::call_once(log_init_flag, []() { init_log_switch(); });
+    std::call_once(log_init_flag, []() {
+        init_log_switch();
+    });
 
     if (runtime == nullptr) {
         LOG_ERROR("%s", "Invalid argument: null Runtime pointer");

--- a/src/a2a3/runtime/host_build_graph/host/runtime_compile_info.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_compile_info.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "host/platform_compile_info.h"
 #include "host/runtime_compile_info.h"
 #include <string.h>
@@ -13,5 +23,4 @@ ToolchainType get_orchestration_compiler(void) {
     // host_build_graph: always host g++ (orchestration runs on host)
     return TOOLCHAIN_HOST_GXX;
 }
-
 }

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -45,7 +45,7 @@
  * @param orch_args  Separated tensor/scalar arguments
  * @return 0 on success, negative on error
  */
-typedef int (*OrchestrationFunc)(Runtime* runtime, const ChipStorageTaskArgs& orch_args);
+typedef int (*OrchestrationFunc)(Runtime *runtime, const ChipStorageTaskArgs &orch_args);
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,7 +67,7 @@ extern "C" {
  * @param orch_args Separated tensor/scalar arguments
  * @return 0 on success, -1 on failure
  */
-int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args) {
+int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args) {
     // Validate inputs
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -79,10 +79,11 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", callable->child_count());
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
-            const auto& kernel = callable->child(i);
-            uint64_t addr = runtime->host_api.upload_kernel_binary(func_id,
-                reinterpret_cast<const uint8_t*>(&kernel),
-                CoreCallable::binary_data_offset() + kernel.binary_size());
+            const auto &kernel = callable->child(i);
+            uint64_t addr = runtime->host_api.upload_kernel_binary(
+                func_id, reinterpret_cast<const uint8_t *>(&kernel),
+                CoreCallable::binary_data_offset() + kernel.binary_size()
+            );
             if (addr == 0) {
                 LOG_ERROR("Failed to upload kernel binary for func_id=%d", func_id);
                 return -1;
@@ -91,9 +92,9 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
         }
     }
 
-    const uint8_t* orch_so_binary = static_cast<const uint8_t*>(callable->binary_data());
+    const uint8_t *orch_so_binary = static_cast<const uint8_t *>(callable->binary_data());
     size_t orch_so_size = callable->binary_size();
-    const char* orch_func_name = callable->func_name();
+    const char *orch_func_name = callable->func_name();
 
     if (orch_so_binary == nullptr || orch_so_size == 0 || orch_func_name[0] == '\0') {
         LOG_ERROR("Invalid orchestration parameters");
@@ -119,7 +120,7 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
     }
     close(fd);
 
-    void* handle = dlopen(fd_path, RTLD_NOW | RTLD_LOCAL);
+    void *handle = dlopen(fd_path, RTLD_NOW | RTLD_LOCAL);
     unlink(fd_path);
     if (handle == nullptr) {
         LOG_ERROR("dlopen failed: %s", dlerror());
@@ -128,7 +129,7 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
 
     dlerror();  // Clear any existing error
     OrchestrationFunc orch_func = reinterpret_cast<OrchestrationFunc>(dlsym(handle, orch_func_name));
-    const char* dlsym_error = dlerror();
+    const char *dlsym_error = dlerror();
     if (dlsym_error != nullptr) {
         LOG_ERROR("dlsym failed for '%s': %s", orch_func_name, dlsym_error);
         dlclose(handle);
@@ -142,10 +143,10 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
 
     LOG_INFO("=== Calling Orchestration Function ===");
 
-    LOG_DEBUG("Args count: %d (%d tensors + %d scalars)",
-        orch_args->tensor_count() + orch_args->scalar_count(),
-        orch_args->tensor_count(),
-        orch_args->scalar_count());
+    LOG_DEBUG(
+        "Args count: %d (%d tensors + %d scalars)", orch_args->tensor_count() + orch_args->scalar_count(),
+        orch_args->tensor_count(), orch_args->scalar_count()
+    );
 
     // Call orchestration function to build task graph
     // The orchestration function handles device memory allocation and copy-to-device
@@ -176,7 +177,7 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-int validate_runtime_impl(Runtime* runtime) {
+int validate_runtime_impl(Runtime *runtime) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -187,11 +188,11 @@ int validate_runtime_impl(Runtime* runtime) {
     LOG_INFO("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair* tensor_pairs = runtime->get_tensor_pairs();
+    TensorPair *tensor_pairs = runtime->get_tensor_pairs();
     int tensor_pair_count = runtime->get_tensor_pair_count();
 
     for (int i = 0; i < tensor_pair_count; i++) {
-        const TensorPair& pair = tensor_pairs[i];
+        const TensorPair &pair = tensor_pairs[i];
         int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, pair.dev_ptr, pair.size);
         if (copy_rc != 0) {
             LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Runtime Class - Implementation
  *
@@ -48,7 +58,7 @@ Runtime::Runtime() {
 // Task Management
 // =============================================================================
 
-int Runtime::add_task(uint64_t* args, int num_args, int func_id, CoreType core_type) {
+int Runtime::add_task(uint64_t *args, int num_args, int func_id, CoreType core_type) {
     // Check bounds
     if (next_task_id >= RUNTIME_MAX_TASKS) {
         LOG_ERROR("[Runtime] Task table full (max=%d)", RUNTIME_MAX_TASKS);
@@ -62,7 +72,7 @@ int Runtime::add_task(uint64_t* args, int num_args, int func_id, CoreType core_t
 
     // Allocate task
     int task_id = next_task_id++;
-    Task* task = &tasks[task_id];
+    Task *task = &tasks[task_id];
 
     // Initialize task fields
     task->task_id = task_id;
@@ -71,8 +81,8 @@ int Runtime::add_task(uint64_t* args, int num_args, int func_id, CoreType core_t
     if (args && num_args > 0) {
         memcpy(task->args, args, num_args * sizeof(uint64_t));
     }
-    task->function_bin_addr = 0;    // Will be set by host before copying to device
-    task->core_type = core_type;    // Set core type
+    task->function_bin_addr = 0;  // Will be set by host before copying to device
+    task->core_type = core_type;  // Set core type
     task->fanin = 0;
     task->fanout_count = 0;
     memset(task->fanout, 0, sizeof(task->fanout));
@@ -92,8 +102,8 @@ void Runtime::add_successor(int from_task, int to_task) {
         return;
     }
 
-    Task* from = &tasks[from_task];
-    Task* to = &tasks[to_task];
+    Task *from = &tasks[from_task];
+    Task *to = &tasks[to_task];
 
     // Add to_task to from_task's fanout
     if (from->fanout_count >= RUNTIME_MAX_FANOUT) {
@@ -109,7 +119,7 @@ void Runtime::add_successor(int from_task, int to_task) {
 // Query Methods
 // =============================================================================
 
-Task* Runtime::get_task(int task_id) {
+Task *Runtime::get_task(int task_id) {
     if (task_id < 0 || task_id >= next_task_id) {
         return nullptr;
     }
@@ -118,7 +128,7 @@ Task* Runtime::get_task(int task_id) {
 
 int Runtime::get_task_count() const { return next_task_id; }
 
-int Runtime::get_initial_ready_tasks(int* ready_tasks) {
+int Runtime::get_initial_ready_tasks(int *ready_tasks) {
     initial_ready_count = 0;
     for (int i = 0; i < next_task_id; i++) {
         if (tasks[i].fanin == 0) {
@@ -145,7 +155,7 @@ void Runtime::print_runtime() const {
     // Print initially ready tasks
     LOG_DEBUG("\nInitially Ready Tasks (fanin==0):");
     LOG_DEBUG("----------------------------------------------------------------------");
-    
+
     // Build ready tasks string
     char ready_tasks_str[1024] = "  ";
     int offset = 2;
@@ -169,23 +179,22 @@ void Runtime::print_runtime() const {
     LOG_DEBUG("----------------------------------------------------------------------");
 
     for (int i = 0; i < next_task_id; i++) {
-        const Task* t = &tasks[i];
+        const Task *t = &tasks[i];
 
         // Build fanout string
         char fanout_str[512];
         int fo_offset = 0;
         for (int j = 0; j < t->fanout_count && fo_offset < 500; j++) {
-            fo_offset += snprintf(fanout_str + fo_offset, sizeof(fanout_str) - fo_offset, 
-                                  "%d%s", t->fanout[j], j < t->fanout_count - 1 ? "," : "");
+            fo_offset += snprintf(
+                fanout_str + fo_offset, sizeof(fanout_str) - fo_offset, "%d%s", t->fanout[j],
+                j < t->fanout_count - 1 ? "," : ""
+            );
         }
 
-        LOG_DEBUG("  Task %d: func_id=%d, fanin=%d, fanout=%d, args=%d [%s]",
-            i,
-            t->func_id,
-            t->fanin.load(),
-            t->fanout_count,
-            t->num_args,
-            fanout_str);
+        LOG_DEBUG(
+            "  Task %d: func_id=%d, fanin=%d, fanout=%d, args=%d [%s]", i, t->func_id, t->fanin.load(), t->fanout_count,
+            t->num_args, fanout_str
+        );
     }
 
     LOG_DEBUG("========================================================================");
@@ -195,7 +204,7 @@ void Runtime::print_runtime() const {
 // Tensor Pair Management
 // =============================================================================
 
-void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
+void Runtime::record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size) {
     if (tensor_pair_count >= RUNTIME_MAX_TENSOR_PAIRS) {
         LOG_ERROR("[Runtime] Tensor pairs full (max=%d)", RUNTIME_MAX_TENSOR_PAIRS);
         return;
@@ -207,14 +216,8 @@ void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
     LOG_DEBUG("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
 }
 
-TensorPair* Runtime::get_tensor_pairs() {
-    return tensor_pairs;
-}
+TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
 
-int Runtime::get_tensor_pair_count() const {
-    return tensor_pair_count;
-}
+int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
-void Runtime::clear_tensor_pairs() {
-    tensor_pair_count = 0;
-}
+void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -130,8 +130,8 @@ struct Handshake {
  * Used for copy-back during finalize.
  */
 struct TensorPair {
-    void* host_ptr;
-    void* dev_ptr;
+    void *host_ptr;
+    void *dev_ptr;
     size_t size;
 };
 
@@ -140,11 +140,11 @@ struct TensorPair {
  * Allows runtime to use pluggable device memory backends.
  */
 struct HostApi {
-    void* (*device_malloc)(size_t size);
-    void (*device_free)(void* dev_ptr);
-    int (*copy_to_device)(void* dev_ptr, const void* host_ptr, size_t size);
-    int (*copy_from_device)(void* host_ptr, const void* dev_ptr, size_t size);
-    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t* bin_data, size_t bin_size);
+    void *(*device_malloc)(size_t size);
+    void (*device_free)(void *dev_ptr);
+    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
+    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t *bin_data, size_t bin_size);
     void (*remove_kernel_binary)(int func_id);
 };
 
@@ -193,7 +193,7 @@ typedef struct {
  * Dependencies are managed manually via add_successor().
  */
 class Runtime {
- public:
+public:
     // Handshake buffers for AICPU-AICore communication
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
@@ -209,7 +209,7 @@ class Runtime {
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
 
- private:
+private:
     int next_task_id;  // Next available task ID
 
     // Initial ready tasks (computed once, read-only after)
@@ -227,7 +227,7 @@ class Runtime {
     int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
     int registered_kernel_count_;
 
- public:
+public:
     /**
      * Constructor - zero-initialize all arrays
      */
@@ -246,7 +246,7 @@ class Runtime {
      * @param core_type Core type for this task (CoreType::AIC or CoreType::AIV)
      * @return Task ID (>= 0) on success, -1 on failure
      */
-    int add_task(uint64_t* args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
+    int add_task(uint64_t *args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
 
     /**
      * Add a dependency edge: from_task -> to_task
@@ -269,7 +269,7 @@ class Runtime {
      * @param task_id  Task ID to query
      * @return Pointer to task, or nullptr if invalid ID
      */
-    Task* get_task(int task_id);
+    Task *get_task(int task_id);
 
     /**
      * Get the total number of tasks in the runtime
@@ -289,7 +289,7 @@ class Runtime {
      * nullptr)
      * @return Number of initially ready tasks
      */
-    int get_initial_ready_tasks(int* ready_tasks);
+    int get_initial_ready_tasks(int *ready_tasks);
 
     // =========================================================================
     // Utility Methods
@@ -313,14 +313,14 @@ class Runtime {
      * @param dev_ptr   Device memory pointer (source for copy-back)
      * @param size     Size of tensor in bytes
      */
-    void record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size);
+    void record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size);
 
     /**
      * Get pointer to tensor pairs array.
      *
      * @return Pointer to tensor pairs array
      */
-    TensorPair* get_tensor_pairs();
+    TensorPair *get_tensor_pairs();
 
     /**
      * Get number of recorded tensor pairs.
@@ -342,7 +342,7 @@ class Runtime {
      * Set PTO2 shared memory pointer (stub for host_build_graph).
      * This is a no-op for host orchestration; only used by rt2.
      */
-    void set_pto2_gm_sm_ptr(void*) { /* no-op */ }
+    void set_pto2_gm_sm_ptr(void *) { /* no-op */ }
 
     /**
      * Get function binary address by func_id.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -22,7 +22,7 @@
  * All kernels follow the same signature: void kernel(__gm__ int64_t* args)
  * This enables simple, switch-free dispatch.
  */
-typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
+typedef void (*UnifiedKernelFunc)(__gm__ int64_t *);
 
 /**
  * Execute task from PTO2DispatchPayload.
@@ -31,13 +31,13 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload *payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
 
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
-    kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
+    kernel(reinterpret_cast<__gm__ int64_t *>(payload->args));
     OUT_OF_ORDER_STORE_BARRIER();
 }
 
@@ -59,8 +59,8 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * @param block_idx Block index (core ID)
  * @param core_type Core type (AIC or AIV)
  */
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
-    __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type) {
+    __gm__ Handshake *my_hank = (__gm__ Handshake *)(&runtime->workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
@@ -86,7 +86,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
-    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+    __gm__ PTO2DispatchPayload *payload = reinterpret_cast<__gm__ PTO2DispatchPayload *>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
 
@@ -126,7 +126,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             // Performance profiling: record task execution
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
-                __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
+                __gm__ PerfBuffer *perf_buf = (__gm__ PerfBuffer *)my_hank->perf_records_addr;
                 perf_aicore_record_task(perf_buf, task_id, start_time, end_time);
             }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -68,15 +68,14 @@
 // The executor binds the current thread's PTO2Runtime into orchestration TLS
 // before calling the user entry.
 typedef void (*DeviceOrchestrationFunc)(
-    const ChipStorageTaskArgs& orch_args, int32_t orch_thread_num, int32_t orch_thread_index);
-typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime* rt);
+    const ChipStorageTaskArgs &orch_args, int32_t orch_thread_num, int32_t orch_thread_index
+);
+typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 
 // Config function exported by orchestration .so
-typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs& orch_args);
+typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs &orch_args);
 
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
-constexpr int32_t MAX_AIC_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD;
-constexpr int32_t MAX_AIV_PER_THREAD = PLATFORM_MAX_AIV_PER_THREAD;
 constexpr int32_t MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 
 constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
@@ -88,7 +87,7 @@ constexpr int32_t STALL_DUMP_CORE_MAX = 8;
 constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
 constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
 
-static PTO2Runtime* rt{nullptr};
+static PTO2Runtime *rt{nullptr};
 
 // Per-core dispatch payload storage (one aligned cache line per physical core)
 static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
@@ -98,7 +97,7 @@ static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
 struct alignas(64) CoreExecState {
     // --- Hot fields (completion + dispatch, every iteration) ---
     uint64_t reg_addr;                        // offset  0: register address (set once in handshake)
-    PTO2TaskSlotState* executing_slot_state;  // offset  8: slot state for running task
+    PTO2TaskSlotState *executing_slot_state;  // offset  8: slot state for running task
     int32_t executing_reg_task_id;            // offset 16: register task ID (AICPU_TASK_INVALID = idle)
     uint32_t dispatch_seq;                    // offset 20: monotonic dispatch counter
     PTO2SubtaskSlot executing_subslot;        // offset 24: which subtask slot is running
@@ -121,29 +120,30 @@ static_assert(sizeof(CoreExecState) == 64, "CoreExecState must occupy exactly on
 //   bit i*3+2 = AIV1 of cluster i
 // Max 21 clusters per tracker (63 bits in uint64_t).
 class alignas(64) CoreTracker {
- public:
+public:
     static inline int32_t MAX_CORE_PER_THREAD = 63;
     static constexpr int32_t MAX_CLUSTERS = 63 / 3;
 
- public:
+public:
     CoreTracker() = default;
 
     class BitStates {
-     public:  // NOLINT(whitespace/indent)
+    public:  // NOLINT(whitespace/indent)
         BitStates() = default;
 
-        explicit BitStates(uint64_t states) : states_(states) {}
+        explicit BitStates(uint64_t states) :
+            states_(states) {}
         void init() { states_ = 0; }
 
         BitStates operator~() const { return BitStates(~states_); }
-        BitStates operator&(const BitStates& other) const { return BitStates(states_ & other.states_); }
-        BitStates operator|(const BitStates& other) const { return BitStates(states_ | other.states_); }
-        BitStates operator^(const BitStates& other) const { return BitStates(states_ ^ other.states_); }
+        BitStates operator&(const BitStates &other) const { return BitStates(states_ & other.states_); }
+        BitStates operator|(const BitStates &other) const { return BitStates(states_ | other.states_); }
+        BitStates operator^(const BitStates &other) const { return BitStates(states_ ^ other.states_); }
         BitStates operator>>(int32_t offset) const { return BitStates(states_ >> offset); }
         BitStates operator<<(int32_t offset) const { return BitStates(states_ << offset); }
-        void operator&=(const BitStates& other) { states_ &= other.states_; }
-        void operator|=(const BitStates& other) { states_ |= other.states_; }
-        void operator^=(const BitStates& other) { states_ ^= other.states_; }
+        void operator&=(const BitStates &other) { states_ &= other.states_; }
+        void operator|=(const BitStates &other) { states_ |= other.states_; }
+        void operator^=(const BitStates &other) { states_ ^= other.states_; }
 
         bool has_value() const { return states_ > 0; }
         int32_t count() const { return __builtin_popcountll(states_); }
@@ -157,11 +157,11 @@ class alignas(64) CoreTracker {
             return pos;
         }
 
-     private:  // NOLINT(whitespace/indent)
+    private:  // NOLINT(whitespace/indent)
         uint64_t states_{0};
     };
 
- public:
+public:
     void init(int32_t cluster_count) {
         cluster_count_ = cluster_count;
         aic_mask_.init();
@@ -220,12 +220,12 @@ class alignas(64) CoreTracker {
 
     BitStates get_valid_cluster_offset_states(PTO2ResourceShape shape) const {
         switch (shape) {
-            case PTO2ResourceShape::AIC:
-                return core_states_ & aic_mask_;
-            case PTO2ResourceShape::AIV:
-                return ((core_states_ >> 1) | (core_states_ >> 2)) & aic_mask_;
-            case PTO2ResourceShape::MIX:
-                return (core_states_ >> 1) & (core_states_ >> 2) & core_states_ & aic_mask_;
+        case PTO2ResourceShape::AIC:
+            return core_states_ & aic_mask_;
+        case PTO2ResourceShape::AIV:
+            return ((core_states_ >> 1) | (core_states_ >> 2)) & aic_mask_;
+        case PTO2ResourceShape::MIX:
+            return (core_states_ >> 1) & (core_states_ >> 2) & core_states_ & aic_mask_;
         }
         return BitStates(0ULL);
     }
@@ -257,7 +257,7 @@ class alignas(64) CoreTracker {
 
     int32_t get_core_id_by_offset(int32_t offset) const { return core_id_map_[offset]; }
 
- private:
+private:
     int32_t cluster_count_;
     BitStates aic_mask_;
     BitStates aiv_mask_;
@@ -318,68 +318,59 @@ struct AicpuExecutor {
     std::atomic<bool> completed_{false};
 
     // Orchestration SO handle - defer dlclose until all tasks complete
-    void* orch_so_handle_{nullptr};
+    void *orch_so_handle_{nullptr};
     char orch_so_path_[256]{};  // Path to orchestration SO file for cleanup
 
     // Shared orchestration function pointer (loaded by first orch thread, used by all)
     DeviceOrchestrationFunc orch_func_{nullptr};
     DeviceOrchestrationBindRuntimeFunc orch_bind_runtime_{nullptr};
-    const ChipStorageTaskArgs* orch_args_cached_{nullptr};
+    const ChipStorageTaskArgs *orch_args_cached_{nullptr};
 
-    uint64_t* func_id_to_addr_;
+    uint64_t *func_id_to_addr_;
     uint64_t get_function_bin_addr(int func_id) const {
         if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
         return func_id_to_addr_[func_id];
     }
 
     // ===== Methods =====
-    int32_t init(Runtime* runtime);
-    int32_t handshake_all_cores(Runtime* runtime);
+    int32_t init(Runtime *runtime);
+    int32_t handshake_all_cores(Runtime *runtime);
     bool assign_cores_to_threads();
     void reassign_cores_for_all_threads();
-    int32_t resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx);
-    int32_t shutdown_aicore(Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num);
-    int32_t run(Runtime* runtime);
-    void deinit(Runtime* runtime);
-    void emergency_shutdown(Runtime* runtime);
+    int32_t resolve_and_dispatch_pto2(Runtime *runtime, int32_t thread_idx);
+    int32_t shutdown_aicore(Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num);
+    int32_t run(Runtime *runtime);
+    void deinit(Runtime *runtime);
+    void emergency_shutdown(Runtime *runtime);
     void diagnose_stuck_state(
-        Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank);
+        Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
+    );
 
     template <CoreType CT>
-    void check_running_cores_for_completion(int32_t thread_idx,
-        Handshake* hank,
-        int32_t& completed_this_turn,
-        int32_t& cur_thread_completed,
-        bool& made_progress,
-        PTO2TaskSlotState* deferred_release_slot_states[],
-        int32_t& deferred_release_count,
-        PTO2LocalReadyBuffer* local_bufs
+    void check_running_cores_for_completion(
+        int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
+        bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
+        PTO2LocalReadyBuffer *local_bufs
 #if PTO2_PROFILING
         ,
-        bool profiling_enabled,
-        uint32_t& phase_complete_count
+        bool profiling_enabled, uint32_t &phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
         ,
-        uint64_t& complete_probe_count,
-        uint64_t& complete_hit_count,
-        uint64_t& notify_edges_total,
-        int32_t& notify_max_degree,
-        uint64_t& notify_tasks_enqueued,
-        uint64_t& fanin_edges_total,
-        int32_t& fanin_max_degree,
-        uint64_t& sched_complete_perf_cycle
+        uint64_t &complete_probe_count, uint64_t &complete_hit_count, uint64_t &notify_edges_total,
+        int32_t &notify_max_degree, uint64_t &notify_tasks_enqueued, uint64_t &fanin_edges_total,
+        int32_t &fanin_max_degree, uint64_t &sched_complete_perf_cycle
 #endif
     ) {
 #if !PTO2_PROFILING
         (void)hank;  // NOLINT(readability/casting)
 #endif
-        CoreTracker& tracker = core_trackers_[thread_idx];
+        CoreTracker &tracker = core_trackers_[thread_idx];
         auto running_core_states = tracker.get_running_cores<CT>();
         while (running_core_states.has_value()) {
             int32_t bit_pos = running_core_states.pop_first();
             int32_t core_id = tracker.get_core_id_by_offset(bit_pos);
-            CoreExecState& core_exec_state = core_exec_states_[core_id];
+            CoreExecState &core_exec_state = core_exec_states_[core_id];
             uint64_t reg_addr = core_exec_state.reg_addr;
 
             int32_t expected_reg_task_id = core_exec_state.executing_reg_task_id;
@@ -398,7 +389,7 @@ struct AicpuExecutor {
 
             if (done) {
                 core_exec_state.executing_reg_task_id = AICPU_TASK_INVALID;
-                PTO2TaskSlotState& slot_state = *core_exec_state.executing_slot_state;
+                PTO2TaskSlotState &slot_state = *core_exec_state.executing_slot_state;
 
                 // Completion: increment atomic counter, trigger task-level completion on last subtask
                 bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state);
@@ -423,7 +414,8 @@ struct AicpuExecutor {
                         while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
                             int32_t fe = rt->scheduler.on_task_release(
-                                *deferred_release_slot_states[--deferred_release_count], thread_idx);
+                                *deferred_release_slot_states[--deferred_release_count], thread_idx
+                            );
 #else
                             int32_t fe =
                                 rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
@@ -443,32 +435,29 @@ struct AicpuExecutor {
 #if PTO2_SCHED_PROFILING
                     uint64_t t_perf_start = get_sys_cnt_aicpu();
 #endif
-                    Handshake* h = &hank[core_id];
+                    Handshake *h = &hank[core_id];
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
+                    PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
 
                     // Pre-extract fanout (platform layer cannot depend on PTO2DepListEntry)
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     int32_t fanout_n = 0;
-                    PTO2DepListEntry* cur = slot_state.fanout_head;
+                    PTO2DepListEntry *cur = slot_state.fanout_head;
                     while (cur != nullptr && fanout_n < RUNTIME_MAX_FANOUT) {
                         fanout_arr[fanout_n++] = cur->slot_state->task->task_id.raw;
                         cur = cur->next;
                     }
 
                     int32_t perf_slot_idx = static_cast<int32_t>(core_exec_state.executing_subslot);
-                    if (perf_aicpu_complete_record(perf_buf,
-                            static_cast<uint32_t>(expected_reg_task_id),
-                            slot_state.task->task_id.raw,
-                            slot_state.task->kernel_id[perf_slot_idx],
-                            CT,
-                            core_exec_state.dispatch_timestamp,
-                            finish_ts,
-                            fanout_arr,
-                            fanout_n) != 0) {
-                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task 0x%" PRIx64,
-                            core_id,
-                            static_cast<uint64_t>(slot_state.task->task_id.raw));
+                    if (perf_aicpu_complete_record(
+                            perf_buf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
+                            slot_state.task->kernel_id[perf_slot_idx], CT, core_exec_state.dispatch_timestamp,
+                            finish_ts, fanout_arr, fanout_n
+                        ) != 0) {
+                        DEV_ERROR(
+                            "Core %d: perf_aicpu_complete_record failed for task 0x%" PRIx64, core_id,
+                            static_cast<uint64_t>(slot_state.task->task_id.raw)
+                        );
                     }
 #if PTO2_SCHED_PROFILING
                     sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
@@ -476,12 +465,10 @@ struct AicpuExecutor {
                 }
 #endif
 
-                DEV_DEBUG("Thread %d: %s core %d completed PTO2 task %d (mixed_complete=%d)",
-                    thread_idx,
-                    CT == CoreType::AIC ? "AIC" : "AIV",
-                    core_id,
-                    expected_reg_task_id,
-                    mixed_complete ? 1 : 0);
+                DEV_DEBUG(
+                    "Thread %d: %s core %d completed PTO2 task %d (mixed_complete=%d)", thread_idx,
+                    CT == CoreType::AIC ? "AIC" : "AIV", core_id, expected_reg_task_id, mixed_complete ? 1 : 0
+                );
                 cur_thread_completed++;
                 if (mixed_complete) {
                     completed_this_turn++;
@@ -491,14 +478,14 @@ struct AicpuExecutor {
         }
     }
 
-    static const char* shape_name(PTO2ResourceShape shape) {
+    static const char *shape_name(PTO2ResourceShape shape) {
         switch (shape) {
-            case PTO2ResourceShape::AIC:
-                return "AIC";
-            case PTO2ResourceShape::AIV:
-                return "AIV";
-            case PTO2ResourceShape::MIX:
-                return "MIX";
+        case PTO2ResourceShape::AIC:
+            return "AIC";
+        case PTO2ResourceShape::AIV:
+            return "AIV";
+        case PTO2ResourceShape::MIX:
+            return "MIX";
         }
         return "UNKNOWN";
     }
@@ -509,7 +496,7 @@ struct AicpuExecutor {
      * Even/odd threads use different fallback orders (AIC-first vs AIV-first)
      * to reduce contention on the same ready queue across adjacent threads.
      */
-    static const PTO2ResourceShape* get_dispatch_order(int32_t thread_idx) {
+    static const PTO2ResourceShape *get_dispatch_order(int32_t thread_idx) {
         // Even threads: AIC-first fallback after widest
         static constexpr PTO2ResourceShape kEvenOrder[PTO2_NUM_RESOURCE_SHAPES] = {
             PTO2ResourceShape::MIX,
@@ -525,30 +512,22 @@ struct AicpuExecutor {
         return (thread_idx % 2 == 0) ? kEvenOrder : kOddOrder;
     }
 
-    int pop_ready_tasks_batch(PTO2ResourceShape shape,
-        int32_t thread_idx,
-        PTO2LocalReadyBuffer& local_buf,
-        PTO2TaskSlotState** out,
+    int pop_ready_tasks_batch(
+        PTO2ResourceShape shape, int32_t thread_idx, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out,
         int max_count
 #if PTO2_SCHED_PROFILING
         ,
-        uint64_t& pop_hit,
-        uint64_t& pop_miss,
-        uint64_t& local_dispatch_count,
-        uint64_t& sched_dispatch_pop_cycle
+        uint64_t &pop_hit, uint64_t &pop_miss, uint64_t &local_dispatch_count, uint64_t &sched_dispatch_pop_cycle
 #endif
     ) {
         (void)thread_idx;  // NOLINT(readability/casting)
 #if PTO2_SCHED_PROFILING
         extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
         uint64_t t_pop_start = get_sys_cnt_aicpu();
-        int count = rt->scheduler.get_ready_tasks_batch(shape,
-            local_buf,
-            out,
-            max_count,
-            g_sched_pop_atomic_count[thread_idx],
-            g_sched_pop_wait_cycle[thread_idx],
-            local_dispatch_count);
+        int count = rt->scheduler.get_ready_tasks_batch(
+            shape, local_buf, out, max_count, g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx],
+            local_dispatch_count
+        );
         sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
         if (count > 0) {
             pop_hit += count;
@@ -572,12 +551,12 @@ struct AicpuExecutor {
      * GlobalContext (sub_block_id) is NOT written here — it is initialized once
      * at runtime startup by init_global_context().
      */
-    void build_payload(PTO2DispatchPayload& dispatch_payload, PTO2TaskSlotState& slot_state, PTO2SubtaskSlot subslot) {
+    void build_payload(PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot) {
         int32_t slot_idx = static_cast<int32_t>(subslot);
         uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
-        const CoreCallable* callable = reinterpret_cast<const CoreCallable*>(callable_addr);
+        const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
         dispatch_payload.function_bin_addr = callable->resolved_addr();
-        auto& payload = *slot_state.payload;
+        auto &payload = *slot_state.payload;
         int n = 0;
         for (int32_t i = 0; i < payload.tensor_count; i++) {
             dispatch_payload.args[n++] = reinterpret_cast<uint64_t>(&payload.tensors[i]);
@@ -595,23 +574,21 @@ struct AicpuExecutor {
         dispatch_payload.args[SPMD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.global_context);
     }
 
-    void dispatch_subtask_to_core(Runtime* runtime,
-        int32_t thread_idx,
-        int32_t core_offset,
-        PTO2TaskSlotState& slot_state,
+    void dispatch_subtask_to_core(
+        Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,
         PTO2SubtaskSlot subslot
 #if PTO2_PROFILING
         ,
         bool profiling_enabled
 #endif
     ) {
-        CoreTracker& tracker = core_trackers_[thread_idx];
+        CoreTracker &tracker = core_trackers_[thread_idx];
         auto core_id = tracker.get_core_id_by_offset(core_offset);
 #if !PTO2_PROFILING
         (void)runtime;  // NOLINT(readability/casting)
 #endif
-        CoreExecState& core_exec_state = core_exec_states_[core_id];
-        PTO2DispatchPayload& payload = s_pto2_payload_per_core[core_id];
+        CoreExecState &core_exec_state = core_exec_states_[core_id];
+        PTO2DispatchPayload &payload = s_pto2_payload_per_core[core_id];
         build_payload(payload, slot_state, subslot);
         core_exec_state.executing_subslot = subslot;
         core_exec_state.executing_slot_state = &slot_state;
@@ -654,8 +631,8 @@ static AicpuExecutor g_aicpu_executor;
  * Handshake with all cores and discover their types
  * Sets up register addresses for fast dispatch.
  */
-int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+int32_t AicpuExecutor::handshake_all_cores(Runtime *runtime) {
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     cores_total_num_ = runtime->worker_count;
 
     // Validate cores_total_num_ before using as array index
@@ -684,33 +661,31 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     // Step 2: Wait for all cores to respond, collect core type and register addresses
     bool handshake_failed = false;
     for (int32_t i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_handshakes[i];
+        Handshake *hank = &all_handshakes[i];
 
-        while (hank->aicore_regs_ready == 0) {
-        }
+        while (hank->aicore_regs_ready == 0) {}
 
         uint32_t physical_core_id = hank->physical_core_id;
 
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
-            DEV_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                i,
-                physical_core_id,
-                max_physical_cores_count);
+            DEV_ERROR(
+                "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
+                max_physical_cores_count
+            );
             handshake_failed = true;
             continue;
         }
 
         // Get register address using physical_core_id
-        uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
+        uint64_t *regs = reinterpret_cast<uint64_t *>(regs_);
         uint64_t reg_addr = regs[physical_core_id];
 
         // Initialize AICore registers after discovery (first round)
         platform_init_aicore_regs(reg_addr);
         hank->aicpu_regs_ready = 1;
 
-        while (hank->aicore_done == 0) {
-        }
+        while (hank->aicore_done == 0) {}
 
         CoreType type = hank->core_type;
 
@@ -756,11 +731,10 @@ bool AicpuExecutor::assign_cores_to_threads() {
         return false;
     }
 
-    DEV_INFO("Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)",
-        cluster_count,
-        divisor,
-        aic_count_,
-        aiv_count_);
+    DEV_INFO(
+        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count, divisor,
+        aic_count_, aiv_count_
+    );
 
     for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
         core_exec_states_[i].executing_reg_task_id = AICPU_TASK_INVALID;
@@ -787,7 +761,7 @@ bool AicpuExecutor::assign_cores_to_threads() {
 
     for (int32_t ci = 0; ci < cluster_count; ci++) {
         int32_t t = ci % divisor;
-        int32_t& idx = core_idx[t];
+        int32_t &idx = core_idx[t];
 
         int32_t aic_wid = aic_worker_ids_[ci];
         int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
@@ -874,16 +848,14 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
     for (int32_t t = 0; t < thread_num_; t++) {
         int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
         int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
-        DEV_INFO("  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)",
-            t,
-            core_count_per_thread_[t],
-            core_trackers_[t].get_cluster_count(),
-            aic_running,
-            aiv_running);
+        DEV_INFO(
+            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_count_per_thread_[t],
+            core_trackers_[t].get_cluster_count(), aic_running, aiv_running
+        );
     }
 }
 
-int32_t AicpuExecutor::init(Runtime* runtime) {
+int32_t AicpuExecutor::init(Runtime *runtime) {
     bool expected = false;
     if (!initialized_.compare_exchange_strong(expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
         return 0;
@@ -909,7 +881,8 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
     if (!orch_to_sched_ && sched_thread_num_ == 0) {
         DEV_ERROR(
             "no scheduler and orch not trans to schedulers when finished, maybe you need set env PTO2_ORCH_TO_SCHED=1 "
-            "or scale down orch number.");
+            "or scale down orch number."
+        );
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -941,7 +914,7 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
     // Initialize runtime execution state
     // Task count comes from PTO2 shared memory
     if (runtime->get_pto2_gm_sm_ptr()) {
-        auto* header = static_cast<PTO2SharedMemoryHeader*>(runtime->get_pto2_gm_sm_ptr());
+        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_pto2_gm_sm_ptr());
         int32_t pto2_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
@@ -964,7 +937,7 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
     // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
     // This is done once at startup and never modified afterwards.
     for (int32_t t = 0; t < sched_thread_num_; t++) {
-        CoreTracker& tracker = core_trackers_[t];
+        CoreTracker &tracker = core_trackers_[t];
         for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
             int32_t cluster_offset = c * 3;  // Each cluster = 1 AIC + 2 AIV
             auto aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
@@ -987,7 +960,8 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
 int32_t AicpuExecutor::shutdown_aicore(
-    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num) {
+    Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num
+) {
     (void)runtime;  // NOLINT(readability/casting)
     if (core_num == 0) return 0;
 
@@ -1006,30 +980,30 @@ int32_t AicpuExecutor::shutdown_aicore(
     return 0;
 }
 
-int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx) {
-    int32_t& core_num = core_count_per_thread_[thread_idx];
-    CoreTracker& tracker = core_trackers_[thread_idx];
+int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t thread_idx) {
+    int32_t &core_num = core_count_per_thread_[thread_idx];
+    CoreTracker &tracker = core_trackers_[thread_idx];
     DEV_INFO("Thread %d: resolve_and_dispatch_pto2 entry", thread_idx);
 
-    void* sm_base = runtime->get_pto2_gm_sm_ptr();
+    void *sm_base = runtime->get_pto2_gm_sm_ptr();
     if (!sm_base) {
         DEV_ERROR("PTO2 dispatch: sm_base is null");
         return -1;
     }
     DEV_INFO("Thread %d: sm_base=%p", thread_idx, sm_base);
 
-    PTO2SharedMemoryHeader* header = static_cast<PTO2SharedMemoryHeader*>(sm_base);
-    DEV_INFO("Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu",
-        thread_idx,
-        static_cast<void*>(header),
+    PTO2SharedMemoryHeader *header = static_cast<PTO2SharedMemoryHeader *>(sm_base);
+    DEV_INFO(
+        "Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu", thread_idx, static_cast<void *>(header),
         static_cast<uint64_t>(header->rings[0].task_descriptors_offset),
-        static_cast<uint64_t>(header->rings[0].task_window_size));
+        static_cast<uint64_t>(header->rings[0].task_window_size)
+    );
 
-    Handshake* hank = static_cast<Handshake*>(runtime->workers);
-    DEV_INFO("Thread %d: hank=%p, window_size=%lu",
-        thread_idx,
-        static_cast<void*>(hank),
-        static_cast<uint64_t>(header->rings[0].task_window_size));
+    Handshake *hank = static_cast<Handshake *>(runtime->workers);
+    DEV_INFO(
+        "Thread %d: hank=%p, window_size=%lu", thread_idx, static_cast<void *>(hank),
+        static_cast<uint64_t>(header->rings[0].task_window_size)
+    );
 
     // One-time init: assign perf buffers (one thread does it; others wait)
     if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
@@ -1092,12 +1066,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     // Local-first dispatch buffers (stack-allocated, one per CoreType per scheduling thread).
     // Initialized once; must be empty at the start of each iteration.
     constexpr int LOCAL_READY_CAP_PER_TYPE = 64;
-    PTO2TaskSlotState* local_ptrs[PTO2_NUM_RESOURCE_SHAPES][LOCAL_READY_CAP_PER_TYPE];
+    PTO2TaskSlotState *local_ptrs[PTO2_NUM_RESOURCE_SHAPES][LOCAL_READY_CAP_PER_TYPE];
     PTO2LocalReadyBuffer local_bufs[PTO2_NUM_RESOURCE_SHAPES];
     for (int32_t i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         local_bufs[i].reset(local_ptrs[i], LOCAL_READY_CAP_PER_TYPE);
     }
-    PTO2TaskSlotState* deferred_release_slot_states[256];
+    PTO2TaskSlotState *deferred_release_slot_states[256];
     int32_t deferred_release_count = 0;
 
     bool cores_released = false;
@@ -1123,10 +1097,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     DEV_ERROR(
                         "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
                         "completed_tasks=%d, total_tasks=%d",
-                        thread_idx,
-                        orch_err,
-                        completed_tasks_.load(std::memory_order_relaxed),
-                        total_tasks_);
+                        thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
+                    );
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1136,10 +1108,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 task_count = total_tasks_;
                 if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
                     completed_.store(true, std::memory_order_release);
-                    DEV_INFO("Thread %d: PTO2 completed tasks %d/%d",
-                        thread_idx,
-                        completed_tasks_.load(std::memory_order_relaxed),
-                        task_count);
+                    DEV_INFO(
+                        "Thread %d: PTO2 completed tasks %d/%d", thread_idx,
+                        completed_tasks_.load(std::memory_order_relaxed), task_count
+                    );
                     break;
                 }
             }
@@ -1177,29 +1149,17 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         bool try_completed = false;
         if (tracker.has_running_cores<CoreType::AIC>()) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIC>(thread_idx,
-                hank,
-                completed_this_turn,
-                cur_thread_completed,
-                made_progress,
-                deferred_release_slot_states,
-                deferred_release_count,
-                local_bufs
+            check_running_cores_for_completion<CoreType::AIC>(
+                thread_idx, hank, completed_this_turn, cur_thread_completed, made_progress,
+                deferred_release_slot_states, deferred_release_count, local_bufs
 #if PTO2_PROFILING
                 ,
-                profiling_enabled,
-                phase_complete_count
+                profiling_enabled, phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
                 ,
-                complete_probe_count,
-                complete_hit_count,
-                notify_edges_total,
-                notify_max_degree,
-                notify_tasks_enqueued,
-                fanin_edges_total,
-                fanin_max_degree,
-                sched_complete_perf_cycle
+                complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
 #endif
             );
         }
@@ -1207,29 +1167,17 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Check AIV running cores
         if (tracker.has_running_cores<CoreType::AIV>()) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIV>(thread_idx,
-                hank,
-                completed_this_turn,
-                cur_thread_completed,
-                made_progress,
-                deferred_release_slot_states,
-                deferred_release_count,
-                local_bufs
+            check_running_cores_for_completion<CoreType::AIV>(
+                thread_idx, hank, completed_this_turn, cur_thread_completed, made_progress,
+                deferred_release_slot_states, deferred_release_count, local_bufs
 #if PTO2_PROFILING
                 ,
-                profiling_enabled,
-                phase_complete_count
+                profiling_enabled, phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
                 ,
-                complete_probe_count,
-                complete_hit_count,
-                notify_edges_total,
-                notify_max_degree,
-                notify_tasks_enqueued,
-                fanin_edges_total,
-                fanin_max_degree,
-                sched_complete_perf_cycle
+                complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
 #endif
             );
         }
@@ -1243,10 +1191,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             if (thread_idx == 0 && task_count > 0) {
                 if (new_total <= PROGRESS_VERBOSE_THRESHOLD ||
                     new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL || new_total >= task_count) {
-                    DEV_ALWAYS("PTO2 progress: completed=%d total=%d (%.1f%%)",
-                        new_total,
-                        task_count,
-                        100.0 * new_total / task_count);
+                    DEV_ALWAYS(
+                        "PTO2 progress: completed=%d total=%d (%.1f%%)", new_total, task_count,
+                        100.0 * new_total / task_count
+                    );
                 }
             }
         }
@@ -1258,7 +1206,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             CYCLE_COUNT_LAP(sched_complete_cycle);
             if (profiling_enabled && phase_complete_count > 0) {
                 perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, sched_loop_count, phase_complete_count);
+                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, sched_loop_count, phase_complete_count
+                );
                 _t0_phase = _t1;
                 phase_complete_count = 0;
             }
@@ -1266,35 +1215,29 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #endif
 
         bool try_pushed = false;
-        const PTO2ResourceShape* dispatch_order = get_dispatch_order(thread_idx);
+        const PTO2ResourceShape *dispatch_order = get_dispatch_order(thread_idx);
         for (int32_t si = 0; si < PTO2_NUM_RESOURCE_SHAPES; si++) {
             PTO2ResourceShape shape = dispatch_order[si];
             auto valid_cluster_states = tracker.get_valid_cluster_offset_states(shape);
             if (!valid_cluster_states.has_value()) {
                 continue;
             }
-            auto& local_buf = local_bufs[static_cast<int32_t>(shape)];
+            auto &local_buf = local_bufs[static_cast<int32_t>(shape)];
 
             while (valid_cluster_states.has_value()) {
                 int want = valid_cluster_states.count();
-                PTO2TaskSlotState* batch[CoreTracker::MAX_CLUSTERS];
-                int got = pop_ready_tasks_batch(shape,
-                    thread_idx,
-                    local_buf,
-                    batch,
-                    want
+                PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS];
+                int got = pop_ready_tasks_batch(
+                    shape, thread_idx, local_buf, batch, want
 #if PTO2_SCHED_PROFILING
                     ,
-                    pop_hit,
-                    pop_miss,
-                    local_dispatch_count,
-                    sched_dispatch_pop_cycle
+                    pop_hit, pop_miss, local_dispatch_count, sched_dispatch_pop_cycle
 #endif
                 );
                 if (got == 0) break;
 
                 for (int bi = 0; bi < got; bi++) {
-                    PTO2TaskSlotState* slot_state = batch[bi];
+                    PTO2TaskSlotState *slot_state = batch[bi];
                     try_pushed = true;
 #if PTO2_SCHED_PROFILING
                     uint64_t t_setup_start = get_sys_cnt_aicpu();
@@ -1307,11 +1250,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                             // Full-cluster: all active subtasks share the same block_idx.
                             uint8_t mask = slot_state->active_mask;
                             if (mask & PTO2_SUBTASK_MASK_AIC) {
-                                dispatch_subtask_to_core(runtime,
-                                    thread_idx,
-                                    tracker.get_aic_core_offset(current_valid_cluster_offset),
-                                    *slot_state,
-                                    PTO2SubtaskSlot::AIC
+                                dispatch_subtask_to_core(
+                                    runtime, thread_idx, tracker.get_aic_core_offset(current_valid_cluster_offset),
+                                    *slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                                     ,
                                     profiling_enabled
@@ -1319,11 +1260,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                                 );
                             }
                             if (mask & PTO2_SUBTASK_MASK_AIV0) {
-                                dispatch_subtask_to_core(runtime,
-                                    thread_idx,
-                                    tracker.get_aiv0_core_offset(current_valid_cluster_offset),
-                                    *slot_state,
-                                    PTO2SubtaskSlot::AIV0
+                                dispatch_subtask_to_core(
+                                    runtime, thread_idx, tracker.get_aiv0_core_offset(current_valid_cluster_offset),
+                                    *slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                                     ,
                                     profiling_enabled
@@ -1331,11 +1270,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                                 );
                             }
                             if (mask & PTO2_SUBTASK_MASK_AIV1) {
-                                dispatch_subtask_to_core(runtime,
-                                    thread_idx,
-                                    tracker.get_aiv1_core_offset(current_valid_cluster_offset),
-                                    *slot_state,
-                                    PTO2SubtaskSlot::AIV1
+                                dispatch_subtask_to_core(
+                                    runtime, thread_idx, tracker.get_aiv1_core_offset(current_valid_cluster_offset),
+                                    *slot_state, PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
                                     ,
                                     profiling_enabled
@@ -1344,11 +1281,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                             }
                             slot_state->next_block_idx++;
                         } else if (shape == PTO2ResourceShape::AIC) {
-                            dispatch_subtask_to_core(runtime,
-                                thread_idx,
-                                tracker.get_aic_core_offset(current_valid_cluster_offset),
-                                *slot_state,
-                                PTO2SubtaskSlot::AIC
+                            dispatch_subtask_to_core(
+                                runtime, thread_idx, tracker.get_aic_core_offset(current_valid_cluster_offset),
+                                *slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                                 ,
                                 profiling_enabled
@@ -1356,14 +1291,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                             );
                             slot_state->next_block_idx++;
                         } else {  // shape == PTO2ResourceShape::AIV
-                            auto core_offset = tracker.is_aiv0_core_idle(current_valid_cluster_offset)
-                                                   ? tracker.get_aiv0_core_offset(current_valid_cluster_offset)
-                                                   : tracker.get_aiv1_core_offset(current_valid_cluster_offset);
-                            dispatch_subtask_to_core(runtime,
-                                thread_idx,
-                                core_offset,
-                                *slot_state,
-                                PTO2SubtaskSlot::AIV0
+                            auto core_offset = tracker.is_aiv0_core_idle(current_valid_cluster_offset) ?
+                                                   tracker.get_aiv0_core_offset(current_valid_cluster_offset) :
+                                                   tracker.get_aiv1_core_offset(current_valid_cluster_offset);
+                            dispatch_subtask_to_core(
+                                runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                                 ,
                                 profiling_enabled
@@ -1379,13 +1311,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_PROFILING
                         phase_dispatch_count += __builtin_popcount(slot_state->active_mask);
 #endif
-                        DEV_DEBUG("Thread %d: Dispatched %s task %" PRId64 " block %d/%d to cluster_offset %d",
-                            thread_idx,
-                            shape_name(shape),
-                            static_cast<int64_t>(slot_state->task->task_id.raw),
-                            slot_state->next_block_idx - 1,
-                            slot_state->block_num,
-                            current_valid_cluster_offset);
+                        DEV_DEBUG(
+                            "Thread %d: Dispatched %s task %" PRId64 " block %d/%d to cluster_offset %d", thread_idx,
+                            shape_name(shape), static_cast<int64_t>(slot_state->task->task_id.raw),
+                            slot_state->next_block_idx - 1, slot_state->block_num, current_valid_cluster_offset
+                        );
                     } while (slot_state->next_block_idx < slot_state->block_num && valid_cluster_states.has_value());
 
                     // Re-enqueue only if blocks remain after exhausting local clusters
@@ -1408,8 +1338,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // requeue in global ready queue
         for (int32_t si = 0; si < PTO2_NUM_RESOURCE_SHAPES; si++) {
             PTO2ResourceShape shape = dispatch_order[si];
-            auto& local_buf = local_bufs[static_cast<int32_t>(shape)];
-            auto& ready_queue = rt->scheduler.ready_queues[static_cast<int32_t>(shape)];
+            auto &local_buf = local_bufs[static_cast<int32_t>(shape)];
+            auto &ready_queue = rt->scheduler.ready_queues[static_cast<int32_t>(shape)];
 #if PTO2_SCHED_PROFILING
             local_overflow_count += local_buf.count;
 #endif
@@ -1426,7 +1356,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             CYCLE_COUNT_LAP(sched_dispatch_cycle);
             if (profiling_enabled && phase_dispatch_count > 0) {
                 perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, sched_loop_count, phase_dispatch_count);
+                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, sched_loop_count, phase_dispatch_count
+                );
                 _t0_phase = _t1;
                 phase_dispatch_count = 0;
             }
@@ -1465,9 +1396,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
                 int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
                 if (orch_err != PTO2_ERROR_NONE) {
-                    DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores",
-                        thread_idx,
-                        orch_err);
+                    DEV_ERROR(
+                        "Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx,
+                        orch_err
+                    );
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1476,20 +1408,19 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
             if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
                 int32_t c = completed_tasks_.load(std::memory_order_relaxed);
-                DEV_ALWAYS("PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
-                    idle_iterations,
-                    c,
-                    task_count,
-                    last_progress_count);
+                DEV_ALWAYS(
+                    "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
+                    idle_iterations, c, task_count, last_progress_count
+                );
                 // Scan all task slots to find truly stuck tasks using scheduler state
-                PTO2SchedulerState* sched = &rt->scheduler;
-                PTO2SharedMemoryHeader* sm_header_diag = static_cast<PTO2SharedMemoryHeader*>(sm_base);
+                PTO2SchedulerState *sched = &rt->scheduler;
+                PTO2SharedMemoryHeader *sm_header_diag = static_cast<PTO2SharedMemoryHeader *>(sm_base);
                 int32_t cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
                     int32_t ring_task_count =
                         sm_header_diag->rings[r].fc.current_task_index.load(std::memory_order_relaxed);
                     for (int32_t si = 0; si < ring_task_count; si++) {
-                        PTO2TaskSlotState& slot_state = sched->get_slot_state(r, si);
+                        PTO2TaskSlotState &slot_state = sched->get_slot_state(r, si);
                         PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
                         int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
                         int32_t fi = slot_state.fanin_count;
@@ -1507,12 +1438,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                                 DEV_ALWAYS(
                                     "  STUCK-READY  ring=%d task_id=%" PRId64
                                     " kernel_id=%d refcount=%d fanin=%d state=%d",  // NOLINT(whitespace/line_length)
-                                    r,
-                                    static_cast<int64_t>(slot_state.task->task_id.raw),
-                                    kid,
-                                    rc,
-                                    fi,
-                                    static_cast<int32_t>(st));
+                                    r, static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi,
+                                    static_cast<int32_t>(st)
+                                );
                             }
                         } else {
                             cnt_waiting++;
@@ -1520,30 +1448,24 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                                 DEV_ALWAYS(
                                     "  STUCK-WAIT   ring=%d task_id=%" PRId64
                                     " kernel_id=%d refcount=%d fanin=%d state=%d",  // NOLINT(whitespace/line_length)
-                                    r,
-                                    static_cast<int64_t>(slot_state.task->task_id.raw),
-                                    kid,
-                                    rc,
-                                    fi,
-                                    static_cast<int32_t>(st));
+                                    r, static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi,
+                                    static_cast<int32_t>(st)
+                                );
                             }
                         }
                     }
                 }
-                DEV_ALWAYS("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d",
-                    cnt_ready,
-                    cnt_waiting,
-                    cnt_inflight);
+                DEV_ALWAYS(
+                    "  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight
+                );
                 // Log this thread's dispatch state
                 int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
                 int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
                 int32_t total_running = aic_running + aiv_running;
-                DEV_ALWAYS("  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d",
-                    thread_idx,
-                    total_running,
-                    aic_running,
-                    aiv_running,
-                    core_num);
+                DEV_ALWAYS(
+                    "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running,
+                    aiv_running, core_num
+                );
                 // Dump running cores
                 auto all_running = tracker.get_all_running_cores();
                 int32_t dump_count = 0;
@@ -1558,25 +1480,21 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         hw_kernel = core_exec_states_[cid].executing_slot_state->task->kernel_id[diag_slot];
                     }
                     uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
-                    DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
-                        cid,
-                        static_cast<unsigned>(cond_reg),
-                        EXTRACT_TASK_STATE(cond_reg),
-                        EXTRACT_TASK_ID(cond_reg),
-                        sw_tid,
-                        hw_kernel);
+                    DEV_ALWAYS(
+                        "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid,
+                        static_cast<unsigned>(cond_reg), EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
+                        sw_tid, hw_kernel
+                    );
                 }
                 // Dump cluster state
                 for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
                     int32_t offset = cli * 3;
-                    DEV_ALWAYS("    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)",
-                        cli,
-                        tracker.get_aic_core_id(offset),
-                        tracker.is_aic_core_idle(offset) ? "idle" : "busy",
-                        tracker.get_aiv0_core_id(offset),
-                        tracker.is_aiv0_core_idle(offset) ? "idle" : "busy",
-                        tracker.get_aiv1_core_id(offset),
-                        tracker.is_aiv1_core_idle(offset) ? "idle" : "busy");
+                    DEV_ALWAYS(
+                        "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
+                        tracker.is_aic_core_idle(offset) ? "idle" : "busy", tracker.get_aiv0_core_id(offset),
+                        tracker.is_aiv0_core_idle(offset) ? "idle" : "busy", tracker.get_aiv1_core_id(offset),
+                        tracker.is_aiv1_core_idle(offset) ? "idle" : "busy"
+                    );
                 }
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
@@ -1584,11 +1502,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_PROFILING
                 // Benchmark: scheduler lifetime end timestamp on timeout path
                 uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
-                DEV_ALWAYS("Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus",
-                    thread_idx,
-                    static_cast<uint64_t>(sched_start_ts),
-                    static_cast<uint64_t>(sched_timeout_ts),
-                    cycles_to_us(sched_timeout_ts - sched_start_ts));
+                DEV_ALWAYS(
+                    "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+                    static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_timeout_ts),
+                    cycles_to_us(sched_timeout_ts - sched_start_ts)
+                );
 #endif
                 return -1;
             } else {
@@ -1607,11 +1525,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_PROFILING
     // Record sched_end before any DEV_ALWAYS to avoid init cost contamination
     uint64_t sched_end_ts = get_sys_cnt_aicpu();
-    DEV_ALWAYS("Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus",
-        thread_idx,
-        static_cast<uint64_t>(sched_start_ts),
-        static_cast<uint64_t>(sched_end_ts),
-        cycles_to_us(sched_end_ts - sched_start_ts));
+    DEV_ALWAYS(
+        "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+        static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_end_ts),
+        cycles_to_us(sched_end_ts - sched_start_ts)
+    );
 
     // Scheduler summary logging (always print when PTO2_PROFILING=1)
     uint64_t sched_total = sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
@@ -1622,143 +1540,131 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     {
         PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
         uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
-        uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle)
-                                     ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle)
-                                     : 0;
-        uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle)
-                                     ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle)
-                                     : 0;
+        uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle) ?
+                                     (sched_complete_cycle - otc_total - sched_complete_perf_cycle) :
+                                     0;
+        uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle) ?
+                                     (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) :
+                                     0;
 
-        DEV_ALWAYS("Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===",
-            thread_idx,
-            cycles_to_us(sched_total),
-            cur_thread_completed);
+        DEV_ALWAYS(
+            "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
+            cycles_to_us(sched_total), cur_thread_completed
+        );
 
         // Level 1: complete
         double notify_avg =
             cur_thread_completed > 0 ? static_cast<double>(notify_edges_total) / cur_thread_completed : 0.0;
         double fanin_avg =
             cur_thread_completed > 0 ? static_cast<double>(fanin_edges_total) / cur_thread_completed : 0.0;
-        DEV_ALWAYS("Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
-                   ", max_degree=%d, avg=%.1f]  [fanin: "  // NOLINT(whitespace/line_length)
-                   "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
-            thread_idx,
-            cycles_to_us(sched_complete_cycle),
-            sched_complete_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(notify_edges_total),
-            notify_max_degree,
-            notify_avg,
-            static_cast<uint64_t>(fanin_edges_total),
-            fanin_max_degree,
-            fanin_avg);
+        DEV_ALWAYS(
+            "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
+            ", max_degree=%d, avg=%.1f]  [fanin: "  // NOLINT(whitespace/line_length)
+            "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
+            thread_idx, cycles_to_us(sched_complete_cycle), sched_complete_cycle * 100.0 / sched_total,
+            static_cast<uint64_t>(notify_edges_total), notify_max_degree, notify_avg,
+            static_cast<uint64_t>(fanin_edges_total), fanin_max_degree, fanin_avg
+        );
 
         // Level 2: complete sub-phases (percentage relative to complete)
         uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
         uint64_t complete_miss_count =
             (complete_probe_count > complete_hit_count) ? (complete_probe_count - complete_hit_count) : 0;
         double complete_hit_rate = complete_probe_count > 0 ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
-        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
-            thread_idx,
-            cycles_to_us(complete_poll),
-            complete_poll * 100.0 / c_parent,
-            static_cast<uint64_t>(complete_hit_count),
-            static_cast<uint64_t>(complete_miss_count),
-            complete_hit_rate);
-        DEV_ALWAYS("Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.lock_cycle),
-            sp.lock_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle),
-            cycles_to_us(sp.lock_wait_cycle),
-            static_cast<uint64_t>(sp.lock_atomic_count));
-        DEV_ALWAYS("Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.fanout_cycle),
-            sp.fanout_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle),
-            cycles_to_us(sp.push_wait_cycle),
-            static_cast<uint64_t>(sp.fanout_atomic_count));
-        DEV_ALWAYS("Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.fanin_cycle),
-            sp.fanin_cycle * 100.0 / c_parent,
-            static_cast<uint64_t>(sp.fanin_atomic_count));
-        DEV_ALWAYS("Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.self_consumed_cycle),
-            sp.self_consumed_cycle * 100.0 / c_parent,
-            static_cast<uint64_t>(sp.self_atomic_count));
-        DEV_ALWAYS("Thread %d:     perf         : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_complete_perf_cycle),
-            sched_complete_perf_cycle * 100.0 / c_parent);
+        DEV_ALWAYS(
+            "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
+            thread_idx, cycles_to_us(complete_poll), complete_poll * 100.0 / c_parent,
+            static_cast<uint64_t>(complete_hit_count), static_cast<uint64_t>(complete_miss_count), complete_hit_rate
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
+            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
+            static_cast<uint64_t>(sp.lock_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
+            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
+            static_cast<uint64_t>(sp.fanout_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.fanin_cycle), sp.fanin_cycle * 100.0 / c_parent,
+            static_cast<uint64_t>(sp.fanin_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.self_consumed_cycle), sp.self_consumed_cycle * 100.0 / c_parent,
+            static_cast<uint64_t>(sp.self_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_complete_perf_cycle),
+            sched_complete_perf_cycle * 100.0 / c_parent
+        );
 
         // Level 1: dispatch
         uint64_t pop_total = pop_hit + pop_miss;
         double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
-        DEV_ALWAYS("Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64
-                   ", hit_rate=%.1f%%]",  // NOLINT(whitespace/line_length)
-            thread_idx,
-            cycles_to_us(sched_dispatch_cycle),
-            sched_dispatch_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(pop_hit),
-            static_cast<uint64_t>(pop_miss),
-            pop_hit_rate);
+        DEV_ALWAYS(
+            "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64
+            ", hit_rate=%.1f%%]",  // NOLINT(whitespace/line_length)
+            thread_idx, cycles_to_us(sched_dispatch_cycle), sched_dispatch_cycle * 100.0 / sched_total,
+            static_cast<uint64_t>(pop_hit), static_cast<uint64_t>(pop_miss), pop_hit_rate
+        );
         uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
         uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
         double local_hit_rate = total_dispatched > 0 ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
-        DEV_ALWAYS("Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
-                   ", local_rate=%.1f%%",  // NOLINT(whitespace/line_length)
-            thread_idx,
-            static_cast<uint64_t>(local_dispatch_count),
-            static_cast<uint64_t>(global_dispatch_count),
-            static_cast<uint64_t>(local_overflow_count),
-            local_hit_rate);
+        DEV_ALWAYS(
+            "Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
+            ", local_rate=%.1f%%",  // NOLINT(whitespace/line_length)
+            thread_idx, static_cast<uint64_t>(local_dispatch_count), static_cast<uint64_t>(global_dispatch_count),
+            static_cast<uint64_t>(local_overflow_count), local_hit_rate
+        );
 
         // Level 2: dispatch sub-phases (percentage relative to dispatch)
         uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
-        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(dispatch_poll),
-            dispatch_poll * 100.0 / d_parent);
-        DEV_ALWAYS("Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sched_dispatch_pop_cycle),
-            sched_dispatch_pop_cycle * 100.0 / d_parent,
-            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle),
-            cycles_to_us(sp.pop_wait_cycle),
-            static_cast<uint64_t>(sp.pop_atomic_count));
-        DEV_ALWAYS("Thread %d:     setup        : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_dispatch_setup_cycle),
-            sched_dispatch_setup_cycle * 100.0 / d_parent);
+        DEV_ALWAYS(
+            "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
+            dispatch_poll * 100.0 / d_parent
+        );
+        DEV_ALWAYS(
+            "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sched_dispatch_pop_cycle), sched_dispatch_pop_cycle * 100.0 / d_parent,
+            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+            static_cast<uint64_t>(sp.pop_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
+            sched_dispatch_setup_cycle * 100.0 / d_parent
+        );
 
         // Level 1: scan
-        DEV_ALWAYS("Thread %d:   scan           : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_scan_cycle),
-            sched_scan_cycle * 100.0 / sched_total);
+        DEV_ALWAYS(
+            "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_scan_cycle),
+            sched_scan_cycle * 100.0 / sched_total
+        );
 
         // Level 1: idle
-        DEV_ALWAYS("Thread %d:   idle           : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_idle_cycle),
-            sched_idle_cycle * 100.0 / sched_total);
+        DEV_ALWAYS(
+            "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_idle_cycle),
+            sched_idle_cycle * 100.0 / sched_total
+        );
 
         // Average per completion
         if (cur_thread_completed > 0) {
-            DEV_ALWAYS("Thread %d:   avg/complete   : %.3fus",
-                thread_idx,
-                cycles_to_us(sched_complete_cycle) / cur_thread_completed);
+            DEV_ALWAYS(
+                "Thread %d:   avg/complete   : %.3fus", thread_idx,
+                cycles_to_us(sched_complete_cycle) / cur_thread_completed
+            );
         }
     }
 #endif
     // Summary line (always print when PTO2_PROFILING=1)
-    DEV_ALWAYS("Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d",
-        thread_idx,
-        cycles_to_us(sched_total),
-        static_cast<uint64_t>(sched_loop_count),
-        cur_thread_completed);
+    DEV_ALWAYS(
+        "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
+        cycles_to_us(sched_total), static_cast<uint64_t>(sched_loop_count), cur_thread_completed
+    );
 #endif
 
 #if PTO2_PROFILING
@@ -1772,7 +1678,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     return cur_thread_completed;
 }
 
-int32_t AicpuExecutor::run(Runtime* runtime) {
+int32_t AicpuExecutor::run(Runtime *runtime) {
     int32_t thread_idx = thread_idx_++;
     DEV_INFO("Thread %d: Start", thread_idx);
 
@@ -1790,7 +1696,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             if (orch_idx == 0) {
                 DEV_INFO("Thread %d: Primary orchestrator, loading SO via dlopen", thread_idx);
 
-                const void* so_data = runtime->get_device_orch_so_data();
+                const void *so_data = runtime->get_device_orch_so_data();
                 size_t so_size = runtime->get_device_orch_so_size();
 
                 if (so_data == nullptr || so_size == 0) {
@@ -1801,27 +1707,26 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 // Try multiple paths that may allow execution on AICPU
                 char so_path[256];
                 bool file_created = false;
-                const char* candidate_dirs[] = {
-                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"};
+                const char *candidate_dirs[] = {
+                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
+                };
                 const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
 
                 for (int32_t i = 0; i < num_candidates && !file_created; i++) {
                     snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
                     int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
                     if (fd < 0) {
-                        DEV_INFO("Thread %d: Cannot create SO at %s (errno=%d), trying next path",
-                            thread_idx,
-                            so_path,
-                            errno);
+                        DEV_INFO(
+                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
                         continue;
                     }
                     ssize_t written = write(fd, so_data, so_size);
                     close(fd);
                     if (written != static_cast<ssize_t>(so_size)) {
-                        DEV_INFO("Thread %d: Cannot write SO to %s (errno=%d), trying next path",
-                            thread_idx,
-                            so_path,
-                            errno);
+                        DEV_INFO(
+                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
                         unlink(so_path);
                         continue;
                     }
@@ -1835,8 +1740,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 }
 
                 dlerror();
-                void* handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
-                const char* dlopen_err = dlerror();
+                void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+                const char *dlopen_err = dlerror();
                 if (handle == nullptr) {
                     DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
                     unlink(so_path);
@@ -1851,7 +1756,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 dlerror();
                 DeviceOrchestrationFunc orch_func =
                     reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
-                const char* dlsym_error = dlerror();
+                const char *dlsym_error = dlerror();
                 if (dlsym_error != nullptr) {
                     DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
                     dlclose(handle);
@@ -1868,29 +1773,27 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 dlerror();
                 auto bind_runtime_func =
                     reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
-                const char* bind_runtime_error = dlerror();
+                const char *bind_runtime_error = dlerror();
                 if (bind_runtime_error != nullptr) {
                     DEV_INFO("Thread %d: Optional TLS runtime binder not found: %s", thread_idx, bind_runtime_error);
                     bind_runtime_func = nullptr;
                 }
 
-                const ChipStorageTaskArgs& args = runtime->get_orch_args();
+                const ChipStorageTaskArgs &args = runtime->get_orch_args();
                 int32_t arg_count = args.tensor_count() + args.scalar_count();
                 DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
                 for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
-                    const ContinuousTensor& t = args.tensor(i);
-                    DEV_INFO("Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)",
-                        thread_idx,
-                        i,
-                        static_cast<uint64_t>(t.data),
-                        t.ndims,
-                        static_cast<unsigned>(t.dtype));
+                    const ContinuousTensor &t = args.tensor(i);
+                    DEV_INFO(
+                        "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
+                        static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
+                    );
                 }
                 for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
-                    DEV_INFO("Thread %d: orch_args[%d] = SCALAR(0x%lx)",
-                        thread_idx,
-                        args.tensor_count() + i,
-                        static_cast<uint64_t>(args.scalar(i)));
+                    DEV_INFO(
+                        "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
+                        static_cast<uint64_t>(args.scalar(i))
+                    );
                 }
 
                 uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
@@ -1921,17 +1824,16 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 if (runtime->pto2_dep_pool_size > 0) {
                     dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
                 }
-                DEV_INFO("Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d",
-                    thread_idx,
-                    static_cast<uint64_t>(task_window_size),
-                    static_cast<uint64_t>(heap_size),
-                    dep_pool_capacity);
+                DEV_INFO(
+                    "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
+                    static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
+                );
 
-                void* sm_ptr = runtime->get_pto2_gm_sm_ptr();
-                void* gm_heap = runtime->get_pto2_gm_heap_ptr();
+                void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
+                void *gm_heap = runtime->get_pto2_gm_heap_ptr();
 
                 uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
-                PTO2SharedMemoryHandle* sm_handle =
+                PTO2SharedMemoryHandle *sm_handle =
                     pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
                 if (!sm_handle) {
                     DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
@@ -1941,7 +1843,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 }
 
                 rt = pto2_runtime_create_from_sm(
-                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity);
+                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity
+                );
                 if (!rt) {
                     DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                     pto2_sm_destroy(sm_handle);
@@ -2023,62 +1926,62 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             uint64_t total =
                 p.sync_cycle + p.alloc_cycle + p.params_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
-            DEV_ALWAYS("Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===",
-                thread_idx,
-                static_cast<int64_t>(p.submit_count),
-                cycles_to_us(total));
-            DEV_ALWAYS("Thread %d:   task+heap_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-                thread_idx,
-                cycles_to_us(p.alloc_cycle),
-                p.alloc_cycle * 100.0 / total,
-                cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle),
-                cycles_to_us(p.alloc_wait_cycle),
-                static_cast<uint64_t>(p.alloc_atomic_count));
-            DEV_ALWAYS("Thread %d:   sync_tensormap : %.3fus (%.1f%%)",
-                thread_idx,
-                cycles_to_us(p.sync_cycle),
-                p.sync_cycle * 100.0 / total);
-            DEV_ALWAYS("Thread %d:   lookup+dep     : %.3fus (%.1f%%)",
-                thread_idx,
-                cycles_to_us(p.lookup_cycle),
-                p.lookup_cycle * 100.0 / total);
-            DEV_ALWAYS("Thread %d:   tensormap_ins  : %.3fus (%.1f%%)",
-                thread_idx,
-                cycles_to_us(p.insert_cycle),
-                p.insert_cycle * 100.0 / total);
-            DEV_ALWAYS("Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "",
-                thread_idx,
-                cycles_to_us(p.params_cycle),
-                p.params_cycle * 100.0 / total,
-                static_cast<uint64_t>(p.params_atomic_count));
-            DEV_ALWAYS("Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-                thread_idx,
-                cycles_to_us(p.fanin_cycle),
-                p.fanin_cycle * 100.0 / total,
-                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle),
-                cycles_to_us(p.fanin_wait_cycle),
-                static_cast<uint64_t>(p.fanin_atomic_count));
-            DEV_ALWAYS("Thread %d:   avg/task       : %.3fus",
-                thread_idx,
-                p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0);
+            DEV_ALWAYS(
+                "Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===", thread_idx,
+                static_cast<int64_t>(p.submit_count), cycles_to_us(total)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   task+heap_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(p.alloc_cycle), p.alloc_cycle * 100.0 / total,
+                cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle), cycles_to_us(p.alloc_wait_cycle),
+                static_cast<uint64_t>(p.alloc_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   sync_tensormap : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.sync_cycle),
+                p.sync_cycle * 100.0 / total
+            );
+            DEV_ALWAYS(
+                "Thread %d:   lookup+dep     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.lookup_cycle),
+                p.lookup_cycle * 100.0 / total
+            );
+            DEV_ALWAYS(
+                "Thread %d:   tensormap_ins  : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.insert_cycle),
+                p.insert_cycle * 100.0 / total
+            );
+            DEV_ALWAYS(
+                "Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+                cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total,
+                static_cast<uint64_t>(p.params_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
+                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
+                static_cast<uint64_t>(p.fanin_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   avg/task       : %.3fus", thread_idx,
+                p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0
+            );
 
 #if PTO2_TENSORMAP_PROFILING
             PTO2TensorMapProfilingData tp = pto2_tensormap_get_profiling();
             DEV_ALWAYS("Thread %d: === TensorMap Lookup Stats ===", thread_idx);
-            DEV_ALWAYS("Thread %d:   lookups        : %" PRIu64 ", inserts: %" PRIu64 "",
-                thread_idx,
-                static_cast<uint64_t>(tp.lookup_count),
-                static_cast<uint64_t>(tp.insert_count));
-            DEV_ALWAYS("Thread %d:   chain walked   : total=%" PRIu64 ", avg=%.1f, max=%d",
-                thread_idx,
+            DEV_ALWAYS(
+                "Thread %d:   lookups        : %" PRIu64 ", inserts: %" PRIu64 "", thread_idx,
+                static_cast<uint64_t>(tp.lookup_count), static_cast<uint64_t>(tp.insert_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   chain walked   : total=%" PRIu64 ", avg=%.1f, max=%d", thread_idx,
                 static_cast<uint64_t>(tp.lookup_chain_total),
                 tp.lookup_count > 0 ? static_cast<double>(tp.lookup_chain_total) / tp.lookup_count : 0.0,
-                tp.lookup_chain_max);
-            DEV_ALWAYS("Thread %d:   overlap checks : %" PRIu64 ", hits=%" PRIu64 " (%.1f%%)",
-                thread_idx,
-                static_cast<uint64_t>(tp.overlap_checks),
-                static_cast<uint64_t>(tp.overlap_hits),
-                tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0);
+                tp.lookup_chain_max
+            );
+            DEV_ALWAYS(
+                "Thread %d:   overlap checks : %" PRIu64 ", hits=%" PRIu64 " (%.1f%%)", thread_idx,
+                static_cast<uint64_t>(tp.overlap_checks), static_cast<uint64_t>(tp.overlap_hits),
+                tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0
+            );
 #endif
 
 #if PTO2_PROFILING
@@ -2105,7 +2008,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             // Write core-to-thread mapping (one-time, after orchestration)
             if (runtime->enable_profiling) {
                 perf_aicpu_write_core_assignments(
-                    core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_);
+                    core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
+                );
                 // Flush orchestrator's phase record buffer
                 perf_aicpu_flush_phase_buffers(thread_idx);
             }
@@ -2117,8 +2021,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 // Last orchestrator: signal completion and trigger core transition
                 pto2_rt_orchestration_done(rt);
 
-                void* sm = runtime->get_pto2_gm_sm_ptr();
-                PTO2SharedMemoryHeader* sm_header = static_cast<PTO2SharedMemoryHeader*>(sm);
+                void *sm = runtime->get_pto2_gm_sm_ptr();
+                PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
                 int32_t pto2_task_count = 0;
                 if (sm_header) {
                     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -2135,10 +2039,10 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 orchestrator_done_ = true;
                 {
                     int32_t orch_err = 0;
-                    void* sm = runtime->get_pto2_gm_sm_ptr();
+                    void *sm = runtime->get_pto2_gm_sm_ptr();
                     if (sm) {
                         orch_err =
-                            static_cast<PTO2SharedMemoryHeader*>(sm)->orch_error_code.load(std::memory_order_relaxed);
+                            static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
                     }
 
                     // Fatal error: shutdown AICore immediately before core transition.
@@ -2166,7 +2070,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     transition_requested_.store(true, std::memory_order_release);
 #if PTO2_PROFILING
                     DEV_ALWAYS(
-                        "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts));
+                        "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
+                    );
 #endif
 
                     // Wait for scheduler threads to acknowledge transition request
@@ -2187,10 +2092,10 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 
 #if PTO2_ORCH_PROFILING
                 uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
-                DEV_ALWAYS("Thread %d: reassign, cost %.3fus (orch_idx=%d)",
-                    thread_idx,
-                    cycles_to_us(reassign_cycle_end - reassign_cycle_start),
-                    orch_idx);
+                DEV_ALWAYS(
+                    "Thread %d: reassign, cost %.3fus (orch_idx=%d)", thread_idx,
+                    cycles_to_us(reassign_cycle_end - reassign_cycle_start), orch_idx
+                );
 #endif
             } else {
                 // Non-last orchestrator: wait for last orchestrator to finish setup
@@ -2209,15 +2114,16 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
         }
 #if PTO2_PROFILING
         uint64_t orch_end_ts = get_sys_cnt_aicpu();
-        DEV_ALWAYS("Thread %d: orch_start=%" PRIu64 " orch_end=%" PRIu64 " orch_cost=%.3fus",
-            thread_idx,
-            static_cast<uint64_t>(orch_cycle_start),
-            static_cast<uint64_t>(orch_end_ts),
-            cycles_to_us(orch_end_ts - orch_cycle_start));
+        DEV_ALWAYS(
+            "Thread %d: orch_start=%" PRIu64 " orch_end=%" PRIu64 " orch_cost=%.3fus", thread_idx,
+            static_cast<uint64_t>(orch_cycle_start), static_cast<uint64_t>(orch_end_ts),
+            cycles_to_us(orch_end_ts - orch_cycle_start)
+        );
         if (pto2_submitted_tasks >= 0) {
-            DEV_ALWAYS("PTO2 total submitted tasks = %d, already executed %d tasks",
-                pto2_submitted_tasks,
-                completed_tasks_.load(std::memory_order_acquire));
+            DEV_ALWAYS(
+                "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_submitted_tasks,
+                completed_tasks_.load(std::memory_order_acquire)
+            );
         }
 #endif
         DEV_INFO("Thread %d: Orchestrator completed (orch_idx=%d)", thread_idx, orch_idx);
@@ -2240,7 +2146,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     // platform_deinit_aicore_regs is idempotent; orchestrator threads have
     // core_count_per_thread_ == 0 so they skip the loop harmlessly.
     {
-        const int32_t* shutdown_cores = core_assignments_[thread_idx];
+        const int32_t *shutdown_cores = core_assignments_[thread_idx];
         int32_t shutdown_count = core_count_per_thread_[thread_idx];
         if (shutdown_count > 0) {
             auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
@@ -2272,7 +2178,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     return 0;
 }
 
-void AicpuExecutor::deinit(Runtime* runtime) {
+void AicpuExecutor::deinit(Runtime *runtime) {
     // 1. Invalidate AICPU cache for Runtime address range.
     //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
     //    bypasses this cache. Invalidating now ensures next round reads from HBM.
@@ -2327,11 +2233,11 @@ void AicpuExecutor::deinit(Runtime* runtime) {
     DEV_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
+void AicpuExecutor::emergency_shutdown(Runtime *runtime) {
     DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     for (int32_t i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_handshakes[i];
+        Handshake *hank = &all_handshakes[i];
         OUT_OF_ORDER_STORE_BARRIER();
         hank->aicpu_regs_ready = 1;
         if (core_exec_states_[i].reg_addr != 0) {
@@ -2343,9 +2249,10 @@ void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
 }
 
 void AicpuExecutor::diagnose_stuck_state(
-    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank) {
+    Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
+) {
     (void)runtime;  // NOLINT(readability/casting)
-    PTO2SchedulerState* sched = &rt->scheduler;
+    PTO2SchedulerState *sched = &rt->scheduler;
     DEV_ALWAYS("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
 
     int32_t completed = completed_tasks_.load(std::memory_order_acquire);
@@ -2366,8 +2273,8 @@ void AicpuExecutor::diagnose_stuck_state(
     DEV_ALWAYS("Core Status:");
     for (int32_t i = 0; i < core_num; i++) {
         int32_t core_id = cur_thread_cores[i];
-        Handshake* h = &hank[core_id];
-        const char* core_type_str = core_type_to_string(h->core_type);
+        Handshake *h = &hank[core_id];
+        const char *core_type_str = core_type_to_string(h->core_type);
 
         uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
         uint64_t reg_val = read_reg(reg_addr, RegId::COND);
@@ -2386,20 +2293,14 @@ void AicpuExecutor::diagnose_stuck_state(
                 DEV_ALWAYS(
                     "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_reg_task_id=%d, "
                     "kernel_id=%d",
-                    core_id,
-                    core_type_str,
-                    reg_val,
-                    reg_task_id,
-                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
-                    task_id,
-                    kernel_id);
+                    core_id, core_type_str, reg_val, reg_task_id, reg_state == TASK_FIN_STATE ? "FIN" : "ACK", task_id,
+                    kernel_id
+                );
             } else {
-                DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked",
-                    core_id,
-                    core_type_str,
-                    reg_val,
-                    reg_task_id,
-                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK");
+                DEV_ALWAYS(
+                    "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked", core_id,
+                    core_type_str, reg_val, reg_task_id, reg_state == TASK_FIN_STATE ? "FIN" : "ACK"
+                );
             }
         } else {
             idle_cores++;
@@ -2436,7 +2337,7 @@ void AicpuExecutor::diagnose_stuck_state(
  * @param runtime Pointer to Runtime structure
  * @return 0 on success, non-zero on error
  */
-extern "C" int32_t aicpu_execute(Runtime* runtime) {
+extern "C" int32_t aicpu_execute(Runtime *runtime) {
     if (runtime == nullptr) {
         DEV_ERROR("%s", "Invalid argument: null Runtime pointer");
         return -1;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -109,9 +109,9 @@ struct LocalContext {
  * Single-AIV tasks have no intra-cluster communication, so sub_block_id
  * has no meaning and should not be used.
  */
-static __aicore__ inline int32_t get_sub_block_id(__gm__ int64_t* args) {
-    __gm__ GlobalContext* ctx =
-        reinterpret_cast<__gm__ GlobalContext*>(static_cast<uint64_t>(args[SPMD_GLOBAL_CONTEXT_INDEX]));
+static __aicore__ inline int32_t get_sub_block_id(__gm__ int64_t *args) {
+    __gm__ GlobalContext *ctx =
+        reinterpret_cast<__gm__ GlobalContext *>(static_cast<uint64_t>(args[SPMD_GLOBAL_CONTEXT_INDEX]));
     return ctx->sub_block_id;
 }
 
@@ -120,9 +120,9 @@ static __aicore__ inline int32_t get_sub_block_id(__gm__ int64_t* args) {
  * Range: [0, get_block_num(args)).
  * Within the same task, different blocks receive different indices.
  */
-static __aicore__ inline int32_t get_block_idx(__gm__ int64_t* args) {
-    __gm__ LocalContext* ctx =
-        reinterpret_cast<__gm__ LocalContext*>(static_cast<uint64_t>(args[SPMD_LOCAL_CONTEXT_INDEX]));
+static __aicore__ inline int32_t get_block_idx(__gm__ int64_t *args) {
+    __gm__ LocalContext *ctx =
+        reinterpret_cast<__gm__ LocalContext *>(static_cast<uint64_t>(args[SPMD_LOCAL_CONTEXT_INDEX]));
     return ctx->block_idx;
 }
 
@@ -134,8 +134,8 @@ static __aicore__ inline int32_t get_block_idx(__gm__ int64_t* args) {
  * Note: this is NOT the same as RUNTIME_CONFIG.block_dim in
  * kernel_config.py, which controls how many physical cores are launched.
  */
-static __aicore__ inline int32_t get_block_num(__gm__ int64_t* args) {
-    __gm__ LocalContext* ctx =
-        reinterpret_cast<__gm__ LocalContext*>(static_cast<uint64_t>(args[SPMD_LOCAL_CONTEXT_INDEX]));
+static __aicore__ inline int32_t get_block_num(__gm__ int64_t *args) {
+    __gm__ LocalContext *ctx =
+        reinterpret_cast<__gm__ LocalContext *>(static_cast<uint64_t>(args[SPMD_LOCAL_CONTEXT_INDEX]));
     return ctx->block_num;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_compile_info.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_compile_info.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "host/platform_compile_info.h"
 #include "host/runtime_compile_info.h"
 #include <string.h>
@@ -14,5 +24,4 @@ ToolchainType get_orchestration_compiler(void) {
     if (strcmp(get_platform(), "a2a3") == 0) return TOOLCHAIN_AARCH64_GXX;
     return TOOLCHAIN_HOST_GXX;
 }
-
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -52,10 +52,10 @@ static int64_t _now_ms() {
  * Parse an environment variable as uint64_t with optional power-of-2 constraint.
  * Returns the parsed value on success, or 0 if unset or validation fails.
  */
-static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool require_power_of_2) {
-    const char* env = std::getenv(name);
+static uint64_t parse_env_uint64(const char *name, uint64_t min_val, bool require_power_of_2) {
+    const char *env = std::getenv(name);
     if (!env) return 0;
-    char* endptr;
+    char *endptr;
     errno = 0;
     uint64_t val = strtoull(env, &endptr, 10);
     if (errno == ERANGE || endptr == env || *endptr != '\0' || val < min_val) {
@@ -85,7 +85,7 @@ static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool requir
  * @param orch_args Separated tensor/scalar arguments
  * @return 0 on success, -1 on failure
  */
-extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args) {
+extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args) {
     // Validate inputs
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -97,10 +97,11 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", callable->child_count());
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
-            const auto& kernel = callable->child(i);
-            uint64_t addr = runtime->host_api.upload_kernel_binary(func_id,
-                reinterpret_cast<const uint8_t*>(&kernel),
-                CoreCallable::binary_data_offset() + kernel.binary_size());
+            const auto &kernel = callable->child(i);
+            uint64_t addr = runtime->host_api.upload_kernel_binary(
+                func_id, reinterpret_cast<const uint8_t *>(&kernel),
+                CoreCallable::binary_data_offset() + kernel.binary_size()
+            );
             if (addr == 0) {
                 LOG_ERROR("Failed to upload kernel binary for func_id=%d", func_id);
                 return -1;
@@ -109,7 +110,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
         }
     }
 
-    const uint8_t* orch_so_binary = static_cast<const uint8_t*>(callable->binary_data());
+    const uint8_t *orch_so_binary = static_cast<const uint8_t *>(callable->binary_data());
     size_t orch_so_size = callable->binary_size();
 
     if (orch_so_binary == nullptr || orch_so_size == 0) {
@@ -135,10 +136,10 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
     for (int i = 0; i < tensor_count; i++) {
         ContinuousTensor t = orch_args->tensor(i);
 
-        void* host_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(t.data));
+        void *host_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(t.data));
         size_t size = static_cast<size_t>(t.nbytes());
 
-        void* dev_ptr = runtime->host_api.device_malloc(size);
+        void *dev_ptr = runtime->host_api.device_malloc(size);
         if (dev_ptr == nullptr) {
             LOG_ERROR("Failed to allocate device memory for tensor %d", i);
             return -1;
@@ -163,7 +164,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
 
     // Copy orchestration SO to device memory (AICPU cannot access host memory)
     int64_t t_so_start = _now_ms();
-    void* dev_so = runtime->host_api.device_malloc(orch_so_size);
+    void *dev_so = runtime->host_api.device_malloc(orch_so_size);
     if (dev_so == nullptr) {
         LOG_ERROR("Failed to allocate device memory for orchestration SO");
         return -1;
@@ -184,17 +185,17 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
 
     // Read ready queue shard count from environment for AICPU scheduler
     {
-        const char* env_shards = std::getenv("PTO2_READY_QUEUE_SHARDS");
+        const char *env_shards = std::getenv("PTO2_READY_QUEUE_SHARDS");
         if (env_shards) {
-            char* endptr;
+            char *endptr;
             int64_t val = strtol(env_shards, &endptr, 10);
             if (endptr != env_shards && *endptr == '\0' && val >= 1 && val <= PLATFORM_MAX_AICPU_THREADS) {
                 runtime->ready_queue_shards = static_cast<int>(val);
             } else {
-                LOG_WARN("PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d",
-                    env_shards,
-                    PLATFORM_MAX_AICPU_THREADS,
-                    RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
+                LOG_WARN(
+                    "PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d", env_shards,
+                    PLATFORM_MAX_AICPU_THREADS, RUNTIME_DEFAULT_READY_QUEUE_SHARDS
+                );
                 runtime->ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
             }
         }
@@ -203,7 +204,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
 
     // Read orchestrator-to-scheduler transition flag from environment
     {
-        const char* env_val = std::getenv("PTO2_ORCH_TO_SCHED");
+        const char *env_val = std::getenv("PTO2_ORCH_TO_SCHED");
         if (env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T')) {
             runtime->orch_to_sched = true;
         }
@@ -216,10 +217,12 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
         runtime->pto2_heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
         runtime->pto2_dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
         if (runtime->pto2_task_window_size || runtime->pto2_heap_size || runtime->pto2_dep_pool_size) {
-            LOG_INFO("Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
+            LOG_INFO(
+                "Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
                 (uint64_t)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE),
                 (uint64_t)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
-                (uint64_t)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE));
+                (uint64_t)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE)
+            );
         }
     }
 
@@ -231,7 +234,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
     // Allocate GM heap for orchestrator output buffers (all rings combined)
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
     int64_t t_heap_start = _now_ms();
-    void* gm_heap = runtime->host_api.device_malloc(total_heap_size);
+    void *gm_heap = runtime->host_api.device_malloc(total_heap_size);
     int64_t t_heap_end = _now_ms();
     if (gm_heap == nullptr) {
         LOG_ERROR("Failed to allocate GM heap");
@@ -243,7 +246,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
     // Allocate PTO2 shared memory
     int64_t t_sm_start = _now_ms();
     uint64_t sm_size = pto2_sm_calculate_size(eff_task_window_size);
-    void* sm_ptr = runtime->host_api.device_malloc(sm_size);
+    void *sm_ptr = runtime->host_api.device_malloc(sm_size);
     int64_t t_sm_end = _now_ms();
     if (sm_ptr == nullptr) {
         LOG_ERROR("Failed to allocate PTO2 shared memory");
@@ -279,7 +282,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime* runtime) {
+extern "C" int validate_runtime_impl(Runtime *runtime) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -290,13 +293,13 @@ extern "C" int validate_runtime_impl(Runtime* runtime) {
     LOG_INFO("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair* tensor_pairs = runtime->get_tensor_pairs();
+    TensorPair *tensor_pairs = runtime->get_tensor_pairs();
     int tensor_pair_count = runtime->get_tensor_pair_count();
 
     LOG_INFO("Tensor pairs to process: %d", tensor_pair_count);
 
     // PTO2 (device orchestration): graph output may be in packed buffer
-    void* pto2_sm = runtime->get_pto2_gm_sm_ptr();
+    void *pto2_sm = runtime->get_pto2_gm_sm_ptr();
     uint64_t graph_out_ptr = 0;
     uint64_t graph_out_size = 0;
 
@@ -317,7 +320,7 @@ extern "C" int validate_runtime_impl(Runtime* runtime) {
 
     bool first_output_tensor = true;
     for (int i = 0; i < tensor_pair_count; i++) {
-        const TensorPair& pair = tensor_pairs[i];
+        const TensorPair &pair = tensor_pairs[i];
 
         // Skip if device pointer is null
         if (pair.dev_ptr == nullptr) {
@@ -331,12 +334,12 @@ extern "C" int validate_runtime_impl(Runtime* runtime) {
             continue;
         }
 
-        void* src_ptr = pair.dev_ptr;
+        void *src_ptr = pair.dev_ptr;
         size_t copy_size = pair.size;
 
         // Use graph_output_ptr for the first output tensor if available
         if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
-            src_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(graph_out_ptr));
+            src_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(graph_out_ptr));
             copy_size = static_cast<size_t>(graph_out_size);
             LOG_INFO("Using packed output buffer for tensor %d", i);
             first_output_tensor = false;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "common.h"
 #include "pto_orchestration_api.h"
 
@@ -19,34 +29,33 @@ namespace {
 // crash (BZ #32412) when the orchestration SO is dlclose'd/re-dlopen'd
 // between execution rounds.  All orchestrator threads bind the same rt
 // value, so per-thread storage is unnecessary.
-PTO2Runtime* g_pto2_current_runtime = nullptr;
-}
+PTO2Runtime *g_pto2_current_runtime = nullptr;
+}  // namespace
 
-extern "C" __attribute__((visibility("default"))) void pto2_framework_bind_runtime(PTO2Runtime* rt) {
+extern "C" __attribute__((visibility("default"))) void pto2_framework_bind_runtime(PTO2Runtime *rt) {
     g_pto2_current_runtime = rt;
 }
 
 // Keep current_runtime local to this .so so orchestration helpers do not
 // accidentally bind to the AICPU binary's same-named symbol.
-extern "C" __attribute__((visibility("hidden"))) PTO2Runtime* pto2_framework_current_runtime() {
+extern "C" __attribute__((visibility("hidden"))) PTO2Runtime *pto2_framework_current_runtime() {
     return g_pto2_current_runtime;
 }
 
 /**
- * 使用 addr2line 将地址转换为 文件:行号 信息
- * 使用 -i 标志展开内联，返回第一行（最内层实际代码位置）
- * 如果存在内联，同时通过 inline_chain 返回外层调用链
+ * Use addr2line to convert an address to file:line information.
+ * Uses the -i flag to expand inlines; returns the first line (innermost actual code location).
+ * If inlining is present, also returns the outer call chain via inline_chain.
  */
 #ifdef __linux__
-static std::string addr_to_line(const char* executable, void* addr,
-                                std::string* inline_chain = nullptr) {
+static std::string addr_to_line(const char *executable, void *addr, std::string *inline_chain = nullptr) {
     char cmd[512];
     snprintf(cmd, sizeof(cmd), "addr2line -e %s -f -C -p -i %p 2>/dev/null", executable, addr);
 
     std::array<char, 256> buffer;
     std::string raw_output;
 
-    FILE* pipe = popen(cmd, "r");
+    FILE *pipe = popen(cmd, "r");
     if (pipe) {
         while (fgets(buffer.data(), buffer.size(), pipe) != nullptr) {
             raw_output += buffer.data();
@@ -58,21 +67,22 @@ static std::string addr_to_line(const char* executable, void* addr,
         return "";
     }
 
-    // 按行分割
+    // Split by lines
     std::vector<std::string> lines;
     size_t pos = 0;
     while (pos < raw_output.size()) {
         size_t nl = raw_output.find('\n', pos);
         if (nl == std::string::npos) nl = raw_output.size();
         std::string line = raw_output.substr(pos, nl - pos);
-        while (!line.empty() && line.back() == '\r') line.pop_back();
+        while (!line.empty() && line.back() == '\r')
+            line.pop_back();
         if (!line.empty()) lines.push_back(line);
         pos = nl + 1;
     }
 
     if (lines.empty()) return "";
 
-    // 第一行是最内层的实际代码位置，后续行是外层内联调用者
+    // First line is the innermost actual code location; subsequent lines are outer inline callers
     if (inline_chain && lines.size() > 1) {
         *inline_chain = "";
         for (size_t j = 1; j < lines.size(); j++) {
@@ -85,29 +95,29 @@ static std::string addr_to_line(const char* executable, void* addr,
 #endif
 
 /**
- * 获取当前调用栈信息（包含文件路径和行号）
- * 通过 dladdr 定位每个栈帧所在的共享库，并用相对地址调用 addr2line
+ * Get current stack trace information (including file paths and line numbers).
+ * Uses dladdr to locate the shared library for each stack frame, then calls addr2line with relative addresses.
  */
 std::string get_stacktrace(int skip_frames) {
     (void)skip_frames;  // May be unused on non-Linux platforms
     std::string result;
 #ifdef __linux__
     const int max_frames = 64;
-    void* buffer[max_frames];
+    void *buffer[max_frames];
     int nframes = backtrace(buffer, max_frames);
-    char** symbols = backtrace_symbols(buffer, nframes);
+    char **symbols = backtrace_symbols(buffer, nframes);
 
     if (symbols) {
         result = "Stack trace:\n";
         for (int i = skip_frames; i < nframes; i++) {
             std::string frame_info;
 
-            void* addr = (void*)((char*)buffer[i] - 1);
+            void *addr = (void *)((char *)buffer[i] - 1);
 
             Dl_info dl_info;
             std::string inline_chain;
             if (dladdr(addr, &dl_info) && dl_info.dli_fname) {
-                void* rel_addr = (void*)((char*)addr - (char*)dl_info.dli_fbase);
+                void *rel_addr = (void *)((char *)addr - (char *)dl_info.dli_fbase);
                 std::string addr2line_result = addr_to_line(dl_info.dli_fname, rel_addr, &inline_chain);
 
                 if (addr2line_result.empty()) {
@@ -127,7 +137,7 @@ std::string get_stacktrace(int skip_frames) {
                 if (start != std::string::npos && end != std::string::npos) {
                     std::string mangled = frame.substr(start + 1, end - start - 1);
                     int status;
-                    char* demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &status);
+                    char *demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &status);
                     if (status == 0 && demangled) {
                         frame = frame.substr(0, start + 1) + demangled + frame.substr(end);
                         free(demangled);
@@ -146,24 +156,26 @@ std::string get_stacktrace(int skip_frames) {
         free(symbols);
     }
 #else
-    result = "(调用栈仅在 Linux 上可用)\n";
+    result = "(Stack trace is only available on Linux)\n";
 #endif
     return result;
 }
 
-// AssertionError 构造函数
-static std::string build_assert_message(const char* condition, const char* file, int line) {
+// AssertionError constructor
+static std::string build_assert_message(const char *condition, const char *file, int line) {
     std::string msg = "Assertion failed: " + std::string(condition) + "\n";
     msg += "  Location: " + std::string(file) + ":" + std::to_string(line) + "\n";
     msg += get_stacktrace(3);
     return msg;
 }
 
-AssertionError::AssertionError(const char* condition, const char* file, int line)
-    : std::runtime_error(build_assert_message(condition, file, line)),
-      condition_(condition), file_(file), line_(line) {}
+AssertionError::AssertionError(const char *condition, const char *file, int line) :
+    std::runtime_error(build_assert_message(condition, file, line)),
+    condition_(condition),
+    file_(file),
+    line_(line) {}
 
-[[noreturn]] void assert_impl(const char* condition, const char* file, int line) {
+[[noreturn]] void assert_impl(const char *condition, const char *file, int line) {
     LOG_ERROR("\n========================================");
     LOG_ERROR("Assertion failed: %s", condition);
     LOG_ERROR("Location: %s:%d", file, line);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -44,18 +44,17 @@
 /**
  * Create a Tensor for pre-allocated external memory.
  */
-inline Tensor make_tensor_external(void* addr,
-    const uint32_t shapes[],
-    uint32_t ndims,
-    DataType dtype = DataType::FLOAT32,
-    bool manual_dep = false,
-    int32_t version = 0) {
+inline Tensor make_tensor_external(
+    void *addr, const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false,
+    int32_t version = 0
+) {
     static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
     uint64_t total = 1;
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(addr,
+    return {
+        addr,
         total * get_element_size(dtype),
         shapes,
         shapes,
@@ -65,15 +64,18 @@ inline Tensor make_tensor_external(void* addr,
         version,
         /*is_all_offset_zero=*/true,
         /*is_raw_eq_shapes=*/true,
-        manual_dep);
+        manual_dep
+    };
 }
 
 // Convert ContinuousTensor to Tensor
 static_assert(
-    CONTINUOUS_TENSOR_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "ContinuousTensor and runtime max dims must match");
-inline Tensor from_tensor_arg(const ContinuousTensor& t, bool manual_dep = false, int32_t version = 0) {
+    CONTINUOUS_TENSOR_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "ContinuousTensor and runtime max dims must match"
+);
+inline Tensor from_tensor_arg(const ContinuousTensor &t, bool manual_dep = false, int32_t version = 0) {
     return make_tensor_external(
-        reinterpret_cast<void*>(static_cast<uintptr_t>(t.data)), t.shapes, t.ndims, t.dtype, manual_dep, version);
+        reinterpret_cast<void *>(static_cast<uintptr_t>(t.data)), t.shapes, t.ndims, t.dtype, manual_dep, version
+    );
 }
 
 // =============================================================================
@@ -98,8 +100,8 @@ extern "C" {
  * aicpu_orchestration_entry(), so orchestration helpers can fetch the
  * current PTO2Runtime without explicit parameter threading.
  */
-PTO2Runtime* pto2_framework_current_runtime(void);
-void pto2_framework_bind_runtime(PTO2Runtime* rt);
+PTO2Runtime *pto2_framework_current_runtime(void);
+void pto2_framework_bind_runtime(PTO2Runtime *rt);
 
 #ifdef __cplusplus
 }
@@ -110,24 +112,25 @@ void pto2_framework_bind_runtime(PTO2Runtime* rt);
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
 typedef struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const Arg& args);
-    void (*scope_begin)(PTO2Runtime* rt);
-    void (*scope_end)(PTO2Runtime* rt);
-    void (*orchestration_done)(PTO2Runtime* rt);
-    bool (*is_fatal)(PTO2Runtime* rt);
+    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    void (*scope_begin)(PTO2Runtime *rt);
+    void (*scope_end)(PTO2Runtime *rt);
+    void (*orchestration_done)(PTO2Runtime *rt);
+    bool (*is_fatal)(PTO2Runtime *rt);
 
     // Logging (populated by runtime, called by orchestration)
-    void (*log_error)(const char* func, const char* fmt, ...);
-    void (*log_warn)(const char* func, const char* fmt, ...);
-    void (*log_info)(const char* func, const char* fmt, ...);
-    void (*log_debug)(const char* func, const char* fmt, ...);
-    void (*log_always)(const char* func, const char* fmt, ...);
+    void (*log_error)(const char *func, const char *fmt, ...);
+    void (*log_warn)(const char *func, const char *fmt, ...);
+    void (*log_info)(const char *func, const char *fmt, ...);
+    void (*log_debug)(const char *func, const char *fmt, ...);
+    void (*log_always)(const char *func, const char *fmt, ...);
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
+    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]);
     void (*set_tensor_data)(
-        PTO2Runtime* rt, const Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value);
+        PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    );
 } PTO2RuntimeOps;
 
 /**
@@ -138,25 +141,25 @@ typedef struct PTO2RuntimeOps {
  * is well-defined (C struct layout guarantee).
  */
 struct PTO2Runtime {
-    const PTO2RuntimeOps* ops;
+    const PTO2RuntimeOps *ops;
 };
 
 // =============================================================================
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline PTO2Runtime* pto2_current_runtime() { return pto2_framework_current_runtime(); }
+static inline PTO2Runtime *pto2_current_runtime() { return pto2_framework_current_runtime(); }
 
-static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels& mixed_kernels, const Arg& args) {
-    PTO2Runtime* rt = pto2_current_runtime();
+static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+    PTO2Runtime *rt = pto2_current_runtime();
     return rt->ops->submit_task(rt, mixed_kernels, args);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
-static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const Arg& args) {
-    PTO2Runtime* rt = pto2_current_runtime();
+static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
+    PTO2Runtime *rt = pto2_current_runtime();
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
@@ -165,30 +168,30 @@ static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
-static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const Arg& args) {
-    PTO2Runtime* rt = pto2_current_runtime();
+static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
+    PTO2Runtime *rt = pto2_current_runtime();
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
 }
 
 static inline void pto2_rt_scope_begin() {
-    PTO2Runtime* rt = pto2_current_runtime();
+    PTO2Runtime *rt = pto2_current_runtime();
     rt->ops->scope_begin(rt);
 }
 
 static inline void pto2_rt_scope_end() {
-    PTO2Runtime* rt = pto2_current_runtime();
+    PTO2Runtime *rt = pto2_current_runtime();
     rt->ops->scope_end(rt);
 }
 
 static inline void pto2_rt_orchestration_done() {
-    PTO2Runtime* rt = pto2_current_runtime();
+    PTO2Runtime *rt = pto2_current_runtime();
     rt->ops->orchestration_done(rt);
 }
 
 static inline bool pto2_rt_is_fatal() {
-    PTO2Runtime* rt = pto2_current_runtime();
+    PTO2Runtime *rt = pto2_current_runtime();
     return rt->ops->is_fatal(rt);
 }
 
@@ -220,8 +223,8 @@ static inline bool pto2_rt_is_fatal() {
  * are read immediately without waiting.
  */
 template <typename T = uint64_t>
-static inline T get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[]) {
-    PTO2Runtime* rt = pto2_current_runtime();
+static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
+    PTO2Runtime *rt = pto2_current_runtime();
     return from_u64<T>(rt->ops->get_tensor_data(rt, tensor, ndims, indices));
 }
 
@@ -253,8 +256,8 @@ static inline T get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint
  * add_output(TensorCreateInfo) after submit returns.
  */
 template <typename T = uint64_t>
-static inline void set_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[], T value) {
-    PTO2Runtime* rt = pto2_current_runtime();
+static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {
+    PTO2Runtime *rt = pto2_current_runtime();
     rt->ops->set_tensor_data(rt, tensor, ndims, indices, to_u64(value));
 }
 
@@ -267,11 +270,14 @@ static inline void set_tensor_data(const Tensor& tensor, uint32_t ndims, const u
  */
 class PTO2ScopeGuard {
 public:  // NOLINT(whitespace/indent)
-    PTO2ScopeGuard() : rt_(pto2_current_runtime()) { rt_->ops->scope_begin(rt_); }
+    PTO2ScopeGuard() :
+        rt_(pto2_current_runtime()) {
+        rt_->ops->scope_begin(rt_);
+    }
     ~PTO2ScopeGuard() { rt_->ops->scope_end(rt_); }
 
 private:  // NOLINT(whitespace/indent)
-    PTO2Runtime* rt_;
+    PTO2Runtime *rt_;
 };
 
 #define _PTO2_CONCATENATE_IMPL(x, y) x##y

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/common.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/common.h
@@ -27,16 +27,16 @@ std::string get_stacktrace(int skip_frames = 1);
  * Assertion failure exception with condition, file, line, and stack trace.
  */
 class AssertionError : public std::runtime_error {
- public:
-    AssertionError(const char* condition, const char* file, int line);
+public:
+    AssertionError(const char *condition, const char *file, int line);
 
-    const char* condition() const { return condition_; }
-    const char* file() const { return file_; }
+    const char *condition() const { return condition_; }
+    const char *file() const { return file_; }
     int line() const { return line_; }
 
- private:
-    const char* condition_;
-    const char* file_;
+private:
+    const char *condition_;
+    const char *file_;
     int line_;
 };
 
@@ -44,7 +44,7 @@ class AssertionError : public std::runtime_error {
  * Assertion failure handler.
  * Implemented in common.cpp.
  */
-[[noreturn]] void assert_impl(const char* condition, const char* file, int line);
+[[noreturn]] void assert_impl(const char *condition, const char *file, int line);
 
 /**
  * debug_assert macro:

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -50,10 +50,13 @@
 #endif
 
 // Verify hardcoded indices in intrinsic.h match the computed values.
-static_assert((MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) == SPMD_LOCAL_CONTEXT_INDEX,
-    "LOCAL_CONTEXT_INDEX out of sync with intrinsic.h");
-static_assert((MAX_TENSOR_ARGS + MAX_SCALAR_ARGS + 1) == SPMD_GLOBAL_CONTEXT_INDEX,
-    "GLOBAL_CONTEXT_INDEX out of sync with intrinsic.h");
+static_assert(
+    (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) == SPMD_LOCAL_CONTEXT_INDEX, "LOCAL_CONTEXT_INDEX out of sync with intrinsic.h"
+);
+static_assert(
+    (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS + 1) == SPMD_GLOBAL_CONTEXT_INDEX,
+    "GLOBAL_CONTEXT_INDEX out of sync with intrinsic.h"
+);
 
 /**
  * Per-core dispatch payload: function address + args[] + SPMD context.
@@ -80,6 +83,8 @@ struct alignas(64) PTO2DispatchPayload {
     GlobalContext global_context;
 
     static_assert(sizeof(args[0]) == 8);
-    static_assert(PTO2_ALIGN_UP((MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0]), 64) ==
-                  (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0]));
+    static_assert(
+        PTO2_ALIGN_UP((MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0]), 64) ==
+        (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0])
+    );
 };

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -53,8 +53,8 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // Weak fallback for builds that don't link performance_collector_aicpu.cpp.
 // The strong symbol from the AICPU build wins when profiling is available.
 // Also hidden to prevent HOST .so from polluting the global symbol table.
-__attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
+__attribute__((weak, visibility("hidden"))) void
+perf_aicpu_record_orch_phase(AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 // Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // unified task+heap alloc
@@ -90,8 +90,8 @@ uint64_t g_orch_scope_end_atomic_count = 0;
 #include "aicpu/device_time.h"
 #include "aicpu/performance_collector_aicpu.h"
 __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
-__attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
+__attribute__((weak, visibility("hidden"))) void
+perf_aicpu_record_orch_phase(AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 // submit_idx needed for swimlane task_id tagging (no cycle accumulation at this level)
 static uint32_t g_orch_submit_idx = 0;
 #define CYCLE_COUNT_START()                     \
@@ -114,14 +114,10 @@ static uint32_t g_orch_submit_idx = 0;
 #define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)
 #endif
 
-static bool pto2_append_fanin_or_fail(PTO2OrchestratorState* orch,
-    PTO2TaskId task_id,
-    int32_t tensor_arg_index,
-    TensorArgType ptype,
-    PTO2TaskSlotState* prod_state,
-    PTO2TaskSlotState* fanin_states[],
-    int32_t* fanin_count,
-    const char* reason) {
+static bool pto2_append_fanin_or_fail(
+    PTO2OrchestratorState *orch, PTO2TaskId task_id, int32_t tensor_arg_index, TensorArgType ptype,
+    PTO2TaskSlotState *prod_state, PTO2TaskSlotState *fanin_states[], int32_t *fanin_count, const char *reason
+) {
     for (int32_t j = 0; j < *fanin_count; j++) {
         if (fanin_states[j] == prod_state) {
             return true;
@@ -153,11 +149,10 @@ static bool pto2_append_fanin_or_fail(PTO2OrchestratorState* orch,
 // Orchestrator Initialization
 // =============================================================================
 
-bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
-    PTO2SharedMemoryHandle* sm_handle,
-    void* gm_heap,
-    uint64_t heap_size,
-    int32_t dep_pool_capacity) {
+bool pto2_orchestrator_init(
+    PTO2OrchestratorState *orch, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
+    int32_t dep_pool_capacity
+) {
     *orch = PTO2OrchestratorState{};
 
     orch->sm_handle = sm_handle;
@@ -167,21 +162,18 @@ bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
 
     // Initialize per-ring resources
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        void* ring_heap_base = reinterpret_cast<char*>(gm_heap) + r * heap_size;
-        auto& fc = sm_handle->header->rings[r].fc;
+        void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + r * heap_size;
+        auto &fc = sm_handle->header->rings[r].fc;
 
         // Initialize unified task allocator
-        orch->rings[r].task_allocator.init(sm_handle->task_descriptors[r],
-            sm_handle->header->rings[r].task_window_size,
-            &fc.current_task_index,
-            &fc.last_task_alive,
-            ring_heap_base,
-            heap_size,
-            &sm_handle->header->orch_error_code);
+        orch->rings[r].task_allocator.init(
+            sm_handle->task_descriptors[r], sm_handle->header->rings[r].task_window_size, &fc.current_task_index,
+            &fc.last_task_alive, ring_heap_base, heap_size, &sm_handle->header->orch_error_code
+        );
 
         // Allocate and initialize dependency list pool (per-ring)
-        PTO2DepListEntry* dep_entries =
-            reinterpret_cast<PTO2DepListEntry*>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
+        PTO2DepListEntry *dep_entries =
+            reinterpret_cast<PTO2DepListEntry *>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
         if (!dep_entries) {
             // Cleanup previously allocated rings
             for (int j = 0; j < r; j++) {
@@ -208,8 +200,8 @@ bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
     // Initialize scope stack: one flat buffer for task IDs + one array for begin offsets
     uint64_t max_depth = PTO2_MAX_SCOPE_DEPTH;
     int32_t init_cap = PTO2_SCOPE_TASKS_INIT_CAP;
-    orch->scope_tasks = reinterpret_cast<PTO2TaskSlotState**>(malloc(init_cap * sizeof(PTO2TaskSlotState*)));
-    orch->scope_begins = reinterpret_cast<int32_t*>(malloc(max_depth * sizeof(int32_t)));
+    orch->scope_tasks = reinterpret_cast<PTO2TaskSlotState **>(malloc(init_cap * sizeof(PTO2TaskSlotState *)));
+    orch->scope_begins = reinterpret_cast<int32_t *>(malloc(max_depth * sizeof(int32_t)));
     if (!orch->scope_tasks || !orch->scope_begins) {
         free(orch->scope_tasks);
         free(orch->scope_begins);
@@ -227,7 +219,7 @@ bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
     return true;
 }
 
-void pto2_orchestrator_destroy(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_destroy(PTO2OrchestratorState *orch) {
     orch->tensor_map.destroy();
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -241,7 +233,7 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState* orch) {
     orch->scope_begins = NULL;
 }
 
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler) {
+void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler) {
     orch->scheduler = scheduler;
 }
 
@@ -249,11 +241,11 @@ void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerS
 // Scope Management
 // =============================================================================
 
-static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState* task_slot_state) {
+static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         int32_t new_cap = orch->scope_tasks_capacity * 2;
-        PTO2TaskSlotState** new_buf =
-            reinterpret_cast<PTO2TaskSlotState**>(realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState*)));
+        PTO2TaskSlotState **new_buf =
+            reinterpret_cast<PTO2TaskSlotState **>(realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState *)));
         assert(new_buf && "Failed to grow scope task buffer");
         orch->scope_tasks = new_buf;
         orch->scope_tasks_capacity = new_cap;
@@ -261,7 +253,7 @@ static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState* tas
     orch->scope_tasks[orch->scope_tasks_size++] = task_slot_state;
 }
 
-void pto2_scope_begin(PTO2OrchestratorState* orch) {
+void pto2_scope_begin(PTO2OrchestratorState *orch) {
     if (orch->fatal) {
         return;
     }
@@ -271,7 +263,7 @@ void pto2_scope_begin(PTO2OrchestratorState* orch) {
     orch->scope_begins[orch->scope_stack_top] = orch->scope_tasks_size;
 }
 
-void pto2_scope_end(PTO2OrchestratorState* orch) {
+void pto2_scope_end(PTO2OrchestratorState *orch) {
     if (orch->fatal) {
         return;
     }
@@ -301,8 +293,8 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
 // =============================================================================
 // Task Submission
 // =============================================================================
-TaskOutputTensors pto2_submit_mixed_task(
-    PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const Arg& args) {
+TaskOutputTensors
+pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args) {
     CYCLE_COUNT_START();
 
     TaskOutputTensors result;
@@ -328,9 +320,9 @@ TaskOutputTensors pto2_submit_mixed_task(
 
     // Determine which ring this task belongs to
     uint8_t ring_id = orch->current_ring_id();
-    auto& allocator = orch->rings[ring_id].task_allocator;
-    PTO2SchedulerState* sched = orch->scheduler;
-    PTO2RingFlowControl& fc = orch->sm_handle->header->rings[ring_id].fc;
+    auto &allocator = orch->rings[ring_id].task_allocator;
+    PTO2SchedulerState *sched = orch->scheduler;
+    PTO2RingFlowControl &fc = orch->sm_handle->header->rings[ring_id].fc;
 
     // === Validate submit inputs ===
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
@@ -369,7 +361,8 @@ TaskOutputTensors pto2_submit_mixed_task(
             LOG_ERROR("FATAL: Scope Deadlock Detected! (ring %d)", ring_id);
             LOG_ERROR("========================================");
             LOG_ERROR(
-                "Tasks in current scope (%d) >= task_window_size (%d).", scope_task_count, allocator.window_size());
+                "Tasks in current scope (%d) >= task_window_size (%d).", scope_task_count, allocator.window_size()
+            );
             LOG_ERROR("  scope_depth:        %d", orch->scope_stack_top + 1);
             LOG_ERROR("  ring_id:            %d", ring_id);
             LOG_ERROR("  scope_task_count:   %d", scope_task_count);
@@ -414,8 +407,8 @@ TaskOutputTensors pto2_submit_mixed_task(
     int32_t slot = alloc_result.slot;
     PTO2TaskId task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(local_id));
 
-    PTO2TaskDescriptor& task = allocator.task_by_slot(slot);
-    PTO2TaskPayload* payload = &orch->sm_handle->task_payloads[ring_id][slot];
+    PTO2TaskDescriptor &task = allocator.task_by_slot(slot);
+    PTO2TaskPayload *payload = &orch->sm_handle->task_payloads[ring_id][slot];
 
     // Early write-prefetch payload GM cache lines to issue RFO in background.
     // ~130 lines of computation (lookup, insert) follow before
@@ -423,19 +416,19 @@ TaskOutputTensors pto2_submit_mixed_task(
     // Use locality=3 (PSTL1KEEP) so prefetched CLs survive lookup/insert eviction.
     for (int32_t i = 0; i < args.tensor_count(); i++) {
         __builtin_prefetch(&payload->tensors[i], 1, 3);
-        __builtin_prefetch(reinterpret_cast<char*>(&payload->tensors[i]) + 64, 1, 3);
+        __builtin_prefetch(reinterpret_cast<char *>(&payload->tensors[i]) + 64, 1, 3);
     }
     for (int32_t i = 0; i < args.scalar_count(); i += 8) {
         __builtin_prefetch(&payload->scalars[i], 1, 3);
     }
     __builtin_prefetch(payload, 1, 3);
-    __builtin_prefetch(reinterpret_cast<char*>(payload) + 64, 1, 3);
-    __builtin_prefetch(reinterpret_cast<char*>(payload) + 128, 1, 3);
+    __builtin_prefetch(reinterpret_cast<char *>(payload) + 64, 1, 3);
+    __builtin_prefetch(reinterpret_cast<char *>(payload) + 128, 1, 3);
 
     // Initialize slot state (scheduler-private)
     if (sched) {
-        auto& rs = sched->ring_sched_states[ring_id];
-        PTO2TaskSlotState& slot_state = rs.get_slot_state_by_slot(slot);
+        auto &rs = sched->ring_sched_states[ring_id];
+        PTO2TaskSlotState &slot_state = rs.get_slot_state_by_slot(slot);
         slot_state.fanin_count = 0;
         slot_state.fanout_head = nullptr;
         slot_state.fanout_lock.store(0, std::memory_order_relaxed);
@@ -454,7 +447,7 @@ TaskOutputTensors pto2_submit_mixed_task(
     }
 
     // Temporary storage for fanin (cached slot state pointers, avoids repeated ring/slot lookups)
-    PTO2TaskSlotState* fanin_states[PTO2_MAX_INPUTS];
+    PTO2TaskSlotState *fanin_states[PTO2_MAX_INPUTS];
     int32_t fanin_count = 0;
 
     CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, task_id.raw);
@@ -486,15 +479,16 @@ TaskOutputTensors pto2_submit_mixed_task(
             continue;
         }
 
-        const Tensor* tensor = args.tensor(i).ptr;
+        const Tensor *tensor = args.tensor(i).ptr;
 
         // Step A: creator retention — all existing tensors extend their creator lifetime.
         PTO2TaskId owner = tensor->owner_task_id;
         if (owner.is_valid() && sched != nullptr) {
-            PTO2TaskSlotState* prod_state =
+            PTO2TaskSlotState *prod_state =
                 &sched->ring_sched_states[owner.ring()].get_slot_state_by_task_id(owner.local());
             if (!pto2_append_fanin_or_fail(
-                    orch, task_id, i, ptype, prod_state, fanin_states, &fanin_count, "creator retention")) {
+                    orch, task_id, i, ptype, prod_state, fanin_states, &fanin_count, "creator retention"
+                )) {
                 return result;
             }
         }
@@ -511,13 +505,14 @@ TaskOutputTensors pto2_submit_mixed_task(
         orch->tensor_map.lookup(*tensor, lookup_result);
 
         for (int r = 0; r < lookup_result.count; r++) {
-            PTO2TensorMapEntry& entry = *lookup_result.entries[r].entry;
+            PTO2TensorMapEntry &entry = *lookup_result.entries[r].entry;
             auto overlap_status = lookup_result.entries[r].overlap_status;
             auto prod_ring = entry.producer_task_id.ring();
             auto prod_local = entry.producer_task_id.local();
-            PTO2TaskSlotState* prod_state = &sched->ring_sched_states[prod_ring].get_slot_state_by_task_id(prod_local);
+            PTO2TaskSlotState *prod_state = &sched->ring_sched_states[prod_ring].get_slot_state_by_task_id(prod_local);
             if (!pto2_append_fanin_or_fail(
-                    orch, task_id, i, ptype, prod_state, fanin_states, &fanin_count, "overlap lookup")) {
+                    orch, task_id, i, ptype, prod_state, fanin_states, &fanin_count, "overlap lookup"
+                )) {
                 return result;
             }
             if (ptype == TensorArgType::INOUT && overlap_status == OverlapStatus::COVERED) {
@@ -556,7 +551,7 @@ TaskOutputTensors pto2_submit_mixed_task(
     // Prefetch producer slot_states and cur_slot_state (written at init but likely
     // evicted by lookup/insert/heap). param_copy below provides hide time.
     if (sched) {
-        auto& rs = sched->ring_sched_states[ring_id];
+        auto &rs = sched->ring_sched_states[ring_id];
         __builtin_prefetch(&rs.get_slot_state_by_slot(slot), 1, 0);
         for (int i = 0; i < fanin_count; i++) {
             __builtin_prefetch(fanin_states[i], 1, 0);
@@ -581,8 +576,8 @@ TaskOutputTensors pto2_submit_mixed_task(
     // === STEP 6: Finalize fanin list ===
     // First build the fanin list
     if (sched) {
-        auto& rs = sched->ring_sched_states[ring_id];
-        PTO2TaskSlotState& cur_slot_state = rs.get_slot_state_by_slot(slot);
+        auto &rs = sched->ring_sched_states[ring_id];
+        PTO2TaskSlotState &cur_slot_state = rs.get_slot_state_by_slot(slot);
         // Initialize scheduler state BEFORE adding to producer fanout lists,
         // so concurrent on_mixed_task_complete can safely access task_state/fanout_refcount.
         cur_slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
@@ -592,7 +587,7 @@ TaskOutputTensors pto2_submit_mixed_task(
         cur_slot_state.block_num = block_num;
         cur_slot_state.next_block_idx = 0;
 
-        auto& dep_pool = orch->rings[ring_id].dep_pool;
+        auto &dep_pool = orch->rings[ring_id].dep_pool;
         // Ensure dep pool has space: fanin_count entries + 1 pre-alloc
         dep_pool.ensure_space(*sched, fc, ring_id, fanin_count + 1);
 
@@ -603,7 +598,7 @@ TaskOutputTensors pto2_submit_mixed_task(
             payload->fanin_slot_states[i] = fanin_states[i];
         }
         for (int i = 0; i < fanin_count; i++) {
-            PTO2TaskSlotState& producer_slot_state = *fanin_states[i];
+            PTO2TaskSlotState &producer_slot_state = *fanin_states[i];
 #if PTO2_ORCH_PROFILING
             pto2_fanout_lock(producer_slot_state, g_orch_fanin_atomic_count, g_orch_fanin_wait_cycle);
 #else
@@ -658,21 +653,18 @@ TaskOutputTensors pto2_submit_mixed_task(
 // Flow Control
 // =============================================================================
 
-void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         int32_t total_tasks = orch->rings[r].task_allocator.active_count();
         if (total_tasks > 0) {
             LOG_INFO("=== [Orchestrator] ring %d: total_tasks=%d ===", r, total_tasks);
         }
-        auto& pool = orch->rings[r].dep_pool;
+        auto &pool = orch->rings[r].dep_pool;
         if (pool.top > 0) {
-            LOG_INFO("=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===",
-                r,
-                pool.top,
-                pool.tail,
-                pool.top - pool.tail,
-                pool.high_water,
-                pool.capacity);
+            LOG_INFO(
+                "=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===", r, pool.top, pool.tail,
+                pool.top - pool.tail, pool.high_water, pool.capacity
+            );
         }
     }
     orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
@@ -685,7 +677,7 @@ void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
 // Debug Utilities
 // =============================================================================
 
-void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch) {
     LOG_INFO("=== Orchestrator Statistics ===");
 #if PTO2_PROFILING
     LOG_INFO("Tasks submitted:     %" PRId64, orch->tasks_submitted);
@@ -697,19 +689,20 @@ void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
         int32_t active = orch->rings[r].task_allocator.active_count();
         if (active > 0) {
             LOG_INFO("Ring %d task active:  %d", r, active);
-            LOG_INFO("Ring %d heap used:    %" PRIu64 " / %" PRIu64,
-                r,
-                orch->rings[r].task_allocator.heap_top(),
-                orch->rings[r].task_allocator.heap_capacity());
             LOG_INFO(
-                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity);
+                "Ring %d heap used:    %" PRIu64 " / %" PRIu64, r, orch->rings[r].task_allocator.heap_top(),
+                orch->rings[r].task_allocator.heap_capacity()
+            );
+            LOG_INFO(
+                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity
+            );
         }
     }
     LOG_INFO("TensorMap valid:     %d", orch->tensor_map.valid_count());
     LOG_INFO("===============================");
 }
 
-void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState *orch) {
     LOG_INFO("=== Scope Stack ===");
     LOG_INFO("Depth: %d", orch->scope_stack_top + 1);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Orchestrator Interface
  *
@@ -37,37 +47,37 @@
  */
 struct PTO2OrchestratorState {
     // === SHARED MEMORY ACCESS ===
-    PTO2SharedMemoryHandle* sm_handle;
+    PTO2SharedMemoryHandle *sm_handle;
 
     // === PER-RING RESOURCES ===
     PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
 
     // === TENSOR MAP (Private) ===
-    PTO2TensorMap tensor_map;        // Producer lookup
+    PTO2TensorMap tensor_map;  // Producer lookup
 
     // === SCOPE STACK (Private) ===
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    PTO2TaskSlotState** scope_tasks; // Flat buffer of taskSlotState (all scopes concatenated)
-    int32_t scope_tasks_size;       // Number of task IDs currently in the buffer
-    int32_t scope_tasks_capacity;   // Allocated capacity of scope_tasks
-    int32_t* scope_begins;         // scope_begins[i] = start index of scope i in scope_tasks
-    int32_t scope_stack_top;       // Current top of stack (-1 = no scope open)
-    uint64_t scope_stack_capacity;   // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+    PTO2TaskSlotState **scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
+    int32_t scope_tasks_size;         // Number of task IDs currently in the buffer
+    int32_t scope_tasks_capacity;     // Allocated capacity of scope_tasks
+    int32_t *scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
+    int32_t scope_stack_top;          // Current top of stack (-1 = no scope open)
+    uint64_t scope_stack_capacity;    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
 
     // === SCHEDULER REFERENCE ===
     // Note: In simulated mode, orchestrator and scheduler share address space
     // In real mode, they communicate via shared memory only
-    PTO2SchedulerState* scheduler;  // For simulated mode only
+    PTO2SchedulerState *scheduler;  // For simulated mode only
 #if PTO2_PROFILING
     // Runtime profiling switch copied from Runtime::enable_profiling.
     bool enable_profiling;
 #endif
 
     // === GM HEAP (for output buffers) ===
-    void* gm_heap_base;    // Base address of GM heap
-    uint64_t gm_heap_size;   // Total size of GM heap (all rings)
+    void *gm_heap_base;     // Base address of GM heap
+    uint64_t gm_heap_size;  // Total size of GM heap (all rings)
 
     // === FATAL ERROR ===
     // Fatal error flag (single-thread access by orchestrator, no atomic needed)
@@ -90,7 +100,6 @@ struct PTO2OrchestratorState {
         if (depth < 0) depth = 0;
         return depth < PTO2_MAX_RING_DEPTH ? static_cast<uint8_t>(depth) : PTO2_MAX_RING_DEPTH - 1;
     }
-
 };
 
 // =============================================================================
@@ -107,19 +116,19 @@ struct PTO2OrchestratorState {
  * @return true on success
  */
 bool pto2_orchestrator_init(
-    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, uint64_t heap_size,
-    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    PTO2OrchestratorState *orch, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 
 /**
  * Destroy orchestrator state and free resources
  */
-void pto2_orchestrator_destroy(PTO2OrchestratorState* orch);
+void pto2_orchestrator_destroy(PTO2OrchestratorState *orch);
 
 /**
  * Set scheduler reference (for simulated mode)
  */
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler);
-
+void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler);
 
 // =============================================================================
 // Scope Management
@@ -132,7 +141,7 @@ void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerS
  * Tasks submitted while this scope is at the top of the stack are
  * owned by it and have their fanout_count initialized to 1.
  */
-void pto2_scope_begin(PTO2OrchestratorState* orch);
+void pto2_scope_begin(PTO2OrchestratorState *orch);
 
 /**
  * End current scope
@@ -141,7 +150,7 @@ void pto2_scope_begin(PTO2OrchestratorState* orch);
  * directly owned by that scope.
  * May trigger buffer release for tasks that are now fully consumed.
  */
-void pto2_scope_end(PTO2OrchestratorState* orch);
+void pto2_scope_end(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Task Submission
@@ -161,9 +170,8 @@ void pto2_scope_end(PTO2OrchestratorState* orch);
  * @param mixed_kernels  Kernel IDs for AIC/AIV0/AIV1 slots
  * @param args      Aggregated tensor and scalar parameters
  */
-TaskOutputTensors pto2_submit_mixed_task(PTO2OrchestratorState* orch,
-    const MixedKernels& mixed_kernels,
-    const Arg& args);
+TaskOutputTensors
+pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args);
 
 // =============================================================================
 // Flow Control
@@ -174,7 +182,7 @@ TaskOutputTensors pto2_submit_mixed_task(PTO2OrchestratorState* orch,
  *
  * Signals to scheduler that no more tasks will be submitted.
  */
-void pto2_orchestrator_done(PTO2OrchestratorState* orch);
+void pto2_orchestrator_done(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Debug Utilities
@@ -183,12 +191,12 @@ void pto2_orchestrator_done(PTO2OrchestratorState* orch);
 /**
  * Print orchestrator statistics
  */
-void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch);
+void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch);
 
 /**
  * Print scope stack state
  */
-void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch);
+void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Orchestrator Profiling Data
@@ -197,16 +205,16 @@ void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch);
 #if PTO2_ORCH_PROFILING
 struct PTO2OrchProfilingData {
     uint64_t sync_cycle;
-    uint64_t alloc_cycle;           // Combined task slot + heap allocation
+    uint64_t alloc_cycle;  // Combined task slot + heap allocation
     uint64_t args_cycle;
     uint64_t lookup_cycle;
     uint64_t insert_cycle;
     uint64_t fanin_cycle;
     uint64_t scope_end_cycle;
-    int64_t  submit_count;
+    int64_t submit_count;
     // Wait time tracking for blocking phases
-    uint64_t alloc_wait_cycle;      // Cycles spent waiting in unified alloc
-    uint64_t fanin_wait_cycle;      // Cycles spent waiting in fanout_lock
+    uint64_t alloc_wait_cycle;  // Cycles spent waiting in unified alloc
+    uint64_t fanin_wait_cycle;  // Cycles spent waiting in fanout_lock
     // Atomic operation counts per phase
     uint64_t alloc_atomic_count;
     uint64_t args_atomic_count;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Ring Buffer Implementation
  *
@@ -17,7 +27,7 @@
 // =============================================================================
 // Dependency List Pool Implementation
 // =============================================================================
-void PTO2DepListPool::reclaim(PTO2SchedulerState& sched, uint8_t ring_id, int32_t sm_last_task_alive) {
+void PTO2DepListPool::reclaim(PTO2SchedulerState &sched, uint8_t ring_id, int32_t sm_last_task_alive) {
     if (sm_last_task_alive >= last_reclaimed + PTO2_DEP_POOL_CLEANUP_INTERVAL && sm_last_task_alive > 0) {
         int32_t mark = sched.ring_sched_states[ring_id].get_slot_state_by_task_id(sm_last_task_alive - 1).dep_pool_mark;
         if (mark > 0) {
@@ -28,7 +38,8 @@ void PTO2DepListPool::reclaim(PTO2SchedulerState& sched, uint8_t ring_id, int32_
 }
 
 void PTO2DepListPool::ensure_space(
-    PTO2SchedulerState& sched, PTO2RingFlowControl& fc, uint8_t ring_id, int32_t needed) {
+    PTO2SchedulerState &sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed
+) {
     if (available() >= needed) return;
 
     int spin_count = 0;
@@ -52,10 +63,10 @@ void PTO2DepListPool::ensure_space(
             LOG_ERROR("FATAL: Dependency Pool Deadlock Detected! (ring %d)", ring_id);
             LOG_ERROR("========================================");
             LOG_ERROR("DepListPool cannot reclaim space after %d spins (no progress).", spin_count);
-            LOG_ERROR("  - Pool used:     %d / %d (%.1f%%)",
-                used(),
-                capacity,
-                (capacity > 0) ? (100.0 * used() / capacity) : 0.0);
+            LOG_ERROR(
+                "  - Pool used:     %d / %d (%.1f%%)", used(), capacity,
+                (capacity > 0) ? (100.0 * used() / capacity) : 0.0
+            );
             LOG_ERROR("  - Pool top:      %d (linear)", top);
             LOG_ERROR("  - Pool tail:     %d (linear)", tail);
             LOG_ERROR("  - High water:    %d", high_water);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Ring Buffer Data Structures
  *
@@ -12,7 +22,7 @@
  *    - Ring buffer for linked list entries
  *    - O(1) prepend operation
  *    - Implicit reclamation with task ring
- * 
+ *
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
@@ -33,12 +43,12 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 #endif
 
 // Block notification interval (in spin counts)
-#define PTO2_BLOCK_NOTIFY_INTERVAL  10000
+#define PTO2_BLOCK_NOTIFY_INTERVAL 10000
 // Alloc spin limit - after this, report deadlock and exit
-#define PTO2_ALLOC_SPIN_LIMIT       100000
+#define PTO2_ALLOC_SPIN_LIMIT 100000
 
 // Dep pool spin limit - if exceeded, dep pool capacity too small for workload
-#define PTO2_DEP_POOL_SPIN_LIMIT      100000
+#define PTO2_DEP_POOL_SPIN_LIMIT 100000
 
 // =============================================================================
 // Task Allocator (unified task slot + heap buffer allocation)
@@ -48,10 +58,10 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
  * Result of a unified task allocation.
  */
 struct PTO2TaskAllocResult {
-    int32_t task_id;      // Absolute task ID (not wrapped), -1 on failure
-    int32_t slot;         // task_id & (window_size - 1)
-    void* packed_base;    // Heap allocation result (nullptr if output_size == 0)
-    void* packed_end;     // packed_base + aligned output_size
+    int32_t task_id;    // Absolute task ID (not wrapped), -1 on failure
+    int32_t slot;       // task_id & (window_size - 1)
+    void *packed_base;  // Heap allocation result (nullptr if output_size == 0)
+    void *packed_end;   // packed_base + aligned output_size
 
     bool failed() const { return task_id < 0; }
 };
@@ -71,11 +81,10 @@ public:
     /**
      * Initialize the allocator with task ring and heap ring resources.
      */
-    void init(PTO2TaskDescriptor* descriptors, int32_t window_size,
-              std::atomic<int32_t>* current_index_ptr,
-              std::atomic<int32_t>* last_alive_ptr,
-              void* heap_base, uint64_t heap_size,
-              std::atomic<int32_t>* error_code_ptr) {
+    void init(
+        PTO2TaskDescriptor *descriptors, int32_t window_size, std::atomic<int32_t> *current_index_ptr,
+        std::atomic<int32_t> *last_alive_ptr, void *heap_base, uint64_t heap_size, std::atomic<int32_t> *error_code_ptr
+    ) {
         descriptors_ = descriptors;
         window_size_ = window_size;
         window_mask_ = window_size - 1;
@@ -101,8 +110,8 @@ public:
      * @return Allocation result; check failed() for errors
      */
     PTO2TaskAllocResult alloc(int32_t output_size) {
-        uint64_t aligned_size = output_size > 0
-            ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
+        uint64_t aligned_size =
+            output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
 
         int spin_count = 0;
         int32_t prev_last_alive = last_alive_ptr_->load(std::memory_order_acquire);
@@ -116,15 +125,14 @@ public:
 
         while (true) {
             // Check both resources; commit only if both available
-            if (local_task_id_ - last_alive  + 1 < window_size_) {
-                void* heap_ptr = try_bump_heap(aligned_size);
+            if (local_task_id_ - last_alive + 1 < window_size_) {
+                void *heap_ptr = try_bump_heap(aligned_size);
                 if (heap_ptr) {
                     int32_t task_id = commit_task();
 #if PTO2_ORCH_PROFILING
                     record_wait(spin_count, wait_start, waiting);
 #endif
-                    return {task_id, task_id & window_mask_,
-                            heap_ptr, static_cast<char*>(heap_ptr) + aligned_size};
+                    return {task_id, task_id & window_mask_, heap_ptr, static_cast<char *>(heap_ptr) + aligned_size};
                 }
                 blocked_on_heap = true;
             } else {
@@ -134,7 +142,10 @@ public:
             // Spin: wait for scheduler to advance last_task_alive
             spin_count++;
 #if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+            if (!waiting) {
+                wait_start = get_sys_cnt_aicpu();
+                waiting = true;
+            }
 #endif
             last_alive = last_alive_ptr_->load(std::memory_order_acquire);
             update_heap_tail(last_alive);
@@ -144,13 +155,11 @@ public:
             } else {
 #if PTO2_SPIN_VERBOSE_LOGGING
                 if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0) {
-                    LOG_WARN("[TaskAllocator] BLOCKED: tasks=%d/%d, heap=%" PRIu64 "/%" PRIu64 ", on=%s, spins=%d",
-                        local_task_id_ - last_alive,
-                        window_size_,
-                        heap_top_,
-                        heap_size_,
-                        blocked_on_heap ? "heap" : "task",
-                        spin_count);
+                    LOG_WARN(
+                        "[TaskAllocator] BLOCKED: tasks=%d/%d, heap=%" PRIu64 "/%" PRIu64 ", on=%s, spins=%d",
+                        local_task_id_ - last_alive, window_size_, heap_top_, heap_size_,
+                        blocked_on_heap ? "heap" : "task", spin_count
+                    );
                 }
 #endif
                 if (spin_count >= PTO2_ALLOC_SPIN_LIMIT) {
@@ -166,13 +175,9 @@ public:
     // Task descriptor accessors
     // =========================================================================
 
-    PTO2TaskDescriptor& task(int32_t task_id) const {
-        return descriptors_[task_id & window_mask_];
-    }
+    PTO2TaskDescriptor &task(int32_t task_id) const { return descriptors_[task_id & window_mask_]; }
 
-    PTO2TaskDescriptor& task_by_slot(int32_t slot) const {
-        return descriptors_[slot];
-    }
+    PTO2TaskDescriptor &task_by_slot(int32_t slot) const { return descriptors_[slot]; }
 
     // =========================================================================
     // State queries
@@ -200,24 +205,24 @@ public:
 
 private:
     // --- Task Ring ---
-    PTO2TaskDescriptor* descriptors_ = nullptr;
+    PTO2TaskDescriptor *descriptors_ = nullptr;
     int32_t window_size_ = 0;
     int32_t window_mask_ = 0;
-    std::atomic<int32_t>* current_index_ptr_ = nullptr;
-    std::atomic<int32_t>* last_alive_ptr_ = nullptr;
+    std::atomic<int32_t> *current_index_ptr_ = nullptr;
+    std::atomic<int32_t> *last_alive_ptr_ = nullptr;
 
     // --- Heap ---
-    void*    heap_base_ = nullptr;
+    void *heap_base_ = nullptr;
     uint64_t heap_size_ = 0;
 
     // --- Local state (single-writer, no atomics needed) ---
-    int32_t  local_task_id_ = 0;      // Next task ID to allocate
-    uint64_t heap_top_ = 0;     // Current heap allocation pointer
-    uint64_t heap_tail_ = 0;    // Heap reclamation pointer (derived from consumed tasks)
-    int32_t  last_alive_seen_ = 0;    // last_task_alive at last heap_tail derivation
+    int32_t local_task_id_ = 0;    // Next task ID to allocate
+    uint64_t heap_top_ = 0;        // Current heap allocation pointer
+    uint64_t heap_tail_ = 0;       // Heap reclamation pointer (derived from consumed tasks)
+    int32_t last_alive_seen_ = 0;  // last_task_alive at last heap_tail derivation
 
     // --- Shared ---
-    std::atomic<int32_t>* error_code_ptr_ = nullptr;
+    std::atomic<int32_t> *error_code_ptr_ = nullptr;
 
     // =========================================================================
     // Internal helpers
@@ -244,9 +249,9 @@ private:
         if (last_alive <= last_alive_seen_) return;
         last_alive_seen_ = last_alive;
 
-        PTO2TaskDescriptor& desc = descriptors_[(last_alive - 1) & window_mask_];
-        heap_tail_ = static_cast<uint64_t>(
-            static_cast<char*>(desc.packed_buffer_end) - static_cast<char*>(heap_base_));
+        PTO2TaskDescriptor &desc = descriptors_[(last_alive - 1) & window_mask_];
+        heap_tail_ =
+            static_cast<uint64_t>(static_cast<char *>(desc.packed_buffer_end) - static_cast<char *>(heap_base_));
     }
 
     /**
@@ -254,18 +259,18 @@ private:
      * Returns the allocated pointer, or nullptr if insufficient space.
      * When alloc_size == 0, returns current position without advancing.
      */
-    void* try_bump_heap(uint64_t alloc_size) {
+    void *try_bump_heap(uint64_t alloc_size) {
         uint64_t top = heap_top_;
         if (alloc_size == 0) {
-            return static_cast<char*>(heap_base_) + top;
+            return static_cast<char *>(heap_base_) + top;
         }
         uint64_t tail = heap_tail_;
-        void* result;
+        void *result;
 
         if (top >= tail) {
             uint64_t space_at_end = heap_size_ - top;
             if (space_at_end >= alloc_size) {
-                result = static_cast<char*>(heap_base_) + top;
+                result = static_cast<char *>(heap_base_) + top;
                 heap_top_ = top + alloc_size;
             } else if (tail > alloc_size) {
                 result = heap_base_;
@@ -275,7 +280,7 @@ private:
             }
         } else {
             if (tail - top >= alloc_size) {
-                result = static_cast<char*>(heap_base_) + top;
+                result = static_cast<char *>(heap_base_) + top;
                 heap_top_ = top + alloc_size;
             } else {
                 return nullptr;
@@ -314,18 +319,19 @@ private:
         }
         LOG_ERROR("========================================");
         LOG_ERROR("No progress after %d spins.", PTO2_ALLOC_SPIN_LIMIT);
-        LOG_ERROR("  Task ring:  current=%d, last_alive=%d, active=%d/%d (%.1f%%)",
-                  local_task_id_, last_alive, active_tasks, window_size_,
-                  100.0 * active_tasks / window_size_);
-        LOG_ERROR("  Heap ring:  top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64
-                  ", available=%" PRIu64,
-                  heap_top_, htail, heap_size_, heap_available());
+        LOG_ERROR(
+            "  Task ring:  current=%d, last_alive=%d, active=%d/%d (%.1f%%)", local_task_id_, last_alive, active_tasks,
+            window_size_, 100.0 * active_tasks / window_size_
+        );
+        LOG_ERROR(
+            "  Heap ring:  top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64 ", available=%" PRIu64, heap_top_, htail,
+            heap_size_, heap_available()
+        );
         if (heap_blocked) {
             LOG_ERROR("  Requested:  %d bytes", requested_output_size);
         }
         LOG_ERROR("Diagnosis:");
-        LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d",
-                  last_alive, last_alive);
+        LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d", last_alive, last_alive);
         LOG_ERROR("  cannot transition to CONSUMED. Possible causes:");
         LOG_ERROR("  1. Task %d still executing (subtasks not complete)", last_alive);
         LOG_ERROR("  2. Task %d fanout not fully released (downstream not done)", last_alive);
@@ -333,22 +339,19 @@ private:
         LOG_ERROR("  4. Orchestrator blocked here -> can't call scope_end -> circular wait");
         LOG_ERROR("Solution:");
         if (heap_blocked) {
-            LOG_ERROR("  Increase heap size (current: %" PRIu64 ", recommended: %" PRIu64 ")",
-                      heap_size_, heap_size_ * 2);
+            LOG_ERROR(
+                "  Increase heap size (current: %" PRIu64 ", recommended: %" PRIu64 ")", heap_size_, heap_size_ * 2
+            );
             LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
-            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %" PRIu64 ")",
-                      heap_size_ * 2);
+            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %" PRIu64 ")", heap_size_ * 2);
         } else {
-            LOG_ERROR("  Increase task window size (current: %d, recommended: %d)",
-                      window_size_, active_tasks * 2);
+            LOG_ERROR("  Increase task window size (current: %d, recommended: %d)", window_size_, active_tasks * 2);
             LOG_ERROR("  Compile-time: PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");
-            LOG_ERROR("  Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2> (e.g. %d)",
-                      active_tasks * 2);
+            LOG_ERROR("  Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2> (e.g. %d)", active_tasks * 2);
         }
         LOG_ERROR("========================================");
         if (error_code_ptr_) {
-            int32_t code = heap_blocked ? PTO2_ERROR_HEAP_RING_DEADLOCK
-                                        : PTO2_ERROR_FLOW_CONTROL_DEADLOCK;
+            int32_t code = heap_blocked ? PTO2_ERROR_HEAP_RING_DEADLOCK : PTO2_ERROR_FLOW_CONTROL_DEADLOCK;
             error_code_ptr_->store(code, std::memory_order_release);
         }
     }
@@ -369,15 +372,15 @@ private:
  * is obtained via modulo: base[linear_index % capacity].
  */
 struct PTO2DepListPool {
-    PTO2DepListEntry* base;   // Pool base address
-    int32_t capacity;         // Total number of entries
-    int32_t top;              // Linear next-allocation counter (starts from 1)
-    int32_t tail;             // Linear first-alive counter (entries before this are dead)
-    int32_t high_water;       // Peak concurrent usage (top - tail)
-    int32_t last_reclaimed{0}; // last_task_alive at last successful reclamation
+    PTO2DepListEntry *base;     // Pool base address
+    int32_t capacity;           // Total number of entries
+    int32_t top;                // Linear next-allocation counter (starts from 1)
+    int32_t tail;               // Linear first-alive counter (entries before this are dead)
+    int32_t high_water;         // Peak concurrent usage (top - tail)
+    int32_t last_reclaimed{0};  // last_task_alive at last successful reclamation
 
     // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
-    std::atomic<int32_t>* error_code_ptr = nullptr;
+    std::atomic<int32_t> *error_code_ptr = nullptr;
 
     /**
      * Initialize dependency list pool
@@ -385,7 +388,7 @@ struct PTO2DepListPool {
      * @param base      Pool base address from shared memory
      * @param capacity  Total number of entries
      */
-    void init(PTO2DepListEntry* in_base, int32_t in_capacity, std::atomic<int32_t>* in_error_code_ptr) {
+    void init(PTO2DepListEntry *in_base, int32_t in_capacity, std::atomic<int32_t> *in_error_code_ptr) {
         base = in_base;
         capacity = in_capacity;
         top = 1;   // Start from 1, 0 means NULL/empty
@@ -408,20 +411,20 @@ struct PTO2DepListPool {
      * @param ring_id            Ring layer index
      * @param sm_last_task_alive Current last_task_alive from shared memory
      */
-    void reclaim(PTO2SchedulerState& sched, uint8_t ring_id, int32_t sm_last_task_alive);
+    void reclaim(PTO2SchedulerState &sched, uint8_t ring_id, int32_t sm_last_task_alive);
 
     /**
      * Ensure dep pool for a specific ring has at least `needed` entries available.
      * Spin-waits for reclamation if under pressure. Detects deadlock if no progress.
      */
-    void ensure_space(PTO2SchedulerState& sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed);
+    void ensure_space(PTO2SchedulerState &sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed);
 
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)
      *
      * @return Pointer to allocated entry, or nullptr on fatal error
      */
-    PTO2DepListEntry* alloc() {
+    PTO2DepListEntry *alloc() {
         int32_t used = top - tail;
         if (used >= capacity) {
             LOG_ERROR("========================================");
@@ -467,8 +470,8 @@ struct PTO2DepListPool {
      * @param task_slot     Task slot to prepend
      * @return New head offset
      */
-    PTO2DepListEntry* prepend(PTO2DepListEntry* cur, PTO2TaskSlotState* slot_state) {
-        PTO2DepListEntry* new_entry = alloc();
+    PTO2DepListEntry *prepend(PTO2DepListEntry *cur, PTO2TaskSlotState *slot_state) {
+        PTO2DepListEntry *new_entry = alloc();
         if (!new_entry) return nullptr;
         new_entry->slot_state = slot_state;
         new_entry->next = cur;
@@ -476,20 +479,16 @@ struct PTO2DepListPool {
     }
 
     /**
-    * Get entry by offset
-    */
-    PTO2DepListEntry* pto2_dep_pool_get(int32_t offset) {
+     * Get entry by offset
+     */
+    PTO2DepListEntry *pto2_dep_pool_get(int32_t offset) {
         if (offset <= 0) return NULL;
         return &base[offset];
     }
 
-    int32_t used() const {
-        return top - tail;
-    }
+    int32_t used() const { return top - tail; }
 
-    int32_t available() const {
-        return capacity - used();
-    }
+    int32_t available() const { return capacity - used(); }
 };
 
 // =============================================================================
@@ -502,7 +501,7 @@ struct PTO2DepListPool {
  */
 struct PTO2RingSet {
     PTO2TaskAllocator task_allocator;
-    PTO2DepListPool   dep_pool;
+    PTO2DepListPool dep_pool;
 };
 
-#endif // PTO_RING_BUFFER_H
+#endif  // PTO_RING_BUFFER_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -45,17 +45,17 @@ void pto2_set_orch_thread_idx(int idx) { pto2_current_orch_idx = idx; }
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
-static TaskOutputTensors submit_task_impl(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const Arg& args) {
+static TaskOutputTensors submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
     return pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels, args);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime* rt) { pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]); }
+void pto2_rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_scope_end(PTO2Runtime* rt) { pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]); }
+void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_orchestration_done(PTO2Runtime* rt) { pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]); }
+void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]); }
 
-static bool is_fatal_impl(PTO2Runtime* rt) { return rt->orchestrators[pto2_current_orch_idx].fatal; }
+static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrators[pto2_current_orch_idx].fatal; }
 
 // Wait for all producers of this tensor to be safe for data access.
 // Checks owner metadata (lifecycle anchor) and OverlapMap (modifier writers).
@@ -65,13 +65,13 @@ static bool is_fatal_impl(PTO2Runtime* rt) { return rt->orchestrators[pto2_curre
 // Uses cycle-based timeout (checked every 1024 spins).
 // Returns false on timeout (sets orch.fatal).
 MAYBE_UNINITIALIZED_BEGIN
-static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor, bool wait_for_consumers, const char* caller) {
-    PTO2OrchestratorState& orch = rt->orchestrators[pto2_current_orch_idx];
+static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wait_for_consumers, const char *caller) {
+    PTO2OrchestratorState &orch = rt->orchestrators[pto2_current_orch_idx];
 
     // Collect producer slot states from both maps, deduplicated by pointer.
     // +1: one creator slot + up to PTO2_LOOKUP_MAX_RESULTS modifier slots.
     constexpr int kMaxWait = PTO2_LOOKUP_MAX_RESULTS + 1;
-    PTO2TaskSlotState* slots[kMaxWait];
+    PTO2TaskSlotState *slots[kMaxWait];
     int slot_count = 0;
 
     // Step A: creator retention — read owner directly from tensor metadata
@@ -85,7 +85,7 @@ static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor, bool wa
     orch.tensor_map.lookup(tensor, lookup_result);
     for (int r = 0; r < lookup_result.count; r++) {
         PTO2TaskId pid = lookup_result.entries[r].entry->producer_task_id;
-        PTO2TaskSlotState* s = &rt->scheduler.ring_sched_states[pid.ring()].get_slot_state_by_task_id(pid.local());
+        PTO2TaskSlotState *s = &rt->scheduler.ring_sched_states[pid.ring()].get_slot_state_by_task_id(pid.local());
         bool already = false;
         for (int j = 0; j < slot_count; j++) {
             if (slots[j] == s) {
@@ -100,7 +100,7 @@ static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor, bool wa
 
     // Wait for each producer
     for (int p = 0; p < slot_count; p++) {
-        PTO2TaskSlotState& slot = *slots[p];
+        PTO2TaskSlotState &slot = *slots[p];
         uint8_t ring_id = slot.ring_id;
         int32_t local_id = static_cast<int32_t>(slot.task->task_id.local());
 
@@ -110,11 +110,11 @@ static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor, bool wa
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
                 orch.fatal = true;
-                unified_log_error(caller,
-                    "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
+                unified_log_error(
+                    caller, "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
                     (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES,  // NOLINT(runtime/int)
-                    ring_id,
-                    local_id);
+                    ring_id, local_id
+                );
                 return false;
             }
         }
@@ -126,11 +126,11 @@ static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor, bool wa
                 SPIN_WAIT_HINT();
                 if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
                     orch.fatal = true;
-                    unified_log_error(caller,
-                        "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
+                    unified_log_error(
+                        caller, "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
                         (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES,  // NOLINT(runtime/int)
-                        ring_id,
-                        local_id);
+                        ring_id, local_id
+                    );
                     return false;
                 }
             }
@@ -140,11 +140,12 @@ static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor, bool wa
 }
 MAYBE_UNINITIALIZED_END
 
-uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor, uint32_t ndims, const uint32_t indices[]) {
+uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     if (tensor.buffer.addr == 0) {
-        unified_log_error(__FUNCTION__,
-            "get_tensor_data: buffer not allocated (addr=0). "
-            "Use the Tensor returned by add_output(TensorCreateInfo) after submit returns.");
+        unified_log_error(
+            __FUNCTION__, "get_tensor_data: buffer not allocated (addr=0). "
+                          "Use the Tensor returned by add_output(TensorCreateInfo) after submit returns."
+        );
         return 0;
     }
 
@@ -154,18 +155,20 @@ uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor, uint32_t nd
 
     uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
     uint64_t elem_size = get_element_size(tensor.dtype);
-    const void* ptr = reinterpret_cast<const void*>(tensor.buffer.addr + flat_offset * elem_size);
+    const void *ptr = reinterpret_cast<const void *>(tensor.buffer.addr + flat_offset * elem_size);
     uint64_t result = 0;
     memcpy(&result, ptr, elem_size);
     return result;
 }
 
 void pto2_set_tensor_data(
-    PTO2Runtime* rt, const Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value) {
+    PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+) {
     if (tensor.buffer.addr == 0) {
-        unified_log_error(__FUNCTION__,
-            "set_tensor_data: buffer not allocated (addr=0). "
-            "Use the Tensor returned by add_output(TensorCreateInfo) after submit returns.");
+        unified_log_error(
+            __FUNCTION__, "set_tensor_data: buffer not allocated (addr=0). "
+                          "Use the Tensor returned by add_output(TensorCreateInfo) after submit returns."
+        );
         return;
     }
 
@@ -176,7 +179,7 @@ void pto2_set_tensor_data(
 
     uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
     uint64_t elem_size = get_element_size(tensor.dtype);
-    void* ptr = reinterpret_cast<void*>(tensor.buffer.addr + flat_offset * elem_size);
+    void *ptr = reinterpret_cast<void *>(tensor.buffer.addr + flat_offset * elem_size);
     memcpy(ptr, &value, elem_size);
 }
 
@@ -199,14 +202,15 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // Runtime Creation and Destruction
 // =============================================================================
 
-PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode) {
+PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode) {
     return pto2_runtime_create_custom(mode, PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
 }
 
-PTO2Runtime* pto2_runtime_create_custom(
-    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity) {
+PTO2Runtime *pto2_runtime_create_custom(
+    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity
+) {
     // Allocate runtime context
-    PTO2Runtime* rt = static_cast<PTO2Runtime*>(calloc(1, sizeof(PTO2Runtime)));
+    PTO2Runtime *rt = static_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) {
         return NULL;
     }
@@ -262,17 +266,15 @@ PTO2Runtime* pto2_runtime_create_custom(
     return rt;
 }
 
-PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-    PTO2SharedMemoryHandle* sm_handle,
-    void* gm_heap,
-    uint64_t heap_size,
-    int orch_count,
-    int32_t dep_pool_capacity) {
+PTO2Runtime *pto2_runtime_create_from_sm(
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count,
+    int32_t dep_pool_capacity
+) {
     if (!sm_handle) return NULL;
     if (orch_count < 1) orch_count = 1;
     if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
 
-    PTO2Runtime* rt = static_cast<PTO2Runtime*>(calloc(1, sizeof(PTO2Runtime)));
+    PTO2Runtime *rt = static_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) return NULL;
 
     rt->ops = &s_runtime_ops;
@@ -311,7 +313,7 @@ PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
     return rt;
 }
 
-void pto2_runtime_destroy(PTO2Runtime* rt) {
+void pto2_runtime_destroy(PTO2Runtime *rt) {
     if (!rt) return;
 
     pto2_scheduler_destroy(&rt->scheduler);
@@ -330,7 +332,7 @@ void pto2_runtime_destroy(PTO2Runtime* rt) {
     free(rt);
 }
 
-void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode) {
+void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Main Interface
  *
@@ -59,27 +69,25 @@ enum PTO2RuntimeMode {
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                        const Arg& args);
-    void (*scope_begin)(PTO2Runtime* rt);
-    void (*scope_end)(PTO2Runtime* rt);
-    void (*orchestration_done)(PTO2Runtime* rt);
-    bool (*is_fatal)(PTO2Runtime* rt);
+    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    void (*scope_begin)(PTO2Runtime *rt);
+    void (*scope_end)(PTO2Runtime *rt);
+    void (*orchestration_done)(PTO2Runtime *rt);
+    bool (*is_fatal)(PTO2Runtime *rt);
 
     // Logging (populated by runtime, called by orchestration)
-    void (*log_error)(const char* func, const char* fmt, ...);
-    void (*log_warn)(const char* func, const char* fmt, ...);
-    void (*log_info)(const char* func, const char* fmt, ...);
-    void (*log_debug)(const char* func, const char* fmt, ...);
-    void (*log_always)(const char* func, const char* fmt, ...);
+    void (*log_error)(const char *func, const char *fmt, ...);
+    void (*log_warn)(const char *func, const char *fmt, ...);
+    void (*log_info)(const char *func, const char *fmt, ...);
+    void (*log_debug)(const char *func, const char *fmt, ...);
+    void (*log_always)(const char *func, const char *fmt, ...);
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
-                                uint32_t ndims, const uint32_t indices[]);
-    void (*set_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
-                            uint32_t ndims, const uint32_t indices[],
-                            uint64_t value);
+    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]);
+    void (*set_tensor_data)(
+        PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    );
 };
 
 /**
@@ -90,24 +98,24 @@ struct PTO2RuntimeOps {
  */
 struct PTO2Runtime {
     // Ops table (first field — used by orchestration .so via function pointers)
-    const PTO2RuntimeOps*   ops;
+    const PTO2RuntimeOps *ops;
 
     // Components
-    PTO2SharedMemoryHandle* sm_handle;
-    PTO2OrchestratorState   orchestrators[PTO2_MAX_ORCH_THREADS];
-    int                     orch_count;     // Number of active orchestrator states
-    PTO2SchedulerState      scheduler;
+    PTO2SharedMemoryHandle *sm_handle;
+    PTO2OrchestratorState orchestrators[PTO2_MAX_ORCH_THREADS];
+    int orch_count;  // Number of active orchestrator states
+    PTO2SchedulerState scheduler;
 
     // GM Heap for output buffers
-    void*                   gm_heap;
-    uint64_t                  gm_heap_size;
-    bool                    gm_heap_owned;  // True if we allocated it
+    void *gm_heap;
+    uint64_t gm_heap_size;
+    bool gm_heap_owned;  // True if we allocated it
 
     // Mode
-    PTO2RuntimeMode         mode;
+    PTO2RuntimeMode mode;
 
     // Statistics
-    int64_t                 total_cycles;
+    int64_t total_cycles;
 };
 
 // =============================================================================
@@ -120,7 +128,7 @@ struct PTO2Runtime {
  * @param mode Execution mode
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode);
+PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode);
 
 /**
  * Create runtime with custom sizes
@@ -130,10 +138,10 @@ PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode);
  * @param heap_size        Size of GM heap
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
-                                         uint64_t task_window_size,
-                                         uint64_t heap_size,
-                                         int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+PTO2Runtime *pto2_runtime_create_custom(
+    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 
 /**
  * Create runtime from existing shared memory and GM heap (e.g. on device).
@@ -145,22 +153,20 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
  * @param heap_size GM heap size in bytes
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-                                          PTO2SharedMemoryHandle* sm_handle,
-                                          void* gm_heap,
-                                          uint64_t heap_size,
-                                          int orch_count = 1,
-                                          int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+PTO2Runtime *pto2_runtime_create_from_sm(
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count = 1,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 
 /**
  * Destroy runtime and free all resources
  */
-void pto2_runtime_destroy(PTO2Runtime* rt);
+void pto2_runtime_destroy(PTO2Runtime *rt);
 
 /**
  * Set execution mode
  */
-void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode);
+void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
 
 /**
  * Set the orchestrator index for the current thread.
@@ -179,7 +185,7 @@ void pto2_set_orch_thread_idx(int idx);
  * bounded by the scope. When scope_end() is called, the scope
  * releases its reference to all enclosed tasks.
  */
-void pto2_rt_scope_begin(PTO2Runtime* rt);
+void pto2_rt_scope_begin(PTO2Runtime *rt);
 
 /**
  * End current scope
@@ -187,29 +193,28 @@ void pto2_rt_scope_begin(PTO2Runtime* rt);
  * Releases scope reference for all tasks submitted since scope_begin().
  * Tasks whose refcount reaches zero will have their buffers released.
  */
-void pto2_rt_scope_end(PTO2Runtime* rt);
+void pto2_rt_scope_end(PTO2Runtime *rt);
 
 /**
  * Mark orchestration as complete
  *
  * Signals that no more tasks will be submitted.
  */
-void pto2_rt_orchestration_done(PTO2Runtime* rt);
+void pto2_rt_orchestration_done(PTO2Runtime *rt);
 
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.
  */
-uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
-                              uint32_t ndims, const uint32_t indices[]);
+uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]);
 
 /**
  * Cross-layer data access: write a value to a tensor at given indices.
  * Waits for producer completion (WAW) and all consumers (WAR) via TensorMap.
  * See set_tensor_data in pto_orchestration_api.h for full documentation.
  */
-void pto2_set_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
-                          uint32_t ndims, const uint32_t indices[],
-                          uint64_t value);
+void pto2_set_tensor_data(
+    PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+);
 
 /**
  * Slim config struct exported by orchestration .so via aicpu_orchestration_config().
@@ -218,8 +223,8 @@ void pto2_set_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
 struct PTO2OrchestrationConfig {
-    int         expected_arg_count;
+    int expected_arg_count;
 };
 #endif
 
-#endif // PTO_RUNTIME2_H
+#endif  // PTO_RUNTIME2_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -236,7 +236,7 @@ typedef enum {
  * Multiple logical tensors can share the same raw tensor (aliasing).
  */
 typedef struct {
-    void* base_ptr;      // Base pointer of allocated memory
+    void *base_ptr;      // Base pointer of allocated memory
     int64_t total_size;  // Total size in bytes
     int32_t refcount;    // Number of logical tensors referencing this storage
                          // (for memory management, 0 = can be freed)
@@ -263,7 +263,7 @@ typedef struct {
  */
 typedef struct {
     // === Raw tensor reference (shared storage) ===
-    void* raw_base;          // Pointer to raw tensor's base (for aliasing check)
+    void *raw_base;          // Pointer to raw tensor's base (for aliasing check)
     int64_t raw_total_size;  // Total size of raw tensor in bytes
 
     // === Storage offset ===
@@ -304,8 +304,8 @@ typedef struct {
  */
 struct PTO2TaskSlotState;  // Forward declaration
 struct PTO2DepListEntry {
-    PTO2TaskSlotState* slot_state;  // Consumer slot state (direct pointer)
-    PTO2DepListEntry* next;         // next entry
+    PTO2TaskSlotState *slot_state;  // Consumer slot state (direct pointer)
+    PTO2DepListEntry *next;         // next entry
 };
 
 // =============================================================================
@@ -329,8 +329,8 @@ struct PTO2TaskDescriptor {
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];
 
     // Packed output buffer (all outputs packed into single contiguous buffer)
-    void* packed_buffer_base;  // Start of packed buffer in GM Heap
-    void* packed_buffer_end;   // End of packed buffer (for heap reclamation)
+    void *packed_buffer_base;  // Start of packed buffer in GM Heap
+    void *packed_buffer_end;   // End of packed buffer (for heap reclamation)
 };
 
 // =============================================================================
@@ -351,7 +351,7 @@ struct PTO2TaskPayload {
     int32_t scalar_count{0};
     int32_t fanin_actual_count{0};  // Actual fanin count (without the +1 redundance)
     int32_t _reserved{0};           // Reserved (dep_pool_mark moved to SlotState for local access)
-    PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
+    PTO2TaskSlotState *fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
     // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
     // === Cache lines 35-50 (1024B) — scalars ===
@@ -371,8 +371,8 @@ struct PTO2TaskPayload {
      * @param args                Task arguments (tensors + scalars)
      * @param materialized_outputs  Materialized output tensors (from TensorCreateInfo path)
      */
-    void init(
-        const Arg& args, TaskOutputTensors& result, void* base_addr, uint64_t offsets[], uint64_t buffer_sizes[]) {
+    void
+    init(const Arg &args, TaskOutputTensors &result, void *base_addr, uint64_t offsets[], uint64_t buffer_sizes[]) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
@@ -381,9 +381,10 @@ struct PTO2TaskPayload {
             if (args.tag(i) != TensorArgType::OUTPUT) {
                 tensors[i].copy(*args.tensor(i).ptr);
             } else {
-                tensors[i].init_from_create_info(*args.tensor(i).create_info,
-                    reinterpret_cast<void*>(reinterpret_cast<char*>(base_addr) + offsets[i]),
-                    buffer_sizes[i]);
+                tensors[i].init_from_create_info(
+                    *args.tensor(i).create_info,
+                    reinterpret_cast<void *>(reinterpret_cast<char *>(base_addr) + offsets[i]), buffer_sizes[i]
+                );
                 result.materialize_output(tensors[i]);
             }
             tensors[i].update_start_offset();
@@ -396,8 +397,10 @@ struct PTO2TaskPayload {
 
 // PTO2TaskPayload layout verification (offsetof requires complete type).
 static_assert(offsetof(PTO2TaskPayload, tensors) == 192, "tensors must start at byte 192 (cache line 3)");
-static_assert(offsetof(PTO2TaskPayload, scalars) == 192 + MAX_TENSOR_ARGS * sizeof(Tensor),
-    "scalars must immediately follow tensors");
+static_assert(
+    offsetof(PTO2TaskPayload, scalars) == 192 + MAX_TENSOR_ARGS * sizeof(Tensor),
+    "scalars must immediately follow tensors"
+);
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
@@ -416,7 +419,7 @@ struct alignas(64) PTO2TaskSlotState {
     std::atomic<int32_t> fanout_lock;  // Per-task spinlock (0=unlocked, 1=locked)
     int32_t fanout_count;              // 1 (owning scope) + number of consumers
 
-    PTO2DepListEntry* fanout_head;  // Pointer to first fanout entry (nullptr = empty)
+    PTO2DepListEntry *fanout_head;  // Pointer to first fanout entry (nullptr = empty)
 
     // Task state (completion, consumed check, ready check)
     std::atomic<PTO2TaskState> task_state;  // PENDING/READY/RUNNING/COMPLETED/CONSUMED
@@ -428,9 +431,9 @@ struct alignas(64) PTO2TaskSlotState {
     // Fanout refcount (accessed with fanout_count in check_and_handle_consumed)
     std::atomic<int32_t> fanout_refcount;  // Dynamic: counts released references
 
-    PTO2TaskPayload* payload;
+    PTO2TaskPayload *payload;
 
-    PTO2TaskDescriptor* task;
+    PTO2TaskDescriptor *task;
 
     // Hot-path completion fields (moved from TaskDescriptor to avoid cross-struct access)
     uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
@@ -455,7 +458,7 @@ static_assert(sizeof(PTO2TaskSlotState) == 64);
  * Cycle cost function pointer type
  * Returns estimated cycle count for the InCore function
  */
-typedef int64_t (*PTO2CycleCostFunc)(void** args, int32_t num_args);
+typedef int64_t (*PTO2CycleCostFunc)(void **args, int32_t num_args);
 
 // =============================================================================
 // InCore Function Type
@@ -465,7 +468,7 @@ typedef int64_t (*PTO2CycleCostFunc)(void** args, int32_t num_args);
  * InCore function signature
  * All InCore functions must match this signature
  */
-typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
+typedef void (*PTO2InCoreFunc)(void **args, int32_t num_args);
 
 // =============================================================================
 // Utility Macros
@@ -510,7 +513,7 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 #endif
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& atomic_count, uint64_t& wait_cycle) {
+static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
     uint64_t t0 = get_sys_cnt_aicpu();
     bool contended = false;
     uint32_t atomic_ops = 0;
@@ -523,7 +526,8 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& ato
         }
         int32_t expected = 0;
         if (slot_state.fanout_lock.compare_exchange_weak(
-                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             atomic_ops++;  // successful CAS = 1 atomic
             atomic_count += atomic_ops;
             if (contended) {
@@ -537,20 +541,21 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& ato
 }
 #endif
 
-static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state) {
+static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state) {
     for (;;) {
         while (slot_state.fanout_lock.load(std::memory_order_acquire) != 0) {
             SPIN_WAIT_HINT();
         }
         int32_t expected = 0;
         if (slot_state.fanout_lock.compare_exchange_weak(
-                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             return;
         }
     }
 }
 
-static inline void pto2_fanout_unlock(PTO2TaskSlotState& slot_state) {
+static inline void pto2_fanout_unlock(PTO2TaskSlotState &slot_state) {
     slot_state.fanout_lock.store(0, std::memory_order_release);
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Scheduler Implementation
  *
@@ -57,14 +67,20 @@ PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
 // Task State Names
 // =============================================================================
 
-const char* pto2_task_state_name(PTO2TaskState state) {
+const char *pto2_task_state_name(PTO2TaskState state) {
     switch (state) {
-        case PTO2_TASK_PENDING:   return "PENDING";
-        case PTO2_TASK_READY:     return "READY";
-        case PTO2_TASK_RUNNING:   return "RUNNING";
-        case PTO2_TASK_COMPLETED: return "COMPLETED";
-        case PTO2_TASK_CONSUMED:  return "CONSUMED";
-        default:                  return "UNKNOWN";
+    case PTO2_TASK_PENDING:
+        return "PENDING";
+    case PTO2_TASK_READY:
+        return "READY";
+    case PTO2_TASK_RUNNING:
+        return "RUNNING";
+    case PTO2_TASK_COMPLETED:
+        return "COMPLETED";
+    case PTO2_TASK_CONSUMED:
+        return "CONSUMED";
+    default:
+        return "UNKNOWN";
     }
 }
 
@@ -72,8 +88,8 @@ const char* pto2_task_state_name(PTO2TaskState state) {
 // Ready Queue Implementation
 // =============================================================================
 
-bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity) {
-    queue->slots = (PTO2ReadyQueueSlot*)malloc(capacity * sizeof(PTO2ReadyQueueSlot));
+bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity) {
+    queue->slots = (PTO2ReadyQueueSlot *)malloc(capacity * sizeof(PTO2ReadyQueueSlot));
     if (!queue->slots) {
         return false;
     }
@@ -91,7 +107,7 @@ bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity) {
     return true;
 }
 
-void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
+void pto2_ready_queue_destroy(PTO2ReadyQueue *queue) {
     if (queue->slots) {
         free(queue->slots);
         queue->slots = NULL;
@@ -102,8 +118,7 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
 // Scheduler Initialization
 // =============================================================================
 
-bool PTO2SchedulerState::RingSchedState::init(
-    PTO2SharedMemoryHandle* sm_handle, int32_t ring_id) {
+bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id) {
     task_descriptors = sm_handle->task_descriptors[ring_id];
     task_window_size = sm_handle->header->rings[ring_id].task_window_size;
     task_window_mask = static_cast<int32_t>(task_window_size - 1);
@@ -142,8 +157,7 @@ void PTO2SchedulerState::RingSchedState::destroy() {
     slot_states = nullptr;
 }
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle) {
+bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle) {
     sched->sm_handle = sm_handle;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -177,7 +191,7 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
     return true;
 }
 
-void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
+void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].destroy();
     }
@@ -191,7 +205,7 @@ void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
 // Debug Utilities
 // =============================================================================
 
-void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
+void pto2_scheduler_print_stats(PTO2SchedulerState *sched) {
     LOG_INFO("=== Scheduler Statistics ===");
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         if (sched->ring_sched_states[r].last_task_alive > 0) {
@@ -206,14 +220,13 @@ void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
     LOG_INFO("============================");
 }
 
-void pto2_scheduler_print_queues(PTO2SchedulerState* sched) {
+void pto2_scheduler_print_queues(PTO2SchedulerState *sched) {
     LOG_INFO("=== Ready Queues ===");
 
-    const char* shape_names[] = {"AIC", "AIV", "MIX"};
+    const char *shape_names[] = {"AIC", "AIV", "MIX"};
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        LOG_INFO("  %s: count=%" PRIu64, shape_names[i],
-                 sched->ready_queues[i].size());
+        LOG_INFO("  %s: count=%" PRIu64, shape_names[i], sched->ready_queues[i].size());
     }
 
     LOG_INFO("====================");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -56,7 +56,7 @@
  */
 struct PTO2ReadyQueueSlot {
     std::atomic<int64_t> sequence;
-    PTO2TaskSlotState* slot_state;
+    PTO2TaskSlotState *slot_state;
 };
 
 /**
@@ -74,17 +74,17 @@ struct PTO2ReadyQueueSlot {
 static constexpr int PTO2_LOCAL_DISPATCH_TYPE_NUM = 2;
 
 struct PTO2LocalReadyBuffer {
-    PTO2TaskSlotState** slot_states = nullptr;
+    PTO2TaskSlotState **slot_states = nullptr;
     int count = 0;
     int capacity = 0;
 
-    void reset(PTO2TaskSlotState** buf, int cap) {
+    void reset(PTO2TaskSlotState **buf, int cap) {
         slot_states = buf;
         count = 0;
         capacity = cap;
     }
 
-    bool try_push(PTO2TaskSlotState* s) {
+    bool try_push(PTO2TaskSlotState *s) {
         if (slot_states && count < capacity) {
             slot_states[count++] = s;
             return true;
@@ -92,7 +92,7 @@ struct PTO2LocalReadyBuffer {
         return false;
     }
 
-    PTO2TaskSlotState* pop() { return (count > 0) ? slot_states[--count] : nullptr; }
+    PTO2TaskSlotState *pop() { return (count > 0) ? slot_states[--count] : nullptr; }
 };
 
 /**
@@ -106,7 +106,7 @@ struct PTO2LocalReadyBuffer {
  *   consumers only touch dequeue_pos
  */
 struct alignas(64) PTO2ReadyQueue {
-    PTO2ReadyQueueSlot* slots;
+    PTO2ReadyQueueSlot *slots;
     uint64_t capacity;
     uint64_t mask;        // capacity - 1
     char _pad0[64 - 24];  // Pad to own cache line
@@ -123,9 +123,9 @@ struct alignas(64) PTO2ReadyQueue {
         return (e >= d) ? (e - d) : 0;
     }
 
-    bool push(PTO2TaskSlotState* slot_state) {
+    bool push(PTO2TaskSlotState *slot_state) {
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         while (true) {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
@@ -133,7 +133,8 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - static_cast<int64_t>(pos);
             if (diff == 0) {
                 if (enqueue_pos.compare_exchange_weak(
-                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    )) {
                     break;
                 }
             } else if (diff < 0) {
@@ -148,7 +149,7 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch push: reserve count slots with a single CAS after confirming
     // every target slot is available under the usual Vyukov sequence check.
-    void push_batch(PTO2TaskSlotState** items, int count) {
+    void push_batch(PTO2TaskSlotState **items, int count) {
         if (count == 0) return;
 
         uint64_t pos;
@@ -156,7 +157,7 @@ struct alignas(64) PTO2ReadyQueue {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             bool ready = true;
             for (int i = 0; i < count; i++) {
-                PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
+                PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
                 int64_t diff = seq - static_cast<int64_t>(pos + i);
                 if (diff != 0) {
@@ -168,22 +169,23 @@ struct alignas(64) PTO2ReadyQueue {
                 continue;
             }
             if (enqueue_pos.compare_exchange_weak(
-                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed)) {
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed
+                )) {
                 break;
             }
         }
 
         for (int i = 0; i < count; i++) {
-            PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
+            PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             slot->slot_state = items[i];
             slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    bool push(PTO2TaskSlotState* slot_state, uint64_t& atomic_count, uint64_t& wait_cycle) {
+    bool push(PTO2TaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         uint64_t t0 = get_sys_cnt_aicpu();
         bool contended = false;
         uint32_t atomic_ops = 0;
@@ -195,7 +197,8 @@ struct alignas(64) PTO2ReadyQueue {
             atomic_ops += 2;  // enqueue_pos.load + sequence.load
             if (diff == 0) {
                 if (enqueue_pos.compare_exchange_weak(
-                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    )) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -219,7 +222,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 #endif
 
-    PTO2TaskSlotState* pop() {
+    PTO2TaskSlotState *pop() {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -228,7 +231,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         while (true) {
             pos = dequeue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
@@ -236,20 +239,21 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - static_cast<int64_t>(pos + 1);
             if (diff == 0) {
                 if (dequeue_pos.compare_exchange_weak(
-                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed))
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    ))
                     break;
             } else if (diff < 0) {
                 return nullptr;  // Queue empty
             }
         }
 
-        PTO2TaskSlotState* result = slot->slot_state;
+        PTO2TaskSlotState *result = slot->slot_state;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
 
 #if PTO2_SCHED_PROFILING
-    PTO2TaskSlotState* pop(uint64_t& atomic_count, uint64_t& wait_cycle) {
+    PTO2TaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -259,7 +263,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         uint64_t t0 = get_sys_cnt_aicpu();
         bool contended = false;
         uint32_t atomic_ops = 0;
@@ -271,7 +275,8 @@ struct alignas(64) PTO2ReadyQueue {
             atomic_ops += 2;  // dequeue_pos.load + sequence.load
             if (diff == 0) {
                 if (dequeue_pos.compare_exchange_weak(
-                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    )) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -290,7 +295,7 @@ struct alignas(64) PTO2ReadyQueue {
             wait_cycle += (get_sys_cnt_aicpu() - t0);
         }
 
-        PTO2TaskSlotState* result = slot->slot_state;
+        PTO2TaskSlotState *result = slot->slot_state;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
@@ -298,14 +303,14 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch pop: reserve a contiguous run of ready slots with a single CAS.
     // Returns actual number of items popped (may be less than max_count).
-    int pop_batch(PTO2TaskSlotState** out, int max_count) {
+    int pop_batch(PTO2TaskSlotState **out, int max_count) {
         uint64_t pos;
         int count;
         while (true) {
             pos = dequeue_pos.load(std::memory_order_relaxed);
             count = 0;
             while (count < max_count) {
-                PTO2ReadyQueueSlot* slot = &slots[(pos + count) & mask];
+                PTO2ReadyQueueSlot *slot = &slots[(pos + count) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
                 int64_t diff = seq - static_cast<int64_t>(pos + count + 1);
                 if (diff == 0) {
@@ -321,13 +326,14 @@ struct alignas(64) PTO2ReadyQueue {
             if (count == 0) return 0;
             if (count < 0) continue;
             if (dequeue_pos.compare_exchange_weak(
-                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed)) {
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed
+                )) {
                 break;
             }
         }
 
         for (int i = 0; i < count; i++) {
-            PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
+            PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
             slot->sequence.store(static_cast<int64_t>(pos + i + mask + 1), std::memory_order_release);
         }
@@ -335,7 +341,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if PTO2_SCHED_PROFILING
-    int pop_batch(PTO2TaskSlotState** out, int max_count, uint64_t& atomic_count, uint64_t& wait_cycle) {
+    int pop_batch(PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
         int count;
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -346,7 +352,7 @@ struct alignas(64) PTO2ReadyQueue {
             atomic_ops++;  // dequeue_pos.load
             count = 0;
             while (count < max_count) {
-                PTO2ReadyQueueSlot* slot = &slots[(pos + count) & mask];
+                PTO2ReadyQueueSlot *slot = &slots[(pos + count) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
                 int64_t diff = seq - static_cast<int64_t>(pos + count + 1);
                 atomic_ops++;  // sequence.load
@@ -369,7 +375,8 @@ struct alignas(64) PTO2ReadyQueue {
                 continue;
             }
             if (dequeue_pos.compare_exchange_weak(
-                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed)) {
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed
+                )) {
                 atomic_ops++;  // successful CAS
                 break;
             }
@@ -378,7 +385,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         for (int i = 0; i < count; i++) {
-            PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
+            PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
             slot->sequence.store(static_cast<int64_t>(pos + i + mask + 1), std::memory_order_release);
             atomic_ops++;  // sequence.store
@@ -393,8 +400,8 @@ struct alignas(64) PTO2ReadyQueue {
 };
 
 // Cold-path ready queue operations (defined in pto_scheduler.cpp)
-bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity);
-void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
+bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity);
+void pto2_ready_queue_destroy(PTO2ReadyQueue *queue);
 
 // =============================================================================
 // Scheduler State
@@ -419,35 +426,35 @@ struct PTO2CompletionStats {
  */
 struct PTO2SchedulerState {
     // Shared memory access
-    PTO2SharedMemoryHandle* sm_handle;
+    PTO2SharedMemoryHandle *sm_handle;
 
     // Per-ring state
     struct RingSchedState {
-        PTO2TaskDescriptor* task_descriptors;
-        PTO2TaskSlotState* slot_states;
+        PTO2TaskDescriptor *task_descriptors;
+        PTO2TaskSlotState *slot_states;
         int32_t last_task_alive;
         int32_t task_window_mask;
         uint64_t task_window_size;
         // Try-lock used to advance this ring's last_task_alive pointer.
         std::atomic<int32_t> advance_lock;
 
-        bool init(PTO2SharedMemoryHandle* sm_handle, int32_t ring_id);
+        bool init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id);
         void destroy();
 
-        PTO2TaskSlotState& get_slot_state_by_task_id(int32_t local_id) {
+        PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
             return slot_states[local_id & task_window_mask];
         }
-        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
+        PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
-        void sync_to_sm(PTO2SharedMemoryRingHeader& ring) {
+        void sync_to_sm(PTO2SharedMemoryRingHeader &ring) {
             ring.fc.last_task_alive.store(last_task_alive, std::memory_order_release);
         }
 
-        void advance_ring_pointers(PTO2SharedMemoryRingHeader& ring) {
+        void advance_ring_pointers(PTO2SharedMemoryRingHeader &ring) {
             int32_t current_task_index = ring.fc.current_task_index.load(std::memory_order_acquire);
 
             while (last_task_alive < current_task_index) {
-                PTO2TaskSlotState& slot_state = get_slot_state_by_task_id(last_task_alive);
+                PTO2TaskSlotState &slot_state = get_slot_state_by_task_id(last_task_alive);
                 if (slot_state.task_state.load(std::memory_order_acquire) != PTO2_TASK_CONSUMED) {
                     break;
                 }
@@ -469,19 +476,20 @@ struct PTO2SchedulerState {
     // =========================================================================
     // Inline hot-path methods
     // =========================================================================
-    PTO2TaskSlotState& get_slot_state(int32_t ring_id, int32_t local_id) {
+    PTO2TaskSlotState &get_slot_state(int32_t ring_id, int32_t local_id) {
         return ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
     }
-    PTO2TaskSlotState& get_slot_state_by_slot(int32_t ring_id, int32_t slot) {
+    PTO2TaskSlotState &get_slot_state_by_slot(int32_t ring_id, int32_t slot) {
         return ring_sched_states[ring_id].get_slot_state_by_slot(slot);
     }
 
-    void check_and_handle_consumed(PTO2TaskSlotState& slot_state) {
+    void check_and_handle_consumed(PTO2TaskSlotState &slot_state) {
         if (slot_state.fanout_refcount.load(std::memory_order_acquire) != slot_state.fanout_count) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
         if (!slot_state.task_state.compare_exchange_strong(
-                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire)) {
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
             return;
         }
 
@@ -493,14 +501,15 @@ struct PTO2SchedulerState {
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
         if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
-                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
         }
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    void check_and_handle_consumed(PTO2TaskSlotState& slot_state, uint64_t& atomic_count) {
+    void check_and_handle_consumed(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
         int32_t fc = slot_state.fanout_count;
         int32_t rc = slot_state.fanout_refcount.load(std::memory_order_acquire);
 
@@ -510,7 +519,8 @@ struct PTO2SchedulerState {
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
         if (!slot_state.task_state.compare_exchange_strong(
-                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire)) {
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
             atomic_count += 1;  // failed CAS
             return;
         }
@@ -525,7 +535,8 @@ struct PTO2SchedulerState {
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
         if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
-                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
             atomic_count += 2;  // try-lock CAS + unlock store
@@ -535,20 +546,20 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    void release_producer(PTO2TaskSlotState& slot_state) {
+    void release_producer(PTO2TaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         check_and_handle_consumed(slot_state);
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    void release_producer(PTO2TaskSlotState& slot_state, uint64_t& atomic_count) {
+    void release_producer(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         atomic_count += 1;  // fanout_refcount.fetch_add
         check_and_handle_consumed(slot_state, atomic_count);
     }
 #endif
 
-    bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state, PTO2LocalReadyBuffer* local_bufs = nullptr) {
+    bool release_fanin_and_check_ready(PTO2TaskSlotState &slot_state, PTO2LocalReadyBuffer *local_bufs = nullptr) {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
         // init release, making fanin_count visible — plain load suffices.
@@ -567,17 +578,18 @@ struct PTO2SchedulerState {
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state,
-        uint64_t& atomic_count,
-        uint64_t& push_wait,
-        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+    bool release_fanin_and_check_ready(
+        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
+        PTO2LocalReadyBuffer *local_bufs = nullptr
+    ) {
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
         atomic_count += 1;  // fanin_refcount.fetch_add
 
         if (new_refcount == slot_state.fanin_count) {
             PTO2TaskState expected = PTO2_TASK_PENDING;
             if (slot_state.task_state.compare_exchange_strong(
-                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
+                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire
+                )) {
                 atomic_count += 1;  // CAS(task_state PENDING→READY)
                 // Local-first: try per-CoreType thread-local buffer before global queue
                 PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state.active_mask);
@@ -592,7 +604,8 @@ struct PTO2SchedulerState {
 #endif
 
     int get_ready_tasks_batch(
-        PTO2ResourceShape shape, PTO2LocalReadyBuffer& local_buf, PTO2TaskSlotState** out, int max_count) {
+        PTO2ResourceShape shape, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out, int max_count
+    ) {
         int count = 0;
         while (count < max_count && local_buf.count > 0) {
             out[count++] = local_buf.slot_states[--local_buf.count];
@@ -605,13 +618,10 @@ struct PTO2SchedulerState {
     }
 
 #if PTO2_SCHED_PROFILING
-    int get_ready_tasks_batch(PTO2ResourceShape shape,
-        PTO2LocalReadyBuffer& local_buf,
-        PTO2TaskSlotState** out,
-        int max_count,
-        uint64_t& atomic_count,
-        uint64_t& wait_cycle,
-        uint64_t& local_dispatch_count) {
+    int get_ready_tasks_batch(
+        PTO2ResourceShape shape, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out, int max_count,
+        uint64_t &atomic_count, uint64_t &wait_cycle, uint64_t &local_dispatch_count
+    ) {
         int count = 0;
         while (count < max_count && local_buf.count > 0) {
             local_dispatch_count++;
@@ -626,7 +636,7 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    void on_scope_end(PTO2TaskSlotState** task_slot_states, int32_t count) {
+    void on_scope_end(PTO2TaskSlotState **task_slot_states, int32_t count) {
 #if PTO2_ORCH_PROFILING
         extern uint64_t g_orch_scope_end_atomic_count;
         if (count > 0) __builtin_prefetch(task_slot_states[0], 1, 0);
@@ -651,7 +661,7 @@ struct PTO2SchedulerState {
      *
      * @return true if this was the last subtask, completing the entire task.
      */
-    bool on_subtask_complete(PTO2TaskSlotState& slot_state) {
+    bool on_subtask_complete(PTO2TaskSlotState &slot_state) {
         int16_t prev = slot_state.completed_subtasks.fetch_add(1, std::memory_order_acq_rel);
         return (prev + 1) == slot_state.total_required_subtasks;
     }
@@ -667,12 +677,14 @@ struct PTO2SchedulerState {
 #else
     void
 #endif
-    on_mixed_task_complete(PTO2TaskSlotState& slot_state,
+    on_mixed_task_complete(
+        PTO2TaskSlotState &slot_state,
 #if PTO2_SCHED_PROFILING
         int thread_idx,
 #endif
 
-        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+        PTO2LocalReadyBuffer *local_bufs = nullptr
+    ) {
 #if PTO2_SCHED_PROFILING
         PTO2CompletionStats stats = {0, 0, 0, true};
 #endif
@@ -690,7 +702,7 @@ struct PTO2SchedulerState {
         pto2_fanout_lock(slot_state);
 #endif
         slot_state.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
-        PTO2DepListEntry* current = slot_state.fanout_head;  // Protected by fanout_lock
+        PTO2DepListEntry *current = slot_state.fanout_head;  // Protected by fanout_lock
         pto2_fanout_unlock(slot_state);
 
 #if PTO2_SCHED_PROFILING
@@ -705,7 +717,7 @@ struct PTO2SchedulerState {
         uint64_t fanout_atomics = 0, push_wait = 0;
 #endif
         while (current != nullptr) {
-            PTO2TaskSlotState& consumer_slot = *current->slot_state;
+            PTO2TaskSlotState &consumer_slot = *current->slot_state;
 #if PTO2_SCHED_PROFILING
             stats.fanout_edges++;
             if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait, local_bufs)) {
@@ -731,7 +743,7 @@ struct PTO2SchedulerState {
      */
 
 #if PTO2_SCHED_PROFILING
-    int32_t on_task_release(PTO2TaskSlotState& slot_state, int32_t thread_idx) {
+    int32_t on_task_release(PTO2TaskSlotState &slot_state, int32_t thread_idx) {
         PTO2_SCHED_CYCLE_START();
         extern uint64_t g_sched_fanin_cycle[], g_sched_fanin_atomic_count[];
         extern uint64_t g_sched_self_atomic_count[];
@@ -739,9 +751,9 @@ struct PTO2SchedulerState {
         extern uint64_t g_sched_complete_count[];
         uint64_t fanin_atomics = 0;
 #else
-    int32_t on_task_release(PTO2TaskSlotState& slot_state) {
+    int32_t on_task_release(PTO2TaskSlotState &slot_state) {
 #endif
-        PTO2TaskPayload* payload = slot_state.payload;
+        PTO2TaskPayload *payload = slot_state.payload;
         int32_t fanin_edges = payload->fanin_actual_count;
         for (int32_t i = 0; i < fanin_edges; i++) {
 #if PTO2_SCHED_PROFILING
@@ -773,16 +785,16 @@ struct PTO2SchedulerState {
 // Scheduler API (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched, PTO2SharedMemoryHandle* sm_handle);
-void pto2_scheduler_destroy(PTO2SchedulerState* sched);
+bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle);
+void pto2_scheduler_destroy(PTO2SchedulerState *sched);
 
 // =============================================================================
 // Debug Utilities (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-void pto2_scheduler_print_stats(PTO2SchedulerState* sched);
-void pto2_scheduler_print_queues(PTO2SchedulerState* sched);
-const char* pto2_task_state_name(PTO2TaskState state);
+void pto2_scheduler_print_stats(PTO2SchedulerState *sched);
+void pto2_scheduler_print_queues(PTO2SchedulerState *sched);
+const char *pto2_task_state_name(PTO2TaskState state);
 
 // =============================================================================
 // Scheduler Profiling Data

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Shared Memory Implementation
  *
@@ -44,26 +54,25 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
 // Creation and Destruction
 // =============================================================================
 
-static void pto2_sm_setup_pointers_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
-    char* ptr = (char*)handle->sm_base;
+static void
+pto2_sm_setup_pointers_per_ring(PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+    char *ptr = (char *)handle->sm_base;
 
     // Header
-    handle->header = (PTO2SharedMemoryHeader*)ptr;
+    handle->header = (PTO2SharedMemoryHeader *)ptr;
     ptr += PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
 
     // Per-ring task descriptors and payloads
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        handle->task_descriptors[r] = (PTO2TaskDescriptor*)ptr;
+        handle->task_descriptors[r] = (PTO2TaskDescriptor *)ptr;
         ptr += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
 
-        handle->task_payloads[r] = (PTO2TaskPayload*)ptr;
+        handle->task_payloads[r] = (PTO2TaskPayload *)ptr;
         ptr += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
     }
 }
 
-static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle* handle, uint64_t task_window_size) {
+static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle *handle, uint64_t task_window_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
@@ -71,10 +80,9 @@ static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle* handle, uint64_t task
     pto2_sm_setup_pointers_per_ring(handle, task_window_sizes);
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size) {
+PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_size) {
     // Allocate handle
-    PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
+    PTO2SharedMemoryHandle *handle = (PTO2SharedMemoryHandle *)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) {
         return NULL;
     }
@@ -82,19 +90,19 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     // Calculate total size
     uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
 
-    // Allocate shared memory (aligned for DMA efficiency)
-    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-        if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
-            free(handle);
-            return NULL;
-        }
-    #else
-        handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
-        if (!handle->sm_base) {
-            free(handle);
-            return NULL;
-        }
-    #endif
+// Allocate shared memory (aligned for DMA efficiency)
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+    if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
+        free(handle);
+        return NULL;
+    }
+#else
+    handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
+    if (!handle->sm_base) {
+        free(handle);
+        return NULL;
+    }
+#endif
 
     handle->sm_size = sm_size;
     handle->is_owner = true;
@@ -111,21 +119,16 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     return handle;
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create_default(void) {
-    return pto2_sm_create(PTO2_TASK_WINDOW_SIZE,
-                          PTO2_HEAP_SIZE);
-}
+PTO2SharedMemoryHandle *pto2_sm_create_default(void) { return pto2_sm_create(PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE); }
 
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size) {
+PTO2SharedMemoryHandle *
+pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size) {
     if (!sm_base || sm_size == 0) return NULL;
 
     uint64_t required = pto2_sm_calculate_size(task_window_size);
     if (sm_size < required) return NULL;
 
-    PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
+    PTO2SharedMemoryHandle *handle = (PTO2SharedMemoryHandle *)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) return NULL;
 
     handle->sm_base = sm_base;
@@ -138,7 +141,7 @@ PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
     return handle;
 }
 
-void pto2_sm_destroy(PTO2SharedMemoryHandle* handle) {
+void pto2_sm_destroy(PTO2SharedMemoryHandle *handle) {
     if (!handle) return;
 
     if (handle->is_owner && handle->sm_base) {
@@ -153,9 +156,7 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle* handle) {
 // =============================================================================
 //
 // no need init data in pool, init pool data when used
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size) {
+void pto2_sm_init_header(PTO2SharedMemoryHandle *handle, uint64_t task_window_size, uint64_t heap_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -166,10 +167,10 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
 }
 
 void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]) {
-    PTO2SharedMemoryHeader* header = handle->header;
+    PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+) {
+    PTO2SharedMemoryHeader *header = handle->header;
 
     // Per-ring flow control (start at 0)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -203,10 +204,10 @@ void pto2_sm_init_header_per_ring(
 // Debug Utilities
 // =============================================================================
 
-void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
+void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle) {
     if (!handle || !handle->header) return;
 
-    PTO2SharedMemoryHeader* h = handle->header;
+    PTO2SharedMemoryHeader *h = handle->header;
 
     LOG_INFO("=== PTO2 Shared Memory Layout ===");
     LOG_INFO("Base address:       %p", handle->sm_base);
@@ -216,8 +217,10 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
         LOG_INFO("Ring %d:", r);
         LOG_INFO("  task_window_size: %" PRIu64, h->rings[r].task_window_size);
         LOG_INFO("  heap_size:        %" PRIu64 " bytes", h->rings[r].heap_size);
-        LOG_INFO("  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")",
-                 h->rings[r].task_descriptors_offset, h->rings[r].task_descriptors_offset);
+        LOG_INFO(
+            "  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")", h->rings[r].task_descriptors_offset,
+            h->rings[r].task_descriptors_offset
+        );
         LOG_INFO("  heap_top:         %" PRIu64, h->rings[r].fc.heap_top.load(std::memory_order_acquire));
         LOG_INFO("  heap_tail:        %" PRIu64, h->rings[r].fc.heap_tail.load(std::memory_order_acquire));
         LOG_INFO("  current_task_idx: %d", h->rings[r].fc.current_task_index.load(std::memory_order_acquire));
@@ -232,12 +235,12 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
     LOG_INFO("================================");
 }
 
-bool pto2_sm_validate(PTO2SharedMemoryHandle* handle) {
+bool pto2_sm_validate(PTO2SharedMemoryHandle *handle) {
     if (!handle) return false;
     if (!handle->sm_base) return false;
     if (!handle->header) return false;
 
-    PTO2SharedMemoryHeader* h = handle->header;
+    PTO2SharedMemoryHeader *h = handle->header;
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         if (!h->rings[r].fc.validate(handle, r)) return false;
@@ -246,12 +249,12 @@ bool pto2_sm_validate(PTO2SharedMemoryHandle* handle) {
     return true;
 }
 
-bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle* handle, int32_t ring_id) const {
+bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const {
     if (!handle) return false;
     if (!handle->header) return false;
     if (ring_id < 0 || ring_id >= PTO2_MAX_RING_DEPTH) return false;
 
-    const PTO2SharedMemoryHeader* h = handle->header;
+    const PTO2SharedMemoryHeader *h = handle->header;
 
     // Check that offsets are within bounds
     if (h->rings[ring_id].task_descriptors_offset >= h->total_size) return false;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Shared Memory Layout
  *
@@ -50,9 +60,9 @@ struct PTO2RingFlowControl {
     int32_t _pad0;                            // Alignment padding
 
     // Written by Scheduler, Read by Orchestrator (for back-pressure)
-    std::atomic<uint64_t> heap_tail;          // Heap ring free pointer
-    std::atomic<int32_t> last_task_alive;     // Task ring tail (oldest active task)
-    int32_t _pad1;                            // Alignment padding
+    std::atomic<uint64_t> heap_tail;       // Heap ring free pointer
+    std::atomic<int32_t> last_task_alive;  // Task ring tail (oldest active task)
+    int32_t _pad1;                         // Alignment padding
 
     void init() {
         heap_top.store(0, std::memory_order_relaxed);
@@ -61,7 +71,7 @@ struct PTO2RingFlowControl {
         last_task_alive.store(0, std::memory_order_relaxed);
     }
 
-    bool validate(PTO2SharedMemoryHandle* handle, int32_t ring_id) const;
+    bool validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const;
 };
 
 /**
@@ -86,7 +96,7 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
 
     // === GLOBAL FIELDS ===
-    std::atomic<int32_t> orchestrator_done;   // Flag: orchestration complete
+    std::atomic<int32_t> orchestrator_done;  // Flag: orchestration complete
 
     // Total shared memory size (for validation)
     uint64_t total_size;
@@ -104,13 +114,15 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
 
     // Scheduler error state (Scheduler → Host, independent of orchestrator)
     // Written by scheduler threads on timeout; read by orchestrator and host.
-    std::atomic<int32_t> sched_error_bitmap;   // Bit X set = thread X had error
-    std::atomic<int32_t> sched_error_code;     // Last scheduler error code (last-writer-wins)
-    std::atomic<int32_t> sched_error_thread;   // Thread index of last error writer
+    std::atomic<int32_t> sched_error_bitmap;  // Bit X set = thread X had error
+    std::atomic<int32_t> sched_error_code;    // Last scheduler error code (last-writer-wins)
+    std::atomic<int32_t> sched_error_thread;  // Thread index of last error writer
 };
 
-static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
-              "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)");
+static_assert(
+    sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
+    "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)"
+);
 
 // =============================================================================
 // Shared Memory Handle
@@ -121,17 +133,16 @@ static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
  * Provides both Orchestrator and Scheduler views of the same memory
  */
 struct PTO2SharedMemoryHandle {
-    void*   sm_base;              // Base address of shared memory
-    uint64_t sm_size;             // Total size of shared memory
+    void *sm_base;     // Base address of shared memory
+    uint64_t sm_size;  // Total size of shared memory
 
     // Quick pointers into shared memory regions (per-ring)
-    PTO2SharedMemoryHeader* header;
-    PTO2TaskDescriptor*     task_descriptors[PTO2_MAX_RING_DEPTH];
-    PTO2TaskPayload*        task_payloads[PTO2_MAX_RING_DEPTH];
+    PTO2SharedMemoryHeader *header;
+    PTO2TaskDescriptor *task_descriptors[PTO2_MAX_RING_DEPTH];
+    PTO2TaskPayload *task_payloads[PTO2_MAX_RING_DEPTH];
 
     // Ownership flag
-    bool    is_owner;             // True if this handle allocated the memory
-
+    bool is_owner;  // True if this handle allocated the memory
 };
 
 // =============================================================================
@@ -161,13 +172,12 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
  * @param heap_size         Heap size per ring for output buffers
  * @return Handle with both views, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size);
+PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Create shared memory with default sizes
  */
-PTO2SharedMemoryHandle* pto2_sm_create_default(void);
+PTO2SharedMemoryHandle *pto2_sm_create_default(void);
 
 /**
  * Wrap an existing buffer as shared memory (e.g. device GM buffer).
@@ -179,31 +189,27 @@ PTO2SharedMemoryHandle* pto2_sm_create_default(void);
  * @param heap_size          Heap size per ring (for layout; buffer has no heap region)
  * @return Handle, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size);
+PTO2SharedMemoryHandle *
+pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Destroy shared memory and free resources
  */
-void pto2_sm_destroy(PTO2SharedMemoryHandle* handle);
+void pto2_sm_destroy(PTO2SharedMemoryHandle *handle);
 
 /**
  * Initialize shared memory header with layout information
  * Called after memory is allocated
  */
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size);
+void pto2_sm_init_header(PTO2SharedMemoryHandle *handle, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Initialize shared memory header with per-ring layout information.
  */
 void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]);
+    PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+);
 
 // =============================================================================
 // Debug Utilities
@@ -212,16 +218,16 @@ void pto2_sm_init_header_per_ring(
 /**
  * Print shared memory layout info
  */
-void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle);
+void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle);
 
 /**
  * Validate shared memory integrity
  * @return true if valid, false if corrupted
  */
-bool pto2_sm_validate(PTO2SharedMemoryHandle* handle);
+bool pto2_sm_validate(PTO2SharedMemoryHandle *handle);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // PTO_SHARED_MEMORY_H
+#endif  // PTO_SHARED_MEMORY_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -92,7 +92,7 @@ static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
 /**
  * Compute active_mask from MixedKernels.
  */
-static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels& mk) {
+static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels &mk) {
     uint8_t mask = 0;
     if (mk.aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
     if (mk.aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
@@ -108,12 +108,12 @@ static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels& mk) 
  * block_idx in [0, block_num) via the per-dispatch LocalContext.
  */
 class PTO2LaunchSpec {
- public:
+public:
     constexpr PTO2LaunchSpec() = default;
 
     int16_t block_num() const { return block_num_; }
     void set_block_num(int16_t n) { block_num_ = n; }
 
- private:
+private:
     int16_t block_num_{1};
 };

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_task_id.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_task_id.h
@@ -43,8 +43,8 @@ struct PTO2TaskId {
     constexpr uint32_t local() const { return static_cast<uint32_t>(raw & 0xFFFFFFFFu); }
     constexpr bool is_valid() const { return raw != UINT64_MAX; }
 
-    constexpr bool operator==(const PTO2TaskId& other) const { return raw == other.raw; }
-    constexpr bool operator!=(const PTO2TaskId& other) const { return raw != other.raw; }
+    constexpr bool operator==(const PTO2TaskId &other) const { return raw == other.raw; }
+    constexpr bool operator!=(const PTO2TaskId &other) const { return raw != other.raw; }
 };
 
 static_assert(sizeof(PTO2TaskId) == 8, "PTO2TaskId must stay 8 bytes (shared memory ABI)");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - TensorMap Implementation
  *
@@ -28,7 +38,7 @@
 #if PTO2_TENSORMAP_PROFILING
 uint64_t g_lookup_chain_total = 0;
 uint64_t g_lookup_count = 0;
-int32_t  g_lookup_chain_max = 0;
+int32_t g_lookup_chain_max = 0;
 uint64_t g_lookup_overlap_checks = 0;
 uint64_t g_lookup_overlap_hits = 0;
 uint64_t g_insert_count = 0;
@@ -38,14 +48,16 @@ uint64_t g_insert_count = 0;
 // Initialization and Destruction
 // =============================================================================
 
-bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+bool PTO2TensorMap::init(
+    int32_t new_num_buckets, int32_t new_pool_size, const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]
+) {
     // Validate power of 2 for fast modulo
     if ((new_num_buckets & (new_num_buckets - 1)) != 0) {
         return false;  // num_buckets must be power of 2
     }
 
     // Allocate buckets
-    buckets = (PTO2TensorMapEntry**)malloc(new_num_buckets * sizeof(PTO2TensorMapEntry*));
+    buckets = (PTO2TensorMapEntry **)malloc(new_num_buckets * sizeof(PTO2TensorMapEntry *));
     if (!buckets) {
         return false;
     }
@@ -58,7 +70,8 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const i
     num_buckets = new_num_buckets;
 
     // Allocate entry pool (64-byte aligned for cache-line-aligned entries)
-    entry_pool = (PTO2TensorMapEntry*)aligned_alloc(alignof(PTO2TensorMapEntry), new_pool_size * sizeof(PTO2TensorMapEntry));
+    entry_pool =
+        (PTO2TensorMapEntry *)aligned_alloc(alignof(PTO2TensorMapEntry), new_pool_size * sizeof(PTO2TensorMapEntry));
     if (!entry_pool) {
         free(buckets);
         buckets = NULL;
@@ -67,7 +80,7 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const i
     memset(entry_pool, 0, new_pool_size * sizeof(PTO2TensorMapEntry));
 
     // Allocate free entry list
-    free_entry_list = (PTO2TensorMapEntry**)calloc(new_pool_size, sizeof(PTO2TensorMapEntry*));
+    free_entry_list = (PTO2TensorMapEntry **)calloc(new_pool_size, sizeof(PTO2TensorMapEntry *));
     if (!free_entry_list) {
         free(buckets);
         free(entry_pool);
@@ -92,7 +105,7 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const i
 
     // Allocate per-ring per-task entry tracking (each ring has its own window size)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_entry_heads[r] = (PTO2TensorMapEntry**)malloc(new_task_window_sizes[r] * sizeof(PTO2TensorMapEntry*));
+        task_entry_heads[r] = (PTO2TensorMapEntry **)malloc(new_task_window_sizes[r] * sizeof(PTO2TensorMapEntry *));
         if (!task_entry_heads[r]) {
             // Cleanup previously allocated rings
             for (int j = 0; j < r; j++) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -86,7 +86,7 @@ extern uint64_t g_insert_count;
 struct alignas(64) PTO2TensorMapEntry {
     // === Cache line 1 (64B) — lookup hot path ===
     uint64_t buffer_addr;                // 8B: tensor base address (hash key)
-    PTO2TensorMapEntry* next_in_bucket;  // 8B: next entry in hash bucket chain
+    PTO2TensorMapEntry *next_in_bucket;  // 8B: next entry in hash bucket chain
     PTO2TaskId producer_task_id;         // 8B: raw (ring_id << 32) | local_id
     int32_t bucket_index;                // 4B: bucket index (-1 if unlinked)
     uint32_t __padding0__;               // 4B: occupies Tensor::start_offset high half
@@ -98,16 +98,16 @@ struct alignas(64) PTO2TensorMapEntry {
     uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // 20B: shape per dimension
 
     // === Cache line 2 (64B) — insert/remove/slow-path ===
-    PTO2TensorMapEntry* prev_in_bucket;         // 8B: prev in hash bucket chain
-    PTO2TensorMapEntry* next_in_task;           // 8B: next entry for same task
-    PTO2TensorMapEntry* prev_in_task;           // 8B: prev entry for same task
+    PTO2TensorMapEntry *prev_in_bucket;         // 8B: prev in hash bucket chain
+    PTO2TensorMapEntry *next_in_task;           // 8B: next entry for same task
+    PTO2TensorMapEntry *prev_in_task;           // 8B: prev entry for same task
     uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];  // 20B: only when !is_all_offset_zero
     // padding: 20B to fill 64B
 
     /**
      * Copy overlap-relevant fields from a Tensor into this entry.
      */
-    void copy_from_tensor(const Tensor& tensor) {
+    void copy_from_tensor(const Tensor &tensor) {
         memcpy(this, &tensor, 64);
         if (!tensor.is_all_offset_zero) {
             for (uint32_t i = 0; i < tensor.ndims; i++) {
@@ -116,7 +116,7 @@ struct alignas(64) PTO2TensorMapEntry {
         }
     }
 
-    void copy_tensor_create_info(const TensorCreateInfo& tensor_create_info, uint64_t addr) {
+    void copy_tensor_create_info(const TensorCreateInfo &tensor_create_info, uint64_t addr) {
         memcpy(this, &tensor_create_info, 64);
         buffer_addr = addr;
     }
@@ -125,7 +125,7 @@ struct alignas(64) PTO2TensorMapEntry {
      * Check overlap between input tensor and this entry (the producer output).
      * Mirrors Tensor::is_overlap() logic but operates on entry fields directly.
      */
-    OverlapStatus check_overlap(const Tensor& input) const {
+    OverlapStatus check_overlap(const Tensor &input) const {
         debug_assert(input.buffer.addr == buffer_addr);
         debug_assert(input.version >= version);
         if (input.version > version) {
@@ -166,7 +166,8 @@ static_assert(offsetof(PTO2TensorMapEntry, ndims) == offsetof(Tensor, ndims));
 static_assert(offsetof(PTO2TensorMapEntry, is_all_offset_zero) == offsetof(Tensor, is_all_offset_zero));
 static_assert(offsetof(PTO2TensorMapEntry, shapes) == offsetof(Tensor, shapes));
 static_assert(
-    offsetof(PTO2TensorMapEntry, prev_in_bucket) == 64, "TensorMapEntry must be exactly 2 cache lines (128 bytes)");
+    offsetof(PTO2TensorMapEntry, prev_in_bucket) == 64, "TensorMapEntry must be exactly 2 cache lines (128 bytes)"
+);
 
 /**
  * Stack-allocated lookup result (avoids heap allocation per lookup)
@@ -177,13 +178,13 @@ static_assert(
 // =============================================================================
 struct PTO2LookupResult {
     struct Entry {
-        PTO2TensorMapEntry* entry;
+        PTO2TensorMapEntry *entry;
         OverlapStatus overlap_status;
     };
     Entry entries[PTO2_LOOKUP_MAX_RESULTS];
     int32_t count{0};
 
-    void push(PTO2TensorMapEntry* entry, OverlapStatus s) {
+    void push(PTO2TensorMapEntry *entry, OverlapStatus s) {
         if (count < PTO2_LOOKUP_MAX_RESULTS) {
             entries[count++] = {entry, s};
         }
@@ -197,19 +198,19 @@ struct PTO2LookupResult {
  */
 struct PTO2TensorMap {
     // Hash table buckets (fixed size, power of 2)
-    PTO2TensorMapEntry** buckets;  // Array of offsets into entry_pool (-1 = empty)
+    PTO2TensorMapEntry **buckets;  // Array of offsets into entry_pool (-1 = empty)
     int32_t num_buckets;           // Must be power of 2 for fast modulo
 
     // Entry pool as ring buffer
-    PTO2TensorMapEntry* entry_pool;        // Ring buffer of entries
-    PTO2TensorMapEntry** free_entry_list;  // free entry ids
+    PTO2TensorMapEntry *entry_pool;        // Ring buffer of entries
+    PTO2TensorMapEntry **free_entry_list;  // free entry ids
     int32_t pool_size;                     // Total pool capacity
     int32_t next_entry_idx;                // id when next entry insert
     int32_t free_num;                      // free entry number in entry pool
 
     // Per-ring per-task entry tracking (for efficient bucket cleanup)
     // Indexed by [ring_id][local_id & (task_window_sizes[ring_id] - 1)]
-    PTO2TensorMapEntry** task_entry_heads[PTO2_MAX_RING_DEPTH];
+    PTO2TensorMapEntry **task_entry_heads[PTO2_MAX_RING_DEPTH];
     int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];  // Per-ring task window size (for slot masking)
 
     // Per-ring validity threshold (for lazy invalidation)
@@ -218,22 +219,22 @@ struct PTO2TensorMap {
     // Per-ring cleanup progress (for periodic cleanup_retired)
     int32_t last_cleanup[PTO2_MAX_RING_DEPTH]{};
 
-    PTO2OrchestratorState* orch{nullptr};
+    PTO2OrchestratorState *orch{nullptr};
 
     // new_entry only allocates memory, does not assign attributes
-    PTO2TensorMapEntry* new_entry() {
+    PTO2TensorMapEntry *new_entry() {
         if (free_num > 0) {
-            PTO2TensorMapEntry* res = free_entry_list[--free_num];
+            PTO2TensorMapEntry *res = free_entry_list[--free_num];
             debug_assert(res->bucket_index == -1);
             return res;
         }
         always_assert(next_entry_idx < pool_size);
-        PTO2TensorMapEntry* res = &entry_pool[next_entry_idx++];
+        PTO2TensorMapEntry *res = &entry_pool[next_entry_idx++];
         debug_assert(res->bucket_index == -1);
         return res;
     }
 
-    void free_entry(PTO2TensorMapEntry& entry) {
+    void free_entry(PTO2TensorMapEntry &entry) {
         always_assert(entry.bucket_index != -1);  // must still be in a bucket
 
         // Update predecessor's next pointer (O(1) via prev_in_bucket)
@@ -299,9 +300,9 @@ struct PTO2TensorMap {
      * @param tensor  Tensor to look up
      * @param result  Output: stack-allocated result buffer
      */
-    void lookup(const Tensor& tensor, PTO2LookupResult& result) {
+    void lookup(const Tensor &tensor, PTO2LookupResult &result) {
         uint32_t bucket_index = hash(tensor.buffer.addr);
-        PTO2TensorMapEntry* cur_entry = buckets[bucket_index];
+        PTO2TensorMapEntry *cur_entry = buckets[bucket_index];
 
         result.count = 0;
 #if PTO2_TENSORMAP_PROFILING
@@ -310,7 +311,7 @@ struct PTO2TensorMap {
 #endif
 
         while (cur_entry != nullptr) {
-            PTO2TensorMapEntry* next_entry = cur_entry->next_in_bucket;
+            PTO2TensorMapEntry *next_entry = cur_entry->next_in_bucket;
 
 #if PTO2_TENSORMAP_PROFILING
             chain_len++;
@@ -357,8 +358,8 @@ struct PTO2TensorMap {
      * @param tensor            Tensor produced
      * @param producer_task_id  Task ID of producer
      */
-    void insert(const Tensor& tensor, PTO2TaskId producer_task_id) {
-        PTO2TensorMapEntry* entry = new_entry();
+    void insert(const Tensor &tensor, PTO2TaskId producer_task_id) {
+        PTO2TensorMapEntry *entry = new_entry();
         entry->copy_from_tensor(tensor);
         link_entry(entry, tensor.buffer.addr, producer_task_id);
     }
@@ -376,14 +377,16 @@ struct PTO2TensorMap {
         // Iterate through retired tasks on this ring and remove their entries
         for (int32_t local_id = old_last_task_alive; local_id < new_last_task_alive; local_id++) {
             int32_t task_slot = local_id & (task_window_sizes[ring_id] - 1);
-            PTO2TensorMapEntry* cur_entry = task_entry_heads[ring_id][task_slot];
+            PTO2TensorMapEntry *cur_entry = task_entry_heads[ring_id][task_slot];
 
             while (cur_entry != nullptr) {
-                PTO2TensorMapEntry* next_entry = cur_entry->next_in_task;  // Save before clearing
+                PTO2TensorMapEntry *next_entry = cur_entry->next_in_task;  // Save before clearing
                 // Only remove if this entry belongs to the retiring task
                 // (slot may have been reused by a newer task)
-                debug_assert(cur_entry->producer_task_id ==
-                             PTO2TaskId::make(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id)));
+                debug_assert(
+                    cur_entry->producer_task_id ==
+                    PTO2TaskId::make(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id))
+                );
                 free_entry(*cur_entry);
                 cur_entry = next_entry;
             }
@@ -413,7 +416,7 @@ struct PTO2TensorMap {
     /**
      * Link an initialized entry into bucket and task chains.
      */
-    void link_entry(PTO2TensorMapEntry* entry, uint64_t addr, PTO2TaskId producer_task_id) {
+    void link_entry(PTO2TensorMapEntry *entry, uint64_t addr, PTO2TaskId producer_task_id) {
 #if PTO2_TENSORMAP_PROFILING
         g_insert_count++;
 #endif
@@ -445,11 +448,11 @@ struct PTO2TensorMap {
     /**
      * Check if entry is valid (producer has not retired)
      */
-    bool entry_valid(const PTO2TensorMapEntry& entry) const {
+    bool entry_valid(const PTO2TensorMapEntry &entry) const {
         return static_cast<int32_t>(entry.producer_task_id.local()) >= last_task_alives[entry.producer_task_id.ring()];
     }
 
-    void remove_entry(PTO2TensorMapEntry& entry) {
+    void remove_entry(PTO2TensorMapEntry &entry) {
         remove_from_task(entry);
         free_entry(entry);
     }
@@ -458,7 +461,7 @@ struct PTO2TensorMap {
      * Remove entry from its task chain (O(1) with prev pointer)
      * Called during pool wrap-around to unlink reused entries.
      */
-    void remove_from_task(PTO2TensorMapEntry& entry) {
+    void remove_from_task(PTO2TensorMapEntry &entry) {
         always_assert(entry.bucket_index != -1);  // must still be in a bucket
         // Update predecessor's next pointer (O(1) via prev_in_task)
         if (entry.prev_in_task == nullptr) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -61,28 +61,29 @@
  * binding get_ref() on an rvalue is compile-time rejected to prevent dangling.
  */
 class TaskOutputTensors {
- public:  // NOLINT(whitespace/indent)
-    TaskOutputTensors() : output_count_(0) {}
+public:  // NOLINT(whitespace/indent)
+    TaskOutputTensors() :
+        output_count_(0) {}
 
     bool empty() const { return output_count_ == 0; }
     uint32_t size() const { return output_count_; }
 
     /// Borrow a materialized output tensor by index (lvalue only).
-    const Tensor& get_ref(uint32_t index) const& {
+    const Tensor &get_ref(uint32_t index) const & {
         always_assert(index < output_count_);
         return *tensors_[index];
     }
-    const Tensor& get_ref(uint32_t index) const&& = delete;
+    const Tensor &get_ref(uint32_t index) const && = delete;
 
     /// Runtime-internal: append one materialized output Tensor.
-    void materialize_output(const Tensor& tensor) {
+    void materialize_output(const Tensor &tensor) {
         always_assert(output_count_ < PTO2_MAX_OUTPUTS);
         tensors_[output_count_++] = &tensor;
     }
 
- private:  // NOLINT(whitespace/indent)
+private:  // NOLINT(whitespace/indent)
     uint32_t output_count_;
-    const Tensor* tensors_[PTO2_MAX_OUTPUTS];
+    const Tensor *tensors_[PTO2_MAX_OUTPUTS];
 };
 
 // =============================================================================
@@ -96,9 +97,10 @@ class TaskOutputTensors {
  * The active member is determined by TensorArgType (OUTPUT → create_info, else → ptr).
  */
 union TensorRef {
-    const Tensor* ptr;
-    const TensorCreateInfo* create_info;
-    TensorRef() : ptr(nullptr) {}
+    const Tensor *ptr;
+    const TensorCreateInfo *create_info;
+    TensorRef() :
+        ptr(nullptr) {}
 };
 
 /**
@@ -126,7 +128,7 @@ union TensorRef {
  */
 struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType> {
     bool has_error{false};
-    const char* error_msg{nullptr};
+    const char *error_msg{nullptr};
     PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
 
     void reset() {
@@ -135,7 +137,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         error_msg = nullptr;
     }
 
-    void set_error(const char* msg) {
+    void set_error(const char *msg) {
         if (!has_error) {
             has_error = true;
             error_msg = msg;
@@ -146,7 +148,8 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         if (scalar_count_ != 0) {
             set_error(
                 "add_input/add_output/add_inout called after add_scalar: "
-                "all tensors must be added before any scalars");
+                "all tensors must be added before any scalars"
+            );
             return false;
         }
         if (tensor_count_ >= MAX_TENSOR_ARGS) {
@@ -156,7 +159,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         return true;
     }
 
-    void add_input(const Tensor& t) {
+    void add_input(const Tensor &t) {
         if (!check_add_tensor_valid()) {
             return;
         }
@@ -168,7 +171,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
     /// Standard future-output path: runtime allocates buffer from heap,
     /// materializes Tensor into TaskOutputTensors.
     /// The TensorCreateInfo must outlive the submit call (pointer is stored).
-    void add_output(const TensorCreateInfo& ci) {
+    void add_output(const TensorCreateInfo &ci) {
         if (!check_add_tensor_valid()) {
             return;
         }
@@ -178,9 +181,9 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
     }
 
     /// Prevent passing temporaries — the pointer would dangle before submit.
-    void add_output(TensorCreateInfo&&) = delete;
+    void add_output(TensorCreateInfo &&) = delete;
 
-    void add_inout(const Tensor& t) {
+    void add_inout(const Tensor &t) {
         if (!check_add_tensor_valid()) {
             return;
         }
@@ -190,7 +193,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
     }
 
     /// Write-only existing tensor: skips OverlapMap lookup, depends on creator.
-    void add_output(const Tensor& t) {
+    void add_output(const Tensor &t) {
         if (!check_add_tensor_valid()) return;
         tensors_[tensor_count_].ptr = &t;
         tags_[tensor_count_] = TensorArgType::OUTPUT_EXISTING;
@@ -198,7 +201,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
     }
 
     /// No-dependency existing tensor: skips OverlapMap lookup, depends on creator only.
-    void add_no_dep(const Tensor& t) {
+    void add_no_dep(const Tensor &t) {
         if (!check_add_tensor_valid()) return;
         tensors_[tensor_count_].ptr = &t;
         tags_[tensor_count_] = TensorArgType::NO_DEP;
@@ -222,7 +225,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         scalars_[scalar_count_++] = to_u64(value);
     }
 
-    void add_scalars(const uint64_t* values, int count) {
+    void add_scalars(const uint64_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
             return;
@@ -237,16 +240,16 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
      * (e.g., -1 → 0x00000000FFFFFFFF, not 0xFFFFFFFFFFFFFFFF).
      * Uses NEON to process 4 elements per iteration on aarch64.
      */
-    void add_scalars_i32(const int32_t* values, int count) {
+    void add_scalars_i32(const int32_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
             return;
         }
-        uint64_t* dst = &scalars_[scalar_count_];
+        uint64_t *dst = &scalars_[scalar_count_];
 #if defined(__aarch64__)
         int i = 0;
         for (; i + 4 <= count; i += 4) {
-            uint32x4_t v = vld1q_u32(reinterpret_cast<const uint32_t*>(values + i));
+            uint32x4_t v = vld1q_u32(reinterpret_cast<const uint32_t *>(values + i));
             uint64x2_t lo = vmovl_u32(vget_low_u32(v));
             uint64x2_t hi = vmovl_u32(vget_high_u32(v));
             vst1q_u64(dst + i, lo);
@@ -267,7 +270,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
      * Copy scalars from another Arg's scalar array.
      * Useful when multiple tasks share the same scalar data (e.g., block indices).
      */
-    void copy_scalars_from(const Arg& src, int src_offset, int count) {
+    void copy_scalars_from(const Arg &src, int src_offset, int count) {
         if (src_offset + count > src.scalar_count_) {
             set_error("Source scalar range out of bounds in copy_scalars_from");
             return;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -66,7 +66,7 @@ Runtime::Runtime() {
 // Tensor Pair Management
 // =============================================================================
 
-void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
+void Runtime::record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size) {
     if (tensor_pair_count >= RUNTIME_MAX_TENSOR_PAIRS) {
         LOG_ERROR("[Runtime] Tensor pairs full (max=%d)", RUNTIME_MAX_TENSOR_PAIRS);
         return;
@@ -78,7 +78,7 @@ void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
     LOG_INFO("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
 }
 
-TensorPair* Runtime::get_tensor_pairs() { return tensor_pairs; }
+TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
 
 int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
@@ -89,18 +89,18 @@ void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 // =============================================================================
 
 bool Runtime::get_orch_built_on_host() const { return orch_built_on_host_; }
-void* Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
-void* Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
-const ChipStorageTaskArgs& Runtime::get_orch_args() const { return orch_args_storage_; }
+void *Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
+void *Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
+const ChipStorageTaskArgs &Runtime::get_orch_args() const { return orch_args_storage_; }
 void Runtime::set_orch_built_on_host(bool v) { orch_built_on_host_ = v; }
-void Runtime::set_pto2_gm_sm_ptr(void* p) { pto2_gm_sm_ptr_ = p; }
-void Runtime::set_pto2_gm_heap(void* p) { pto2_gm_heap_ptr_ = p; }
-void Runtime::set_pto2_slot_states_ptr(void* p) { pto2_slot_states_ptr_ = p; }
-void Runtime::set_orch_args(const ChipStorageTaskArgs& args) { orch_args_storage_ = args; }
+void Runtime::set_pto2_gm_sm_ptr(void *p) { pto2_gm_sm_ptr_ = p; }
+void Runtime::set_pto2_gm_heap(void *p) { pto2_gm_heap_ptr_ = p; }
+void Runtime::set_pto2_slot_states_ptr(void *p) { pto2_slot_states_ptr_ = p; }
+void Runtime::set_orch_args(const ChipStorageTaskArgs &args) { orch_args_storage_ = args; }
 
 // Device orchestration SO binary (for dlopen on AICPU thread 3)
 // Copies data to internal storage to avoid lifetime issues with Python ctypes arrays
-void Runtime::set_device_orch_so(const void* data, size_t size) {
+void Runtime::set_device_orch_so(const void *data, size_t size) {
     if (data == nullptr || size == 0) {
         device_orch_so_size_ = 0;
         return;
@@ -114,7 +114,7 @@ void Runtime::set_device_orch_so(const void* data, size_t size) {
     device_orch_so_size_ = size;
 }
 
-const void* Runtime::get_device_orch_so_data() const {
+const void *Runtime::get_device_orch_so_data() const {
     return device_orch_so_size_ > 0 ? device_orch_so_storage_ : nullptr;
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -109,8 +109,8 @@ struct Handshake {
  * Used for copy-back during finalize.
  */
 struct TensorPair {
-    void* host_ptr;
-    void* dev_ptr;
+    void *host_ptr;
+    void *dev_ptr;
     size_t size;
 };
 
@@ -119,11 +119,11 @@ struct TensorPair {
  * Allows runtime to use pluggable device memory backends.
  */
 struct HostApi {
-    void* (*device_malloc)(size_t size);
-    void (*device_free)(void* dev_ptr);
-    int (*copy_to_device)(void* dev_ptr, const void* host_ptr, size_t size);
-    int (*copy_from_device)(void* host_ptr, const void* dev_ptr, size_t size);
-    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t* bin_data, size_t bin_size);
+    void *(*device_malloc)(size_t size);
+    void (*device_free)(void *dev_ptr);
+    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
+    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t *bin_data, size_t bin_size);
     void (*remove_kernel_binary)(int func_id);
 };
 
@@ -151,7 +151,7 @@ struct Task {
  * execution control and device orchestration state.
  */
 class Runtime {
- public:  // NOLINT(whitespace/indent)
+public:  // NOLINT(whitespace/indent)
     // Handshake buffers for AICPU-AICore communication
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
@@ -180,7 +180,7 @@ class Runtime {
     bool orch_to_sched;
     uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
 
- private:  // NOLINT(whitespace/indent)
+private:  // NOLINT(whitespace/indent)
     // Tensor pairs for host-device memory tracking
     TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
     int tensor_pair_count;
@@ -191,9 +191,9 @@ class Runtime {
 
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
-    void* pto2_gm_sm_ptr_;                   // GM pointer to PTO2 shared memory (device)
-    void* pto2_gm_heap_ptr_;                 // GM heap for orchestrator output buffers (device)
-    void* pto2_slot_states_ptr_;             // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
+    void *pto2_gm_sm_ptr_;                   // GM pointer to PTO2 shared memory (device)
+    void *pto2_gm_heap_ptr_;                 // GM heap for orchestrator output buffers (device)
+    void *pto2_slot_states_ptr_;             // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
     ChipStorageTaskArgs orch_args_storage_;  // Copy of args for device
 
     // Device orchestration SO binary (for dlopen on AICPU thread 3)
@@ -201,7 +201,7 @@ class Runtime {
     uint8_t device_orch_so_storage_[RUNTIME_MAX_ORCH_SO_SIZE];
     size_t device_orch_so_size_;
 
- public:  // NOLINT(whitespace/indent)
+public:  // NOLINT(whitespace/indent)
     /**
      * Constructor - zero-initialize all arrays
      */
@@ -214,12 +214,12 @@ class Runtime {
     /**
      * Record a host-device tensor pair for copy-back during finalize.
      */
-    void record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size);
+    void record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size);
 
     /**
      * Get pointer to tensor pairs array.
      */
-    TensorPair* get_tensor_pairs();
+    TensorPair *get_tensor_pairs();
 
     /**
      * Get number of recorded tensor pairs.
@@ -240,18 +240,18 @@ class Runtime {
     // =========================================================================
 
     bool get_orch_built_on_host() const;
-    void* get_pto2_gm_sm_ptr() const;
-    void* get_pto2_gm_heap_ptr() const;
-    const ChipStorageTaskArgs& get_orch_args() const;
+    void *get_pto2_gm_sm_ptr() const;
+    void *get_pto2_gm_heap_ptr() const;
+    const ChipStorageTaskArgs &get_orch_args() const;
     void set_orch_built_on_host(bool v);
-    void set_pto2_gm_sm_ptr(void* p);
-    void set_pto2_gm_heap(void* p);
-    void set_pto2_slot_states_ptr(void* p);
-    void set_orch_args(const ChipStorageTaskArgs& args);
+    void set_pto2_gm_sm_ptr(void *p);
+    void set_pto2_gm_heap(void *p);
+    void set_pto2_slot_states_ptr(void *p);
+    void set_orch_args(const ChipStorageTaskArgs &args);
 
     // Device orchestration SO binary (for dlopen on AICPU thread 3)
-    void set_device_orch_so(const void* data, size_t size);
-    const void* get_device_orch_so_data() const;
+    void set_device_orch_so(const void *data, size_t size);
+    const void *get_device_orch_so_data() const;
     size_t get_device_orch_so_size() const;
 
     uint64_t get_function_bin_addr(int func_id) const;
@@ -270,7 +270,7 @@ class Runtime {
     int get_task_count() const { return 0; }
 
     /** @deprecated RT2 uses PTO2DispatchPayload, not Task. Always returns nullptr. */
-    Task* get_task(int) { return nullptr; }
+    Task *get_task(int) { return nullptr; }
 
     /** @deprecated Use PTO2 dispatch mode */
     bool get_use_pto2_dispatch() const { return true; }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -45,8 +45,8 @@ struct Segment {
     uint64_t begin;
     uint64_t end;
 
-    bool line_segment_intersection(const Segment& other) const { return end > other.begin && other.end > begin; }
-    bool contains(const Segment& other) const { return begin <= other.begin && other.end <= end; }
+    bool line_segment_intersection(const Segment &other) const { return end > other.begin && other.end > begin; }
+    bool contains(const Segment &other) const { return begin <= other.begin && other.end <= end; }
 };
 
 /**
@@ -64,23 +64,24 @@ struct Segment {
  * must remain valid (not a temporary) until after the submit call.
  */
 class alignas(64) TensorCreateInfo {
- public:  // NOLINT(whitespace/indent)
+public:  // NOLINT(whitespace/indent)
     TensorCreateInfo(
-        const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false)
-        : initial_value(0),
-          has_initial_value(false),
-          version(0),
-          ndims(ndims),
-          dtype(dtype),
-          is_all_offset_zero(true),
-          is_raw_eq_shapes(true),
-          manual_dep(manual_dep) {
+        const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false
+    ) :
+        initial_value(0),
+        has_initial_value(false),
+        version(0),
+        ndims(ndims),
+        dtype(dtype),
+        is_all_offset_zero(true),
+        is_raw_eq_shapes(true),
+        manual_dep(manual_dep) {
         for (uint32_t i = 0; i < ndims; i++) {
             raw_shapes[i] = shapes[i];
         }
     }
 
-    void copy(const TensorCreateInfo& other) { memcpy(this, &other, sizeof(other)); }
+    void copy(const TensorCreateInfo &other) { memcpy(this, &other, sizeof(other)); }
 
     template <typename T = uint64_t>
     void set_initial_value(T value) {
@@ -96,7 +97,7 @@ class alignas(64) TensorCreateInfo {
         return total * get_element_size(dtype);
     }
 
- public:  // NOLINT(whitespace/indent)
+public:  // NOLINT(whitespace/indent)
     // --- Bytes [0, 32): TensorCreateInfo-only fields ---
     // These occupy the same positions as Tensor::buffer, Tensor::owner_task_id,
     // and Tensor::start_offset. The runtime overwrites owner metadata after the
@@ -172,28 +173,22 @@ struct alignas(64) Tensor {
     uint8_t _pad_cl2[24];                          // Tail padding (bytes 104–127)
 
     // --- Copy / move / destroy are public (valid tensors can be freely copied) ---
-    Tensor(const Tensor&) = default;
-    Tensor& operator=(const Tensor&) = default;
-    Tensor(Tensor&&) = default;
-    Tensor& operator=(Tensor&&) = default;
+    Tensor(const Tensor &) = default;
+    Tensor &operator=(const Tensor &) = default;
+    Tensor(Tensor &&) = default;
+    Tensor &operator=(Tensor &&) = default;
     ~Tensor() = default;
 
     /// Return the effective raw_shapes pointer (shapes[] when is_raw_eq_shapes).
     /// Avoids cache line 2 access for the common case.
-    const uint32_t* get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
+    const uint32_t *get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
 
     // --- Initialization (operates on already-constructed Tensor) ---
-    void init(void* addr,
-        uint64_t buffer_size_bytes,
-        const uint32_t in_raw_shapes[],
-        const uint32_t in_shapes[],
-        const uint32_t in_offsets[],
-        uint32_t in_ndims,
-        DataType in_dtype,
-        int32_t in_version,
-        bool in_is_all_offset_zero = false,
-        bool in_is_raw_eq_shapes = false,
-        bool in_manual_dep = false) {
+    void init(
+        void *addr, uint64_t buffer_size_bytes, const uint32_t in_raw_shapes[], const uint32_t in_shapes[],
+        const uint32_t in_offsets[], uint32_t in_ndims, DataType in_dtype, int32_t in_version,
+        bool in_is_all_offset_zero = false, bool in_is_raw_eq_shapes = false, bool in_manual_dep = false
+    ) {
         buffer = {reinterpret_cast<uint64_t>(addr), buffer_size_bytes};
         ndims = in_ndims;
         dtype = in_dtype;
@@ -217,7 +212,7 @@ struct alignas(64) Tensor {
         owner_task_id = PTO2TaskId::invalid();
     }
 
-    void init(const Tensor& other) {
+    void init(const Tensor &other) {
         memcpy(this, &other, 64);  // fast copy cache line 1
         if (!other.is_raw_eq_shapes) {
             for (uint32_t i = 0; i < other.ndims; i++) {
@@ -232,7 +227,8 @@ struct alignas(64) Tensor {
     }
 
     void init_with_view(
-        const Tensor& other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) {
+        const Tensor &other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false
+    ) {
         buffer = other.buffer;
         ndims = other.ndims;
         dtype = other.dtype;
@@ -241,7 +237,7 @@ struct alignas(64) Tensor {
         // view always diverges shapes from raw_shapes, so is_raw_eq_shapes = false.
         // Read parent's effective raw_shapes (avoids parent cache line 2 when parent is_raw_eq_shapes).
         is_raw_eq_shapes = false;
-        const uint32_t* parent_raw = other.get_raw_shapes();
+        const uint32_t *parent_raw = other.get_raw_shapes();
         for (uint32_t i = 0; i < ndims; i++) {
             raw_shapes[i] = parent_raw[i];
             shapes[i] = view_shapes[i];
@@ -274,19 +270,21 @@ struct alignas(64) Tensor {
     /// Uses Horner's method (forward traversal, no stride variable).
     uint64_t compute_flat_offset(const uint32_t indices[], uint32_t in_ndims) const {
         if (in_ndims == 0) return 0;
-        const uint32_t* rs = get_raw_shapes();
+        const uint32_t *rs = get_raw_shapes();
         uint64_t offset = 0;
         if (is_all_offset_zero) {
-            for (uint32_t d = 0; d < in_ndims; d++) offset = offset * rs[d] + indices[d];
+            for (uint32_t d = 0; d < in_ndims; d++)
+                offset = offset * rs[d] + indices[d];
         } else {
-            for (uint32_t d = 0; d < in_ndims; d++) offset = offset * rs[d] + indices[d] + offsets[d];
+            for (uint32_t d = 0; d < in_ndims; d++)
+                offset = offset * rs[d] + indices[d] + offsets[d];
         }
         return offset;
     }
 
     /// Materialize a TensorCreateInfo into this Tensor (fresh contiguous output).
     /// Single 64B memcpy covers the entire cacheline 1, then buffer is overwritten.
-    void init_from_create_info(const TensorCreateInfo& ci, void* addr, uint64_t buffer_size) {
+    void init_from_create_info(const TensorCreateInfo &ci, void *addr, uint64_t buffer_size) {
         memcpy(this, &ci, 64);
         buffer = {reinterpret_cast<uint64_t>(addr), buffer_size};
         owner_task_id = PTO2TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
@@ -296,9 +294,9 @@ struct alignas(64) Tensor {
     }
 
     void fill_initial_value(uint64_t initial_value) {
-        always_assert(reinterpret_cast<char*>(buffer.addr) != nullptr);
+        always_assert(reinterpret_cast<char *>(buffer.addr) != nullptr);
         uint64_t elem_size = get_element_size(dtype);
-        char* dst = reinterpret_cast<char*>(buffer.addr);
+        char *dst = reinterpret_cast<char *>(buffer.addr);
         constexpr uint64_t BLK = 64;
         uint64_t blk = (buffer.size < BLK) ? buffer.size : BLK;
         for (uint64_t b = 0; b < blk; b += elem_size) {
@@ -318,7 +316,7 @@ struct alignas(64) Tensor {
             start_offset = 0;
             return;
         }
-        const uint32_t* rs = get_raw_shapes();
+        const uint32_t *rs = get_raw_shapes();
         uint64_t result = 0;
         uint64_t stride = 1;
         for (int i = static_cast<int>(ndims) - 1; i >= 0; i--) {
@@ -328,7 +326,7 @@ struct alignas(64) Tensor {
         start_offset = result;
     }
 
-    void copy(const Tensor& other) { init(other); }
+    void copy(const Tensor &other) { init(other); }
 
     Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
         Tensor result;
@@ -401,19 +399,19 @@ struct alignas(64) Tensor {
         return total;
     }
 
-    bool is_same_memref(const Tensor& other) const { return buffer.addr == other.buffer.addr; }
+    bool is_same_memref(const Tensor &other) const { return buffer.addr == other.buffer.addr; }
 
     std::string dump() const {
         std::stringstream ss;
         std::string indent = "    ";
-        ss << "{" << std::endl;
-        ss << indent << "buffer.addr: " << buffer.addr << std::endl;
-        ss << indent << "buffer.size: " << buffer.size << " bytes" << std::endl;
-        ss << indent << "dtype: " << get_dtype_name(dtype) << std::endl;
-        ss << indent << "ndims: " << ndims << std::endl;
-        ss << indent << "version: " << version << std::endl;
+        ss << "{" << '\n';
+        ss << indent << "buffer.addr: " << buffer.addr << '\n';
+        ss << indent << "buffer.size: " << buffer.size << " bytes" << '\n';
+        ss << indent << "dtype: " << get_dtype_name(dtype) << '\n';
+        ss << indent << "ndims: " << ndims << '\n';
+        ss << indent << "version: " << version << '\n';
 
-        const uint32_t* rs = get_raw_shapes();
+        const uint32_t *rs = get_raw_shapes();
         ss << indent << "raw_shapes: [";
         for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
@@ -421,7 +419,7 @@ struct alignas(64) Tensor {
             }
             ss << rs[i];
         }
-        ss << "]" << std::endl;
+        ss << "]" << '\n';
         ss << indent << "shapes: [";
         for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
@@ -429,7 +427,7 @@ struct alignas(64) Tensor {
             }
             ss << shapes[i];
         }
-        ss << "]" << std::endl;
+        ss << "]" << '\n';
         ss << indent << "offsets: [";
         for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
@@ -437,44 +435,32 @@ struct alignas(64) Tensor {
             }
             ss << (is_all_offset_zero ? 0u : offsets[i]);
         }
-        ss << "]" << std::endl;
-        ss << "}" << std::endl;
+        ss << "]" << '\n';
+        ss << "}" << '\n';
         return ss.str();
     }
 
- private:
+private:
     // Default and parameterized constructors are private.
     // Valid Tensors come only from controlled entry points.
     Tensor() = default;
 
-    Tensor(void* addr,
-        uint64_t buffer_size_bytes,
-        const uint32_t raw_shapes[],
-        const uint32_t shapes[],
-        const uint32_t offsets[],
-        uint32_t ndims,
-        DataType dtype,
-        int32_t version,
-        bool is_all_offset_zero = false,
-        bool is_raw_eq_shapes = false,
-        bool manual_dep = false) {
-        init(addr,
-            buffer_size_bytes,
-            raw_shapes,
-            shapes,
-            offsets,
-            ndims,
-            dtype,
-            version,
-            is_all_offset_zero,
-            is_raw_eq_shapes,
-            manual_dep);
+    Tensor(
+        void *addr, uint64_t buffer_size_bytes, const uint32_t raw_shapes[], const uint32_t shapes[],
+        const uint32_t offsets[], uint32_t ndims, DataType dtype, int32_t version, bool is_all_offset_zero = false,
+        bool is_raw_eq_shapes = false, bool manual_dep = false
+    ) {
+        init(
+            addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version, is_all_offset_zero,
+            is_raw_eq_shapes, manual_dep
+        );
     }
 
     // Friends that need to construct Tensors
     friend struct PTO2TaskPayload;
     friend inline Tensor make_tensor_external(
-        void* addr, const uint32_t shapes[], uint32_t ndims, DataType dtype, bool manual_dep, int32_t version);
+        void *addr, const uint32_t shapes[], uint32_t ndims, DataType dtype, bool manual_dep, int32_t version
+    );
 };
 
 static_assert(sizeof(Tensor) == 128, "Tensor must be exactly 2 cache lines (128 bytes)");

--- a/src/a5/platform/include/aicore/performance_collector_aicore.h
+++ b/src/a5/platform/include/aicore/performance_collector_aicore.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file performance_collector_aicore.h
  * @brief AICore performance data collection interface
@@ -36,18 +46,13 @@
  * @param start_time Start timestamp
  * @param end_time End timestamp
  */
-__aicore__ __attribute__((always_inline))
-static inline void perf_aicore_record_task(
-    __gm__ PerfBuffer* perf_buf,
-    uint32_t task_id,
-    uint64_t start_time,
-    uint64_t end_time) {
-
+__aicore__ __attribute__((always_inline)) static inline void
+perf_aicore_record_task(__gm__ PerfBuffer *perf_buf, uint32_t task_id, uint64_t start_time, uint64_t end_time) {
     // Read current buffer count (AICPU owns the count, AICore reads only)
     dcci(&perf_buf->count, SINGLE_CACHE_LINE);
     uint32_t idx = perf_buf->count;
 
-    __gm__ PerfRecord* record = &perf_buf->records[idx];
+    __gm__ PerfRecord *record = &perf_buf->records[idx];
 
     // Write record data (func_id, core_type, and count filled by AICPU at completion)
     record->start_time = start_time;

--- a/src/a5/platform/include/aicpu/device_log.h
+++ b/src/a5/platform/include/aicpu/device_log.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file device_log.h
  * @brief Unified Device Logging Interface for AICPU
@@ -40,58 +50,58 @@ extern bool g_is_log_enable_warn;
 extern bool g_is_log_enable_error;
 
 // Platform constant (defined in platform-specific device_log.cpp)
-extern const char* TILE_FWK_DEVICE_MACHINE;
+extern const char *TILE_FWK_DEVICE_MACHINE;
 
 // =============================================================================
 // Platform-Specific Logging Functions (Low-Level Layer)
 // =============================================================================
 
 // Platform-specific logging functions (implemented in device_log.cpp)
-void dev_log_debug(const char* func, const char* fmt, ...);
-void dev_log_info(const char* func, const char* fmt, ...);
-void dev_log_warn(const char* func, const char* fmt, ...);
-void dev_log_error(const char* func, const char* fmt, ...);
-void dev_log_always(const char* func, const char* fmt, ...);
+void dev_log_debug(const char *func, const char *fmt, ...);
+void dev_log_info(const char *func, const char *fmt, ...);
+void dev_log_warn(const char *func, const char *fmt, ...);
+void dev_log_error(const char *func, const char *fmt, ...);
+void dev_log_always(const char *func, const char *fmt, ...);
 
 // =============================================================================
 // High-Level Logging Macros (Platform-Independent Layer)
 // =============================================================================
 
-#define D_DEV_LOGD(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_debug()) { \
+#define D_DEV_LOGD(MODE_NAME, fmt, ...)                      \
+    do {                                                     \
+        if (is_log_enable_debug()) {                         \
             dev_log_debug(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                    \
+    } while (0)
 
-#define D_DEV_LOGI(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_info()) { \
+#define D_DEV_LOGI(MODE_NAME, fmt, ...)                     \
+    do {                                                    \
+        if (is_log_enable_info()) {                         \
             dev_log_info(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                   \
+    } while (0)
 
-#define D_DEV_LOGW(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_warn()) { \
+#define D_DEV_LOGW(MODE_NAME, fmt, ...)                     \
+    do {                                                    \
+        if (is_log_enable_warn()) {                         \
             dev_log_warn(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                   \
+    } while (0)
 
-#define D_DEV_LOGE(MODE_NAME, fmt, ...) \
-    do { \
-        if (is_log_enable_error()) { \
+#define D_DEV_LOGE(MODE_NAME, fmt, ...)                      \
+    do {                                                     \
+        if (is_log_enable_error()) {                         \
             dev_log_error(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                    \
+    } while (0)
 
 // =============================================================================
 // Convenience Macros
 // =============================================================================
 
 #define DEV_DEBUG(fmt, args...) D_DEV_LOGD(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_INFO(fmt, args...)  D_DEV_LOGI(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_WARN(fmt, args...)  D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
+#define DEV_INFO(fmt, args...) D_DEV_LOGI(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
+#define DEV_WARN(fmt, args...) D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
 #define DEV_ERROR(fmt, args...) D_DEV_LOGE(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
 #define DEV_ALWAYS(fmt, args...) dev_log_always(__FUNCTION__, fmt, ##args)
 
@@ -110,32 +120,32 @@ void dev_log_always(const char* func, const char* fmt, ...);
 // Conditional Check Macros
 // =============================================================================
 
-#define DEV_CHECK_COND_RETURN_VOID(cond, fmt, ...)          \
-    do {                                                    \
-        if (!(cond)) {                                      \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return;                                         \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_COND_RETURN_VOID(cond, fmt, ...) \
+    do {                                           \
+        if (!(cond)) {                             \
+            DEV_ERROR(fmt, ##__VA_ARGS__);         \
+            DEV_ASSERT(0);                         \
+            return;                                \
+        }                                          \
+    } while (0)
 
-#define DEV_CHECK_COND_RETURN(cond, retval, fmt, ...)       \
-    do {                                                    \
-        if (!(cond)) {                                      \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return (retval);                                \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_COND_RETURN(cond, retval, fmt, ...) \
+    do {                                              \
+        if (!(cond)) {                                \
+            DEV_ERROR(fmt, ##__VA_ARGS__);            \
+            DEV_ASSERT(0);                            \
+            return (retval);                          \
+        }                                             \
+    } while (0)
 
-#define DEV_CHECK_POINTER_NULL_RETURN_VOID(ptr, fmt, ...)   \
-    do {                                                    \
-        if ((ptr) == nullptr) {                             \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                  \
-            DEV_ASSERT(0);                                  \
-            return;                                         \
-        }                                                   \
-    } while(0)
+#define DEV_CHECK_POINTER_NULL_RETURN_VOID(ptr, fmt, ...) \
+    do {                                                  \
+        if ((ptr) == nullptr) {                           \
+            DEV_ERROR(fmt, ##__VA_ARGS__);                \
+            DEV_ASSERT(0);                                \
+            return;                                       \
+        }                                                 \
+    } while (0)
 
 // =============================================================================
 // Helper Functions
@@ -143,8 +153,8 @@ void dev_log_always(const char* func, const char* fmt, ...);
 
 // Check if log level is enabled (inline for efficiency)
 inline bool is_log_enable_debug() { return g_is_log_enable_debug; }
-inline bool is_log_enable_info()  { return g_is_log_enable_info; }
-inline bool is_log_enable_warn()  { return g_is_log_enable_warn; }
+inline bool is_log_enable_info() { return g_is_log_enable_info; }
+inline bool is_log_enable_warn() { return g_is_log_enable_warn; }
 inline bool is_log_enable_error() { return g_is_log_enable_error; }
 
 // Initialize log switch (platform-specific implementation)

--- a/src/a5/platform/include/aicpu/device_malloc.h
+++ b/src/a5/platform/include/aicpu/device_malloc.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file device_malloc.h
  * @brief Device Memory Allocation Interface for AICPU
@@ -29,7 +39,7 @@
  * @param size  Number of bytes to allocate
  * @return Pointer to allocated memory, or nullptr on failure
  */
-void* aicpu_device_malloc(size_t size);
+void *aicpu_device_malloc(size_t size);
 
 /**
  * Free device memory previously allocated by aicpu_device_malloc().
@@ -38,6 +48,6 @@ void* aicpu_device_malloc(size_t size);
  *
  * @param ptr  Pointer to free (may be nullptr)
  */
-void aicpu_device_free(void* ptr);
+void aicpu_device_free(void *ptr);
 
 #endif  // PLATFORM_DEVICE_MALLOC_H_

--- a/src/a5/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/performance_collector_aicpu.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file performance_collector_aicpu.h
  * @brief AICPU performance data collection interface
@@ -26,7 +36,7 @@
  *
  * @param runtime Runtime instance pointer
  */
-void perf_aicpu_init_profiling(Runtime* runtime);
+void perf_aicpu_init_profiling(Runtime *runtime);
 
 /**
  * Complete a PerfRecord with AICPU-side metadata after AICore task completion
@@ -45,15 +55,10 @@ void perf_aicpu_init_profiling(Runtime* runtime);
  * @param fanout                Pre-extracted successor task ID array (nullptr if none)
  * @param fanout_count          Number of entries in fanout array (0 if none)
  */
-int perf_aicpu_complete_record(PerfBuffer* perf_buf,
-                                uint32_t expected_reg_task_id,
-                                uint64_t task_id,
-                                uint32_t func_id,
-                                CoreType core_type,
-                                uint64_t dispatch_time,
-                                uint64_t finish_time,
-                                const uint64_t* fanout,
-                                int32_t fanout_count);
+int perf_aicpu_complete_record(
+    PerfBuffer *perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
+    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
+);
 
 /**
  * Switch performance buffer when current buffer is full
@@ -64,7 +69,7 @@ int perf_aicpu_complete_record(PerfBuffer* perf_buf,
  * @param core_id Core ID
  * @param thread_idx Thread index
  */
-void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx);
+void perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx);
 
 /**
  * Flush remaining performance data
@@ -76,10 +81,7 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx);
  * @param cur_thread_cores Array of core IDs managed by this thread
  * @param core_num Number of cores managed by this thread
  */
-void perf_aicpu_flush_buffers(Runtime* runtime,
-                               int thread_idx,
-                               const int* cur_thread_cores,
-                               int core_num);
+void perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cur_thread_cores, int core_num);
 
 /**
  * Update total task count in performance header
@@ -90,7 +92,7 @@ void perf_aicpu_flush_buffers(Runtime* runtime,
  * @param runtime Runtime instance pointer
  * @param total_tasks Current total task count
  */
-void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks);
+void perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks);
 
 /**
  * Initialize AICPU phase profiling
@@ -102,7 +104,7 @@ void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks);
  * @param num_sched_threads Number of scheduler threads
  * @param num_orch_threads Number of orchestrator threads (may become schedulers after transition)
  */
-void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, int num_orch_threads = 1);
+void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, int num_orch_threads = 1);
 
 /**
  * Record a single scheduler phase
@@ -119,10 +121,10 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
  *                        full PTO2 task_id encoding (ring_id << 32) | local_id (orchestrator
  *                        phases in multi-ring runtimes: tensormap_and_ringbuffer, aicpu_build_graph)
  */
-void perf_aicpu_record_phase(int thread_idx,
-                              AicpuPhaseId phase_id,
-                              uint64_t start_time, uint64_t end_time,
-                              uint32_t loop_iter, uint64_t tasks_processed);
+void perf_aicpu_record_phase(
+    int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
+    uint64_t tasks_processed
+);
 
 /**
  * Write orchestrator cumulative summary
@@ -132,7 +134,7 @@ void perf_aicpu_record_phase(int thread_idx,
  *
  * @param src Pointer to populated AicpuOrchSummary (magic field is set internally)
  */
-void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src);
+void perf_aicpu_write_orch_summary(const AicpuOrchSummary *src);
 
 /**
  * Set orchestrator thread index for per-task phase recording
@@ -154,13 +156,13 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx);
  * @param start_time Phase start timestamp
  * @param end_time Phase end timestamp
  * @param submit_idx Task submission index (acts as loop_iter)
- * @param task_id Task identifier. For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), this is the full PTO2 encoding:
- *               (ring_id << 32) | local_id, enabling cross-view correlation between orchestrator
- *               and scheduler swimlanes.
+ * @param task_id Task identifier. For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), this is the
+ * full PTO2 encoding: (ring_id << 32) | local_id, enabling cross-view correlation between orchestrator and scheduler
+ * swimlanes.
  */
-void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
-                                   uint64_t start_time, uint64_t end_time,
-                                   uint32_t submit_idx, uint64_t task_id);
+void perf_aicpu_record_orch_phase(
+    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id
+);
 
 /**
  * Write core-to-thread assignment mapping to shared memory
@@ -173,10 +175,10 @@ void perf_aicpu_record_orch_phase(AicpuPhaseId phase_id,
  * @param num_threads Number of scheduler threads
  * @param total_cores Total number of cores
  */
-void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
-                                        const int* core_counts,
-                                        int num_threads,
-                                        int total_cores);
+void perf_aicpu_write_core_assignments(
+    const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
+    int total_cores
+);
 
 /**
  * Flush remaining phase records for a thread

--- a/src/a5/platform/include/aicpu/platform_regs.h
+++ b/src/a5/platform/include/aicpu/platform_regs.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file platform_regs.h
  * @brief Platform-level register access interface for AICPU
@@ -109,6 +119,6 @@ uint32_t platform_get_physical_cores_count();
  * @param addr  Start address of the memory range
  * @param size  Size of the memory range in bytes
  */
-void cache_invalidate_range(const void* addr, size_t size);
+void cache_invalidate_range(const void *addr, size_t size);
 
 #endif  // PLATFORM_AICPU_PLATFORM_REGS_H_

--- a/src/a5/platform/include/common/compile_strategy.h
+++ b/src/a5/platform/include/common/compile_strategy.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Compile Strategy - Toolchain Type Definitions
  *
@@ -16,10 +26,10 @@
 #define COMPILE_STRATEGY_H
 
 typedef enum {
-    TOOLCHAIN_CCEC = 0,          // ccec (Ascend AICore compiler)
-    TOOLCHAIN_HOST_GXX_15 = 1,   // g++-15 (host, simulation kernels)
-    TOOLCHAIN_HOST_GXX = 2,      // g++ (host, orchestration .so)
-    TOOLCHAIN_AARCH64_GXX = 3,   // aarch64-target-linux-gnu-g++ (cross-compile)
+    TOOLCHAIN_CCEC = 0,         // ccec (Ascend AICore compiler)
+    TOOLCHAIN_HOST_GXX_15 = 1,  // g++-15 (host, simulation kernels)
+    TOOLCHAIN_HOST_GXX = 2,     // g++ (host, orchestration .so)
+    TOOLCHAIN_AARCH64_GXX = 3,  // aarch64-target-linux-gnu-g++ (cross-compile)
 } ToolchainType;
 
 #endif /* COMPILE_STRATEGY_H */

--- a/src/a5/platform/include/common/core_type.h
+++ b/src/a5/platform/include/common/core_type.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file core_type.h
  * @brief Core type enumeration and utilities for AICore platform
@@ -32,7 +42,7 @@ enum class CoreType : int32_t {
  * @param type_str  String representation ("aic" or "aiv", case-insensitive)
  * @return Core type enum value, or CoreType::AIC if invalid
  */
-inline CoreType core_type_from_string(const char* type_str) {
+inline CoreType core_type_from_string(const char *type_str) {
     if (type_str == nullptr) {
         return CoreType::AIC;
     }
@@ -51,11 +61,14 @@ inline CoreType core_type_from_string(const char* type_str) {
  * @param core_type  Core type enum value
  * @return String representation ("AIC", "AIV", or "UNKNOWN")
  */
-inline const char* core_type_to_string(CoreType core_type) {
+inline const char *core_type_to_string(CoreType core_type) {
     switch (core_type) {
-        case CoreType::AIC: return "AIC";
-        case CoreType::AIV: return "AIV";
-        default: return "UNKNOWN";
+    case CoreType::AIC:
+        return "AIC";
+    case CoreType::AIV:
+        return "AIV";
+    default:
+        return "UNKNOWN";
     }
 }
 

--- a/src/a5/platform/include/common/kernel_args.h
+++ b/src/a5/platform/include/common/kernel_args.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file kernel_args.h
  * @brief KernelArgs Structure - Shared between Host, AICPU, and AICore
@@ -56,8 +66,8 @@ extern "C" {
  */
 struct KernelArgs {
     uint64_t unused[5] = {0};          // Alignment padding (required by CANN runtime offset)
-    DeviceArgs* device_args{nullptr};  // Device arguments (AICPU reads, contains SO info)
-    Runtime* runtime_args{nullptr};    // Task runtime in device memory
+    DeviceArgs *device_args{nullptr};  // Device arguments (AICPU reads, contains SO info)
+    Runtime *runtime_args{nullptr};    // Task runtime in device memory
     uint64_t regs{0};                  // Per-core register base address array (platform-specific)
 };
 

--- a/src/a5/platform/include/common/perf_profiling.h
+++ b/src/a5/platform/include/common/perf_profiling.h
@@ -353,7 +353,7 @@ inline size_t calc_perf_data_size(int num_cores) {
  * @param base_ptr Shared memory base address (device_ptr or host_ptr)
  * @return PerfDataHeader pointer
  */
-inline PerfDataHeader* get_perf_header(void* base_ptr) { return reinterpret_cast<PerfDataHeader*>(base_ptr); }
+inline PerfDataHeader *get_perf_header(void *base_ptr) { return reinterpret_cast<PerfDataHeader *>(base_ptr); }
 
 /**
  * Get PerfBufferState array start address
@@ -361,8 +361,8 @@ inline PerfDataHeader* get_perf_header(void* base_ptr) { return reinterpret_cast
  * @param base_ptr Shared memory base address
  * @return PerfBufferState array pointer
  */
-inline PerfBufferState* get_perf_buffer_states(void* base_ptr) {
-    return reinterpret_cast<PerfBufferState*>(reinterpret_cast<char*>(base_ptr) + sizeof(PerfDataHeader));
+inline PerfBufferState *get_perf_buffer_states(void *base_ptr) {
+    return reinterpret_cast<PerfBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(PerfDataHeader));
 }
 
 /**
@@ -372,7 +372,7 @@ inline PerfBufferState* get_perf_buffer_states(void* base_ptr) {
  * @param core_index Core index (0 ~ num_cores-1)
  * @return PerfBufferState pointer
  */
-inline PerfBufferState* get_perf_buffer_state(void* base_ptr, int core_index) {
+inline PerfBufferState *get_perf_buffer_state(void *base_ptr, int core_index) {
     return &get_perf_buffer_states(base_ptr)[core_index];
 }
 
@@ -394,8 +394,8 @@ inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threa
  * @param num_cores Number of AICore instances
  * @return AicpuPhaseHeader pointer
  */
-inline AicpuPhaseHeader* get_phase_header(void* base_ptr, int num_cores) {
-    return reinterpret_cast<AicpuPhaseHeader*>(reinterpret_cast<char*>(base_ptr) + calc_perf_data_size(num_cores));
+inline AicpuPhaseHeader *get_phase_header(void *base_ptr, int num_cores) {
+    return reinterpret_cast<AicpuPhaseHeader *>(reinterpret_cast<char *>(base_ptr) + calc_perf_data_size(num_cores));
 }
 
 /**
@@ -405,9 +405,10 @@ inline AicpuPhaseHeader* get_phase_header(void* base_ptr, int num_cores) {
  * @param num_cores Number of AICore instances
  * @return PhaseBufferState array pointer
  */
-inline PhaseBufferState* get_phase_buffer_states(void* base_ptr, int num_cores) {
-    return reinterpret_cast<PhaseBufferState*>(
-        reinterpret_cast<char*>(get_phase_header(base_ptr, num_cores)) + sizeof(AicpuPhaseHeader));
+inline PhaseBufferState *get_phase_buffer_states(void *base_ptr, int num_cores) {
+    return reinterpret_cast<PhaseBufferState *>(
+        reinterpret_cast<char *>(get_phase_header(base_ptr, num_cores)) + sizeof(AicpuPhaseHeader)
+    );
 }
 
 /**
@@ -418,7 +419,7 @@ inline PhaseBufferState* get_phase_buffer_states(void* base_ptr, int num_cores) 
  * @param thread_idx Thread index
  * @return PhaseBufferState pointer
  */
-inline PhaseBufferState* get_phase_buffer_state(void* base_ptr, int num_cores, int thread_idx) {
+inline PhaseBufferState *get_phase_buffer_state(void *base_ptr, int num_cores, int thread_idx) {
     return &get_phase_buffer_states(base_ptr, num_cores)[thread_idx];
 }
 

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -159,7 +159,7 @@ constexpr uint32_t AICORE_COREID_MASK = 0x0FFF;
 /**
  * Register identifier for unified read_reg/write_reg interface
  */
-enum class RegId : uint32_t {
+enum class RegId : uint8_t {
     DATA_MAIN_BASE = 0,  // Task dispatch (AICPU→AICore)
     COND = 1,            // Status (AICore→AICPU)
 };
@@ -169,10 +169,10 @@ enum class RegId : uint32_t {
  */
 constexpr uint32_t reg_offset(RegId reg) {
     switch (reg) {
-        case RegId::DATA_MAIN_BASE:
-            return REG_SPR_DATA_MAIN_BASE_OFFSET;
-        case RegId::COND:
-            return REG_SPR_COND_OFFSET;
+    case RegId::DATA_MAIN_BASE:
+        return REG_SPR_DATA_MAIN_BASE_OFFSET;
+    case RegId::COND:
+        return REG_SPR_COND_OFFSET;
     }
     return 0;  // unreachable: all RegId cases handled above
 }
@@ -206,7 +206,7 @@ constexpr uint32_t SIM_REG_TOTAL_SIZE = SIM_REG_PAGE0_SIZE + SIM_REG_PAGE1_SIZE;
  * @param offset    Hardware register offset (e.g., 0xD0, 0x5108)
  * @return Pointer to the actual memory location (as uint8_t*)
  */
-inline volatile uint8_t* sparse_reg_ptr(volatile uint8_t* reg_base, uint32_t offset) {
+inline volatile uint8_t *sparse_reg_ptr(volatile uint8_t *reg_base, uint32_t offset) {
     if (offset < SIM_REG_PAGE1_BASE) {
         // Register in page 0 (0x0000-0x0FFF)
         return reg_base + offset;
@@ -255,8 +255,7 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = PLATFORM_NUM_DIES * PLATFORM_AI
 #define TASK_ID_MASK 0x7FFFFFFFU
 #define TASK_STATE_MASK 0x80000000U
 
-#define TASK_ACK_STATE 0
-#define TASK_FIN_STATE 1
+enum : uint8_t { TASK_ACK_STATE = 0, TASK_FIN_STATE = 1 };
 
 #define EXTRACT_TASK_ID(regval) (static_cast<int>((regval) & TASK_ID_MASK))
 #define EXTRACT_TASK_STATE(regval) (static_cast<int>(((regval) & TASK_STATE_MASK) >> 31))
@@ -265,13 +264,14 @@ constexpr uint32_t PLATFORM_MAX_PHYSICAL_CORES = PLATFORM_NUM_DIES * PLATFORM_AI
 
 // These values are RESERVED and must never be used as real task IDs.
 // Valid task IDs: 0 to 0x7FFFFFEF (2147483631)
-#define AICORE_IDLE_TASK_ID 0x7FFFFFFFU
+enum : uint32_t {
+    AICORE_IDLE_TASK_ID = 0x7FFFFFFFU,
+    AICORE_EXIT_TASK_ID = 0x7FFFFFFEU,
+    AICPU_IDLE_TASK_ID = 0x7FFFFFFDU,
+};
 #define AICORE_IDLE_VALUE MAKE_FIN_VALUE(AICORE_IDLE_TASK_ID)
 
-#define AICORE_EXIT_TASK_ID 0x7FFFFFFEU
 #define AICORE_EXITED_VALUE MAKE_FIN_VALUE(AICORE_EXIT_TASK_ID)
-
-#define AICPU_IDLE_TASK_ID 0x7FFFFFFDU
 
 // =============================================================================
 // Task State Constants

--- a/src/a5/platform/include/common/qualifier.h
+++ b/src/a5/platform/include/common/qualifier.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file qualifier.h
  * @brief Memory qualifier fallbacks for non-AICore builds

--- a/src/a5/platform/include/common/unified_log.h
+++ b/src/a5/platform/include/common/unified_log.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file unified_log.h
  * @brief Unified logging interface using link-time polymorphism
@@ -18,11 +28,11 @@ extern "C" {
 #endif
 
 // Unified logging functions
-void unified_log_error(const char* func, const char* fmt, ...);
-void unified_log_warn(const char* func, const char* fmt, ...);
-void unified_log_info(const char* func, const char* fmt, ...);
-void unified_log_debug(const char* func, const char* fmt, ...);
-void unified_log_always(const char* func, const char* fmt, ...);
+void unified_log_error(const char *func, const char *fmt, ...);
+void unified_log_warn(const char *func, const char *fmt, ...);
+void unified_log_info(const char *func, const char *fmt, ...);
+void unified_log_debug(const char *func, const char *fmt, ...);
+void unified_log_always(const char *func, const char *fmt, ...);
 
 #ifdef __cplusplus
 }
@@ -32,10 +42,9 @@ void unified_log_always(const char* func, const char* fmt, ...);
 
 // Convenience macros (automatically capture function name)
 #define LOG_ERROR(fmt, ...) unified_log_error(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
-#define LOG_WARN(fmt, ...)  unified_log_warn(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
-#define LOG_INFO(fmt, ...)  unified_log_info(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) unified_log_warn(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...) unified_log_info(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 #define LOG_DEBUG(fmt, ...) unified_log_debug(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 #define LOG_ALWAYS(fmt, ...) unified_log_always(__FUNCTION__, "[%s:%d] " fmt, __FILENAME__, __LINE__, ##__VA_ARGS__)
 
 #endif  // PLATFORM_UNIFIED_LOG_H_
-

--- a/src/a5/platform/include/host/function_cache.h
+++ b/src/a5/platform/include/host/function_cache.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file function_cache.h
  * @brief Function Cache Structures for Kernel Binary Management
@@ -77,29 +87,27 @@ struct CoreFunctionBinCache {
      * Get offset array pointer
      * @return Pointer to array of offsets
      */
-    uint64_t* get_offsets() {
-        return reinterpret_cast<uint64_t*>(reinterpret_cast<uint8_t*>(this) + sizeof(CoreFunctionBinCache));
+    uint64_t *get_offsets() {
+        return reinterpret_cast<uint64_t *>(reinterpret_cast<uint8_t *>(this) + sizeof(CoreFunctionBinCache));
     }
 
     /**
      * Get pointer to binary data region
      * @return Pointer to start of binary data
      */
-    uint8_t* get_binary_data() {
-        return reinterpret_cast<uint8_t*>(get_offsets()) + num_kernels * sizeof(uint64_t);
-    }
+    uint8_t *get_binary_data() { return reinterpret_cast<uint8_t *>(get_offsets()) + num_kernels * sizeof(uint64_t); }
 
     /**
      * Get CoreFunctionBin by index
      * @param index  Kernel index
      * @return Pointer to CoreFunctionBin structure, nullptr if invalid index
      */
-    CoreFunctionBin* get_kernel(uint64_t index) {
+    CoreFunctionBin *get_kernel(uint64_t index) {
         if (index >= num_kernels) {
             return nullptr;
         }
         uint64_t offset = get_offsets()[index];
-        return reinterpret_cast<CoreFunctionBin*>(get_binary_data() + offset);
+        return reinterpret_cast<CoreFunctionBin *>(get_binary_data() + offset);
     }
 
     /**

--- a/src/a5/platform/include/host/host_regs.h
+++ b/src/a5/platform/include/host/host_regs.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file host_regs.h
  * @brief AICore register address retrieval via CANN HAL APIs
@@ -35,8 +45,8 @@ constexpr uint32_t REG_AICORE_MAP_SIZE = 0x300000;
 /**
  * Register offsets for AIV sub-cores relative to AICore base
  */
-constexpr uint64_t REG_AIV_FIRST_OFFSET = REG_SUB_CORE_STRIDE;        // 1M
-constexpr uint64_t REG_AIV_SECOND_OFFSET = 2 * REG_SUB_CORE_STRIDE;   // 2M
+constexpr uint64_t REG_AIV_FIRST_OFFSET = REG_SUB_CORE_STRIDE;       // 1M
+constexpr uint64_t REG_AIV_SECOND_OFFSET = 2 * REG_SUB_CORE_STRIDE;  // 2M
 
 /**
  * Initialize AICore register addresses for runtime
@@ -49,9 +59,6 @@ constexpr uint64_t REG_AIV_SECOND_OFFSET = 2 * REG_SUB_CORE_STRIDE;   // 2M
  * @param allocator Memory allocator for device memory
  * @return 0 on success, negative on failure
  */
-int init_aicore_register_addresses(
-    uint64_t* runtime_regs_ptr,
-    uint64_t device_id,
-    MemoryAllocator& allocator);
+int init_aicore_register_addresses(uint64_t *runtime_regs_ptr, uint64_t device_id, MemoryAllocator &allocator);
 
 #endif  // PLATFORM_HOST_HOST_REGS_H_

--- a/src/a5/platform/include/host/memory_allocator.h
+++ b/src/a5/platform/include/host/memory_allocator.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file memory_allocator.h
  * @brief Memory Allocator - Centralized Memory Management
@@ -38,8 +48,8 @@ public:
     ~MemoryAllocator();
 
     // Prevent copying
-    MemoryAllocator(const MemoryAllocator&) = delete;
-    MemoryAllocator& operator=(const MemoryAllocator&) = delete;
+    MemoryAllocator(const MemoryAllocator &) = delete;
+    MemoryAllocator &operator=(const MemoryAllocator &) = delete;
 
     /**
      * Allocate memory and track the pointer
@@ -51,7 +61,7 @@ public:
      * @param size  Size in bytes to allocate
      * @return Memory pointer on success, nullptr on failure
      */
-    void* alloc(size_t size);
+    void *alloc(size_t size);
 
     /**
      * Free memory if tracked
@@ -67,7 +77,7 @@ public:
      * @param ptr  Memory pointer to free
      * @return 0 on success, error code on failure, 0 if ptr not tracked
      */
-    int free(void* ptr);
+    int free(void *ptr);
 
     /**
      * Free all remaining tracked allocations
@@ -88,7 +98,7 @@ public:
     size_t get_allocation_count() const { return ptr_set_.size(); }
 
 private:
-    std::set<void*> ptr_set_;
+    std::set<void *> ptr_set_;
     bool finalized_{false};
 };
 

--- a/src/a5/platform/include/host/performance_collector.h
+++ b/src/a5/platform/include/host/performance_collector.h
@@ -45,7 +45,7 @@
  * @param user_data User-provided context pointer
  * @return Allocated device memory pointer, or nullptr on failure
  */
-using PerfAllocCallback = void* (*)(size_t size, void* user_data);
+using PerfAllocCallback = void *(*)(size_t size, void *user_data);
 
 /**
  * Memory registration callback (for Host-Device shared memory)
@@ -57,7 +57,7 @@ using PerfAllocCallback = void* (*)(size_t size, void* user_data);
  * @param[out] host_ptr Host-mapped pointer
  * @return 0 on success, error code on failure
  */
-using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id, void* user_data, void** host_ptr);
+using PerfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void *user_data, void **host_ptr);
 
 /**
  * Memory unregister callback
@@ -67,7 +67,7 @@ using PerfRegisterCallback = int (*)(void* dev_ptr, size_t size, int device_id, 
  * @param user_data User-provided context pointer
  * @return 0 on success, error code on failure
  */
-using PerfUnregisterCallback = int (*)(void* dev_ptr, int device_id, void* user_data);
+using PerfUnregisterCallback = int (*)(void *dev_ptr, int device_id, void *user_data);
 
 /**
  * Memory free callback
@@ -76,7 +76,7 @@ using PerfUnregisterCallback = int (*)(void* dev_ptr, int device_id, void* user_
  * @param user_data User-provided context pointer
  * @return 0 on success, error code on failure
  */
-using PerfFreeCallback = int (*)(void* dev_ptr, void* user_data);
+using PerfFreeCallback = int (*)(void *dev_ptr, void *user_data);
 
 // =============================================================================
 // ProfMemoryManager - Dynamic Buffer Memory Management Thread
@@ -94,8 +94,8 @@ struct ReadyBufferInfo {
     ProfBufferType type;
     uint32_t index;         // core_index (PERF_RECORD) or thread_idx (PHASE)
     uint32_t slot_idx;      // Reserved (unused in free queue design)
-    void* dev_buffer_ptr;   // Device address of the full buffer
-    void* host_buffer_ptr;  // Host-mapped address (sim: same as dev)
+    void *dev_buffer_ptr;   // Device address of the full buffer
+    void *host_buffer_ptr;  // Host-mapped address (sim: same as dev)
     uint32_t buffer_seq;    // Sequence number for ordering
 };
 
@@ -103,7 +103,7 @@ struct ReadyBufferInfo {
  * Notification that a buffer has been copied and can be freed
  */
 struct CopyDoneInfo {
-    void* dev_buffer_ptr;  // Device buffer to free
+    void *dev_buffer_ptr;  // Device buffer to free
     ProfBufferType type;   // Buffer type (for recycling)
 };
 
@@ -118,13 +118,13 @@ struct CopyDoneInfo {
  * 5. Frees device buffers after main thread confirms copy is done
  */
 class ProfMemoryManager {
- public:
+public:
     ProfMemoryManager() = default;
     ~ProfMemoryManager();
 
     // Disable copy
-    ProfMemoryManager(const ProfMemoryManager&) = delete;
-    ProfMemoryManager& operator=(const ProfMemoryManager&) = delete;
+    ProfMemoryManager(const ProfMemoryManager &) = delete;
+    ProfMemoryManager &operator=(const ProfMemoryManager &) = delete;
 
     // Allow PerformanceCollector to register initial buffer mappings
     friend class PerformanceCollector;
@@ -141,14 +141,10 @@ class ProfMemoryManager {
      * @param user_data User context for callbacks
      * @param device_id Device ID for registration
      */
-    void start(void* shared_mem_host,
-        int num_cores,
-        int num_phase_threads,
-        PerfAllocCallback alloc_cb,
-        PerfRegisterCallback register_cb,
-        PerfFreeCallback free_cb,
-        void* user_data,
-        int device_id);
+    void start(
+        void *shared_mem_host, int num_cores, int num_phase_threads, PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb, PerfFreeCallback free_cb, void *user_data, int device_id
+    );
 
     /**
      * Stop the memory management thread
@@ -162,7 +158,7 @@ class ProfMemoryManager {
      * @param[out] info Ready buffer info
      * @return true if an item was available, false otherwise
      */
-    bool try_pop_ready(ReadyBufferInfo& info);
+    bool try_pop_ready(ReadyBufferInfo &info);
 
     /**
      * Wait for a ready buffer info with timeout
@@ -171,26 +167,26 @@ class ProfMemoryManager {
      * @param timeout Maximum wait time
      * @return true if an item was available, false on timeout
      */
-    bool wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout);
+    bool wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout);
 
     /**
      * Notify that a buffer has been copied and can be freed
      *
      * @param info Copy done notification
      */
-    void notify_copy_done(const CopyDoneInfo& info);
+    void notify_copy_done(const CopyDoneInfo &info);
 
     /**
      * Check if the manager thread is running
      */
     bool is_running() const { return running_.load(); }
 
- private:
+private:
     std::thread mgmt_thread_;
     std::atomic<bool> running_{false};
 
     // Shared memory references
-    void* shared_mem_host_{nullptr};
+    void *shared_mem_host_{nullptr};
     int num_cores_{0};
     int num_phase_threads_{0};
 
@@ -198,7 +194,7 @@ class ProfMemoryManager {
     PerfAllocCallback alloc_cb_{nullptr};
     PerfRegisterCallback register_cb_{nullptr};
     PerfFreeCallback free_cb_{nullptr};
-    void* user_data_{nullptr};
+    void *user_data_{nullptr};
     int device_id_{-1};
 
     // Management thread → main thread (ready buffers)
@@ -211,29 +207,29 @@ class ProfMemoryManager {
     std::queue<CopyDoneInfo> done_queue_;
 
     // Device-to-host pointer mapping (populated during alloc_and_register)
-    std::unordered_map<void*, void*> dev_to_host_;
+    std::unordered_map<void *, void *> dev_to_host_;
 
     // Recycled buffer pools (avoids alloc/free churn in mgmt_loop)
-    std::vector<void*> recycled_perf_buffers_;
-    std::vector<void*> recycled_phase_buffers_;
+    std::vector<void *> recycled_perf_buffers_;
+    std::vector<void *> recycled_phase_buffers_;
 
     // Management thread main loop
     void mgmt_loop();
 
     // Allocate a new buffer and optionally register for host access
-    void* alloc_and_register(size_t size, void** host_ptr_out);
+    void *alloc_and_register(size_t size, void **host_ptr_out);
 
     // Free a previously allocated buffer
-    void free_buffer(void* dev_ptr);
+    void free_buffer(void *dev_ptr);
 
     // Resolve device pointer to host pointer
-    void* resolve_host_ptr(void* dev_ptr);
+    void *resolve_host_ptr(void *dev_ptr);
 
     // Register an external dev→host mapping (for initial buffers)
-    void register_mapping(void* dev_ptr, void* host_ptr);
+    void register_mapping(void *dev_ptr, void *host_ptr);
 
     // Process one ReadyQueue entry
-    void process_ready_entry(PerfDataHeader* header, int thread_idx, const ReadyQueueEntry& entry);
+    void process_ready_entry(PerfDataHeader *header, int thread_idx, const ReadyQueueEntry &entry);
 };
 
 // =============================================================================
@@ -252,13 +248,13 @@ class ProfMemoryManager {
  * Platform-agnostic: Memory management delegated to callbacks
  */
 class PerformanceCollector {
- public:
+public:
     PerformanceCollector() = default;
     ~PerformanceCollector();
 
     // Disable copy and move
-    PerformanceCollector(const PerformanceCollector&) = delete;
-    PerformanceCollector& operator=(const PerformanceCollector&) = delete;
+    PerformanceCollector(const PerformanceCollector &) = delete;
+    PerformanceCollector &operator=(const PerformanceCollector &) = delete;
 
     /**
      * Initialize performance profiling
@@ -275,13 +271,10 @@ class PerformanceCollector {
      * @param user_data User-provided context pointer passed to callbacks
      * @return 0 on success, error code on failure
      */
-    int initialize(Runtime& runtime,
-        int num_aicore,
-        int device_id,
-        PerfAllocCallback alloc_cb,
-        PerfRegisterCallback register_cb,
-        PerfFreeCallback free_cb,
-        void* user_data);
+    int initialize(
+        Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb, void *user_data
+    );
 
     /**
      * Start the memory management thread
@@ -307,7 +300,7 @@ class PerformanceCollector {
      * @param output_path Output directory path
      * @return 0 on success, error code on failure
      */
-    int export_swimlane_json(const std::string& output_path = "outputs");
+    int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
      * Stop the memory management thread and clean up remaining data
@@ -324,7 +317,7 @@ class PerformanceCollector {
      * @param user_data User-provided context pointer
      * @return 0 on success, error code on failure
      */
-    int finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data);
+    int finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void *user_data);
 
     /**
      * Check if collector is initialized
@@ -369,12 +362,12 @@ class PerformanceCollector {
     /**
      * Get collected records (for testing)
      */
-    const std::vector<std::vector<PerfRecord>>& get_records() const { return collected_perf_records_; }
+    const std::vector<std::vector<PerfRecord>> &get_records() const { return collected_perf_records_; }
 
- private:
+private:
     // Shared memory pointers
-    void* perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
-    void* perf_shared_mem_host_{nullptr};  // Host-mapped pointer (slot arrays)
+    void *perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
+    void *perf_shared_mem_host_{nullptr};  // Host-mapped pointer (slot arrays)
     bool was_registered_{false};           // True if register_cb was called successfully
     int device_id_{-1};
 
@@ -385,7 +378,7 @@ class PerformanceCollector {
     PerfAllocCallback alloc_cb_{nullptr};
     PerfRegisterCallback register_cb_{nullptr};
     PerfFreeCallback free_cb_{nullptr};
-    void* user_data_{nullptr};
+    void *user_data_{nullptr};
 
     // Memory manager
     ProfMemoryManager memory_manager_;
@@ -405,7 +398,7 @@ class PerformanceCollector {
     std::atomic<bool> execution_complete_{false};
 
     // Allocate a single buffer (PerfBuffer or PhaseBuffer) and register it
-    void* alloc_single_buffer(size_t size, void** host_ptr_out);
+    void *alloc_single_buffer(size_t size, void **host_ptr_out);
 };
 
 #endif  // SRC_A5_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_

--- a/src/a5/platform/include/host/platform_compile_info.h
+++ b/src/a5/platform/include/host/platform_compile_info.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Platform Compile Info Interface
  *
@@ -18,7 +28,7 @@ extern "C" {
  *
  * @return Platform identifier string (e.g., "a5", "a5sim")
  */
-const char* get_platform(void);
+const char *get_platform(void);
 
 #ifdef __cplusplus
 }

--- a/src/a5/platform/include/host/pto_runtime_c_api.h
+++ b/src/a5/platform/include/host/pto_runtime_c_api.h
@@ -52,7 +52,7 @@ extern "C" {
  * Opaque pointer types for C interface.
  * These hide the C++ class implementations.
  */
-typedef void* RuntimeHandle;
+typedef void *RuntimeHandle;
 
 /* ===========================================================================
  * Runtime API
@@ -84,7 +84,7 @@ size_t get_runtime_size(void);
  * @param orch_args Separated tensor/scalar arguments for orchestration
  * @return 0 on success, -1 on failure
  */
-int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args);
+int init_runtime(RuntimeHandle runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args);
 
 /* ===========================================================================
  * Device Memory API (for use by orchestration functions)
@@ -97,14 +97,14 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
  * @param size  Size in bytes to allocate
  * @return Device pointer on success, NULL on failure
  */
-void* device_malloc(size_t size);
+void *device_malloc(size_t size);
 
 /**
  * Free device memory.
  *
  * @param dev_ptr  Device pointer to free
  */
-void device_free(void* dev_ptr);
+void device_free(void *dev_ptr);
 
 /**
  * Copy data from host to device.
@@ -114,7 +114,7 @@ void device_free(void* dev_ptr);
  * @param size     Size in bytes to copy
  * @return 0 on success, error code on failure
  */
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
+int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size);
 
 /**
  * Copy data from device to host.
@@ -124,7 +124,7 @@ int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
  * @param size     Size in bytes to copy
  * @return 0 on success, error code on failure
  */
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
+int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size);
 
 /**
  * Execute a runtime on the device.
@@ -144,15 +144,10 @@ int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
  * @param orch_thread_num  Number of orchestrator threads (default 1)
  * @return 0 on success, error code on failure
  */
-int launch_runtime(RuntimeHandle runtime,
-    int aicpu_thread_num,
-    int block_dim,
-    int device_id,
-    const uint8_t* aicpu_binary,
-    size_t aicpu_size,
-    const uint8_t* aicore_binary,
-    size_t aicore_size,
-    int orch_thread_num);
+int launch_runtime(
+    RuntimeHandle runtime, int aicpu_thread_num, int block_dim, int device_id, const uint8_t *aicpu_binary,
+    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size, int orch_thread_num
+);
 
 /**
  * Finalize and cleanup a runtime instance.
@@ -197,7 +192,7 @@ int set_device(int device_id);
  * @param dev_ptr   Device memory pointer
  * @param size      Size of tensor in bytes
  */
-void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size);
+void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, size_t size);
 
 /**
  * Enable or disable performance profiling for swimlane visualization.

--- a/src/a5/platform/include/host/raii_scope_guard.h
+++ b/src/a5/platform/include/host/raii_scope_guard.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #ifndef PLATFORM_RAII_SCOPE_GUARD_H_
 #define PLATFORM_RAII_SCOPE_GUARD_H_
 
@@ -17,8 +27,9 @@
 template <typename F>
 class RAIIScopeGuard {
 public:
-    explicit RAIIScopeGuard(F fn)
-        : fn_(std::move(fn)), active_(true) {}
+    explicit RAIIScopeGuard(F fn) :
+        fn_(std::move(fn)),
+        active_(true) {}
 
     ~RAIIScopeGuard() {
         if (active_) {
@@ -26,17 +37,16 @@ public:
         }
     }
 
-    RAIIScopeGuard(RAIIScopeGuard&& other) noexcept
-        : fn_(std::move(other.fn_)), active_(other.active_) {
+    RAIIScopeGuard(RAIIScopeGuard &&other) noexcept :
+        fn_(std::move(other.fn_)),
+        active_(other.active_) {
         other.active_ = false;
     }
 
-    RAIIScopeGuard(const RAIIScopeGuard&) = delete;
-    RAIIScopeGuard& operator=(const RAIIScopeGuard&) = delete;
+    RAIIScopeGuard(const RAIIScopeGuard &) = delete;
+    RAIIScopeGuard &operator=(const RAIIScopeGuard &) = delete;
 
-    void dismiss() noexcept {
-        active_ = false;
-    }
+    void dismiss() noexcept { active_ = false; }
 
 private:
     F fn_;

--- a/src/a5/platform/onboard/aicore/inner_kernel.h
+++ b/src/a5/platform/onboard/aicore/inner_kernel.h
@@ -54,13 +54,13 @@
  */
 __aicore__ inline uint64_t read_reg(RegId reg) {
     switch (reg) {
-        case RegId::DATA_MAIN_BASE: {
-            uint32_t val;
-            __asm__ volatile("MOV %0, DATA_MAIN_BASE\n" : "=l"(val));
-            return static_cast<uint64_t>(val);
-        }
-        case RegId::COND:
-            return 0;
+    case RegId::DATA_MAIN_BASE: {
+        uint32_t val;
+        __asm__ volatile("MOV %0, DATA_MAIN_BASE\n" : "=l"(val));
+        return static_cast<uint64_t>(val);
+    }
+    case RegId::COND:
+        return 0;
     }
 }
 
@@ -72,11 +72,11 @@ __aicore__ inline uint64_t read_reg(RegId reg) {
  */
 __aicore__ inline void write_reg(RegId reg, uint64_t value) {
     switch (reg) {
-        case RegId::COND:
-            set_cond(static_cast<uint32_t>(value));
-            break;
-        case RegId::DATA_MAIN_BASE:
-            break;
+    case RegId::COND:
+        set_cond(static_cast<uint32_t>(value));
+        break;
+    case RegId::DATA_MAIN_BASE:
+        break;
     }
 }
 

--- a/src/a5/platform/onboard/aicore/kernel.cpp
+++ b/src/a5/platform/onboard/aicore/kernel.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Minimal AICore Kernel
  */
@@ -8,7 +18,7 @@ class Runtime;
 
 #ifdef __DAV_VEC__
 #define KERNEL_ENTRY(x) \
-    x##_0_mix_aiv  // 动态生成函数名 KERNEL_ENTRY(my_kernel) ->
+    x##_0_mix_aiv  // Dynamically generate function name: KERNEL_ENTRY(my_kernel) ->
                    // my_kernel_0_mix_aiv
 #define block_idx block_idx_aiv
 #define core_type core_type_aiv
@@ -21,7 +31,7 @@ class Runtime;
 [[block_local]] int block_idx;
 [[block_local]] CoreType core_type;
 
-extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
+extern __aicore__ void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type);
 
 /**
  * Kernel entry point with control loop
@@ -38,7 +48,7 @@ extern __aicore__ void aicore_execute(__gm__ Runtime* runtime, int block_idx, Co
  *
  * @param runtime Address of Runtime structure in device memory
  */
-extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime* runtime) {
+extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime *runtime) {
     // Calculate block_idx for this core
 #ifdef __DAV_VEC__
     block_idx = get_block_idx() * get_subblockdim() + get_subblockid() + get_block_num();

--- a/src/a5/platform/onboard/aicpu/cache_ops.cpp
+++ b/src/a5/platform/onboard/aicpu/cache_ops.cpp
@@ -1,17 +1,27 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstddef>
 #include <cstdint>
 
 #include "aicpu/platform_regs.h"
 
-void cache_invalidate_range(const void* addr, size_t size) {
+void cache_invalidate_range(const void *addr, size_t size) {
     if (size == 0) {
         return;
     }
     const size_t kCacheLineSize = 64;
     uintptr_t start = (uintptr_t)addr & ~(kCacheLineSize - 1);
-    uintptr_t end   = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    uintptr_t end = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
     for (uintptr_t p = start; p < end; p += kCacheLineSize) {
-        __asm__ __volatile__("dc civac, %0" :: "r"(p) : "memory");
+        __asm__ __volatile__("dc civac, %0" ::"r"(p) : "memory");
     }
     __asm__ __volatile__("dsb sy" ::: "memory");
     __asm__ __volatile__("isb" ::: "memory");

--- a/src/a5/platform/onboard/aicpu/device_log.cpp
+++ b/src/a5/platform/onboard/aicpu/device_log.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Device logging implementation for AICPU kernel
  */
@@ -12,7 +22,7 @@ bool g_is_log_enable_info = false;
 bool g_is_log_enable_warn = false;
 bool g_is_log_enable_error = false;
 
-const char* TILE_FWK_DEVICE_MACHINE = "AI_CPU";
+const char *TILE_FWK_DEVICE_MACHINE = "AI_CPU";
 
 void init_log_switch() {
     g_is_log_enable_debug = CheckLogLevel(AICPU, DLOG_DEBUG);
@@ -25,7 +35,7 @@ void init_log_switch() {
 // Platform-Specific Logging Functions (Real Hardware: use CANN dlog API)
 // =============================================================================
 
-void dev_log_debug(const char* func, const char* fmt, ...) {
+void dev_log_debug(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];
@@ -35,7 +45,7 @@ void dev_log_debug(const char* func, const char* fmt, ...) {
     dlog_debug(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
 }
 
-void dev_log_info(const char* func, const char* fmt, ...) {
+void dev_log_info(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];
@@ -44,7 +54,7 @@ void dev_log_info(const char* func, const char* fmt, ...) {
     dlog_info(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
 }
 
-void dev_log_warn(const char* func, const char* fmt, ...) {
+void dev_log_warn(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];
@@ -53,7 +63,7 @@ void dev_log_warn(const char* func, const char* fmt, ...) {
     dlog_warn(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
 }
 
-void dev_log_error(const char* func, const char* fmt, ...) {
+void dev_log_error(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];
@@ -62,7 +72,7 @@ void dev_log_error(const char* func, const char* fmt, ...) {
     dlog_error(AICPU, "%lu %s\n\"%s\"", GET_TID(), func, buffer);
 }
 
-void dev_log_always(const char* func, const char* fmt, ...) {
+void dev_log_always(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];

--- a/src/a5/platform/onboard/aicpu/device_malloc.cpp
+++ b/src/a5/platform/onboard/aicpu/device_malloc.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file device_malloc.cpp
  * @brief Device Memory Allocation for Real Hardware (a5)
@@ -13,8 +23,8 @@
 #include <dlfcn.h>
 #include <cstdlib>
 
-using HalMemAllocFn = int (*)(void** pp, unsigned long long size, unsigned long long flag);
-using HalMemFreeFn = int (*)(void* pp);
+using HalMemAllocFn = int (*)(void **pp, unsigned long long size, unsigned long long flag);
+using HalMemFreeFn = int (*)(void *pp);
 
 static HalMemAllocFn g_halMemAlloc = nullptr;
 static HalMemFreeFn g_halMemFree = nullptr;
@@ -34,7 +44,7 @@ static void resolve_hal_mem_functions() {
     g_hal_resolved = true;
 }
 
-void* aicpu_device_malloc(size_t size) {
+void *aicpu_device_malloc(size_t size) {
     resolve_hal_mem_functions();
 
     if (g_halMemAlloc == nullptr) {
@@ -42,7 +52,7 @@ void* aicpu_device_malloc(size_t size) {
         return nullptr;
     }
 
-    void* ptr = nullptr;
+    void *ptr = nullptr;
     // halMemAlloc flag layout (ascend_hal_define.h):
     //   bit0~9:   devid (0 for local device)
     //   bit10~13: virt mem type (MEM_SVM=0x0 << 10)
@@ -57,7 +67,7 @@ void* aicpu_device_malloc(size_t size) {
     return ptr;
 }
 
-void aicpu_device_free(void* ptr) {
+void aicpu_device_free(void *ptr) {
     if (ptr == nullptr) {
         return;
     }

--- a/src/a5/platform/onboard/aicpu/inner_platform_regs.cpp
+++ b/src/a5/platform/onboard/aicpu/inner_platform_regs.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file inner_platform_regs.cpp
  * @brief AICPU register read/write for real hardware (a5)
@@ -13,7 +23,7 @@
 
 uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
     uint32_t offset = reg_offset(reg);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(reg_base_addr + offset);
+    volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(reg_base_addr + offset);
 
     __sync_synchronize();
     uint64_t value = static_cast<uint64_t>(*ptr);
@@ -24,7 +34,7 @@ uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
 
 void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(reg_base_addr + offset);
+    volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(reg_base_addr + offset);
 
     __sync_synchronize();
     *ptr = static_cast<uint32_t>(value);

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdio>
 
 #include "common/unified_log.h"
@@ -72,8 +82,7 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_platform_regs(k_args->regs);
 
     // Affinity gate: drop excess threads before entering runtime
-    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num,
-                                      PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
+    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
         LOG_INFO("Thread dropped by cluster affinity");
         return 0;
     }

--- a/src/a5/platform/onboard/aicpu/platform_aicpu_affinity.cpp
+++ b/src/a5/platform/onboard/aicpu/platform_aicpu_affinity.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "aicpu/platform_aicpu_affinity.h"
 
 #include <atomic>
@@ -21,9 +31,7 @@ static std::atomic<int32_t> s_gate_ready{0};
 static int32_t s_thread_cpu[MAX_GATE_THREADS];
 static bool s_thread_survive[MAX_GATE_THREADS];
 
-static inline int32_t popcount64(uint64_t v) {
-    return __builtin_popcountll(static_cast<unsigned long long>(v));
-}
+static inline int32_t popcount64(uint64_t v) { return __builtin_popcountll(static_cast<unsigned long long>(v)); }
 
 bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched) {
     if (logical_count >= total_launched) {
@@ -55,13 +63,11 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
 
     // Barrier: wait until all total_launched threads have reported
     while (popcount64(s_cpumask.load(std::memory_order_acquire)) < total_launched &&
-           s_reported.load(std::memory_order_acquire) < total_launched) {
-    }
+           s_reported.load(std::memory_order_acquire) < total_launched) {}
 
     // CAS winner does cluster classification
     int32_t expected = 0;
-    if (s_gate_init.compare_exchange_strong(expected, 1,
-            std::memory_order_acq_rel, std::memory_order_acquire)) {
+    if (s_gate_init.compare_exchange_strong(expected, 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
         // Initialize survive flags
         for (int32_t i = 0; i < total_launched; ++i) {
             s_thread_survive[i] = false;
@@ -78,7 +84,7 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
             if (c < 0) continue;
             int32_t cluster_id = c / CPUS_PER_CLUSTER;
             if (cluster_id < 0 || cluster_id >= MAX_CLUSTERS) continue;
-            ClusterInfo& info = clusters[cluster_id];
+            ClusterInfo &info = clusters[cluster_id];
             if (info.count < MAX_GATE_THREADS) info.tids[info.count++] = tid;
         }
 
@@ -87,8 +93,10 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
         int32_t major_cnt = clusters[major_id].count;
         int32_t minor_cnt = clusters[minor_id].count;
 
-        LOG_INFO("AICPU affinity gate: major=%d(cnt=%d) minor=%d(cnt=%d) logical=%d",
-                 major_id, major_cnt, minor_id, minor_cnt, logical_count);
+        LOG_INFO(
+            "AICPU affinity gate: major=%d(cnt=%d) minor=%d(cnt=%d) logical=%d", major_id, major_cnt, minor_id,
+            minor_cnt, logical_count
+        );
 
         if (major_cnt == logical_count && minor_cnt == (total_launched - logical_count)) {
             // Expected topology: major cluster threads survive
@@ -97,9 +105,11 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
             }
         } else {
             // Unexpected topology: fall back to first logical_count threads
-            LOG_WARN("AICPU affinity gate: unexpected topology (major=%d minor=%d), "
-                     "falling back to index-based cutoff",
-                     major_cnt, minor_cnt);
+            LOG_WARN(
+                "AICPU affinity gate: unexpected topology (major=%d minor=%d), "
+                "falling back to index-based cutoff",
+                major_cnt, minor_cnt
+            );
             for (int32_t i = 0; i < logical_count && i < total_launched; ++i) {
                 s_thread_survive[i] = true;
             }
@@ -109,8 +119,7 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
     }
 
     // Wait for classification to complete
-    while (s_gate_ready.load(std::memory_order_acquire) == 0) {
-    }
+    while (s_gate_ready.load(std::memory_order_acquire) == 0) {}
 
     bool survive = (idx < total_launched) ? s_thread_survive[idx] : false;
 

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -35,10 +35,10 @@
 // =============================================================================
 
 namespace {
-void* g_hal_handle = nullptr;
+void *g_hal_handle = nullptr;
 
-using HalHostRegisterFn = int (*)(void* dev_ptr, size_t size, unsigned int flags, int device_id, void** host_ptr);
-using HalHostUnregisterFn = int (*)(void* host_ptr, int device_id);
+using HalHostRegisterFn = int (*)(void *dev_ptr, size_t size, unsigned int flags, int device_id, void **host_ptr);
+using HalHostUnregisterFn = int (*)(void *host_ptr, int device_id);
 
 int load_hal_if_needed() {
     if (g_hal_handle != nullptr) {
@@ -71,18 +71,18 @@ HalHostUnregisterFn get_halHostUnregister() {
 // KernelArgsHelper Implementation
 // =============================================================================
 
-int KernelArgsHelper::init_device_args(const DeviceArgs& host_device_args, MemoryAllocator& allocator) {
+int KernelArgsHelper::init_device_args(const DeviceArgs &host_device_args, MemoryAllocator &allocator) {
     allocator_ = &allocator;
 
     // Allocate device memory for device_args
     if (args.device_args == nullptr) {
         uint64_t device_args_size = sizeof(DeviceArgs);
-        void* device_args_dev = allocator_->alloc(device_args_size);
+        void *device_args_dev = allocator_->alloc(device_args_size);
         if (device_args_dev == nullptr) {
             LOG_ERROR("Alloc for device_args failed");
             return -1;
         }
-        args.device_args = reinterpret_cast<DeviceArgs*>(device_args_dev);
+        args.device_args = reinterpret_cast<DeviceArgs *>(device_args_dev);
     }
     // Copy host_device_args to device memory via device_args
     int rc =
@@ -105,17 +105,17 @@ int KernelArgsHelper::finalize_device_args() {
     return 0;
 }
 
-int KernelArgsHelper::init_runtime_args(const Runtime& host_runtime, MemoryAllocator& allocator) {
+int KernelArgsHelper::init_runtime_args(const Runtime &host_runtime, MemoryAllocator &allocator) {
     allocator_ = &allocator;
 
     if (args.runtime_args == nullptr) {
         uint64_t runtime_size = sizeof(Runtime);
-        void* runtime_dev = allocator_->alloc(runtime_size);
+        void *runtime_dev = allocator_->alloc(runtime_size);
         if (runtime_dev == nullptr) {
             LOG_ERROR("Alloc for runtime_args failed");
             return -1;
         }
-        args.runtime_args = reinterpret_cast<Runtime*>(runtime_dev);
+        args.runtime_args = reinterpret_cast<Runtime *>(runtime_dev);
     }
     int rc = rtMemcpy(args.runtime_args, sizeof(Runtime), &host_runtime, sizeof(Runtime), RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
@@ -140,7 +140,7 @@ int KernelArgsHelper::finalize_runtime_args() {
 // AicpuSoInfo Implementation
 // =============================================================================
 
-int AicpuSoInfo::init(const std::vector<uint8_t>& aicpu_so_binary, MemoryAllocator& allocator) {
+int AicpuSoInfo::init(const std::vector<uint8_t> &aicpu_so_binary, MemoryAllocator &allocator) {
     allocator_ = &allocator;
 
     if (aicpu_so_binary.empty()) {
@@ -149,7 +149,7 @@ int AicpuSoInfo::init(const std::vector<uint8_t>& aicpu_so_binary, MemoryAllocat
     }
 
     size_t file_size = aicpu_so_binary.size();
-    void* d_aicpu_data = allocator_->alloc(file_size);
+    void *d_aicpu_data = allocator_->alloc(file_size);
     if (d_aicpu_data == nullptr) {
         LOG_ERROR("Alloc failed for AICPU SO");
         return -1;
@@ -170,7 +170,7 @@ int AicpuSoInfo::init(const std::vector<uint8_t>& aicpu_so_binary, MemoryAllocat
 
 int AicpuSoInfo::finalize() {
     if (aicpu_so_bin != 0 && allocator_ != nullptr) {
-        int rc = allocator_->free(reinterpret_cast<void*>(aicpu_so_bin));
+        int rc = allocator_->free(reinterpret_cast<void *>(aicpu_so_bin));
         aicpu_so_bin = 0;
         return rc;
     }
@@ -181,7 +181,7 @@ int AicpuSoInfo::finalize() {
 // DeviceRunner Implementation
 // =============================================================================
 
-DeviceRunner& DeviceRunner::get() {
+DeviceRunner &DeviceRunner::get() {
     static DeviceRunner runner;
     return runner;
 }
@@ -189,7 +189,8 @@ DeviceRunner& DeviceRunner::get() {
 DeviceRunner::~DeviceRunner() { finalize(); }
 
 int DeviceRunner::ensure_device_initialized(
-    int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
+    int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+) {
     // First ensure device is set and streams are created
     int rc = ensure_device_set(device_id);
     if (rc != 0) {
@@ -235,7 +236,8 @@ int DeviceRunner::ensure_device_set(int device_id) {
 }
 
 int DeviceRunner::ensure_binaries_loaded(
-    const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
+    const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+) {
     // Check if already loaded
     if (binaries_loaded_) {
         // Just update kernel binary if different
@@ -275,28 +277,26 @@ int DeviceRunner::ensure_binaries_loaded(
     return 0;
 }
 
-void* DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
+void *DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
 
-void DeviceRunner::free_tensor(void* dev_ptr) {
+void DeviceRunner::free_tensor(void *dev_ptr) {
     if (dev_ptr != nullptr) {
         mem_alloc_.free(dev_ptr);
     }
 }
 
-int DeviceRunner::copy_to_device(void* dev_ptr, const void* host_ptr, size_t bytes) {
+int DeviceRunner::copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes) {
     return rtMemcpy(dev_ptr, bytes, host_ptr, bytes, RT_MEMCPY_HOST_TO_DEVICE);
 }
 
-int DeviceRunner::copy_from_device(void* host_ptr, const void* dev_ptr, size_t bytes) {
+int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes) {
     return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
-int DeviceRunner::run(Runtime& runtime,
-    int block_dim,
-    int device_id,
-    const std::vector<uint8_t>& aicpu_so_binary,
-    const std::vector<uint8_t>& aicore_kernel_binary,
-    int launch_aicpu_num) {
+int DeviceRunner::run(
+    Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
+) {
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -314,7 +314,8 @@ int DeviceRunner::run(Runtime& runtime,
 
     if (runtime.orch_thread_num > launch_aicpu_num) {
         LOG_ERROR(
-            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num);
+            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num
+        );
         return -1;
     }
 
@@ -322,19 +323,21 @@ int DeviceRunner::run(Runtime& runtime,
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
             LOG_ERROR(
-                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num);
+                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num
+            );
             return -1;
         }
     } else {
         LOG_INFO(
-            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num);
+            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num
+        );
         // Post-transition: all threads become schedulers
         if (block_dim % launch_aicpu_num != 0) {
             LOG_WARN(
                 "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
                 "some threads will have different core counts after transition",
-                block_dim,
-                launch_aicpu_num);
+                block_dim, launch_aicpu_num
+            );
         }
     }
 
@@ -385,7 +388,7 @@ int DeviceRunner::run(Runtime& runtime,
     // device address; compute binary code address using compile-time offset
     LOG_DEBUG("Setting function_bin_addr for Tasks");
     for (int i = 0; i < runtime.get_task_count(); i++) {
-        Task* task = runtime.get_task(i);
+        Task *task = runtime.get_task(i);
         if (task != nullptr) {
             uint64_t callable_addr = runtime.get_function_bin_addr(task->func_id);
             task->function_bin_addr = callable_addr + CoreCallable::binary_data_offset();
@@ -397,12 +400,14 @@ int DeviceRunner::run(Runtime& runtime,
     // Scope guards for cleanup on all exit paths
     auto regs_cleanup = RAIIScopeGuard([this]() {
         if (kernel_args_.args.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.args.regs));
+            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.regs));
             kernel_args_.args.regs = 0;
         }
     });
 
-    auto runtime_args_cleanup = RAIIScopeGuard([this]() { kernel_args_.finalize_runtime_args(); });
+    auto runtime_args_cleanup = RAIIScopeGuard([this]() {
+        kernel_args_.finalize_runtime_args();
+    });
 
     // Initialize performance profiling if enabled
     if (runtime.enable_profiling) {
@@ -441,7 +446,8 @@ int DeviceRunner::run(Runtime& runtime,
     std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServer===" << '\n';
     // Launch AICPU main kernel (over-launch for affinity gate)
     rc = launch_aicpu_kernel(
-        stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH);
+        stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
+    );
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
         return rc;
@@ -459,8 +465,9 @@ int DeviceRunner::run(Runtime& runtime,
         // Poll and collect performance data in a separate collector thread
         std::thread collector_thread;
         if (runtime.enable_profiling) {
-            collector_thread =
-                std::thread([this, &runtime]() { poll_and_collect_performance_data(runtime.get_task_count()); });
+            collector_thread = std::thread([this, &runtime]() {
+                poll_and_collect_performance_data(runtime.get_task_count());
+            });
         }
         auto thread_guard = RAIIScopeGuard([&]() {
             if (runtime.enable_profiling && collector_thread.joinable()) {
@@ -516,12 +523,10 @@ void DeviceRunner::print_handshake_results() {
 
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
-        LOG_DEBUG("  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d",
-            i,
-            workers[i].aicore_done,
-            workers[i].aicpu_ready,
-            workers[i].control,
-            workers[i].task);
+        LOG_DEBUG(
+            "  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d", i, workers[i].aicore_done,
+            workers[i].aicpu_ready, workers[i].control, workers[i].task
+        );
     }
 }
 
@@ -540,8 +545,8 @@ int DeviceRunner::finalize() {
     if (!func_id_to_addr_.empty()) {
         LOG_ERROR("finalize() called with %zu kernel binaries still cached (memory leak)", func_id_to_addr_.size());
         // Cleanup leaked binaries to prevent memory leaks
-        for (const auto& pair : func_id_to_addr_) {
-            void* gm_addr = reinterpret_cast<void*>(pair.second);
+        for (const auto &pair : func_id_to_addr_) {
+            void *gm_addr = reinterpret_cast<void *>(pair.second);
             mem_alloc_.free(gm_addr);
             LOG_DEBUG("Freed leaked kernel binary: func_id=%d, addr=0x%lx", pair.first, pair.second);
         }
@@ -561,7 +566,7 @@ int DeviceRunner::finalize() {
 
     // Cleanup performance profiling
     if (perf_collector_.is_initialized()) {
-        auto unregister_cb = [](void* dev_ptr, int device_id, void* user_data) -> int {
+        auto unregister_cb = [](void *dev_ptr, int device_id, void *user_data) -> int {
             (void)user_data;
             HalHostUnregisterFn fn = get_halHostUnregister();
             if (fn != nullptr) {
@@ -570,8 +575,8 @@ int DeviceRunner::finalize() {
             return 0;
         };
 
-        auto free_cb = [](void* dev_ptr, void* user_data) -> int {
-            auto* allocator = static_cast<MemoryAllocator*>(user_data);
+        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+            auto *allocator = static_cast<MemoryAllocator *>(user_data);
             return allocator->free(dev_ptr);
         };
 
@@ -589,7 +594,7 @@ int DeviceRunner::finalize() {
     return 0;
 }
 
-int DeviceRunner::launch_aicpu_kernel(rtStream_t stream, KernelArgs* k_args, const char* kernel_name, int aicpu_num) {
+int DeviceRunner::launch_aicpu_kernel(rtStream_t stream, KernelArgs *k_args, const char *kernel_name, int aicpu_num) {
     struct Args {
         KernelArgs k_args;
         char kernel_name[32];
@@ -609,17 +614,18 @@ int DeviceRunner::launch_aicpu_kernel(rtStream_t stream, KernelArgs* k_args, con
     rt_args.soNameAddrOffset = offsetof(struct Args, so_name);
 
     return rtAicpuKernelLaunchExWithArgs(
-        rtKernelType_t::KERNEL_TYPE_AICPU_KFC, "AST_DYN_AICPU", aicpu_num, &rt_args, nullptr, stream, 0);
+        rtKernelType_t::KERNEL_TYPE_AICPU_KFC, "AST_DYN_AICPU", aicpu_num, &rt_args, nullptr, stream, 0
+    );
 }
 
-int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime* runtime) {
+int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime *runtime) {
     if (aicore_kernel_binary_.empty()) {
         LOG_ERROR("AICore kernel binary is empty");
         return -1;
     }
 
     size_t bin_size = aicore_kernel_binary_.size();
-    const void* bin_data = aicore_kernel_binary_.data();
+    const void *bin_data = aicore_kernel_binary_.data();
 
     rtDevBinary_t binary;
     std::memset(&binary, 0, sizeof(binary));
@@ -627,7 +633,7 @@ int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime* runtime) {
     binary.version = 0;
     binary.data = bin_data;
     binary.length = bin_size;
-    void* bin_handle = nullptr;
+    void *bin_handle = nullptr;
     int rc = rtRegisterAllKernel(&binary, &bin_handle);
     if (rc != RT_ERROR_NONE) {
         LOG_ERROR("rtRegisterAllKernel failed: %d", rc);
@@ -635,7 +641,7 @@ int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime* runtime) {
     }
 
     struct Args {
-        Runtime* runtime;
+        Runtime *runtime;
     };
     // Pass device address of Runtime to AICore
     Args args = {runtime};
@@ -660,7 +666,7 @@ int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime* runtime) {
 // Kernel Binary Upload (returns device address for caller to store in Runtime)
 // =============================================================================
 
-uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data, size_t bin_size) {
+uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size) {
     if (bin_data == nullptr || bin_size == 0) {
         LOG_ERROR("Invalid kernel binary data");
         return 0;
@@ -682,7 +688,7 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     LOG_DEBUG("Uploading kernel binary: func_id=%d, size=%zu bytes", func_id, bin_size);
 
     // Allocate device GM memory for kernel binary
-    void* gm_addr = mem_alloc_.alloc(bin_size);
+    void *gm_addr = mem_alloc_.alloc(bin_size);
     if (gm_addr == nullptr) {
         LOG_ERROR("Failed to allocate device GM memory for kernel func_id=%d", func_id);
         return 0;
@@ -694,7 +700,7 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     assert((callable_addr & (CALLABLE_ALIGN - 1)) == 0 && "device alloc must be CALLABLE_ALIGN-byte aligned");
     uint64_t binary_code_addr = callable_addr + CoreCallable::binary_data_offset();
     // Write resolved_addr_ into the host-side buffer (the field lives at a fixed offset)
-    CoreCallable* host_callable = reinterpret_cast<CoreCallable*>(const_cast<uint8_t*>(bin_data));
+    CoreCallable *host_callable = reinterpret_cast<CoreCallable *>(const_cast<uint8_t *>(bin_data));
     host_callable->set_resolved_addr(binary_code_addr);
 
     // Copy the full CoreCallable (header + binary) to device
@@ -719,7 +725,7 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
     }
 
     uint64_t function_bin_addr = it->second;
-    void* gm_addr = reinterpret_cast<void*>(function_bin_addr);
+    void *gm_addr = reinterpret_cast<void *>(function_bin_addr);
 
     mem_alloc_.free(gm_addr);
     func_id_to_addr_.erase(it);
@@ -727,15 +733,15 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
     LOG_DEBUG("Removed kernel binary: func_id=%d, addr=0x%lx", func_id, function_bin_addr);
 }
 
-int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, int device_id) {
+int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, int device_id) {
     // Define allocation callback (a5: use MemoryAllocator)
-    auto alloc_cb = [](size_t size, void* user_data) -> void* {
-        auto* allocator = static_cast<MemoryAllocator*>(user_data);
+    auto alloc_cb = [](size_t size, void *user_data) -> void * {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
         return allocator->alloc(size);
     };
 
     // Define registration callback (a5: use halHostRegister for shared memory)
-    auto register_cb = [](void* dev_ptr, size_t size, int device_id, void* user_data, void** host_ptr) -> int {
+    auto register_cb = [](void *dev_ptr, size_t size, int device_id, void *user_data, void **host_ptr) -> int {
         (void)user_data;  // Not needed for registration
         if (load_hal_if_needed() != 0) {
             LOG_ERROR("Failed to load ascend_hal for profiling: %s", dlerror());
@@ -749,8 +755,8 @@ int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, i
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
 
-    auto free_cb = [](void* dev_ptr, void* user_data) -> int {
-        auto* allocator = static_cast<MemoryAllocator*>(user_data);
+    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
         return allocator->free(dev_ptr);
     };
 
@@ -761,6 +767,6 @@ void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
     perf_collector_.poll_and_collect(expected_tasks);
 }
 
-int DeviceRunner::export_swimlane_json(const std::string& output_path) {
+int DeviceRunner::export_swimlane_json(const std::string &output_path) {
     return perf_collector_.export_swimlane_json(output_path);
 }

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Device Runner - Ascend Device Execution Utilities
  *
@@ -59,7 +69,7 @@ struct DeviceArgs {
  */
 struct KernelArgsHelper {
     KernelArgs args;
-    MemoryAllocator* allocator_{nullptr};
+    MemoryAllocator *allocator_{nullptr};
 
     /**
      * Initialize device arguments by allocating device memory and copying data
@@ -68,7 +78,7 @@ struct KernelArgsHelper {
      * @param allocator       Memory allocator to use
      * @return 0 on success, error code on failure
      */
-    int init_device_args(const DeviceArgs& host_device_args, MemoryAllocator& allocator);
+    int init_device_args(const DeviceArgs &host_device_args, MemoryAllocator &allocator);
 
     /**
      * Free device memory allocated for device arguments
@@ -84,7 +94,7 @@ struct KernelArgsHelper {
      * @param allocator  Memory allocator to use
      * @return 0 on success, error code on failure
      */
-    int init_runtime_args(const Runtime& host_runtime, MemoryAllocator& allocator);
+    int init_runtime_args(const Runtime &host_runtime, MemoryAllocator &allocator);
 
     /**
      * Free device memory allocated for runtime arguments
@@ -100,8 +110,8 @@ struct KernelArgsHelper {
      * is expected, enabling transparent device memory management while
      * maintaining API compatibility.
      */
-    operator KernelArgs*() { return &args; }
-    KernelArgs* operator&() { return &args; }
+    operator KernelArgs *() { return &args; }
+    KernelArgs *operator&() { return &args; }
 };
 
 /**
@@ -113,7 +123,7 @@ struct KernelArgsHelper {
 struct AicpuSoInfo {
     uint64_t aicpu_so_bin{0};
     uint64_t aicpu_so_len{0};
-    MemoryAllocator* allocator_{nullptr};
+    MemoryAllocator *allocator_{nullptr};
 
     /**
      * Load shared object binary data and copy to device memory
@@ -122,7 +132,7 @@ struct AicpuSoInfo {
      * @param allocator      Memory allocator to use
      * @return 0 on success, error code on failure
      */
-    int init(const std::vector<uint8_t>& aicpu_so_binary, MemoryAllocator& allocator);
+    int init(const std::vector<uint8_t> &aicpu_so_binary, MemoryAllocator &allocator);
 
     /**
      * Free device memory allocated for shared object
@@ -151,7 +161,7 @@ public:
      *
      * @return Reference to the singleton DeviceRunner instance
      */
-    static DeviceRunner& get();
+    static DeviceRunner &get();
 
     /**
      * Allocate device tensor memory
@@ -159,14 +169,14 @@ public:
      * @param bytes  Size of tensor in bytes
      * @return Device pointer on success, nullptr on failure
      */
-    void* allocate_tensor(size_t bytes);
+    void *allocate_tensor(size_t bytes);
 
     /**
      * Free device tensor memory
      *
      * @param dev_ptr  Device pointer to free
      */
-    void free_tensor(void* dev_ptr);
+    void free_tensor(void *dev_ptr);
 
     /**
      * Copy data from host to device
@@ -176,7 +186,7 @@ public:
      * @param bytes    Number of bytes to copy
      * @return 0 on success, error code on failure
      */
-    int copy_to_device(void* dev_ptr, const void* host_ptr, size_t bytes);
+    int copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes);
 
     /**
      * Copy data from device to host
@@ -186,7 +196,7 @@ public:
      * @param bytes    Number of bytes to copy
      * @return 0 on success, error code on failure
      */
-    int copy_from_device(void* host_ptr, const void* dev_ptr, size_t bytes);
+    int copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes);
 
     /**
      * Execute a runtime
@@ -210,12 +220,9 @@ public:
      * @param launch_aicpu_num      Number of AICPU instances (default: 1)
      * @return 0 on success, error code on failure
      */
-    int run(Runtime& runtime,
-        int block_dim,
-        int device_id,
-        const std::vector<uint8_t>& aicpu_so_binary,
-        const std::vector<uint8_t>& aicore_kernel_binary,
-        int launch_aicpu_num = 1);
+    int
+    run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
 
     /**
      * Print handshake results from device
@@ -246,7 +253,7 @@ public:
      * @param output_path Path to output directory (default: "outputs")
      * @return 0 on success, error code on failure
      */
-    int export_swimlane_json(const std::string& output_path = "outputs");
+    int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
      * Cleanup all resources
@@ -270,7 +277,7 @@ public:
      * @param aicpu_num    Number of AICPU instances to launch
      * @return 0 on success, error code on failure
      */
-    int launch_aicpu_kernel(rtStream_t stream, KernelArgs* k_args, const char* kernel_name, int aicpu_num);
+    int launch_aicpu_kernel(rtStream_t stream, KernelArgs *k_args, const char *kernel_name, int aicpu_num);
 
     /**
      * Launch an AICore kernel
@@ -282,7 +289,7 @@ public:
      * @param runtime   Pointer to device runtime
      * @return 0 on success, error code on failure
      */
-    int launch_aicore_kernel(rtStream_t stream, Runtime* runtime);
+    int launch_aicore_kernel(rtStream_t stream, Runtime *runtime);
 
     /**
      * Upload a kernel binary to device memory
@@ -303,7 +310,7 @@ public:
      * @param bin_size  Size of binary data in bytes
      * @return Device GM address of kernel on success, 0 on error
      */
-    uint64_t upload_kernel_binary(int func_id, const uint8_t* bin_data, size_t bin_size);
+    uint64_t upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size);
 
     /**
      * Remove a kernel binary from device memory
@@ -350,7 +357,7 @@ private:
     DeviceArgs device_args_;
 
     // Kernel binary management
-    bool binaries_loaded_{false};            // true after AICPU SO loaded
+    bool binaries_loaded_{false};              // true after AICPU SO loaded
     std::map<int, uint64_t> func_id_to_addr_;  // func_id -> function_bin_addr (device GM)
 
     // Performance profiling
@@ -370,9 +377,9 @@ private:
      * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int ensure_device_initialized(int device_id,
-                                const std::vector<uint8_t>& aicpu_so_binary,
-                                const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_device_initialized(
+        int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+    );
 
     /**
      * Load AICPU SO and initialize device args
@@ -385,7 +392,9 @@ private:
      * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int ensure_binaries_loaded(const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
+    int ensure_binaries_loaded(
+        const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+    );
 
     /**
      * Initialize performance profiling shared memory
@@ -398,7 +407,7 @@ private:
      * @param device_id Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_performance_profiling(Runtime& runtime, int num_aicore, int device_id);
+    int init_performance_profiling(Runtime &runtime, int num_aicore, int device_id);
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a5/platform/onboard/host/host_regs.cpp
+++ b/src/a5/platform/onboard/host/host_regs.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file host_regs.cpp
  * @brief Host-side AICore register address retrieval implementation
@@ -18,11 +28,11 @@
  * Each AICore has 3 sub-cores (1 AIC + 2 AIV), and the chip has 2 dies with
  * 18 AICores per die.
  */
-static int get_aicore_reg_info(std::vector<int64_t>& regs, int64_t device_id) {
-
+static int get_aicore_reg_info(std::vector<int64_t> &regs, int64_t device_id) {
     // halResMap: Maps individual AICore resources (DAV_3510-specific)
-    auto halFunc = (int (*)(uint32_t devId, struct res_map_info* res_info, uint64_t* va,
-        uint32_t* len))dlsym(nullptr, "halResMap");
+    auto halFunc = (int (*)(uint32_t devId, struct res_map_info *res_info, uint64_t *va, uint32_t *len))dlsym(
+        nullptr, "halResMap"
+    );
 
     if (halFunc == nullptr) {
         LOG_ERROR("halResMap not found in symbol table");
@@ -75,7 +85,7 @@ static int get_aicore_reg_info(std::vector<int64_t>& regs, int64_t device_id) {
     return 0;
 }
 
-static void get_aicore_regs(std::vector<int64_t>& regs, uint64_t device_id) {
+static void get_aicore_regs(std::vector<int64_t> &regs, uint64_t device_id) {
     int rt = get_aicore_reg_info(regs, device_id);
 
     if (rt != 0) {
@@ -101,11 +111,7 @@ static void get_aicore_regs(std::vector<int64_t>& regs, uint64_t device_id) {
     LOG_INFO("get_aicore_regs: Retrieved %zu register addresses", regs.size());
 }
 
-int init_aicore_register_addresses(
-    uint64_t* runtime_regs_ptr,
-    uint64_t device_id,
-    MemoryAllocator& allocator) {
-
+int init_aicore_register_addresses(uint64_t *runtime_regs_ptr, uint64_t device_id, MemoryAllocator &allocator) {
     if (runtime_regs_ptr == nullptr) {
         LOG_ERROR("init_aicore_register_addresses: Invalid parameters");
         return -1;
@@ -124,7 +130,7 @@ int init_aicore_register_addresses(
 
     // Step 2: Allocate device memory for register address array
     size_t regs_size = host_regs.size() * sizeof(int64_t);
-    void* reg_ptr = allocator.alloc(regs_size);
+    void *reg_ptr = allocator.alloc(regs_size);
     if (reg_ptr == nullptr) {
         LOG_ERROR("Failed to allocate device memory for register addresses");
         return -1;
@@ -141,8 +147,10 @@ int init_aicore_register_addresses(
     // Step 4: Store device pointer in output regs field
     *runtime_regs_ptr = reinterpret_cast<uint64_t>(reg_ptr);
 
-    LOG_INFO("Successfully initialized register addresses: %zu addresses at device 0x%llx",
-             host_regs.size(), *runtime_regs_ptr);
+    LOG_INFO(
+        "Successfully initialized register addresses: %zu addresses at device 0x%llx", host_regs.size(),
+        *runtime_regs_ptr
+    );
 
     return 0;
 }

--- a/src/a5/platform/onboard/host/memory_allocator.cpp
+++ b/src/a5/platform/onboard/host/memory_allocator.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Memory Allocator Implementation
  *
@@ -13,8 +23,8 @@
 
 MemoryAllocator::~MemoryAllocator() { finalize(); }
 
-void* MemoryAllocator::alloc(size_t size) {
-    void* ptr = nullptr;
+void *MemoryAllocator::alloc(size_t size) {
+    void *ptr = nullptr;
     int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
     if (rc != 0) {
         LOG_ERROR("rtMalloc failed: %d (size=%zu)", rc, size);
@@ -26,7 +36,7 @@ void* MemoryAllocator::alloc(size_t size) {
     return ptr;
 }
 
-int MemoryAllocator::free(void* ptr) {
+int MemoryAllocator::free(void *ptr) {
     if (ptr == nullptr) {
         return 0;
     }
@@ -59,7 +69,7 @@ int MemoryAllocator::finalize() {
     int last_error = 0;
 
     // Free all remaining tracked pointers
-    for (void* ptr : ptr_set_) {
+    for (void *ptr : ptr_set_) {
         int rc = rtFree(ptr);
         if (rc != 0) {
             LOG_ERROR("rtFree failed during Finalize: %d", rc);

--- a/src/a5/platform/onboard/host/platform_compile_info.cpp
+++ b/src/a5/platform/onboard/host/platform_compile_info.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "host/platform_compile_info.h"
 
-extern "C" const char* get_platform(void) { return "a5"; }
+extern "C" const char *get_platform(void) { return "a5"; }

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -30,15 +30,15 @@ extern "C" {
 /* Runtime Implementation Functions (defined in runtimemaker.cpp) */
 /* ===========================================================================
  */
-int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args);
-int validate_runtime_impl(Runtime* runtime);
+int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args);
+int validate_runtime_impl(Runtime *runtime);
 
 /* Forward declarations for device memory functions used in init_runtime */
-void* device_malloc(size_t size);
-void device_free(void* dev_ptr);
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
+void *device_malloc(size_t size);
+void device_free(void *dev_ptr);
+int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size);
+int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size);
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size);
 void remove_kernel_binary_wrapper(int func_id);
 
 /* ===========================================================================
@@ -49,7 +49,7 @@ void remove_kernel_binary_wrapper(int func_id);
 
 size_t get_runtime_size(void) { return sizeof(Runtime); }
 
-int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args) {
+int init_runtime(RuntimeHandle runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args) {
     if (runtime == NULL) {
         return -1;
     }
@@ -58,7 +58,7 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
 
     try {
         // Placement new to construct Runtime in user-allocated memory
-        Runtime* r = new (runtime) Runtime();
+        Runtime *r = new (runtime) Runtime();
 
         // Initialize host API function pointers (host-only, not available on device)
         r->host_api.device_malloc = device_malloc;
@@ -68,7 +68,7 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
         r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
         r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
 
-        LOG_DEBUG("About to call init_runtime_impl, r=%p", (void*)r);
+        LOG_DEBUG("About to call init_runtime_impl, r=%p", (void *)r);
 
         // Delegate kernel registration, SO loading, and orchestration to init_runtime_impl
         int result = init_runtime_impl(r, callable, orch_args);
@@ -96,54 +96,54 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
 /* ===========================================================================
  */
 
-void* device_malloc(size_t size) {
+void *device_malloc(size_t size) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.allocate_tensor(size);
     } catch (...) {
         return NULL;
     }
 }
 
-void device_free(void* dev_ptr) {
+void device_free(void *dev_ptr) {
     if (dev_ptr == NULL) {
         return;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         runner.free_tensor(dev_ptr);
     } catch (...) {
         // Ignore errors during free
     }
 }
 
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size) {
+int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size) {
     if (dev_ptr == NULL || host_ptr == NULL) {
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.copy_to_device(dev_ptr, host_ptr, size);
     } catch (...) {
         return -1;
     }
 }
 
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size) {
+int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     if (host_ptr == NULL || dev_ptr == NULL) {
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.copy_from_device(host_ptr, dev_ptr, size);
     } catch (...) {
         return -1;
     }
 }
 
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size) {
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.upload_kernel_binary(func_id, bin_data, bin_size);
     } catch (...) {
         return 0;
@@ -152,22 +152,17 @@ uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size
 
 void remove_kernel_binary_wrapper(int func_id) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         runner.remove_kernel_binary(func_id);
     } catch (...) {
         // Ignore errors during cleanup
     }
 }
 
-int launch_runtime(RuntimeHandle runtime,
-    int aicpu_thread_num,
-    int block_dim,
-    int device_id,
-    const uint8_t* aicpu_binary,
-    size_t aicpu_size,
-    const uint8_t* aicore_binary,
-    size_t aicore_size,
-    int orch_thread_num) {
+int launch_runtime(
+    RuntimeHandle runtime, int aicpu_thread_num, int block_dim, int device_id, const uint8_t *aicpu_binary,
+    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size, int orch_thread_num
+) {
     if (runtime == NULL) {
         return -1;
     }
@@ -175,14 +170,14 @@ int launch_runtime(RuntimeHandle runtime,
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
 
         // Convert to vectors for run()
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
 
         // Run the runtime (device initialization is handled internally)
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         r->orch_thread_num = orch_thread_num;
         return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
@@ -195,7 +190,7 @@ int finalize_runtime(RuntimeHandle runtime) {
         return -1;
     }
     try {
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         int rc = validate_runtime_impl(r);
 
         // Call destructor (user will call free())
@@ -208,7 +203,7 @@ int finalize_runtime(RuntimeHandle runtime) {
 
 int set_device(int device_id) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.ensure_device_set(device_id);
     } catch (...) {
         return -1;
@@ -220,11 +215,11 @@ int set_device(int device_id) {
  * registration and stores addresses in Runtime's func_id_to_addr_[] array.
  */
 
-void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size) {
+void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, size_t size) {
     if (runtime == NULL) {
         return;
     }
-    Runtime* r = static_cast<Runtime*>(runtime);
+    Runtime *r = static_cast<Runtime *>(runtime);
     r->record_tensor_pair(host_ptr, dev_ptr, size);
 }
 
@@ -233,7 +228,7 @@ int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
         return -1;
     }
     try {
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         r->enable_profiling = (enabled != 0);
         return 0;
     } catch (...) {

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -142,7 +142,7 @@ inline uint64_t get_sys_cnt_aicore() {
  * Set by the kernel wrapper before calling aicore_execute().
  * Points to the first 4KB page of the sparse register block.
  */
-extern thread_local volatile uint8_t* g_sim_reg_base;
+extern thread_local volatile uint8_t *g_sim_reg_base;
 
 /**
  * Per-thread simulated physical core ID.
@@ -160,7 +160,7 @@ extern thread_local uint32_t g_sim_physical_core_id;
  */
 inline uint64_t read_reg(RegId reg) {
     uint32_t offset = reg_offset(reg);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(sparse_reg_ptr(g_sim_reg_base, offset));
+    volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(sparse_reg_ptr(g_sim_reg_base, offset));
 
     uint64_t val = static_cast<uint64_t>(*ptr);
     OUT_OF_ORDER_LOAD_BARRIER();
@@ -177,7 +177,7 @@ inline uint64_t read_reg(RegId reg) {
  */
 inline void write_reg(RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(sparse_reg_ptr(g_sim_reg_base, offset));
+    volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(sparse_reg_ptr(g_sim_reg_base, offset));
 
     *ptr = static_cast<uint32_t>(value);
     OUT_OF_ORDER_STORE_BARRIER();

--- a/src/a5/platform/sim/aicore/kernel.cpp
+++ b/src/a5/platform/sim/aicore/kernel.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * AICore Kernel Wrapper for Simulation
  *
@@ -12,23 +22,25 @@
 #include "runtime.h"
 
 // Thread-local simulated register base (declared in inner_kernel.h)
-thread_local volatile uint8_t* g_sim_reg_base = nullptr;
+thread_local volatile uint8_t *g_sim_reg_base = nullptr;
 
 // Thread-local simulated physical core ID (declared in inner_kernel.h)
 thread_local uint32_t g_sim_physical_core_id = 0;
 
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
-void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type);
+void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type);
 
 // Wrapper with extern "C" for dlsym lookup
 // NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
-extern "C" void aicore_execute_wrapper(__gm__ Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs) {
+extern "C" void aicore_execute_wrapper(
+    __gm__ Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs
+) {
     // Set up simulated register base for this thread.
     // regs points to an array of uint64_t base addresses (one per core).
     // physical_core_id indexes into it to get this core's register block.
     if (regs != 0) {
-        uint64_t* regs_array = reinterpret_cast<uint64_t*>(regs);
-        g_sim_reg_base = reinterpret_cast<volatile uint8_t*>(regs_array[physical_core_id]);
+        uint64_t *regs_array = reinterpret_cast<uint64_t *>(regs);
+        g_sim_reg_base = reinterpret_cast<volatile uint8_t *>(regs_array[physical_core_id]);
     }
 
     g_sim_physical_core_id = physical_core_id;

--- a/src/a5/platform/sim/aicpu/cache_ops.cpp
+++ b/src/a5/platform/sim/aicpu/cache_ops.cpp
@@ -1,7 +1,17 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstddef>
 
 #include "aicpu/platform_regs.h"
 
-void cache_invalidate_range(const void* /* addr */, size_t /* size */) {
+void cache_invalidate_range(const void * /* addr */, size_t /* size */) {
     // No-op on simulation: no hardware cache to invalidate
 }

--- a/src/a5/platform/sim/aicpu/device_log.cpp
+++ b/src/a5/platform/sim/aicpu/device_log.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file device_log.cpp
  * @brief Simulation Platform Log Implementation
@@ -26,7 +36,7 @@ bool g_is_log_enable_error = true;
 // Platform Constant
 // =============================================================================
 
-const char* TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
+const char *TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
 
 // =============================================================================
 // Log Initialization (Read from PTO_LOG_LEVEL environment variable)
@@ -34,18 +44,18 @@ const char* TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
 
 void init_log_switch() {
     // Read PTO_LOG_LEVEL environment variable
-    const char* level_str = std::getenv("PTO_LOG_LEVEL");
-    
+    const char *level_str = std::getenv("PTO_LOG_LEVEL");
+
     if (level_str != nullptr) {
         // Convert to lowercase for comparison
         char level[64];
         strncpy(level, level_str, sizeof(level) - 1);
         level[sizeof(level) - 1] = '\0';
-        
-        for (char* p = level; *p; ++p) {
+
+        for (char *p = level; *p; ++p) {
             *p = tolower(*p);
         }
-        
+
         // Parse log level
         if (strcmp(level, "silent") == 0 || strcmp(level, "error") == 0) {
             // Silent/Error: only errors
@@ -85,7 +95,7 @@ void init_log_switch() {
 // Platform-Specific Logging Functions (Simulation: use printf)
 // =============================================================================
 
-void dev_log_debug(const char* func, const char* fmt, ...) {
+void dev_log_debug(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     printf("[DEBUG] %s: ", func);
@@ -94,7 +104,7 @@ void dev_log_debug(const char* func, const char* fmt, ...) {
     va_end(args);
 }
 
-void dev_log_info(const char* func, const char* fmt, ...) {
+void dev_log_info(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     printf("[INFO] %s: ", func);
@@ -103,7 +113,7 @@ void dev_log_info(const char* func, const char* fmt, ...) {
     va_end(args);
 }
 
-void dev_log_warn(const char* func, const char* fmt, ...) {
+void dev_log_warn(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     printf("[WARN] %s: ", func);
@@ -112,7 +122,7 @@ void dev_log_warn(const char* func, const char* fmt, ...) {
     va_end(args);
 }
 
-void dev_log_error(const char* func, const char* fmt, ...) {
+void dev_log_error(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     printf("[ERROR] %s: ", func);
@@ -121,7 +131,7 @@ void dev_log_error(const char* func, const char* fmt, ...) {
     va_end(args);
 }
 
-void dev_log_always(const char* func, const char* fmt, ...) {
+void dev_log_always(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     printf("[ALWAYS] %s: ", func);

--- a/src/a5/platform/sim/aicpu/device_malloc.cpp
+++ b/src/a5/platform/sim/aicpu/device_malloc.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file device_malloc.cpp
  * @brief Device Memory Allocation for Simulation (a5sim)
@@ -10,10 +20,6 @@
 
 #include <cstdlib>
 
-void* aicpu_device_malloc(size_t size) {
-    return malloc(size);
-}
+void *aicpu_device_malloc(size_t size) { return malloc(size); }
 
-void aicpu_device_free(void* ptr) {
-    free(ptr);
-}
+void aicpu_device_free(void *ptr) { free(ptr); }

--- a/src/a5/platform/sim/aicpu/device_time.cpp
+++ b/src/a5/platform/sim/aicpu/device_time.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "aicpu/device_time.h"
 
 #include <chrono>
@@ -6,13 +16,10 @@
 
 uint64_t get_sys_cnt_aicpu() {
     auto now = std::chrono::high_resolution_clock::now();
-    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        now.time_since_epoch()
-    ).count();
+    uint64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
     constexpr uint64_t kNsPerSec = std::nano::den;
     uint64_t seconds = elapsed_ns / kNsPerSec;
     uint64_t remaining_ns = elapsed_ns % kNsPerSec;
-    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ +
-                     (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
+    uint64_t ticks = seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
     return ticks;
 }

--- a/src/a5/platform/sim/aicpu/inner_platform_regs.cpp
+++ b/src/a5/platform/sim/aicpu/inner_platform_regs.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file inner_platform_regs.cpp
  * @brief AICPU register read/write for simulation (a5sim)
@@ -14,9 +24,8 @@
 
 uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
     uint32_t offset = reg_offset(reg);
-    volatile uint8_t* reg_base = reinterpret_cast<volatile uint8_t*>(reg_base_addr);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        sparse_reg_ptr(reg_base, offset));
+    volatile uint8_t *reg_base = reinterpret_cast<volatile uint8_t *>(reg_base_addr);
+    volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(sparse_reg_ptr(reg_base, offset));
 
     __sync_synchronize();
     uint64_t value = static_cast<uint64_t>(*ptr);
@@ -27,9 +36,8 @@ uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
 
 void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
-    volatile uint8_t* reg_base = reinterpret_cast<volatile uint8_t*>(reg_base_addr);
-    volatile uint32_t* ptr = reinterpret_cast<volatile uint32_t*>(
-        sparse_reg_ptr(reg_base, offset));
+    volatile uint8_t *reg_base = reinterpret_cast<volatile uint8_t *>(reg_base_addr);
+    volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(sparse_reg_ptr(reg_base, offset));
 
     __sync_synchronize();
     *ptr = static_cast<uint32_t>(value);

--- a/src/a5/platform/sim/aicpu/platform_aicpu_affinity.cpp
+++ b/src/a5/platform/sim/aicpu/platform_aicpu_affinity.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "aicpu/platform_aicpu_affinity.h"
 
 #include <atomic>
@@ -17,8 +27,10 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
     bool survive = (idx < logical_count);
 
     if (!survive) {
-        LOG_INFO("AICPU affinity gate (sim): thread idx=%d DROPPED (logical=%d, launched=%d)",
-                 idx, logical_count, total_launched);
+        LOG_INFO(
+            "AICPU affinity gate (sim): thread idx=%d DROPPED (logical=%d, launched=%d)", idx, logical_count,
+            total_launched
+        );
     }
 
     // Last thread resets state for next invocation

--- a/src/a5/platform/sim/aicpu/spin_hint.h
+++ b/src/a5/platform/sim/aicpu/spin_hint.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file spin_hint.h
  * @brief Platform-specific spin-wait hint for AICPU (simulation)
@@ -19,9 +29,17 @@
 #include <sched.h>
 
 #if defined(__aarch64__)
-#define SPIN_WAIT_HINT() do { __asm__ volatile("yield" ::: "memory"); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()                        \
+    do {                                        \
+        __asm__ volatile("yield" ::: "memory"); \
+        sched_yield();                          \
+    } while (0)
 #elif defined(__x86_64__)
-#define SPIN_WAIT_HINT() do { __builtin_ia32_pause(); sched_yield(); } while(0)
+#define SPIN_WAIT_HINT()        \
+    do {                        \
+        __builtin_ia32_pause(); \
+        sched_yield();          \
+    } while (0)
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -35,16 +35,17 @@
 #include "host/raii_scope_guard.h"
 
 // Function pointer types for dynamically loaded executors
-typedef int (*aicpu_execute_func_t)(Runtime* runtime);
+typedef int (*aicpu_execute_func_t)(Runtime *runtime);
 typedef void (*aicore_execute_func_t)(
-    Runtime* runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs);
+    Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs
+);
 typedef void (*set_platform_regs_func_t)(uint64_t regs);
 
 // =============================================================================
 // DeviceRunner Implementation
 // =============================================================================
 
-DeviceRunner& DeviceRunner::get() {
+DeviceRunner &DeviceRunner::get() {
     static DeviceRunner runner;
     return runner;
 }
@@ -52,13 +53,15 @@ DeviceRunner& DeviceRunner::get() {
 DeviceRunner::~DeviceRunner() { finalize(); }
 
 int DeviceRunner::ensure_device_initialized(
-    int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
+    int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+) {
     device_id_ = device_id;
     return ensure_binaries_loaded(aicpu_so_binary, aicore_kernel_binary);
 }
 
 int DeviceRunner::ensure_binaries_loaded(
-    const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary) {
+    const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+) {
     // Close any previously loaded binaries before reloading
     unload_executor_binaries();
 
@@ -70,7 +73,7 @@ int DeviceRunner::ensure_binaries_loaded(
             LOG_ERROR("Failed to create temp file for AICPU SO: %s", aicpu_so_path_.c_str());
             return -1;
         }
-        ofs.write(reinterpret_cast<const char*>(aicpu_so_binary.data()), aicpu_so_binary.size());
+        ofs.write(reinterpret_cast<const char *>(aicpu_so_binary.data()), aicpu_so_binary.size());
         ofs.close();
 
         aicpu_so_handle_ = dlopen(aicpu_so_path_.c_str(), RTLD_NOW | RTLD_GLOBAL);
@@ -79,7 +82,7 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
-        aicpu_execute_func_ = reinterpret_cast<int (*)(Runtime*)>(dlsym(aicpu_so_handle_, "aicpu_execute"));
+        aicpu_execute_func_ = reinterpret_cast<int (*)(Runtime *)>(dlsym(aicpu_so_handle_, "aicpu_execute"));
         if (aicpu_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicpu_execute: %s", dlerror());
             return -1;
@@ -102,7 +105,7 @@ int DeviceRunner::ensure_binaries_loaded(
             LOG_ERROR("Failed to create temp file for AICore SO: %s", aicore_so_path_.c_str());
             return -1;
         }
-        ofs.write(reinterpret_cast<const char*>(aicore_kernel_binary.data()), aicore_kernel_binary.size());
+        ofs.write(reinterpret_cast<const char *>(aicore_kernel_binary.data()), aicore_kernel_binary.size());
         ofs.close();
 
         aicore_so_handle_ = dlopen(aicore_so_path_.c_str(), RTLD_NOW | RTLD_GLOBAL);
@@ -111,8 +114,9 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
-        aicore_execute_func_ = reinterpret_cast<void (*)(Runtime*, int, CoreType, uint32_t, uint64_t)>(
-            dlsym(aicore_so_handle_, "aicore_execute_wrapper"));
+        aicore_execute_func_ = reinterpret_cast<void (*)(Runtime *, int, CoreType, uint32_t, uint64_t)>(
+            dlsym(aicore_so_handle_, "aicore_execute_wrapper")
+        );
         if (aicore_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicore_execute_wrapper: %s", dlerror());
             return -1;
@@ -123,32 +127,30 @@ int DeviceRunner::ensure_binaries_loaded(
     return 0;
 }
 
-void* DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
+void *DeviceRunner::allocate_tensor(size_t bytes) { return mem_alloc_.alloc(bytes); }
 
-void DeviceRunner::free_tensor(void* dev_ptr) {
+void DeviceRunner::free_tensor(void *dev_ptr) {
     if (dev_ptr != nullptr) {
         mem_alloc_.free(dev_ptr);
     }
 }
 
-int DeviceRunner::copy_to_device(void* dev_ptr, const void* host_ptr, size_t bytes) {
+int DeviceRunner::copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes) {
     // In simulation, this is just a memcpy
     std::memcpy(dev_ptr, host_ptr, bytes);
     return 0;
 }
 
-int DeviceRunner::copy_from_device(void* host_ptr, const void* dev_ptr, size_t bytes) {
+int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes) {
     // In simulation, this is just a memcpy
     std::memcpy(host_ptr, dev_ptr, bytes);
     return 0;
 }
 
-int DeviceRunner::run(Runtime& runtime,
-    int block_dim,
-    int device_id,
-    const std::vector<uint8_t>& aicpu_so_binary,
-    const std::vector<uint8_t>& aicore_kernel_binary,
-    int launch_aicpu_num) {
+int DeviceRunner::run(
+    Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
+) {
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -166,7 +168,8 @@ int DeviceRunner::run(Runtime& runtime,
 
     if (runtime.orch_thread_num > launch_aicpu_num) {
         LOG_ERROR(
-            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num);
+            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num
+        );
         return -1;
     }
 
@@ -174,19 +177,21 @@ int DeviceRunner::run(Runtime& runtime,
     if (scheduler_thread_num > 0) {
         if (block_dim % scheduler_thread_num != 0) {
             LOG_ERROR(
-                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num);
+                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num
+            );
             return -1;
         }
     } else {
         LOG_INFO(
-            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num);
+            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num
+        );
         // Post-transition: all threads become schedulers
         if (block_dim % launch_aicpu_num != 0) {
             LOG_WARN(
                 "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
                 "some threads will have different core counts after transition",
-                block_dim,
-                launch_aicpu_num);
+                block_dim, launch_aicpu_num
+            );
         }
     }
 
@@ -228,10 +233,10 @@ int DeviceRunner::run(Runtime& runtime,
     // host address; dereference resolved_addr_ for the dlsym function pointer
     LOG_DEBUG("Setting function_bin_addr for Tasks (Simulation)");
     for (int i = 0; i < runtime.get_task_count(); i++) {
-        Task* task = runtime.get_task(i);
+        Task *task = runtime.get_task(i);
         if (task != nullptr) {
             uint64_t callable_addr = runtime.get_function_bin_addr(task->func_id);
-            const CoreCallable* c = reinterpret_cast<const CoreCallable*>(callable_addr);
+            const CoreCallable *c = reinterpret_cast<const CoreCallable *>(callable_addr);
             task->function_bin_addr = c->resolved_addr();
             LOG_DEBUG("Task %d (func_id=%d) -> function_bin_addr=0x%lx", i, task->func_id, task->function_bin_addr);
         }
@@ -261,37 +266,40 @@ int DeviceRunner::run(Runtime& runtime,
     // Allocate simulated register blocks for all AICore cores
     // Using sparse mapping: 2 x 4KB pages per core instead of 24KB contiguous block
     size_t total_reg_size = num_aicore * SIM_REG_TOTAL_SIZE;
-    void* reg_blocks = mem_alloc_.alloc(total_reg_size);
+    void *reg_blocks = mem_alloc_.alloc(total_reg_size);
     if (reg_blocks == nullptr) {
         LOG_ERROR("Failed to allocate simulated register memory (%zu bytes)", total_reg_size);
         return -1;
     }
     std::memset(reg_blocks, 0, total_reg_size);
 
-    auto reg_blocks_cleanup = RAIIScopeGuard([this, reg_blocks]() { mem_alloc_.free(reg_blocks); });
+    auto reg_blocks_cleanup = RAIIScopeGuard([this, reg_blocks]() {
+        mem_alloc_.free(reg_blocks);
+    });
 
     // Build array of per-core register base addresses
     // Each core gets a pointer to its 8KB region (containing two 4KB pages)
     size_t regs_array_size = num_aicore * sizeof(uint64_t);
-    uint64_t* regs_array = reinterpret_cast<uint64_t*>(mem_alloc_.alloc(regs_array_size));
+    uint64_t *regs_array = reinterpret_cast<uint64_t *>(mem_alloc_.alloc(regs_array_size));
     if (regs_array == nullptr) {
         LOG_ERROR("Failed to allocate register address array");
         return -1;
     }
     for (int i = 0; i < num_aicore; i++) {
-        regs_array[i] = reinterpret_cast<uint64_t>(static_cast<uint8_t*>(reg_blocks) + i * SIM_REG_TOTAL_SIZE);
+        regs_array[i] = reinterpret_cast<uint64_t>(static_cast<uint8_t *>(reg_blocks) + i * SIM_REG_TOTAL_SIZE);
     }
     kernel_args_.regs = reinterpret_cast<uint64_t>(regs_array);
 
     auto regs_array_cleanup = RAIIScopeGuard([this]() {
         if (kernel_args_.regs != 0) {
-            mem_alloc_.free(reinterpret_cast<void*>(kernel_args_.regs));
+            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.regs));
             kernel_args_.regs = 0;
         }
     });
 
     LOG_INFO(
-        "Allocated simulated registers: %d cores x 0x%x bytes (sparse: 2x4KB pages)", num_aicore, SIM_REG_TOTAL_SIZE);
+        "Allocated simulated registers: %d cores x 0x%x bytes (sparse: 2x4KB pages)", num_aicore, SIM_REG_TOTAL_SIZE
+    );
 
     // Check if executors are loaded
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr) {
@@ -306,6 +314,7 @@ int DeviceRunner::run(Runtime& runtime,
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
     LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
     std::vector<std::thread> aicpu_threads;
+    aicpu_threads.reserve(over_launch);
     for (int i = 0; i < over_launch; i++) {
         aicpu_threads.emplace_back([this, &runtime, launch_aicpu_num, over_launch]() {
             if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
@@ -329,16 +338,17 @@ int DeviceRunner::run(Runtime& runtime,
     // Poll and collect performance data during execution (if enabled)
     std::thread collector_thread;
     if (runtime.enable_profiling) {
-        collector_thread =
-            std::thread([this, &runtime]() { poll_and_collect_performance_data(runtime.get_task_count()); });
+        collector_thread = std::thread([this, &runtime]() {
+            poll_and_collect_performance_data(runtime.get_task_count());
+        });
     }
 
     // Wait for all threads to complete
     LOG_INFO("Waiting for threads to complete");
-    for (auto& t : aicpu_threads) {
+    for (auto &t : aicpu_threads) {
         t.join();
     }
-    for (auto& t : aicore_threads) {
+    for (auto &t : aicore_threads) {
         t.join();
     }
 
@@ -382,12 +392,10 @@ void DeviceRunner::print_handshake_results() {
 
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
-        LOG_DEBUG("  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d",
-            i,
-            last_runtime_->workers[i].aicore_done,
-            last_runtime_->workers[i].aicpu_ready,
-            last_runtime_->workers[i].control,
-            last_runtime_->workers[i].task);
+        LOG_DEBUG(
+            "  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d", i, last_runtime_->workers[i].aicore_done,
+            last_runtime_->workers[i].aicpu_ready, last_runtime_->workers[i].control, last_runtime_->workers[i].task
+        );
     }
 }
 
@@ -422,7 +430,7 @@ int DeviceRunner::finalize() {
 
     // Cleanup performance profiling
     if (perf_collector_.is_initialized()) {
-        auto free_cb = [](void* dev_ptr, void* user_data) -> int {
+        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
             (void)user_data;
             free(dev_ptr);
             return 0;
@@ -435,8 +443,8 @@ int DeviceRunner::finalize() {
     if (!func_id_to_addr_.empty()) {
         LOG_ERROR("finalize() called with %zu kernel binaries still cached", func_id_to_addr_.size());
         // Cleanup leaked handles and host copies
-        for (auto& pair : func_id_to_addr_) {
-            MappedKernel& kernel = pair.second;
+        for (auto &pair : func_id_to_addr_) {
+            MappedKernel &kernel = pair.second;
             if (kernel.dl_handle != nullptr) {
                 dlclose(kernel.dl_handle);
                 LOG_DEBUG("Closed leaked kernel: func_id=%d", pair.first);
@@ -464,7 +472,7 @@ int DeviceRunner::finalize() {
 // Kernel Binary Upload (returns function address for caller to store in Runtime)
 // =============================================================================
 
-uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data, size_t bin_size) {
+uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size) {
     if (bin_data == nullptr || bin_size == 0) {
         LOG_ERROR("Invalid kernel data");
         return 0;
@@ -478,8 +486,8 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     }
 
     // Extract binary from CoreCallable envelope
-    const CoreCallable* callable = reinterpret_cast<const CoreCallable*>(bin_data);
-    const void* kernel_binary = callable->binary_data();
+    const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(bin_data);
+    const void *kernel_binary = callable->binary_data();
     size_t kernel_size = callable->binary_size();
 
     // 1. Generate temp file path
@@ -492,13 +500,13 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
         LOG_ERROR("Failed to create temp file: %s", tmpfile);
         return 0;
     }
-    ofs.write(reinterpret_cast<const char*>(kernel_binary), kernel_size);
+    ofs.write(reinterpret_cast<const char *>(kernel_binary), kernel_size);
     ofs.close();
 
     LOG_DEBUG("Uploading kernel .so: %s (size=%zu bytes)", tmpfile, kernel_size);
 
     // 3. dlopen to load .so (RTLD_NOW ensures all symbols resolved immediately)
-    void* handle = dlopen(tmpfile, RTLD_NOW | RTLD_LOCAL);
+    void *handle = dlopen(tmpfile, RTLD_NOW | RTLD_LOCAL);
 
     // 4. Remove temp file immediately (.so is already in memory)
     std::remove(tmpfile);
@@ -509,7 +517,7 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     }
 
     // 5. dlsym to get kernel function address (unified entry point: "kernel_entry")
-    void* func = dlsym(handle, "kernel_entry");
+    void *func = dlsym(handle, "kernel_entry");
     if (!func) {
         LOG_ERROR("dlsym failed for 'kernel_entry': %s", dlerror());
         dlclose(handle);
@@ -517,9 +525,9 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     }
 
     // 6. Create host-memory copy of CoreCallable with resolved_addr_ = func_ptr
-    uint8_t* copy = new uint8_t[bin_size];
+    uint8_t *copy = new uint8_t[bin_size];
     std::memcpy(copy, bin_data, bin_size);
-    CoreCallable* callable_copy = reinterpret_cast<CoreCallable*>(copy);
+    CoreCallable *callable_copy = reinterpret_cast<CoreCallable *>(copy);
     callable_copy->set_resolved_addr(reinterpret_cast<uint64_t>(func));
 
     // 7. Store mapping info for cleanup
@@ -528,11 +536,10 @@ uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t* bin_data
     kernel.callable_buf = copy;
     func_id_to_addr_[func_id] = kernel;
 
-    LOG_DEBUG("Registered kernel (dlopen): func_id=%d -> callable=0x%lx, func_addr=0x%lx, handle=%p",
-        func_id,
-        reinterpret_cast<uint64_t>(copy),
-        reinterpret_cast<uint64_t>(func),
-        handle);
+    LOG_DEBUG(
+        "Registered kernel (dlopen): func_id=%d -> callable=0x%lx, func_addr=0x%lx, handle=%p", func_id,
+        reinterpret_cast<uint64_t>(copy), reinterpret_cast<uint64_t>(func), handle
+    );
 
     return reinterpret_cast<uint64_t>(copy);
 }
@@ -543,7 +550,7 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
         return;
     }
 
-    MappedKernel& kernel = it->second;
+    MappedKernel &kernel = it->second;
     if (kernel.dl_handle != nullptr) {
         dlclose(kernel.dl_handle);
         LOG_DEBUG("Removed kernel binary (dlclose): func_id=%d, handle=%p", func_id, kernel.dl_handle);
@@ -557,15 +564,15 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
 // Performance Profiling Implementation
 // =============================================================================
 
-int DeviceRunner::init_performance_profiling(Runtime& runtime, int num_aicore, int device_id) {
+int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, int device_id) {
     // Define allocation callback (a5sim: use malloc)
-    auto alloc_cb = [](size_t size, void* user_data) -> void* {
+    auto alloc_cb = [](size_t size, void *user_data) -> void * {
         (void)user_data;  // Not needed for malloc
         return malloc(size);
     };
 
     // Define free callback (a5sim: use free)
-    auto free_cb = [](void* dev_ptr, void* user_data) -> int {
+    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
         (void)user_data;  // Not needed for free
         free(dev_ptr);
         return 0;
@@ -579,6 +586,6 @@ void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
     perf_collector_.poll_and_collect(expected_tasks);
 }
 
-int DeviceRunner::export_swimlane_json(const std::string& output_path) {
+int DeviceRunner::export_swimlane_json(const std::string &output_path) {
     return perf_collector_.export_swimlane_json(output_path);
 }

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -56,8 +56,8 @@
  * proper handling of external symbols (e.g., std::exp) via PLT/GOT.
  */
 struct MappedKernel {
-    void* dl_handle{nullptr};        // dlopen handle
-    uint8_t* callable_buf{nullptr};  // host-memory copy of CoreCallable (owns memory)
+    void *dl_handle{nullptr};        // dlopen handle
+    uint8_t *callable_buf{nullptr};  // host-memory copy of CoreCallable (owns memory)
 };
 
 /**
@@ -73,11 +73,11 @@ struct MappedKernel {
  * - Kernel .text binaries are loaded into mmap'd executable memory
  */
 class DeviceRunner {
- public:
+public:
     /**
      * Get singleton instance
      */
-    static DeviceRunner& get();
+    static DeviceRunner &get();
 
     /**
      * Allocate tensor memory (host memory in simulation)
@@ -85,14 +85,14 @@ class DeviceRunner {
      * @param bytes  Size of tensor in bytes
      * @return Pointer on success, nullptr on failure
      */
-    void* allocate_tensor(size_t bytes);
+    void *allocate_tensor(size_t bytes);
 
     /**
      * Free tensor memory
      *
      * @param dev_ptr  Pointer to free
      */
-    void free_tensor(void* dev_ptr);
+    void free_tensor(void *dev_ptr);
 
     /**
      * Copy data (memcpy in simulation)
@@ -102,7 +102,7 @@ class DeviceRunner {
      * @param bytes     Number of bytes to copy
      * @return 0 on success
      */
-    int copy_to_device(void* dev_ptr, const void* host_ptr, size_t bytes);
+    int copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes);
 
     /**
      * Copy data (memcpy in simulation)
@@ -112,7 +112,7 @@ class DeviceRunner {
      * @param bytes     Number of bytes to copy
      * @return 0 on success
      */
-    int copy_from_device(void* host_ptr, const void* dev_ptr, size_t bytes);
+    int copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes);
 
     /**
      * Execute a runtime using threads
@@ -132,12 +132,9 @@ class DeviceRunner {
      * @param launch_aicpu_num     Number of AICPU threads
      * @return 0 on success
      */
-    int run(Runtime& runtime,
-        int block_dim,
-        int device_id,
-        const std::vector<uint8_t>& aicpu_so_binary,
-        const std::vector<uint8_t>& aicore_kernel_binary,
-        int launch_aicpu_num = 1);
+    int
+    run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
 
     /**
      * Print handshake results
@@ -165,7 +162,7 @@ class DeviceRunner {
      * @param output_path Path to output directory (default: "outputs")
      * @return 0 on success, error code on failure
      */
-    int export_swimlane_json(const std::string& output_path = "outputs");
+    int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
      * Cleanup all resources
@@ -191,7 +188,7 @@ class DeviceRunner {
      * @param bin_size     Size of binary data in bytes
      * @return Function pointer address on success, 0 on error
      */
-    uint64_t upload_kernel_binary(int func_id, const uint8_t* bin_data, size_t bin_size);
+    uint64_t upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size);
 
     /**
      * Remove a kernel binary from memory
@@ -203,7 +200,7 @@ class DeviceRunner {
      */
     void remove_kernel_binary(int func_id);
 
- private:
+private:
     DeviceRunner() = default;
     ~DeviceRunner();
 
@@ -223,14 +220,14 @@ class DeviceRunner {
     std::map<int, MappedKernel> func_id_to_addr_;
 
     // Runtime pointer for print_handshake_results
-    Runtime* last_runtime_{nullptr};
+    Runtime *last_runtime_{nullptr};
 
     // Dynamically loaded executor libraries and function pointers
-    void* aicpu_so_handle_{nullptr};
-    void* aicore_so_handle_{nullptr};
-    int (*aicpu_execute_func_)(Runtime*){nullptr};                                       // NOLINT(readability/braces)
-    void (*aicore_execute_func_)(Runtime*, int, CoreType, uint32_t, uint64_t){nullptr};  // NOLINT(readability/braces)
-    void (*set_platform_regs_func_)(uint64_t){nullptr};                                  // NOLINT(readability/braces)
+    void *aicpu_so_handle_{nullptr};
+    void *aicore_so_handle_{nullptr};
+    int (*aicpu_execute_func_)(Runtime *){nullptr};                                       // NOLINT(readability/braces)
+    void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t){nullptr};  // NOLINT(readability/braces)
+    void (*set_platform_regs_func_)(uint64_t){nullptr};                                   // NOLINT(readability/braces)
     std::string aicpu_so_path_;
     std::string aicore_so_path_;
 
@@ -239,9 +236,11 @@ class DeviceRunner {
 
     // Private helper methods
     int ensure_device_initialized(
-        int device_id, const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
+        int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+    );
     int ensure_binaries_loaded(
-        const std::vector<uint8_t>& aicpu_so_binary, const std::vector<uint8_t>& aicore_kernel_binary);
+        const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+    );
     void unload_executor_binaries();
 
     /**
@@ -254,7 +253,7 @@ class DeviceRunner {
      * @param device_id Device ID (ignored in simulation)
      * @return 0 on success, error code on failure
      */
-    int init_performance_profiling(Runtime& runtime, int num_aicore, int device_id);
+    int init_performance_profiling(Runtime &runtime, int num_aicore, int device_id);
 };
 
 #endif  // SRC_A5_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a5/platform/sim/host/memory_allocator.cpp
+++ b/src/a5/platform/sim/host/memory_allocator.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Memory Allocator Implementation (Simulation)
  *
@@ -9,12 +19,10 @@
 #include <cstdlib>
 #include "common/unified_log.h"
 
-MemoryAllocator::~MemoryAllocator() {
-    finalize();
-}
+MemoryAllocator::~MemoryAllocator() { finalize(); }
 
-void* MemoryAllocator::alloc(size_t size) {
-    void* ptr = std::malloc(size);
+void *MemoryAllocator::alloc(size_t size) {
+    void *ptr = std::malloc(size);
     if (ptr == nullptr) {
         LOG_ERROR("malloc failed (size=%zu)", size);
         return nullptr;
@@ -25,7 +33,7 @@ void* MemoryAllocator::alloc(size_t size) {
     return ptr;
 }
 
-int MemoryAllocator::free(void* ptr) {
+int MemoryAllocator::free(void *ptr) {
     if (ptr == nullptr) {
         return 0;
     }
@@ -52,7 +60,7 @@ int MemoryAllocator::finalize() {
     }
 
     // Free all remaining tracked pointers
-    for (void* ptr : ptr_set_) {
+    for (void *ptr : ptr_set_) {
         std::free(ptr);
     }
 

--- a/src/a5/platform/sim/host/platform_compile_info.cpp
+++ b/src/a5/platform/sim/host/platform_compile_info.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "host/platform_compile_info.h"
 
-extern "C" const char* get_platform(void) { return "a5sim"; }
+extern "C" const char *get_platform(void) { return "a5sim"; }

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -31,15 +31,15 @@ extern "C" {
  * Runtime Implementation Functions (defined in runtimemaker.cpp)
  * ===========================================================================
  */
-int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args);
-int validate_runtime_impl(Runtime* runtime);
+int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args);
+int validate_runtime_impl(Runtime *runtime);
 
 /* Forward declarations */
-void* device_malloc(size_t size);
-void device_free(void* dev_ptr);
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size);
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size);
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size);
+void *device_malloc(size_t size);
+void device_free(void *dev_ptr);
+int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size);
+int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size);
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size);
 void remove_kernel_binary_wrapper(int func_id);
 
 /* ===========================================================================
@@ -49,7 +49,7 @@ void remove_kernel_binary_wrapper(int func_id);
 
 size_t get_runtime_size(void) { return sizeof(Runtime); }
 
-int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args) {
+int init_runtime(RuntimeHandle runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args) {
     if (runtime == NULL) {
         return -1;
     }
@@ -58,7 +58,7 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
 
     try {
         // Placement new to construct Runtime in user-allocated memory
-        Runtime* r = new (runtime) Runtime();
+        Runtime *r = new (runtime) Runtime();
 
         // Initialize host API function pointers
         r->host_api.device_malloc = device_malloc;
@@ -91,54 +91,54 @@ int init_runtime(RuntimeHandle runtime, const ChipCallable* callable, const Chip
  * ===========================================================================
  */
 
-void* device_malloc(size_t size) {
+void *device_malloc(size_t size) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.allocate_tensor(size);
     } catch (...) {
         return NULL;
     }
 }
 
-void device_free(void* dev_ptr) {
+void device_free(void *dev_ptr) {
     if (dev_ptr == NULL) {
         return;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         runner.free_tensor(dev_ptr);
     } catch (...) {
         // Ignore errors during free
     }
 }
 
-int copy_to_device(void* dev_ptr, const void* host_ptr, size_t size) {
+int copy_to_device(void *dev_ptr, const void *host_ptr, size_t size) {
     if (dev_ptr == NULL || host_ptr == NULL) {
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.copy_to_device(dev_ptr, host_ptr, size);
     } catch (...) {
         return -1;
     }
 }
 
-int copy_from_device(void* host_ptr, const void* dev_ptr, size_t size) {
+int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     if (host_ptr == NULL || dev_ptr == NULL) {
         return -1;
     }
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.copy_from_device(host_ptr, dev_ptr, size);
     } catch (...) {
         return -1;
     }
 }
 
-uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size_t bin_size) {
+uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         return runner.upload_kernel_binary(func_id, bin_data, bin_size);
     } catch (...) {
         return 0;
@@ -147,28 +147,23 @@ uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t* bin_data, size
 
 void remove_kernel_binary_wrapper(int func_id) {
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
         runner.remove_kernel_binary(func_id);
     } catch (...) {
         // Ignore errors during cleanup
     }
 }
 
-int launch_runtime(RuntimeHandle runtime,
-    int aicpu_thread_num,
-    int block_dim,
-    int device_id,
-    const uint8_t* aicpu_binary,
-    size_t aicpu_size,
-    const uint8_t* aicore_binary,
-    size_t aicore_size,
-    int orch_thread_num) {
+int launch_runtime(
+    RuntimeHandle runtime, int aicpu_thread_num, int block_dim, int device_id, const uint8_t *aicpu_binary,
+    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size, int orch_thread_num
+) {
     if (runtime == NULL) {
         return -1;
     }
 
     try {
-        DeviceRunner& runner = DeviceRunner::get();
+        DeviceRunner &runner = DeviceRunner::get();
 
         // In simulation, binaries are ignored
         std::vector<uint8_t> aicpu_vec;
@@ -181,7 +176,7 @@ int launch_runtime(RuntimeHandle runtime,
             aicore_vec.assign(aicore_binary, aicore_binary + aicore_size);
         }
 
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         r->orch_thread_num = orch_thread_num;
         return runner.run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
     } catch (...) {
@@ -194,7 +189,7 @@ int finalize_runtime(RuntimeHandle runtime) {
         return -1;
     }
     try {
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         int rc = validate_runtime_impl(r);
 
         // Call destructor (user will call free())
@@ -215,7 +210,7 @@ int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
         return -1;
     }
     try {
-        Runtime* r = static_cast<Runtime*>(runtime);
+        Runtime *r = static_cast<Runtime *>(runtime);
         r->enable_profiling = (enabled != 0);
         return 0;
     } catch (...) {
@@ -228,11 +223,11 @@ int enable_runtime_profiling(RuntimeHandle runtime, int enabled) {
  * registration and stores addresses in Runtime's func_id_to_addr_[] array.
  */
 
-void record_tensor_pair(RuntimeHandle runtime, void* host_ptr, void* dev_ptr, size_t size) {
+void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, size_t size) {
     if (runtime == NULL) {
         return;
     }
-    Runtime* r = static_cast<Runtime*>(runtime);
+    Runtime *r = static_cast<Runtime *>(runtime);
     r->record_tensor_pair(host_ptr, dev_ptr, size);
 }
 

--- a/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -28,15 +28,15 @@
 #include "common/unified_log.h"
 
 // Cached pointers for hot-path access (set during init)
-static AicpuPhaseHeader* s_phase_header = nullptr;
-static PerfDataHeader* s_perf_header = nullptr;
+static AicpuPhaseHeader *s_phase_header = nullptr;
+static PerfDataHeader *s_perf_header = nullptr;
 
 // Per-core PerfBufferState cache
-static PerfBufferState* s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
+static PerfBufferState *s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
 
 // Per-thread PhaseBufferState cache
-static PhaseBufferState* s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
-static PhaseBuffer* s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
+static PhaseBufferState *s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
+static PhaseBuffer *s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
 static __thread int s_orch_thread_idx = -1;
 
@@ -51,12 +51,10 @@ static __thread int s_orch_thread_idx = -1;
  * @param is_phase 0 = PerfRecord, 1 = Phase
  * @return 0 on success, -1 if queue full
  */
-static int enqueue_ready_buffer(PerfDataHeader* header,
-    int thread_idx,
-    uint32_t core_index,
-    uint64_t buffer_ptr,
-    uint32_t buffer_seq,
-    uint32_t is_phase) {
+static int enqueue_ready_buffer(
+    PerfDataHeader *header, int thread_idx, uint32_t core_index, uint64_t buffer_ptr, uint32_t buffer_seq,
+    uint32_t is_phase
+) {
     uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
     uint32_t current_tail = header->queue_tails[thread_idx];
     uint32_t current_head = header->queue_heads[thread_idx];
@@ -76,8 +74,8 @@ static int enqueue_ready_buffer(PerfDataHeader* header,
     return 0;
 }
 
-void perf_aicpu_init_profiling(Runtime* runtime) {
-    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
+void perf_aicpu_init_profiling(Runtime *runtime) {
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize profiling");
         return;
@@ -92,8 +90,8 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
 
     // Pop first buffer from free_queue for each core
     for (int i = 0; i < runtime->worker_count; i++) {
-        Handshake* h = &runtime->workers[i];
-        PerfBufferState* state = get_perf_buffer_state(perf_base, i);
+        Handshake *h = &runtime->workers[i];
+        PerfBufferState *state = get_perf_buffer_state(perf_base, i);
 
         s_perf_buffer_states[i] = state;
 
@@ -110,7 +108,7 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
             state->current_buf_seq = 0;
             wmb();
 
-            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(buf_ptr);
+            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(buf_ptr);
             buf->count = 0;
             h->perf_records_addr = buf_ptr;
 
@@ -127,20 +125,15 @@ void perf_aicpu_init_profiling(Runtime* runtime) {
     LOG_INFO("Performance profiling initialized for %d cores", runtime->worker_count);
 }
 
-int perf_aicpu_complete_record(PerfBuffer* perf_buf,
-    uint32_t expected_reg_task_id,
-    uint64_t task_id,
-    uint32_t func_id,
-    CoreType core_type,
-    uint64_t dispatch_time,
-    uint64_t finish_time,
-    const uint64_t* fanout,
-    int32_t fanout_count) {
+int perf_aicpu_complete_record(
+    PerfBuffer *perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
+    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
+) {
     rmb();
     uint32_t count = perf_buf->count;
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
 
-    PerfRecord* record = &perf_buf->records[count];
+    PerfRecord *record = &perf_buf->records[count];
     if (static_cast<uint32_t>(record->task_id) != expected_reg_task_id) return -1;
 
     record->task_id = task_id;
@@ -164,18 +157,18 @@ int perf_aicpu_complete_record(PerfBuffer* perf_buf,
     return 0;
 }
 
-void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
-    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
+void perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx) {
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
 
-    PerfBufferState* state = s_perf_buffer_states[core_id];
+    PerfBufferState *state = s_perf_buffer_states[core_id];
     if (state == nullptr) {
         return;
     }
 
-    PerfBuffer* full_buf = reinterpret_cast<PerfBuffer*>(state->current_buf_ptr);
+    PerfBuffer *full_buf = reinterpret_cast<PerfBuffer *>(state->current_buf_ptr);
     if (full_buf == nullptr) {
         return;
     }
@@ -214,23 +207,23 @@ void perf_aicpu_switch_buffer(Runtime* runtime, int core_id, int thread_idx) {
     state->current_buf_seq = seq + 1;
     wmb();
 
-    PerfBuffer* new_buf = reinterpret_cast<PerfBuffer*>(new_buf_ptr);
+    PerfBuffer *new_buf = reinterpret_cast<PerfBuffer *>(new_buf_ptr);
     new_buf->count = 0;
 
     // Update handshake for AICore
-    Handshake* h = &runtime->workers[core_id];
+    Handshake *h = &runtime->workers[core_id];
     h->perf_records_addr = new_buf_ptr;
     wmb();
 
     LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
 }
 
-void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
+void perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cur_thread_cores, int core_num) {
     if (!runtime->enable_profiling) {
         return;
     }
 
-    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
@@ -243,7 +236,7 @@ void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_t
 
     for (int i = 0; i < core_num; i++) {
         int core_id = cur_thread_cores[i];
-        PerfBufferState* state = s_perf_buffer_states[core_id];
+        PerfBufferState *state = s_perf_buffer_states[core_id];
         if (state == nullptr) continue;
 
         rmb();
@@ -253,7 +246,7 @@ void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_t
             continue;
         }
 
-        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(buf_ptr);
+        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(buf_ptr);
         if (buf->count == 0) {
             continue;
         }
@@ -275,19 +268,19 @@ void perf_aicpu_flush_buffers(Runtime* runtime, int thread_idx, const int* cur_t
     LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
 }
 
-void perf_aicpu_update_total_tasks(Runtime* runtime, uint32_t total_tasks) {
-    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
+void perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks) {
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
 
-    PerfDataHeader* header = get_perf_header(perf_base);
+    PerfDataHeader *header = get_perf_header(perf_base);
     header->total_tasks = total_tasks;
     wmb();
 }
 
-void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, int num_orch_threads) {
-    void* perf_base = reinterpret_cast<void*>(runtime->perf_data_base);
+void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, int num_orch_threads) {
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize phase profiling");
         return;
@@ -311,7 +304,7 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
         total_threads = PLATFORM_MAX_AICPU_THREADS;
     }
     for (int t = 0; t < total_threads; t++) {
-        PhaseBufferState* state = get_phase_buffer_state(perf_base, runtime->worker_count, t);
+        PhaseBufferState *state = get_phase_buffer_state(perf_base, runtime->worker_count, t);
 
         s_phase_buffer_states[t] = state;
 
@@ -328,7 +321,7 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
             state->current_buf_seq = 0;
             wmb();
 
-            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
             buf->count = 0;
             s_current_phase_buf[t] = buf;
 
@@ -348,10 +341,10 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
 
     wmb();
 
-    LOG_INFO("Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread",
-        num_sched_threads,
-        num_orch_threads,
-        PLATFORM_PHASE_RECORDS_PER_THREAD);
+    LOG_INFO(
+        "Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread", num_sched_threads,
+        num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD
+    );
 }
 
 /**
@@ -362,10 +355,10 @@ void perf_aicpu_init_phase_profiling(Runtime* runtime, int num_sched_threads, in
  * records are dropped (preserving already-enqueued data).
  */
 static void switch_phase_buffer(int thread_idx) {
-    PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
     if (state == nullptr) return;
 
-    PhaseBuffer* full_buf = s_current_phase_buf[thread_idx];
+    PhaseBuffer *full_buf = s_current_phase_buf[thread_idx];
     if (full_buf == nullptr) return;
 
     LOG_INFO("Thread %d: phase buffer is full (count=%u)", thread_idx, full_buf->count);
@@ -393,7 +386,7 @@ static void switch_phase_buffer(int thread_idx) {
         state->current_buf_seq = seq + 1;
         wmb();
 
-        PhaseBuffer* new_buf = reinterpret_cast<PhaseBuffer*>(new_buf_ptr);
+        PhaseBuffer *new_buf = reinterpret_cast<PhaseBuffer *>(new_buf_ptr);
         new_buf->count = 0;
         s_current_phase_buf[thread_idx] = new_buf;
 
@@ -407,21 +400,19 @@ static void switch_phase_buffer(int thread_idx) {
     }
 }
 
-void perf_aicpu_record_phase(int thread_idx,
-    AicpuPhaseId phase_id,
-    uint64_t start_time,
-    uint64_t end_time,
-    uint32_t loop_iter,
-    uint64_t tasks_processed) {
+void perf_aicpu_record_phase(
+    int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
+    uint64_t tasks_processed
+) {
     if (s_phase_header == nullptr) {
         return;
     }
 
-    PhaseBuffer* buf = s_current_phase_buf[thread_idx];
+    PhaseBuffer *buf = s_current_phase_buf[thread_idx];
 
     // Try to recover from nullptr (no buffer was available on previous switch)
     if (buf == nullptr) {
-        PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+        PhaseBufferState *state = s_phase_buffer_states[thread_idx];
         if (state == nullptr) return;
 
         rmb();
@@ -436,7 +427,7 @@ void perf_aicpu_record_phase(int thread_idx,
             state->current_buf_seq = state->current_buf_seq + 1;
             wmb();
 
-            buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
+            buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
             buf->count = 0;
             s_current_phase_buf[thread_idx] = buf;
 
@@ -458,7 +449,7 @@ void perf_aicpu_record_phase(int thread_idx,
         }
     }
 
-    AicpuPhaseRecord* record = &buf->records[idx];
+    AicpuPhaseRecord *record = &buf->records[idx];
     record->start_time = start_time;
     record->end_time = end_time;
     record->loop_iter = loop_iter;
@@ -468,12 +459,12 @@ void perf_aicpu_record_phase(int thread_idx,
     buf->count = idx + 1;
 }
 
-void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src) {
+void perf_aicpu_write_orch_summary(const AicpuOrchSummary *src) {
     if (s_phase_header == nullptr) {
         return;
     }
 
-    AicpuOrchSummary* dst = &s_phase_header->orch_summary;
+    AicpuOrchSummary *dst = &s_phase_header->orch_summary;
 
     memcpy(dst, src, sizeof(AicpuOrchSummary));
     dst->magic = AICPU_PHASE_MAGIC;
@@ -481,15 +472,17 @@ void perf_aicpu_write_orch_summary(const AicpuOrchSummary* src) {
 
     wmb();
 
-    LOG_INFO("Orchestrator summary written: %" PRId64 " tasks, %.3fus",
-        static_cast<int64_t>(src->submit_count),
-        cycles_to_us(src->end_time - src->start_time));
+    LOG_INFO(
+        "Orchestrator summary written: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(src->submit_count),
+        cycles_to_us(src->end_time - src->start_time)
+    );
 }
 
 void perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }
 
 void perf_aicpu_record_orch_phase(
-    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id) {
+    AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id
+) {
     if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
     perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
 }
@@ -499,7 +492,7 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
         return;
     }
 
-    PhaseBufferState* state = s_phase_buffer_states[thread_idx];
+    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
     if (state == nullptr) return;
 
     rmb();
@@ -509,7 +502,7 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
         return;
     }
 
-    PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(buf_ptr);
+    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
     if (buf->count == 0) {
         return;
     }
@@ -528,10 +521,10 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
     wmb();
 }
 
-void perf_aicpu_write_core_assignments(const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD],
-    const int* core_counts,
-    int num_threads,
-    int total_cores) {
+void perf_aicpu_write_core_assignments(
+    const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
+    int total_cores
+) {
     if (s_phase_header == nullptr) {
         return;
     }

--- a/src/a5/platform/src/aicpu/platform_regs.cpp
+++ b/src/a5/platform/src/aicpu/platform_regs.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file platform_regs.cpp
  * @brief AICPU register interface - shared implementation
@@ -14,13 +24,9 @@
 
 static uint64_t g_platform_regs = 0;
 
-void set_platform_regs(uint64_t regs) {
-    g_platform_regs = regs;
-}
+void set_platform_regs(uint64_t regs) { g_platform_regs = regs; }
 
-uint64_t get_platform_regs() {
-    return g_platform_regs;
-}
+uint64_t get_platform_regs() { return g_platform_regs; }
 
 void platform_init_aicore_regs(uint64_t reg_addr) {
     // Initialize task dispatch register to idle state
@@ -32,8 +38,7 @@ void platform_deinit_aicore_regs(uint64_t reg_addr) {
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
 
     // Wait for AICore to acknowledge exit by writing AICORE_EXITED_VALUE to COND
-    while (read_reg(reg_addr, RegId::COND) != AICORE_EXITED_VALUE) {
-    }
+    while (read_reg(reg_addr, RegId::COND) != AICORE_EXITED_VALUE) {}
 
     // Initialize task dispatch register to idle state
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);

--- a/src/a5/platform/src/aicpu/unified_log_device.cpp
+++ b/src/a5/platform/src/aicpu/unified_log_device.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file unified_log_device.cpp
  * @brief Unified logging - Device implementation
@@ -8,7 +18,7 @@
 
 #include <cstdarg>
 
-void unified_log_error(const char* func, const char* fmt, ...) {
+void unified_log_error(const char *func, const char *fmt, ...) {
     if (!is_log_enable_error()) {
         return;
     }
@@ -20,52 +30,52 @@ void unified_log_error(const char* func, const char* fmt, ...) {
     dev_log_error(func, "%s", buffer);
 }
 
-void unified_log_warn(const char* func, const char* fmt, ...) {
+void unified_log_warn(const char *func, const char *fmt, ...) {
     if (!is_log_enable_warn()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_warn(func, "%s", buffer);
 }
 
-void unified_log_info(const char* func, const char* fmt, ...) {
+void unified_log_info(const char *func, const char *fmt, ...) {
     if (!is_log_enable_info()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_info(func, "%s", buffer);
 }
 
-void unified_log_debug(const char* func, const char* fmt, ...) {
+void unified_log_debug(const char *func, const char *fmt, ...) {
     if (!is_log_enable_debug()) {
         return;
     }
-    
+
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     dev_log_debug(func, "%s", buffer);
 }
 
-void unified_log_always(const char* func, const char* fmt, ...) {
+void unified_log_always(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];

--- a/src/a5/platform/src/host/host_log.cpp
+++ b/src/a5/platform/src/host/host_log.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file host_log.cpp
  * @brief Implementation of Unified Host Logging System
@@ -13,24 +23,22 @@
 // HostLogger Implementation
 // =============================================================================
 
-HostLogger& HostLogger::get_instance() {
+HostLogger &HostLogger::get_instance() {
     static HostLogger instance;
     return instance;
 }
 
-HostLogger::HostLogger() 
-    : current_level_(HostLogLevel::INFO),
-      log_file_path_(""),
-      log_file_handle_(nullptr),
-      initialized_(false) {
+HostLogger::HostLogger() :
+    current_level_(HostLogLevel::INFO),
+    log_file_path_(""),
+    log_file_handle_(nullptr),
+    initialized_(false) {
     init_from_env();
 }
 
 HostLogger::~HostLogger() {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (log_file_handle_ != nullptr && 
-        log_file_handle_ != stdout && 
-        log_file_handle_ != stderr) {
+    if (log_file_handle_ != nullptr && log_file_handle_ != stdout && log_file_handle_ != stderr) {
         fclose(log_file_handle_);
         log_file_handle_ = nullptr;
     }
@@ -38,17 +46,17 @@ HostLogger::~HostLogger() {
 
 void HostLogger::init_from_env() {
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     // Parse PTO_LOG_LEVEL environment variable
-    const char* level_str = std::getenv("PTO_LOG_LEVEL");
+    const char *level_str = std::getenv("PTO_LOG_LEVEL");
     if (level_str != nullptr) {
         std::string level(level_str);
-        
+
         // Convert to lowercase for comparison
-        for (char& c : level) {
+        for (char &c : level) {
             c = std::tolower(c);
         }
-        
+
         // Map log level strings to enum values (1-to-1 mapping)
         if (level == "error") {
             current_level_ = HostLogLevel::ERROR;
@@ -66,19 +74,17 @@ void HostLogger::init_from_env() {
         // Default to INFO
         current_level_ = HostLogLevel::INFO;
     }
-    
+
     // Parse PTO_LOG_FILE environment variable
-    const char* file_path = std::getenv("PTO_LOG_FILE");
+    const char *file_path = std::getenv("PTO_LOG_FILE");
     if (file_path != nullptr && strlen(file_path) > 0) {
         log_file_path_ = file_path;
-        
+
         // Close previous file handle if it exists
-        if (log_file_handle_ != nullptr && 
-            log_file_handle_ != stdout && 
-            log_file_handle_ != stderr) {
+        if (log_file_handle_ != nullptr && log_file_handle_ != stdout && log_file_handle_ != stderr) {
             fclose(log_file_handle_);
         }
-        
+
         // Open log file in append mode
         log_file_handle_ = fopen(log_file_path_.c_str(), "a");
         if (log_file_handle_ == nullptr) {
@@ -88,7 +94,7 @@ void HostLogger::init_from_env() {
             log_file_path_.clear();
         }
     }
-    
+
     initialized_ = true;
 }
 
@@ -101,29 +107,29 @@ bool HostLogger::is_enabled(HostLogLevel level) const {
     return static_cast<int>(level) <= static_cast<int>(current_level_);
 }
 
-const char* HostLogger::get_level_name(HostLogLevel level) const {
+const char *HostLogger::get_level_name(HostLogLevel level) const {
     switch (level) {
-        case HostLogLevel::ERROR:
-            return "ERROR";
-        case HostLogLevel::WARN:
-            return "WARN";
-        case HostLogLevel::INFO:
-            return "INFO";
-        case HostLogLevel::DEBUG:
-            return "DEBUG";
-        case HostLogLevel::ALWAYS:
-            return "ALWAYS";
-        default:
-            return "UNKNOWN";
+    case HostLogLevel::ERROR:
+        return "ERROR";
+    case HostLogLevel::WARN:
+        return "WARN";
+    case HostLogLevel::INFO:
+        return "INFO";
+    case HostLogLevel::DEBUG:
+        return "DEBUG";
+    case HostLogLevel::ALWAYS:
+        return "ALWAYS";
+    default:
+        return "UNKNOWN";
     }
 }
 
-FILE* HostLogger::get_output_file(HostLogLevel level) {
+FILE *HostLogger::get_output_file(HostLogLevel level) {
     // If log file is configured, use it for all levels
     if (log_file_handle_ != nullptr) {
         return log_file_handle_;
     }
-    
+
     // Otherwise, use stderr for ERROR/WARN, stdout for INFO/DEBUG
     if (level == HostLogLevel::ERROR || level == HostLogLevel::WARN) {
         return stderr;
@@ -132,35 +138,34 @@ FILE* HostLogger::get_output_file(HostLogLevel level) {
     }
 }
 
-void HostLogger::log(HostLogLevel level, const char* format, ...) {
+void HostLogger::log(HostLogLevel level, const char *format, ...) {
     // Check if this level is enabled
     if (!is_enabled(level)) {
         return;
     }
-    
+
     std::lock_guard<std::mutex> lock(mutex_);
-    
+
     // Get output file
-    FILE* output = get_output_file(level);
+    FILE *output = get_output_file(level);
     if (output == nullptr) {
         return;
     }
-    
+
     // Print log level prefix (matching Python format)
     fprintf(output, "[%s] ", get_level_name(level));
-    
+
     // Print formatted message
     va_list args;
     va_start(args, format);
     vfprintf(output, format, args);
     va_end(args);
-    
+
     // Add newline if not already present
     if (format[strlen(format) - 1] != '\n') {
         fprintf(output, "\n");
     }
-    
+
     // Flush to ensure immediate output
     fflush(output);
 }
-

--- a/src/a5/platform/src/host/host_log.h
+++ b/src/a5/platform/src/host/host_log.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file host_log.h
  * @brief Unified Host Logging System
@@ -30,11 +40,11 @@
 // =============================================================================
 
 enum class HostLogLevel {
-    ALWAYS = -1, // always logging
-    ERROR = 0,   // error level only
-    WARN = 1,    // warn level and above
-    INFO = 2,    // info level and above (default)
-    DEBUG = 3    // debug level (all messages)
+    ALWAYS = -1,  // always logging
+    ERROR = 0,    // error level only
+    WARN = 1,     // warn level and above
+    INFO = 2,     // info level and above (default)
+    DEBUG = 3     // debug level (all messages)
 };
 
 // =============================================================================
@@ -44,11 +54,11 @@ enum class HostLogLevel {
 class HostLogger {
 public:
     // Get singleton instance
-    static HostLogger& get_instance();
+    static HostLogger &get_instance();
 
     // Log a message with specified level
-    void log(HostLogLevel level, const char* format, ...);
-    
+    void log(HostLogLevel level, const char *format, ...);
+
     // Check if a log level is enabled
     bool is_enabled(HostLogLevel level) const;
 
@@ -58,26 +68,26 @@ public:
 private:
     HostLogger();
     ~HostLogger();
-    
+
     // Delete copy/move constructors
-    HostLogger(const HostLogger&) = delete;
-    HostLogger& operator=(const HostLogger&) = delete;
-    HostLogger(HostLogger&&) = delete;
-    HostLogger& operator=(HostLogger&&) = delete;
+    HostLogger(const HostLogger &) = delete;
+    HostLogger &operator=(const HostLogger &) = delete;
+    HostLogger(HostLogger &&) = delete;
+    HostLogger &operator=(HostLogger &&) = delete;
 
     // Initialize from environment variables
     void init_from_env();
-    
+
     // Get level name string
-    const char* get_level_name(HostLogLevel level) const;
-    
+    const char *get_level_name(HostLogLevel level) const;
+
     // Get output file handle (FILE* for stdout/stderr or file)
-    FILE* get_output_file(HostLogLevel level);
+    FILE *get_output_file(HostLogLevel level);
 
     // Member variables
     HostLogLevel current_level_;
     std::string log_file_path_;
-    FILE* log_file_handle_;
+    FILE *log_file_handle_;
     std::mutex mutex_;
     bool initialized_;
 };
@@ -86,29 +96,28 @@ private:
 // Logging Macros (High-Level Interface)
 // =============================================================================
 
-#define HOST_LOG_ERROR(fmt, ...) \
-    do { \
+#define HOST_LOG_ERROR(fmt, ...)                                                 \
+    do {                                                                         \
         HostLogger::get_instance().log(HostLogLevel::ERROR, fmt, ##__VA_ARGS__); \
-    } while(0)
+    } while (0)
 
-#define HOST_LOG_WARN(fmt, ...) \
-    do { \
+#define HOST_LOG_WARN(fmt, ...)                                                 \
+    do {                                                                        \
         HostLogger::get_instance().log(HostLogLevel::WARN, fmt, ##__VA_ARGS__); \
-    } while(0)
+    } while (0)
 
-#define HOST_LOG_INFO(fmt, ...) \
-    do { \
-        if (HostLogger::get_instance().is_enabled(HostLogLevel::INFO)) { \
+#define HOST_LOG_INFO(fmt, ...)                                                     \
+    do {                                                                            \
+        if (HostLogger::get_instance().is_enabled(HostLogLevel::INFO)) {            \
             HostLogger::get_instance().log(HostLogLevel::INFO, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                                           \
+    } while (0)
 
-#define HOST_LOG_DEBUG(fmt, ...) \
-    do { \
-        if (HostLogger::get_instance().is_enabled(HostLogLevel::DEBUG)) { \
+#define HOST_LOG_DEBUG(fmt, ...)                                                     \
+    do {                                                                             \
+        if (HostLogger::get_instance().is_enabled(HostLogLevel::DEBUG)) {            \
             HostLogger::get_instance().log(HostLogLevel::DEBUG, fmt, ##__VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                                            \
+    } while (0)
 
-#endif // PLATFORM_HOST_LOG_H_
-
+#endif  // PLATFORM_HOST_LOG_H_

--- a/src/a5/platform/src/host/performance_collector.cpp
+++ b/src/a5/platform/src/host/performance_collector.cpp
@@ -45,14 +45,10 @@ ProfMemoryManager::~ProfMemoryManager() {
     }
 }
 
-void ProfMemoryManager::start(void* shared_mem_host,
-    int num_cores,
-    int num_phase_threads,
-    PerfAllocCallback alloc_cb,
-    PerfRegisterCallback register_cb,
-    PerfFreeCallback free_cb,
-    void* user_data,
-    int device_id) {
+void ProfMemoryManager::start(
+    void *shared_mem_host, int num_cores, int num_phase_threads, PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb, PerfFreeCallback free_cb, void *user_data, int device_id
+) {
     shared_mem_host_ = shared_mem_host;
     num_cores_ = num_cores;
     num_phase_threads_ = num_phase_threads;
@@ -85,11 +81,11 @@ void ProfMemoryManager::stop() {
     }
 
     // Free recycled buffers
-    for (void* ptr : recycled_perf_buffers_) {
+    for (void *ptr : recycled_perf_buffers_) {
         free_buffer(ptr);
     }
     recycled_perf_buffers_.clear();
-    for (void* ptr : recycled_phase_buffers_) {
+    for (void *ptr : recycled_phase_buffers_) {
         free_buffer(ptr);
     }
     recycled_phase_buffers_.clear();
@@ -97,7 +93,7 @@ void ProfMemoryManager::stop() {
     LOG_INFO("ProfMemoryManager stopped");
 }
 
-bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo& info) {
+bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo &info) {
     std::lock_guard<std::mutex> lock(ready_mutex_);
     if (ready_queue_.empty()) {
         return false;
@@ -107,9 +103,11 @@ bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo& info) {
     return true;
 }
 
-bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo& info, std::chrono::milliseconds timeout) {
+bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout) {
     std::unique_lock<std::mutex> lock(ready_mutex_);
-    if (ready_cv_.wait_for(lock, timeout, [this] { return !ready_queue_.empty(); })) {
+    if (ready_cv_.wait_for(lock, timeout, [this] {
+            return !ready_queue_.empty();
+        })) {
         info = ready_queue_.front();
         ready_queue_.pop();
         return true;
@@ -117,24 +115,24 @@ bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo& info, std::chrono::milli
     return false;
 }
 
-void ProfMemoryManager::notify_copy_done(const CopyDoneInfo& info) {
+void ProfMemoryManager::notify_copy_done(const CopyDoneInfo &info) {
     std::lock_guard<std::mutex> lock(done_mutex_);
     done_queue_.push(info);
 }
 
-void* ProfMemoryManager::alloc_and_register(size_t size, void** host_ptr_out) {
-    void* dev_ptr = alloc_cb_(size, user_data_);
+void *ProfMemoryManager::alloc_and_register(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size, user_data_);
     if (dev_ptr == nullptr) {
-        const char* hint = (size == sizeof(PerfBuffer))
-                               ? "increase PLATFORM_PROF_BUFFERS_PER_CORE to reduce profiling data loss"
-                               : "increase PLATFORM_PROF_BUFFERS_PER_THREAD to reduce profiling data loss";
+        const char *hint = (size == sizeof(PerfBuffer)) ?
+                               "increase PLATFORM_PROF_BUFFERS_PER_CORE to reduce profiling data loss" :
+                               "increase PLATFORM_PROF_BUFFERS_PER_THREAD to reduce profiling data loss";
         LOG_WARN("ProfMemoryManager: alloc failed for %zu bytes, %s", size, hint);
         *host_ptr_out = nullptr;
         return nullptr;
     }
 
     if (register_cb_ != nullptr) {
-        void* host_ptr = nullptr;
+        void *host_ptr = nullptr;
         int rc = register_cb_(dev_ptr, size, device_id_, user_data_, &host_ptr);
         if (rc != 0 || host_ptr == nullptr) {
             LOG_ERROR("ProfMemoryManager: register failed: %d", rc);
@@ -152,14 +150,14 @@ void* ProfMemoryManager::alloc_and_register(size_t size, void** host_ptr_out) {
     return dev_ptr;
 }
 
-void ProfMemoryManager::free_buffer(void* dev_ptr) {
+void ProfMemoryManager::free_buffer(void *dev_ptr) {
     if (dev_ptr != nullptr && free_cb_ != nullptr) {
         dev_to_host_.erase(dev_ptr);
         free_cb_(dev_ptr, user_data_);
     }
 }
 
-void* ProfMemoryManager::resolve_host_ptr(void* dev_ptr) {
+void *ProfMemoryManager::resolve_host_ptr(void *dev_ptr) {
     if (register_cb_ == nullptr) {
         return dev_ptr;  // Simulation mode: dev_ptr == host_ptr
     }
@@ -171,10 +169,11 @@ void* ProfMemoryManager::resolve_host_ptr(void* dev_ptr) {
     return nullptr;
 }
 
-void ProfMemoryManager::register_mapping(void* dev_ptr, void* host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
+void ProfMemoryManager::register_mapping(void *dev_ptr, void *host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
 
 void ProfMemoryManager::process_ready_entry(
-    PerfDataHeader* /*header*/, int /*thread_idx*/, const ReadyQueueEntry& entry) {
+    PerfDataHeader * /*header*/, int /*thread_idx*/, const ReadyQueueEntry &entry
+) {
     bool is_phase = (entry.is_phase != 0);
     uint64_t old_dev_ptr = entry.buffer_ptr;
     uint32_t seq = entry.buffer_seq;
@@ -186,7 +185,7 @@ void ProfMemoryManager::process_ready_entry(
             return;
         }
 
-        PhaseBufferState* state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
+        PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
 
         // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
         rmb();
@@ -196,8 +195,8 @@ void ProfMemoryManager::process_ready_entry(
 
         int to_push = PLATFORM_PROF_SLOT_COUNT;
         for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
-            void* host_ptr = nullptr;
-            void* new_dev_ptr = nullptr;
+            void *host_ptr = nullptr;
+            void *new_dev_ptr = nullptr;
 
             if (!recycled_phase_buffers_.empty()) {
                 new_dev_ptr = recycled_phase_buffers_.back();
@@ -211,8 +210,7 @@ void ProfMemoryManager::process_ready_entry(
                     done_queue_.pop();
                     if (dinfo.type == ProfBufferType::PERF_RECORD)
                         recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
-                    else
-                        recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
                 }
             }
             if (new_dev_ptr == nullptr && !recycled_phase_buffers_.empty()) {
@@ -225,7 +223,7 @@ void ProfMemoryManager::process_ready_entry(
             }
             if (new_dev_ptr == nullptr) break;
 
-            reinterpret_cast<PhaseBuffer*>(host_ptr)->count = 0;
+            reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
             uint32_t cur_tail = tail + p;
             state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
                 reinterpret_cast<uint64_t>(new_dev_ptr);
@@ -235,10 +233,12 @@ void ProfMemoryManager::process_ready_entry(
         }
 
         // Resolve host pointer of old buffer
-        void* old_host_ptr = resolve_host_ptr(reinterpret_cast<void*>(old_dev_ptr));
+        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
         if (old_host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p",
-                reinterpret_cast<void*>(old_dev_ptr));
+            LOG_ERROR(
+                "ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p",
+                reinterpret_cast<void *>(old_dev_ptr)
+            );
             return;
         }
 
@@ -247,7 +247,7 @@ void ProfMemoryManager::process_ready_entry(
         info.type = ProfBufferType::PHASE;
         info.index = tidx;
         info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = reinterpret_cast<void*>(old_dev_ptr);
+        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
         info.host_buffer_ptr = old_host_ptr;
         info.buffer_seq = seq;
 
@@ -264,7 +264,7 @@ void ProfMemoryManager::process_ready_entry(
             return;
         }
 
-        PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, core_index);
+        PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, core_index);
 
         // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
         rmb();
@@ -274,8 +274,8 @@ void ProfMemoryManager::process_ready_entry(
 
         int to_push = PLATFORM_PROF_SLOT_COUNT;
         for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
-            void* host_ptr = nullptr;
-            void* new_dev_ptr = nullptr;
+            void *host_ptr = nullptr;
+            void *new_dev_ptr = nullptr;
 
             if (!recycled_perf_buffers_.empty()) {
                 new_dev_ptr = recycled_perf_buffers_.back();
@@ -289,8 +289,7 @@ void ProfMemoryManager::process_ready_entry(
                     done_queue_.pop();
                     if (dinfo.type == ProfBufferType::PERF_RECORD)
                         recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
-                    else
-                        recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
                 }
             }
             if (new_dev_ptr == nullptr && !recycled_perf_buffers_.empty()) {
@@ -303,7 +302,7 @@ void ProfMemoryManager::process_ready_entry(
             }
             if (new_dev_ptr == nullptr) break;
 
-            reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+            reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
             uint32_t cur_tail = tail + p;
             state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
                 reinterpret_cast<uint64_t>(new_dev_ptr);
@@ -312,10 +311,12 @@ void ProfMemoryManager::process_ready_entry(
             wmb();
         }
 
-        void* old_host_ptr = resolve_host_ptr(reinterpret_cast<void*>(old_dev_ptr));
+        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
         if (old_host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p",
-                reinterpret_cast<void*>(old_dev_ptr));
+            LOG_ERROR(
+                "ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p",
+                reinterpret_cast<void *>(old_dev_ptr)
+            );
             return;
         }
 
@@ -323,7 +324,7 @@ void ProfMemoryManager::process_ready_entry(
         info.type = ProfBufferType::PERF_RECORD;
         info.index = core_index;
         info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = reinterpret_cast<void*>(old_dev_ptr);
+        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
         info.host_buffer_ptr = old_host_ptr;
         info.buffer_seq = seq;
 
@@ -336,7 +337,7 @@ void ProfMemoryManager::process_ready_entry(
 }
 
 void ProfMemoryManager::mgmt_loop() {
-    PerfDataHeader* header = get_perf_header(shared_mem_host_);
+    PerfDataHeader *header = get_perf_header(shared_mem_host_);
 
     while (running_.load()) {
         // 1. Recycle done queue: move completed buffers to recycled pools for reuse
@@ -362,11 +363,10 @@ void ProfMemoryManager::mgmt_loop() {
 
             // Validate indices to prevent OOB access from corrupted shared memory
             if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-                LOG_ERROR("mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)",
-                    t,
-                    head,
-                    tail,
-                    PLATFORM_PROF_READYQUEUE_SIZE);
+                LOG_ERROR(
+                    "mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)", t, head, tail,
+                    PLATFORM_PROF_READYQUEUE_SIZE
+                );
                 continue;
             }
 
@@ -395,15 +395,15 @@ void ProfMemoryManager::mgmt_loop() {
         //    is completely empty (avail == 0). Try recycled pool first, alloc as fallback.
         if (!recycled_perf_buffers_.empty() || !recycled_phase_buffers_.empty()) {
             for (int i = 0; i < num_cores_ && !recycled_perf_buffers_.empty(); i++) {
-                PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, i);
+                PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
                 rmb();
                 uint32_t avail = state->free_queue.tail - state->free_queue.head;
                 if (avail == 0) {
-                    void* dev_ptr = recycled_perf_buffers_.back();
+                    void *dev_ptr = recycled_perf_buffers_.back();
                     recycled_perf_buffers_.pop_back();
-                    void* host_ptr = resolve_host_ptr(dev_ptr);
+                    void *host_ptr = resolve_host_ptr(dev_ptr);
                     if (host_ptr != nullptr) {
-                        reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+                        reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
                         uint32_t t_val = state->free_queue.tail;
                         state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
                             reinterpret_cast<uint64_t>(dev_ptr);
@@ -414,15 +414,15 @@ void ProfMemoryManager::mgmt_loop() {
                 }
             }
             for (int t = 0; t < num_phase_threads_ && !recycled_phase_buffers_.empty(); t++) {
-                PhaseBufferState* state = get_phase_buffer_state(shared_mem_host_, num_cores_, t);
+                PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, t);
                 rmb();
                 uint32_t avail = state->free_queue.tail - state->free_queue.head;
                 if (avail == 0) {
-                    void* dev_ptr = recycled_phase_buffers_.back();
+                    void *dev_ptr = recycled_phase_buffers_.back();
                     recycled_phase_buffers_.pop_back();
-                    void* host_ptr = resolve_host_ptr(dev_ptr);
+                    void *host_ptr = resolve_host_ptr(dev_ptr);
                     if (host_ptr != nullptr) {
-                        reinterpret_cast<PhaseBuffer*>(host_ptr)->count = 0;
+                        reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
                         uint32_t t_val = state->free_queue.tail;
                         state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
                             reinterpret_cast<uint64_t>(dev_ptr);
@@ -437,13 +437,13 @@ void ProfMemoryManager::mgmt_loop() {
         // This only triggers when ALL pre-allocated buffers are in-flight (extreme workloads).
         if (recycled_perf_buffers_.empty() && recycled_phase_buffers_.empty()) {
             for (int i = 0; i < num_cores_; i++) {
-                PerfBufferState* state = get_perf_buffer_state(shared_mem_host_, i);
+                PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
                 rmb();
                 if (state->free_queue.tail - state->free_queue.head == 0) {
-                    void* host_ptr = nullptr;
-                    void* dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
+                    void *host_ptr = nullptr;
+                    void *dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
                     if (dev_ptr == nullptr) break;
-                    reinterpret_cast<PerfBuffer*>(host_ptr)->count = 0;
+                    reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
                     uint32_t t_val = state->free_queue.tail;
                     state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
                         reinterpret_cast<uint64_t>(dev_ptr);
@@ -462,7 +462,7 @@ void ProfMemoryManager::mgmt_loop() {
     }
 
     // Final drain: process any remaining entries
-    PerfDataHeader* hdr = get_perf_header(shared_mem_host_);
+    PerfDataHeader *hdr = get_perf_header(shared_mem_host_);
     for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
         rmb();
         uint32_t head = hdr->queue_heads[t];
@@ -506,8 +506,8 @@ PerformanceCollector::~PerformanceCollector() {
     }
 }
 
-void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out) {
-    void* dev_ptr = alloc_cb_(size, user_data_);
+void *PerformanceCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size, user_data_);
     if (dev_ptr == nullptr) {
         LOG_ERROR("Failed to allocate buffer (%zu bytes)", size);
         *host_ptr_out = nullptr;
@@ -515,7 +515,7 @@ void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out
     }
 
     if (register_cb_ != nullptr) {
-        void* host_ptr = nullptr;
+        void *host_ptr = nullptr;
         int rc = register_cb_(dev_ptr, size, device_id_, user_data_, &host_ptr);
         if (rc != 0 || host_ptr == nullptr) {
             LOG_ERROR("Buffer registration failed: %d", rc);
@@ -532,13 +532,10 @@ void* PerformanceCollector::alloc_single_buffer(size_t size, void** host_ptr_out
     return dev_ptr;
 }
 
-int PerformanceCollector::initialize(Runtime& runtime,
-    int num_aicore,
-    int device_id,
-    PerfAllocCallback alloc_cb,
-    PerfRegisterCallback register_cb,
-    PerfFreeCallback free_cb,
-    void* user_data) {
+int PerformanceCollector::initialize(
+    Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb, void *user_data
+) {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
         return -1;
@@ -570,7 +567,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
 
     // Step 2: Allocate shared memory for slot arrays
-    void* perf_dev_ptr = alloc_cb(total_size, user_data);
+    void *perf_dev_ptr = alloc_cb(total_size, user_data);
     if (perf_dev_ptr == nullptr) {
         LOG_ERROR("Failed to allocate shared memory (%zu bytes)", total_size);
         return -1;
@@ -578,7 +575,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     LOG_DEBUG("Allocated shared memory: %p", perf_dev_ptr);
 
     // Step 3: Register to host mapping (optional)
-    void* perf_host_ptr = nullptr;
+    void *perf_host_ptr = nullptr;
     if (register_cb != nullptr) {
         int rc = register_cb(perf_dev_ptr, total_size, device_id, user_data, &perf_host_ptr);
         if (rc != 0) {
@@ -597,7 +594,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
     }
 
     // Step 4: Initialize header
-    PerfDataHeader* header = get_perf_header(perf_host_ptr);
+    PerfDataHeader *header = get_perf_header(perf_host_ptr);
 
     for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
         memset(header->queues[t], 0, sizeof(header->queues[t]));
@@ -615,7 +612,7 @@ int PerformanceCollector::initialize(Runtime& runtime,
 
     // Step 5: Initialize PerfBufferStates — 1 buffer per core in free_queue, rest to recycled pool
     for (int i = 0; i < num_aicore; i++) {
-        PerfBufferState* state = get_perf_buffer_state(perf_host_ptr, i);
+        PerfBufferState *state = get_perf_buffer_state(perf_host_ptr, i);
         memset(state, 0, sizeof(PerfBufferState));
 
         state->free_queue.head = 0;
@@ -624,13 +621,13 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->current_buf_seq = 0;
 
         for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_CORE; s++) {
-            void* host_buf_ptr = nullptr;
-            void* dev_buf_ptr = alloc_single_buffer(sizeof(PerfBuffer), &host_buf_ptr);
+            void *host_buf_ptr = nullptr;
+            void *dev_buf_ptr = alloc_single_buffer(sizeof(PerfBuffer), &host_buf_ptr);
             if (dev_buf_ptr == nullptr) {
                 LOG_ERROR("Failed to allocate PerfBuffer for core %d, buffer %d", i, s);
                 return -1;
             }
-            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(host_buf_ptr);
+            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(host_buf_ptr);
             memset(buf, 0, sizeof(PerfBuffer));
             buf->count = 0;
 
@@ -644,13 +641,14 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->free_queue.tail = 1;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PerfBufferStates: 1 buffer/core, %d in recycled pool",
-        num_aicore,
-        num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1));
+    LOG_DEBUG(
+        "Initialized %d PerfBufferStates: 1 buffer/core, %d in recycled pool", num_aicore,
+        num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1)
+    );
 
     // Step 6: Initialize PhaseBufferStates — 1 buffer per thread in free_queue, rest to recycled pool
     for (int t = 0; t < num_phase_threads; t++) {
-        PhaseBufferState* state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
+        PhaseBufferState *state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
         memset(state, 0, sizeof(PhaseBufferState));
 
         state->free_queue.head = 0;
@@ -659,13 +657,13 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->current_buf_seq = 0;
 
         for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_THREAD; s++) {
-            void* host_buf_ptr = nullptr;
-            void* dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
+            void *host_buf_ptr = nullptr;
+            void *dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
             if (dev_buf_ptr == nullptr) {
                 LOG_ERROR("Failed to allocate PhaseBuffer for thread %d, buffer %d", t, s);
                 return -1;
             }
-            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(host_buf_ptr);
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(host_buf_ptr);
             memset(buf, 0, sizeof(PhaseBuffer));
             buf->count = 0;
 
@@ -679,9 +677,10 @@ int PerformanceCollector::initialize(Runtime& runtime,
         state->free_queue.tail = 1;
         wmb();
     }
-    LOG_DEBUG("Initialized %d PhaseBufferStates: 1 buffer/thread, %d in recycled pool",
-        num_phase_threads,
-        num_phase_threads * (PLATFORM_PROF_BUFFERS_PER_THREAD - 1));
+    LOG_DEBUG(
+        "Initialized %d PhaseBufferStates: 1 buffer/thread, %d in recycled pool", num_phase_threads,
+        num_phase_threads * (PLATFORM_PROF_BUFFERS_PER_THREAD - 1)
+    );
 
     wmb();
 
@@ -701,14 +700,10 @@ void PerformanceCollector::start_memory_manager() {
         return;
     }
 
-    memory_manager_.start(perf_shared_mem_host_,
-        num_aicore_,
-        PLATFORM_MAX_AICPU_THREADS,
-        alloc_cb_,
-        register_cb_,
-        free_cb_,
-        user_data_,
-        device_id_);
+    memory_manager_.start(
+        perf_shared_mem_host_, num_aicore_, PLATFORM_MAX_AICPU_THREADS, alloc_cb_, register_cb_, free_cb_, user_data_,
+        device_id_
+    );
 }
 
 void PerformanceCollector::stop_memory_manager() {
@@ -728,7 +723,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
 
     LOG_INFO("Collecting performance data");
 
-    PerfDataHeader* header = get_perf_header(perf_shared_mem_host_);
+    PerfDataHeader *header = get_perf_header(perf_shared_mem_host_);
 
     const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);
     std::optional<std::chrono::steady_clock::time_point> idle_start;
@@ -759,8 +754,10 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
 
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
-                LOG_ERROR("Timeout waiting for AICPU task count after %ld seconds",
-                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                LOG_ERROR(
+                    "Timeout waiting for AICPU task count after %ld seconds",
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
+                );
                 return;
             }
 
@@ -768,7 +765,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             ReadyBufferInfo info;
             if (memory_manager_.try_pop_ready(info)) {
                 if (info.type == ProfBufferType::PERF_RECORD) {
-                    PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
+                    PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
                     rmb();
                     uint32_t count = buf->count;
                     if (count > PLATFORM_PROF_BUFFER_SIZE) {
@@ -782,7 +779,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                         total_records_collected += count;
                     }
                 } else {
-                    PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
+                    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
                     rmb();
                     uint32_t count = buf->count;
                     if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -802,7 +799,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
     LOG_DEBUG("Initial expected tasks: %d", expected_tasks);
 
     // Check phase header for scheduler thread info
-    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
     int num_sched_for_poll = 0;
     if (phase_header->magic == AICPU_PHASE_MAGIC) {
         num_sched_for_poll = phase_header->num_sched_threads;
@@ -831,7 +828,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             idle_start.reset();
 
             if (info.type == ProfBufferType::PERF_RECORD) {
-                PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
+                PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
                 rmb();
                 uint32_t count = buf->count;
                 if (count > PLATFORM_PROF_BUFFER_SIZE) {
@@ -846,14 +843,13 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                     total_records_collected += count;
                 }
 
-                LOG_DEBUG("Collected %u perf records from core %u (total: %d/%d)",
-                    count,
-                    core_index,
-                    total_records_collected,
-                    expected_tasks);
+                LOG_DEBUG(
+                    "Collected %u perf records from core %u (total: %d/%d)", count, core_index, total_records_collected,
+                    expected_tasks
+                );
 
             } else {
-                PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
+                PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
                 rmb();
                 uint32_t count = buf->count;
                 if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -878,7 +874,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                 ReadyBufferInfo drain_info;
                 while (memory_manager_.try_pop_ready(drain_info)) {
                     if (drain_info.type == ProfBufferType::PERF_RECORD) {
-                        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(drain_info.host_buffer_ptr);
+                        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(drain_info.host_buffer_ptr);
                         rmb();
                         uint32_t count = buf->count;
                         if (count > PLATFORM_PROF_BUFFER_SIZE) count = PLATFORM_PROF_BUFFER_SIZE;
@@ -890,7 +886,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                             total_records_collected += count;
                         }
                     } else {
-                        PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(drain_info.host_buffer_ptr);
+                        PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(drain_info.host_buffer_ptr);
                         rmb();
                         uint32_t count = buf->count;
                         if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD))
@@ -903,9 +899,10 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
                     memory_manager_.notify_copy_done({drain_info.dev_buffer_ptr, drain_info.type});
                     buffers_processed++;
                 }
-                LOG_INFO("Execution complete signal received, exiting with %d/%d records",
-                    total_records_collected,
-                    expected_tasks);
+                LOG_INFO(
+                    "Execution complete signal received, exiting with %d/%d records", total_records_collected,
+                    expected_tasks
+                );
                 break;
             }
             if (!idle_start.has_value()) {
@@ -913,8 +910,10 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
             }
             auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
             if (elapsed >= timeout_duration) {
-                LOG_ERROR("Performance data collection idle timeout after %ld seconds",
-                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count());
+                LOG_ERROR(
+                    "Performance data collection idle timeout after %ld seconds",
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
+                );
                 LOG_ERROR("Collected %d / %d records before timeout", total_records_collected, expected_tasks);
                 break;
             }
@@ -937,7 +936,7 @@ void PerformanceCollector::drain_remaining_buffers() {
     }
 
     // Ensure phase record storage is initialized
-    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
     rmb();
     int num_sched = 0;
     if (phase_header->magic == AICPU_PHASE_MAGIC) {
@@ -953,7 +952,7 @@ void PerformanceCollector::drain_remaining_buffers() {
     ReadyBufferInfo info;
     while (memory_manager_.try_pop_ready(info)) {
         if (info.type == ProfBufferType::PERF_RECORD) {
-            PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(info.host_buffer_ptr);
+            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
             rmb();
             uint32_t count = buf->count;
             if (count > PLATFORM_PROF_BUFFER_SIZE) {
@@ -967,7 +966,7 @@ void PerformanceCollector::drain_remaining_buffers() {
                 drained_perf += count;
             }
         } else {
-            PhaseBuffer* buf = reinterpret_cast<PhaseBuffer*>(info.host_buffer_ptr);
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
             rmb();
             uint32_t count = buf->count;
             if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -1002,7 +1001,7 @@ void PerformanceCollector::scan_remaining_perf_buffers() {
     int total_recovered = 0;
 
     for (int core_index = 0; core_index < num_aicore_; core_index++) {
-        PerfBufferState* state = get_perf_buffer_state(perf_shared_mem_host_, core_index);
+        PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, core_index);
 
         rmb();
         uint64_t buf_ptr = state->current_buf_ptr;
@@ -1010,15 +1009,16 @@ void PerformanceCollector::scan_remaining_perf_buffers() {
             continue;
         }
 
-        void* host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void*>(buf_ptr));
+        void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
         if (host_ptr == nullptr) {
-            LOG_ERROR("scan_remaining_perf_buffers: no host mapping for dev_ptr=%p (core %d)",
-                reinterpret_cast<void*>(buf_ptr),
-                core_index);
+            LOG_ERROR(
+                "scan_remaining_perf_buffers: no host mapping for dev_ptr=%p (core %d)",
+                reinterpret_cast<void *>(buf_ptr), core_index
+            );
             continue;
         }
 
-        PerfBuffer* buf = reinterpret_cast<PerfBuffer*>(host_ptr);
+        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(host_ptr);
         uint32_t count = buf->count;
         if (count == 0) {
             continue;
@@ -1045,19 +1045,21 @@ void PerformanceCollector::collect_phase_data() {
 
     rmb();
 
-    AicpuPhaseHeader* phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
 
     // Validate magic
     if (phase_header->magic != AICPU_PHASE_MAGIC) {
         LOG_INFO(
-            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC);
+            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC
+        );
         return;
     }
 
     int num_sched_threads = phase_header->num_sched_threads;
     if (num_sched_threads > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR(
-            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS);
+            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS
+        );
         return;
     }
     LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
@@ -1070,19 +1072,20 @@ void PerformanceCollector::collect_phase_data() {
     // contains partial data that was never enqueued (the active buffer when execution ended).
     int total_phase_records = 0;
     for (int t = 0; t < total_slots; t++) {
-        PhaseBufferState* state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
 
         rmb();
         uint64_t buf_ptr = state->current_buf_ptr;
         if (buf_ptr != 0) {
-            void* host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void*>(buf_ptr));
+            void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
             if (host_ptr == nullptr) {
-                LOG_ERROR("collect_phase_data: no host mapping for dev_ptr=%p (thread %d)",
-                    reinterpret_cast<void*>(buf_ptr),
-                    t);
+                LOG_ERROR(
+                    "collect_phase_data: no host mapping for dev_ptr=%p (thread %d)", reinterpret_cast<void *>(buf_ptr),
+                    t
+                );
                 continue;
             }
-            PhaseBuffer* pbuf = reinterpret_cast<PhaseBuffer*>(host_ptr);
+            PhaseBuffer *pbuf = reinterpret_cast<PhaseBuffer *>(host_ptr);
             if (pbuf->count > 0) {
                 uint32_t count = pbuf->count;
                 if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
@@ -1101,17 +1104,14 @@ void PerformanceCollector::collect_phase_data() {
     for (size_t t = 0; t < collected_phase_records_.size(); t++) {
         if (!collected_phase_records_[t].empty()) {
             size_t sched_count = 0, orch_count = 0;
-            for (const auto& r : collected_phase_records_[t]) {
-                if (is_scheduler_phase(r.phase_id))
-                    sched_count++;
-                else
-                    orch_count++;
+            for (const auto &r : collected_phase_records_[t]) {
+                if (is_scheduler_phase(r.phase_id)) sched_count++;
+                else orch_count++;
             }
-            LOG_INFO("  Thread %zu: %zu records (sched=%zu, orch=%zu)",
-                t,
-                collected_phase_records_[t].size(),
-                sched_count,
-                orch_count);
+            LOG_INFO(
+                "  Thread %zu: %zu records (sched=%zu, orch=%zu)", t, collected_phase_records_[t].size(), sched_count,
+                orch_count
+            );
         }
     }
 
@@ -1120,9 +1120,10 @@ void PerformanceCollector::collect_phase_data() {
     bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
 
     if (orch_valid) {
-        LOG_INFO("  Orchestrator: %" PRId64 " tasks, %.3fus",
-            static_cast<int64_t>(collected_orch_summary_.submit_count),
-            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time));
+        LOG_INFO(
+            "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
+            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time)
+        );
     } else {
         LOG_INFO("  Orchestrator: no summary data");
     }
@@ -1130,7 +1131,7 @@ void PerformanceCollector::collect_phase_data() {
     // Check if drain_remaining_buffers() already accumulated some Phase records
     bool has_accumulated = has_phase_data_;
     if (!has_accumulated) {
-        for (const auto& v : collected_phase_records_) {
+        for (const auto &v : collected_phase_records_) {
             if (!v.empty()) {
                 has_accumulated = true;
                 break;
@@ -1146,15 +1147,16 @@ void PerformanceCollector::collect_phase_data() {
         LOG_INFO("  Core-to-thread mapping: %d cores", num_cores);
     }
 
-    LOG_INFO("Phase data collection complete: %d remaining records, orch_summary=%s",
-        total_phase_records,
-        orch_valid ? "yes" : "no");
+    LOG_INFO(
+        "Phase data collection complete: %d remaining records, orch_summary=%s", total_phase_records,
+        orch_valid ? "yes" : "no"
+    );
 }
 
-int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
+int PerformanceCollector::export_swimlane_json(const std::string &output_path) {
     // Step 1: Validate collected data
     bool has_any_records = false;
-    for (const auto& core_records : collected_perf_records_) {
+    for (const auto &core_records : collected_perf_records_) {
         if (!core_records.empty()) {
             has_any_records = true;
             break;
@@ -1176,29 +1178,29 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
     // Step 3: Flatten per-core vectors into tagged records with core_id derived from index
     struct TaggedRecord {
-        const PerfRecord* record;
+        const PerfRecord *record;
         uint32_t core_id;
     };
     std::vector<TaggedRecord> tagged_records;
     size_t total_records = 0;
-    for (const auto& core_records : collected_perf_records_) {
+    for (const auto &core_records : collected_perf_records_) {
         total_records += core_records.size();
     }
     tagged_records.reserve(total_records);
     for (size_t core_idx = 0; core_idx < collected_perf_records_.size(); core_idx++) {
-        for (const auto& record : collected_perf_records_[core_idx]) {
+        for (const auto &record : collected_perf_records_[core_idx]) {
             tagged_records.push_back({&record, static_cast<uint32_t>(core_idx)});
         }
     }
 
     // Sort by canonical task_id (64-bit PTO2 raw)
-    std::sort(tagged_records.begin(), tagged_records.end(), [](const TaggedRecord& a, const TaggedRecord& b) {
+    std::sort(tagged_records.begin(), tagged_records.end(), [](const TaggedRecord &a, const TaggedRecord &b) {
         return a.record->task_id < b.record->task_id;
     });
 
     // Step 4: Calculate base time (minimum timestamp across all records)
     uint64_t base_time_cycles = UINT64_MAX;
-    for (const auto& tagged : tagged_records) {
+    for (const auto &tagged : tagged_records) {
         if (tagged.record->start_time < base_time_cycles) {
             base_time_cycles = tagged.record->start_time;
         }
@@ -1209,8 +1211,8 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
     // Include phase record timestamps in base_time calculation
     if (has_phase_data_) {
-        for (const auto& thread_records : collected_phase_records_) {
-            for (const auto& pr : thread_records) {
+        for (const auto &thread_records : collected_phase_records_) {
+            for (const auto &pr : thread_records) {
                 if (pr.start_time > 0 && pr.start_time < base_time_cycles) {
                     base_time_cycles = pr.start_time;
                 }
@@ -1224,7 +1226,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
     // Step 5: Generate filename with timestamp (YYYYMMDD_HHMMSS)
     std::time_t now = time(nullptr);
-    std::tm* timeinfo = std::localtime(&now);
+    std::tm *timeinfo = std::localtime(&now);
     char time_buffer[32];
     std::strftime(time_buffer, sizeof(time_buffer), "%Y%m%d_%H%M%S", timeinfo);
     std::string filepath = output_path + "/perf_swimlane_" + std::string(time_buffer) + ".json";
@@ -1243,8 +1245,8 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     outfile << "  \"tasks\": [\n";
 
     for (size_t i = 0; i < tagged_records.size(); ++i) {
-        const auto& tagged = tagged_records[i];
-        const auto& record = *tagged.record;
+        const auto &tagged = tagged_records[i];
+        const auto &record = *tagged.record;
 
         // Convert times to microseconds
         double start_us = cycles_to_us(record.start_time - base_time_cycles);
@@ -1253,7 +1255,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         double dispatch_us = (record.dispatch_time > 0) ? cycles_to_us(record.dispatch_time - base_time_cycles) : 0.0;
         double finish_us = (record.finish_time > 0) ? cycles_to_us(record.finish_time - base_time_cycles) : 0.0;
 
-        const char* core_type_str = (record.core_type == CoreType::AIC) ? "aic" : "aiv";
+        const char *core_type_str = (record.core_type == CoreType::AIC) ? "aic" : "aiv";
 
         outfile << "    {\n";
         outfile << "      \"task_id\": " << record.task_id << ",\n";
@@ -1287,43 +1289,43 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
     // Step 8: Write phase profiling data (version 2)
     if (has_phase_data_) {
-        auto sched_phase_name = [](AicpuPhaseId id) -> const char* {
+        auto sched_phase_name = [](AicpuPhaseId id) -> const char * {
             switch (id) {
-                case AicpuPhaseId::SCHED_COMPLETE:
-                    return "complete";
-                case AicpuPhaseId::SCHED_DISPATCH:
-                    return "dispatch";
-                case AicpuPhaseId::SCHED_SCAN:
-                    return "scan";
-                case AicpuPhaseId::SCHED_IDLE_WAIT:
-                    return "idle";
-                default:
-                    return "unknown";
+            case AicpuPhaseId::SCHED_COMPLETE:
+                return "complete";
+            case AicpuPhaseId::SCHED_DISPATCH:
+                return "dispatch";
+            case AicpuPhaseId::SCHED_SCAN:
+                return "scan";
+            case AicpuPhaseId::SCHED_IDLE_WAIT:
+                return "idle";
+            default:
+                return "unknown";
             }
         };
 
-        auto orch_phase_name = [](AicpuPhaseId id) -> const char* {
+        auto orch_phase_name = [](AicpuPhaseId id) -> const char * {
             switch (id) {
-                case AicpuPhaseId::ORCH_SYNC:
-                    return "orch_sync";
-                case AicpuPhaseId::ORCH_ALLOC:
-                    return "orch_alloc";
-                case AicpuPhaseId::ORCH_PARAMS:
-                    return "orch_params";
-                case AicpuPhaseId::ORCH_LOOKUP:
-                    return "orch_lookup";
-                case AicpuPhaseId::ORCH_HEAP:
-                    return "orch_heap";
-                case AicpuPhaseId::ORCH_INSERT:
-                    return "orch_insert";
-                case AicpuPhaseId::ORCH_FANIN:
-                    return "orch_fanin";
-                case AicpuPhaseId::ORCH_FINALIZE:
-                    return "orch_finalize";
-                case AicpuPhaseId::ORCH_SCOPE_END:
-                    return "orch_scope_end";
-                default:
-                    return "unknown";
+            case AicpuPhaseId::ORCH_SYNC:
+                return "orch_sync";
+            case AicpuPhaseId::ORCH_ALLOC:
+                return "orch_alloc";
+            case AicpuPhaseId::ORCH_PARAMS:
+                return "orch_params";
+            case AicpuPhaseId::ORCH_LOOKUP:
+                return "orch_lookup";
+            case AicpuPhaseId::ORCH_HEAP:
+                return "orch_heap";
+            case AicpuPhaseId::ORCH_INSERT:
+                return "orch_insert";
+            case AicpuPhaseId::ORCH_FANIN:
+                return "orch_fanin";
+            case AicpuPhaseId::ORCH_FINALIZE:
+                return "orch_finalize";
+            case AicpuPhaseId::ORCH_SCOPE_END:
+                return "orch_scope_end";
+            default:
+                return "unknown";
             }
         };
 
@@ -1332,7 +1334,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
         for (size_t t = 0; t < collected_phase_records_.size(); t++) {
             outfile << "    [\n";
             bool first = true;
-            for (const auto& pr : collected_phase_records_[t]) {
+            for (const auto &pr : collected_phase_records_[t]) {
                 if (!is_scheduler_phase(pr.phase_id)) continue;
                 double start_us = cycles_to_us(pr.start_time - base_time_cycles);
                 double end_us = cycles_to_us(pr.end_time - base_time_cycles);
@@ -1383,8 +1385,8 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
 
         // Per-task orchestrator phase records (filtered from unified collected_phase_records_)
         bool has_orch_phases = false;
-        for (const auto& v : collected_phase_records_) {
-            for (const auto& r : v) {
+        for (const auto &v : collected_phase_records_) {
+            for (const auto &r : v) {
                 if (!is_scheduler_phase(r.phase_id)) {
                     has_orch_phases = true;
                     break;
@@ -1397,7 +1399,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
             for (size_t t = 0; t < collected_phase_records_.size(); t++) {
                 outfile << "    [\n";
                 bool first = true;
-                for (const auto& pr : collected_phase_records_[t]) {
+                for (const auto &pr : collected_phase_records_[t]) {
                     if (is_scheduler_phase(pr.phase_id)) continue;
                     double start_us = cycles_to_us(pr.start_time - base_time_cycles);
                     double end_us = cycles_to_us(pr.end_time - base_time_cycles);
@@ -1440,7 +1442,7 @@ int PerformanceCollector::export_swimlane_json(const std::string& output_path) {
     return 0;
 }
 
-int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void* user_data) {
+int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void *user_data) {
     if (perf_shared_mem_host_ == nullptr) {
         return 0;
     }
@@ -1455,11 +1457,11 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFre
     // The memory manager frees old buffers after copy; initial buffers in free_queues remain.
     // Free all buffers in the free_queues and current_buf_ptr.
     for (int i = 0; i < num_aicore_; i++) {
-        PerfBufferState* state = get_perf_buffer_state(perf_shared_mem_host_, i);
+        PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, i);
 
         // Free current buffer if any
         if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            free_cb(reinterpret_cast<void*>(state->current_buf_ptr), user_data);
+            free_cb(reinterpret_cast<void *>(state->current_buf_ptr), user_data);
         }
 
         // Free all buffers in free_queue (limit iterations to max capacity)
@@ -1470,7 +1472,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFre
         while (head != tail && max_iters-- > 0) {
             uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
             if (buf_ptr != 0 && free_cb != nullptr) {
-                free_cb(reinterpret_cast<void*>(buf_ptr), user_data);
+                free_cb(reinterpret_cast<void *>(buf_ptr), user_data);
             }
             head++;
         }
@@ -1481,11 +1483,11 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFre
 
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
     for (int t = 0; t < num_phase_threads; t++) {
-        PhaseBufferState* state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
 
         // Free current buffer if any
         if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            free_cb(reinterpret_cast<void*>(state->current_buf_ptr), user_data);
+            free_cb(reinterpret_cast<void *>(state->current_buf_ptr), user_data);
         }
 
         // Free all buffers in free_queue (limit iterations to max capacity)
@@ -1496,7 +1498,7 @@ int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFre
         while (head != tail && max_iters-- > 0) {
             uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
             if (buf_ptr != 0 && free_cb != nullptr) {
-                free_cb(reinterpret_cast<void*>(buf_ptr), user_data);
+                free_cb(reinterpret_cast<void *>(buf_ptr), user_data);
             }
             head++;
         }

--- a/src/a5/platform/src/host/unified_log_host.cpp
+++ b/src/a5/platform/src/host/unified_log_host.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file unified_log_host.cpp
  * @brief Unified logging - Host implementation
@@ -9,7 +19,7 @@
 #include <cstdarg>
 #include <cstdio>
 
-void unified_log_error(const char* func, const char* fmt, ...) {
+void unified_log_error(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];
@@ -18,18 +28,18 @@ void unified_log_error(const char* func, const char* fmt, ...) {
     HostLogger::get_instance().log(HostLogLevel::ERROR, "%s: %s", func, buffer);
 }
 
-void unified_log_warn(const char* func, const char* fmt, ...) {
+void unified_log_warn(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    
+
     char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    
+
     HostLogger::get_instance().log(HostLogLevel::WARN, "%s: %s", func, buffer);
 }
 
-void unified_log_info(const char* func, const char* fmt, ...) {
+void unified_log_info(const char *func, const char *fmt, ...) {
     if (!HostLogger::get_instance().is_enabled(HostLogLevel::INFO)) {
         return;
     }
@@ -41,7 +51,7 @@ void unified_log_info(const char* func, const char* fmt, ...) {
     HostLogger::get_instance().log(HostLogLevel::INFO, "%s: %s", func, buffer);
 }
 
-void unified_log_debug(const char* func, const char* fmt, ...) {
+void unified_log_debug(const char *func, const char *fmt, ...) {
     if (!HostLogger::get_instance().is_enabled(HostLogLevel::DEBUG)) {
         return;
     }
@@ -53,7 +63,7 @@ void unified_log_debug(const char* func, const char* fmt, ...) {
     HostLogger::get_instance().log(HostLogLevel::DEBUG, "%s: %s", func, buffer);
 }
 
-void unified_log_always(const char* func, const char* fmt, ...) {
+void unified_log_always(const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     char buffer[2048];

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -15,19 +15,19 @@
 #include "common/platform_config.h"  // Platform configuration (C/C++ compatible)
 #include "runtime.h"                 // NOLINT(build/include_subdir)
 
-typedef void (*KernelFunc)(__gm__ int64_t*);
+typedef void (*KernelFunc)(__gm__ int64_t *);
 
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* task) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task *task) {
     if (task->function_bin_addr == 0) {
         return;
     }
     KernelFunc kernel = (KernelFunc)task->function_bin_addr;
-    kernel(reinterpret_cast<__gm__ int64_t*>(task->args));
+    kernel(reinterpret_cast<__gm__ int64_t *>(task->args));
     OUT_OF_ORDER_STORE_BARRIER();
 }
 
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type) {
-    __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[core_idx]);
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, int core_idx, CoreType core_type) {
+    __gm__ Handshake *my_hank = (__gm__ Handshake *)(&runtime->workers[core_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
@@ -74,14 +74,14 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             uint32_t actual_task_id = task_id;
             write_reg(RegId::COND, MAKE_ACK_VALUE(actual_task_id));
 
-            __gm__ Task* task_ptr = &(runtime->tasks[actual_task_id]);
+            __gm__ Task *task_ptr = &(runtime->tasks[actual_task_id]);
             uint64_t start_time = get_sys_cnt_aicore();
 
             execute_task(task_ptr);
 
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
-                __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
+                __gm__ PerfBuffer *perf_buf = (__gm__ PerfBuffer *)my_hank->perf_records_addr;
                 perf_aicore_record_task(perf_buf, actual_task_id, start_time, end_time);
             }
 

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -100,37 +100,28 @@ struct AicpuExecutor {
     uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER];  // Per-core total dispatched task counter
 
     // ===== Methods =====
-    int init(Runtime* runtime);
-    int handshake_all_cores(Runtime* runtime);
+    int init(Runtime *runtime);
+    int handshake_all_cores(Runtime *runtime);
     void assign_cores_to_threads();
-    void classify_and_distribute_initial_tasks(Runtime* runtime);
-    int resolve_and_dispatch(Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num);
-    int shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores);
-    int run(Runtime* runtime);
-    void deinit(Runtime* runtime);
-    void emergency_shutdown(Runtime* runtime);
-    void diagnose_stuck_state(
-        Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num, Handshake* hank);
+    void classify_and_distribute_initial_tasks(Runtime *runtime);
+    int resolve_and_dispatch(Runtime &runtime, int thread_idx, const int *cur_thread_cores, int core_num);
+    int shutdown_aicore(Runtime *runtime, int thread_idx, const int *cur_thread_cores);
+    int run(Runtime *runtime);
+    void deinit(Runtime *runtime);
+    void emergency_shutdown(Runtime *runtime);
+    void
+    diagnose_stuck_state(Runtime &runtime, int thread_idx, const int *cur_thread_cores, int core_num, Handshake *hank);
 
     // Helper functions (inline to avoid linker issues, not always_inline to preserve barriers)
-    inline void resolve_task_dependencies(Task* task,
-        Runtime& runtime,
-        int* cur_ready_queue_aic,
-        int& cur_aic_tail,
-        int& cur_aic_ready_count,
-        int* cur_ready_queue_aiv,
-        int& cur_aiv_tail,
-        int& cur_aiv_ready_count);
+    inline void resolve_task_dependencies(
+        Task *task, Runtime &runtime, int *cur_ready_queue_aic, int &cur_aic_tail, int &cur_aic_ready_count,
+        int *cur_ready_queue_aiv, int &cur_aiv_tail, int &cur_aiv_ready_count
+    );
 
-    inline bool try_dispatch_task(int core_id,
-        uint64_t reg_addr,
-        CoreType core_type,
-        int thread_idx,
-        int* local_queue,
-        int& head,
-        int& ready_count,
-        bool profiling_enabled,
-        Runtime& runtime);
+    inline bool try_dispatch_task(
+        int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head,
+        int &ready_count, bool profiling_enabled, Runtime &runtime
+    );
 };
 
 static AicpuExecutor g_aicpu_executor;
@@ -138,17 +129,13 @@ static AicpuExecutor g_aicpu_executor;
 // ===== Helper Function Implementations =====
 
 // Resolve dependencies: decrement fanin and enqueue newly ready tasks
-inline void AicpuExecutor::resolve_task_dependencies(Task* task,
-    Runtime& runtime,
-    int* cur_ready_queue_aic,
-    int& cur_aic_tail,
-    int& cur_aic_ready_count,
-    int* cur_ready_queue_aiv,
-    int& cur_aiv_tail,
-    int& cur_aiv_ready_count) {
+inline void AicpuExecutor::resolve_task_dependencies(
+    Task *task, Runtime &runtime, int *cur_ready_queue_aic, int &cur_aic_tail, int &cur_aic_ready_count,
+    int *cur_ready_queue_aiv, int &cur_aiv_tail, int &cur_aiv_ready_count
+) {
     for (int j = 0; j < task->fanout_count; j++) {
         int dep_id = task->fanout[j];
-        Task* dep = runtime.get_task(dep_id);
+        Task *dep = runtime.get_task(dep_id);
         int prev_fanin = dep->fanin.fetch_sub(1, std::memory_order_acq_rel);
 
         if (prev_fanin == 1) {
@@ -180,15 +167,10 @@ inline void AicpuExecutor::resolve_task_dependencies(Task* task,
 }
 
 // Try to dispatch a task from thread-local queue to a core
-inline bool AicpuExecutor::try_dispatch_task(int core_id,
-    uint64_t reg_addr,
-    CoreType core_type,
-    int thread_idx,
-    int* local_queue,
-    int& head,
-    int& ready_count,
-    bool profiling_enabled,
-    Runtime& runtime) {
+inline bool AicpuExecutor::try_dispatch_task(
+    int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head, int &ready_count,
+    bool profiling_enabled, Runtime &runtime
+) {
     if (ready_count <= 0) {
         return false;
     }
@@ -207,13 +189,11 @@ inline bool AicpuExecutor::try_dispatch_task(int core_id,
         }
     }
 
-    const char* core_type_str = (core_type == CoreType::AIC) ? "AIC" : "AIV";
-    LOG_INFO("Thread %d: Dispatching %s task %d to core %d (running_id=%d)",
-        thread_idx,
-        core_type_str,
-        task_id,
-        core_id,
-        running_task_ids_[core_id]);
+    const char *core_type_str = (core_type == CoreType::AIC) ? "AIC" : "AIV";
+    LOG_INFO(
+        "Thread %d: Dispatching %s task %d to core %d (running_id=%d)", thread_idx, core_type_str, task_id, core_id,
+        running_task_ids_[core_id]
+    );
 
     // Set state before writing register to avoid race with AICore ACK
     pending_task_ids_[core_id] = task_id;
@@ -225,7 +205,7 @@ inline bool AicpuExecutor::try_dispatch_task(int core_id,
 
 // ===== AicpuExecutor Method Implementations =====
 
-int AicpuExecutor::init(Runtime* runtime) {
+int AicpuExecutor::init(Runtime *runtime) {
     bool expected = false;
     if (!initialized_.compare_exchange_strong(expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
         return 0;
@@ -306,8 +286,8 @@ int AicpuExecutor::init(Runtime* runtime) {
  * @param runtime Runtime pointer
  * @return 0 on success, -1 on failure
  */
-int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+int AicpuExecutor::handshake_all_cores(Runtime *runtime) {
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     cores_total_num_ = runtime->worker_count;
 
     // Validate cores_total_num_ before using as array index
@@ -332,7 +312,7 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     // Step 2: Wait for all cores to respond and collect core type information
     bool handshake_failed = false;
     for (int i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_handshakes[i];
+        Handshake *hank = &all_handshakes[i];
 
         // Wait for aicore_regs_ready signal
         while (hank->aicore_regs_ready == 0) {
@@ -343,24 +323,23 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
 
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
-            LOG_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                i,
-                physical_core_id,
-                max_physical_cores_count);
+            LOG_ERROR(
+                "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
+                max_physical_cores_count
+            );
             handshake_failed = true;
             continue;
         }
 
         // Get register address using physical_core_id
-        uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
+        uint64_t *regs = reinterpret_cast<uint64_t *>(regs_);
         uint64_t reg_addr = regs[physical_core_id];
 
         // Initialize AICore registers after discovery (first round)
         platform_init_aicore_regs(reg_addr);
         hank->aicpu_regs_ready = 1;
 
-        while (hank->aicore_done == 0) {
-        }
+        while (hank->aicore_done == 0) {}
 
         CoreType type = hank->core_type;
 
@@ -383,11 +362,10 @@ int AicpuExecutor::handshake_all_cores(Runtime* runtime) {
 
         core_id_to_reg_addr_[i] = reg_addr;
 
-        LOG_INFO("  Core %d: type=%s, physical_id=%u, reg_addr=0x%lx",
-            i,
-            core_type_to_string(type),
-            physical_core_id,
-            reg_addr);
+        LOG_INFO(
+            "  Core %d: type=%s, physical_id=%u, reg_addr=0x%lx", i, core_type_to_string(type), physical_core_id,
+            reg_addr
+        );
     }
 
     if (handshake_failed) {
@@ -407,12 +385,10 @@ void AicpuExecutor::assign_cores_to_threads() {
     aic_per_thread_ = (aic_count_ + thread_num_ - 1) / thread_num_;
     aiv_per_thread_ = (aiv_count_ + thread_num_ - 1) / thread_num_;
 
-    LOG_INFO("Core Assignment: %d AIC cores, %d AIV cores across %d threads (max %d AIC/thread, %d AIV/thread)",
-        aic_count_,
-        aiv_count_,
-        thread_num_,
-        aic_per_thread_,
-        aiv_per_thread_);
+    LOG_INFO(
+        "Core Assignment: %d AIC cores, %d AIV cores across %d threads (max %d AIC/thread, %d AIV/thread)", aic_count_,
+        aiv_count_, thread_num_, aic_per_thread_, aiv_per_thread_
+    );
 
     for (int t = 0; t < thread_num_; t++) {
         int core_idx = 0;
@@ -433,7 +409,8 @@ void AicpuExecutor::assign_cores_to_threads() {
         int offset = 0;
 
         offset += snprintf(
-            log_buffer + offset, sizeof(log_buffer) - offset, "Thread %d: assigned %d cores - AIC[", t, core_idx);
+            log_buffer + offset, sizeof(log_buffer) - offset, "Thread %d: assigned %d cores - AIC[", t, core_idx
+        );
 
         for (int k = 0, i = t; i < aic_count_; i += thread_num_, k++) {
             if (k > 0) offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, ",");
@@ -454,7 +431,7 @@ void AicpuExecutor::assign_cores_to_threads() {
 }
 
 // Classify and distribute initial ready tasks to thread-local and shared queues
-void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime* runtime) {
+void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime *runtime) {
     ready_queue_aic_head_ = 0;
     ready_queue_aic_tail_ = 0;
     ready_queue_aiv_head_ = 0;
@@ -471,7 +448,7 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime* runtime) {
     int initial_aiv_count = 0;
 
     for (int i = 0; i < initial_count; i++) {
-        Task* task = runtime->get_task(initial_ready[i]);
+        Task *task = runtime->get_task(initial_ready[i]);
         if (task->core_type == CoreType::AIC) {
             initial_aic[initial_aic_count++] = initial_ready[i];
         } else {
@@ -534,12 +511,14 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime* runtime) {
     }
     ready_count_aiv_.store(aiv_shared_count, std::memory_order_release);
 
-    LOG_INFO("Init: Task distribution complete - AIC: %d in local queues, %d in shared queue",
-        initial_aic_count - aic_shared_count,
-        aic_shared_count);
-    LOG_INFO("Init: Task distribution complete - AIV: %d in local queues, %d in shared queue",
-        initial_aiv_count - aiv_shared_count,
-        aiv_shared_count);
+    LOG_INFO(
+        "Init: Task distribution complete - AIC: %d in local queues, %d in shared queue",
+        initial_aic_count - aic_shared_count, aic_shared_count
+    );
+    LOG_INFO(
+        "Init: Task distribution complete - AIV: %d in local queues, %d in shared queue",
+        initial_aiv_count - aiv_shared_count, aiv_shared_count
+    );
 
     for (int t = 0; t < thread_num_; t++) {
         int aic_size =
@@ -553,14 +532,14 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime* runtime) {
 /**
  * Shutdown AICore - Send quit signal to all AICore kernels
  */
-int AicpuExecutor::shutdown_aicore(Runtime* runtime, int thread_idx, const int* cur_thread_cores) {
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+int AicpuExecutor::shutdown_aicore(Runtime *runtime, int thread_idx, const int *cur_thread_cores) {
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
 
     LOG_INFO("Thread %d: Shutting down %d cores", thread_idx, thread_cores_num_[thread_idx]);
 
     for (int i = 0; i < thread_cores_num_[thread_idx]; i++) {
         int core_id = cur_thread_cores[i];
-        Handshake* hank = &all_handshakes[core_id];
+        Handshake *hank = &all_handshakes[core_id];
         LOG_INFO("Thread %d: AICPU hank addr = 0x%lx", thread_idx, (uint64_t)hank);
 
         uint64_t reg_addr = core_id_to_reg_addr_[core_id];
@@ -577,8 +556,8 @@ int AicpuExecutor::shutdown_aicore(Runtime* runtime, int thread_idx, const int* 
 /**
  * Resolve dependencies and dispatch tasks using fast-path scheduling
  */
-int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num) {
-    Handshake* hank = reinterpret_cast<Handshake*>(runtime.workers);
+int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const int *cur_thread_cores, int core_num) {
+    Handshake *hank = reinterpret_cast<Handshake *>(runtime.workers);
 
     LOG_INFO("Thread %d: Starting execution with %d cores", thread_idx, core_num);
 
@@ -596,8 +575,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
     bool profiling_enabled = runtime.enable_profiling;
 
     // Extract array pointers as local variables for better readability and performance
-    int* cur_ready_queue_aic = cur_ready_queue_aic_[thread_idx];
-    int* cur_ready_queue_aiv = cur_ready_queue_aiv_[thread_idx];
+    int *cur_ready_queue_aic = cur_ready_queue_aic_[thread_idx];
+    int *cur_ready_queue_aiv = cur_ready_queue_aiv_[thread_idx];
 
     // Initialize local circular queue pointers from member variables (set by init())
     // After this point, only use local variables for lock-free performance
@@ -611,7 +590,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
     int cur_aiv_ready_count = (cur_aiv_tail - cur_aiv_head + MAX_CORES_PER_THREAD) % MAX_CORES_PER_THREAD;
 
     LOG_INFO(
-        "Thread %d: Initial state - local queue: %d AIC, %d AIV", thread_idx, cur_aic_ready_count, cur_aiv_ready_count);
+        "Thread %d: Initial state - local queue: %d AIC, %d AIV", thread_idx, cur_aic_ready_count, cur_aiv_ready_count
+    );
 
     // Initialize dispatch timestamps for all cores
     uint64_t dispatch_start_time = get_sys_cnt_aicpu();
@@ -625,7 +605,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
         for (int i = 0; i < core_num; i++) {
             int core_id = cur_thread_cores[i];
             uint64_t reg_addr = core_id_to_reg_addr_[core_id];
-            Handshake* h = &hank[core_id];
+            Handshake *h = &hank[core_id];
 
             uint64_t reg_val = read_reg(reg_addr, RegId::COND);
             int reg_task_id = EXTRACT_TASK_ID(reg_val);
@@ -633,32 +613,27 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
 
             // Case 1: Pending task finished directly
             if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {
-                LOG_INFO("Thread %d: Core %d completed task %d (running_id=%d)",
-                    thread_idx,
-                    core_id,
-                    pending_task_ids_[core_id],
-                    running_task_ids_[core_id]);
+                LOG_INFO(
+                    "Thread %d: Core %d completed task %d (running_id=%d)", thread_idx, core_id,
+                    pending_task_ids_[core_id], running_task_ids_[core_id]
+                );
 
                 int completed_task_id = pending_task_ids_[core_id];
 
                 // Profiling
                 if (profiling_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
-                    Task* task = &runtime.tasks[completed_task_id];
+                    PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
+                    Task *task = &runtime.tasks[completed_task_id];
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     for (int i = 0; i < task->fanout_count; i++) {
                         fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
                     }
-                    if (perf_aicpu_complete_record(perf_buf,
-                            static_cast<uint32_t>(completed_task_id),
-                            static_cast<uint64_t>(completed_task_id),
-                            task->func_id,
-                            h->core_type,
-                            dispatch_timestamps_[core_id],
-                            finish_ts,
-                            fanout_arr,
-                            task->fanout_count) != 0) {
+                    if (perf_aicpu_complete_record(
+                            perf_buf, static_cast<uint32_t>(completed_task_id),
+                            static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
+                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                        ) != 0) {
                         DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d", core_id, completed_task_id);
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
@@ -675,25 +650,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 // This allows the core to start next task immediately
                 bool dispatched = false;
                 if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
-                    dispatched = try_dispatch_task(core_id,
-                        reg_addr,
-                        CoreType::AIC,
-                        thread_idx,
-                        cur_ready_queue_aic,
-                        cur_aic_head,
-                        cur_aic_ready_count,
-                        profiling_enabled,
-                        runtime);
+                    dispatched = try_dispatch_task(
+                        core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
+                        cur_aic_ready_count, profiling_enabled, runtime
+                    );
                 } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
-                    dispatched = try_dispatch_task(core_id,
-                        reg_addr,
-                        CoreType::AIV,
-                        thread_idx,
-                        cur_ready_queue_aiv,
-                        cur_aiv_head,
-                        cur_aiv_ready_count,
-                        profiling_enabled,
-                        runtime);
+                    dispatched = try_dispatch_task(
+                        core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
+                        cur_aiv_ready_count, profiling_enabled, runtime
+                    );
                 }
 
                 // Resolve old running task dependencies (if exists)
@@ -704,28 +669,20 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     cur_thread_completed++;
                     completed_tasks_.fetch_add(1, std::memory_order_release);
 
-                    Task* prev_running_task = runtime.get_task(prev_running_id);
-                    resolve_task_dependencies(prev_running_task,
-                        runtime,
-                        cur_ready_queue_aic,
-                        cur_aic_tail,
-                        cur_aic_ready_count,
-                        cur_ready_queue_aiv,
-                        cur_aiv_tail,
-                        cur_aiv_ready_count);
+                    Task *prev_running_task = runtime.get_task(prev_running_id);
+                    resolve_task_dependencies(
+                        prev_running_task, runtime, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
+                        cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                    );
 
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
-                Task* task = runtime.get_task(completed_task_id);
-                resolve_task_dependencies(task,
-                    runtime,
-                    cur_ready_queue_aic,
-                    cur_aic_tail,
-                    cur_aic_ready_count,
-                    cur_ready_queue_aiv,
-                    cur_aiv_tail,
-                    cur_aiv_ready_count);
+                Task *task = runtime.get_task(completed_task_id);
+                resolve_task_dependencies(
+                    task, runtime, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count, cur_ready_queue_aiv,
+                    cur_aiv_tail, cur_aiv_ready_count
+                );
 
                 made_progress = true;
 
@@ -734,11 +691,10 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
             } else if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_ACK_STATE) {  // Case 2: ACK
-                LOG_INFO("Thread %d: Core %d ACKed task %d (running_id=%d)",
-                    thread_idx,
-                    core_id,
-                    pending_task_ids_[core_id],
-                    running_task_ids_[core_id]);
+                LOG_INFO(
+                    "Thread %d: Core %d ACKed task %d (running_id=%d)", thread_idx, core_id, pending_task_ids_[core_id],
+                    running_task_ids_[core_id]
+                );
 
                 int prev_running_id = running_task_ids_[core_id];
 
@@ -754,15 +710,11 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                     cur_thread_completed++;
                     completed_tasks_.fetch_add(1, std::memory_order_release);
 
-                    Task* prev_running_task = runtime.get_task(prev_running_id);
-                    resolve_task_dependencies(prev_running_task,
-                        runtime,
-                        cur_ready_queue_aic,
-                        cur_aic_tail,
-                        cur_aic_ready_count,
-                        cur_ready_queue_aiv,
-                        cur_aiv_tail,
-                        cur_aiv_ready_count);
+                    Task *prev_running_task = runtime.get_task(prev_running_id);
+                    resolve_task_dependencies(
+                        prev_running_task, runtime, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
+                        cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                    );
 
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
@@ -770,31 +722,26 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 // Core can accept new task now (pipeline!)
                 // Continue to Case 4 to dispatch next task
             } else if (reg_task_id == running_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {  // Case 3: FIN
-                LOG_INFO("Thread %d: Core %d completed task %d (pending_id=%d)",
-                    thread_idx,
-                    core_id,
-                    running_task_ids_[core_id],
-                    pending_task_ids_[core_id]);
+                LOG_INFO(
+                    "Thread %d: Core %d completed task %d (pending_id=%d)", thread_idx, core_id,
+                    running_task_ids_[core_id], pending_task_ids_[core_id]
+                );
 
                 int completed_task_id = running_task_ids_[core_id];
 
                 if (profiling_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
-                    Task* task = &runtime.tasks[completed_task_id];
+                    PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
+                    Task *task = &runtime.tasks[completed_task_id];
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     for (int i = 0; i < task->fanout_count; i++) {
                         fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
                     }
-                    if (perf_aicpu_complete_record(perf_buf,
-                            static_cast<uint32_t>(completed_task_id),
-                            static_cast<uint64_t>(completed_task_id),
-                            task->func_id,
-                            h->core_type,
-                            dispatch_timestamps_[core_id],
-                            finish_ts,
-                            fanout_arr,
-                            task->fanout_count) != 0) {
+                    if (perf_aicpu_complete_record(
+                            perf_buf, static_cast<uint32_t>(completed_task_id),
+                            static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
+                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                        ) != 0) {
                         DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task %d", core_id, completed_task_id);
                     }
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
@@ -808,37 +755,23 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 bool dispatched = false;
                 if (pending_task_ids_[core_id] == AICPU_TASK_INVALID) {
                     if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
-                        dispatched = try_dispatch_task(core_id,
-                            reg_addr,
-                            CoreType::AIC,
-                            thread_idx,
-                            cur_ready_queue_aic,
-                            cur_aic_head,
-                            cur_aic_ready_count,
-                            profiling_enabled,
-                            runtime);
+                        dispatched = try_dispatch_task(
+                            core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
+                            cur_aic_ready_count, profiling_enabled, runtime
+                        );
                     } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
-                        dispatched = try_dispatch_task(core_id,
-                            reg_addr,
-                            CoreType::AIV,
-                            thread_idx,
-                            cur_ready_queue_aiv,
-                            cur_aiv_head,
-                            cur_aiv_ready_count,
-                            profiling_enabled,
-                            runtime);
+                        dispatched = try_dispatch_task(
+                            core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
+                            cur_aiv_ready_count, profiling_enabled, runtime
+                        );
                     }
                 }
 
-                Task* task = runtime.get_task(completed_task_id);
-                resolve_task_dependencies(task,
-                    runtime,
-                    cur_ready_queue_aic,
-                    cur_aic_tail,
-                    cur_aic_ready_count,
-                    cur_ready_queue_aiv,
-                    cur_aiv_tail,
-                    cur_aiv_ready_count);
+                Task *task = runtime.get_task(completed_task_id);
+                resolve_task_dependencies(
+                    task, runtime, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count, cur_ready_queue_aiv,
+                    cur_aiv_tail, cur_aiv_ready_count
+                );
 
                 made_progress = true;
 
@@ -851,27 +784,17 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             // Case 4: Dispatch new task if pending slot is available
             if (pending_task_ids_[core_id] == AICPU_TASK_INVALID) {
                 if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
-                    if (try_dispatch_task(core_id,
-                            reg_addr,
-                            CoreType::AIC,
-                            thread_idx,
-                            cur_ready_queue_aic,
-                            cur_aic_head,
-                            cur_aic_ready_count,
-                            profiling_enabled,
-                            runtime)) {
+                    if (try_dispatch_task(
+                            core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
+                            cur_aic_ready_count, profiling_enabled, runtime
+                        )) {
                         made_progress = true;
                     }
                 } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
-                    if (try_dispatch_task(core_id,
-                            reg_addr,
-                            CoreType::AIV,
-                            thread_idx,
-                            cur_ready_queue_aiv,
-                            cur_aiv_head,
-                            cur_aiv_ready_count,
-                            profiling_enabled,
-                            runtime)) {
+                    if (try_dispatch_task(
+                            core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
+                            cur_aiv_ready_count, profiling_enabled, runtime
+                        )) {
                         made_progress = true;
                     }
                 }
@@ -895,7 +818,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 cur_aic_ready_count += to_grab;
 
                 LOG_INFO(
-                    "Thread %d: Grabbed %d AIC tasks from shared queue (available=%d)", thread_idx, to_grab, available);
+                    "Thread %d: Grabbed %d AIC tasks from shared queue (available=%d)", thread_idx, to_grab, available
+                );
             }
         }
 
@@ -915,7 +839,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 cur_aiv_ready_count += to_grab;
 
                 LOG_INFO(
-                    "Thread %d: Grabbed %d AIV tasks from shared queue (available=%d)", thread_idx, to_grab, available);
+                    "Thread %d: Grabbed %d AIV tasks from shared queue (available=%d)", thread_idx, to_grab, available
+                );
             }
         }
 
@@ -935,13 +860,9 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                         LOG_WARN(
                             "Thread %d: Counter reached %d/%d but core %d still has work (COND=0x%lx, pending_id=%d, "
                             "running_id=%d)",
-                            thread_idx,
-                            completed_tasks_.load(std::memory_order_acquire),
-                            task_count,
-                            core_id,
-                            reg_val,
-                            pending_task_ids_[core_id],
-                            running_task_ids_[core_id]);
+                            thread_idx, completed_tasks_.load(std::memory_order_acquire), task_count, core_id, reg_val,
+                            pending_task_ids_[core_id], running_task_ids_[core_id]
+                        );
                     }
                     break;
                 }
@@ -952,19 +873,20 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
                 int aic_remaining = ready_count_aic_.load(std::memory_order_acquire);
                 int aiv_remaining = ready_count_aiv_.load(std::memory_order_acquire);
                 if (aic_remaining > 0 || aiv_remaining > 0) {
-                    LOG_WARN("Thread %d: Queues not empty after completion! AIC=%d, AIV=%d",
-                        thread_idx,
-                        aic_remaining,
-                        aiv_remaining);
+                    LOG_WARN(
+                        "Thread %d: Queues not empty after completion! AIC=%d, AIV=%d", thread_idx, aic_remaining,
+                        aiv_remaining
+                    );
                 }
                 break;  // Exit main loop
             }
 
             verification_warning_count++;
             if (verification_warning_count > MAX_VERIFICATION_WARNINGS) {
-                LOG_ERROR("Thread %d: Counter reached but cores still working after %d checks!",
-                    thread_idx,
-                    verification_warning_count);
+                LOG_ERROR(
+                    "Thread %d: Counter reached but cores still working after %d checks!", thread_idx,
+                    verification_warning_count
+                );
                 diagnose_stuck_state(runtime, thread_idx, cur_thread_cores, core_num, hank);
                 return -1;
             }
@@ -975,11 +897,10 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
             idle_iterations++;
             if (idle_iterations % WARN_INTERVAL == 0) {
                 int current = completed_tasks_.load(std::memory_order_acquire);
-                LOG_WARN("Thread %d: %d idle iterations, progress %d/%d tasks",
-                    thread_idx,
-                    idle_iterations,
-                    current,
-                    task_count);
+                LOG_WARN(
+                    "Thread %d: %d idle iterations, progress %d/%d tasks", thread_idx, idle_iterations, current,
+                    task_count
+                );
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
                 LOG_ERROR("Thread %d: Timeout after %d idle iterations!", thread_idx, idle_iterations);
@@ -998,12 +919,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime& runtime, int thread_idx, const 
     return cur_thread_completed;
 }
 
-int AicpuExecutor::run(Runtime* runtime) {
+int AicpuExecutor::run(Runtime *runtime) {
     int thread_idx = thread_idx_++;
 
     LOG_INFO("Thread %d: Start", thread_idx);
 
-    const int* cur_thread_cores = core_assignments_[thread_idx];
+    const int *cur_thread_cores = core_assignments_[thread_idx];
 
     LOG_INFO("Thread %d: Runtime has %d tasks", thread_idx, runtime->get_task_count());
     int completed = resolve_and_dispatch(*runtime, thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
@@ -1030,7 +951,7 @@ int AicpuExecutor::run(Runtime* runtime) {
     return 0;
 }
 
-void AicpuExecutor::deinit(Runtime* runtime) {
+void AicpuExecutor::deinit(Runtime *runtime) {
     // === Exit cleanup: reset all inter-round state ===
 
     // 1. Invalidate AICPU cache for Runtime address range.
@@ -1075,11 +996,11 @@ void AicpuExecutor::deinit(Runtime* runtime) {
     LOG_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
+void AicpuExecutor::emergency_shutdown(Runtime *runtime) {
     LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     for (int i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_handshakes[i];
+        Handshake *hank = &all_handshakes[i];
         OUT_OF_ORDER_STORE_BARRIER();
         hank->aicpu_regs_ready = 1;
         if (core_id_to_reg_addr_[i] != 0) {
@@ -1091,7 +1012,8 @@ void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
 }
 
 void AicpuExecutor::diagnose_stuck_state(
-    Runtime& runtime, int thread_idx, const int* cur_thread_cores, int core_num, Handshake* hank) {
+    Runtime &runtime, int thread_idx, const int *cur_thread_cores, int core_num, Handshake *hank
+) {
     LOG_ERROR("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
 
     int completed = completed_tasks_.load(std::memory_order_acquire);
@@ -1108,9 +1030,9 @@ void AicpuExecutor::diagnose_stuck_state(
     LOG_ERROR("Core Status:");
     for (int i = 0; i < core_num; i++) {
         int core_id = cur_thread_cores[i];
-        Handshake* h = &hank[core_id];
+        Handshake *h = &hank[core_id];
 
-        const char* core_type_str = core_type_to_string(h->core_type);
+        const char *core_type_str = core_type_to_string(h->core_type);
 
         uint64_t reg_addr = core_id_to_reg_addr_[core_id];
         uint64_t reg_val = read_reg(reg_addr, RegId::COND);
@@ -1124,34 +1046,22 @@ void AicpuExecutor::diagnose_stuck_state(
             busy_cores++;
 
             if (pending_id != AICPU_TASK_INVALID) {
-                Task* task = runtime.get_task(pending_id);
+                Task *task = runtime.get_task(pending_id);
                 LOG_ERROR(
                     "  Core %d [%s, PENDING]: COND=0x%lx (reg_task_id=%d, reg_state=%d), pending_id=%d, func_id=%d, "
                     "fanin=%d, fanout=%d",
-                    core_id,
-                    core_type_str,
-                    reg_val,
-                    reg_task_id,
-                    reg_state,
-                    task->task_id,
-                    task->func_id,
-                    task->fanin.load(std::memory_order_acquire),
-                    task->fanout_count);
+                    core_id, core_type_str, reg_val, reg_task_id, reg_state, task->task_id, task->func_id,
+                    task->fanin.load(std::memory_order_acquire), task->fanout_count
+                );
             }
             if (running_id != AICPU_TASK_INVALID) {
-                Task* task = runtime.get_task(running_id);
+                Task *task = runtime.get_task(running_id);
                 LOG_ERROR(
                     "  Core %d [%s, RUNNING]: COND=0x%lx (reg_task_id=%d, reg_state=%d), running_id=%d, func_id=%d, "
                     "fanin=%d, fanout=%d",
-                    core_id,
-                    core_type_str,
-                    reg_val,
-                    reg_task_id,
-                    reg_state,
-                    task->task_id,
-                    task->func_id,
-                    task->fanin.load(std::memory_order_acquire),
-                    task->fanout_count);
+                    core_id, core_type_str, reg_val, reg_task_id, reg_state, task->task_id, task->func_id,
+                    task->fanin.load(std::memory_order_acquire), task->fanout_count
+                );
             }
         } else {
             idle_cores++;
@@ -1168,7 +1078,7 @@ void AicpuExecutor::diagnose_stuck_state(
         LOG_ERROR("Tasks with fanin > 0:");
         int stuck_count = 0;
         for (int tid = 0; tid < total && stuck_count < 10; tid++) {
-            Task* t = runtime.get_task(tid);
+            Task *t = runtime.get_task(tid);
             int fanin = t->fanin.load(std::memory_order_acquire);
             if (fanin > 0) {
                 LOG_ERROR("  Task %d: fanin=%d (waiting for dependencies)", tid, fanin);
@@ -1201,10 +1111,12 @@ void AicpuExecutor::diagnose_stuck_state(
  * @param runtime Pointer to Runtime structure
  * @return 0 on success, non-zero on error
  */
-extern "C" int aicpu_execute(Runtime* runtime) {
+extern "C" int aicpu_execute(Runtime *runtime) {
     // Initialize log switches (only once, thread-safe)
     static std::once_flag log_init_flag;
-    std::call_once(log_init_flag, []() { init_log_switch(); });
+    std::call_once(log_init_flag, []() {
+        init_log_switch();
+    });
 
     if (runtime == nullptr) {
         LOG_ERROR("%s", "Invalid argument: null Runtime pointer");

--- a/src/a5/runtime/host_build_graph/host/runtime_compile_info.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_compile_info.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "host/platform_compile_info.h"
 #include "host/runtime_compile_info.h"
 #include <string.h>
@@ -13,5 +23,4 @@ ToolchainType get_orchestration_compiler(void) {
     // host_build_graph: always host g++ (orchestration runs on host)
     return TOOLCHAIN_HOST_GXX;
 }
-
 }

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -45,7 +45,7 @@
  * @param orch_args  Separated tensor/scalar arguments
  * @return 0 on success, negative on error
  */
-typedef int (*OrchestrationFunc)(Runtime* runtime, const ChipStorageTaskArgs& orch_args);
+typedef int (*OrchestrationFunc)(Runtime *runtime, const ChipStorageTaskArgs &orch_args);
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,7 +67,7 @@ extern "C" {
  * @param orch_args Separated tensor/scalar arguments
  * @return 0 on success, -1 on failure
  */
-int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args) {
+int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args) {
     // Validate inputs
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -79,10 +79,11 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", callable->child_count());
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
-            const auto& kernel = callable->child(i);
-            uint64_t addr = runtime->host_api.upload_kernel_binary(func_id,
-                reinterpret_cast<const uint8_t*>(&kernel),
-                CoreCallable::binary_data_offset() + kernel.binary_size());
+            const auto &kernel = callable->child(i);
+            uint64_t addr = runtime->host_api.upload_kernel_binary(
+                func_id, reinterpret_cast<const uint8_t *>(&kernel),
+                CoreCallable::binary_data_offset() + kernel.binary_size()
+            );
             if (addr == 0) {
                 LOG_ERROR("Failed to upload kernel binary for func_id=%d", func_id);
                 return -1;
@@ -91,9 +92,9 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
         }
     }
 
-    const uint8_t* orch_so_binary = static_cast<const uint8_t*>(callable->binary_data());
+    const uint8_t *orch_so_binary = static_cast<const uint8_t *>(callable->binary_data());
     size_t orch_so_size = callable->binary_size();
-    const char* orch_func_name = callable->func_name();
+    const char *orch_func_name = callable->func_name();
 
     if (orch_so_binary == nullptr || orch_so_size == 0 || orch_func_name[0] == '\0') {
         LOG_ERROR("Invalid orchestration parameters");
@@ -119,7 +120,7 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
     }
     close(fd);
 
-    void* handle = dlopen(fd_path, RTLD_NOW | RTLD_LOCAL);
+    void *handle = dlopen(fd_path, RTLD_NOW | RTLD_LOCAL);
     unlink(fd_path);
     if (handle == nullptr) {
         LOG_ERROR("dlopen failed: %s", dlerror());
@@ -128,7 +129,7 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
 
     dlerror();  // Clear any existing error
     OrchestrationFunc orch_func = reinterpret_cast<OrchestrationFunc>(dlsym(handle, orch_func_name));
-    const char* dlsym_error = dlerror();
+    const char *dlsym_error = dlerror();
     if (dlsym_error != nullptr) {
         LOG_ERROR("dlsym failed for '%s': %s", orch_func_name, dlsym_error);
         dlclose(handle);
@@ -142,10 +143,10 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
 
     LOG_INFO("=== Calling Orchestration Function ===");
 
-    LOG_DEBUG("Args count: %d (%d tensors + %d scalars)",
-        orch_args->tensor_count() + orch_args->scalar_count(),
-        orch_args->tensor_count(),
-        orch_args->scalar_count());
+    LOG_DEBUG(
+        "Args count: %d (%d tensors + %d scalars)", orch_args->tensor_count() + orch_args->scalar_count(),
+        orch_args->tensor_count(), orch_args->scalar_count()
+    );
 
     // Call orchestration function to build task graph
     // The orchestration function handles device memory allocation and copy-to-device
@@ -176,7 +177,7 @@ int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const Chip
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-int validate_runtime_impl(Runtime* runtime) {
+int validate_runtime_impl(Runtime *runtime) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -187,11 +188,11 @@ int validate_runtime_impl(Runtime* runtime) {
     LOG_INFO("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair* tensor_pairs = runtime->get_tensor_pairs();
+    TensorPair *tensor_pairs = runtime->get_tensor_pairs();
     int tensor_pair_count = runtime->get_tensor_pair_count();
 
     for (int i = 0; i < tensor_pair_count; i++) {
-        const TensorPair& pair = tensor_pairs[i];
+        const TensorPair &pair = tensor_pairs[i];
         int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, pair.dev_ptr, pair.size);
         if (copy_rc != 0) {
             LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Runtime Class - Implementation
  *
@@ -48,7 +58,7 @@ Runtime::Runtime() {
 // Task Management
 // =============================================================================
 
-int Runtime::add_task(uint64_t* args, int num_args, int func_id, CoreType core_type) {
+int Runtime::add_task(uint64_t *args, int num_args, int func_id, CoreType core_type) {
     // Check bounds
     if (next_task_id >= RUNTIME_MAX_TASKS) {
         LOG_ERROR("[Runtime] Task table full (max=%d)", RUNTIME_MAX_TASKS);
@@ -62,7 +72,7 @@ int Runtime::add_task(uint64_t* args, int num_args, int func_id, CoreType core_t
 
     // Allocate task
     int task_id = next_task_id++;
-    Task* task = &tasks[task_id];
+    Task *task = &tasks[task_id];
 
     // Initialize task fields
     task->task_id = task_id;
@@ -71,8 +81,8 @@ int Runtime::add_task(uint64_t* args, int num_args, int func_id, CoreType core_t
     if (args && num_args > 0) {
         memcpy(task->args, args, num_args * sizeof(uint64_t));
     }
-    task->function_bin_addr = 0;    // Will be set by host before copying to device
-    task->core_type = core_type;    // Set core type
+    task->function_bin_addr = 0;  // Will be set by host before copying to device
+    task->core_type = core_type;  // Set core type
     task->fanin = 0;
     task->fanout_count = 0;
     memset(task->fanout, 0, sizeof(task->fanout));
@@ -92,8 +102,8 @@ void Runtime::add_successor(int from_task, int to_task) {
         return;
     }
 
-    Task* from = &tasks[from_task];
-    Task* to = &tasks[to_task];
+    Task *from = &tasks[from_task];
+    Task *to = &tasks[to_task];
 
     // Add to_task to from_task's fanout
     if (from->fanout_count >= RUNTIME_MAX_FANOUT) {
@@ -109,7 +119,7 @@ void Runtime::add_successor(int from_task, int to_task) {
 // Query Methods
 // =============================================================================
 
-Task* Runtime::get_task(int task_id) {
+Task *Runtime::get_task(int task_id) {
     if (task_id < 0 || task_id >= next_task_id) {
         return nullptr;
     }
@@ -118,7 +128,7 @@ Task* Runtime::get_task(int task_id) {
 
 int Runtime::get_task_count() const { return next_task_id; }
 
-int Runtime::get_initial_ready_tasks(int* ready_tasks) {
+int Runtime::get_initial_ready_tasks(int *ready_tasks) {
     initial_ready_count = 0;
     for (int i = 0; i < next_task_id; i++) {
         if (tasks[i].fanin == 0) {
@@ -145,7 +155,7 @@ void Runtime::print_runtime() const {
     // Print initially ready tasks
     LOG_DEBUG("\nInitially Ready Tasks (fanin==0):");
     LOG_DEBUG("----------------------------------------------------------------------");
-    
+
     // Build ready tasks string
     char ready_tasks_str[1024] = "  ";
     int offset = 2;
@@ -169,23 +179,22 @@ void Runtime::print_runtime() const {
     LOG_DEBUG("----------------------------------------------------------------------");
 
     for (int i = 0; i < next_task_id; i++) {
-        const Task* t = &tasks[i];
+        const Task *t = &tasks[i];
 
         // Build fanout string
         char fanout_str[512];
         int fo_offset = 0;
         for (int j = 0; j < t->fanout_count && fo_offset < 500; j++) {
-            fo_offset += snprintf(fanout_str + fo_offset, sizeof(fanout_str) - fo_offset, 
-                                  "%d%s", t->fanout[j], j < t->fanout_count - 1 ? "," : "");
+            fo_offset += snprintf(
+                fanout_str + fo_offset, sizeof(fanout_str) - fo_offset, "%d%s", t->fanout[j],
+                j < t->fanout_count - 1 ? "," : ""
+            );
         }
 
-        LOG_DEBUG("  Task %d: func_id=%d, fanin=%d, fanout=%d, args=%d [%s]",
-            i,
-            t->func_id,
-            t->fanin.load(),
-            t->fanout_count,
-            t->num_args,
-            fanout_str);
+        LOG_DEBUG(
+            "  Task %d: func_id=%d, fanin=%d, fanout=%d, args=%d [%s]", i, t->func_id, t->fanin.load(), t->fanout_count,
+            t->num_args, fanout_str
+        );
     }
 
     LOG_DEBUG("========================================================================");
@@ -195,7 +204,7 @@ void Runtime::print_runtime() const {
 // Tensor Pair Management
 // =============================================================================
 
-void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
+void Runtime::record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size) {
     if (tensor_pair_count >= RUNTIME_MAX_TENSOR_PAIRS) {
         LOG_ERROR("[Runtime] Tensor pairs full (max=%d)", RUNTIME_MAX_TENSOR_PAIRS);
         return;
@@ -207,14 +216,8 @@ void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
     LOG_DEBUG("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
 }
 
-TensorPair* Runtime::get_tensor_pairs() {
-    return tensor_pairs;
-}
+TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
 
-int Runtime::get_tensor_pair_count() const {
-    return tensor_pair_count;
-}
+int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
-void Runtime::clear_tensor_pairs() {
-    tensor_pair_count = 0;
-}
+void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -130,8 +130,8 @@ struct Handshake {
  * Used for copy-back during finalize.
  */
 struct TensorPair {
-    void* host_ptr;
-    void* dev_ptr;
+    void *host_ptr;
+    void *dev_ptr;
     size_t size;
 };
 
@@ -140,11 +140,11 @@ struct TensorPair {
  * Allows runtime to use pluggable device memory backends.
  */
 struct HostApi {
-    void* (*device_malloc)(size_t size);
-    void (*device_free)(void* dev_ptr);
-    int (*copy_to_device)(void* dev_ptr, const void* host_ptr, size_t size);
-    int (*copy_from_device)(void* host_ptr, const void* dev_ptr, size_t size);
-    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t* bin_data, size_t bin_size);
+    void *(*device_malloc)(size_t size);
+    void (*device_free)(void *dev_ptr);
+    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
+    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t *bin_data, size_t bin_size);
     void (*remove_kernel_binary)(int func_id);
 };
 
@@ -193,7 +193,7 @@ typedef struct {
  * Dependencies are managed manually via add_successor().
  */
 class Runtime {
- public:
+public:
     // Handshake buffers for AICPU-AICore communication
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
@@ -209,7 +209,7 @@ class Runtime {
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
 
- private:
+private:
     int next_task_id;  // Next available task ID
 
     // Initial ready tasks (computed once, read-only after)
@@ -227,7 +227,7 @@ class Runtime {
     int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
     int registered_kernel_count_;
 
- public:
+public:
     /**
      * Constructor - zero-initialize all arrays
      */
@@ -246,7 +246,7 @@ class Runtime {
      * @param core_type Core type for this task (CoreType::AIC or CoreType::AIV)
      * @return Task ID (>= 0) on success, -1 on failure
      */
-    int add_task(uint64_t* args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
+    int add_task(uint64_t *args, int num_args, int func_id, CoreType core_type = CoreType::AIC);
 
     /**
      * Add a dependency edge: from_task -> to_task
@@ -269,7 +269,7 @@ class Runtime {
      * @param task_id  Task ID to query
      * @return Pointer to task, or nullptr if invalid ID
      */
-    Task* get_task(int task_id);
+    Task *get_task(int task_id);
 
     /**
      * Get the total number of tasks in the runtime
@@ -289,7 +289,7 @@ class Runtime {
      * nullptr)
      * @return Number of initially ready tasks
      */
-    int get_initial_ready_tasks(int* ready_tasks);
+    int get_initial_ready_tasks(int *ready_tasks);
 
     // =========================================================================
     // Utility Methods
@@ -313,14 +313,14 @@ class Runtime {
      * @param dev_ptr   Device memory pointer (source for copy-back)
      * @param size     Size of tensor in bytes
      */
-    void record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size);
+    void record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size);
 
     /**
      * Get pointer to tensor pairs array.
      *
      * @return Pointer to tensor pairs array
      */
-    TensorPair* get_tensor_pairs();
+    TensorPair *get_tensor_pairs();
 
     /**
      * Get number of recorded tensor pairs.
@@ -342,7 +342,7 @@ class Runtime {
      * Set PTO2 shared memory pointer (stub for host_build_graph).
      * This is a no-op for host orchestration; only used by rt2.
      */
-    void set_pto2_gm_sm_ptr(void*) { /* no-op */ }
+    void set_pto2_gm_sm_ptr(void *) { /* no-op */ }
 
     /**
      * Get function binary address by func_id.

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -22,7 +22,7 @@
  * All kernels follow the same signature: void kernel(__gm__ int64_t* args)
  * This enables simple, switch-free dispatch.
  */
-typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
+typedef void (*UnifiedKernelFunc)(__gm__ int64_t *);
 
 /**
  * Execute task from PTO2DispatchPayload.
@@ -31,13 +31,13 @@ typedef void (*UnifiedKernelFunc)(__gm__ int64_t*);
  *
  * @param payload Pointer to PTO2DispatchPayload in global memory
  */
-__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload* payload) {
+__aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2DispatchPayload *payload) {
     if (payload == nullptr || payload->function_bin_addr == 0) {
         return;
     }
 
     UnifiedKernelFunc kernel = (UnifiedKernelFunc)payload->function_bin_addr;
-    kernel(reinterpret_cast<__gm__ int64_t*>(payload->args));
+    kernel(reinterpret_cast<__gm__ int64_t *>(payload->args));
     OUT_OF_ORDER_STORE_BARRIER();
 }
 
@@ -59,8 +59,8 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * @param core_idx Block index (core ID)
  * @param core_type Core type (AIC or AIV)
  */
-__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type) {
-    __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[core_idx]);
+__aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, int core_idx, CoreType core_type) {
+    __gm__ Handshake *my_hank = (__gm__ Handshake *)(&runtime->workers[core_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
@@ -86,7 +86,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
     // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
-    __gm__ PTO2DispatchPayload* payload = reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
+    __gm__ PTO2DispatchPayload *payload = reinterpret_cast<__gm__ PTO2DispatchPayload *>(my_hank->task);
 
     bool profiling_enabled = runtime->enable_profiling;
 
@@ -126,7 +126,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             // Performance profiling: record task execution
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
-                __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;
+                __gm__ PerfBuffer *perf_buf = (__gm__ PerfBuffer *)my_hank->perf_records_addr;
                 perf_aicore_record_task(perf_buf, task_id, start_time, end_time);
             }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -68,15 +68,14 @@
 // The executor binds the current thread's PTO2Runtime into orchestration TLS
 // before calling the user entry.
 typedef void (*DeviceOrchestrationFunc)(
-    const ChipStorageTaskArgs& orch_args, int32_t orch_thread_num, int32_t orch_thread_index);
-typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime* rt);
+    const ChipStorageTaskArgs &orch_args, int32_t orch_thread_num, int32_t orch_thread_index
+);
+typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 
 // Config function exported by orchestration .so
-typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs& orch_args);
+typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs &orch_args);
 
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
-constexpr int32_t MAX_AIC_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD;
-constexpr int32_t MAX_AIV_PER_THREAD = PLATFORM_MAX_AIV_PER_THREAD;
 constexpr int32_t MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 
 constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
@@ -88,7 +87,7 @@ constexpr int32_t STALL_DUMP_CORE_MAX = 8;
 constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
 constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
 
-static PTO2Runtime* rt{nullptr};
+static PTO2Runtime *rt{nullptr};
 
 // Per-core dispatch payload storage (one aligned cache line per physical core)
 static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
@@ -98,7 +97,7 @@ static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
 struct alignas(64) CoreExecState {
     // --- Hot fields (completion + dispatch, every iteration) ---
     uint64_t reg_addr;                        // offset  0: register address (set once in handshake)
-    PTO2TaskSlotState* executing_slot_state;  // offset  8: slot state for running task
+    PTO2TaskSlotState *executing_slot_state;  // offset  8: slot state for running task
     int32_t executing_reg_task_id;            // offset 16: register task ID (AICPU_TASK_INVALID = idle)
     uint32_t dispatch_seq;                    // offset 20: monotonic dispatch counter
     PTO2SubtaskSlot executing_subslot;        // offset 24: which subtask slot is running
@@ -121,29 +120,30 @@ static_assert(sizeof(CoreExecState) == 64, "CoreExecState must occupy exactly on
 //   bit i*3+2 = AIV1 of cluster i
 // Max 21 clusters per tracker (63 bits in uint64_t).
 class alignas(64) CoreTracker {
- public:
+public:
     static inline int32_t MAX_CORE_PER_THREAD = 63;
     static constexpr int32_t MAX_CLUSTERS = 63 / 3;
 
- public:
+public:
     CoreTracker() = default;
 
     class BitStates {
-     public:  // NOLINT(whitespace/indent)
+    public:  // NOLINT(whitespace/indent)
         BitStates() = default;
 
-        explicit BitStates(uint64_t states) : states_(states) {}
+        explicit BitStates(uint64_t states) :
+            states_(states) {}
         void init() { states_ = 0; }
 
         BitStates operator~() const { return BitStates(~states_); }
-        BitStates operator&(const BitStates& other) const { return BitStates(states_ & other.states_); }
-        BitStates operator|(const BitStates& other) const { return BitStates(states_ | other.states_); }
-        BitStates operator^(const BitStates& other) const { return BitStates(states_ ^ other.states_); }
+        BitStates operator&(const BitStates &other) const { return BitStates(states_ & other.states_); }
+        BitStates operator|(const BitStates &other) const { return BitStates(states_ | other.states_); }
+        BitStates operator^(const BitStates &other) const { return BitStates(states_ ^ other.states_); }
         BitStates operator>>(int32_t offset) const { return BitStates(states_ >> offset); }
         BitStates operator<<(int32_t offset) const { return BitStates(states_ << offset); }
-        void operator&=(const BitStates& other) { states_ &= other.states_; }
-        void operator|=(const BitStates& other) { states_ |= other.states_; }
-        void operator^=(const BitStates& other) { states_ ^= other.states_; }
+        void operator&=(const BitStates &other) { states_ &= other.states_; }
+        void operator|=(const BitStates &other) { states_ |= other.states_; }
+        void operator^=(const BitStates &other) { states_ ^= other.states_; }
 
         bool has_value() const { return states_ > 0; }
         int32_t count() const { return __builtin_popcountll(states_); }
@@ -157,11 +157,11 @@ class alignas(64) CoreTracker {
             return pos;
         }
 
-     private:  // NOLINT(whitespace/indent)
+    private:  // NOLINT(whitespace/indent)
         uint64_t states_{0};
     };
 
- public:
+public:
     void init(int32_t cluster_count) {
         cluster_count_ = cluster_count;
         aic_mask_.init();
@@ -220,12 +220,12 @@ class alignas(64) CoreTracker {
 
     BitStates get_valid_cluster_offset_states(PTO2ResourceShape shape) const {
         switch (shape) {
-            case PTO2ResourceShape::AIC:
-                return core_states_ & aic_mask_;
-            case PTO2ResourceShape::AIV:
-                return ((core_states_ >> 1) | (core_states_ >> 2)) & aic_mask_;
-            case PTO2ResourceShape::MIX:
-                return (core_states_ >> 1) & (core_states_ >> 2) & core_states_ & aic_mask_;
+        case PTO2ResourceShape::AIC:
+            return core_states_ & aic_mask_;
+        case PTO2ResourceShape::AIV:
+            return ((core_states_ >> 1) | (core_states_ >> 2)) & aic_mask_;
+        case PTO2ResourceShape::MIX:
+            return (core_states_ >> 1) & (core_states_ >> 2) & core_states_ & aic_mask_;
         }
         return BitStates(0ULL);
     }
@@ -257,7 +257,7 @@ class alignas(64) CoreTracker {
 
     int32_t get_core_id_by_offset(int32_t offset) const { return core_id_map_[offset]; }
 
- private:
+private:
     int32_t cluster_count_;
     BitStates aic_mask_;
     BitStates aiv_mask_;
@@ -318,68 +318,59 @@ struct AicpuExecutor {
     std::atomic<bool> completed_{false};
 
     // Orchestration SO handle - defer dlclose until all tasks complete
-    void* orch_so_handle_{nullptr};
+    void *orch_so_handle_{nullptr};
     char orch_so_path_[256]{};  // Path to orchestration SO file for cleanup
 
     // Shared orchestration function pointer (loaded by first orch thread, used by all)
     DeviceOrchestrationFunc orch_func_{nullptr};
     DeviceOrchestrationBindRuntimeFunc orch_bind_runtime_{nullptr};
-    const ChipStorageTaskArgs* orch_args_cached_{nullptr};
+    const ChipStorageTaskArgs *orch_args_cached_{nullptr};
 
-    uint64_t* func_id_to_addr_;
+    uint64_t *func_id_to_addr_;
     uint64_t get_function_bin_addr(int func_id) const {
         if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
         return func_id_to_addr_[func_id];
     }
 
     // ===== Methods =====
-    int32_t init(Runtime* runtime);
-    int32_t handshake_all_cores(Runtime* runtime);
+    int32_t init(Runtime *runtime);
+    int32_t handshake_all_cores(Runtime *runtime);
     bool assign_cores_to_threads();
     void reassign_cores_for_all_threads();
-    int32_t resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx);
-    int32_t shutdown_aicore(Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num);
-    int32_t run(Runtime* runtime);
-    void deinit(Runtime* runtime);
-    void emergency_shutdown(Runtime* runtime);
+    int32_t resolve_and_dispatch_pto2(Runtime *runtime, int32_t thread_idx);
+    int32_t shutdown_aicore(Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num);
+    int32_t run(Runtime *runtime);
+    void deinit(Runtime *runtime);
+    void emergency_shutdown(Runtime *runtime);
     void diagnose_stuck_state(
-        Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank);
+        Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
+    );
 
     template <CoreType CT>
-    void check_running_cores_for_completion(int32_t thread_idx,
-        Handshake* hank,
-        int32_t& completed_this_turn,
-        int32_t& cur_thread_completed,
-        bool& made_progress,
-        PTO2TaskSlotState* deferred_release_slot_states[],
-        int32_t& deferred_release_count,
-        PTO2LocalReadyBuffer* local_bufs
+    void check_running_cores_for_completion(
+        int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
+        bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
+        PTO2LocalReadyBuffer *local_bufs
 #if PTO2_PROFILING
         ,
-        bool profiling_enabled,
-        uint32_t& phase_complete_count
+        bool profiling_enabled, uint32_t &phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
         ,
-        uint64_t& complete_probe_count,
-        uint64_t& complete_hit_count,
-        uint64_t& notify_edges_total,
-        int32_t& notify_max_degree,
-        uint64_t& notify_tasks_enqueued,
-        uint64_t& fanin_edges_total,
-        int32_t& fanin_max_degree,
-        uint64_t& sched_complete_perf_cycle
+        uint64_t &complete_probe_count, uint64_t &complete_hit_count, uint64_t &notify_edges_total,
+        int32_t &notify_max_degree, uint64_t &notify_tasks_enqueued, uint64_t &fanin_edges_total,
+        int32_t &fanin_max_degree, uint64_t &sched_complete_perf_cycle
 #endif
     ) {
 #if !PTO2_PROFILING
         (void)hank;  // NOLINT(readability/casting)
 #endif
-        CoreTracker& tracker = core_trackers_[thread_idx];
+        CoreTracker &tracker = core_trackers_[thread_idx];
         auto running_core_states = tracker.get_running_cores<CT>();
         while (running_core_states.has_value()) {
             int32_t bit_pos = running_core_states.pop_first();
             int32_t core_id = tracker.get_core_id_by_offset(bit_pos);
-            CoreExecState& core_exec_state = core_exec_states_[core_id];
+            CoreExecState &core_exec_state = core_exec_states_[core_id];
             uint64_t reg_addr = core_exec_state.reg_addr;
 
             int32_t expected_reg_task_id = core_exec_state.executing_reg_task_id;
@@ -399,7 +390,7 @@ struct AicpuExecutor {
             if (done) {
                 core_exec_state.executing_reg_task_id = AICPU_TASK_INVALID;
                 PTO2SubtaskSlot subslot = core_exec_state.executing_subslot;
-                PTO2TaskSlotState& slot_state = *core_exec_state.executing_slot_state;
+                PTO2TaskSlotState &slot_state = *core_exec_state.executing_slot_state;
 
                 // Two-stage completion: mark subtask done, then handle mixed-task completion
                 bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state, subslot);
@@ -424,7 +415,8 @@ struct AicpuExecutor {
                         while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
                             int32_t fe = rt->scheduler.on_task_release(
-                                *deferred_release_slot_states[--deferred_release_count], thread_idx);
+                                *deferred_release_slot_states[--deferred_release_count], thread_idx
+                            );
 #else
                             int32_t fe =
                                 rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
@@ -444,32 +436,29 @@ struct AicpuExecutor {
 #if PTO2_SCHED_PROFILING
                     uint64_t t_perf_start = get_sys_cnt_aicpu();
 #endif
-                    Handshake* h = &hank[core_id];
+                    Handshake *h = &hank[core_id];
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    PerfBuffer* perf_buf = reinterpret_cast<PerfBuffer*>(h->perf_records_addr);
+                    PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
 
                     // Pre-extract fanout (platform layer cannot depend on PTO2DepListEntry)
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     int32_t fanout_n = 0;
-                    PTO2DepListEntry* cur = slot_state.fanout_head;
+                    PTO2DepListEntry *cur = slot_state.fanout_head;
                     while (cur != nullptr && fanout_n < RUNTIME_MAX_FANOUT) {
                         fanout_arr[fanout_n++] = cur->slot_state->task->task_id.raw;
                         cur = cur->next;
                     }
 
                     int32_t perf_slot_idx = static_cast<int32_t>(core_exec_state.executing_subslot);
-                    if (perf_aicpu_complete_record(perf_buf,
-                            static_cast<uint32_t>(expected_reg_task_id),
-                            slot_state.task->task_id.raw,
-                            slot_state.task->kernel_id[perf_slot_idx],
-                            CT,
-                            core_exec_state.dispatch_timestamp,
-                            finish_ts,
-                            fanout_arr,
-                            fanout_n) != 0) {
-                        DEV_ERROR("Core %d: perf_aicpu_complete_record failed for task 0x%" PRIx64,
-                            core_id,
-                            static_cast<uint64_t>(slot_state.task->task_id.raw));
+                    if (perf_aicpu_complete_record(
+                            perf_buf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
+                            slot_state.task->kernel_id[perf_slot_idx], CT, core_exec_state.dispatch_timestamp,
+                            finish_ts, fanout_arr, fanout_n
+                        ) != 0) {
+                        DEV_ERROR(
+                            "Core %d: perf_aicpu_complete_record failed for task 0x%" PRIx64, core_id,
+                            static_cast<uint64_t>(slot_state.task->task_id.raw)
+                        );
                     }
 #if PTO2_SCHED_PROFILING
                     sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
@@ -477,12 +466,10 @@ struct AicpuExecutor {
                 }
 #endif
 
-                DEV_DEBUG("Thread %d: %s core %d completed PTO2 task %d (mixed_complete=%d)",
-                    thread_idx,
-                    CT == CoreType::AIC ? "AIC" : "AIV",
-                    core_id,
-                    expected_reg_task_id,
-                    mixed_complete ? 1 : 0);
+                DEV_DEBUG(
+                    "Thread %d: %s core %d completed PTO2 task %d (mixed_complete=%d)", thread_idx,
+                    CT == CoreType::AIC ? "AIC" : "AIV", core_id, expected_reg_task_id, mixed_complete ? 1 : 0
+                );
                 cur_thread_completed++;
                 if (mixed_complete) {
                     completed_this_turn++;
@@ -492,14 +479,14 @@ struct AicpuExecutor {
         }
     }
 
-    static const char* shape_name(PTO2ResourceShape shape) {
+    static const char *shape_name(PTO2ResourceShape shape) {
         switch (shape) {
-            case PTO2ResourceShape::AIC:
-                return "AIC";
-            case PTO2ResourceShape::AIV:
-                return "AIV";
-            case PTO2ResourceShape::MIX:
-                return "MIX";
+        case PTO2ResourceShape::AIC:
+            return "AIC";
+        case PTO2ResourceShape::AIV:
+            return "AIV";
+        case PTO2ResourceShape::MIX:
+            return "MIX";
         }
         return "UNKNOWN";
     }
@@ -510,7 +497,7 @@ struct AicpuExecutor {
      * Even/odd threads use different fallback orders (AIC-first vs AIV-first)
      * to reduce contention on the same ready queue across adjacent threads.
      */
-    static const PTO2ResourceShape* get_dispatch_order(int32_t thread_idx) {
+    static const PTO2ResourceShape *get_dispatch_order(int32_t thread_idx) {
         // Even threads: AIC-first fallback after widest
         static constexpr PTO2ResourceShape kEvenOrder[PTO2_NUM_RESOURCE_SHAPES] = {
             PTO2ResourceShape::MIX,
@@ -526,30 +513,22 @@ struct AicpuExecutor {
         return (thread_idx % 2 == 0) ? kEvenOrder : kOddOrder;
     }
 
-    int pop_ready_tasks_batch(PTO2ResourceShape shape,
-        int32_t thread_idx,
-        PTO2LocalReadyBuffer& local_buf,
-        PTO2TaskSlotState** out,
+    int pop_ready_tasks_batch(
+        PTO2ResourceShape shape, int32_t thread_idx, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out,
         int max_count
 #if PTO2_SCHED_PROFILING
         ,
-        uint64_t& pop_hit,
-        uint64_t& pop_miss,
-        uint64_t& local_dispatch_count,
-        uint64_t& sched_dispatch_pop_cycle
+        uint64_t &pop_hit, uint64_t &pop_miss, uint64_t &local_dispatch_count, uint64_t &sched_dispatch_pop_cycle
 #endif
     ) {
         (void)thread_idx;  // NOLINT(readability/casting)
 #if PTO2_SCHED_PROFILING
         extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
         uint64_t t_pop_start = get_sys_cnt_aicpu();
-        int count = rt->scheduler.get_ready_tasks_batch(shape,
-            local_buf,
-            out,
-            max_count,
-            g_sched_pop_atomic_count[thread_idx],
-            g_sched_pop_wait_cycle[thread_idx],
-            local_dispatch_count);
+        int count = rt->scheduler.get_ready_tasks_batch(
+            shape, local_buf, out, max_count, g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx],
+            local_dispatch_count
+        );
         sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
         if (count > 0) {
             pop_hit += count;
@@ -562,26 +541,24 @@ struct AicpuExecutor {
         return count;
     }
 
-    void dispatch_subtask_to_core(Runtime* runtime,
-        int32_t thread_idx,
-        int32_t core_offset,
-        PTO2TaskSlotState& slot_state,
+    void dispatch_subtask_to_core(
+        Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,
         PTO2SubtaskSlot subslot
 #if PTO2_PROFILING
         ,
         bool profiling_enabled
 #endif
     ) {
-        CoreTracker& tracker = core_trackers_[thread_idx];
+        CoreTracker &tracker = core_trackers_[thread_idx];
         auto core_id = tracker.get_core_id_by_offset(core_offset);
 #if !PTO2_PROFILING
         (void)runtime;  // NOLINT(readability/casting)
 #endif
-        CoreExecState& core_exec_state = core_exec_states_[core_id];
-        PTO2DispatchPayload& payload = s_pto2_payload_per_core[core_id];
+        CoreExecState &core_exec_state = core_exec_states_[core_id];
+        PTO2DispatchPayload &payload = s_pto2_payload_per_core[core_id];
         int32_t slot_idx = static_cast<int32_t>(subslot);
         uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
-        const CoreCallable* callable = reinterpret_cast<const CoreCallable*>(callable_addr);
+        const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
         payload.function_bin_addr = callable->resolved_addr();
         payload.args = slot_state.payload->dispatch_args;
         core_exec_state.executing_subslot = subslot;
@@ -625,8 +602,8 @@ static AicpuExecutor g_aicpu_executor;
  * Handshake with all cores and discover their types
  * Sets up register addresses for fast dispatch.
  */
-int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+int32_t AicpuExecutor::handshake_all_cores(Runtime *runtime) {
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     cores_total_num_ = runtime->worker_count;
 
     // Validate cores_total_num_ before using as array index
@@ -655,33 +632,31 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime* runtime) {
     // Step 2: Wait for all cores to respond, collect core type and register addresses
     bool handshake_failed = false;
     for (int32_t i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_handshakes[i];
+        Handshake *hank = &all_handshakes[i];
 
-        while (hank->aicore_regs_ready == 0) {
-        }
+        while (hank->aicore_regs_ready == 0) {}
 
         uint32_t physical_core_id = hank->physical_core_id;
 
         // Validate physical_core_id before using as array index
         if (physical_core_id >= max_physical_cores_count) {
-            DEV_ERROR("Core %d reported invalid physical_core_id=%u (platform max=%u)",
-                i,
-                physical_core_id,
-                max_physical_cores_count);
+            DEV_ERROR(
+                "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
+                max_physical_cores_count
+            );
             handshake_failed = true;
             continue;
         }
 
         // Get register address using physical_core_id
-        uint64_t* regs = reinterpret_cast<uint64_t*>(regs_);
+        uint64_t *regs = reinterpret_cast<uint64_t *>(regs_);
         uint64_t reg_addr = regs[physical_core_id];
 
         // Initialize AICore registers after discovery (first round)
         platform_init_aicore_regs(reg_addr);
         hank->aicpu_regs_ready = 1;
 
-        while (hank->aicore_done == 0) {
-        }
+        while (hank->aicore_done == 0) {}
 
         CoreType type = hank->core_type;
 
@@ -727,11 +702,10 @@ bool AicpuExecutor::assign_cores_to_threads() {
         return false;
     }
 
-    DEV_INFO("Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)",
-        cluster_count,
-        divisor,
-        aic_count_,
-        aiv_count_);
+    DEV_INFO(
+        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count, divisor,
+        aic_count_, aiv_count_
+    );
 
     for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
         core_exec_states_[i].executing_reg_task_id = AICPU_TASK_INVALID;
@@ -758,7 +732,7 @@ bool AicpuExecutor::assign_cores_to_threads() {
 
     for (int32_t ci = 0; ci < cluster_count; ci++) {
         int32_t t = ci % divisor;
-        int32_t& idx = core_idx[t];
+        int32_t &idx = core_idx[t];
 
         int32_t aic_wid = aic_worker_ids_[ci];
         int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
@@ -845,16 +819,14 @@ void AicpuExecutor::reassign_cores_for_all_threads() {
     for (int32_t t = 0; t < thread_num_; t++) {
         int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
         int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
-        DEV_INFO("  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)",
-            t,
-            core_count_per_thread_[t],
-            core_trackers_[t].get_cluster_count(),
-            aic_running,
-            aiv_running);
+        DEV_INFO(
+            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_count_per_thread_[t],
+            core_trackers_[t].get_cluster_count(), aic_running, aiv_running
+        );
     }
 }
 
-int32_t AicpuExecutor::init(Runtime* runtime) {
+int32_t AicpuExecutor::init(Runtime *runtime) {
     bool expected = false;
     if (!initialized_.compare_exchange_strong(expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
         return 0;
@@ -880,7 +852,8 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
     if (!orch_to_sched_ && sched_thread_num_ == 0) {
         DEV_ERROR(
             "no scheduler and orch not trans to schedulers when finished, maybe you need set env PTO2_ORCH_TO_SCHED=1 "
-            "or scale down orch number.");
+            "or scale down orch number."
+        );
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -912,7 +885,7 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
     // Initialize runtime execution state
     // Task count comes from PTO2 shared memory
     if (runtime->get_pto2_gm_sm_ptr()) {
-        auto* header = static_cast<PTO2SharedMemoryHeader*>(runtime->get_pto2_gm_sm_ptr());
+        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_pto2_gm_sm_ptr());
         int32_t pto2_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
@@ -945,7 +918,8 @@ int32_t AicpuExecutor::init(Runtime* runtime) {
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
 int32_t AicpuExecutor::shutdown_aicore(
-    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num) {
+    Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num
+) {
     (void)runtime;  // NOLINT(readability/casting)
     if (core_num == 0) return 0;
 
@@ -964,30 +938,30 @@ int32_t AicpuExecutor::shutdown_aicore(
     return 0;
 }
 
-int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t thread_idx) {
-    int32_t& core_num = core_count_per_thread_[thread_idx];
-    CoreTracker& tracker = core_trackers_[thread_idx];
+int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t thread_idx) {
+    int32_t &core_num = core_count_per_thread_[thread_idx];
+    CoreTracker &tracker = core_trackers_[thread_idx];
     DEV_INFO("Thread %d: resolve_and_dispatch_pto2 entry", thread_idx);
 
-    void* sm_base = runtime->get_pto2_gm_sm_ptr();
+    void *sm_base = runtime->get_pto2_gm_sm_ptr();
     if (!sm_base) {
         DEV_ERROR("PTO2 dispatch: sm_base is null");
         return -1;
     }
     DEV_INFO("Thread %d: sm_base=%p", thread_idx, sm_base);
 
-    PTO2SharedMemoryHeader* header = static_cast<PTO2SharedMemoryHeader*>(sm_base);
-    DEV_INFO("Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu",
-        thread_idx,
-        static_cast<void*>(header),
+    PTO2SharedMemoryHeader *header = static_cast<PTO2SharedMemoryHeader *>(sm_base);
+    DEV_INFO(
+        "Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu", thread_idx, static_cast<void *>(header),
         static_cast<uint64_t>(header->rings[0].task_descriptors_offset),
-        static_cast<uint64_t>(header->rings[0].task_window_size));
+        static_cast<uint64_t>(header->rings[0].task_window_size)
+    );
 
-    Handshake* hank = static_cast<Handshake*>(runtime->workers);
-    DEV_INFO("Thread %d: hank=%p, window_size=%lu",
-        thread_idx,
-        static_cast<void*>(hank),
-        static_cast<uint64_t>(header->rings[0].task_window_size));
+    Handshake *hank = static_cast<Handshake *>(runtime->workers);
+    DEV_INFO(
+        "Thread %d: hank=%p, window_size=%lu", thread_idx, static_cast<void *>(hank),
+        static_cast<uint64_t>(header->rings[0].task_window_size)
+    );
 
     // One-time init: assign perf buffers (one thread does it; others wait)
     if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
@@ -1050,12 +1024,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     // Local-first dispatch buffers (stack-allocated, one per CoreType per scheduling thread).
     // Initialized once; must be empty at the start of each iteration.
     constexpr int LOCAL_READY_CAP_PER_TYPE = 64;
-    PTO2TaskSlotState* local_ptrs[PTO2_NUM_RESOURCE_SHAPES][LOCAL_READY_CAP_PER_TYPE];
+    PTO2TaskSlotState *local_ptrs[PTO2_NUM_RESOURCE_SHAPES][LOCAL_READY_CAP_PER_TYPE];
     PTO2LocalReadyBuffer local_bufs[PTO2_NUM_RESOURCE_SHAPES];
     for (int32_t i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         local_bufs[i].reset(local_ptrs[i], LOCAL_READY_CAP_PER_TYPE);
     }
-    PTO2TaskSlotState* deferred_release_slot_states[256];
+    PTO2TaskSlotState *deferred_release_slot_states[256];
     int32_t deferred_release_count = 0;
 
     bool cores_released = false;
@@ -1081,10 +1055,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                     DEV_ERROR(
                         "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
                         "completed_tasks=%d, total_tasks=%d",
-                        thread_idx,
-                        orch_err,
-                        completed_tasks_.load(std::memory_order_relaxed),
-                        total_tasks_);
+                        thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
+                    );
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1094,10 +1066,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                 task_count = total_tasks_;
                 if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
                     completed_.store(true, std::memory_order_release);
-                    DEV_INFO("Thread %d: PTO2 completed tasks %d/%d",
-                        thread_idx,
-                        completed_tasks_.load(std::memory_order_relaxed),
-                        task_count);
+                    DEV_INFO(
+                        "Thread %d: PTO2 completed tasks %d/%d", thread_idx,
+                        completed_tasks_.load(std::memory_order_relaxed), task_count
+                    );
                     break;
                 }
             }
@@ -1135,29 +1107,17 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         bool try_completed = false;
         if (tracker.has_running_cores<CoreType::AIC>()) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIC>(thread_idx,
-                hank,
-                completed_this_turn,
-                cur_thread_completed,
-                made_progress,
-                deferred_release_slot_states,
-                deferred_release_count,
-                local_bufs
+            check_running_cores_for_completion<CoreType::AIC>(
+                thread_idx, hank, completed_this_turn, cur_thread_completed, made_progress,
+                deferred_release_slot_states, deferred_release_count, local_bufs
 #if PTO2_PROFILING
                 ,
-                profiling_enabled,
-                phase_complete_count
+                profiling_enabled, phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
                 ,
-                complete_probe_count,
-                complete_hit_count,
-                notify_edges_total,
-                notify_max_degree,
-                notify_tasks_enqueued,
-                fanin_edges_total,
-                fanin_max_degree,
-                sched_complete_perf_cycle
+                complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
 #endif
             );
         }
@@ -1165,29 +1125,17 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // Check AIV running cores
         if (tracker.has_running_cores<CoreType::AIV>()) {
             try_completed = true;
-            check_running_cores_for_completion<CoreType::AIV>(thread_idx,
-                hank,
-                completed_this_turn,
-                cur_thread_completed,
-                made_progress,
-                deferred_release_slot_states,
-                deferred_release_count,
-                local_bufs
+            check_running_cores_for_completion<CoreType::AIV>(
+                thread_idx, hank, completed_this_turn, cur_thread_completed, made_progress,
+                deferred_release_slot_states, deferred_release_count, local_bufs
 #if PTO2_PROFILING
                 ,
-                profiling_enabled,
-                phase_complete_count
+                profiling_enabled, phase_complete_count
 #endif
 #if PTO2_SCHED_PROFILING
                 ,
-                complete_probe_count,
-                complete_hit_count,
-                notify_edges_total,
-                notify_max_degree,
-                notify_tasks_enqueued,
-                fanin_edges_total,
-                fanin_max_degree,
-                sched_complete_perf_cycle
+                complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
 #endif
             );
         }
@@ -1201,10 +1149,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             if (thread_idx == 0 && task_count > 0) {
                 if (new_total <= PROGRESS_VERBOSE_THRESHOLD ||
                     new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL || new_total >= task_count) {
-                    DEV_ALWAYS("PTO2 progress: completed=%d total=%d (%.1f%%)",
-                        new_total,
-                        task_count,
-                        100.0 * new_total / task_count);
+                    DEV_ALWAYS(
+                        "PTO2 progress: completed=%d total=%d (%.1f%%)", new_total, task_count,
+                        100.0 * new_total / task_count
+                    );
                 }
             }
         }
@@ -1216,7 +1164,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             CYCLE_COUNT_LAP(sched_complete_cycle);
             if (profiling_enabled && phase_complete_count > 0) {
                 perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, sched_loop_count, phase_complete_count);
+                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, sched_loop_count, phase_complete_count
+                );
                 _t0_phase = _t1;
                 phase_complete_count = 0;
             }
@@ -1224,35 +1173,29 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #endif
 
         bool try_pushed = false;
-        const PTO2ResourceShape* dispatch_order = get_dispatch_order(thread_idx);
+        const PTO2ResourceShape *dispatch_order = get_dispatch_order(thread_idx);
         for (int32_t si = 0; si < PTO2_NUM_RESOURCE_SHAPES; si++) {
             PTO2ResourceShape shape = dispatch_order[si];
             auto valid_cluster_states = tracker.get_valid_cluster_offset_states(shape);
             if (!valid_cluster_states.has_value()) {
                 continue;
             }
-            auto& local_buf = local_bufs[static_cast<int32_t>(shape)];
+            auto &local_buf = local_bufs[static_cast<int32_t>(shape)];
 
             while (valid_cluster_states.has_value()) {
                 int want = valid_cluster_states.count();
-                PTO2TaskSlotState* batch[CoreTracker::MAX_CLUSTERS];
-                int got = pop_ready_tasks_batch(shape,
-                    thread_idx,
-                    local_buf,
-                    batch,
-                    want
+                PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS];
+                int got = pop_ready_tasks_batch(
+                    shape, thread_idx, local_buf, batch, want
 #if PTO2_SCHED_PROFILING
                     ,
-                    pop_hit,
-                    pop_miss,
-                    local_dispatch_count,
-                    sched_dispatch_pop_cycle
+                    pop_hit, pop_miss, local_dispatch_count, sched_dispatch_pop_cycle
 #endif
                 );
                 if (got == 0) break;
 
                 for (int bi = 0; bi < got; bi++) {
-                    PTO2TaskSlotState* slot_state = batch[bi];
+                    PTO2TaskSlotState *slot_state = batch[bi];
                     try_pushed = true;
 #if PTO2_PROFILING
                     phase_dispatch_count++;
@@ -1267,11 +1210,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         uint8_t mask = slot_state->active_mask;
                         if (mask & PTO2_SUBTASK_MASK_AIC) {
                             auto core_offset = tracker.get_aic_core_offset(current_valid_cluster_offset);
-                            dispatch_subtask_to_core(runtime,
-                                thread_idx,
-                                core_offset,
-                                *slot_state,
-                                PTO2SubtaskSlot::AIC
+                            dispatch_subtask_to_core(
+                                runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                                 ,
                                 profiling_enabled
@@ -1280,11 +1220,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         }
                         if (mask & PTO2_SUBTASK_MASK_AIV0) {
                             auto core_offset = tracker.get_aiv0_core_offset(current_valid_cluster_offset);
-                            dispatch_subtask_to_core(runtime,
-                                thread_idx,
-                                core_offset,
-                                *slot_state,
-                                PTO2SubtaskSlot::AIV0
+                            dispatch_subtask_to_core(
+                                runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                                 ,
                                 profiling_enabled
@@ -1293,11 +1230,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         }
                         if (mask & PTO2_SUBTASK_MASK_AIV1) {
                             auto core_offset = tracker.get_aiv1_core_offset(current_valid_cluster_offset);
-                            dispatch_subtask_to_core(runtime,
-                                thread_idx,
-                                core_offset,
-                                *slot_state,
-                                PTO2SubtaskSlot::AIV1
+                            dispatch_subtask_to_core(
+                                runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
                                 ,
                                 profiling_enabled
@@ -1306,25 +1240,19 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         }
                     } else if (shape == PTO2ResourceShape::AIC) {
                         auto core_offset = tracker.get_aic_core_offset(current_valid_cluster_offset);
-                        dispatch_subtask_to_core(runtime,
-                            thread_idx,
-                            core_offset,
-                            *slot_state,
-                            PTO2SubtaskSlot::AIC
+                        dispatch_subtask_to_core(
+                            runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                             ,
                             profiling_enabled
 #endif
                         );
                     } else {  // shape == PTO2ResourceShape::AIV
-                        auto core_offset = tracker.is_aiv0_core_idle(current_valid_cluster_offset)
-                                               ? tracker.get_aiv0_core_offset(current_valid_cluster_offset)
-                                               : tracker.get_aiv1_core_offset(current_valid_cluster_offset);
-                        dispatch_subtask_to_core(runtime,
-                            thread_idx,
-                            core_offset,
-                            *slot_state,
-                            PTO2SubtaskSlot::AIV0
+                        auto core_offset = tracker.is_aiv0_core_idle(current_valid_cluster_offset) ?
+                                               tracker.get_aiv0_core_offset(current_valid_cluster_offset) :
+                                               tracker.get_aiv1_core_offset(current_valid_cluster_offset);
+                        dispatch_subtask_to_core(
+                            runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                             ,
                             profiling_enabled
@@ -1335,11 +1263,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_SCHED_PROFILING
                     sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
-                    DEV_DEBUG("Thread %d: Dispatching %s task %" PRId64 " to cluster_offset %d",
-                        thread_idx,
-                        shape_name(shape),
-                        static_cast<int64_t>(slot_state->task->task_id.raw),
-                        current_valid_cluster_offset);
+                    DEV_DEBUG(
+                        "Thread %d: Dispatching %s task %" PRId64 " to cluster_offset %d", thread_idx,
+                        shape_name(shape), static_cast<int64_t>(slot_state->task->task_id.raw),
+                        current_valid_cluster_offset
+                    );
                 }
 
                 // lazy update valid_cluster_states
@@ -1352,8 +1280,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
         // requeue in global ready queue
         for (int32_t si = 0; si < PTO2_NUM_RESOURCE_SHAPES; si++) {
             PTO2ResourceShape shape = dispatch_order[si];
-            auto& local_buf = local_bufs[static_cast<int32_t>(shape)];
-            auto& ready_queue = rt->scheduler.ready_queues[static_cast<int32_t>(shape)];
+            auto &local_buf = local_bufs[static_cast<int32_t>(shape)];
+            auto &ready_queue = rt->scheduler.ready_queues[static_cast<int32_t>(shape)];
 #if PTO2_SCHED_PROFILING
             local_overflow_count += local_buf.count;
 #endif
@@ -1370,7 +1298,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             CYCLE_COUNT_LAP(sched_dispatch_cycle);
             if (profiling_enabled && phase_dispatch_count > 0) {
                 perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, sched_loop_count, phase_dispatch_count);
+                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, sched_loop_count, phase_dispatch_count
+                );
                 _t0_phase = _t1;
                 phase_dispatch_count = 0;
             }
@@ -1409,9 +1338,10 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
             if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
                 int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
                 if (orch_err != PTO2_ERROR_NONE) {
-                    DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores",
-                        thread_idx,
-                        orch_err);
+                    DEV_ERROR(
+                        "Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx,
+                        orch_err
+                    );
                     emergency_shutdown(runtime);
                     completed_.store(true, std::memory_order_release);
                     break;
@@ -1420,20 +1350,19 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 
             if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
                 int32_t c = completed_tasks_.load(std::memory_order_relaxed);
-                DEV_ALWAYS("PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
-                    idle_iterations,
-                    c,
-                    task_count,
-                    last_progress_count);
+                DEV_ALWAYS(
+                    "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
+                    idle_iterations, c, task_count, last_progress_count
+                );
                 // Scan all task slots to find truly stuck tasks using scheduler state
-                PTO2SchedulerState* sched = &rt->scheduler;
-                PTO2SharedMemoryHeader* sm_header_diag = static_cast<PTO2SharedMemoryHeader*>(sm_base);
+                PTO2SchedulerState *sched = &rt->scheduler;
+                PTO2SharedMemoryHeader *sm_header_diag = static_cast<PTO2SharedMemoryHeader *>(sm_base);
                 int32_t cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
                     int32_t ring_task_count =
                         sm_header_diag->rings[r].fc.current_task_index.load(std::memory_order_relaxed);
                     for (int32_t si = 0; si < ring_task_count; si++) {
-                        PTO2TaskSlotState& slot_state = sched->get_slot_state(r, si);
+                        PTO2TaskSlotState &slot_state = sched->get_slot_state(r, si);
                         PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
                         int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
                         int32_t fi = slot_state.fanin_count;
@@ -1451,12 +1380,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                                 DEV_ALWAYS(
                                     "  STUCK-READY  ring=%d task_id=%" PRId64
                                     " kernel_id=%d refcount=%d fanin=%d state=%d",  // NOLINT(whitespace/line_length)
-                                    r,
-                                    static_cast<int64_t>(slot_state.task->task_id.raw),
-                                    kid,
-                                    rc,
-                                    fi,
-                                    static_cast<int32_t>(st));
+                                    r, static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi,
+                                    static_cast<int32_t>(st)
+                                );
                             }
                         } else {
                             cnt_waiting++;
@@ -1464,30 +1390,24 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                                 DEV_ALWAYS(
                                     "  STUCK-WAIT   ring=%d task_id=%" PRId64
                                     " kernel_id=%d refcount=%d fanin=%d state=%d",  // NOLINT(whitespace/line_length)
-                                    r,
-                                    static_cast<int64_t>(slot_state.task->task_id.raw),
-                                    kid,
-                                    rc,
-                                    fi,
-                                    static_cast<int32_t>(st));
+                                    r, static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi,
+                                    static_cast<int32_t>(st)
+                                );
                             }
                         }
                     }
                 }
-                DEV_ALWAYS("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d",
-                    cnt_ready,
-                    cnt_waiting,
-                    cnt_inflight);
+                DEV_ALWAYS(
+                    "  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight
+                );
                 // Log this thread's dispatch state
                 int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
                 int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
                 int32_t total_running = aic_running + aiv_running;
-                DEV_ALWAYS("  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d",
-                    thread_idx,
-                    total_running,
-                    aic_running,
-                    aiv_running,
-                    core_num);
+                DEV_ALWAYS(
+                    "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running,
+                    aiv_running, core_num
+                );
                 // Dump running cores
                 auto all_running = tracker.get_all_running_cores();
                 int32_t dump_count = 0;
@@ -1502,25 +1422,21 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
                         hw_kernel = core_exec_states_[cid].executing_slot_state->task->kernel_id[diag_slot];
                     }
                     uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
-                    DEV_ALWAYS("    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d",
-                        cid,
-                        static_cast<unsigned>(cond_reg),
-                        EXTRACT_TASK_STATE(cond_reg),
-                        EXTRACT_TASK_ID(cond_reg),
-                        sw_tid,
-                        hw_kernel);
+                    DEV_ALWAYS(
+                        "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid,
+                        static_cast<unsigned>(cond_reg), EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
+                        sw_tid, hw_kernel
+                    );
                 }
                 // Dump cluster state
                 for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
                     int32_t offset = cli * 3;
-                    DEV_ALWAYS("    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)",
-                        cli,
-                        tracker.get_aic_core_id(offset),
-                        tracker.is_aic_core_idle(offset) ? "idle" : "busy",
-                        tracker.get_aiv0_core_id(offset),
-                        tracker.is_aiv0_core_idle(offset) ? "idle" : "busy",
-                        tracker.get_aiv1_core_id(offset),
-                        tracker.is_aiv1_core_idle(offset) ? "idle" : "busy");
+                    DEV_ALWAYS(
+                        "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
+                        tracker.is_aic_core_idle(offset) ? "idle" : "busy", tracker.get_aiv0_core_id(offset),
+                        tracker.is_aiv0_core_idle(offset) ? "idle" : "busy", tracker.get_aiv1_core_id(offset),
+                        tracker.is_aiv1_core_idle(offset) ? "idle" : "busy"
+                    );
                 }
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
@@ -1528,11 +1444,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_PROFILING
                 // Benchmark: scheduler lifetime end timestamp on timeout path
                 uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
-                DEV_ALWAYS("Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus",
-                    thread_idx,
-                    static_cast<uint64_t>(sched_start_ts),
-                    static_cast<uint64_t>(sched_timeout_ts),
-                    cycles_to_us(sched_timeout_ts - sched_start_ts));
+                DEV_ALWAYS(
+                    "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+                    static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_timeout_ts),
+                    cycles_to_us(sched_timeout_ts - sched_start_ts)
+                );
 #endif
                 return -1;
             } else {
@@ -1551,11 +1467,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
 #if PTO2_PROFILING
     // Record sched_end before any DEV_ALWAYS to avoid init cost contamination
     uint64_t sched_end_ts = get_sys_cnt_aicpu();
-    DEV_ALWAYS("Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus",
-        thread_idx,
-        static_cast<uint64_t>(sched_start_ts),
-        static_cast<uint64_t>(sched_end_ts),
-        cycles_to_us(sched_end_ts - sched_start_ts));
+    DEV_ALWAYS(
+        "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+        static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_end_ts),
+        cycles_to_us(sched_end_ts - sched_start_ts)
+    );
 
     // Scheduler summary logging (always print when PTO2_PROFILING=1)
     uint64_t sched_total = sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
@@ -1566,143 +1482,131 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     {
         PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
         uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
-        uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle)
-                                     ? (sched_complete_cycle - otc_total - sched_complete_perf_cycle)
-                                     : 0;
-        uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle)
-                                     ? (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle)
-                                     : 0;
+        uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle) ?
+                                     (sched_complete_cycle - otc_total - sched_complete_perf_cycle) :
+                                     0;
+        uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle) ?
+                                     (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) :
+                                     0;
 
-        DEV_ALWAYS("Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===",
-            thread_idx,
-            cycles_to_us(sched_total),
-            cur_thread_completed);
+        DEV_ALWAYS(
+            "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
+            cycles_to_us(sched_total), cur_thread_completed
+        );
 
         // Level 1: complete
         double notify_avg =
             cur_thread_completed > 0 ? static_cast<double>(notify_edges_total) / cur_thread_completed : 0.0;
         double fanin_avg =
             cur_thread_completed > 0 ? static_cast<double>(fanin_edges_total) / cur_thread_completed : 0.0;
-        DEV_ALWAYS("Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
-                   ", max_degree=%d, avg=%.1f]  [fanin: "  // NOLINT(whitespace/line_length)
-                   "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
-            thread_idx,
-            cycles_to_us(sched_complete_cycle),
-            sched_complete_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(notify_edges_total),
-            notify_max_degree,
-            notify_avg,
-            static_cast<uint64_t>(fanin_edges_total),
-            fanin_max_degree,
-            fanin_avg);
+        DEV_ALWAYS(
+            "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
+            ", max_degree=%d, avg=%.1f]  [fanin: "  // NOLINT(whitespace/line_length)
+            "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
+            thread_idx, cycles_to_us(sched_complete_cycle), sched_complete_cycle * 100.0 / sched_total,
+            static_cast<uint64_t>(notify_edges_total), notify_max_degree, notify_avg,
+            static_cast<uint64_t>(fanin_edges_total), fanin_max_degree, fanin_avg
+        );
 
         // Level 2: complete sub-phases (percentage relative to complete)
         uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
         uint64_t complete_miss_count =
             (complete_probe_count > complete_hit_count) ? (complete_probe_count - complete_hit_count) : 0;
         double complete_hit_rate = complete_probe_count > 0 ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
-        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
-            thread_idx,
-            cycles_to_us(complete_poll),
-            complete_poll * 100.0 / c_parent,
-            static_cast<uint64_t>(complete_hit_count),
-            static_cast<uint64_t>(complete_miss_count),
-            complete_hit_rate);
-        DEV_ALWAYS("Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.lock_cycle),
-            sp.lock_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle),
-            cycles_to_us(sp.lock_wait_cycle),
-            static_cast<uint64_t>(sp.lock_atomic_count));
-        DEV_ALWAYS("Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.fanout_cycle),
-            sp.fanout_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle),
-            cycles_to_us(sp.push_wait_cycle),
-            static_cast<uint64_t>(sp.fanout_atomic_count));
-        DEV_ALWAYS("Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.fanin_cycle),
-            sp.fanin_cycle * 100.0 / c_parent,
-            static_cast<uint64_t>(sp.fanin_atomic_count));
-        DEV_ALWAYS("Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sp.self_consumed_cycle),
-            sp.self_consumed_cycle * 100.0 / c_parent,
-            static_cast<uint64_t>(sp.self_atomic_count));
-        DEV_ALWAYS("Thread %d:     perf         : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_complete_perf_cycle),
-            sched_complete_perf_cycle * 100.0 / c_parent);
+        DEV_ALWAYS(
+            "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
+            thread_idx, cycles_to_us(complete_poll), complete_poll * 100.0 / c_parent,
+            static_cast<uint64_t>(complete_hit_count), static_cast<uint64_t>(complete_miss_count), complete_hit_rate
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
+            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
+            static_cast<uint64_t>(sp.lock_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
+            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
+            static_cast<uint64_t>(sp.fanout_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.fanin_cycle), sp.fanin_cycle * 100.0 / c_parent,
+            static_cast<uint64_t>(sp.fanin_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.self_consumed_cycle), sp.self_consumed_cycle * 100.0 / c_parent,
+            static_cast<uint64_t>(sp.self_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_complete_perf_cycle),
+            sched_complete_perf_cycle * 100.0 / c_parent
+        );
 
         // Level 1: dispatch
         uint64_t pop_total = pop_hit + pop_miss;
         double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
-        DEV_ALWAYS("Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64
-                   ", hit_rate=%.1f%%]",  // NOLINT(whitespace/line_length)
-            thread_idx,
-            cycles_to_us(sched_dispatch_cycle),
-            sched_dispatch_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(pop_hit),
-            static_cast<uint64_t>(pop_miss),
-            pop_hit_rate);
+        DEV_ALWAYS(
+            "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64
+            ", hit_rate=%.1f%%]",  // NOLINT(whitespace/line_length)
+            thread_idx, cycles_to_us(sched_dispatch_cycle), sched_dispatch_cycle * 100.0 / sched_total,
+            static_cast<uint64_t>(pop_hit), static_cast<uint64_t>(pop_miss), pop_hit_rate
+        );
         uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
         uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
         double local_hit_rate = total_dispatched > 0 ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
-        DEV_ALWAYS("Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
-                   ", local_rate=%.1f%%",  // NOLINT(whitespace/line_length)
-            thread_idx,
-            static_cast<uint64_t>(local_dispatch_count),
-            static_cast<uint64_t>(global_dispatch_count),
-            static_cast<uint64_t>(local_overflow_count),
-            local_hit_rate);
+        DEV_ALWAYS(
+            "Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
+            ", local_rate=%.1f%%",  // NOLINT(whitespace/line_length)
+            thread_idx, static_cast<uint64_t>(local_dispatch_count), static_cast<uint64_t>(global_dispatch_count),
+            static_cast<uint64_t>(local_overflow_count), local_hit_rate
+        );
 
         // Level 2: dispatch sub-phases (percentage relative to dispatch)
         uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
-        DEV_ALWAYS("Thread %d:     poll         : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(dispatch_poll),
-            dispatch_poll * 100.0 / d_parent);
-        DEV_ALWAYS("Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx,
-            cycles_to_us(sched_dispatch_pop_cycle),
-            sched_dispatch_pop_cycle * 100.0 / d_parent,
-            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle),
-            cycles_to_us(sp.pop_wait_cycle),
-            static_cast<uint64_t>(sp.pop_atomic_count));
-        DEV_ALWAYS("Thread %d:     setup        : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_dispatch_setup_cycle),
-            sched_dispatch_setup_cycle * 100.0 / d_parent);
+        DEV_ALWAYS(
+            "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
+            dispatch_poll * 100.0 / d_parent
+        );
+        DEV_ALWAYS(
+            "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sched_dispatch_pop_cycle), sched_dispatch_pop_cycle * 100.0 / d_parent,
+            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+            static_cast<uint64_t>(sp.pop_atomic_count)
+        );
+        DEV_ALWAYS(
+            "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
+            sched_dispatch_setup_cycle * 100.0 / d_parent
+        );
 
         // Level 1: scan
-        DEV_ALWAYS("Thread %d:   scan           : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_scan_cycle),
-            sched_scan_cycle * 100.0 / sched_total);
+        DEV_ALWAYS(
+            "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_scan_cycle),
+            sched_scan_cycle * 100.0 / sched_total
+        );
 
         // Level 1: idle
-        DEV_ALWAYS("Thread %d:   idle           : %.3fus (%.1f%%)",
-            thread_idx,
-            cycles_to_us(sched_idle_cycle),
-            sched_idle_cycle * 100.0 / sched_total);
+        DEV_ALWAYS(
+            "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_idle_cycle),
+            sched_idle_cycle * 100.0 / sched_total
+        );
 
         // Average per completion
         if (cur_thread_completed > 0) {
-            DEV_ALWAYS("Thread %d:   avg/complete   : %.3fus",
-                thread_idx,
-                cycles_to_us(sched_complete_cycle) / cur_thread_completed);
+            DEV_ALWAYS(
+                "Thread %d:   avg/complete   : %.3fus", thread_idx,
+                cycles_to_us(sched_complete_cycle) / cur_thread_completed
+            );
         }
     }
 #endif
     // Summary line (always print when PTO2_PROFILING=1)
-    DEV_ALWAYS("Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d",
-        thread_idx,
-        cycles_to_us(sched_total),
-        static_cast<uint64_t>(sched_loop_count),
-        cur_thread_completed);
+    DEV_ALWAYS(
+        "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
+        cycles_to_us(sched_total), static_cast<uint64_t>(sched_loop_count), cur_thread_completed
+    );
 #endif
 
 #if PTO2_PROFILING
@@ -1716,7 +1620,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime* runtime, int32_t threa
     return cur_thread_completed;
 }
 
-int32_t AicpuExecutor::run(Runtime* runtime) {
+int32_t AicpuExecutor::run(Runtime *runtime) {
     int32_t thread_idx = thread_idx_++;
     DEV_INFO("Thread %d: Start", thread_idx);
 
@@ -1734,7 +1638,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             if (orch_idx == 0) {
                 DEV_INFO("Thread %d: Primary orchestrator, loading SO via dlopen", thread_idx);
 
-                const void* so_data = runtime->get_device_orch_so_data();
+                const void *so_data = runtime->get_device_orch_so_data();
                 size_t so_size = runtime->get_device_orch_so_size();
 
                 if (so_data == nullptr || so_size == 0) {
@@ -1745,27 +1649,26 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 // Try multiple paths that may allow execution on AICPU
                 char so_path[256];
                 bool file_created = false;
-                const char* candidate_dirs[] = {
-                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"};
+                const char *candidate_dirs[] = {
+                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
+                };
                 const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
 
                 for (int32_t i = 0; i < num_candidates && !file_created; i++) {
                     snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
                     int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
                     if (fd < 0) {
-                        DEV_INFO("Thread %d: Cannot create SO at %s (errno=%d), trying next path",
-                            thread_idx,
-                            so_path,
-                            errno);
+                        DEV_INFO(
+                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
                         continue;
                     }
                     ssize_t written = write(fd, so_data, so_size);
                     close(fd);
                     if (written != static_cast<ssize_t>(so_size)) {
-                        DEV_INFO("Thread %d: Cannot write SO to %s (errno=%d), trying next path",
-                            thread_idx,
-                            so_path,
-                            errno);
+                        DEV_INFO(
+                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
                         unlink(so_path);
                         continue;
                     }
@@ -1779,8 +1682,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 }
 
                 dlerror();
-                void* handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
-                const char* dlopen_err = dlerror();
+                void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+                const char *dlopen_err = dlerror();
                 if (handle == nullptr) {
                     DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
                     unlink(so_path);
@@ -1795,7 +1698,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 dlerror();
                 DeviceOrchestrationFunc orch_func =
                     reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
-                const char* dlsym_error = dlerror();
+                const char *dlsym_error = dlerror();
                 if (dlsym_error != nullptr) {
                     DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
                     dlclose(handle);
@@ -1812,29 +1715,27 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 dlerror();
                 auto bind_runtime_func =
                     reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
-                const char* bind_runtime_error = dlerror();
+                const char *bind_runtime_error = dlerror();
                 if (bind_runtime_error != nullptr) {
                     DEV_INFO("Thread %d: Optional TLS runtime binder not found: %s", thread_idx, bind_runtime_error);
                     bind_runtime_func = nullptr;
                 }
 
-                const ChipStorageTaskArgs& args = runtime->get_orch_args();
+                const ChipStorageTaskArgs &args = runtime->get_orch_args();
                 int32_t arg_count = args.tensor_count() + args.scalar_count();
                 DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
                 for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
-                    const ContinuousTensor& t = args.tensor(i);
-                    DEV_INFO("Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)",
-                        thread_idx,
-                        i,
-                        static_cast<uint64_t>(t.data),
-                        t.ndims,
-                        static_cast<unsigned>(t.dtype));
+                    const ContinuousTensor &t = args.tensor(i);
+                    DEV_INFO(
+                        "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
+                        static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
+                    );
                 }
                 for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
-                    DEV_INFO("Thread %d: orch_args[%d] = SCALAR(0x%lx)",
-                        thread_idx,
-                        args.tensor_count() + i,
-                        static_cast<uint64_t>(args.scalar(i)));
+                    DEV_INFO(
+                        "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
+                        static_cast<uint64_t>(args.scalar(i))
+                    );
                 }
 
                 uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
@@ -1865,17 +1766,16 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 if (runtime->pto2_dep_pool_size > 0) {
                     dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
                 }
-                DEV_INFO("Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d",
-                    thread_idx,
-                    static_cast<uint64_t>(task_window_size),
-                    static_cast<uint64_t>(heap_size),
-                    dep_pool_capacity);
+                DEV_INFO(
+                    "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
+                    static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
+                );
 
-                void* sm_ptr = runtime->get_pto2_gm_sm_ptr();
-                void* gm_heap = runtime->get_pto2_gm_heap_ptr();
+                void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
+                void *gm_heap = runtime->get_pto2_gm_heap_ptr();
 
                 uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
-                PTO2SharedMemoryHandle* sm_handle =
+                PTO2SharedMemoryHandle *sm_handle =
                     pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
                 if (!sm_handle) {
                     DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
@@ -1885,7 +1785,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 }
 
                 rt = pto2_runtime_create_from_sm(
-                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity);
+                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity
+                );
                 if (!rt) {
                     DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                     pto2_sm_destroy(sm_handle);
@@ -1967,62 +1868,62 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             uint64_t total =
                 p.sync_cycle + p.alloc_cycle + p.params_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
-            DEV_ALWAYS("Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===",
-                thread_idx,
-                static_cast<int64_t>(p.submit_count),
-                cycles_to_us(total));
-            DEV_ALWAYS("Thread %d:   task+heap_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-                thread_idx,
-                cycles_to_us(p.alloc_cycle),
-                p.alloc_cycle * 100.0 / total,
-                cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle),
-                cycles_to_us(p.alloc_wait_cycle),
-                static_cast<uint64_t>(p.alloc_atomic_count));
-            DEV_ALWAYS("Thread %d:   sync_tensormap : %.3fus (%.1f%%)",
-                thread_idx,
-                cycles_to_us(p.sync_cycle),
-                p.sync_cycle * 100.0 / total);
-            DEV_ALWAYS("Thread %d:   lookup+dep     : %.3fus (%.1f%%)",
-                thread_idx,
-                cycles_to_us(p.lookup_cycle),
-                p.lookup_cycle * 100.0 / total);
-            DEV_ALWAYS("Thread %d:   tensormap_ins  : %.3fus (%.1f%%)",
-                thread_idx,
-                cycles_to_us(p.insert_cycle),
-                p.insert_cycle * 100.0 / total);
-            DEV_ALWAYS("Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "",
-                thread_idx,
-                cycles_to_us(p.params_cycle),
-                p.params_cycle * 100.0 / total,
-                static_cast<uint64_t>(p.params_atomic_count));
-            DEV_ALWAYS("Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-                thread_idx,
-                cycles_to_us(p.fanin_cycle),
-                p.fanin_cycle * 100.0 / total,
-                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle),
-                cycles_to_us(p.fanin_wait_cycle),
-                static_cast<uint64_t>(p.fanin_atomic_count));
-            DEV_ALWAYS("Thread %d:   avg/task       : %.3fus",
-                thread_idx,
-                p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0);
+            DEV_ALWAYS(
+                "Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===", thread_idx,
+                static_cast<int64_t>(p.submit_count), cycles_to_us(total)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   task+heap_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(p.alloc_cycle), p.alloc_cycle * 100.0 / total,
+                cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle), cycles_to_us(p.alloc_wait_cycle),
+                static_cast<uint64_t>(p.alloc_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   sync_tensormap : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.sync_cycle),
+                p.sync_cycle * 100.0 / total
+            );
+            DEV_ALWAYS(
+                "Thread %d:   lookup+dep     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.lookup_cycle),
+                p.lookup_cycle * 100.0 / total
+            );
+            DEV_ALWAYS(
+                "Thread %d:   tensormap_ins  : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.insert_cycle),
+                p.insert_cycle * 100.0 / total
+            );
+            DEV_ALWAYS(
+                "Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+                cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total,
+                static_cast<uint64_t>(p.params_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
+                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
+                static_cast<uint64_t>(p.fanin_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   avg/task       : %.3fus", thread_idx,
+                p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0
+            );
 
 #if PTO2_TENSORMAP_PROFILING
             PTO2TensorMapProfilingData tp = pto2_tensormap_get_profiling();
             DEV_ALWAYS("Thread %d: === TensorMap Lookup Stats ===", thread_idx);
-            DEV_ALWAYS("Thread %d:   lookups        : %" PRIu64 ", inserts: %" PRIu64 "",
-                thread_idx,
-                static_cast<uint64_t>(tp.lookup_count),
-                static_cast<uint64_t>(tp.insert_count));
-            DEV_ALWAYS("Thread %d:   chain walked   : total=%" PRIu64 ", avg=%.1f, max=%d",
-                thread_idx,
+            DEV_ALWAYS(
+                "Thread %d:   lookups        : %" PRIu64 ", inserts: %" PRIu64 "", thread_idx,
+                static_cast<uint64_t>(tp.lookup_count), static_cast<uint64_t>(tp.insert_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:   chain walked   : total=%" PRIu64 ", avg=%.1f, max=%d", thread_idx,
                 static_cast<uint64_t>(tp.lookup_chain_total),
                 tp.lookup_count > 0 ? static_cast<double>(tp.lookup_chain_total) / tp.lookup_count : 0.0,
-                tp.lookup_chain_max);
-            DEV_ALWAYS("Thread %d:   overlap checks : %" PRIu64 ", hits=%" PRIu64 " (%.1f%%)",
-                thread_idx,
-                static_cast<uint64_t>(tp.overlap_checks),
-                static_cast<uint64_t>(tp.overlap_hits),
-                tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0);
+                tp.lookup_chain_max
+            );
+            DEV_ALWAYS(
+                "Thread %d:   overlap checks : %" PRIu64 ", hits=%" PRIu64 " (%.1f%%)", thread_idx,
+                static_cast<uint64_t>(tp.overlap_checks), static_cast<uint64_t>(tp.overlap_hits),
+                tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0
+            );
 #endif
 
 #if PTO2_PROFILING
@@ -2049,7 +1950,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
             // Write core-to-thread mapping (one-time, after orchestration)
             if (runtime->enable_profiling) {
                 perf_aicpu_write_core_assignments(
-                    core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_);
+                    core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
+                );
                 // Flush orchestrator's phase record buffer
                 perf_aicpu_flush_phase_buffers(thread_idx);
             }
@@ -2061,8 +1963,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 // Last orchestrator: signal completion and trigger core transition
                 pto2_rt_orchestration_done(rt);
 
-                void* sm = runtime->get_pto2_gm_sm_ptr();
-                PTO2SharedMemoryHeader* sm_header = static_cast<PTO2SharedMemoryHeader*>(sm);
+                void *sm = runtime->get_pto2_gm_sm_ptr();
+                PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
                 int32_t pto2_task_count = 0;
                 if (sm_header) {
                     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -2079,10 +1981,10 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                 orchestrator_done_ = true;
                 {
                     int32_t orch_err = 0;
-                    void* sm = runtime->get_pto2_gm_sm_ptr();
+                    void *sm = runtime->get_pto2_gm_sm_ptr();
                     if (sm) {
                         orch_err =
-                            static_cast<PTO2SharedMemoryHeader*>(sm)->orch_error_code.load(std::memory_order_relaxed);
+                            static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
                     }
 
                     // Fatal error: shutdown AICore immediately before core transition.
@@ -2110,7 +2012,8 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
                     transition_requested_.store(true, std::memory_order_release);
 #if PTO2_PROFILING
                     DEV_ALWAYS(
-                        "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts));
+                        "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
+                    );
 #endif
 
                     // Wait for scheduler threads to acknowledge transition request
@@ -2131,10 +2034,10 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
 
 #if PTO2_ORCH_PROFILING
                 uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
-                DEV_ALWAYS("Thread %d: reassign, cost %.3fus (orch_idx=%d)",
-                    thread_idx,
-                    cycles_to_us(reassign_cycle_end - reassign_cycle_start),
-                    orch_idx);
+                DEV_ALWAYS(
+                    "Thread %d: reassign, cost %.3fus (orch_idx=%d)", thread_idx,
+                    cycles_to_us(reassign_cycle_end - reassign_cycle_start), orch_idx
+                );
 #endif
             } else {
                 // Non-last orchestrator: wait for last orchestrator to finish setup
@@ -2153,15 +2056,16 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
         }
 #if PTO2_PROFILING
         uint64_t orch_end_ts = get_sys_cnt_aicpu();
-        DEV_ALWAYS("Thread %d: orch_start=%" PRIu64 " orch_end=%" PRIu64 " orch_cost=%.3fus",
-            thread_idx,
-            static_cast<uint64_t>(orch_cycle_start),
-            static_cast<uint64_t>(orch_end_ts),
-            cycles_to_us(orch_end_ts - orch_cycle_start));
+        DEV_ALWAYS(
+            "Thread %d: orch_start=%" PRIu64 " orch_end=%" PRIu64 " orch_cost=%.3fus", thread_idx,
+            static_cast<uint64_t>(orch_cycle_start), static_cast<uint64_t>(orch_end_ts),
+            cycles_to_us(orch_end_ts - orch_cycle_start)
+        );
         if (pto2_submitted_tasks >= 0) {
-            DEV_ALWAYS("PTO2 total submitted tasks = %d, already executed %d tasks",
-                pto2_submitted_tasks,
-                completed_tasks_.load(std::memory_order_acquire));
+            DEV_ALWAYS(
+                "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_submitted_tasks,
+                completed_tasks_.load(std::memory_order_acquire)
+            );
         }
 #endif
         DEV_INFO("Thread %d: Orchestrator completed (orch_idx=%d)", thread_idx, orch_idx);
@@ -2184,7 +2088,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     // platform_deinit_aicore_regs is idempotent; orchestrator threads have
     // core_count_per_thread_ == 0 so they skip the loop harmlessly.
     {
-        const int32_t* shutdown_cores = core_assignments_[thread_idx];
+        const int32_t *shutdown_cores = core_assignments_[thread_idx];
         int32_t shutdown_count = core_count_per_thread_[thread_idx];
         if (shutdown_count > 0) {
             auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
@@ -2216,7 +2120,7 @@ int32_t AicpuExecutor::run(Runtime* runtime) {
     return 0;
 }
 
-void AicpuExecutor::deinit(Runtime* runtime) {
+void AicpuExecutor::deinit(Runtime *runtime) {
     // 1. Invalidate AICPU cache for Runtime address range.
     //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
     //    bypasses this cache. Invalidating now ensures next round reads from HBM.
@@ -2271,11 +2175,11 @@ void AicpuExecutor::deinit(Runtime* runtime) {
     DEV_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
+void AicpuExecutor::emergency_shutdown(Runtime *runtime) {
     DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    Handshake* all_handshakes = reinterpret_cast<Handshake*>(runtime->workers);
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     for (int32_t i = 0; i < cores_total_num_; i++) {
-        Handshake* hank = &all_handshakes[i];
+        Handshake *hank = &all_handshakes[i];
         OUT_OF_ORDER_STORE_BARRIER();
         hank->aicpu_regs_ready = 1;
         if (core_exec_states_[i].reg_addr != 0) {
@@ -2287,9 +2191,10 @@ void AicpuExecutor::emergency_shutdown(Runtime* runtime) {
 }
 
 void AicpuExecutor::diagnose_stuck_state(
-    Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank) {
+    Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
+) {
     (void)runtime;  // NOLINT(readability/casting)
-    PTO2SchedulerState* sched = &rt->scheduler;
+    PTO2SchedulerState *sched = &rt->scheduler;
     DEV_ALWAYS("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
 
     int32_t completed = completed_tasks_.load(std::memory_order_acquire);
@@ -2310,8 +2215,8 @@ void AicpuExecutor::diagnose_stuck_state(
     DEV_ALWAYS("Core Status:");
     for (int32_t i = 0; i < core_num; i++) {
         int32_t core_id = cur_thread_cores[i];
-        Handshake* h = &hank[core_id];
-        const char* core_type_str = core_type_to_string(h->core_type);
+        Handshake *h = &hank[core_id];
+        const char *core_type_str = core_type_to_string(h->core_type);
 
         uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
         uint64_t reg_val = read_reg(reg_addr, RegId::COND);
@@ -2330,20 +2235,14 @@ void AicpuExecutor::diagnose_stuck_state(
                 DEV_ALWAYS(
                     "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), executing_reg_task_id=%d, "
                     "kernel_id=%d",
-                    core_id,
-                    core_type_str,
-                    reg_val,
-                    reg_task_id,
-                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK",
-                    task_id,
-                    kernel_id);
+                    core_id, core_type_str, reg_val, reg_task_id, reg_state == TASK_FIN_STATE ? "FIN" : "ACK", task_id,
+                    kernel_id
+                );
             } else {
-                DEV_ALWAYS("  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked",
-                    core_id,
-                    core_type_str,
-                    reg_val,
-                    reg_task_id,
-                    reg_state == TASK_FIN_STATE ? "FIN" : "ACK");
+                DEV_ALWAYS(
+                    "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked", core_id,
+                    core_type_str, reg_val, reg_task_id, reg_state == TASK_FIN_STATE ? "FIN" : "ACK"
+                );
             }
         } else {
             idle_cores++;
@@ -2380,7 +2279,7 @@ void AicpuExecutor::diagnose_stuck_state(
  * @param runtime Pointer to Runtime structure
  * @return 0 on success, non-zero on error
  */
-extern "C" int32_t aicpu_execute(Runtime* runtime) {
+extern "C" int32_t aicpu_execute(Runtime *runtime) {
     if (runtime == nullptr) {
         DEV_ERROR("%s", "Invalid argument: null Runtime pointer");
         return -1;

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_compile_info.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_compile_info.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "host/platform_compile_info.h"
 #include "host/runtime_compile_info.h"
 #include <string.h>
@@ -14,5 +24,4 @@ ToolchainType get_orchestration_compiler(void) {
     if (strcmp(get_platform(), "a2a3") == 0) return TOOLCHAIN_AARCH64_GXX;
     return TOOLCHAIN_HOST_GXX;
 }
-
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -52,10 +52,10 @@ static int64_t _now_ms() {
  * Parse an environment variable as uint64_t with optional power-of-2 constraint.
  * Returns the parsed value on success, or 0 if unset or validation fails.
  */
-static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool require_power_of_2) {
-    const char* env = std::getenv(name);
+static uint64_t parse_env_uint64(const char *name, uint64_t min_val, bool require_power_of_2) {
+    const char *env = std::getenv(name);
     if (!env) return 0;
-    char* endptr;
+    char *endptr;
     errno = 0;
     uint64_t val = strtoull(env, &endptr, 10);
     if (errno == ERANGE || endptr == env || *endptr != '\0' || val < min_val) {
@@ -85,7 +85,7 @@ static uint64_t parse_env_uint64(const char* name, uint64_t min_val, bool requir
  * @param orch_args Separated tensor/scalar arguments
  * @return 0 on success, -1 on failure
  */
-extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable, const ChipStorageTaskArgs* orch_args) {
+extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const ChipStorageTaskArgs *orch_args) {
     // Validate inputs
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -97,10 +97,11 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", callable->child_count());
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
-            const auto& kernel = callable->child(i);
-            uint64_t addr = runtime->host_api.upload_kernel_binary(func_id,
-                reinterpret_cast<const uint8_t*>(&kernel),
-                CoreCallable::binary_data_offset() + kernel.binary_size());
+            const auto &kernel = callable->child(i);
+            uint64_t addr = runtime->host_api.upload_kernel_binary(
+                func_id, reinterpret_cast<const uint8_t *>(&kernel),
+                CoreCallable::binary_data_offset() + kernel.binary_size()
+            );
             if (addr == 0) {
                 LOG_ERROR("Failed to upload kernel binary for func_id=%d", func_id);
                 return -1;
@@ -109,7 +110,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
         }
     }
 
-    const uint8_t* orch_so_binary = static_cast<const uint8_t*>(callable->binary_data());
+    const uint8_t *orch_so_binary = static_cast<const uint8_t *>(callable->binary_data());
     size_t orch_so_size = callable->binary_size();
 
     if (orch_so_binary == nullptr || orch_so_size == 0) {
@@ -135,10 +136,10 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
     for (int i = 0; i < tensor_count; i++) {
         ContinuousTensor t = orch_args->tensor(i);
 
-        void* host_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(t.data));
+        void *host_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(t.data));
         size_t size = static_cast<size_t>(t.nbytes());
 
-        void* dev_ptr = runtime->host_api.device_malloc(size);
+        void *dev_ptr = runtime->host_api.device_malloc(size);
         if (dev_ptr == nullptr) {
             LOG_ERROR("Failed to allocate device memory for tensor %d", i);
             return -1;
@@ -163,7 +164,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
 
     // Copy orchestration SO to device memory (AICPU cannot access host memory)
     int64_t t_so_start = _now_ms();
-    void* dev_so = runtime->host_api.device_malloc(orch_so_size);
+    void *dev_so = runtime->host_api.device_malloc(orch_so_size);
     if (dev_so == nullptr) {
         LOG_ERROR("Failed to allocate device memory for orchestration SO");
         return -1;
@@ -184,17 +185,17 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
 
     // Read ready queue shard count from environment for AICPU scheduler
     {
-        const char* env_shards = std::getenv("PTO2_READY_QUEUE_SHARDS");
+        const char *env_shards = std::getenv("PTO2_READY_QUEUE_SHARDS");
         if (env_shards) {
-            char* endptr;
+            char *endptr;
             int64_t val = strtol(env_shards, &endptr, 10);
             if (endptr != env_shards && *endptr == '\0' && val >= 1 && val <= PLATFORM_MAX_AICPU_THREADS) {
                 runtime->ready_queue_shards = static_cast<int>(val);
             } else {
-                LOG_WARN("PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d",
-                    env_shards,
-                    PLATFORM_MAX_AICPU_THREADS,
-                    RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
+                LOG_WARN(
+                    "PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d", env_shards,
+                    PLATFORM_MAX_AICPU_THREADS, RUNTIME_DEFAULT_READY_QUEUE_SHARDS
+                );
                 runtime->ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
             }
         }
@@ -203,7 +204,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
 
     // Read orchestrator-to-scheduler transition flag from environment
     {
-        const char* env_val = std::getenv("PTO2_ORCH_TO_SCHED");
+        const char *env_val = std::getenv("PTO2_ORCH_TO_SCHED");
         if (env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T')) {
             runtime->orch_to_sched = true;
         }
@@ -216,10 +217,12 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
         runtime->pto2_heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
         runtime->pto2_dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
         if (runtime->pto2_task_window_size || runtime->pto2_heap_size || runtime->pto2_dep_pool_size) {
-            LOG_INFO("Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
+            LOG_INFO(
+                "Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
                 (uint64_t)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE),
                 (uint64_t)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
-                (uint64_t)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE));
+                (uint64_t)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE)
+            );
         }
     }
 
@@ -231,7 +234,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
     // Allocate GM heap for orchestrator output buffers (all rings combined)
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
     int64_t t_heap_start = _now_ms();
-    void* gm_heap = runtime->host_api.device_malloc(total_heap_size);
+    void *gm_heap = runtime->host_api.device_malloc(total_heap_size);
     int64_t t_heap_end = _now_ms();
     if (gm_heap == nullptr) {
         LOG_ERROR("Failed to allocate GM heap");
@@ -243,7 +246,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
     // Allocate PTO2 shared memory
     int64_t t_sm_start = _now_ms();
     uint64_t sm_size = pto2_sm_calculate_size(eff_task_window_size);
-    void* sm_ptr = runtime->host_api.device_malloc(sm_size);
+    void *sm_ptr = runtime->host_api.device_malloc(sm_size);
     int64_t t_sm_end = _now_ms();
     if (sm_ptr == nullptr) {
         LOG_ERROR("Failed to allocate PTO2 shared memory");
@@ -279,7 +282,7 @@ extern "C" int init_runtime_impl(Runtime* runtime, const ChipCallable* callable,
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime* runtime) {
+extern "C" int validate_runtime_impl(Runtime *runtime) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -290,13 +293,13 @@ extern "C" int validate_runtime_impl(Runtime* runtime) {
     LOG_INFO("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair* tensor_pairs = runtime->get_tensor_pairs();
+    TensorPair *tensor_pairs = runtime->get_tensor_pairs();
     int tensor_pair_count = runtime->get_tensor_pair_count();
 
     LOG_INFO("Tensor pairs to process: %d", tensor_pair_count);
 
     // PTO2 (device orchestration): graph output may be in packed buffer
-    void* pto2_sm = runtime->get_pto2_gm_sm_ptr();
+    void *pto2_sm = runtime->get_pto2_gm_sm_ptr();
     uint64_t graph_out_ptr = 0;
     uint64_t graph_out_size = 0;
 
@@ -317,7 +320,7 @@ extern "C" int validate_runtime_impl(Runtime* runtime) {
 
     bool first_output_tensor = true;
     for (int i = 0; i < tensor_pair_count; i++) {
-        const TensorPair& pair = tensor_pairs[i];
+        const TensorPair &pair = tensor_pairs[i];
 
         // Skip if device pointer is null
         if (pair.dev_ptr == nullptr) {
@@ -331,12 +334,12 @@ extern "C" int validate_runtime_impl(Runtime* runtime) {
             continue;
         }
 
-        void* src_ptr = pair.dev_ptr;
+        void *src_ptr = pair.dev_ptr;
         size_t copy_size = pair.size;
 
         // Use graph_output_ptr for the first output tensor if available
         if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
-            src_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(graph_out_ptr));
+            src_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(graph_out_ptr));
             copy_size = static_cast<size_t>(graph_out_size);
             LOG_INFO("Using packed output buffer for tensor %d", i);
             first_output_tensor = false;

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include "common.h"
 #include "pto_orchestration_api.h"
 
@@ -19,34 +29,33 @@ namespace {
 // crash (BZ #32412) when the orchestration SO is dlclose'd/re-dlopen'd
 // between execution rounds.  All orchestrator threads bind the same rt
 // value, so per-thread storage is unnecessary.
-PTO2Runtime* g_pto2_current_runtime = nullptr;
-}
+PTO2Runtime *g_pto2_current_runtime = nullptr;
+}  // namespace
 
-extern "C" __attribute__((visibility("default"))) void pto2_framework_bind_runtime(PTO2Runtime* rt) {
+extern "C" __attribute__((visibility("default"))) void pto2_framework_bind_runtime(PTO2Runtime *rt) {
     g_pto2_current_runtime = rt;
 }
 
 // Keep current_runtime local to this .so so orchestration helpers do not
 // accidentally bind to the AICPU binary's same-named symbol.
-extern "C" __attribute__((visibility("hidden"))) PTO2Runtime* pto2_framework_current_runtime() {
+extern "C" __attribute__((visibility("hidden"))) PTO2Runtime *pto2_framework_current_runtime() {
     return g_pto2_current_runtime;
 }
 
 /**
- * 使用 addr2line 将地址转换为 文件:行号 信息
- * 使用 -i 标志展开内联，返回第一行（最内层实际代码位置）
- * 如果存在内联，同时通过 inline_chain 返回外层调用链
+ * Use addr2line to convert an address to file:line information.
+ * Uses the -i flag to expand inlines; returns the first line (innermost actual code location).
+ * If inlining is present, also returns the outer call chain via inline_chain.
  */
 #ifdef __linux__
-static std::string addr_to_line(const char* executable, void* addr,
-                                std::string* inline_chain = nullptr) {
+static std::string addr_to_line(const char *executable, void *addr, std::string *inline_chain = nullptr) {
     char cmd[512];
     snprintf(cmd, sizeof(cmd), "addr2line -e %s -f -C -p -i %p 2>/dev/null", executable, addr);
 
     std::array<char, 256> buffer;
     std::string raw_output;
 
-    FILE* pipe = popen(cmd, "r");
+    FILE *pipe = popen(cmd, "r");
     if (pipe) {
         while (fgets(buffer.data(), buffer.size(), pipe) != nullptr) {
             raw_output += buffer.data();
@@ -58,21 +67,22 @@ static std::string addr_to_line(const char* executable, void* addr,
         return "";
     }
 
-    // 按行分割
+    // Split by lines
     std::vector<std::string> lines;
     size_t pos = 0;
     while (pos < raw_output.size()) {
         size_t nl = raw_output.find('\n', pos);
         if (nl == std::string::npos) nl = raw_output.size();
         std::string line = raw_output.substr(pos, nl - pos);
-        while (!line.empty() && line.back() == '\r') line.pop_back();
+        while (!line.empty() && line.back() == '\r')
+            line.pop_back();
         if (!line.empty()) lines.push_back(line);
         pos = nl + 1;
     }
 
     if (lines.empty()) return "";
 
-    // 第一行是最内层的实际代码位置，后续行是外层内联调用者
+    // First line is the innermost actual code location; subsequent lines are outer inline callers
     if (inline_chain && lines.size() > 1) {
         *inline_chain = "";
         for (size_t j = 1; j < lines.size(); j++) {
@@ -85,29 +95,29 @@ static std::string addr_to_line(const char* executable, void* addr,
 #endif
 
 /**
- * 获取当前调用栈信息（包含文件路径和行号）
- * 通过 dladdr 定位每个栈帧所在的共享库，并用相对地址调用 addr2line
+ * Get current stack trace information (including file paths and line numbers).
+ * Uses dladdr to locate the shared library for each stack frame, then calls addr2line with relative addresses.
  */
 std::string get_stacktrace(int skip_frames) {
     (void)skip_frames;  // May be unused on non-Linux platforms
     std::string result;
 #ifdef __linux__
     const int max_frames = 64;
-    void* buffer[max_frames];
+    void *buffer[max_frames];
     int nframes = backtrace(buffer, max_frames);
-    char** symbols = backtrace_symbols(buffer, nframes);
+    char **symbols = backtrace_symbols(buffer, nframes);
 
     if (symbols) {
         result = "Stack trace:\n";
         for (int i = skip_frames; i < nframes; i++) {
             std::string frame_info;
 
-            void* addr = (void*)((char*)buffer[i] - 1);
+            void *addr = (void *)((char *)buffer[i] - 1);
 
             Dl_info dl_info;
             std::string inline_chain;
             if (dladdr(addr, &dl_info) && dl_info.dli_fname) {
-                void* rel_addr = (void*)((char*)addr - (char*)dl_info.dli_fbase);
+                void *rel_addr = (void *)((char *)addr - (char *)dl_info.dli_fbase);
                 std::string addr2line_result = addr_to_line(dl_info.dli_fname, rel_addr, &inline_chain);
 
                 if (addr2line_result.empty()) {
@@ -127,7 +137,7 @@ std::string get_stacktrace(int skip_frames) {
                 if (start != std::string::npos && end != std::string::npos) {
                     std::string mangled = frame.substr(start + 1, end - start - 1);
                     int status;
-                    char* demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &status);
+                    char *demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &status);
                     if (status == 0 && demangled) {
                         frame = frame.substr(0, start + 1) + demangled + frame.substr(end);
                         free(demangled);
@@ -146,24 +156,26 @@ std::string get_stacktrace(int skip_frames) {
         free(symbols);
     }
 #else
-    result = "(调用栈仅在 Linux 上可用)\n";
+    result = "(Stack trace is only available on Linux)\n";
 #endif
     return result;
 }
 
-// AssertionError 构造函数
-static std::string build_assert_message(const char* condition, const char* file, int line) {
+// AssertionError constructor
+static std::string build_assert_message(const char *condition, const char *file, int line) {
     std::string msg = "Assertion failed: " + std::string(condition) + "\n";
     msg += "  Location: " + std::string(file) + ":" + std::to_string(line) + "\n";
     msg += get_stacktrace(3);
     return msg;
 }
 
-AssertionError::AssertionError(const char* condition, const char* file, int line)
-    : std::runtime_error(build_assert_message(condition, file, line)),
-      condition_(condition), file_(file), line_(line) {}
+AssertionError::AssertionError(const char *condition, const char *file, int line) :
+    std::runtime_error(build_assert_message(condition, file, line)),
+    condition_(condition),
+    file_(file),
+    line_(line) {}
 
-[[noreturn]] void assert_impl(const char* condition, const char* file, int line) {
+[[noreturn]] void assert_impl(const char *condition, const char *file, int line) {
     LOG_ERROR("\n========================================");
     LOG_ERROR("Assertion failed: %s", condition);
     LOG_ERROR("Location: %s:%d", file, line);

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -44,18 +44,17 @@
 /**
  * Create a Tensor for pre-allocated external memory.
  */
-inline Tensor make_tensor_external(void* addr,
-    const uint32_t shapes[],
-    uint32_t ndims,
-    DataType dtype = DataType::FLOAT32,
-    bool manual_dep = false,
-    int32_t version = 0) {
+inline Tensor make_tensor_external(
+    void *addr, const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false,
+    int32_t version = 0
+) {
     static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
     uint64_t total = 1;
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return Tensor(addr,
+    return {
+        addr,
         total * get_element_size(dtype),
         shapes,
         shapes,
@@ -65,15 +64,18 @@ inline Tensor make_tensor_external(void* addr,
         version,
         /*is_all_offset_zero=*/true,
         /*is_raw_eq_shapes=*/true,
-        manual_dep);
+        manual_dep
+    };
 }
 
 // Convert ContinuousTensor to Tensor
 static_assert(
-    CONTINUOUS_TENSOR_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "ContinuousTensor and runtime max dims must match");
-inline Tensor from_tensor_arg(const ContinuousTensor& t, bool manual_dep = false, int32_t version = 0) {
+    CONTINUOUS_TENSOR_MAX_DIMS == RUNTIME_MAX_TENSOR_DIMS, "ContinuousTensor and runtime max dims must match"
+);
+inline Tensor from_tensor_arg(const ContinuousTensor &t, bool manual_dep = false, int32_t version = 0) {
     return make_tensor_external(
-        reinterpret_cast<void*>(static_cast<uintptr_t>(t.data)), t.shapes, t.ndims, t.dtype, manual_dep, version);
+        reinterpret_cast<void *>(static_cast<uintptr_t>(t.data)), t.shapes, t.ndims, t.dtype, manual_dep, version
+    );
 }
 
 // =============================================================================
@@ -98,8 +100,8 @@ extern "C" {
  * aicpu_orchestration_entry(), so orchestration helpers can fetch the
  * current PTO2Runtime without explicit parameter threading.
  */
-PTO2Runtime* pto2_framework_current_runtime(void);
-void pto2_framework_bind_runtime(PTO2Runtime* rt);
+PTO2Runtime *pto2_framework_current_runtime(void);
+void pto2_framework_bind_runtime(PTO2Runtime *rt);
 
 #ifdef __cplusplus
 }
@@ -110,24 +112,25 @@ void pto2_framework_bind_runtime(PTO2Runtime* rt);
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
 typedef struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels, const Arg& args);
-    void (*scope_begin)(PTO2Runtime* rt);
-    void (*scope_end)(PTO2Runtime* rt);
-    void (*orchestration_done)(PTO2Runtime* rt);
-    bool (*is_fatal)(PTO2Runtime* rt);
+    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    void (*scope_begin)(PTO2Runtime *rt);
+    void (*scope_end)(PTO2Runtime *rt);
+    void (*orchestration_done)(PTO2Runtime *rt);
+    bool (*is_fatal)(PTO2Runtime *rt);
 
     // Logging (populated by runtime, called by orchestration)
-    void (*log_error)(const char* func, const char* fmt, ...);
-    void (*log_warn)(const char* func, const char* fmt, ...);
-    void (*log_info)(const char* func, const char* fmt, ...);
-    void (*log_debug)(const char* func, const char* fmt, ...);
-    void (*log_always)(const char* func, const char* fmt, ...);
+    void (*log_error)(const char *func, const char *fmt, ...);
+    void (*log_warn)(const char *func, const char *fmt, ...);
+    void (*log_info)(const char *func, const char *fmt, ...);
+    void (*log_debug)(const char *func, const char *fmt, ...);
+    void (*log_always)(const char *func, const char *fmt, ...);
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
+    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]);
     void (*set_tensor_data)(
-        PTO2Runtime* rt, const Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value);
+        PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    );
 } PTO2RuntimeOps;
 
 /**
@@ -138,25 +141,25 @@ typedef struct PTO2RuntimeOps {
  * is well-defined (C struct layout guarantee).
  */
 struct PTO2Runtime {
-    const PTO2RuntimeOps* ops;
+    const PTO2RuntimeOps *ops;
 };
 
 // =============================================================================
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline PTO2Runtime* pto2_current_runtime() { return pto2_framework_current_runtime(); }
+static inline PTO2Runtime *pto2_current_runtime() { return pto2_framework_current_runtime(); }
 
-static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels& mixed_kernels, const Arg& args) {
-    PTO2Runtime* rt = pto2_current_runtime();
+static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+    PTO2Runtime *rt = pto2_current_runtime();
     return rt->ops->submit_task(rt, mixed_kernels, args);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
-static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const Arg& args) {
-    PTO2Runtime* rt = pto2_current_runtime();
+static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
+    PTO2Runtime *rt = pto2_current_runtime();
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
@@ -165,30 +168,30 @@ static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
-static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const Arg& args) {
-    PTO2Runtime* rt = pto2_current_runtime();
+static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
+    PTO2Runtime *rt = pto2_current_runtime();
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
 }
 
 static inline void pto2_rt_scope_begin() {
-    PTO2Runtime* rt = pto2_current_runtime();
+    PTO2Runtime *rt = pto2_current_runtime();
     rt->ops->scope_begin(rt);
 }
 
 static inline void pto2_rt_scope_end() {
-    PTO2Runtime* rt = pto2_current_runtime();
+    PTO2Runtime *rt = pto2_current_runtime();
     rt->ops->scope_end(rt);
 }
 
 static inline void pto2_rt_orchestration_done() {
-    PTO2Runtime* rt = pto2_current_runtime();
+    PTO2Runtime *rt = pto2_current_runtime();
     rt->ops->orchestration_done(rt);
 }
 
 static inline bool pto2_rt_is_fatal() {
-    PTO2Runtime* rt = pto2_current_runtime();
+    PTO2Runtime *rt = pto2_current_runtime();
     return rt->ops->is_fatal(rt);
 }
 
@@ -215,8 +218,8 @@ static inline bool pto2_rt_is_fatal() {
  *
  * Returns the raw bits as uint64_t; caller reinterprets via bit_cast.
  */
-static inline uint64_t get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[]) {
-    PTO2Runtime* rt = pto2_current_runtime();
+static inline uint64_t get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
+    PTO2Runtime *rt = pto2_current_runtime();
     return rt->ops->get_tensor_data(rt, tensor, ndims, indices);
 }
 
@@ -242,8 +245,8 @@ static inline uint64_t get_tensor_data(const Tensor& tensor, uint32_t ndims, con
  * For runtime-created outputs, call this only on the Tensor returned by
  * add_output(TensorCreateInfo) after submit returns.
  */
-static inline void set_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value) {
-    PTO2Runtime* rt = pto2_current_runtime();
+static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value) {
+    PTO2Runtime *rt = pto2_current_runtime();
     rt->ops->set_tensor_data(rt, tensor, ndims, indices, value);
 }
 
@@ -256,11 +259,14 @@ static inline void set_tensor_data(const Tensor& tensor, uint32_t ndims, const u
  */
 class PTO2ScopeGuard {
 public:  // NOLINT(whitespace/indent)
-    PTO2ScopeGuard() : rt_(pto2_current_runtime()) { rt_->ops->scope_begin(rt_); }
+    PTO2ScopeGuard() :
+        rt_(pto2_current_runtime()) {
+        rt_->ops->scope_begin(rt_);
+    }
     ~PTO2ScopeGuard() { rt_->ops->scope_end(rt_); }
 
 private:  // NOLINT(whitespace/indent)
-    PTO2Runtime* rt_;
+    PTO2Runtime *rt_;
 };
 
 #define _PTO2_CONCATENATE_IMPL(x, y) x##y

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/common.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/common.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #pragma once
 
 #include <stdio.h>
@@ -6,37 +16,37 @@
 #include <string>
 
 /**
- * 获取当前调用栈信息（包含文件路径和行号）
- * 实现在 common.cpp 中
+ * Get current stack trace information (including file paths and line numbers).
+ * Implemented in common.cpp.
  */
 std::string get_stacktrace(int skip_frames = 1);
 
 /**
- * 断言失败异常，包含文件、行号、条件和调用栈信息
+ * Assertion failure exception, containing file, line number, condition, and stack trace information.
  */
 class AssertionError : public std::runtime_error {
 public:
-    AssertionError(const char* condition, const char* file, int line);
+    AssertionError(const char *condition, const char *file, int line);
 
-    const char* condition() const { return condition_; }
-    const char* file() const { return file_; }
+    const char *condition() const { return condition_; }
+    const char *file() const { return file_; }
     int line() const { return line_; }
 
 private:
-    const char* condition_;
-    const char* file_;
+    const char *condition_;
+    const char *file_;
     int line_;
 };
 
 /**
- * 断言失败时的处理函数
- * 实现在 common.cpp 中
+ * Handler function for assertion failures.
+ * Implemented in common.cpp.
  */
-[[noreturn]] void assert_impl(const char* condition, const char* file, int line);
+[[noreturn]] void assert_impl(const char *condition, const char *file, int line);
 
 /**
- * debug_assert 宏 - 在 debug 模式下检查条件，失败时抛出异常并打印调用栈
- * 在 release 模式 (NDEBUG) 下为空操作
+ * debug_assert macro - checks condition in debug mode; throws exception and prints stack trace on failure.
+ * No-op in release mode (NDEBUG).
  */
 #ifdef NDEBUG
 #define debug_assert(cond) ((void)0)
@@ -50,7 +60,7 @@ private:
 #endif
 
 /**
- * always_assert 宏 - 无论 debug 还是 release 模式都检查条件
+ * always_assert macro - checks condition in both debug and release modes.
  */
 #define always_assert(cond)                         \
     do {                                            \

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file pto2_dispatch_payload.h
  * @brief Per-core dispatch payload for AICore kernel execution
@@ -38,8 +48,8 @@
  * Handshake.task) and reads both fields after each DATA_MAIN_BASE change.
  */
 struct alignas(64) PTO2DispatchPayload {
-    uint64_t function_bin_addr;    /**< Kernel entry address in GM (set by Scheduler) */
-    __gm__ uint64_t* args;         /**< Pre-built args in task payload GM (set by Scheduler) */
+    uint64_t function_bin_addr; /**< Kernel entry address in GM (set by Scheduler) */
+    __gm__ uint64_t *args;      /**< Pre-built args in task payload GM (set by Scheduler) */
 };
 
 #endif  // RT2_PTO2_DISPATCH_PAYLOAD_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -53,8 +53,8 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // Weak fallback for builds that don't link performance_collector_aicpu.cpp.
 // The strong symbol from the AICPU build wins when profiling is available.
 // Also hidden to prevent HOST .so from polluting the global symbol table.
-__attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
+__attribute__((weak, visibility("hidden"))) void
+perf_aicpu_record_orch_phase(AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 // Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // unified task+heap alloc
@@ -90,8 +90,8 @@ uint64_t g_orch_scope_end_atomic_count = 0;
 #include "aicpu/device_time.h"
 #include "aicpu/performance_collector_aicpu.h"
 __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
-__attribute__((weak, visibility("hidden"))) void perf_aicpu_record_orch_phase(
-    AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
+__attribute__((weak, visibility("hidden"))) void
+perf_aicpu_record_orch_phase(AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 // submit_idx needed for swimlane task_id tagging (no cycle accumulation at this level)
 static uint32_t g_orch_submit_idx = 0;
 #define CYCLE_COUNT_START()                     \
@@ -118,11 +118,10 @@ static uint32_t g_orch_submit_idx = 0;
 // Orchestrator Initialization
 // =============================================================================
 
-bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
-    PTO2SharedMemoryHandle* sm_handle,
-    void* gm_heap,
-    uint64_t heap_size,
-    int32_t dep_pool_capacity) {
+bool pto2_orchestrator_init(
+    PTO2OrchestratorState *orch, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
+    int32_t dep_pool_capacity
+) {
     *orch = PTO2OrchestratorState{};
 
     orch->sm_handle = sm_handle;
@@ -132,21 +131,18 @@ bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
 
     // Initialize per-ring resources
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        void* ring_heap_base = reinterpret_cast<char*>(gm_heap) + r * heap_size;
-        auto& fc = sm_handle->header->rings[r].fc;
+        void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + r * heap_size;
+        auto &fc = sm_handle->header->rings[r].fc;
 
         // Initialize unified task allocator
-        orch->rings[r].task_allocator.init(sm_handle->task_descriptors[r],
-            sm_handle->header->rings[r].task_window_size,
-            &fc.current_task_index,
-            &fc.last_task_alive,
-            ring_heap_base,
-            heap_size,
-            &sm_handle->header->orch_error_code);
+        orch->rings[r].task_allocator.init(
+            sm_handle->task_descriptors[r], sm_handle->header->rings[r].task_window_size, &fc.current_task_index,
+            &fc.last_task_alive, ring_heap_base, heap_size, &sm_handle->header->orch_error_code
+        );
 
         // Allocate and initialize dependency list pool (per-ring)
-        PTO2DepListEntry* dep_entries =
-            reinterpret_cast<PTO2DepListEntry*>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
+        PTO2DepListEntry *dep_entries =
+            reinterpret_cast<PTO2DepListEntry *>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
         if (!dep_entries) {
             // Cleanup previously allocated rings
             for (int j = 0; j < r; j++) {
@@ -173,8 +169,8 @@ bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
     // Initialize scope stack: one flat buffer for task IDs + one array for begin offsets
     uint64_t max_depth = PTO2_MAX_SCOPE_DEPTH;
     int32_t init_cap = PTO2_SCOPE_TASKS_INIT_CAP;
-    orch->scope_tasks = reinterpret_cast<PTO2TaskSlotState**>(malloc(init_cap * sizeof(PTO2TaskSlotState*)));
-    orch->scope_begins = reinterpret_cast<int32_t*>(malloc(max_depth * sizeof(int32_t)));
+    orch->scope_tasks = reinterpret_cast<PTO2TaskSlotState **>(malloc(init_cap * sizeof(PTO2TaskSlotState *)));
+    orch->scope_begins = reinterpret_cast<int32_t *>(malloc(max_depth * sizeof(int32_t)));
     if (!orch->scope_tasks || !orch->scope_begins) {
         free(orch->scope_tasks);
         free(orch->scope_begins);
@@ -192,7 +188,7 @@ bool pto2_orchestrator_init(PTO2OrchestratorState* orch,
     return true;
 }
 
-void pto2_orchestrator_destroy(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_destroy(PTO2OrchestratorState *orch) {
     orch->tensor_map.destroy();
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -206,7 +202,7 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState* orch) {
     orch->scope_begins = NULL;
 }
 
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler) {
+void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler) {
     orch->scheduler = scheduler;
 }
 
@@ -214,11 +210,11 @@ void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerS
 // Scope Management
 // =============================================================================
 
-static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState* task_slot_state) {
+static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         int32_t new_cap = orch->scope_tasks_capacity * 2;
-        PTO2TaskSlotState** new_buf =
-            reinterpret_cast<PTO2TaskSlotState**>(realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState*)));
+        PTO2TaskSlotState **new_buf =
+            reinterpret_cast<PTO2TaskSlotState **>(realloc(orch->scope_tasks, new_cap * sizeof(PTO2TaskSlotState *)));
         assert(new_buf && "Failed to grow scope task buffer");
         orch->scope_tasks = new_buf;
         orch->scope_tasks_capacity = new_cap;
@@ -226,7 +222,7 @@ static void scope_tasks_push(PTO2OrchestratorState* orch, PTO2TaskSlotState* tas
     orch->scope_tasks[orch->scope_tasks_size++] = task_slot_state;
 }
 
-void pto2_scope_begin(PTO2OrchestratorState* orch) {
+void pto2_scope_begin(PTO2OrchestratorState *orch) {
     if (orch->fatal) {
         return;
     }
@@ -236,7 +232,7 @@ void pto2_scope_begin(PTO2OrchestratorState* orch) {
     orch->scope_begins[orch->scope_stack_top] = orch->scope_tasks_size;
 }
 
-void pto2_scope_end(PTO2OrchestratorState* orch) {
+void pto2_scope_end(PTO2OrchestratorState *orch) {
     if (orch->fatal) {
         return;
     }
@@ -266,8 +262,8 @@ void pto2_scope_end(PTO2OrchestratorState* orch) {
 // =============================================================================
 // Task Submission
 // =============================================================================
-TaskOutputTensors pto2_submit_mixed_task(
-    PTO2OrchestratorState* orch, const MixedKernels& mixed_kernels, const Arg& args) {
+TaskOutputTensors
+pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args) {
     CYCLE_COUNT_START();
 
     TaskOutputTensors result;
@@ -293,9 +289,9 @@ TaskOutputTensors pto2_submit_mixed_task(
 
     // Determine which ring this task belongs to
     uint8_t ring_id = orch->current_ring_id();
-    auto& allocator = orch->rings[ring_id].task_allocator;
-    PTO2SchedulerState* sched = orch->scheduler;
-    PTO2RingFlowControl& fc = orch->sm_handle->header->rings[ring_id].fc;
+    auto &allocator = orch->rings[ring_id].task_allocator;
+    PTO2SchedulerState *sched = orch->scheduler;
+    PTO2RingFlowControl &fc = orch->sm_handle->header->rings[ring_id].fc;
 
     // === Validate submit inputs ===
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
@@ -331,7 +327,8 @@ TaskOutputTensors pto2_submit_mixed_task(
             LOG_ERROR("FATAL: Scope Deadlock Detected! (ring %d)", ring_id);
             LOG_ERROR("========================================");
             LOG_ERROR(
-                "Tasks in current scope (%d) >= task_window_size (%d).", scope_task_count, allocator.window_size());
+                "Tasks in current scope (%d) >= task_window_size (%d).", scope_task_count, allocator.window_size()
+            );
             LOG_ERROR("  scope_depth:        %d", orch->scope_stack_top + 1);
             LOG_ERROR("  ring_id:            %d", ring_id);
             LOG_ERROR("  scope_task_count:   %d", scope_task_count);
@@ -375,8 +372,8 @@ TaskOutputTensors pto2_submit_mixed_task(
     int32_t slot = alloc_result.slot;
     PTO2TaskId task_id = pto2_make_task_id(ring_id, static_cast<uint32_t>(local_id));
 
-    PTO2TaskDescriptor& task = allocator.task_by_slot(slot);
-    PTO2TaskPayload* payload = &orch->sm_handle->task_payloads[ring_id][slot];
+    PTO2TaskDescriptor &task = allocator.task_by_slot(slot);
+    PTO2TaskPayload *payload = &orch->sm_handle->task_payloads[ring_id][slot];
 
     // Early write-prefetch payload GM cache lines to issue RFO in background.
     // ~130 lines of computation (lookup, insert) follow before
@@ -384,19 +381,19 @@ TaskOutputTensors pto2_submit_mixed_task(
     // Use locality=3 (PSTL1KEEP) so prefetched CLs survive lookup/insert eviction.
     for (int32_t i = 0; i < args.tensor_count(); i++) {
         __builtin_prefetch(&payload->tensors[i], 1, 3);
-        __builtin_prefetch(reinterpret_cast<char*>(&payload->tensors[i]) + 64, 1, 3);
+        __builtin_prefetch(reinterpret_cast<char *>(&payload->tensors[i]) + 64, 1, 3);
     }
     for (int32_t i = 0; i < args.tensor_count() + args.scalar_count(); i += 8) {
         __builtin_prefetch(&payload->dispatch_args[i], 1, 3);
     }
     __builtin_prefetch(payload, 1, 3);
-    __builtin_prefetch(reinterpret_cast<char*>(payload) + 64, 1, 3);
-    __builtin_prefetch(reinterpret_cast<char*>(payload) + 128, 1, 3);
+    __builtin_prefetch(reinterpret_cast<char *>(payload) + 64, 1, 3);
+    __builtin_prefetch(reinterpret_cast<char *>(payload) + 128, 1, 3);
 
     // Initialize slot state (scheduler-private)
     if (sched) {
-        auto& rs = sched->ring_sched_states[ring_id];
-        PTO2TaskSlotState& slot_state = rs.get_slot_state_by_slot(slot);
+        auto &rs = sched->ring_sched_states[ring_id];
+        PTO2TaskSlotState &slot_state = rs.get_slot_state_by_slot(slot);
         slot_state.fanin_count = 0;
         slot_state.fanout_head = nullptr;
         slot_state.fanout_lock.store(0, std::memory_order_relaxed);
@@ -415,7 +412,7 @@ TaskOutputTensors pto2_submit_mixed_task(
     }
 
     // Temporary storage for fanin (cached slot state pointers, avoids repeated ring/slot lookups)
-    PTO2TaskSlotState* fanin_states[PTO2_MAX_INPUTS];
+    PTO2TaskSlotState *fanin_states[PTO2_MAX_INPUTS];
     int32_t fanin_count = 0;
 
     CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, task_id.raw);
@@ -440,9 +437,9 @@ TaskOutputTensors pto2_submit_mixed_task(
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, task_id.raw);
 
     // === STEP 3: Lookup inputs + materialize runtime-created outputs ===
-    auto fill_initial_value = [](void* addr, uint64_t buffer_size, DataType dtype, uint64_t initial_value) {
+    auto fill_initial_value = [](void *addr, uint64_t buffer_size, DataType dtype, uint64_t initial_value) {
         uint64_t elem_size = get_element_size(dtype);
-        char* dst = reinterpret_cast<char*>(addr);
+        char *dst = reinterpret_cast<char *>(addr);
         constexpr uint64_t BLK = 64;
         uint64_t blk = (buffer_size < BLK) ? buffer_size : BLK;
         for (uint64_t b = 0; b < blk; b += elem_size) {
@@ -462,61 +459,61 @@ TaskOutputTensors pto2_submit_mixed_task(
         TensorArgType ptype = args.tag(i);
 
         switch (ptype) {
-            case TensorArgType::INOUT:
-            case TensorArgType::INPUT: {
-                if (args.tensor(i).ptr->manual_dep) break;
-                // Look up producer via TensorMap (reads from cached stack tensor)
-                PTO2LookupResult lookup_result;
-                orch->tensor_map.lookup(*args.tensor(i).ptr, lookup_result);
+        case TensorArgType::INOUT:
+        case TensorArgType::INPUT: {
+            if (args.tensor(i).ptr->manual_dep) break;
+            // Look up producer via TensorMap (reads from cached stack tensor)
+            PTO2LookupResult lookup_result;
+            orch->tensor_map.lookup(*args.tensor(i).ptr, lookup_result);
 
-                for (int r = 0; r < lookup_result.count; r++) {
-                    PTO2TensorMapEntry& entry = *lookup_result.entries[r].entry;
-                    auto overlap_status = lookup_result.entries[r].overlap_status;
-                    // Check if this producer is already in fanin list (avoid duplicates)
-                    auto prod_ring = entry.producer_task_id.ring();
-                    auto prod_local = entry.producer_task_id.local();
-                    PTO2TaskSlotState* prod_state =
-                        &sched->ring_sched_states[prod_ring].get_slot_state_by_task_id(prod_local);
-                    bool already_added = false;
-                    for (int j = 0; j < fanin_count; j++) {
-                        if (fanin_states[j] == prod_state) {
-                            already_added = true;
-                            break;
-                        }
-                    }
-
-                    if (!already_added) {
-                        // Add to fanin list (this task depends on producer)
-                        if (fanin_count < PTO2_MAX_INPUTS) {
-                            fanin_states[fanin_count++] = prod_state;
-                        }
-                    }
-                    if (ptype == TensorArgType::INOUT && overlap_status == OverlapStatus::COVERED) {
-                        if (!entry.with_alloc) {
-                            orch->tensor_map.remove_entry(entry);
-                        }
+            for (int r = 0; r < lookup_result.count; r++) {
+                PTO2TensorMapEntry &entry = *lookup_result.entries[r].entry;
+                auto overlap_status = lookup_result.entries[r].overlap_status;
+                // Check if this producer is already in fanin list (avoid duplicates)
+                auto prod_ring = entry.producer_task_id.ring();
+                auto prod_local = entry.producer_task_id.local();
+                PTO2TaskSlotState *prod_state =
+                    &sched->ring_sched_states[prod_ring].get_slot_state_by_task_id(prod_local);
+                bool already_added = false;
+                for (int j = 0; j < fanin_count; j++) {
+                    if (fanin_states[j] == prod_state) {
+                        already_added = true;
+                        break;
                     }
                 }
-                break;
-            }
 
-            case TensorArgType::OUTPUT: {
-                const TensorCreateInfo& ci = args.tensor(i).create_info;
-                uint64_t buffer_size = ci.buffer_size_bytes();
-                uint64_t alloc_addr =
-                    reinterpret_cast<uint64_t>(reinterpret_cast<char*>(alloc_result.packed_base) + offset);
-                offset += PTO2_ALIGN_UP(buffer_size, PTO2_PACKED_OUTPUT_ALIGN);
-                result.output_ptr(result.output_count)
-                    ->init_from_create_info(ci, reinterpret_cast<void*>(alloc_addr), /*version=*/0);
-                if (ci.has_initial_value) {
-                    fill_initial_value(reinterpret_cast<void*>(alloc_addr), buffer_size, ci.dtype, ci.initial_value);
+                if (!already_added) {
+                    // Add to fanin list (this task depends on producer)
+                    if (fanin_count < PTO2_MAX_INPUTS) {
+                        fanin_states[fanin_count++] = prod_state;
+                    }
                 }
-                result.output_count++;
-                break;
+                if (ptype == TensorArgType::INOUT && overlap_status == OverlapStatus::COVERED) {
+                    if (!entry.with_alloc) {
+                        orch->tensor_map.remove_entry(entry);
+                    }
+                }
             }
+            break;
+        }
 
-            default:
-                break;
+        case TensorArgType::OUTPUT: {
+            const TensorCreateInfo &ci = args.tensor(i).create_info;
+            uint64_t buffer_size = ci.buffer_size_bytes();
+            uint64_t alloc_addr =
+                reinterpret_cast<uint64_t>(reinterpret_cast<char *>(alloc_result.packed_base) + offset);
+            offset += PTO2_ALIGN_UP(buffer_size, PTO2_PACKED_OUTPUT_ALIGN);
+            result.output_ptr(result.output_count)
+                ->init_from_create_info(ci, reinterpret_cast<void *>(alloc_addr), /*version=*/0);
+            if (ci.has_initial_value) {
+                fill_initial_value(reinterpret_cast<void *>(alloc_addr), buffer_size, ci.dtype, ci.initial_value);
+            }
+            result.output_count++;
+            break;
+        }
+
+        default:
+            break;
         }
     }
 
@@ -528,10 +525,10 @@ TaskOutputTensors pto2_submit_mixed_task(
         for (int i = 0; i < args.tensor_count(); i++) {
             TensorArgType ptype = args.tag(i);
             if (ptype == TensorArgType::OUTPUT || ptype == TensorArgType::INOUT) {
-                bool skip_dep = (ptype == TensorArgType::OUTPUT) ? args.tensor(i).create_info.manual_dep
-                                                                 : args.tensor(i).ptr->manual_dep;
+                bool skip_dep = (ptype == TensorArgType::OUTPUT) ? args.tensor(i).create_info.manual_dep :
+                                                                   args.tensor(i).ptr->manual_dep;
                 if (!skip_dep) {
-                    const Tensor& t =
+                    const Tensor &t =
                         (ptype == TensorArgType::OUTPUT) ? *result.output_ptr(out_idx) : *args.tensor(i).ptr;
                     orch->tensor_map.insert(t, task_id, needs_alloc[i]);
                 }
@@ -558,7 +555,7 @@ TaskOutputTensors pto2_submit_mixed_task(
     // Prefetch producer slot_states and cur_slot_state (written at init but likely
     // evicted by lookup/insert/heap). param_copy below provides hide time.
     if (sched) {
-        auto& rs = sched->ring_sched_states[ring_id];
+        auto &rs = sched->ring_sched_states[ring_id];
         __builtin_prefetch(&rs.get_slot_state_by_slot(slot), 1, 0);
         for (int i = 0; i < fanin_count; i++) {
             __builtin_prefetch(fanin_states[i], 1, 0);
@@ -575,14 +572,14 @@ TaskOutputTensors pto2_submit_mixed_task(
     // === STEP 6: Finalize fanin list ===
     // First build the fanin list
     if (sched) {
-        auto& rs = sched->ring_sched_states[ring_id];
-        PTO2TaskSlotState& cur_slot_state = rs.get_slot_state_by_slot(slot);
+        auto &rs = sched->ring_sched_states[ring_id];
+        PTO2TaskSlotState &cur_slot_state = rs.get_slot_state_by_slot(slot);
         // Initialize scheduler state BEFORE adding to producer fanout lists,
         // so concurrent on_mixed_task_complete can safely access task_state/fanout_refcount.
         cur_slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
         cur_slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
 
-        auto& dep_pool = orch->rings[ring_id].dep_pool;
+        auto &dep_pool = orch->rings[ring_id].dep_pool;
         // Ensure dep pool has space: fanin_count entries + 1 pre-alloc
         dep_pool.ensure_space(*sched, fc, ring_id, fanin_count + 1);
 
@@ -593,7 +590,7 @@ TaskOutputTensors pto2_submit_mixed_task(
             payload->fanin_slot_states[i] = fanin_states[i];
         }
         for (int i = 0; i < fanin_count; i++) {
-            PTO2TaskSlotState& producer_slot_state = *fanin_states[i];
+            PTO2TaskSlotState &producer_slot_state = *fanin_states[i];
 #if PTO2_ORCH_PROFILING
             pto2_fanout_lock(producer_slot_state, g_orch_fanin_atomic_count, g_orch_fanin_wait_cycle);
 #else
@@ -648,21 +645,18 @@ TaskOutputTensors pto2_submit_mixed_task(
 // Flow Control
 // =============================================================================
 
-void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         int32_t total_tasks = orch->rings[r].task_allocator.active_count();
         if (total_tasks > 0) {
             LOG_INFO("=== [Orchestrator] ring %d: total_tasks=%d ===", r, total_tasks);
         }
-        auto& pool = orch->rings[r].dep_pool;
+        auto &pool = orch->rings[r].dep_pool;
         if (pool.top > 0) {
-            LOG_INFO("=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===",
-                r,
-                pool.top,
-                pool.tail,
-                pool.top - pool.tail,
-                pool.high_water,
-                pool.capacity);
+            LOG_INFO(
+                "=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===", r, pool.top, pool.tail,
+                pool.top - pool.tail, pool.high_water, pool.capacity
+            );
         }
     }
     orch->sm_handle->header->orchestrator_done.store(1, std::memory_order_release);
@@ -675,7 +669,7 @@ void pto2_orchestrator_done(PTO2OrchestratorState* orch) {
 // Debug Utilities
 // =============================================================================
 
-void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch) {
     LOG_INFO("=== Orchestrator Statistics ===");
 #if PTO2_PROFILING
     LOG_INFO("Tasks submitted:     %" PRId64, orch->tasks_submitted);
@@ -687,19 +681,20 @@ void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch) {
         int32_t active = orch->rings[r].task_allocator.active_count();
         if (active > 0) {
             LOG_INFO("Ring %d task active:  %d", r, active);
-            LOG_INFO("Ring %d heap used:    %" PRIu64 " / %" PRIu64,
-                r,
-                orch->rings[r].task_allocator.heap_top(),
-                orch->rings[r].task_allocator.heap_capacity());
             LOG_INFO(
-                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity);
+                "Ring %d heap used:    %" PRIu64 " / %" PRIu64, r, orch->rings[r].task_allocator.heap_top(),
+                orch->rings[r].task_allocator.heap_capacity()
+            );
+            LOG_INFO(
+                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity
+            );
         }
     }
     LOG_INFO("TensorMap valid:     %d", orch->tensor_map.valid_count());
     LOG_INFO("===============================");
 }
 
-void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch) {
+void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState *orch) {
     LOG_INFO("=== Scope Stack ===");
     LOG_INFO("Depth: %d", orch->scope_stack_top + 1);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Orchestrator Interface
  *
@@ -37,37 +47,37 @@
  */
 struct PTO2OrchestratorState {
     // === SHARED MEMORY ACCESS ===
-    PTO2SharedMemoryHandle* sm_handle;
+    PTO2SharedMemoryHandle *sm_handle;
 
     // === PER-RING RESOURCES ===
     PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
 
     // === TENSOR MAP (Private) ===
-    PTO2TensorMap tensor_map;        // Producer lookup
+    PTO2TensorMap tensor_map;  // Producer lookup
 
     // === SCOPE STACK (Private) ===
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    PTO2TaskSlotState** scope_tasks; // Flat buffer of taskSlotState (all scopes concatenated)
-    int32_t scope_tasks_size;       // Number of task IDs currently in the buffer
-    int32_t scope_tasks_capacity;   // Allocated capacity of scope_tasks
-    int32_t* scope_begins;         // scope_begins[i] = start index of scope i in scope_tasks
-    int32_t scope_stack_top;       // Current top of stack (-1 = no scope open)
-    uint64_t scope_stack_capacity;   // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+    PTO2TaskSlotState **scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
+    int32_t scope_tasks_size;         // Number of task IDs currently in the buffer
+    int32_t scope_tasks_capacity;     // Allocated capacity of scope_tasks
+    int32_t *scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
+    int32_t scope_stack_top;          // Current top of stack (-1 = no scope open)
+    uint64_t scope_stack_capacity;    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
 
     // === SCHEDULER REFERENCE ===
     // Note: In simulated mode, orchestrator and scheduler share address space
     // In real mode, they communicate via shared memory only
-    PTO2SchedulerState* scheduler;  // For simulated mode only
+    PTO2SchedulerState *scheduler;  // For simulated mode only
 #if PTO2_PROFILING
     // Runtime profiling switch copied from Runtime::enable_profiling.
     bool enable_profiling;
 #endif
 
     // === GM HEAP (for output buffers) ===
-    void* gm_heap_base;    // Base address of GM heap
-    uint64_t gm_heap_size;   // Total size of GM heap (all rings)
+    void *gm_heap_base;     // Base address of GM heap
+    uint64_t gm_heap_size;  // Total size of GM heap (all rings)
 
     // === FATAL ERROR ===
     // Fatal error flag (single-thread access by orchestrator, no atomic needed)
@@ -90,7 +100,6 @@ struct PTO2OrchestratorState {
         if (depth < 0) depth = 0;
         return depth < PTO2_MAX_RING_DEPTH ? static_cast<uint8_t>(depth) : PTO2_MAX_RING_DEPTH - 1;
     }
-
 };
 
 // =============================================================================
@@ -107,19 +116,19 @@ struct PTO2OrchestratorState {
  * @return true on success
  */
 bool pto2_orchestrator_init(
-    PTO2OrchestratorState* orch, PTO2SharedMemoryHandle* sm_handle, void* gm_heap, uint64_t heap_size,
-    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    PTO2OrchestratorState *orch, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 
 /**
  * Destroy orchestrator state and free resources
  */
-void pto2_orchestrator_destroy(PTO2OrchestratorState* orch);
+void pto2_orchestrator_destroy(PTO2OrchestratorState *orch);
 
 /**
  * Set scheduler reference (for simulated mode)
  */
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerState* scheduler);
-
+void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler);
 
 // =============================================================================
 // Scope Management
@@ -132,7 +141,7 @@ void pto2_orchestrator_set_scheduler(PTO2OrchestratorState* orch, PTO2SchedulerS
  * Tasks submitted while this scope is at the top of the stack are
  * owned by it and have their fanout_count initialized to 1.
  */
-void pto2_scope_begin(PTO2OrchestratorState* orch);
+void pto2_scope_begin(PTO2OrchestratorState *orch);
 
 /**
  * End current scope
@@ -141,7 +150,7 @@ void pto2_scope_begin(PTO2OrchestratorState* orch);
  * directly owned by that scope.
  * May trigger buffer release for tasks that are now fully consumed.
  */
-void pto2_scope_end(PTO2OrchestratorState* orch);
+void pto2_scope_end(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Task Submission
@@ -161,9 +170,8 @@ void pto2_scope_end(PTO2OrchestratorState* orch);
  * @param mixed_kernels  Kernel IDs for AIC/AIV0/AIV1 slots
  * @param args      Aggregated tensor and scalar parameters
  */
-TaskOutputTensors pto2_submit_mixed_task(PTO2OrchestratorState* orch,
-    const MixedKernels& mixed_kernels,
-    const Arg& args);
+TaskOutputTensors
+pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args);
 
 // =============================================================================
 // Flow Control
@@ -174,7 +182,7 @@ TaskOutputTensors pto2_submit_mixed_task(PTO2OrchestratorState* orch,
  *
  * Signals to scheduler that no more tasks will be submitted.
  */
-void pto2_orchestrator_done(PTO2OrchestratorState* orch);
+void pto2_orchestrator_done(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Debug Utilities
@@ -183,12 +191,12 @@ void pto2_orchestrator_done(PTO2OrchestratorState* orch);
 /**
  * Print orchestrator statistics
  */
-void pto2_orchestrator_print_stats(PTO2OrchestratorState* orch);
+void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch);
 
 /**
  * Print scope stack state
  */
-void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch);
+void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Orchestrator Profiling Data
@@ -197,16 +205,16 @@ void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState* orch);
 #if PTO2_ORCH_PROFILING
 struct PTO2OrchProfilingData {
     uint64_t sync_cycle;
-    uint64_t alloc_cycle;           // Combined task slot + heap allocation
+    uint64_t alloc_cycle;  // Combined task slot + heap allocation
     uint64_t args_cycle;
     uint64_t lookup_cycle;
     uint64_t insert_cycle;
     uint64_t fanin_cycle;
     uint64_t scope_end_cycle;
-    int64_t  submit_count;
+    int64_t submit_count;
     // Wait time tracking for blocking phases
-    uint64_t alloc_wait_cycle;      // Cycles spent waiting in unified alloc
-    uint64_t fanin_wait_cycle;      // Cycles spent waiting in fanout_lock
+    uint64_t alloc_wait_cycle;  // Cycles spent waiting in unified alloc
+    uint64_t fanin_wait_cycle;  // Cycles spent waiting in fanout_lock
     // Atomic operation counts per phase
     uint64_t alloc_atomic_count;
     uint64_t args_atomic_count;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Ring Buffer Implementation
  *
@@ -17,7 +27,7 @@
 // =============================================================================
 // Dependency List Pool Implementation
 // =============================================================================
-void PTO2DepListPool::reclaim(PTO2SchedulerState& sched, uint8_t ring_id, int32_t sm_last_task_alive) {
+void PTO2DepListPool::reclaim(PTO2SchedulerState &sched, uint8_t ring_id, int32_t sm_last_task_alive) {
     if (sm_last_task_alive >= last_reclaimed + PTO2_DEP_POOL_CLEANUP_INTERVAL && sm_last_task_alive > 0) {
         int32_t mark = sched.ring_sched_states[ring_id].get_slot_state_by_task_id(sm_last_task_alive - 1).dep_pool_mark;
         if (mark > 0) {
@@ -28,7 +38,8 @@ void PTO2DepListPool::reclaim(PTO2SchedulerState& sched, uint8_t ring_id, int32_
 }
 
 void PTO2DepListPool::ensure_space(
-    PTO2SchedulerState& sched, PTO2RingFlowControl& fc, uint8_t ring_id, int32_t needed) {
+    PTO2SchedulerState &sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed
+) {
     if (available() >= needed) return;
 
     int spin_count = 0;
@@ -52,10 +63,10 @@ void PTO2DepListPool::ensure_space(
             LOG_ERROR("FATAL: Dependency Pool Deadlock Detected! (ring %d)", ring_id);
             LOG_ERROR("========================================");
             LOG_ERROR("DepListPool cannot reclaim space after %d spins (no progress).", spin_count);
-            LOG_ERROR("  - Pool used:     %d / %d (%.1f%%)",
-                used(),
-                capacity,
-                (capacity > 0) ? (100.0 * used() / capacity) : 0.0);
+            LOG_ERROR(
+                "  - Pool used:     %d / %d (%.1f%%)", used(), capacity,
+                (capacity > 0) ? (100.0 * used() / capacity) : 0.0
+            );
             LOG_ERROR("  - Pool top:      %d (linear)", top);
             LOG_ERROR("  - Pool tail:     %d (linear)", tail);
             LOG_ERROR("  - High water:    %d", high_water);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Ring Buffer Data Structures
  *
@@ -12,7 +22,7 @@
  *    - Ring buffer for linked list entries
  *    - O(1) prepend operation
  *    - Implicit reclamation with task ring
- * 
+ *
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
@@ -33,12 +43,12 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 #endif
 
 // Block notification interval (in spin counts)
-#define PTO2_BLOCK_NOTIFY_INTERVAL  10000
+#define PTO2_BLOCK_NOTIFY_INTERVAL 10000
 // Alloc spin limit - after this, report deadlock and exit
-#define PTO2_ALLOC_SPIN_LIMIT       100000
+#define PTO2_ALLOC_SPIN_LIMIT 100000
 
 // Dep pool spin limit - if exceeded, dep pool capacity too small for workload
-#define PTO2_DEP_POOL_SPIN_LIMIT      100000
+#define PTO2_DEP_POOL_SPIN_LIMIT 100000
 
 // =============================================================================
 // Task Allocator (unified task slot + heap buffer allocation)
@@ -48,10 +58,10 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
  * Result of a unified task allocation.
  */
 struct PTO2TaskAllocResult {
-    int32_t task_id;      // Absolute task ID (not wrapped), -1 on failure
-    int32_t slot;         // task_id & (window_size - 1)
-    void* packed_base;    // Heap allocation result (nullptr if output_size == 0)
-    void* packed_end;     // packed_base + aligned output_size
+    int32_t task_id;    // Absolute task ID (not wrapped), -1 on failure
+    int32_t slot;       // task_id & (window_size - 1)
+    void *packed_base;  // Heap allocation result (nullptr if output_size == 0)
+    void *packed_end;   // packed_base + aligned output_size
 
     bool failed() const { return task_id < 0; }
 };
@@ -71,11 +81,10 @@ public:
     /**
      * Initialize the allocator with task ring and heap ring resources.
      */
-    void init(PTO2TaskDescriptor* descriptors, int32_t window_size,
-              std::atomic<int32_t>* current_index_ptr,
-              std::atomic<int32_t>* last_alive_ptr,
-              void* heap_base, uint64_t heap_size,
-              std::atomic<int32_t>* error_code_ptr) {
+    void init(
+        PTO2TaskDescriptor *descriptors, int32_t window_size, std::atomic<int32_t> *current_index_ptr,
+        std::atomic<int32_t> *last_alive_ptr, void *heap_base, uint64_t heap_size, std::atomic<int32_t> *error_code_ptr
+    ) {
         descriptors_ = descriptors;
         window_size_ = window_size;
         window_mask_ = window_size - 1;
@@ -101,8 +110,8 @@ public:
      * @return Allocation result; check failed() for errors
      */
     PTO2TaskAllocResult alloc(int32_t output_size) {
-        uint64_t aligned_size = output_size > 0
-            ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
+        uint64_t aligned_size =
+            output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
 
         int spin_count = 0;
         int32_t prev_last_alive = last_alive_ptr_->load(std::memory_order_acquire);
@@ -116,15 +125,14 @@ public:
 
         while (true) {
             // Check both resources; commit only if both available
-            if (local_task_id_ - last_alive  + 1 < window_size_) {
-                void* heap_ptr = try_bump_heap(aligned_size);
+            if (local_task_id_ - last_alive + 1 < window_size_) {
+                void *heap_ptr = try_bump_heap(aligned_size);
                 if (heap_ptr) {
                     int32_t task_id = commit_task();
 #if PTO2_ORCH_PROFILING
                     record_wait(spin_count, wait_start, waiting);
 #endif
-                    return {task_id, task_id & window_mask_,
-                            heap_ptr, static_cast<char*>(heap_ptr) + aligned_size};
+                    return {task_id, task_id & window_mask_, heap_ptr, static_cast<char *>(heap_ptr) + aligned_size};
                 }
                 blocked_on_heap = true;
             } else {
@@ -134,7 +142,10 @@ public:
             // Spin: wait for scheduler to advance last_task_alive
             spin_count++;
 #if PTO2_ORCH_PROFILING
-            if (!waiting) { wait_start = get_sys_cnt_aicpu(); waiting = true; }
+            if (!waiting) {
+                wait_start = get_sys_cnt_aicpu();
+                waiting = true;
+            }
 #endif
             last_alive = last_alive_ptr_->load(std::memory_order_acquire);
             update_heap_tail(last_alive);
@@ -144,13 +155,11 @@ public:
             } else {
 #if PTO2_SPIN_VERBOSE_LOGGING
                 if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0) {
-                    LOG_WARN("[TaskAllocator] BLOCKED: tasks=%d/%d, heap=%" PRIu64 "/%" PRIu64 ", on=%s, spins=%d",
-                        local_task_id_ - last_alive,
-                        window_size_,
-                        heap_top_,
-                        heap_size_,
-                        blocked_on_heap ? "heap" : "task",
-                        spin_count);
+                    LOG_WARN(
+                        "[TaskAllocator] BLOCKED: tasks=%d/%d, heap=%" PRIu64 "/%" PRIu64 ", on=%s, spins=%d",
+                        local_task_id_ - last_alive, window_size_, heap_top_, heap_size_,
+                        blocked_on_heap ? "heap" : "task", spin_count
+                    );
                 }
 #endif
                 if (spin_count >= PTO2_ALLOC_SPIN_LIMIT) {
@@ -166,13 +175,9 @@ public:
     // Task descriptor accessors
     // =========================================================================
 
-    PTO2TaskDescriptor& task(int32_t task_id) const {
-        return descriptors_[task_id & window_mask_];
-    }
+    PTO2TaskDescriptor &task(int32_t task_id) const { return descriptors_[task_id & window_mask_]; }
 
-    PTO2TaskDescriptor& task_by_slot(int32_t slot) const {
-        return descriptors_[slot];
-    }
+    PTO2TaskDescriptor &task_by_slot(int32_t slot) const { return descriptors_[slot]; }
 
     // =========================================================================
     // State queries
@@ -200,24 +205,24 @@ public:
 
 private:
     // --- Task Ring ---
-    PTO2TaskDescriptor* descriptors_ = nullptr;
+    PTO2TaskDescriptor *descriptors_ = nullptr;
     int32_t window_size_ = 0;
     int32_t window_mask_ = 0;
-    std::atomic<int32_t>* current_index_ptr_ = nullptr;
-    std::atomic<int32_t>* last_alive_ptr_ = nullptr;
+    std::atomic<int32_t> *current_index_ptr_ = nullptr;
+    std::atomic<int32_t> *last_alive_ptr_ = nullptr;
 
     // --- Heap ---
-    void*    heap_base_ = nullptr;
+    void *heap_base_ = nullptr;
     uint64_t heap_size_ = 0;
 
     // --- Local state (single-writer, no atomics needed) ---
-    int32_t  local_task_id_ = 0;      // Next task ID to allocate
-    uint64_t heap_top_ = 0;     // Current heap allocation pointer
-    uint64_t heap_tail_ = 0;    // Heap reclamation pointer (derived from consumed tasks)
-    int32_t  last_alive_seen_ = 0;    // last_task_alive at last heap_tail derivation
+    int32_t local_task_id_ = 0;    // Next task ID to allocate
+    uint64_t heap_top_ = 0;        // Current heap allocation pointer
+    uint64_t heap_tail_ = 0;       // Heap reclamation pointer (derived from consumed tasks)
+    int32_t last_alive_seen_ = 0;  // last_task_alive at last heap_tail derivation
 
     // --- Shared ---
-    std::atomic<int32_t>* error_code_ptr_ = nullptr;
+    std::atomic<int32_t> *error_code_ptr_ = nullptr;
 
     // =========================================================================
     // Internal helpers
@@ -244,9 +249,9 @@ private:
         if (last_alive <= last_alive_seen_) return;
         last_alive_seen_ = last_alive;
 
-        PTO2TaskDescriptor& desc = descriptors_[(last_alive - 1) & window_mask_];
-        heap_tail_ = static_cast<uint64_t>(
-            static_cast<char*>(desc.packed_buffer_end) - static_cast<char*>(heap_base_));
+        PTO2TaskDescriptor &desc = descriptors_[(last_alive - 1) & window_mask_];
+        heap_tail_ =
+            static_cast<uint64_t>(static_cast<char *>(desc.packed_buffer_end) - static_cast<char *>(heap_base_));
     }
 
     /**
@@ -254,18 +259,18 @@ private:
      * Returns the allocated pointer, or nullptr if insufficient space.
      * When alloc_size == 0, returns current position without advancing.
      */
-    void* try_bump_heap(uint64_t alloc_size) {
+    void *try_bump_heap(uint64_t alloc_size) {
         uint64_t top = heap_top_;
         if (alloc_size == 0) {
-            return static_cast<char*>(heap_base_) + top;
+            return static_cast<char *>(heap_base_) + top;
         }
         uint64_t tail = heap_tail_;
-        void* result;
+        void *result;
 
         if (top >= tail) {
             uint64_t space_at_end = heap_size_ - top;
             if (space_at_end >= alloc_size) {
-                result = static_cast<char*>(heap_base_) + top;
+                result = static_cast<char *>(heap_base_) + top;
                 heap_top_ = top + alloc_size;
             } else if (tail > alloc_size) {
                 result = heap_base_;
@@ -275,7 +280,7 @@ private:
             }
         } else {
             if (tail - top >= alloc_size) {
-                result = static_cast<char*>(heap_base_) + top;
+                result = static_cast<char *>(heap_base_) + top;
                 heap_top_ = top + alloc_size;
             } else {
                 return nullptr;
@@ -314,18 +319,19 @@ private:
         }
         LOG_ERROR("========================================");
         LOG_ERROR("No progress after %d spins.", PTO2_ALLOC_SPIN_LIMIT);
-        LOG_ERROR("  Task ring:  current=%d, last_alive=%d, active=%d/%d (%.1f%%)",
-                  local_task_id_, last_alive, active_tasks, window_size_,
-                  100.0 * active_tasks / window_size_);
-        LOG_ERROR("  Heap ring:  top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64
-                  ", available=%" PRIu64,
-                  heap_top_, htail, heap_size_, heap_available());
+        LOG_ERROR(
+            "  Task ring:  current=%d, last_alive=%d, active=%d/%d (%.1f%%)", local_task_id_, last_alive, active_tasks,
+            window_size_, 100.0 * active_tasks / window_size_
+        );
+        LOG_ERROR(
+            "  Heap ring:  top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64 ", available=%" PRIu64, heap_top_, htail,
+            heap_size_, heap_available()
+        );
         if (heap_blocked) {
             LOG_ERROR("  Requested:  %d bytes", requested_output_size);
         }
         LOG_ERROR("Diagnosis:");
-        LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d",
-                  last_alive, last_alive);
+        LOG_ERROR("  last_task_alive is stuck at %d, meaning task %d", last_alive, last_alive);
         LOG_ERROR("  cannot transition to CONSUMED. Possible causes:");
         LOG_ERROR("  1. Task %d still executing (subtasks not complete)", last_alive);
         LOG_ERROR("  2. Task %d fanout not fully released (downstream not done)", last_alive);
@@ -333,22 +339,19 @@ private:
         LOG_ERROR("  4. Orchestrator blocked here -> can't call scope_end -> circular wait");
         LOG_ERROR("Solution:");
         if (heap_blocked) {
-            LOG_ERROR("  Increase heap size (current: %" PRIu64 ", recommended: %" PRIu64 ")",
-                      heap_size_, heap_size_ * 2);
+            LOG_ERROR(
+                "  Increase heap size (current: %" PRIu64 ", recommended: %" PRIu64 ")", heap_size_, heap_size_ * 2
+            );
             LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
-            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %" PRIu64 ")",
-                      heap_size_ * 2);
+            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %" PRIu64 ")", heap_size_ * 2);
         } else {
-            LOG_ERROR("  Increase task window size (current: %d, recommended: %d)",
-                      window_size_, active_tasks * 2);
+            LOG_ERROR("  Increase task window size (current: %d, recommended: %d)", window_size_, active_tasks * 2);
             LOG_ERROR("  Compile-time: PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");
-            LOG_ERROR("  Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2> (e.g. %d)",
-                      active_tasks * 2);
+            LOG_ERROR("  Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2> (e.g. %d)", active_tasks * 2);
         }
         LOG_ERROR("========================================");
         if (error_code_ptr_) {
-            int32_t code = heap_blocked ? PTO2_ERROR_HEAP_RING_DEADLOCK
-                                        : PTO2_ERROR_FLOW_CONTROL_DEADLOCK;
+            int32_t code = heap_blocked ? PTO2_ERROR_HEAP_RING_DEADLOCK : PTO2_ERROR_FLOW_CONTROL_DEADLOCK;
             error_code_ptr_->store(code, std::memory_order_release);
         }
     }
@@ -369,15 +372,15 @@ private:
  * is obtained via modulo: base[linear_index % capacity].
  */
 struct PTO2DepListPool {
-    PTO2DepListEntry* base;   // Pool base address
-    int32_t capacity;         // Total number of entries
-    int32_t top;              // Linear next-allocation counter (starts from 1)
-    int32_t tail;             // Linear first-alive counter (entries before this are dead)
-    int32_t high_water;       // Peak concurrent usage (top - tail)
-    int32_t last_reclaimed{0}; // last_task_alive at last successful reclamation
+    PTO2DepListEntry *base;     // Pool base address
+    int32_t capacity;           // Total number of entries
+    int32_t top;                // Linear next-allocation counter (starts from 1)
+    int32_t tail;               // Linear first-alive counter (entries before this are dead)
+    int32_t high_water;         // Peak concurrent usage (top - tail)
+    int32_t last_reclaimed{0};  // last_task_alive at last successful reclamation
 
     // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
-    std::atomic<int32_t>* error_code_ptr = nullptr;
+    std::atomic<int32_t> *error_code_ptr = nullptr;
 
     /**
      * Initialize dependency list pool
@@ -385,7 +388,7 @@ struct PTO2DepListPool {
      * @param base      Pool base address from shared memory
      * @param capacity  Total number of entries
      */
-    void init(PTO2DepListEntry* in_base, int32_t in_capacity, std::atomic<int32_t>* in_error_code_ptr) {
+    void init(PTO2DepListEntry *in_base, int32_t in_capacity, std::atomic<int32_t> *in_error_code_ptr) {
         base = in_base;
         capacity = in_capacity;
         top = 1;   // Start from 1, 0 means NULL/empty
@@ -408,20 +411,20 @@ struct PTO2DepListPool {
      * @param ring_id            Ring layer index
      * @param sm_last_task_alive Current last_task_alive from shared memory
      */
-    void reclaim(PTO2SchedulerState& sched, uint8_t ring_id, int32_t sm_last_task_alive);
+    void reclaim(PTO2SchedulerState &sched, uint8_t ring_id, int32_t sm_last_task_alive);
 
     /**
      * Ensure dep pool for a specific ring has at least `needed` entries available.
      * Spin-waits for reclamation if under pressure. Detects deadlock if no progress.
      */
-    void ensure_space(PTO2SchedulerState& sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed);
+    void ensure_space(PTO2SchedulerState &sched, PTO2RingFlowControl &fc, uint8_t ring_id, int32_t needed);
 
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)
      *
      * @return Pointer to allocated entry, or nullptr on fatal error
      */
-    PTO2DepListEntry* alloc() {
+    PTO2DepListEntry *alloc() {
         int32_t used = top - tail;
         if (used >= capacity) {
             LOG_ERROR("========================================");
@@ -467,8 +470,8 @@ struct PTO2DepListPool {
      * @param task_slot     Task slot to prepend
      * @return New head offset
      */
-    PTO2DepListEntry* prepend(PTO2DepListEntry* cur, PTO2TaskSlotState* slot_state) {
-        PTO2DepListEntry* new_entry = alloc();
+    PTO2DepListEntry *prepend(PTO2DepListEntry *cur, PTO2TaskSlotState *slot_state) {
+        PTO2DepListEntry *new_entry = alloc();
         if (!new_entry) return nullptr;
         new_entry->slot_state = slot_state;
         new_entry->next = cur;
@@ -476,20 +479,16 @@ struct PTO2DepListPool {
     }
 
     /**
-    * Get entry by offset
-    */
-    PTO2DepListEntry* pto2_dep_pool_get(int32_t offset) {
+     * Get entry by offset
+     */
+    PTO2DepListEntry *pto2_dep_pool_get(int32_t offset) {
         if (offset <= 0) return NULL;
         return &base[offset];
     }
 
-    int32_t used() const {
-        return top - tail;
-    }
+    int32_t used() const { return top - tail; }
 
-    int32_t available() const {
-        return capacity - used();
-    }
+    int32_t available() const { return capacity - used(); }
 };
 
 // =============================================================================
@@ -502,7 +501,7 @@ struct PTO2DepListPool {
  */
 struct PTO2RingSet {
     PTO2TaskAllocator task_allocator;
-    PTO2DepListPool   dep_pool;
+    PTO2DepListPool dep_pool;
 };
 
-#endif // PTO_RING_BUFFER_H
+#endif  // PTO_RING_BUFFER_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Main Implementation
  *
@@ -24,35 +34,23 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 
 thread_local int pto2_current_orch_idx = 0;
 
-void pto2_set_orch_thread_idx(int idx) {
-    pto2_current_orch_idx = idx;
-}
+void pto2_set_orch_thread_idx(int idx) { pto2_current_orch_idx = idx; }
 
 // =============================================================================
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
-static TaskOutputTensors submit_task_impl(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                             const Arg& args) {
-    return pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels,
-                           args);
+static TaskOutputTensors submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
+    return pto2_submit_mixed_task(&rt->orchestrators[pto2_current_orch_idx], mixed_kernels, args);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime* rt) {
-    pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_scope_end(PTO2Runtime* rt) {
-    pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrators[pto2_current_orch_idx]); }
 
-void pto2_rt_orchestration_done(PTO2Runtime* rt) {
-    pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]);
-}
+void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrators[pto2_current_orch_idx]); }
 
-static bool is_fatal_impl(PTO2Runtime* rt) {
-    return rt->orchestrators[pto2_current_orch_idx].fatal;
-}
+static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrators[pto2_current_orch_idx].fatal; }
 
 // Wait for TensorMap producers of this tensor to be safe for data access.
 // For reads: wait until producer COMPLETED (done writing).
@@ -60,31 +58,29 @@ static bool is_fatal_impl(PTO2Runtime* rt) {
 //   (fanout_refcount >= fanout_count - 1, excluding scope reference).
 // Uses cycle-based timeout (checked every 1024 spins).
 // Returns false on timeout (sets orch.fatal).
-static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor,
-                                  bool wait_for_consumers, const char* caller) {
-    PTO2OrchestratorState& orch = rt->orchestrators[pto2_current_orch_idx];
+static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wait_for_consumers, const char *caller) {
+    PTO2OrchestratorState &orch = rt->orchestrators[pto2_current_orch_idx];
     PTO2LookupResult lookup_result;
     orch.tensor_map.lookup(tensor, lookup_result);
 
     for (int r = 0; r < lookup_result.count; r++) {
-        PTO2TensorMapEntry& entry = *lookup_result.entries[r].entry;
+        PTO2TensorMapEntry &entry = *lookup_result.entries[r].entry;
         PTO2TaskId producer_id = entry.producer_task_id;
         uint8_t ring_id = producer_id.ring();
         int32_t local_id = producer_id.local();
-        PTO2TaskSlotState& slot =
-            rt->scheduler.ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
+        PTO2TaskSlotState &slot = rt->scheduler.ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
 
         // Wait for producer to complete (WAW safety)
         uint64_t t0 = get_sys_cnt_aicpu();
         int32_t spin_count = 0;
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
             SPIN_WAIT_HINT();
-            if ((++spin_count & 1023) == 0 &&
-                get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+            if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
                 orch.fatal = true;
-                unified_log_error(caller,
-                    "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
-                    (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id);
+                unified_log_error(
+                    caller, "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
+                    (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
+                );
                 return false;
             }
         }
@@ -95,15 +91,14 @@ static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor,
         if (wait_for_consumers) {
             t0 = get_sys_cnt_aicpu();
             spin_count = 0;
-            while (slot.fanout_refcount.load(std::memory_order_acquire)
-                   < slot.fanout_count - 1) {
+            while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
                 SPIN_WAIT_HINT();
-                if ((++spin_count & 1023) == 0 &&
-                    get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+                if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
                     orch.fatal = true;
-                    unified_log_error(caller,
-                        "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
-                        (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id);
+                    unified_log_error(
+                        caller, "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
+                        (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
+                    );
                     return false;
                 }
             }
@@ -112,12 +107,12 @@ static bool wait_for_tensor_ready(PTO2Runtime* rt, const Tensor& tensor,
     return true;
 }
 
-uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
-                              uint32_t ndims, const uint32_t indices[]) {
+uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     if (tensor.buffer.addr == 0) {
-        unified_log_error(__FUNCTION__,
-            "get_tensor_data: buffer not allocated (addr=0). "
-            "Use the Tensor returned by add_output(TensorCreateInfo) after submit returns.");
+        unified_log_error(
+            __FUNCTION__, "get_tensor_data: buffer not allocated (addr=0). "
+                          "Use the Tensor returned by add_output(TensorCreateInfo) after submit returns."
+        );
         return 0;
     }
 
@@ -127,20 +122,20 @@ uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
 
     uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
     uint64_t elem_size = get_element_size(tensor.dtype);
-    const void* ptr = reinterpret_cast<const void*>(
-        tensor.buffer.addr + flat_offset * elem_size);
+    const void *ptr = reinterpret_cast<const void *>(tensor.buffer.addr + flat_offset * elem_size);
     uint64_t result = 0;
     memcpy(&result, ptr, elem_size);
     return result;
 }
 
-void pto2_set_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
-                          uint32_t ndims, const uint32_t indices[],
-                          uint64_t value) {
+void pto2_set_tensor_data(
+    PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+) {
     if (tensor.buffer.addr == 0) {
-        unified_log_error(__FUNCTION__,
-            "set_tensor_data: buffer not allocated (addr=0). "
-            "Use the Tensor returned by add_output(TensorCreateInfo) after submit returns.");
+        unified_log_error(
+            __FUNCTION__, "set_tensor_data: buffer not allocated (addr=0). "
+                          "Use the Tensor returned by add_output(TensorCreateInfo) after submit returns."
+        );
         return;
     }
 
@@ -151,42 +146,38 @@ void pto2_set_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
 
     uint64_t flat_offset = tensor.compute_flat_offset(indices, ndims);
     uint64_t elem_size = get_element_size(tensor.dtype);
-    void* ptr = reinterpret_cast<void*>(
-        tensor.buffer.addr + flat_offset * elem_size);
+    void *ptr = reinterpret_cast<void *>(tensor.buffer.addr + flat_offset * elem_size);
     memcpy(ptr, &value, elem_size);
 }
 
 static const PTO2RuntimeOps s_runtime_ops = {
-    .submit_task          = submit_task_impl,
-    .scope_begin          = pto2_rt_scope_begin,
-    .scope_end            = pto2_rt_scope_end,
-    .orchestration_done   = pto2_rt_orchestration_done,
-    .is_fatal             = is_fatal_impl,
-    .log_error            = unified_log_error,
-    .log_warn             = unified_log_warn,
-    .log_info             = unified_log_info,
-    .log_debug            = unified_log_debug,
-    .log_always           = unified_log_always,
-    .get_tensor_data      = pto2_get_tensor_data,
-    .set_tensor_data      = pto2_set_tensor_data,
+    .submit_task = submit_task_impl,
+    .scope_begin = pto2_rt_scope_begin,
+    .scope_end = pto2_rt_scope_end,
+    .orchestration_done = pto2_rt_orchestration_done,
+    .is_fatal = is_fatal_impl,
+    .log_error = unified_log_error,
+    .log_warn = unified_log_warn,
+    .log_info = unified_log_info,
+    .log_debug = unified_log_debug,
+    .log_always = unified_log_always,
+    .get_tensor_data = pto2_get_tensor_data,
+    .set_tensor_data = pto2_set_tensor_data,
 };
 
 // =============================================================================
 // Runtime Creation and Destruction
 // =============================================================================
 
-PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode) {
-    return pto2_runtime_create_custom(mode,
-                                       PTO2_TASK_WINDOW_SIZE,
-                                       PTO2_HEAP_SIZE);
+PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode) {
+    return pto2_runtime_create_custom(mode, PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
 }
 
-PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
-                                         uint64_t task_window_size,
-                                         uint64_t heap_size,
-                                         int32_t dep_pool_capacity) {
+PTO2Runtime *pto2_runtime_create_custom(
+    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity
+) {
     // Allocate runtime context
-    PTO2Runtime* rt = (PTO2Runtime*)calloc(1, sizeof(PTO2Runtime));
+    PTO2Runtime *rt = (PTO2Runtime *)calloc(1, sizeof(PTO2Runtime));
     if (!rt) {
         return NULL;
     }
@@ -203,25 +194,24 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
     // Allocate GM heap for output buffers (all rings combined)
     uint64_t total_heap_size = heap_size * PTO2_MAX_RING_DEPTH;
     rt->gm_heap_size = total_heap_size;
-    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-        if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, total_heap_size) != 0) {
-            pto2_sm_destroy(rt->sm_handle);
-            free(rt);
-            return NULL;
-        }
-    #else
-        rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, total_heap_size);
-        if (!rt->gm_heap) {
-            pto2_sm_destroy(rt->sm_handle);
-            free(rt);
-            return NULL;
-        }
-    #endif
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+    if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, total_heap_size) != 0) {
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+#else
+    rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, total_heap_size);
+    if (!rt->gm_heap) {
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+#endif
     rt->gm_heap_owned = true;
 
     // Initialize first orchestrator
-    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle,
-                                 rt->gm_heap, heap_size, dep_pool_capacity)) {
+    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
         free(rt);
@@ -243,17 +233,15 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
     return rt;
 }
 
-PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-                                          PTO2SharedMemoryHandle* sm_handle,
-                                          void* gm_heap,
-                                          uint64_t heap_size,
-                                          int orch_count,
-                                          int32_t dep_pool_capacity) {
+PTO2Runtime *pto2_runtime_create_from_sm(
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count,
+    int32_t dep_pool_capacity
+) {
     if (!sm_handle) return NULL;
     if (orch_count < 1) orch_count = 1;
     if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
 
-    PTO2Runtime* rt = (PTO2Runtime*)calloc(1, sizeof(PTO2Runtime));
+    PTO2Runtime *rt = (PTO2Runtime *)calloc(1, sizeof(PTO2Runtime));
     if (!rt) return NULL;
 
     rt->ops = &s_runtime_ops;
@@ -266,8 +254,7 @@ PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
 
     // Initialize all orchestrator states
     for (int i = 0; i < orch_count; i++) {
-        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle,
-                                    rt->gm_heap, heap_size, dep_pool_capacity)) {
+        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
             for (int j = 0; j < i; j++) {
                 pto2_orchestrator_destroy(&rt->orchestrators[j]);
             }
@@ -293,7 +280,7 @@ PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
     return rt;
 }
 
-void pto2_runtime_destroy(PTO2Runtime* rt) {
+void pto2_runtime_destroy(PTO2Runtime *rt) {
     if (!rt) return;
 
     pto2_scheduler_destroy(&rt->scheduler);
@@ -312,7 +299,7 @@ void pto2_runtime_destroy(PTO2Runtime* rt) {
     free(rt);
 }
 
-void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode) {
+void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Main Interface
  *
@@ -59,27 +69,25 @@ enum PTO2RuntimeMode {
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime* rt, const MixedKernels& mixed_kernels,
-                        const Arg& args);
-    void (*scope_begin)(PTO2Runtime* rt);
-    void (*scope_end)(PTO2Runtime* rt);
-    void (*orchestration_done)(PTO2Runtime* rt);
-    bool (*is_fatal)(PTO2Runtime* rt);
+    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    void (*scope_begin)(PTO2Runtime *rt);
+    void (*scope_end)(PTO2Runtime *rt);
+    void (*orchestration_done)(PTO2Runtime *rt);
+    bool (*is_fatal)(PTO2Runtime *rt);
 
     // Logging (populated by runtime, called by orchestration)
-    void (*log_error)(const char* func, const char* fmt, ...);
-    void (*log_warn)(const char* func, const char* fmt, ...);
-    void (*log_info)(const char* func, const char* fmt, ...);
-    void (*log_debug)(const char* func, const char* fmt, ...);
-    void (*log_always)(const char* func, const char* fmt, ...);
+    void (*log_error)(const char *func, const char *fmt, ...);
+    void (*log_warn)(const char *func, const char *fmt, ...);
+    void (*log_info)(const char *func, const char *fmt, ...);
+    void (*log_debug)(const char *func, const char *fmt, ...);
+    void (*log_always)(const char *func, const char *fmt, ...);
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
-                                uint32_t ndims, const uint32_t indices[]);
-    void (*set_tensor_data)(PTO2Runtime* rt, const Tensor& tensor,
-                            uint32_t ndims, const uint32_t indices[],
-                            uint64_t value);
+    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]);
+    void (*set_tensor_data)(
+        PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    );
 };
 
 /**
@@ -90,24 +98,24 @@ struct PTO2RuntimeOps {
  */
 struct PTO2Runtime {
     // Ops table (first field — used by orchestration .so via function pointers)
-    const PTO2RuntimeOps*   ops;
+    const PTO2RuntimeOps *ops;
 
     // Components
-    PTO2SharedMemoryHandle* sm_handle;
-    PTO2OrchestratorState   orchestrators[PTO2_MAX_ORCH_THREADS];
-    int                     orch_count;     // Number of active orchestrator states
-    PTO2SchedulerState      scheduler;
+    PTO2SharedMemoryHandle *sm_handle;
+    PTO2OrchestratorState orchestrators[PTO2_MAX_ORCH_THREADS];
+    int orch_count;  // Number of active orchestrator states
+    PTO2SchedulerState scheduler;
 
     // GM Heap for output buffers
-    void*                   gm_heap;
-    uint64_t                  gm_heap_size;
-    bool                    gm_heap_owned;  // True if we allocated it
+    void *gm_heap;
+    uint64_t gm_heap_size;
+    bool gm_heap_owned;  // True if we allocated it
 
     // Mode
-    PTO2RuntimeMode         mode;
+    PTO2RuntimeMode mode;
 
     // Statistics
-    int64_t                 total_cycles;
+    int64_t total_cycles;
 };
 
 // =============================================================================
@@ -120,7 +128,7 @@ struct PTO2Runtime {
  * @param mode Execution mode
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode);
+PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode);
 
 /**
  * Create runtime with custom sizes
@@ -130,10 +138,10 @@ PTO2Runtime* pto2_runtime_create(PTO2RuntimeMode mode);
  * @param heap_size        Size of GM heap
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
-                                         uint64_t task_window_size,
-                                         uint64_t heap_size,
-                                         int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+PTO2Runtime *pto2_runtime_create_custom(
+    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 
 /**
  * Create runtime from existing shared memory and GM heap (e.g. on device).
@@ -145,22 +153,20 @@ PTO2Runtime* pto2_runtime_create_custom(PTO2RuntimeMode mode,
  * @param heap_size GM heap size in bytes
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime* pto2_runtime_create_from_sm(PTO2RuntimeMode mode,
-                                          PTO2SharedMemoryHandle* sm_handle,
-                                          void* gm_heap,
-                                          uint64_t heap_size,
-                                          int orch_count = 1,
-                                          int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+PTO2Runtime *pto2_runtime_create_from_sm(
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count = 1,
+    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 
 /**
  * Destroy runtime and free all resources
  */
-void pto2_runtime_destroy(PTO2Runtime* rt);
+void pto2_runtime_destroy(PTO2Runtime *rt);
 
 /**
  * Set execution mode
  */
-void pto2_runtime_set_mode(PTO2Runtime* rt, PTO2RuntimeMode mode);
+void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
 
 /**
  * Set the orchestrator index for the current thread.
@@ -179,7 +185,7 @@ void pto2_set_orch_thread_idx(int idx);
  * bounded by the scope. When scope_end() is called, the scope
  * releases its reference to all enclosed tasks.
  */
-void pto2_rt_scope_begin(PTO2Runtime* rt);
+void pto2_rt_scope_begin(PTO2Runtime *rt);
 
 /**
  * End current scope
@@ -187,29 +193,28 @@ void pto2_rt_scope_begin(PTO2Runtime* rt);
  * Releases scope reference for all tasks submitted since scope_begin().
  * Tasks whose refcount reaches zero will have their buffers released.
  */
-void pto2_rt_scope_end(PTO2Runtime* rt);
+void pto2_rt_scope_end(PTO2Runtime *rt);
 
 /**
  * Mark orchestration as complete
  *
  * Signals that no more tasks will be submitted.
  */
-void pto2_rt_orchestration_done(PTO2Runtime* rt);
+void pto2_rt_orchestration_done(PTO2Runtime *rt);
 
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.
  */
-uint64_t pto2_get_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
-                              uint32_t ndims, const uint32_t indices[]);
+uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]);
 
 /**
  * Cross-layer data access: write a value to a tensor at given indices.
  * Waits for producer completion (WAW) and all consumers (WAR) via TensorMap.
  * See set_tensor_data in pto_orchestration_api.h for full documentation.
  */
-void pto2_set_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
-                          uint32_t ndims, const uint32_t indices[],
-                          uint64_t value);
+void pto2_set_tensor_data(
+    PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+);
 
 /**
  * Slim config struct exported by orchestration .so via aicpu_orchestration_config().
@@ -218,8 +223,8 @@ void pto2_set_tensor_data(PTO2Runtime* rt, const Tensor& tensor,
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
 struct PTO2OrchestrationConfig {
-    int         expected_arg_count;
+    int expected_arg_count;
 };
 #endif
 
-#endif // PTO_RUNTIME2_H
+#endif  // PTO_RUNTIME2_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -137,14 +137,16 @@ constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES = 15 * 1000 * 1000 * 1000ULL;
 struct PTO2TaskId {
     uint64_t raw;
 
-    constexpr PTO2TaskId() : raw(0) {}
-    constexpr explicit PTO2TaskId(uint64_t v) : raw(v) {}
+    constexpr PTO2TaskId() :
+        raw(0) {}
+    constexpr explicit PTO2TaskId(uint64_t v) :
+        raw(v) {}
 
     constexpr uint8_t ring() const { return static_cast<uint8_t>(raw >> 32); }
     constexpr uint32_t local() const { return static_cast<uint32_t>(raw & 0xFFFFFFFFu); }
 
-    constexpr bool operator==(const PTO2TaskId& other) const { return raw == other.raw; }
-    constexpr bool operator!=(const PTO2TaskId& other) const { return raw != other.raw; }
+    constexpr bool operator==(const PTO2TaskId &other) const { return raw == other.raw; }
+    constexpr bool operator!=(const PTO2TaskId &other) const { return raw != other.raw; }
 };
 
 static_assert(sizeof(PTO2TaskId) == 8, "PTO2TaskId must stay 8 bytes (shared memory ABI)");
@@ -257,7 +259,7 @@ typedef enum {
  * Multiple logical tensors can share the same raw tensor (aliasing).
  */
 typedef struct {
-    void* base_ptr;      // Base pointer of allocated memory
+    void *base_ptr;      // Base pointer of allocated memory
     int64_t total_size;  // Total size in bytes
     int32_t refcount;    // Number of logical tensors referencing this storage
                          // (for memory management, 0 = can be freed)
@@ -284,7 +286,7 @@ typedef struct {
  */
 typedef struct {
     // === Raw tensor reference (shared storage) ===
-    void* raw_base;          // Pointer to raw tensor's base (for aliasing check)
+    void *raw_base;          // Pointer to raw tensor's base (for aliasing check)
     int64_t raw_total_size;  // Total size of raw tensor in bytes
 
     // === Storage offset ===
@@ -325,8 +327,8 @@ typedef struct {
  */
 struct PTO2TaskSlotState;  // Forward declaration
 struct PTO2DepListEntry {
-    PTO2TaskSlotState* slot_state;  // Consumer slot state (direct pointer)
-    PTO2DepListEntry* next;         // next entry
+    PTO2TaskSlotState *slot_state;  // Consumer slot state (direct pointer)
+    PTO2DepListEntry *next;         // next entry
 };
 
 // =============================================================================
@@ -350,8 +352,8 @@ struct PTO2TaskDescriptor {
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];
 
     // Packed output buffer (all outputs packed into single contiguous buffer)
-    void* packed_buffer_base;  // Start of packed buffer in GM Heap
-    void* packed_buffer_end;   // End of packed buffer (for heap reclamation)
+    void *packed_buffer_base;  // Start of packed buffer in GM Heap
+    void *packed_buffer_end;   // End of packed buffer (for heap reclamation)
 };
 
 // =============================================================================
@@ -375,7 +377,7 @@ struct PTO2TaskPayload {
     int32_t scalar_count{0};
     int32_t fanin_actual_count{0};  // Actual fanin count (without the +1 redundance)
     int32_t _reserved{0};           // Reserved (dep_pool_mark moved to SlotState for local access)
-    PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
+    PTO2TaskSlotState *fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
     // === Tensors (2048B) — alignas(64) Tensor forces alignment ===
     Tensor tensors[MAX_TENSOR_ARGS];
     // === Pre-built args for AICore dispatch (1152B = 16 tensor ptrs + 128 scalars) ===
@@ -391,13 +393,13 @@ struct PTO2TaskPayload {
      * @param args                Task arguments (tensors + scalars)
      * @param materialized_outputs  Materialized output tensors (from TensorCreateInfo path)
      */
-    void init(const Arg& args, const TaskOutputTensors& materialized_outputs) {
+    void init(const Arg &args, const TaskOutputTensors &materialized_outputs) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
         int32_t out_idx = 0;
         for (int32_t i = 0; i < args.tensor_count(); i++) {
-            const Tensor* src;
+            const Tensor *src;
             if (args.tag(i) == TensorArgType::OUTPUT) {
                 src = materialized_outputs.output_ptr(out_idx++);
             } else {
@@ -409,9 +411,10 @@ struct PTO2TaskPayload {
         }
         // Bulk-copy scalars into dispatch_args[tensor_count..], rounded up to
         // cache-line boundary (extra bytes within the same CL cost nothing).
-        memcpy(&dispatch_args[args.tensor_count()],
-            args.scalar_data(),
-            PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
+        memcpy(
+            &dispatch_args[args.tensor_count()], args.scalar_data(),
+            PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64)
+        );
     }
 };
 
@@ -432,7 +435,7 @@ struct alignas(64) PTO2TaskSlotState {
     std::atomic<int32_t> fanout_lock;  // Per-task spinlock (0=unlocked, 1=locked)
     int32_t fanout_count;              // 1 (owning scope) + number of consumers
 
-    PTO2DepListEntry* fanout_head;  // Pointer to first fanout entry (nullptr = empty)
+    PTO2DepListEntry *fanout_head;  // Pointer to first fanout entry (nullptr = empty)
 
     // Task state (completion, consumed check, ready check)
     std::atomic<PTO2TaskState> task_state;  // PENDING/READY/RUNNING/COMPLETED/CONSUMED
@@ -444,9 +447,9 @@ struct alignas(64) PTO2TaskSlotState {
     // Fanout refcount (accessed with fanout_count in check_and_handle_consumed)
     std::atomic<int32_t> fanout_refcount;  // Dynamic: counts released references
 
-    PTO2TaskPayload* payload;
+    PTO2TaskPayload *payload;
 
-    PTO2TaskDescriptor* task;
+    PTO2TaskDescriptor *task;
 
     // Hot-path completion fields (moved from TaskDescriptor to avoid cross-struct access)
     uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
@@ -465,7 +468,7 @@ static_assert(sizeof(PTO2TaskSlotState) == 64);
  * Cycle cost function pointer type
  * Returns estimated cycle count for the InCore function
  */
-typedef int64_t (*PTO2CycleCostFunc)(void** args, int32_t num_args);
+typedef int64_t (*PTO2CycleCostFunc)(void **args, int32_t num_args);
 
 // =============================================================================
 // InCore Function Type
@@ -475,7 +478,7 @@ typedef int64_t (*PTO2CycleCostFunc)(void** args, int32_t num_args);
  * InCore function signature
  * All InCore functions must match this signature
  */
-typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
+typedef void (*PTO2InCoreFunc)(void **args, int32_t num_args);
 
 // =============================================================================
 // Utility Macros
@@ -520,7 +523,7 @@ typedef void (*PTO2InCoreFunc)(void** args, int32_t num_args);
 #endif
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& atomic_count, uint64_t& wait_cycle) {
+static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
     uint64_t t0 = get_sys_cnt_aicpu();
     bool contended = false;
     uint32_t atomic_ops = 0;
@@ -533,7 +536,8 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& ato
         }
         int32_t expected = 0;
         if (slot_state.fanout_lock.compare_exchange_weak(
-                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             atomic_ops++;  // successful CAS = 1 atomic
             atomic_count += atomic_ops;
             if (contended) {
@@ -547,20 +551,21 @@ static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state, uint64_t& ato
 }
 #endif
 
-static inline void pto2_fanout_lock(PTO2TaskSlotState& slot_state) {
+static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state) {
     for (;;) {
         while (slot_state.fanout_lock.load(std::memory_order_acquire) != 0) {
             SPIN_WAIT_HINT();
         }
         int32_t expected = 0;
         if (slot_state.fanout_lock.compare_exchange_weak(
-                expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                expected, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             return;
         }
     }
 }
 
-static inline void pto2_fanout_unlock(PTO2TaskSlotState& slot_state) {
+static inline void pto2_fanout_unlock(PTO2TaskSlotState &slot_state) {
     slot_state.fanout_lock.store(0, std::memory_order_release);
 }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Scheduler Implementation
  *
@@ -57,14 +67,20 @@ PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
 // Task State Names
 // =============================================================================
 
-const char* pto2_task_state_name(PTO2TaskState state) {
+const char *pto2_task_state_name(PTO2TaskState state) {
     switch (state) {
-        case PTO2_TASK_PENDING:   return "PENDING";
-        case PTO2_TASK_READY:     return "READY";
-        case PTO2_TASK_RUNNING:   return "RUNNING";
-        case PTO2_TASK_COMPLETED: return "COMPLETED";
-        case PTO2_TASK_CONSUMED:  return "CONSUMED";
-        default:                  return "UNKNOWN";
+    case PTO2_TASK_PENDING:
+        return "PENDING";
+    case PTO2_TASK_READY:
+        return "READY";
+    case PTO2_TASK_RUNNING:
+        return "RUNNING";
+    case PTO2_TASK_COMPLETED:
+        return "COMPLETED";
+    case PTO2_TASK_CONSUMED:
+        return "CONSUMED";
+    default:
+        return "UNKNOWN";
     }
 }
 
@@ -72,8 +88,8 @@ const char* pto2_task_state_name(PTO2TaskState state) {
 // Ready Queue Implementation
 // =============================================================================
 
-bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity) {
-    queue->slots = (PTO2ReadyQueueSlot*)malloc(capacity * sizeof(PTO2ReadyQueueSlot));
+bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity) {
+    queue->slots = (PTO2ReadyQueueSlot *)malloc(capacity * sizeof(PTO2ReadyQueueSlot));
     if (!queue->slots) {
         return false;
     }
@@ -91,7 +107,7 @@ bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity) {
     return true;
 }
 
-void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
+void pto2_ready_queue_destroy(PTO2ReadyQueue *queue) {
     if (queue->slots) {
         free(queue->slots);
         queue->slots = NULL;
@@ -102,8 +118,7 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue) {
 // Scheduler Initialization
 // =============================================================================
 
-bool PTO2SchedulerState::RingSchedState::init(
-    PTO2SharedMemoryHandle* sm_handle, int32_t ring_id) {
+bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id) {
     task_descriptors = sm_handle->task_descriptors[ring_id];
     task_window_size = sm_handle->header->rings[ring_id].task_window_size;
     task_window_mask = static_cast<int32_t>(task_window_size - 1);
@@ -142,8 +157,7 @@ void PTO2SchedulerState::RingSchedState::destroy() {
     slot_states = nullptr;
 }
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle) {
+bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle) {
     sched->sm_handle = sm_handle;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -177,7 +191,7 @@ bool pto2_scheduler_init(PTO2SchedulerState* sched,
     return true;
 }
 
-void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
+void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].destroy();
     }
@@ -191,7 +205,7 @@ void pto2_scheduler_destroy(PTO2SchedulerState* sched) {
 // Debug Utilities
 // =============================================================================
 
-void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
+void pto2_scheduler_print_stats(PTO2SchedulerState *sched) {
     LOG_INFO("=== Scheduler Statistics ===");
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         if (sched->ring_sched_states[r].last_task_alive > 0) {
@@ -206,14 +220,13 @@ void pto2_scheduler_print_stats(PTO2SchedulerState* sched) {
     LOG_INFO("============================");
 }
 
-void pto2_scheduler_print_queues(PTO2SchedulerState* sched) {
+void pto2_scheduler_print_queues(PTO2SchedulerState *sched) {
     LOG_INFO("=== Ready Queues ===");
 
-    const char* shape_names[] = {"AIC", "AIV", "MIX"};
+    const char *shape_names[] = {"AIC", "AIV", "MIX"};
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        LOG_INFO("  %s: count=%" PRIu64, shape_names[i],
-                 sched->ready_queues[i].size());
+        LOG_INFO("  %s: count=%" PRIu64, shape_names[i], sched->ready_queues[i].size());
     }
 
     LOG_INFO("====================");

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Scheduler Interface
  *
@@ -30,7 +40,12 @@
 #if PTO2_SCHED_PROFILING
 #include "aicpu/device_time.h"
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
-#define PTO2_SCHED_CYCLE_LAP(acc) do { _st1 = get_sys_cnt_aicpu(); acc += (_st1 - _st0); _st0 = _st1; } while(0)
+#define PTO2_SCHED_CYCLE_LAP(acc)   \
+    do {                            \
+        _st1 = get_sys_cnt_aicpu(); \
+        acc += (_st1 - _st0);       \
+        _st0 = _st1;                \
+    } while (0)
 #endif
 
 // =============================================================================
@@ -42,7 +57,7 @@
  */
 struct PTO2ReadyQueueSlot {
     std::atomic<int64_t> sequence;
-    PTO2TaskSlotState* slot_state;
+    PTO2TaskSlotState *slot_state;
 };
 
 /**
@@ -60,17 +75,17 @@ struct PTO2ReadyQueueSlot {
 static constexpr int PTO2_LOCAL_DISPATCH_TYPE_NUM = 2;
 
 struct PTO2LocalReadyBuffer {
-    PTO2TaskSlotState** slot_states = nullptr;
+    PTO2TaskSlotState **slot_states = nullptr;
     int count = 0;
     int capacity = 0;
 
-    void reset(PTO2TaskSlotState** buf, int cap) {
+    void reset(PTO2TaskSlotState **buf, int cap) {
         slot_states = buf;
         count = 0;
         capacity = cap;
     }
 
-    bool try_push(PTO2TaskSlotState* s) {
+    bool try_push(PTO2TaskSlotState *s) {
         if (slot_states && count < capacity) {
             slot_states[count++] = s;
             return true;
@@ -78,9 +93,7 @@ struct PTO2LocalReadyBuffer {
         return false;
     }
 
-    PTO2TaskSlotState* pop() {
-        return (count > 0) ? slot_states[--count] : nullptr;
-    }
+    PTO2TaskSlotState *pop() { return (count > 0) ? slot_states[--count] : nullptr; }
 };
 
 /**
@@ -94,16 +107,16 @@ struct PTO2LocalReadyBuffer {
  *   consumers only touch dequeue_pos
  */
 struct alignas(64) PTO2ReadyQueue {
-    PTO2ReadyQueueSlot* slots;
+    PTO2ReadyQueueSlot *slots;
     uint64_t capacity;
-    uint64_t mask;                          // capacity - 1
-    char _pad0[64 - 24];                   // Pad to own cache line
+    uint64_t mask;        // capacity - 1
+    char _pad0[64 - 24];  // Pad to own cache line
 
     std::atomic<uint64_t> enqueue_pos;
-    char _pad1[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad1[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     std::atomic<uint64_t> dequeue_pos;
-    char _pad2[64 - sizeof(std::atomic<uint64_t>)];     // Own cache line
+    char _pad2[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     uint64_t size() {
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -111,17 +124,18 @@ struct alignas(64) PTO2ReadyQueue {
         return (e >= d) ? (e - d) : 0;
     }
 
-    bool push(PTO2TaskSlotState* slot_state) {
+    bool push(PTO2TaskSlotState *slot_state) {
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         while (true) {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)pos;
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    )) {
                     break;
                 }
             } else if (diff < 0) {
@@ -136,7 +150,7 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch push: reserve count slots with a single CAS after confirming
     // every target slot is available under the usual Vyukov sequence check.
-    void push_batch(PTO2TaskSlotState** items, int count) {
+    void push_batch(PTO2TaskSlotState **items, int count) {
         if (count == 0) return;
 
         uint64_t pos;
@@ -144,7 +158,7 @@ struct alignas(64) PTO2ReadyQueue {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             bool ready = true;
             for (int i = 0; i < count; i++) {
-                PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
+                PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
                 int64_t diff = seq - (int64_t)(pos + i);
                 if (diff != 0) {
@@ -155,23 +169,24 @@ struct alignas(64) PTO2ReadyQueue {
             if (!ready) {
                 continue;
             }
-            if (enqueue_pos.compare_exchange_weak(pos, pos + count,
-                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+            if (enqueue_pos.compare_exchange_weak(
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed
+                )) {
                 break;
             }
         }
 
         for (int i = 0; i < count; i++) {
-            PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
+            PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             slot->slot_state = items[i];
             slot->sequence.store((int64_t)(pos + i + 1), std::memory_order_release);
         }
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    bool push(PTO2TaskSlotState* slot_state, uint64_t& atomic_count, uint64_t& wait_cycle) {
+    bool push(PTO2TaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         uint64_t t0 = get_sys_cnt_aicpu();
         bool contended = false;
         uint32_t atomic_ops = 0;
@@ -182,8 +197,9 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - (int64_t)pos;
             atomic_ops += 2;  // enqueue_pos.load + sequence.load
             if (diff == 0) {
-                if (enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (enqueue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    )) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -207,7 +223,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 #endif
 
-    PTO2TaskSlotState* pop() {
+    PTO2TaskSlotState *pop() {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -216,28 +232,29 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         while (true) {
             pos = dequeue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
             int64_t diff = seq - (int64_t)(pos + 1);
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed))
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    ))
                     break;
             } else if (diff < 0) {
                 return nullptr;  // Queue empty
             }
         }
 
-        PTO2TaskSlotState* result = slot->slot_state;
+        PTO2TaskSlotState *result = slot->slot_state;
         slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
         return result;
     }
 
 #if PTO2_SCHED_PROFILING
-    PTO2TaskSlotState* pop(uint64_t& atomic_count, uint64_t& wait_cycle) {
+    PTO2TaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -247,7 +264,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         uint64_t pos;
-        PTO2ReadyQueueSlot* slot;
+        PTO2ReadyQueueSlot *slot;
         uint64_t t0 = get_sys_cnt_aicpu();
         bool contended = false;
         uint32_t atomic_ops = 0;
@@ -258,8 +275,9 @@ struct alignas(64) PTO2ReadyQueue {
             int64_t diff = seq - (int64_t)(pos + 1);
             atomic_ops += 2;  // dequeue_pos.load + sequence.load
             if (diff == 0) {
-                if (dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                        std::memory_order_relaxed, std::memory_order_relaxed)) {
+                if (dequeue_pos.compare_exchange_weak(
+                        pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    )) {
                     atomic_ops++;  // successful CAS
                     break;
                 }
@@ -278,7 +296,7 @@ struct alignas(64) PTO2ReadyQueue {
             wait_cycle += (get_sys_cnt_aicpu() - t0);
         }
 
-        PTO2TaskSlotState* result = slot->slot_state;
+        PTO2TaskSlotState *result = slot->slot_state;
         slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
         return result;
     }
@@ -286,14 +304,14 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch pop: reserve a contiguous run of ready slots with a single CAS.
     // Returns actual number of items popped (may be less than max_count).
-    int pop_batch(PTO2TaskSlotState** out, int max_count) {
+    int pop_batch(PTO2TaskSlotState **out, int max_count) {
         uint64_t pos;
         int count;
         while (true) {
             pos = dequeue_pos.load(std::memory_order_relaxed);
             count = 0;
             while (count < max_count) {
-                PTO2ReadyQueueSlot* slot = &slots[(pos + count) & mask];
+                PTO2ReadyQueueSlot *slot = &slots[(pos + count) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
                 int64_t diff = seq - (int64_t)(pos + count + 1);
                 if (diff == 0) {
@@ -308,14 +326,15 @@ struct alignas(64) PTO2ReadyQueue {
             }
             if (count == 0) return 0;
             if (count < 0) continue;
-            if (dequeue_pos.compare_exchange_weak(pos, pos + count,
-                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+            if (dequeue_pos.compare_exchange_weak(
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed
+                )) {
                 break;
             }
         }
 
         for (int i = 0; i < count; i++) {
-            PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
+            PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
             slot->sequence.store((int64_t)(pos + i + mask + 1), std::memory_order_release);
         }
@@ -323,7 +342,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if PTO2_SCHED_PROFILING
-    int pop_batch(PTO2TaskSlotState** out, int max_count, uint64_t& atomic_count, uint64_t& wait_cycle) {
+    int pop_batch(PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
         int count;
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -334,7 +353,7 @@ struct alignas(64) PTO2ReadyQueue {
             atomic_ops++;  // dequeue_pos.load
             count = 0;
             while (count < max_count) {
-                PTO2ReadyQueueSlot* slot = &slots[(pos + count) & mask];
+                PTO2ReadyQueueSlot *slot = &slots[(pos + count) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
                 int64_t diff = seq - (int64_t)(pos + count + 1);
                 atomic_ops++;  // sequence.load
@@ -356,8 +375,9 @@ struct alignas(64) PTO2ReadyQueue {
             if (count < 0) {
                 continue;
             }
-            if (dequeue_pos.compare_exchange_weak(pos, pos + count,
-                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+            if (dequeue_pos.compare_exchange_weak(
+                    pos, pos + count, std::memory_order_relaxed, std::memory_order_relaxed
+                )) {
                 atomic_ops++;  // successful CAS
                 break;
             }
@@ -366,7 +386,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         for (int i = 0; i < count; i++) {
-            PTO2ReadyQueueSlot* slot = &slots[(pos + i) & mask];
+            PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
             slot->sequence.store((int64_t)(pos + i + mask + 1), std::memory_order_release);
             atomic_ops++;  // sequence.store
@@ -381,8 +401,8 @@ struct alignas(64) PTO2ReadyQueue {
 };
 
 // Cold-path ready queue operations (defined in pto_scheduler.cpp)
-bool pto2_ready_queue_init(PTO2ReadyQueue* queue, uint64_t capacity);
-void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
+bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity);
+void pto2_ready_queue_destroy(PTO2ReadyQueue *queue);
 
 // =============================================================================
 // Scheduler State
@@ -392,10 +412,10 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue* queue);
  * Statistics returned by mixed-task completion processing
  */
 struct PTO2CompletionStats {
-    int32_t fanout_edges;      // Number of fanout edges traversed (notify consumers)
-    int32_t tasks_enqueued;    // Number of consumers that became READY
-    int32_t fanin_edges;       // Number of fanin edges traversed (release producers)
-    bool mixed_task_completed; // True only when this callback completed a mixed task
+    int32_t fanout_edges;       // Number of fanout edges traversed (notify consumers)
+    int32_t tasks_enqueued;     // Number of consumers that became READY
+    int32_t fanin_edges;        // Number of fanin edges traversed (release producers)
+    bool mixed_task_completed;  // True only when this callback completed a mixed task
 };
 
 /**
@@ -407,37 +427,35 @@ struct PTO2CompletionStats {
  */
 struct PTO2SchedulerState {
     // Shared memory access
-    PTO2SharedMemoryHandle* sm_handle;
+    PTO2SharedMemoryHandle *sm_handle;
 
     // Per-ring state
     struct RingSchedState {
-        PTO2TaskDescriptor* task_descriptors;
-        PTO2TaskSlotState* slot_states;
+        PTO2TaskDescriptor *task_descriptors;
+        PTO2TaskSlotState *slot_states;
         int32_t last_task_alive;
         int32_t task_window_mask;
         uint64_t task_window_size;
         // Try-lock used to advance this ring's last_task_alive pointer.
         std::atomic<int32_t> advance_lock;
 
-        bool init(PTO2SharedMemoryHandle* sm_handle, int32_t ring_id);
+        bool init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id);
         void destroy();
 
-        PTO2TaskSlotState& get_slot_state_by_task_id(int32_t local_id) {
+        PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
             return slot_states[local_id & task_window_mask];
         }
-        PTO2TaskSlotState& get_slot_state_by_slot(int32_t slot) {
-            return slot_states[slot];
-        }
+        PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
-        void sync_to_sm(PTO2SharedMemoryRingHeader& ring) {
+        void sync_to_sm(PTO2SharedMemoryRingHeader &ring) {
             ring.fc.last_task_alive.store(last_task_alive, std::memory_order_release);
         }
 
-        void advance_ring_pointers(PTO2SharedMemoryRingHeader& ring) {
+        void advance_ring_pointers(PTO2SharedMemoryRingHeader &ring) {
             int32_t current_task_index = ring.fc.current_task_index.load(std::memory_order_acquire);
 
             while (last_task_alive < current_task_index) {
-                PTO2TaskSlotState& slot_state = get_slot_state_by_task_id(last_task_alive);
+                PTO2TaskSlotState &slot_state = get_slot_state_by_task_id(last_task_alive);
                 if (slot_state.task_state.load(std::memory_order_acquire) != PTO2_TASK_CONSUMED) {
                     break;
                 }
@@ -459,19 +477,20 @@ struct PTO2SchedulerState {
     // =========================================================================
     // Inline hot-path methods
     // =========================================================================
-    PTO2TaskSlotState& get_slot_state(int32_t ring_id, int32_t local_id) {
+    PTO2TaskSlotState &get_slot_state(int32_t ring_id, int32_t local_id) {
         return ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
     }
-    PTO2TaskSlotState& get_slot_state_by_slot(int32_t ring_id, int32_t slot) {
+    PTO2TaskSlotState &get_slot_state_by_slot(int32_t ring_id, int32_t slot) {
         return ring_sched_states[ring_id].get_slot_state_by_slot(slot);
     }
 
-    void check_and_handle_consumed(PTO2TaskSlotState& slot_state) {
+    void check_and_handle_consumed(PTO2TaskSlotState &slot_state) {
         if (slot_state.fanout_refcount.load(std::memory_order_acquire) != slot_state.fanout_count) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
             return;
         }
 
@@ -482,15 +501,16 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
         }
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    void check_and_handle_consumed(PTO2TaskSlotState& slot_state, uint64_t& atomic_count) {
+    void check_and_handle_consumed(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
         int32_t fc = slot_state.fanout_count;
         int32_t rc = slot_state.fanout_refcount.load(std::memory_order_acquire);
 
@@ -499,8 +519,9 @@ struct PTO2SchedulerState {
         if (rc != fc) return;
 
         PTO2TaskState expected = PTO2_TASK_COMPLETED;
-        if (!slot_state.task_state.compare_exchange_strong(expected, PTO2_TASK_CONSUMED,
-                                          std::memory_order_acq_rel, std::memory_order_acquire)) {
+        if (!slot_state.task_state.compare_exchange_strong(
+                expected, PTO2_TASK_CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
             atomic_count += 1;  // failed CAS
             return;
         }
@@ -514,8 +535,9 @@ struct PTO2SchedulerState {
         int32_t ring_id = slot_state.ring_id;
         // Try-lock — if another thread is advancing this ring, it will scan our CONSUMED task
         int32_t expected_lock = 0;
-        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(expected_lock, 1,
-                std::memory_order_acquire, std::memory_order_relaxed)) {
+        if (ring_sched_states[ring_id].advance_lock.compare_exchange_strong(
+                expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+            )) {
             ring_sched_states[ring_id].advance_ring_pointers(sm_handle->header->rings[ring_id]);
             ring_sched_states[ring_id].advance_lock.store(0, std::memory_order_release);
             atomic_count += 2;  // try-lock CAS + unlock store
@@ -525,20 +547,20 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    void release_producer(PTO2TaskSlotState& slot_state) {
+    void release_producer(PTO2TaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         check_and_handle_consumed(slot_state);
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    void release_producer(PTO2TaskSlotState& slot_state, uint64_t& atomic_count) {
+    void release_producer(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         atomic_count += 1;  // fanout_refcount.fetch_add
         check_and_handle_consumed(slot_state, atomic_count);
     }
 #endif
 
-    bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state, PTO2LocalReadyBuffer* local_bufs = nullptr) {
+    bool release_fanin_and_check_ready(PTO2TaskSlotState &slot_state, PTO2LocalReadyBuffer *local_bufs = nullptr) {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
         // init release, making fanin_count visible — plain load suffices.
@@ -557,17 +579,18 @@ struct PTO2SchedulerState {
     }
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-    bool release_fanin_and_check_ready(PTO2TaskSlotState& slot_state,
-        uint64_t& atomic_count,
-        uint64_t& push_wait,
-        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+    bool release_fanin_and_check_ready(
+        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
+        PTO2LocalReadyBuffer *local_bufs = nullptr
+    ) {
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
         atomic_count += 1;  // fanin_refcount.fetch_add
 
         if (new_refcount == slot_state.fanin_count) {
             PTO2TaskState expected = PTO2_TASK_PENDING;
             if (slot_state.task_state.compare_exchange_strong(
-                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire)) {
+                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire
+                )) {
                 atomic_count += 1;  // CAS(task_state PENDING→READY)
                 // Local-first: try per-CoreType thread-local buffer before global queue
                 PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state.active_mask);
@@ -581,8 +604,9 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    int get_ready_tasks_batch(PTO2ResourceShape shape, PTO2LocalReadyBuffer& local_buf,
-                              PTO2TaskSlotState** out, int max_count) {
+    int get_ready_tasks_batch(
+        PTO2ResourceShape shape, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out, int max_count
+    ) {
         int count = 0;
         while (count < max_count && local_buf.count > 0) {
             out[count++] = local_buf.slot_states[--local_buf.count];
@@ -595,9 +619,10 @@ struct PTO2SchedulerState {
     }
 
 #if PTO2_SCHED_PROFILING
-    int get_ready_tasks_batch(PTO2ResourceShape shape, PTO2LocalReadyBuffer& local_buf,
-                              PTO2TaskSlotState** out, int max_count,
-                              uint64_t& atomic_count, uint64_t& wait_cycle, uint64_t& local_dispatch_count) {
+    int get_ready_tasks_batch(
+        PTO2ResourceShape shape, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out, int max_count,
+        uint64_t &atomic_count, uint64_t &wait_cycle, uint64_t &local_dispatch_count
+    ) {
         int count = 0;
         while (count < max_count && local_buf.count > 0) {
             local_dispatch_count++;
@@ -605,14 +630,14 @@ struct PTO2SchedulerState {
         }
         int remaining = max_count - count;
         if (remaining > 0) {
-            count += ready_queues[static_cast<int32_t>(shape)].pop_batch(
-                out + count, remaining, atomic_count, wait_cycle);
+            count +=
+                ready_queues[static_cast<int32_t>(shape)].pop_batch(out + count, remaining, atomic_count, wait_cycle);
         }
         return count;
     }
 #endif
 
-    void on_scope_end(PTO2TaskSlotState** task_slot_states, int32_t count) {
+    void on_scope_end(PTO2TaskSlotState **task_slot_states, int32_t count) {
 #if PTO2_ORCH_PROFILING
         extern uint64_t g_orch_scope_end_atomic_count;
         if (count > 0) __builtin_prefetch(task_slot_states[0], 1, 0);
@@ -636,7 +661,7 @@ struct PTO2SchedulerState {
      *
      * @return true if this subtask was the last one, completing the mixed task.
      */
-    bool on_subtask_complete(PTO2TaskSlotState& slot_state, PTO2SubtaskSlot subslot) {
+    bool on_subtask_complete(PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot) {
         uint8_t done_bit = (1u << static_cast<uint8_t>(subslot));
         uint8_t prev_mask = slot_state.subtask_done_mask.fetch_or(done_bit, std::memory_order_acq_rel);
         uint8_t new_mask = prev_mask | done_bit;
@@ -655,12 +680,14 @@ struct PTO2SchedulerState {
 #else
     void
 #endif
-    on_mixed_task_complete(PTO2TaskSlotState& slot_state, 
+    on_mixed_task_complete(
+        PTO2TaskSlotState &slot_state,
 #if PTO2_SCHED_PROFILING
         int thread_idx,
 #endif
 
-        PTO2LocalReadyBuffer* local_bufs = nullptr) {
+        PTO2LocalReadyBuffer *local_bufs = nullptr
+    ) {
 #if PTO2_SCHED_PROFILING
         PTO2CompletionStats stats = {0, 0, 0, true};
 #endif
@@ -678,7 +705,7 @@ struct PTO2SchedulerState {
         pto2_fanout_lock(slot_state);
 #endif
         slot_state.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
-        PTO2DepListEntry* current = slot_state.fanout_head;  // Protected by fanout_lock
+        PTO2DepListEntry *current = slot_state.fanout_head;  // Protected by fanout_lock
         pto2_fanout_unlock(slot_state);
 
 #if PTO2_SCHED_PROFILING
@@ -693,11 +720,10 @@ struct PTO2SchedulerState {
         uint64_t fanout_atomics = 0, push_wait = 0;
 #endif
         while (current != nullptr) {
-            PTO2TaskSlotState& consumer_slot = *current->slot_state;
+            PTO2TaskSlotState &consumer_slot = *current->slot_state;
 #if PTO2_SCHED_PROFILING
             stats.fanout_edges++;
-            if (release_fanin_and_check_ready(consumer_slot,
-                                               fanout_atomics, push_wait, local_bufs)) {
+            if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait, local_bufs)) {
                 stats.tasks_enqueued++;
             }
 #else
@@ -720,7 +746,7 @@ struct PTO2SchedulerState {
      */
 
 #if PTO2_SCHED_PROFILING
-    int32_t on_task_release(PTO2TaskSlotState& slot_state, int32_t thread_idx) {
+    int32_t on_task_release(PTO2TaskSlotState &slot_state, int32_t thread_idx) {
         PTO2_SCHED_CYCLE_START();
         extern uint64_t g_sched_fanin_cycle[], g_sched_fanin_atomic_count[];
         extern uint64_t g_sched_self_atomic_count[];
@@ -728,9 +754,9 @@ struct PTO2SchedulerState {
         extern uint64_t g_sched_complete_count[];
         uint64_t fanin_atomics = 0;
 #else
-    int32_t on_task_release(PTO2TaskSlotState& slot_state) {
+    int32_t on_task_release(PTO2TaskSlotState &slot_state) {
 #endif
-        PTO2TaskPayload* payload = slot_state.payload;
+        PTO2TaskPayload *payload = slot_state.payload;
         int32_t fanin_edges = payload->fanin_actual_count;
         for (int32_t i = 0; i < fanin_edges; i++) {
 #if PTO2_SCHED_PROFILING
@@ -762,17 +788,16 @@ struct PTO2SchedulerState {
 // Scheduler API (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-bool pto2_scheduler_init(PTO2SchedulerState* sched,
-                          PTO2SharedMemoryHandle* sm_handle);
-void pto2_scheduler_destroy(PTO2SchedulerState* sched);
+bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle);
+void pto2_scheduler_destroy(PTO2SchedulerState *sched);
 
 // =============================================================================
 // Debug Utilities (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-void pto2_scheduler_print_stats(PTO2SchedulerState* sched);
-void pto2_scheduler_print_queues(PTO2SchedulerState* sched);
-const char* pto2_task_state_name(PTO2TaskState state);
+void pto2_scheduler_print_stats(PTO2SchedulerState *sched);
+void pto2_scheduler_print_queues(PTO2SchedulerState *sched);
+const char *pto2_task_state_name(PTO2TaskState state);
 
 // =============================================================================
 // Scheduler Profiling Data
@@ -787,9 +812,9 @@ struct PTO2SchedProfilingData {
     uint64_t self_consumed_cycle;  // self check_and_handle_consumed
 
     // Wait times
-    uint64_t lock_wait_cycle;      // spin-wait in fanout_lock
-    uint64_t push_wait_cycle;      // CAS contention in push()
-    uint64_t pop_wait_cycle;       // CAS contention in pop()
+    uint64_t lock_wait_cycle;  // spin-wait in fanout_lock
+    uint64_t push_wait_cycle;  // CAS contention in push()
+    uint64_t pop_wait_cycle;   // CAS contention in pop()
 
     // Atomic counts per sub-phase
     uint64_t lock_atomic_count;
@@ -798,7 +823,7 @@ struct PTO2SchedProfilingData {
     uint64_t self_atomic_count;
     uint64_t pop_atomic_count;
 
-    int64_t  complete_count;
+    int64_t complete_count;
 };
 
 /**
@@ -808,4 +833,4 @@ struct PTO2SchedProfilingData {
 PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
 #endif
 
-#endif // PTO_SCHEDULER_H
+#endif  // PTO_SCHEDULER_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Shared Memory Implementation
  *
@@ -44,26 +54,25 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
 // Creation and Destruction
 // =============================================================================
 
-static void pto2_sm_setup_pointers_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
-    char* ptr = (char*)handle->sm_base;
+static void
+pto2_sm_setup_pointers_per_ring(PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+    char *ptr = (char *)handle->sm_base;
 
     // Header
-    handle->header = (PTO2SharedMemoryHeader*)ptr;
+    handle->header = (PTO2SharedMemoryHeader *)ptr;
     ptr += PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
 
     // Per-ring task descriptors and payloads
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        handle->task_descriptors[r] = (PTO2TaskDescriptor*)ptr;
+        handle->task_descriptors[r] = (PTO2TaskDescriptor *)ptr;
         ptr += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
 
-        handle->task_payloads[r] = (PTO2TaskPayload*)ptr;
+        handle->task_payloads[r] = (PTO2TaskPayload *)ptr;
         ptr += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
     }
 }
 
-static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle* handle, uint64_t task_window_size) {
+static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle *handle, uint64_t task_window_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
@@ -71,10 +80,9 @@ static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle* handle, uint64_t task
     pto2_sm_setup_pointers_per_ring(handle, task_window_sizes);
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size) {
+PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_size) {
     // Allocate handle
-    PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
+    PTO2SharedMemoryHandle *handle = (PTO2SharedMemoryHandle *)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) {
         return NULL;
     }
@@ -82,19 +90,19 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     // Calculate total size
     uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
 
-    // Allocate shared memory (aligned for DMA efficiency)
-    #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-        if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
-            free(handle);
-            return NULL;
-        }
-    #else
-        handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
-        if (!handle->sm_base) {
-            free(handle);
-            return NULL;
-        }
-    #endif
+// Allocate shared memory (aligned for DMA efficiency)
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+    if (posix_memalign(&handle->sm_base, PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size)) != 0) {
+        free(handle);
+        return NULL;
+    }
+#else
+    handle->sm_base = aligned_alloc(PTO2_ALIGN_SIZE, static_cast<size_t>(sm_size));
+    if (!handle->sm_base) {
+        free(handle);
+        return NULL;
+    }
+#endif
 
     handle->sm_size = sm_size;
     handle->is_owner = true;
@@ -111,21 +119,16 @@ PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
     return handle;
 }
 
-PTO2SharedMemoryHandle* pto2_sm_create_default(void) {
-    return pto2_sm_create(PTO2_TASK_WINDOW_SIZE,
-                          PTO2_HEAP_SIZE);
-}
+PTO2SharedMemoryHandle *pto2_sm_create_default(void) { return pto2_sm_create(PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE); }
 
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size) {
+PTO2SharedMemoryHandle *
+pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size) {
     if (!sm_base || sm_size == 0) return NULL;
 
     uint64_t required = pto2_sm_calculate_size(task_window_size);
     if (sm_size < required) return NULL;
 
-    PTO2SharedMemoryHandle* handle = (PTO2SharedMemoryHandle*)calloc(1, sizeof(PTO2SharedMemoryHandle));
+    PTO2SharedMemoryHandle *handle = (PTO2SharedMemoryHandle *)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) return NULL;
 
     handle->sm_base = sm_base;
@@ -138,7 +141,7 @@ PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
     return handle;
 }
 
-void pto2_sm_destroy(PTO2SharedMemoryHandle* handle) {
+void pto2_sm_destroy(PTO2SharedMemoryHandle *handle) {
     if (!handle) return;
 
     if (handle->is_owner && handle->sm_base) {
@@ -153,9 +156,7 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle* handle) {
 // =============================================================================
 //
 // no need init data in pool, init pool data when used
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size) {
+void pto2_sm_init_header(PTO2SharedMemoryHandle *handle, uint64_t task_window_size, uint64_t heap_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -166,10 +167,10 @@ void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
 }
 
 void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]) {
-    PTO2SharedMemoryHeader* header = handle->header;
+    PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+) {
+    PTO2SharedMemoryHeader *header = handle->header;
 
     // Per-ring flow control (start at 0)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -203,10 +204,10 @@ void pto2_sm_init_header_per_ring(
 // Debug Utilities
 // =============================================================================
 
-void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
+void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle) {
     if (!handle || !handle->header) return;
 
-    PTO2SharedMemoryHeader* h = handle->header;
+    PTO2SharedMemoryHeader *h = handle->header;
 
     LOG_INFO("=== PTO2 Shared Memory Layout ===");
     LOG_INFO("Base address:       %p", handle->sm_base);
@@ -216,8 +217,10 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
         LOG_INFO("Ring %d:", r);
         LOG_INFO("  task_window_size: %" PRIu64, h->rings[r].task_window_size);
         LOG_INFO("  heap_size:        %" PRIu64 " bytes", h->rings[r].heap_size);
-        LOG_INFO("  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")",
-                 h->rings[r].task_descriptors_offset, h->rings[r].task_descriptors_offset);
+        LOG_INFO(
+            "  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")", h->rings[r].task_descriptors_offset,
+            h->rings[r].task_descriptors_offset
+        );
         LOG_INFO("  heap_top:         %" PRIu64, h->rings[r].fc.heap_top.load(std::memory_order_acquire));
         LOG_INFO("  heap_tail:        %" PRIu64, h->rings[r].fc.heap_tail.load(std::memory_order_acquire));
         LOG_INFO("  current_task_idx: %d", h->rings[r].fc.current_task_index.load(std::memory_order_acquire));
@@ -232,12 +235,12 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle) {
     LOG_INFO("================================");
 }
 
-bool pto2_sm_validate(PTO2SharedMemoryHandle* handle) {
+bool pto2_sm_validate(PTO2SharedMemoryHandle *handle) {
     if (!handle) return false;
     if (!handle->sm_base) return false;
     if (!handle->header) return false;
 
-    PTO2SharedMemoryHeader* h = handle->header;
+    PTO2SharedMemoryHeader *h = handle->header;
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         if (!h->rings[r].fc.validate(handle, r)) return false;
@@ -246,12 +249,12 @@ bool pto2_sm_validate(PTO2SharedMemoryHandle* handle) {
     return true;
 }
 
-bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle* handle, int32_t ring_id) const {
+bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const {
     if (!handle) return false;
     if (!handle->header) return false;
     if (ring_id < 0 || ring_id >= PTO2_MAX_RING_DEPTH) return false;
 
-    const PTO2SharedMemoryHeader* h = handle->header;
+    const PTO2SharedMemoryHeader *h = handle->header;
 
     // Check that offsets are within bounds
     if (h->rings[ring_id].task_descriptors_offset >= h->total_size) return false;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - Shared Memory Layout
  *
@@ -50,9 +60,9 @@ struct PTO2RingFlowControl {
     int32_t _pad0;                            // Alignment padding
 
     // Written by Scheduler, Read by Orchestrator (for back-pressure)
-    std::atomic<uint64_t> heap_tail;          // Heap ring free pointer
-    std::atomic<int32_t> last_task_alive;     // Task ring tail (oldest active task)
-    int32_t _pad1;                            // Alignment padding
+    std::atomic<uint64_t> heap_tail;       // Heap ring free pointer
+    std::atomic<int32_t> last_task_alive;  // Task ring tail (oldest active task)
+    int32_t _pad1;                         // Alignment padding
 
     void init() {
         heap_top.store(0, std::memory_order_relaxed);
@@ -61,7 +71,7 @@ struct PTO2RingFlowControl {
         last_task_alive.store(0, std::memory_order_relaxed);
     }
 
-    bool validate(PTO2SharedMemoryHandle* handle, int32_t ring_id) const;
+    bool validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const;
 };
 
 /**
@@ -86,7 +96,7 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
 
     // === GLOBAL FIELDS ===
-    std::atomic<int32_t> orchestrator_done;   // Flag: orchestration complete
+    std::atomic<int32_t> orchestrator_done;  // Flag: orchestration complete
 
     // Total shared memory size (for validation)
     uint64_t total_size;
@@ -104,13 +114,15 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
 
     // Scheduler error state (Scheduler → Host, independent of orchestrator)
     // Written by scheduler threads on timeout; read by orchestrator and host.
-    std::atomic<int32_t> sched_error_bitmap;   // Bit X set = thread X had error
-    std::atomic<int32_t> sched_error_code;     // Last scheduler error code (last-writer-wins)
-    std::atomic<int32_t> sched_error_thread;   // Thread index of last error writer
+    std::atomic<int32_t> sched_error_bitmap;  // Bit X set = thread X had error
+    std::atomic<int32_t> sched_error_code;    // Last scheduler error code (last-writer-wins)
+    std::atomic<int32_t> sched_error_thread;  // Thread index of last error writer
 };
 
-static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
-              "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)");
+static_assert(
+    sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
+    "PTO2SharedMemoryHeader must be aligned to cache line (PTO2_ALIGN_SIZE)"
+);
 
 // =============================================================================
 // Shared Memory Handle
@@ -121,17 +133,16 @@ static_assert(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE == 0,
  * Provides both Orchestrator and Scheduler views of the same memory
  */
 struct PTO2SharedMemoryHandle {
-    void*   sm_base;              // Base address of shared memory
-    uint64_t sm_size;             // Total size of shared memory
+    void *sm_base;     // Base address of shared memory
+    uint64_t sm_size;  // Total size of shared memory
 
     // Quick pointers into shared memory regions (per-ring)
-    PTO2SharedMemoryHeader* header;
-    PTO2TaskDescriptor*     task_descriptors[PTO2_MAX_RING_DEPTH];
-    PTO2TaskPayload*        task_payloads[PTO2_MAX_RING_DEPTH];
+    PTO2SharedMemoryHeader *header;
+    PTO2TaskDescriptor *task_descriptors[PTO2_MAX_RING_DEPTH];
+    PTO2TaskPayload *task_payloads[PTO2_MAX_RING_DEPTH];
 
     // Ownership flag
-    bool    is_owner;             // True if this handle allocated the memory
-
+    bool is_owner;  // True if this handle allocated the memory
 };
 
 // =============================================================================
@@ -161,13 +172,12 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
  * @param heap_size         Heap size per ring for output buffers
  * @return Handle with both views, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create(uint64_t task_window_size,
-                                        uint64_t heap_size);
+PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Create shared memory with default sizes
  */
-PTO2SharedMemoryHandle* pto2_sm_create_default(void);
+PTO2SharedMemoryHandle *pto2_sm_create_default(void);
 
 /**
  * Wrap an existing buffer as shared memory (e.g. device GM buffer).
@@ -179,31 +189,27 @@ PTO2SharedMemoryHandle* pto2_sm_create_default(void);
  * @param heap_size          Heap size per ring (for layout; buffer has no heap region)
  * @return Handle, or NULL on failure
  */
-PTO2SharedMemoryHandle* pto2_sm_create_from_buffer(void* sm_base,
-                                                    uint64_t sm_size,
-                                                    uint64_t task_window_size,
-                                                    uint64_t heap_size);
+PTO2SharedMemoryHandle *
+pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Destroy shared memory and free resources
  */
-void pto2_sm_destroy(PTO2SharedMemoryHandle* handle);
+void pto2_sm_destroy(PTO2SharedMemoryHandle *handle);
 
 /**
  * Initialize shared memory header with layout information
  * Called after memory is allocated
  */
-void pto2_sm_init_header(PTO2SharedMemoryHandle* handle,
-                          uint64_t task_window_size,
-                          uint64_t heap_size);
+void pto2_sm_init_header(PTO2SharedMemoryHandle *handle, uint64_t task_window_size, uint64_t heap_size);
 
 /**
  * Initialize shared memory header with per-ring layout information.
  */
 void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle* handle,
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]);
+    PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+);
 
 // =============================================================================
 // Debug Utilities
@@ -212,16 +218,16 @@ void pto2_sm_init_header_per_ring(
 /**
  * Print shared memory layout info
  */
-void pto2_sm_print_layout(PTO2SharedMemoryHandle* handle);
+void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle);
 
 /**
  * Validate shared memory integrity
  * @return true if valid, false if corrupted
  */
-bool pto2_sm_validate(PTO2SharedMemoryHandle* handle);
+bool pto2_sm_validate(PTO2SharedMemoryHandle *handle);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // PTO_SHARED_MEMORY_H
+#endif  // PTO_SHARED_MEMORY_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Submit Types - Shared submit-contract definitions
  *
@@ -21,7 +31,7 @@ inline constexpr int32_t PTO2_SUBTASK_SLOT_COUNT = 3;
  * Subtask slot indices
  */
 enum class PTO2SubtaskSlot : uint8_t {
-    AIC  = 0,
+    AIC = 0,
     AIV0 = 1,
     AIV1 = 2,
 };
@@ -29,7 +39,7 @@ enum class PTO2SubtaskSlot : uint8_t {
 /**
  * Subtask mask bits (for active_mask / subtask_done_mask)
  */
-inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC  = (1u << 0);  // 0x1
+inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC = (1u << 0);   // 0x1
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV0 = (1u << 1);  // 0x2
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV1 = (1u << 2);  // 0x4
 
@@ -61,9 +71,9 @@ struct MixedKernels {
  * cluster remain idle and available for single-core tasks.
  */
 enum class PTO2ResourceShape : uint8_t {
-    AIC = 0,   // Single AIC
-    AIV = 1,   // Single AIV
-    MIX = 2,   // Full cluster (dispatch uses active_mask)
+    AIC = 0,  // Single AIC
+    AIV = 1,  // Single AIV
+    MIX = 2,  // Full cluster (dispatch uses active_mask)
 };
 
 inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 3;
@@ -82,12 +92,12 @@ static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
 /**
  * Compute active_mask from MixedKernels.
  */
-static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels& mk) {
+static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels &mk) {
     uint8_t mask = 0;
-    if (mk.aic_kernel_id  != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
+    if (mk.aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
     if (mk.aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
     if (mk.aiv1_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV1;
     return mask;
 }
 
-#endif // PTO_SUBMIT_TYPES_H
+#endif  // PTO_SUBMIT_TYPES_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - TensorMap Implementation
  *
@@ -28,7 +38,7 @@
 #if PTO2_TENSORMAP_PROFILING
 uint64_t g_lookup_chain_total = 0;
 uint64_t g_lookup_count = 0;
-int32_t  g_lookup_chain_max = 0;
+int32_t g_lookup_chain_max = 0;
 uint64_t g_lookup_overlap_checks = 0;
 uint64_t g_lookup_overlap_hits = 0;
 uint64_t g_insert_count = 0;
@@ -38,14 +48,16 @@ uint64_t g_insert_count = 0;
 // Initialization and Destruction
 // =============================================================================
 
-bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+bool PTO2TensorMap::init(
+    int32_t new_num_buckets, int32_t new_pool_size, const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]
+) {
     // Validate power of 2 for fast modulo
     if ((new_num_buckets & (new_num_buckets - 1)) != 0) {
         return false;  // num_buckets must be power of 2
     }
 
     // Allocate buckets
-    buckets = (PTO2TensorMapEntry**)malloc(new_num_buckets * sizeof(PTO2TensorMapEntry*));
+    buckets = (PTO2TensorMapEntry **)malloc(new_num_buckets * sizeof(PTO2TensorMapEntry *));
     if (!buckets) {
         return false;
     }
@@ -58,7 +70,8 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const i
     num_buckets = new_num_buckets;
 
     // Allocate entry pool (64-byte aligned for cache-line-aligned entries)
-    entry_pool = (PTO2TensorMapEntry*)aligned_alloc(alignof(PTO2TensorMapEntry), new_pool_size * sizeof(PTO2TensorMapEntry));
+    entry_pool =
+        (PTO2TensorMapEntry *)aligned_alloc(alignof(PTO2TensorMapEntry), new_pool_size * sizeof(PTO2TensorMapEntry));
     if (!entry_pool) {
         free(buckets);
         buckets = NULL;
@@ -67,7 +80,7 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const i
     memset(entry_pool, 0, new_pool_size * sizeof(PTO2TensorMapEntry));
 
     // Allocate free entry list
-    free_entry_list = (PTO2TensorMapEntry**)calloc(new_pool_size, sizeof(PTO2TensorMapEntry*));
+    free_entry_list = (PTO2TensorMapEntry **)calloc(new_pool_size, sizeof(PTO2TensorMapEntry *));
     if (!free_entry_list) {
         free(buckets);
         free(entry_pool);
@@ -92,7 +105,7 @@ bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, const i
 
     // Allocate per-ring per-task entry tracking (each ring has its own window size)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_entry_heads[r] = (PTO2TensorMapEntry**)malloc(new_task_window_sizes[r] * sizeof(PTO2TensorMapEntry*));
+        task_entry_heads[r] = (PTO2TensorMapEntry **)malloc(new_task_window_sizes[r] * sizeof(PTO2TensorMapEntry *));
         if (!task_entry_heads[r]) {
             // Cleanup previously allocated rings
             for (int j = 0; j < r; j++) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * PTO Runtime2 - TensorMap Interface
  *
@@ -47,7 +57,7 @@ struct PTO2OrchestratorState;  // forward declare
 #if PTO2_TENSORMAP_PROFILING
 extern uint64_t g_lookup_chain_total;
 extern uint64_t g_lookup_count;
-extern int32_t  g_lookup_chain_max;
+extern int32_t g_lookup_chain_max;
 extern uint64_t g_lookup_overlap_checks;
 extern uint64_t g_lookup_overlap_hits;
 extern uint64_t g_insert_count;
@@ -74,29 +84,29 @@ extern uint64_t g_insert_count;
  */
 struct alignas(64) PTO2TensorMapEntry {
     // === Cache line 1 (64B) — lookup hot path ===
-    PTO2TensorMapEntry* next_in_bucket;    // 8B: next entry in hash bucket chain
-    PTO2TaskId producer_task_id;           // 8B: raw (ring_id << 32) | local_id
-    uint64_t buffer_addr;                  // 8B: tensor base address (hash key)
-    int32_t version;                       // 4B: tensor version for overlap detection
-    uint32_t ndims;                        // 4B: number of dimensions
-    int32_t bucket_index;                  // 4B: bucket index (-1 if unlinked)
-    bool is_all_offset_zero;               // 1B: fast-path flag
-    bool with_alloc;                       // 1B: true=OUTPUT, false=INOUT
+    PTO2TensorMapEntry *next_in_bucket;  // 8B: next entry in hash bucket chain
+    PTO2TaskId producer_task_id;         // 8B: raw (ring_id << 32) | local_id
+    uint64_t buffer_addr;                // 8B: tensor base address (hash key)
+    int32_t version;                     // 4B: tensor version for overlap detection
+    uint32_t ndims;                      // 4B: number of dimensions
+    int32_t bucket_index;                // 4B: bucket index (-1 if unlinked)
+    bool is_all_offset_zero;             // 1B: fast-path flag
+    bool with_alloc;                     // 1B: true=OUTPUT, false=INOUT
     // padding: 2B
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS]; // 20B: shape per dimension
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // 20B: shape per dimension
     // padding: 4B to fill 64B
 
     // === Cache line 2 (64B) — insert/remove/slow-path ===
-    PTO2TensorMapEntry* prev_in_bucket;    // 8B: prev in hash bucket chain
-    PTO2TensorMapEntry* next_in_task;      // 8B: next entry for same task
-    PTO2TensorMapEntry* prev_in_task;      // 8B: prev entry for same task
-    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS]; // 20B: only when !is_all_offset_zero
+    PTO2TensorMapEntry *prev_in_bucket;         // 8B: prev in hash bucket chain
+    PTO2TensorMapEntry *next_in_task;           // 8B: next entry for same task
+    PTO2TensorMapEntry *prev_in_task;           // 8B: prev entry for same task
+    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];  // 20B: only when !is_all_offset_zero
     // padding: 20B to fill 64B
 
     /**
      * Copy overlap-relevant fields from a Tensor into this entry.
      */
-    void copy_from_tensor(const Tensor& t) {
+    void copy_from_tensor(const Tensor &t) {
         buffer_addr = t.buffer.addr;
         version = t.version;
         ndims = t.ndims;
@@ -115,7 +125,7 @@ struct alignas(64) PTO2TensorMapEntry {
      * Check overlap between input tensor and this entry (the producer output).
      * Mirrors Tensor::is_overlap() logic but operates on entry fields directly.
      */
-    OverlapStatus check_overlap(const Tensor& input) const {
+    OverlapStatus check_overlap(const Tensor &input) const {
         debug_assert(input.buffer.addr == buffer_addr);
         debug_assert(input.version >= version);
         if (input.version > version) {
@@ -160,13 +170,13 @@ static_assert(sizeof(PTO2TensorMapEntry) == 128, "TensorMapEntry must be exactly
 // =============================================================================
 struct PTO2LookupResult {
     struct Entry {
-        PTO2TensorMapEntry* entry;
+        PTO2TensorMapEntry *entry;
         OverlapStatus overlap_status;
     };
     Entry entries[PTO2_LOOKUP_MAX_RESULTS];
     int32_t count{0};
 
-    void push(PTO2TensorMapEntry* entry, OverlapStatus s) {
+    void push(PTO2TensorMapEntry *entry, OverlapStatus s) {
         if (count < PTO2_LOOKUP_MAX_RESULTS) {
             entries[count++] = {entry, s};
         }
@@ -180,19 +190,19 @@ struct PTO2LookupResult {
  */
 struct PTO2TensorMap {
     // Hash table buckets (fixed size, power of 2)
-    PTO2TensorMapEntry** buckets;     // Array of offsets into entry_pool (-1 = empty)
-    int32_t num_buckets;  // Must be power of 2 for fast modulo
+    PTO2TensorMapEntry **buckets;  // Array of offsets into entry_pool (-1 = empty)
+    int32_t num_buckets;           // Must be power of 2 for fast modulo
 
     // Entry pool as ring buffer
-    PTO2TensorMapEntry* entry_pool;  // Ring buffer of entries
-    PTO2TensorMapEntry** free_entry_list;        // free entry ids
-    int32_t pool_size;               // Total pool capacity
-    int32_t next_entry_idx;          // id when next entry insert
-    int32_t free_num;                // free entry number in entry pool
+    PTO2TensorMapEntry *entry_pool;        // Ring buffer of entries
+    PTO2TensorMapEntry **free_entry_list;  // free entry ids
+    int32_t pool_size;                     // Total pool capacity
+    int32_t next_entry_idx;                // id when next entry insert
+    int32_t free_num;                      // free entry number in entry pool
 
     // Per-ring per-task entry tracking (for efficient bucket cleanup)
     // Indexed by [ring_id][local_id & (task_window_sizes[ring_id] - 1)]
-    PTO2TensorMapEntry** task_entry_heads[PTO2_MAX_RING_DEPTH];
+    PTO2TensorMapEntry **task_entry_heads[PTO2_MAX_RING_DEPTH];
     int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];  // Per-ring task window size (for slot masking)
 
     // Per-ring validity threshold (for lazy invalidation)
@@ -201,23 +211,23 @@ struct PTO2TensorMap {
     // Per-ring cleanup progress (for periodic cleanup_retired)
     int32_t last_cleanup[PTO2_MAX_RING_DEPTH]{};
 
-    PTO2OrchestratorState* orch{nullptr};
+    PTO2OrchestratorState *orch{nullptr};
 
-    // new_entry目前不负责分配属性，仅分配内存
-    PTO2TensorMapEntry* new_entry() {
+    // new_entry currently only allocates memory, not attributes
+    PTO2TensorMapEntry *new_entry() {
         if (free_num > 0) {
-            PTO2TensorMapEntry* res = free_entry_list[--free_num];
+            PTO2TensorMapEntry *res = free_entry_list[--free_num];
             debug_assert(res->bucket_index == -1);
             return res;
         }
         always_assert(next_entry_idx < pool_size);
-        PTO2TensorMapEntry* res = &entry_pool[next_entry_idx++];
+        PTO2TensorMapEntry *res = &entry_pool[next_entry_idx++];
         debug_assert(res->bucket_index == -1);
         return res;
     }
 
-    void free_entry(PTO2TensorMapEntry& entry) {
-        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+    void free_entry(PTO2TensorMapEntry &entry) {
+        always_assert(entry.bucket_index != -1);  // Must ensure entry is still in a bucket
 
         // Update predecessor's next pointer (O(1) via prev_in_bucket)
         if (entry.prev_in_bucket == nullptr) {
@@ -270,9 +280,7 @@ struct PTO2TensorMap {
      *
      * @param last_task_alive  Current value from shared memory
      */
-    void sync_validity(int32_t ring_id, int32_t last_task_alive) {
-        this->last_task_alives[ring_id] = last_task_alive;
-    }
+    void sync_validity(int32_t ring_id, int32_t last_task_alive) { this->last_task_alives[ring_id] = last_task_alive; }
 
     /**
      * Lookup producer for a tensor region
@@ -284,9 +292,9 @@ struct PTO2TensorMap {
      * @param tensor  Tensor to look up
      * @param result  Output: stack-allocated result buffer
      */
-    void lookup(const Tensor& tensor, PTO2LookupResult& result) {
+    void lookup(const Tensor &tensor, PTO2LookupResult &result) {
         uint32_t bucket_index = hash(tensor.buffer.addr);
-        PTO2TensorMapEntry* cur_entry = buckets[bucket_index];
+        PTO2TensorMapEntry *cur_entry = buckets[bucket_index];
 
         result.count = 0;
 #if PTO2_TENSORMAP_PROFILING
@@ -295,7 +303,7 @@ struct PTO2TensorMap {
 #endif
 
         while (cur_entry != nullptr) {
-            PTO2TensorMapEntry* next_entry = cur_entry->next_in_bucket;
+            PTO2TensorMapEntry *next_entry = cur_entry->next_in_bucket;
 
 #if PTO2_TENSORMAP_PROFILING
             chain_len++;
@@ -342,7 +350,7 @@ struct PTO2TensorMap {
      * @param tensor            Tensor produced
      * @param producer_task_id  Task ID of producer
      */
-    void insert(const Tensor& tensor, PTO2TaskId producer_task_id, bool with_alloc) {
+    void insert(const Tensor &tensor, PTO2TaskId producer_task_id, bool with_alloc) {
 #if PTO2_TENSORMAP_PROFILING
         g_insert_count++;
 #endif
@@ -354,7 +362,7 @@ struct PTO2TensorMap {
         int32_t task_slot = local_id & (task_window_sizes[ring_id] - 1);
 
         // Allocate entry from ring buffer pool
-        PTO2TensorMapEntry* entry = new_entry();
+        PTO2TensorMapEntry *entry = new_entry();
 
         // Initialize new entry
         entry->copy_from_tensor(tensor);
@@ -394,15 +402,16 @@ struct PTO2TensorMap {
         // Iterate through retired tasks on this ring and remove their entries
         for (int32_t local_id = old_last_task_alive; local_id < new_last_task_alive; local_id++) {
             int32_t task_slot = local_id & (task_window_sizes[ring_id] - 1);
-            PTO2TensorMapEntry* cur_entry = task_entry_heads[ring_id][task_slot];
+            PTO2TensorMapEntry *cur_entry = task_entry_heads[ring_id][task_slot];
 
             while (cur_entry != nullptr) {
-                PTO2TensorMapEntry* next_entry = cur_entry->next_in_task;  // Save before clearing
+                PTO2TensorMapEntry *next_entry = cur_entry->next_in_task;  // Save before clearing
                 // Only remove if this entry belongs to the retiring task
                 // (slot may have been reused by a newer task)
-                debug_assert(cur_entry->producer_task_id ==
-                             pto2_make_task_id(static_cast<uint8_t>(ring_id),
-                                               static_cast<uint32_t>(local_id)));
+                debug_assert(
+                    cur_entry->producer_task_id ==
+                    pto2_make_task_id(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id))
+                );
                 free_entry(*cur_entry);
                 cur_entry = next_entry;
             }
@@ -432,11 +441,11 @@ struct PTO2TensorMap {
     /**
      * Check if entry is valid (producer has not retired)
      */
-    bool entry_valid(const PTO2TensorMapEntry& entry) const {
+    bool entry_valid(const PTO2TensorMapEntry &entry) const {
         return static_cast<int32_t>(entry.producer_task_id.local()) >= last_task_alives[entry.producer_task_id.ring()];
     }
 
-    void remove_entry(PTO2TensorMapEntry& entry) {
+    void remove_entry(PTO2TensorMapEntry &entry) {
         remove_from_task(entry);
         free_entry(entry);
     }
@@ -445,8 +454,8 @@ struct PTO2TensorMap {
      * Remove entry from its task chain (O(1) with prev pointer)
      * Called during pool wrap-around to unlink reused entries.
      */
-    void remove_from_task(PTO2TensorMapEntry& entry) {
-        always_assert(entry.bucket_index != -1); // 必须保证仍在桶中
+    void remove_from_task(PTO2TensorMapEntry &entry) {
+        always_assert(entry.bucket_index != -1);  // Must ensure entry is still in a bucket
         // Update predecessor's next pointer (O(1) via prev_in_task)
         if (entry.prev_in_task == nullptr) {
             // Entry is the head of its task chain, update task_entry_heads
@@ -498,7 +507,7 @@ struct PTO2TensorMap {
 struct PTO2TensorMapProfilingData {
     uint64_t lookup_chain_total;
     uint64_t lookup_count;
-    int32_t  lookup_chain_max;
+    int32_t lookup_chain_max;
     uint64_t overlap_checks;
     uint64_t overlap_hits;
     uint64_t insert_count;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -61,7 +61,8 @@
  */
 class TaskOutputTensors {
 public:  // NOLINT(whitespace/indent)
-    TaskOutputTensors() : output_count(0) {}
+    TaskOutputTensors() :
+        output_count(0) {}
 
     uint32_t output_count;
 
@@ -69,16 +70,16 @@ public:  // NOLINT(whitespace/indent)
     uint32_t size() const { return output_count; }
 
     /// Borrow a materialized output tensor by index (lvalue only).
-    const Tensor& get_ref(uint32_t index) const& {
+    const Tensor &get_ref(uint32_t index) const & {
         always_assert(index < output_count);
-        return *reinterpret_cast<const Tensor*>(_storage + index * sizeof(Tensor));
+        return *reinterpret_cast<const Tensor *>(_storage + index * sizeof(Tensor));
     }
-    const Tensor& get_ref(uint32_t index) const&& = delete;
+    const Tensor &get_ref(uint32_t index) const && = delete;
 
     /// Runtime-internal: writable pointer for materialization.
-    Tensor* output_ptr(uint32_t index) { return reinterpret_cast<Tensor*>(_storage + index * sizeof(Tensor)); }
-    const Tensor* output_ptr(uint32_t index) const {
-        return reinterpret_cast<const Tensor*>(_storage + index * sizeof(Tensor));
+    Tensor *output_ptr(uint32_t index) { return reinterpret_cast<Tensor *>(_storage + index * sizeof(Tensor)); }
+    const Tensor *output_ptr(uint32_t index) const {
+        return reinterpret_cast<const Tensor *>(_storage + index * sizeof(Tensor));
     }
 
 private:  // NOLINT(whitespace/indent)
@@ -96,9 +97,10 @@ private:  // NOLINT(whitespace/indent)
  * The active member is determined by TensorArgType (OUTPUT → create_info, else → ptr).
  */
 union TensorRef {
-    const Tensor* ptr;
+    const Tensor *ptr;
     TensorCreateInfo create_info;
-    TensorRef() : ptr(nullptr) {}
+    TensorRef() :
+        ptr(nullptr) {}
 };
 
 /**
@@ -126,7 +128,7 @@ union TensorRef {
  */
 struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType> {
     bool has_error{false};
-    const char* error_msg{nullptr};
+    const char *error_msg{nullptr};
 
     void reset() {
         clear();
@@ -134,7 +136,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         error_msg = nullptr;
     }
 
-    void set_error(const char* msg) {
+    void set_error(const char *msg) {
         if (!has_error) {
             has_error = true;
             error_msg = msg;
@@ -145,7 +147,8 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         if (scalar_count_ != 0) {
             set_error(
                 "add_input/add_output/add_inout called after add_scalar: "
-                "all tensors must be added before any scalars");
+                "all tensors must be added before any scalars"
+            );
             return false;
         }
         if (tensor_count_ >= MAX_TENSOR_ARGS) {
@@ -155,7 +158,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         return true;
     }
 
-    void add_input(const Tensor& t) {
+    void add_input(const Tensor &t) {
         if (!check_add_tensor_valid()) {
             return;
         }
@@ -166,7 +169,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
 
     /// Standard future-output path: runtime allocates buffer from heap,
     /// materializes Tensor into TaskOutputTensors.
-    void add_output(const TensorCreateInfo& ci) {
+    void add_output(const TensorCreateInfo &ci) {
         if (!check_add_tensor_valid()) {
             return;
         }
@@ -177,7 +180,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
 
     /// Runtime-allocated output with an initial element value replicated
     /// across the full buffer after HeapRing allocation.
-    void add_output(const TensorCreateInfo& ci, uint64_t initial_value) {
+    void add_output(const TensorCreateInfo &ci, uint64_t initial_value) {
         if (!check_add_tensor_valid()) {
             return;
         }
@@ -187,7 +190,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         tensor_count_++;
     }
 
-    void add_inout(const Tensor& t) {
+    void add_inout(const Tensor &t) {
         if (!check_add_tensor_valid()) {
             return;
         }
@@ -204,7 +207,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         scalars_[scalar_count_++] = v;
     }
 
-    void add_scalars(const uint64_t* values, int count) {
+    void add_scalars(const uint64_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
             return;
@@ -219,16 +222,16 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
      * (e.g., -1 → 0x00000000FFFFFFFF, not 0xFFFFFFFFFFFFFFFF).
      * Uses NEON to process 4 elements per iteration on aarch64.
      */
-    void add_scalars_i32(const int32_t* values, int count) {
+    void add_scalars_i32(const int32_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
             return;
         }
-        uint64_t* dst = &scalars_[scalar_count_];
+        uint64_t *dst = &scalars_[scalar_count_];
 #if defined(__aarch64__)
         int i = 0;
         for (; i + 4 <= count; i += 4) {
-            uint32x4_t v = vld1q_u32(reinterpret_cast<const uint32_t*>(values + i));
+            uint32x4_t v = vld1q_u32(reinterpret_cast<const uint32_t *>(values + i));
             uint64x2_t lo = vmovl_u32(vget_low_u32(v));
             uint64x2_t hi = vmovl_u32(vget_high_u32(v));
             vst1q_u64(dst + i, lo);
@@ -249,7 +252,7 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
      * Copy scalars from another Arg's scalar array.
      * Useful when multiple tasks share the same scalar data (e.g., block indices).
      */
-    void copy_scalars_from(const Arg& src, int src_offset, int count) {
+    void copy_scalars_from(const Arg &src, int src_offset, int count) {
         if (src_offset + count > src.scalar_count_) {
             set_error("Source scalar range out of bounds in copy_scalars_from");
             return;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -66,7 +66,7 @@ Runtime::Runtime() {
 // Tensor Pair Management
 // =============================================================================
 
-void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
+void Runtime::record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size) {
     if (tensor_pair_count >= RUNTIME_MAX_TENSOR_PAIRS) {
         LOG_ERROR("[Runtime] Tensor pairs full (max=%d)", RUNTIME_MAX_TENSOR_PAIRS);
         return;
@@ -78,7 +78,7 @@ void Runtime::record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size) {
     LOG_INFO("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
 }
 
-TensorPair* Runtime::get_tensor_pairs() { return tensor_pairs; }
+TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
 
 int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
@@ -89,18 +89,18 @@ void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 // =============================================================================
 
 bool Runtime::get_orch_built_on_host() const { return orch_built_on_host_; }
-void* Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
-void* Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
-const ChipStorageTaskArgs& Runtime::get_orch_args() const { return orch_args_storage_; }
+void *Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
+void *Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
+const ChipStorageTaskArgs &Runtime::get_orch_args() const { return orch_args_storage_; }
 void Runtime::set_orch_built_on_host(bool v) { orch_built_on_host_ = v; }
-void Runtime::set_pto2_gm_sm_ptr(void* p) { pto2_gm_sm_ptr_ = p; }
-void Runtime::set_pto2_gm_heap(void* p) { pto2_gm_heap_ptr_ = p; }
-void Runtime::set_pto2_slot_states_ptr(void* p) { pto2_slot_states_ptr_ = p; }
-void Runtime::set_orch_args(const ChipStorageTaskArgs& args) { orch_args_storage_ = args; }
+void Runtime::set_pto2_gm_sm_ptr(void *p) { pto2_gm_sm_ptr_ = p; }
+void Runtime::set_pto2_gm_heap(void *p) { pto2_gm_heap_ptr_ = p; }
+void Runtime::set_pto2_slot_states_ptr(void *p) { pto2_slot_states_ptr_ = p; }
+void Runtime::set_orch_args(const ChipStorageTaskArgs &args) { orch_args_storage_ = args; }
 
 // Device orchestration SO binary (for dlopen on AICPU thread 3)
 // Copies data to internal storage to avoid lifetime issues with Python ctypes arrays
-void Runtime::set_device_orch_so(const void* data, size_t size) {
+void Runtime::set_device_orch_so(const void *data, size_t size) {
     if (data == nullptr || size == 0) {
         device_orch_so_size_ = 0;
         return;
@@ -114,7 +114,7 @@ void Runtime::set_device_orch_so(const void* data, size_t size) {
     device_orch_so_size_ = size;
 }
 
-const void* Runtime::get_device_orch_so_data() const {
+const void *Runtime::get_device_orch_so_data() const {
     return device_orch_so_size_ > 0 ? device_orch_so_storage_ : nullptr;
 }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -108,8 +108,8 @@ struct Handshake {
  * Used for copy-back during finalize.
  */
 struct TensorPair {
-    void* host_ptr;
-    void* dev_ptr;
+    void *host_ptr;
+    void *dev_ptr;
     size_t size;
 };
 
@@ -118,11 +118,11 @@ struct TensorPair {
  * Allows runtime to use pluggable device memory backends.
  */
 struct HostApi {
-    void* (*device_malloc)(size_t size);
-    void (*device_free)(void* dev_ptr);
-    int (*copy_to_device)(void* dev_ptr, const void* host_ptr, size_t size);
-    int (*copy_from_device)(void* host_ptr, const void* dev_ptr, size_t size);
-    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t* bin_data, size_t bin_size);
+    void *(*device_malloc)(size_t size);
+    void (*device_free)(void *dev_ptr);
+    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
+    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t *bin_data, size_t bin_size);
     void (*remove_kernel_binary)(int func_id);
 };
 
@@ -190,9 +190,9 @@ private:  // NOLINT(whitespace/indent)
 
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
-    void* pto2_gm_sm_ptr_;                   // GM pointer to PTO2 shared memory (device)
-    void* pto2_gm_heap_ptr_;                 // GM heap for orchestrator output buffers (device)
-    void* pto2_slot_states_ptr_;             // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
+    void *pto2_gm_sm_ptr_;                   // GM pointer to PTO2 shared memory (device)
+    void *pto2_gm_heap_ptr_;                 // GM heap for orchestrator output buffers (device)
+    void *pto2_slot_states_ptr_;             // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
     ChipStorageTaskArgs orch_args_storage_;  // Copy of args for device
 
     // Device orchestration SO binary (for dlopen on AICPU thread 3)
@@ -213,12 +213,12 @@ public:  // NOLINT(whitespace/indent)
     /**
      * Record a host-device tensor pair for copy-back during finalize.
      */
-    void record_tensor_pair(void* host_ptr, void* dev_ptr, size_t size);
+    void record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size);
 
     /**
      * Get pointer to tensor pairs array.
      */
-    TensorPair* get_tensor_pairs();
+    TensorPair *get_tensor_pairs();
 
     /**
      * Get number of recorded tensor pairs.
@@ -239,18 +239,18 @@ public:  // NOLINT(whitespace/indent)
     // =========================================================================
 
     bool get_orch_built_on_host() const;
-    void* get_pto2_gm_sm_ptr() const;
-    void* get_pto2_gm_heap_ptr() const;
-    const ChipStorageTaskArgs& get_orch_args() const;
+    void *get_pto2_gm_sm_ptr() const;
+    void *get_pto2_gm_heap_ptr() const;
+    const ChipStorageTaskArgs &get_orch_args() const;
     void set_orch_built_on_host(bool v);
-    void set_pto2_gm_sm_ptr(void* p);
-    void set_pto2_gm_heap(void* p);
-    void set_pto2_slot_states_ptr(void* p);
-    void set_orch_args(const ChipStorageTaskArgs& args);
+    void set_pto2_gm_sm_ptr(void *p);
+    void set_pto2_gm_heap(void *p);
+    void set_pto2_slot_states_ptr(void *p);
+    void set_orch_args(const ChipStorageTaskArgs &args);
 
     // Device orchestration SO binary (for dlopen on AICPU thread 3)
-    void set_device_orch_so(const void* data, size_t size);
-    const void* get_device_orch_so_data() const;
+    void set_device_orch_so(const void *data, size_t size);
+    const void *get_device_orch_so_data() const;
     size_t get_device_orch_so_size() const;
 
     uint64_t get_function_bin_addr(int func_id) const;
@@ -269,7 +269,7 @@ public:  // NOLINT(whitespace/indent)
     int get_task_count() const { return 0; }
 
     /** @deprecated RT2 uses PTO2DispatchPayload, not Task. Always returns nullptr. */
-    Task* get_task(int) { return nullptr; }
+    Task *get_task(int) { return nullptr; }
 
     /** @deprecated Use PTO2 dispatch mode */
     bool get_use_pto2_dispatch() const { return true; }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -44,8 +44,8 @@ struct Segment {
     uint64_t begin;
     uint64_t end;
 
-    bool line_segment_intersection(const Segment& other) const { return end > other.begin && other.end > begin; }
-    bool contains(const Segment& other) const { return begin <= other.begin && other.end <= end; }
+    bool line_segment_intersection(const Segment &other) const { return end > other.begin && other.end > begin; }
+    bool contains(const Segment &other) const { return begin <= other.begin && other.end <= end; }
 };
 
 /**
@@ -67,8 +67,13 @@ struct TensorCreateInfo {
     uint64_t initial_value;
 
     TensorCreateInfo(
-        const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false)
-        : dtype(dtype), ndims(ndims), manual_dep(manual_dep), has_initial_value(false), initial_value(0) {
+        const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false
+    ) :
+        dtype(dtype),
+        ndims(ndims),
+        manual_dep(manual_dep),
+        has_initial_value(false),
+        initial_value(0) {
         for (uint32_t i = 0; i < ndims; i++) {
             raw_shapes[i] = shapes[i];
         }
@@ -137,28 +142,22 @@ struct alignas(64) Tensor {
     uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
 
     // --- Copy / move / destroy are public (valid tensors can be freely copied) ---
-    Tensor(const Tensor&) = default;
-    Tensor& operator=(const Tensor&) = default;
-    Tensor(Tensor&&) = default;
-    Tensor& operator=(Tensor&&) = default;
+    Tensor(const Tensor &) = default;
+    Tensor &operator=(const Tensor &) = default;
+    Tensor(Tensor &&) = default;
+    Tensor &operator=(Tensor &&) = default;
     ~Tensor() = default;
 
     /// Return the effective raw_shapes pointer (shapes[] when is_raw_eq_shapes).
     /// Avoids cache line 2 access for the common case.
-    const uint32_t* get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
+    const uint32_t *get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
 
     // --- Initialization (operates on already-constructed Tensor) ---
-    void init(void* addr,
-        uint64_t buffer_size_bytes,
-        const uint32_t in_raw_shapes[],
-        const uint32_t in_shapes[],
-        const uint32_t in_offsets[],
-        uint32_t in_ndims,
-        DataType in_dtype,
-        int32_t in_version,
-        bool in_is_all_offset_zero = false,
-        bool in_is_raw_eq_shapes = false,
-        bool in_manual_dep = false) {
+    void init(
+        void *addr, uint64_t buffer_size_bytes, const uint32_t in_raw_shapes[], const uint32_t in_shapes[],
+        const uint32_t in_offsets[], uint32_t in_ndims, DataType in_dtype, int32_t in_version,
+        bool in_is_all_offset_zero = false, bool in_is_raw_eq_shapes = false, bool in_manual_dep = false
+    ) {
         buffer = {reinterpret_cast<uint64_t>(addr), buffer_size_bytes};
         ndims = in_ndims;
         dtype = in_dtype;
@@ -181,7 +180,7 @@ struct alignas(64) Tensor {
         }
     }
 
-    void init(const Tensor& other) {
+    void init(const Tensor &other) {
         memcpy(this, &other, 64);  // fast copy cache line 1
         if (!other.is_raw_eq_shapes) {
             for (uint32_t i = 0; i < ndims; i++) {
@@ -196,7 +195,8 @@ struct alignas(64) Tensor {
     }
 
     void init_with_view(
-        const Tensor& other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) {
+        const Tensor &other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false
+    ) {
         buffer = other.buffer;
         ndims = other.ndims;
         dtype = other.dtype;
@@ -205,7 +205,7 @@ struct alignas(64) Tensor {
         // view always diverges shapes from raw_shapes, so is_raw_eq_shapes = false.
         // Read parent's effective raw_shapes (avoids parent cache line 2 when parent is_raw_eq_shapes).
         is_raw_eq_shapes = false;
-        const uint32_t* parent_raw = other.get_raw_shapes();
+        const uint32_t *parent_raw = other.get_raw_shapes();
         for (uint32_t i = 0; i < ndims; i++) {
             raw_shapes[i] = parent_raw[i];
             shapes[i] = view_shapes[i];
@@ -237,29 +237,25 @@ struct alignas(64) Tensor {
     /// Uses Horner's method (forward traversal, no stride variable).
     uint64_t compute_flat_offset(const uint32_t indices[], uint32_t in_ndims) const {
         if (in_ndims == 0) return 0;
-        const uint32_t* rs = get_raw_shapes();
+        const uint32_t *rs = get_raw_shapes();
         uint64_t offset = 0;
         if (is_all_offset_zero) {
-            for (uint32_t d = 0; d < in_ndims; d++) offset = offset * rs[d] + indices[d];
+            for (uint32_t d = 0; d < in_ndims; d++)
+                offset = offset * rs[d] + indices[d];
         } else {
-            for (uint32_t d = 0; d < in_ndims; d++) offset = offset * rs[d] + indices[d] + offsets[d];
+            for (uint32_t d = 0; d < in_ndims; d++)
+                offset = offset * rs[d] + indices[d] + offsets[d];
         }
         return offset;
     }
 
     /// Materialize a TensorCreateInfo into this Tensor (fresh contiguous output).
-    void init_from_create_info(const TensorCreateInfo& ci, void* addr, int32_t version_val) {
-        init(addr,
-            ci.buffer_size_bytes(),
-            ci.raw_shapes,
-            ci.raw_shapes,
-            nullptr,
-            ci.ndims,
-            ci.dtype,
-            version_val,
+    void init_from_create_info(const TensorCreateInfo &ci, void *addr, int32_t version_val) {
+        init(
+            addr, ci.buffer_size_bytes(), ci.raw_shapes, ci.raw_shapes, nullptr, ci.ndims, ci.dtype, version_val,
             /*is_all_offset_zero=*/true,
-            /*is_raw_eq_shapes=*/true,
-            ci.manual_dep);
+            /*is_raw_eq_shapes=*/true, ci.manual_dep
+        );
     }
 
     // --- Operations ---
@@ -268,7 +264,7 @@ struct alignas(64) Tensor {
             start_offset = 0;
             return;
         }
-        const uint32_t* rs = get_raw_shapes();
+        const uint32_t *rs = get_raw_shapes();
         uint64_t result = 0;
         uint64_t stride = 1;
         for (int i = static_cast<int>(ndims) - 1; i >= 0; i--) {
@@ -278,7 +274,7 @@ struct alignas(64) Tensor {
         start_offset = result;
     }
 
-    void copy(const Tensor& other) { init(other); }
+    void copy(const Tensor &other) { init(other); }
 
     Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
         Tensor result;
@@ -351,19 +347,19 @@ struct alignas(64) Tensor {
         return total;
     }
 
-    bool is_same_memref(const Tensor& other) const { return buffer.addr == other.buffer.addr; }
+    bool is_same_memref(const Tensor &other) const { return buffer.addr == other.buffer.addr; }
 
     std::string dump() const {
         std::stringstream ss;
         std::string indent = "    ";
-        ss << "{" << std::endl;
-        ss << indent << "buffer.addr: " << buffer.addr << std::endl;
-        ss << indent << "buffer.size: " << buffer.size << " bytes" << std::endl;
-        ss << indent << "dtype: " << get_dtype_name(dtype) << std::endl;
-        ss << indent << "ndims: " << ndims << std::endl;
-        ss << indent << "version: " << version << std::endl;
+        ss << "{" << '\n';
+        ss << indent << "buffer.addr: " << buffer.addr << '\n';
+        ss << indent << "buffer.size: " << buffer.size << " bytes" << '\n';
+        ss << indent << "dtype: " << get_dtype_name(dtype) << '\n';
+        ss << indent << "ndims: " << ndims << '\n';
+        ss << indent << "version: " << version << '\n';
 
-        const uint32_t* rs = get_raw_shapes();
+        const uint32_t *rs = get_raw_shapes();
         ss << indent << "raw_shapes: [";
         for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
@@ -371,7 +367,7 @@ struct alignas(64) Tensor {
             }
             ss << rs[i];
         }
-        ss << "]" << std::endl;
+        ss << "]" << '\n';
         ss << indent << "shapes: [";
         for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
@@ -379,7 +375,7 @@ struct alignas(64) Tensor {
             }
             ss << shapes[i];
         }
-        ss << "]" << std::endl;
+        ss << "]" << '\n';
         ss << indent << "offsets: [";
         for (uint32_t i = 0; i < ndims; i++) {
             if (i > 0) {
@@ -387,8 +383,8 @@ struct alignas(64) Tensor {
             }
             ss << (is_all_offset_zero ? 0u : offsets[i]);
         }
-        ss << "]" << std::endl;
-        ss << "}" << std::endl;
+        ss << "]" << '\n';
+        ss << "}" << '\n';
         return ss.str();
     }
 
@@ -397,34 +393,22 @@ private:
     // Valid Tensors come only from controlled entry points.
     Tensor() = default;
 
-    Tensor(void* addr,
-        uint64_t buffer_size_bytes,
-        const uint32_t raw_shapes[],
-        const uint32_t shapes[],
-        const uint32_t offsets[],
-        uint32_t ndims,
-        DataType dtype,
-        int32_t version,
-        bool is_all_offset_zero = false,
-        bool is_raw_eq_shapes = false,
-        bool manual_dep = false) {
-        init(addr,
-            buffer_size_bytes,
-            raw_shapes,
-            shapes,
-            offsets,
-            ndims,
-            dtype,
-            version,
-            is_all_offset_zero,
-            is_raw_eq_shapes,
-            manual_dep);
+    Tensor(
+        void *addr, uint64_t buffer_size_bytes, const uint32_t raw_shapes[], const uint32_t shapes[],
+        const uint32_t offsets[], uint32_t ndims, DataType dtype, int32_t version, bool is_all_offset_zero = false,
+        bool is_raw_eq_shapes = false, bool manual_dep = false
+    ) {
+        init(
+            addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version, is_all_offset_zero,
+            is_raw_eq_shapes, manual_dep
+        );
     }
 
     // Friends that need to construct Tensors
     friend struct PTO2TaskPayload;
     friend inline Tensor make_tensor_external(
-        void* addr, const uint32_t shapes[], uint32_t ndims, DataType dtype, bool manual_dep, int32_t version);
+        void *addr, const uint32_t shapes[], uint32_t ndims, DataType dtype, bool manual_dep, int32_t version
+    );
 };
 
 static_assert(sizeof(Tensor) == 128, "Tensor must be exactly 2 cache lines (128 bytes)");

--- a/src/common/task_interface/arg_direction.h
+++ b/src/common/task_interface/arg_direction.h
@@ -32,17 +32,17 @@ inline constexpr uint32_t CALLABLE_ALIGN = 64;
 
 static inline uint32_t callable_align_up(uint32_t size) { return (size + CALLABLE_ALIGN - 1) & ~(CALLABLE_ALIGN - 1); }
 
-inline const char* arg_direction_name(ArgDirection d) {
+inline const char *arg_direction_name(ArgDirection d) {
     switch (d) {
-        case ArgDirection::SCALAR:
-            return "SCALAR";
-        case ArgDirection::IN:
-            return "IN";
-        case ArgDirection::OUT:
-            return "OUT";
-        case ArgDirection::INOUT:
-            return "INOUT";
-        default:
-            return "UNKNOWN";
+    case ArgDirection::SCALAR:
+        return "SCALAR";
+    case ArgDirection::IN:
+        return "IN";
+    case ArgDirection::OUT:
+        return "OUT";
+    case ArgDirection::INOUT:
+        return "INOUT";
+    default:
+        return "UNKNOWN";
     }
 }

--- a/src/common/task_interface/callable.h
+++ b/src/common/task_interface/callable.h
@@ -71,19 +71,19 @@ struct Callable<void, MaxSig, 0> {
     // Binary data is placed at the next CALLABLE_ALIGN boundary after the fixed fields.
     // storage_ sits between the fixed fields and the aligned binary; binary_data()
     // skips the padding automatically.
-    const void* binary_data() const { return reinterpret_cast<const char*>(this) + binary_data_offset(); }
+    const void *binary_data() const { return reinterpret_cast<const char *>(this) + binary_data_offset(); }
 
     static constexpr size_t binary_data_offset() {
         constexpr size_t raw = sizeof(ArgDirection) * MaxSig + sizeof(int32_t) + sizeof(uint32_t) + sizeof(uint64_t);
         return (raw + CALLABLE_ALIGN - 1) & ~(static_cast<size_t>(CALLABLE_ALIGN) - 1);
     }
 
- private:
+private:
     Callable() = default;
 
     template <int MS>
-    friend std::vector<uint8_t> make_callable(
-        const ArgDirection* sig, int32_t sig_count, const void* binary, uint32_t binary_size);
+    friend std::vector<uint8_t>
+    make_callable(const ArgDirection *sig, int32_t sig_count, const void *binary, uint32_t binary_size);
 };
 
 // ============================================================================
@@ -109,14 +109,14 @@ struct Callable {
         return signature_[i];
     }
     int32_t sig_count() const { return sig_count_; }
-    const void* binary_data() const { return storage_; }
+    const void *binary_data() const { return storage_; }
     uint32_t binary_size() const { return binary_size_; }
-    const char* func_name() const { return func_name_; }
+    const char *func_name() const { return func_name_; }
     uint32_t func_name_len() const { return func_name_len_; }
 
-    const Child& child(int32_t i) const {
+    const Child &child(int32_t i) const {
         if (i < 0 || i >= child_count_) throw std::out_of_range("Callable: child index out of range");
-        return *reinterpret_cast<const Child*>(storage_ + child_offsets_[i]);
+        return *reinterpret_cast<const Child *>(storage_ + child_offsets_[i]);
     }
     int32_t child_func_id(int32_t i) const {
         if (i < 0 || i >= child_count_) throw std::out_of_range("Callable: child_func_id index out of range");
@@ -128,18 +128,14 @@ struct Callable {
         return child_offsets_[i];
     }
 
- private:
+private:
     Callable() = default;
 
     template <typename C, int MS, int MC>
-    friend std::vector<uint8_t> make_callable(const ArgDirection* sig,
-        int32_t sig_count,
-        const char* func_name,
-        const void* binary,
-        uint32_t binary_size,
-        const int32_t* child_func_ids,
-        const std::vector<uint8_t>* child_buffers,
-        int32_t child_count);
+    friend std::vector<uint8_t> make_callable(
+        const ArgDirection *sig, int32_t sig_count, const char *func_name, const void *binary, uint32_t binary_size,
+        const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count
+    );
 };
 
 // ============================================================================
@@ -157,7 +153,7 @@ struct Callable<void, 0, 0> {
         return signature_[static_cast<size_t>(i)];
     }
     int32_t sig_count() const { return static_cast<int32_t>(signature_.size()); }
-    const void* binary_data() const { return binary_.data(); }
+    const void *binary_data() const { return binary_.data(); }
     uint32_t binary_size() const { return static_cast<uint32_t>(binary_.size()); }
 };
 
@@ -179,10 +175,10 @@ struct Callable<Child, 0, 0> {
         return signature_[static_cast<size_t>(i)];
     }
     int32_t sig_count() const { return static_cast<int32_t>(signature_.size()); }
-    const void* binary_data() const { return binary_.data(); }
+    const void *binary_data() const { return binary_.data(); }
     uint32_t binary_size() const { return static_cast<uint32_t>(binary_.size()); }
 
-    const Child& child(int32_t i) const {
+    const Child &child(int32_t i) const {
         if (i < 0 || static_cast<size_t>(i) >= children_.size())
             throw std::out_of_range("Callable: child index out of range");
         return children_[static_cast<size_t>(i)];
@@ -207,8 +203,8 @@ using ChipCallable = Callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 32>;
 // ============================================================================
 
 template <int MaxSig>
-std::vector<uint8_t> make_callable(
-    const ArgDirection* sig, int32_t sig_count, const void* binary, uint32_t binary_size) {
+std::vector<uint8_t>
+make_callable(const ArgDirection *sig, int32_t sig_count, const void *binary, uint32_t binary_size) {
     if (sig_count > MaxSig) throw std::invalid_argument("make_callable: sig_count exceeds MaxSig");
 
     using T = Callable<void, MaxSig, 0>;
@@ -216,8 +212,9 @@ std::vector<uint8_t> make_callable(
     size_t total_size = aligned_header + binary_size;
     std::vector<uint8_t> buf(total_size, 0);
 
-    T* obj = reinterpret_cast<T*>(buf.data());
-    for (int32_t i = 0; i < sig_count; ++i) obj->signature_[i] = sig[i];
+    T *obj = reinterpret_cast<T *>(buf.data());
+    for (int32_t i = 0; i < sig_count; ++i)
+        obj->signature_[i] = sig[i];
     obj->sig_count_ = sig_count;
     obj->binary_size_ = binary_size;
     obj->resolved_addr_ = 0;
@@ -231,14 +228,10 @@ std::vector<uint8_t> make_callable(
 // ============================================================================
 
 template <typename Child, int MaxSig, int MaxChildren>
-std::vector<uint8_t> make_callable(const ArgDirection* sig,
-    int32_t sig_count,
-    const char* func_name,
-    const void* binary,
-    uint32_t binary_size,
-    const int32_t* child_func_ids,
-    const std::vector<uint8_t>* child_buffers,
-    int32_t child_count) {
+std::vector<uint8_t> make_callable(
+    const ArgDirection *sig, int32_t sig_count, const char *func_name, const void *binary, uint32_t binary_size,
+    const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count
+) {
     if (sig_count > MaxSig) throw std::invalid_argument("make_callable: sig_count exceeds MaxSig");
     if (child_count > MaxChildren) throw std::invalid_argument("make_callable: child_count exceeds MaxChildren");
 
@@ -255,8 +248,9 @@ std::vector<uint8_t> make_callable(const ArgDirection* sig,
     size_t total_size = header_size + offset;
     std::vector<uint8_t> buf(total_size, 0);
 
-    T* obj = reinterpret_cast<T*>(buf.data());
-    for (int32_t i = 0; i < sig_count; ++i) obj->signature_[i] = sig[i];
+    T *obj = reinterpret_cast<T *>(buf.data());
+    for (int32_t i = 0; i < sig_count; ++i)
+        obj->signature_[i] = sig[i];
     obj->sig_count_ = sig_count;
     obj->binary_size_ = binary_size;
 

--- a/src/common/task_interface/data_type.h
+++ b/src/common/task_interface/data_type.h
@@ -20,6 +20,7 @@
 #ifndef SRC_COMMON_TASK_INTERFACE_DATA_TYPE_H_
 #define SRC_COMMON_TASK_INTERFACE_DATA_TYPE_H_
 
+#include <array>
 #include <cstdint>
 
 #if __has_include(<type_traits>)
@@ -55,7 +56,7 @@ static_assert(sizeof(DataType) == 1, "DataType must stay 1 byte");
  */
 inline uint64_t get_element_size(DataType dtype) {
     // Order must match the enum definition exactly
-    static uint64_t data_type_size[static_cast<int>(DataType::DATA_TYPE_NUM)] = {
+    static std::array<uint64_t, static_cast<int>(DataType::DATA_TYPE_NUM)> data_type_size = {
         4,  // case DataType::FLOAT32
         2,  // DataType::FLOAT16
         4,  // DataType::INT32
@@ -75,28 +76,28 @@ inline uint64_t get_element_size(DataType dtype) {
  * @param dtype Data type
  * @return String name of the data type
  */
-inline const char* get_dtype_name(DataType dtype) {
+inline const char *get_dtype_name(DataType dtype) {
     switch (dtype) {
-        case DataType::FLOAT32:
-            return "FLOAT32";
-        case DataType::FLOAT16:
-            return "FLOAT16";
-        case DataType::INT32:
-            return "INT32";
-        case DataType::INT16:
-            return "INT16";
-        case DataType::INT8:
-            return "INT8";
-        case DataType::UINT8:
-            return "UINT8";
-        case DataType::BFLOAT16:
-            return "BFLOAT16";
-        case DataType::INT64:
-            return "INT64";
-        case DataType::UINT64:
-            return "UINT64";
-        default:
-            return "UNKNOWN";
+    case DataType::FLOAT32:
+        return "FLOAT32";
+    case DataType::FLOAT16:
+        return "FLOAT16";
+    case DataType::INT32:
+        return "INT32";
+    case DataType::INT16:
+        return "INT16";
+    case DataType::INT8:
+        return "INT8";
+    case DataType::UINT8:
+        return "UINT8";
+    case DataType::BFLOAT16:
+        return "BFLOAT16";
+    case DataType::INT64:
+        return "INT64";
+    case DataType::UINT64:
+        return "UINT64";
+    default:
+        return "UNKNOWN";
     }
 }
 
@@ -141,7 +142,7 @@ template <typename T>
 PTO_DEVICE_FUNC inline uint64_t to_u64(T value) {
     static_assert(sizeof(T) <= sizeof(uint64_t), "to_u64: type must fit in 8 bytes");
 #if PTO_HAS_TYPE_TRAITS
-    static_assert(std::is_trivially_copyable<T>::value, "to_u64: type must be trivially copyable");
+    static_assert(std::is_trivially_copyable_v<T>, "to_u64: type must be trivially copyable");
 #endif
     union {
         uint64_t u;
@@ -162,7 +163,7 @@ template <typename T>
 PTO_DEVICE_FUNC inline T from_u64(uint64_t bits) {
     static_assert(sizeof(T) <= sizeof(uint64_t), "from_u64: type must fit in 8 bytes");
 #if PTO_HAS_TYPE_TRAITS
-    static_assert(std::is_trivially_copyable<T>::value, "from_u64: type must be trivially copyable");
+    static_assert(std::is_trivially_copyable_v<T>, "from_u64: type must be trivially copyable");
 #endif
     union {
         uint64_t u;

--- a/src/common/task_interface/task_args.h
+++ b/src/common/task_interface/task_args.h
@@ -46,8 +46,8 @@ template <typename TensorTag, size_t MaxT>
 struct TensorTagMixin {
     TensorTag tags_[MaxT]{};
 
-    const TensorTag& tag(int32_t i) const { return tags_[i]; }
-    TensorTag& tag(int32_t i) { return tags_[i]; }
+    const TensorTag &tag(int32_t i) const { return tags_[i]; }
+    TensorTag &tag(int32_t i) { return tags_[i]; }
 };
 
 // Dynamic vector of tags (MaxT == 0, TensorTag != void)
@@ -55,8 +55,8 @@ template <typename TensorTag>
 struct TensorTagMixin<TensorTag, 0> {
     std::vector<TensorTag> tags_;
 
-    const TensorTag& tag(int32_t i) const { return tags_[static_cast<size_t>(i)]; }
-    TensorTag& tag(int32_t i) { return tags_[static_cast<size_t>(i)]; }
+    const TensorTag &tag(int32_t i) const { return tags_[static_cast<size_t>(i)]; }
+    TensorTag &tag(int32_t i) { return tags_[static_cast<size_t>(i)]; }
 };
 
 // Empty: TensorTag == void, static (zero overhead)
@@ -78,7 +78,7 @@ struct TaskArgs : TensorTagMixin<TensorTag, MaxT> {
     int32_t tensor_count_{0};
     int32_t scalar_count_{0};
 
-    void add_tensor(const T& t) {
+    void add_tensor(const T &t) {
         if (scalar_count_ > 0) throw std::logic_error("TaskArgs: cannot add tensor after scalar");
         if (static_cast<size_t>(tensor_count_) >= MaxT) throw std::out_of_range("TaskArgs: tensor capacity exceeded");
         tensors_[tensor_count_++] = t;
@@ -89,16 +89,16 @@ struct TaskArgs : TensorTagMixin<TensorTag, MaxT> {
         scalars_[scalar_count_++] = s;
     }
 
-    const T& tensor(int32_t i) const { return tensors_[i]; }
-    T& tensor(int32_t i) { return tensors_[i]; }
+    const T &tensor(int32_t i) const { return tensors_[i]; }
+    T &tensor(int32_t i) { return tensors_[i]; }
 
     S scalar(int32_t i) const { return scalars_[i]; }
-    S& scalar(int32_t i) { return scalars_[i]; }
+    S &scalar(int32_t i) { return scalars_[i]; }
 
-    const S* scalars() const { return scalars_; }
+    const S *scalars() const { return scalars_; }
 
-    const T* tensor_data() const { return tensors_; }
-    const S* scalar_data() const { return scalars_; }
+    const T *tensor_data() const { return tensors_; }
+    const S *scalar_data() const { return scalars_; }
 
     int32_t tensor_count() const { return tensor_count_; }
     int32_t scalar_count() const { return scalar_count_; }
@@ -118,7 +118,7 @@ struct TaskArgs<T, S, 0, 0, TensorTag> : TensorTagMixin<TensorTag, 0> {
     std::vector<T> tensors_;
     std::vector<S> scalars_;
 
-    void add_tensor(const T& t) {
+    void add_tensor(const T &t) {
         if (!scalars_.empty()) throw std::logic_error("TaskArgs: cannot add tensor after scalar");
         tensors_.push_back(t);
         if constexpr (!std::is_void_v<TensorTag>) {
@@ -128,14 +128,14 @@ struct TaskArgs<T, S, 0, 0, TensorTag> : TensorTagMixin<TensorTag, 0> {
 
     void add_scalar(S s) { scalars_.push_back(s); }
 
-    const T& tensor(int32_t i) const { return tensors_[static_cast<size_t>(i)]; }
-    T& tensor(int32_t i) { return tensors_[static_cast<size_t>(i)]; }
+    const T &tensor(int32_t i) const { return tensors_[static_cast<size_t>(i)]; }
+    T &tensor(int32_t i) { return tensors_[static_cast<size_t>(i)]; }
 
     S scalar(int32_t i) const { return scalars_[static_cast<size_t>(i)]; }
-    S& scalar(int32_t i) { return scalars_[static_cast<size_t>(i)]; }
+    S &scalar(int32_t i) { return scalars_[static_cast<size_t>(i)]; }
 
-    const T* tensor_data() const { return tensors_.data(); }
-    const S* scalar_data() const { return scalars_.data(); }
+    const T *tensor_data() const { return tensors_.data(); }
+    const S *scalar_data() const { return scalars_.data(); }
 
     int32_t tensor_count() const { return static_cast<int32_t>(tensors_.size()); }
     int32_t scalar_count() const { return static_cast<int32_t>(scalars_.size()); }

--- a/src/common/task_interface/tensor_arg.h
+++ b/src/common/task_interface/tensor_arg.h
@@ -29,30 +29,31 @@ struct ContinuousTensor {
     uint32_t ndims;                               // Number of dimensions (1..5)
     DataType dtype;                               // DataType : uint8_t
 
-    uint64_t nbytes() const {
+    [[nodiscard]] uint64_t nbytes() const {
         uint64_t total = 1;
-        for (uint32_t i = 0; i < ndims; i++) total *= shapes[i];
+        for (uint32_t i = 0; i < ndims; i++)
+            total *= shapes[i];
         return total * get_element_size(dtype);
     }
 
     template <typename T>
-    T* data_as() const {
-        return reinterpret_cast<T*>(static_cast<uintptr_t>(data));
+    T *data_as() const {
+        return reinterpret_cast<T *>(static_cast<uintptr_t>(data));
     }
 };
 
+static_assert(std::is_trivially_copyable_v<ContinuousTensor>, "ContinuousTensor must be trivially copyable for DMA");
 static_assert(
-    std::is_trivially_copyable<ContinuousTensor>::value, "ContinuousTensor must be trivially copyable for DMA");
-static_assert(
-    sizeof(ContinuousTensor) == 40, "ContinuousTensor size must be exactly 40B (33B fields + 7B tail padding)");
+    sizeof(ContinuousTensor) == 40, "ContinuousTensor size must be exactly 40B (33B fields + 7B tail padding)"
+);
 
 /**
  * TensorArgType - Distinguishes inputs, outputs, and in-place updates
  */
-enum class TensorArgType : int32_t {
-    INPUT = 0,            // Read-only input buffer
-    OUTPUT = 1,           // Write-only output buffer (runtime allocates)
-    INOUT = 2,            // Read-then-write: modifier for downstream
-    OUTPUT_EXISTING = 3,  // Write-only existing tensor: skips OverlapMap lookup, depends on creator
-    NO_DEP = 4,           // No-dependency existing tensor: skips OverlapMap lookup, no publish
+enum class TensorArgType : int32_t {  // NOLINT(performance-enum-size)
+    INPUT = 0,                        // Read-only input buffer
+    OUTPUT = 1,                       // Write-only output buffer (runtime allocates)
+    INOUT = 2,                        // Read-then-write: modifier for downstream
+    OUTPUT_EXISTING = 3,              // Write-only existing tensor: skips OverlapMap lookup, depends on creator
+    NO_DEP = 4,                       // No-dependency existing tensor: skips OverlapMap lookup, no publish
 };

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -19,10 +19,10 @@
 namespace {
 
 template <typename T>
-T load_symbol(void* handle, const char* name) {
+T load_symbol(void *handle, const char *name) {
     dlerror();  // clear any existing error
-    void* sym = dlsym(handle, name);
-    const char* err = dlerror();
+    void *sym = dlsym(handle, name);
+    const char *err = dlerror();
     if (err) {
         std::string msg = "dlsym failed for '";
         msg += name;
@@ -37,21 +37,19 @@ T load_symbol(void* handle, const char* name) {
 
 ChipWorker::~ChipWorker() { reset(); }
 
-void ChipWorker::init(int device_id,
-    const std::string& host_lib_path,
-    const uint8_t* aicpu_binary,
-    size_t aicpu_size,
-    const uint8_t* aicore_binary,
-    size_t aicore_size) {
+void ChipWorker::init(
+    int device_id, const std::string &host_lib_path, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size
+) {
     if (initialized_) {
         throw std::runtime_error("ChipWorker already initialized; call reset() first");
     }
 
     // Load the host runtime shared library
-    void* handle = dlopen(host_lib_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    void *handle = dlopen(host_lib_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
     if (!handle) {
         std::string err = "dlopen failed: ";
-        const char* msg = dlerror();
+        const char *msg = dlerror();
         err += msg ? msg : "unknown error";
         throw std::runtime_error(err);
     }
@@ -106,12 +104,12 @@ void ChipWorker::reset() {
     initialized_ = false;
 }
 
-void ChipWorker::run(const void* callable, const void* args, const CallConfig& config) {
+void ChipWorker::run(const void *callable, const void *args, const CallConfig &config) {
     if (!initialized_) {
         throw std::runtime_error("ChipWorker not initialized; call init() first");
     }
 
-    void* rt = runtime_buf_.data();
+    void *rt = runtime_buf_.data();
 
     // 1. Placement new + build graph
     int rc = init_runtime_fn_(rt, callable, args);
@@ -128,15 +126,10 @@ void ChipWorker::run(const void* callable, const void* args, const CallConfig& c
     }
 
     // 3. Launch
-    rc = launch_runtime_fn_(rt,
-        config.aicpu_thread_num,
-        config.block_dim,
-        device_id_,
-        aicpu_binary_.data(),
-        aicpu_binary_.size(),
-        aicore_binary_.data(),
-        aicore_binary_.size(),
-        config.orch_thread_num);
+    rc = launch_runtime_fn_(
+        rt, config.aicpu_thread_num, config.block_dim, device_id_, aicpu_binary_.data(), aicpu_binary_.size(),
+        aicore_binary_.data(), aicore_binary_.size(), config.orch_thread_num
+    );
     if (rc != 0) {
         throw std::runtime_error("launch_runtime failed with code " + std::to_string(rc));
     }

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -24,36 +24,34 @@ struct CallConfig {
 };
 
 class ChipWorker {
- public:
+public:
     ChipWorker() = default;
     ~ChipWorker();
 
-    ChipWorker(const ChipWorker&) = delete;
-    ChipWorker& operator=(const ChipWorker&) = delete;
+    ChipWorker(const ChipWorker &) = delete;
+    ChipWorker &operator=(const ChipWorker &) = delete;
 
-    void init(int device_id,
-        const std::string& host_lib_path,
-        const uint8_t* aicpu_binary,
-        size_t aicpu_size,
-        const uint8_t* aicore_binary,
-        size_t aicore_size);
+    void init(
+        int device_id, const std::string &host_lib_path, const uint8_t *aicpu_binary, size_t aicpu_size,
+        const uint8_t *aicore_binary, size_t aicore_size
+    );
 
     void reset();
 
-    void run(const void* callable, const void* args, const CallConfig& config);
+    void run(const void *callable, const void *args, const CallConfig &config);
 
     int device_id() const { return device_id_; }
     bool initialized() const { return initialized_; }
 
- private:
+private:
     using SetDeviceFn = int (*)(int);
     using GetRuntimeSizeFn = size_t (*)();
-    using InitRuntimeFn = int (*)(void*, const void*, const void*);
-    using LaunchRuntimeFn = int (*)(void*, int, int, int, const uint8_t*, size_t, const uint8_t*, size_t, int);
-    using FinalizeRuntimeFn = int (*)(void*);
-    using EnableProfilingFn = int (*)(void*, int);
+    using InitRuntimeFn = int (*)(void *, const void *, const void *);
+    using LaunchRuntimeFn = int (*)(void *, int, int, int, const uint8_t *, size_t, const uint8_t *, size_t, int);
+    using FinalizeRuntimeFn = int (*)(void *);
+    using EnableProfilingFn = int (*)(void *, int);
 
-    void* lib_handle_ = nullptr;
+    void *lib_handle_ = nullptr;
     SetDeviceFn set_device_fn_ = nullptr;
     GetRuntimeSizeFn get_runtime_size_fn_ = nullptr;
     InitRuntimeFn init_runtime_fn_ = nullptr;

--- a/tests/lint/clang_tidy.py
+++ b/tests/lint/clang_tidy.py
@@ -1,0 +1,102 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Run clang-tidy on changed files using per-target compile databases.
+
+For each changed file, every build/cache/<arch>/<variant>/<runtime>/<target>/
+compile_commands.json that contains the file is used as-is (no merging).
+This ensures each file is analysed with the exact flags of its compilation unit.
+
+If no sim build cache exists, the sim runtimes are built first:
+    python examples/scripts/build_runtimes.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_BUILD_RUNTIMES = _ROOT / "examples" / "scripts" / "build_runtimes.py"
+_CACHE_DIR = _ROOT / "build" / "cache"
+
+# Suppress compiler flags that are valid for GCC but unknown to clang.
+_SUPPRESS_ARGS = [
+    "--extra-arg=-Wno-unknown-warning-option",
+    "--extra-arg=-Wno-unused-command-line-argument",
+]
+
+
+def _ensure_sim_cache() -> None:
+    """Build all detectable sim runtimes if no sim compile databases exist."""
+    if list(_CACHE_DIR.glob("*/sim/*/*/compile_commands.json")):
+        return
+
+    print("No sim compile databases found — building runtimes...", flush=True)
+    result = subprocess.run(
+        [sys.executable, str(_BUILD_RUNTIMES), "--platforms", "a2a3sim", "a5sim"], check=False, cwd=_ROOT
+    )
+    if result.returncode != 0:
+        print("ERROR: build_runtimes.py failed; cannot run clang-tidy", file=sys.stderr)
+        sys.exit(result.returncode)
+
+
+def _build_file_index() -> dict[str, list[Path]]:
+    """Return a mapping from absolute source path to the db directories that compile it.
+
+    Each db directory is a build/cache/<arch>/<variant>/<runtime>/<target>/
+    folder that contains a compile_commands.json covering the file.
+    Only sim variant databases are used (avoids cross-compiler sysroot issues).
+    """
+    index: dict[str, list[Path]] = {}
+    for db_file in sorted(_CACHE_DIR.glob("*/sim/*/*/compile_commands.json")):
+        for entry in json.loads(db_file.read_text()):
+            filepath = entry["file"]
+            index.setdefault(filepath, []).append(db_file.parent)
+    return index
+
+
+def main() -> int:
+    changed = [os.path.abspath(f) for f in sys.argv[1:]]
+    if not changed:
+        return 0
+
+    _ensure_sim_cache()
+    file_index = _build_file_index()
+
+    if not file_index:
+        print("ERROR: no sim compile databases found under build/cache/*/sim/", file=sys.stderr)
+        return 1
+
+    failed: set[str] = set()
+    for f in changed:
+        db_dirs = file_index.get(f)
+        if not db_dirs:
+            continue  # file not in any sim compile database (e.g. onboard-only)
+
+        for db_dir in db_dirs:
+            result = subprocess.run(
+                ["clang-tidy", f"-p={db_dir}", "--quiet"] + _SUPPRESS_ARGS + [f],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.stdout:
+                print(result.stdout, end="")
+            if result.returncode != 0:
+                failed.add(f)
+
+    if failed:
+        print(f"\n{len(failed)} file(s) failed clang-tidy")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_hub.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Supports two tile configurations via runtime dispatch:
@@ -24,10 +34,10 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __gm__ Tensor* oi) {
-    __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
-    __gm__ bfloat16_t* vj_addr = reinterpret_cast<__gm__ bfloat16_t*>(vj->buffer.addr);
-    __gm__ float* oi_addr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
+static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __gm__ Tensor *oi) {
+    __gm__ bfloat16_t *pij_addr = reinterpret_cast<__gm__ bfloat16_t *>(pij->buffer.addr);
+    __gm__ bfloat16_t *vj_addr = reinterpret_cast<__gm__ bfloat16_t *>(vj->buffer.addr);
+    __gm__ float *oi_addr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
 
     // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
@@ -61,9 +71,9 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
 
     // Load pij and vj to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, pijGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, vjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
@@ -87,10 +97,10 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* vj = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *vj = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(pij->shapes[0]);
     // args[4] = block_size, args[5] = head_dim
 

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Supports two tile configurations via runtime dispatch:
@@ -24,10 +34,10 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm__ Tensor* sij) {
-    __gm__ bfloat16_t* qi_addr = reinterpret_cast<__gm__ bfloat16_t*>(qi->buffer.addr);
-    __gm__ bfloat16_t* kj_addr = reinterpret_cast<__gm__ bfloat16_t*>(kj->buffer.addr);
-    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
+static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm__ Tensor *sij) {
+    __gm__ bfloat16_t *qi_addr = reinterpret_cast<__gm__ bfloat16_t *>(qi->buffer.addr);
+    __gm__ bfloat16_t *kj_addr = reinterpret_cast<__gm__ bfloat16_t *>(kj->buffer.addr);
+    __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
 
     // qi (M, K) bf16 in ND (row-major) layout
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
@@ -62,9 +72,9 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
 
     // Load A and B to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, qiGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, kjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
@@ -88,10 +98,10 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* qi = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* kj = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *qi = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *kj = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *sij = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
     // args[4] = head_dim (128), args[5] = block_size
 

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_hub.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Operates on full tiles where M=q_tile_size, N=head_dim (128):
@@ -26,22 +36,17 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ Tensor* mij,
-    __gm__ Tensor* lij,
-    __gm__ Tensor* oi_new,
-    __gm__ Tensor* mi,
-    __gm__ Tensor* li,
-    __gm__ Tensor* oi,
-    uint64_t is_first,
-    uint64_t is_last,
-    __gm__ Tensor* dst) {
-    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
-    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
-    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
-    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
-    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+static __aicore__ void online_update_impl(
+    __gm__ Tensor *mij, __gm__ Tensor *lij, __gm__ Tensor *oi_new, __gm__ Tensor *mi, __gm__ Tensor *li,
+    __gm__ Tensor *oi, uint64_t is_first, uint64_t is_last, __gm__ Tensor *dst
+) {
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi->buffer.addr);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li->buffer.addr);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst->buffer.addr);
 
     // Aligned rows for ColMajor DN tiles (32-byte alignment)
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
@@ -126,7 +131,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to the same UB as DN tiles for storing as ND format
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);           // alias same UB as mijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
         TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,21 +178,21 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        TMAX(miNewRow, miRow, mijRow);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        TSUB(alphaRow, miRow, miNewRow);  // alpha_exp = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        TSUB(betaRow, mijRow, miNewRow);  // beta_exp = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        TEXP(betaRow, betaRow);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        TMUL(tmpRow, alphaRow, liRow);  // alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        TMUL(liNewRow, betaRow, lijRow);  // beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         TRESHAPE(alphaDN, alphaRow);
@@ -195,9 +200,9 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
 
         // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
         // Alias ND tiles to the same UB locations as miNewRow and liNewRow
@@ -212,15 +217,15 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }
@@ -228,14 +233,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mi = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* li = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* oi = reinterpret_cast<__gm__ Tensor*>(args[5]);
-    __gm__ Tensor* dst = reinterpret_cast<__gm__ Tensor*>(args[6]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mi = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *li = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *oi = reinterpret_cast<__gm__ Tensor *>(args[5]);
+    __gm__ Tensor *dst = reinterpret_cast<__gm__ Tensor *>(args[6]);
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Softmax Preparation Kernel (AIV) with partial block masking
 //
 // Operates on (M, N) tile where M=q_tile_size, N=block_size:
@@ -31,16 +41,14 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
-    float scale_value,
-    __gm__ Tensor* pij,
-    __gm__ Tensor* mij,
-    __gm__ Tensor* lij) {
+static __aicore__ void softmax_prepare_impl(
+    __gm__ Tensor *sij, float scale_value, __gm__ Tensor *pij, __gm__ Tensor *mij, __gm__ Tensor *lij
+) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
-    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
-    __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
-    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
+    __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
+    __gm__ bfloat16_t *pij_addr = reinterpret_cast<__gm__ bfloat16_t *>(pij->buffer.addr);
+    __gm__ float *mij_addr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_addr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -102,14 +110,14 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     // Truncate pij to bf16 first
     pipe_barrier(PIPE_V);
     TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);        // pij bf16 ready, can store early
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);  // pij bf16 ready, can store early
 
     // Continue computing: bf16 → f32 and rowsum while pij store proceeds in parallel
     pipe_barrier(PIPE_V);
     TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
     pipe_barrier(PIPE_V);
     TROWSUM(sumTile, pijTile, tmpTile);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);        // sum ready
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);  // sum ready
 
     // Store pij (overlaps with TCVT + TROWSUM above)
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -124,11 +132,11 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[3]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *sij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[3]);
     union {
         uint64_t u;
         float f;

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -40,8 +40,8 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
@@ -49,7 +49,8 @@ __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestrati
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    PTO2Runtime* rt, const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+    PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index
+) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 
@@ -74,26 +75,28 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void* query_ptr = orch_args.tensor(0).data_as<void>();
-    void* kc_ptr = orch_args.tensor(1).data_as<void>();
-    void* vc_ptr = orch_args.tensor(2).data_as<void>();
-    void* out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).data_as<void>();
+    void *out_ptr = orch_args.tensor(5).data_as<void>();
 
     uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t value_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t out_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type, false);
     Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type, false);
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
 
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
         uint64_t cur_seq = host_context_lens[b_idx];
@@ -119,9 +122,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 args_inplace.add_output(TensorCreateInfo(li_shapes, 1, DataType::FLOAT32));
                 args_inplace.add_output(TensorCreateInfo(mi_shapes, 1, DataType::FLOAT32));
                 SubmitResult r_hub = pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, args_inplace);
-                const Tensor& oi = r_hub.outputs.get_ref(0);
-                const Tensor& li_update = r_hub.outputs.get_ref(1);
-                const Tensor& mi_update = r_hub.outputs.get_ref(2);
+                const Tensor &oi = r_hub.outputs.get_ref(0);
+                const Tensor &li_update = r_hub.outputs.get_ref(1);
+                const Tensor &mi_update = r_hub.outputs.get_ref(2);
 
                 PTO2TaskId prev_update_task = r_hub.task_id;
 

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_hub.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // SplitK PV Matmul Kernel: Accumulated P @ V across n_blocks
 //
 // Processes n_blocks blocks using SplitK accumulation pattern:
@@ -36,12 +46,9 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void pv_matmul_n_impl(
-    __gm__ bfloat16_t* pij_base,
-    __gm__ bfloat16_t* val_base,
-    __gm__ float* oi_base,
-    uint64_t n_blocks,
-    __gm__ int32_t* block_table) {
-
+    __gm__ bfloat16_t *pij_base, __gm__ bfloat16_t *val_base, __gm__ float *oi_base, uint64_t n_blocks,
+    __gm__ int32_t *block_table
+) {
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
@@ -78,8 +85,8 @@ static __aicore__ void pv_matmul_n_impl(
 
     for (uint64_t i = 0; i < n_blocks; i++) {
         // Select current buffers based on iteration parity
-        TileMatA& curA = (i % 2 == 0) ? aMatTile_ping : aMatTile_pong;
-        TileMatB& curB = (i % 2 == 0) ? bMatTile_ping : bMatTile_pong;
+        TileMatA &curA = (i % 2 == 0) ? aMatTile_ping : aMatTile_pong;
+        TileMatB &curB = (i % 2 == 0) ? bMatTile_ping : bMatTile_pong;
 
         // Wait for current TLOAD to complete
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
@@ -106,8 +113,8 @@ static __aicore__ void pv_matmul_n_impl(
         if (i + 1 < n_blocks) {
             // Signal matmul completion for next iteration's TMOV guard
             set_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
-            TileMatA& nxtA = (i % 2 == 0) ? aMatTile_pong : aMatTile_ping;
-            TileMatB& nxtB = (i % 2 == 0) ? bMatTile_pong : bMatTile_ping;
+            TileMatA &nxtA = (i % 2 == 0) ? aMatTile_pong : aMatTile_ping;
+            TileMatB &nxtB = (i % 2 == 0) ? bMatTile_pong : bMatTile_ping;
             GlobalA pijGlobal_next(pij_base + (i + 1) * M * K);
             GlobalB vjGlobal_next(val_base + block_table[i + 1] * K * N);
             TLOAD(nxtA, pijGlobal_next);
@@ -123,16 +130,16 @@ static __aicore__ void pv_matmul_n_impl(
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ TensorData* pij_buf = reinterpret_cast<__gm__ TensorData*>(args[0]);
-    __gm__ TensorData* value_cache = reinterpret_cast<__gm__ TensorData*>(args[1]);
-    __gm__ TensorData* oi_new = reinterpret_cast<__gm__ TensorData*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ TensorData *pij_buf = reinterpret_cast<__gm__ TensorData *>(args[0]);
+    __gm__ TensorData *value_cache = reinterpret_cast<__gm__ TensorData *>(args[1]);
+    __gm__ TensorData *oi_new = reinterpret_cast<__gm__ TensorData *>(args[2]);
     uint64_t n_blocks = static_cast<uint64_t>(args[3]);
-    __gm__ int32_t* block_table = reinterpret_cast<__gm__ int32_t*>(args[4]);
+    __gm__ int32_t *block_table = reinterpret_cast<__gm__ int32_t *>(args[4]);
 
-    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_buf->buffer.addr) + pij_buf->start_offset;
-    __gm__ bfloat16_t* val_base = reinterpret_cast<__gm__ bfloat16_t*>(value_cache->buffer.addr);
-    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr) + oi_new->start_offset;
+    __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_buf->buffer.addr) + pij_buf->start_offset;
+    __gm__ bfloat16_t *val_base = reinterpret_cast<__gm__ bfloat16_t *>(value_cache->buffer.addr);
+    __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr) + oi_new->start_offset;
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
 

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Multi-block QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N) for each block
 //
 // Processes n_blocks blocks in a single kernel invocation.
@@ -33,12 +43,9 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void qk_matmul_n_impl(
-    __gm__ bfloat16_t* qi_base,
-    __gm__ bfloat16_t* key_base,
-    __gm__ float* sij_base,
-    uint64_t n_blocks,
-    __gm__ int32_t* block_table) {
-
+    __gm__ bfloat16_t *qi_base, __gm__ bfloat16_t *key_base, __gm__ float *sij_base, uint64_t n_blocks,
+    __gm__ int32_t *block_table
+) {
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
@@ -98,16 +105,16 @@ static __aicore__ void qk_matmul_n_impl(
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ TensorData* qi = reinterpret_cast<__gm__ TensorData*>(args[0]);
-    __gm__ TensorData* key_cache = reinterpret_cast<__gm__ TensorData*>(args[1]);
-    __gm__ TensorData* sij_buf = reinterpret_cast<__gm__ TensorData*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ TensorData *qi = reinterpret_cast<__gm__ TensorData *>(args[0]);
+    __gm__ TensorData *key_cache = reinterpret_cast<__gm__ TensorData *>(args[1]);
+    __gm__ TensorData *sij_buf = reinterpret_cast<__gm__ TensorData *>(args[2]);
     uint64_t n_blocks = static_cast<uint64_t>(args[3]);
-    __gm__ int32_t* block_table = reinterpret_cast<__gm__ int32_t*>(args[4]);
+    __gm__ int32_t *block_table = reinterpret_cast<__gm__ int32_t *>(args[4]);
 
-    __gm__ bfloat16_t* qi_base = reinterpret_cast<__gm__ bfloat16_t*>(qi->buffer.addr) + qi->start_offset;
-    __gm__ bfloat16_t* key_base = reinterpret_cast<__gm__ bfloat16_t*>(key_cache->buffer.addr);
-    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_buf->buffer.addr) + sij_buf->start_offset;
+    __gm__ bfloat16_t *qi_base = reinterpret_cast<__gm__ bfloat16_t *>(qi->buffer.addr) + qi->start_offset;
+    __gm__ bfloat16_t *key_base = reinterpret_cast<__gm__ bfloat16_t *>(key_cache->buffer.addr);
+    __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_buf->buffer.addr) + sij_buf->start_offset;
 
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
 

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_hub.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Operates on full tiles where M=q_tile_size, N=head_dim (128):
@@ -26,22 +36,17 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ TensorData* mij,
-    __gm__ TensorData* lij,
-    __gm__ TensorData* oi_new,
-    __gm__ TensorData* mi,
-    __gm__ TensorData* li,
-    __gm__ TensorData* oi,
-    uint64_t is_first,
-    uint64_t is_last,
-    __gm__ TensorData* dst) {
-    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
-    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
-    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
-    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
-    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+static __aicore__ void online_update_impl(
+    __gm__ TensorData *mij, __gm__ TensorData *lij, __gm__ TensorData *oi_new, __gm__ TensorData *mi,
+    __gm__ TensorData *li, __gm__ TensorData *oi, uint64_t is_first, uint64_t is_last, __gm__ TensorData *dst
+) {
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi->buffer.addr);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li->buffer.addr);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst->buffer.addr);
 
     // Aligned rows for ColMajor DN tiles (32-byte alignment)
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
@@ -126,8 +131,8 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to same UB as DN tiles for ND-format store
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);                    // alias same UB as mijDN
-        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);   // alias same UB as lijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
+        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,21 +178,21 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        TMAX(miNewRow, miRow, mijRow);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        TSUB(alphaRow, miRow, miNewRow);  // alpha_exp = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        TSUB(betaRow, mijRow, miNewRow);  // beta_exp = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        TEXP(betaRow, betaRow);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        TMUL(tmpRow, alphaRow, liRow);  // alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        TMUL(liNewRow, betaRow, lijRow);  // beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         TRESHAPE(alphaDN, alphaRow);
@@ -195,9 +200,9 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
 
         // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
         // Alias ND tiles to the same UB locations as miNewRow and liNewRow
@@ -212,15 +217,15 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }
@@ -228,14 +233,14 @@ static __aicore__ void online_update_impl(__gm__ TensorData* mij,
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ TensorData* mij = reinterpret_cast<__gm__ TensorData*>(args[0]);
-    __gm__ TensorData* lij = reinterpret_cast<__gm__ TensorData*>(args[1]);
-    __gm__ TensorData* oi_new = reinterpret_cast<__gm__ TensorData*>(args[2]);
-    __gm__ TensorData* mi = reinterpret_cast<__gm__ TensorData*>(args[3]);
-    __gm__ TensorData* li = reinterpret_cast<__gm__ TensorData*>(args[4]);
-    __gm__ TensorData* oi = reinterpret_cast<__gm__ TensorData*>(args[5]);
-    __gm__ TensorData* dst = reinterpret_cast<__gm__ TensorData*>(args[6]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ TensorData *mij = reinterpret_cast<__gm__ TensorData *>(args[0]);
+    __gm__ TensorData *lij = reinterpret_cast<__gm__ TensorData *>(args[1]);
+    __gm__ TensorData *oi_new = reinterpret_cast<__gm__ TensorData *>(args[2]);
+    __gm__ TensorData *mi = reinterpret_cast<__gm__ TensorData *>(args[3]);
+    __gm__ TensorData *li = reinterpret_cast<__gm__ TensorData *>(args[4]);
+    __gm__ TensorData *oi = reinterpret_cast<__gm__ TensorData *>(args[5]);
+    __gm__ TensorData *dst = reinterpret_cast<__gm__ TensorData *>(args[6]);
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Two-Pass Softmax Kernel (AIV) for n_blocks tiles
 //
 // Input:  sij_buf (n_blocks * M, N) fp32 — QK results stacked vertically
@@ -37,14 +47,9 @@ using namespace pto;
 
 template <int M, int N>
 static __aicore__ void softmax_prepare_n_impl(
-    __gm__ float* sij_base,
-    float scale_value,
-    __gm__ bfloat16_t* pij_base,
-    __gm__ float* mij_addr,
-    __gm__ float* lij_addr,
-    uint64_t n_blocks,
-    uint64_t valid_len_last) {
-
+    __gm__ float *sij_base, float scale_value, __gm__ bfloat16_t *pij_base, __gm__ float *mij_addr,
+    __gm__ float *lij_addr, uint64_t n_blocks, uint64_t valid_len_last
+) {
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
     constexpr int kScalarCols = 32 / sizeof(float);
     constexpr int kScalarRows = M / kScalarCols;
@@ -100,10 +105,10 @@ static __aicore__ void softmax_prepare_n_impl(
     TASSIGN(sumAccTile, 4 * kDataBytes);
     int scalarBase = 5 * kDataBytes;
     TASSIGN(localMaxDN, scalarBase);
-    TASSIGN(localMaxRow, scalarBase);                     // alias: same UB as localMaxDN
+    TASSIGN(localMaxRow, scalarBase);  // alias: same UB as localMaxDN
     TASSIGN(globalMaxDN, scalarBase + kScalarDNBytes);
-    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
-    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);    // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);  // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
     TASSIGN(sumDN, scalarBase + 2 * kScalarDNBytes);
     TASSIGN(pijBf16Tile, scalarBase + 3 * kScalarDNBytes);
 
@@ -228,11 +233,11 @@ static __aicore__ void softmax_prepare_n_impl(
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ TensorData* sij_buf = reinterpret_cast<__gm__ TensorData*>(args[0]);
-    __gm__ TensorData* pij_buf = reinterpret_cast<__gm__ TensorData*>(args[1]);
-    __gm__ TensorData* mij = reinterpret_cast<__gm__ TensorData*>(args[2]);
-    __gm__ TensorData* lij = reinterpret_cast<__gm__ TensorData*>(args[3]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ TensorData *sij_buf = reinterpret_cast<__gm__ TensorData *>(args[0]);
+    __gm__ TensorData *pij_buf = reinterpret_cast<__gm__ TensorData *>(args[1]);
+    __gm__ TensorData *mij = reinterpret_cast<__gm__ TensorData *>(args[2]);
+    __gm__ TensorData *lij = reinterpret_cast<__gm__ TensorData *>(args[3]);
     union {
         uint64_t u;
         float f;
@@ -242,10 +247,10 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t n_blocks = static_cast<uint64_t>(args[5]);
     uint64_t valid_len_last = static_cast<uint64_t>(args[6]);
 
-    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_buf->buffer.addr) + sij_buf->start_offset;
-    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_buf->buffer.addr) + pij_buf->start_offset;
-    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr) + mij->start_offset;
-    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr) + lij->start_offset;
+    __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_buf->buffer.addr) + sij_buf->start_offset;
+    __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_buf->buffer.addr) + pij_buf->start_offset;
+    __gm__ float *mij_addr = reinterpret_cast<__gm__ float *>(mij->buffer.addr) + mij->start_offset;
+    __gm__ float *lij_addr = reinterpret_cast<__gm__ float *>(lij->buffer.addr) + lij->start_offset;
 
     uint64_t q_tile_size = static_cast<uint64_t>(sij_buf->shapes[0]);
 

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -70,8 +70,8 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
@@ -79,7 +79,8 @@ __attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestrati
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    PTO2Runtime* rt, const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+    PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index
+) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 #ifdef ENABLE_PROFILING
@@ -119,26 +120,28 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     CYCLE_COUNT_LAP(prof_param_extract);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void* query_ptr = orch_args.tensor(0).data_as<void>();
-    void* kc_ptr = orch_args.tensor(1).data_as<void>();
-    void* vc_ptr = orch_args.tensor(2).data_as<void>();
-    void* out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).data_as<void>();
+    void *out_ptr = orch_args.tensor(5).data_as<void>();
 
     uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t value_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t out_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type, false);
     Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type, false);
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
 
 #ifdef ENABLE_PROFILING
     CYCLE_COUNT_LAP(prof_ext_tensor);
@@ -146,7 +149,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
     // Prefetch first batch's block table data into cache (4 cache lines = 256 bytes)
     for (int cl = 0; cl < N_UNROLL * static_cast<int>(sizeof(int)); cl += 64) {
-        __builtin_prefetch(reinterpret_cast<char*>(host_block_table) + cl, 0, 3);
+        __builtin_prefetch(reinterpret_cast<char *>(host_block_table) + cl, 0, 3);
     }
     __builtin_prefetch(&host_context_lens[0], 0, 3);
 
@@ -154,13 +157,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         uint64_t cur_seq = host_context_lens[b_idx];
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         // Pre-compute block table base pointer for this batch
-        int* bt_base = host_block_table + b_idx * block_num;
+        int *bt_base = host_block_table + b_idx * block_num;
 
         // Prefetch next batch's block table + context_lens while processing current batch
         if (b_idx + 1 < batch) {
-            int* bt_next = host_block_table + (b_idx + 1) * block_num;
+            int *bt_next = host_block_table + (b_idx + 1) * block_num;
             for (int cl = 0; cl < N_UNROLL * static_cast<int>(sizeof(int)); cl += 64) {
-                __builtin_prefetch(reinterpret_cast<char*>(bt_next) + cl, 0, 3);
+                __builtin_prefetch(reinterpret_cast<char *>(bt_next) + cl, 0, 3);
             }
             __builtin_prefetch(&host_context_lens[b_idx + 1], 0, 3);
         }
@@ -195,9 +198,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 args_inplace.add_output(TensorCreateInfo(mi_shapes, 1, DataType::FLOAT32));
                 CYCLE_COUNT_LAP(prof_param_setup);
                 SubmitResult r_hub = pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, args_inplace);
-                const Tensor& oi = r_hub.outputs.get_ref(0);
-                const Tensor& li_update = r_hub.outputs.get_ref(1);
-                const Tensor& mi_update = r_hub.outputs.get_ref(2);
+                const Tensor &oi = r_hub.outputs.get_ref(0);
+                const Tensor &li_update = r_hub.outputs.get_ref(1);
+                const Tensor &mi_update = r_hub.outputs.get_ref(2);
 #ifdef ENABLE_PROFILING
                 prof_submit_count++;
                 CYCLE_COUNT_LAP(prof_submit_task);
@@ -219,7 +222,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
                     // === Task 1: Batched QK matmul ===
                     uint32_t sij_buf_shapes[2] = {
-                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)};
+                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)
+                    };
 
 #ifdef ENABLE_PROFILING
                     prof_make_count += 1;
@@ -241,7 +245,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
                     // === Task 2: Two-pass softmax over all blocks in group ===
                     uint32_t pij_buf_shapes[2] = {
-                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)};
+                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)
+                    };
 #ifdef ENABLE_PROFILING
                     prof_make_count += 3;
                     CYCLE_COUNT_LAP(prof_make_tensor);
@@ -323,47 +328,41 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 #ifdef ENABLE_PROFILING
     uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
                      prof_submit_task + prof_scope_and_loop;
-    LOG_ALWAYS(rt,
-        "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
-        prof_submit_count,
-        prof_make_count,
-        prof_view_count,
-        cycles_to_us(total));
+    LOG_ALWAYS(
+        rt, "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===", prof_submit_count,
+        prof_make_count, prof_view_count, cycles_to_us(total)
+    );
     if (total > 0) {
-        LOG_ALWAYS(rt,
-            "  param_extract    : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_extract),
-            prof_param_extract * 100.0 / total);
-        LOG_ALWAYS(rt,
-            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_ext_tensor),
-            prof_ext_tensor * 100.0 / total);
-        LOG_ALWAYS(rt,
-            "  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_make_count,
-            cycles_to_us(prof_make_tensor),
+        LOG_ALWAYS(
+            rt, "  param_extract    : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_extract),
+            prof_param_extract * 100.0 / total
+        );
+        LOG_ALWAYS(
+            rt, "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total
+        );
+        LOG_ALWAYS(
+            rt, "  make_tensor(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_make_count, cycles_to_us(prof_make_tensor),
             prof_make_tensor * 100.0 / total,
-            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
-        LOG_ALWAYS(rt,
-            "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_view_count,
-            cycles_to_us(prof_tensor_view),
+            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0
+        );
+        LOG_ALWAYS(
+            rt, "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_view_count, cycles_to_us(prof_tensor_view),
             prof_tensor_view * 100.0 / total,
-            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
-        LOG_ALWAYS(rt,
-            "  param_setup      : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_setup),
-            prof_param_setup * 100.0 / total);
-        LOG_ALWAYS(rt,
-            "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_submit_count,
-            cycles_to_us(prof_submit_task),
+            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0
+        );
+        LOG_ALWAYS(
+            rt, "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup),
+            prof_param_setup * 100.0 / total
+        );
+        LOG_ALWAYS(
+            rt, "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_submit_count, cycles_to_us(prof_submit_task),
             prof_submit_task * 100.0 / total,
-            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
-        LOG_ALWAYS(rt,
-            "  scope_and_loop   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_scope_and_loop),
-            prof_scope_and_loop * 100.0 / total);
+            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0
+        );
+        LOG_ALWAYS(
+            rt, "  scope_and_loop   : %7.3fus (%5.1f%%)", cycles_to_us(prof_scope_and_loop),
+            prof_scope_and_loop * 100.0 / total
+        );
     }
 #endif
 

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Supports two tile configurations via runtime dispatch:
@@ -22,19 +32,18 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw)
-{
-    __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
-    __gm__ bfloat16_t* vj  = reinterpret_cast<__gm__ bfloat16_t*>(vj_raw);
-    __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
+static __aicore__ void pv_matmul_impl(__gm__ uint8_t *pij_raw, __gm__ uint8_t *vj_raw, __gm__ uint8_t *oi_raw) {
+    __gm__ bfloat16_t *pij = reinterpret_cast<__gm__ bfloat16_t *>(pij_raw);
+    __gm__ bfloat16_t *vj = reinterpret_cast<__gm__ bfloat16_t *>(vj_raw);
+    __gm__ float *oi = reinterpret_cast<__gm__ float *>(oi_raw);
 
     // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
-    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, N, 1>>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   pijGlobal(pij);
-    GlobalB   vjGlobal(vj);
+    GlobalA pijGlobal(pij);
+    GlobalB vjGlobal(vj);
     GlobalOut oiGlobal(oi);
 
     // L1 Mat tiles: standard ND pattern for both A and B
@@ -42,18 +51,18 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<bfloat16_t, M, K, M, K>;
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -81,11 +90,10 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     TSTORE(oiGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* pij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* vj     = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *pij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *vj = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *oi_new = reinterpret_cast<__gm__ uint8_t *>(args[2]);
     int q_tile_size = static_cast<int>(args[3]);
     // args[4] = block_size, args[5] = head_dim
 

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Supports two tile configurations via runtime dispatch:
@@ -22,20 +32,19 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw)
-{
-    __gm__ bfloat16_t* qi  = reinterpret_cast<__gm__ bfloat16_t*>(qi_raw);
-    __gm__ bfloat16_t* kj  = reinterpret_cast<__gm__ bfloat16_t*>(kj_raw);
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+static __aicore__ void qk_matmul_impl(__gm__ uint8_t *qi_raw, __gm__ uint8_t *kj_raw, __gm__ uint8_t *sij_raw) {
+    __gm__ bfloat16_t *qi = reinterpret_cast<__gm__ bfloat16_t *>(qi_raw);
+    __gm__ bfloat16_t *kj = reinterpret_cast<__gm__ bfloat16_t *>(kj_raw);
+    __gm__ float *sij = reinterpret_cast<__gm__ float *>(sij_raw);
 
     // qi (M, K) bf16 in ND (row-major) layout
-    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   qiGlobal(qi);
-    GlobalB   kjGlobal(kj);
+    GlobalA qiGlobal(qi);
+    GlobalB kjGlobal(kj);
     GlobalOut sijGlobal(sij);
 
     // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
@@ -43,18 +52,18 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<bfloat16_t, M, K, M, K>;
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -82,11 +91,10 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     TSTORE(sijGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* qi  = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* kj  = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *qi = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *kj = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *sij = reinterpret_cast<__gm__ uint8_t *>(args[2]);
     int q_tile_size = static_cast<int>(args[3]);
     // args[4] = head_dim (128), args[5] = block_size
 

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Operates on full tiles where M=q_tile_size, N=head_dim (128):
@@ -24,18 +34,17 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_t* lij_raw,
-                               __gm__ uint8_t* oi_new_raw, __gm__ uint8_t* mi_raw,
-                               __gm__ uint8_t* li_raw, __gm__ uint8_t* oi_raw,
-                               int is_first, int is_last, __gm__ uint8_t* dst_raw)
-{
-    __gm__ float* mij_ptr    = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float* lij_ptr    = reinterpret_cast<__gm__ float*>(lij_raw);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new_raw);
-    __gm__ float* mi_ptr     = reinterpret_cast<__gm__ float*>(mi_raw);
-    __gm__ float* li_ptr     = reinterpret_cast<__gm__ float*>(li_raw);
-    __gm__ float* oi_ptr     = reinterpret_cast<__gm__ float*>(oi_raw);
-    __gm__ float* dst_ptr    = reinterpret_cast<__gm__ float*>(dst_raw);
+static __aicore__ void online_update_impl(
+    __gm__ uint8_t *mij_raw, __gm__ uint8_t *lij_raw, __gm__ uint8_t *oi_new_raw, __gm__ uint8_t *mi_raw,
+    __gm__ uint8_t *li_raw, __gm__ uint8_t *oi_raw, int is_first, int is_last, __gm__ uint8_t *dst_raw
+) {
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij_raw);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij_raw);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new_raw);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi_raw);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li_raw);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi_raw);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst_raw);
 
     // Scalar tile dimensions for RowMajor layout:
     // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
@@ -51,12 +60,11 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
 
     // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
-    using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
-                                        Stride<1, 1, 1, kScalarCols, 1>>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, Stride<1, 1, 1, kScalarCols, 1>>;
 
     // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
-                                        Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -78,8 +86,8 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     // --- Tile types ---
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
-    using TileScalarND = Tile<TileType::Vec, float, kScalarRows, kScalarCols,
-                              BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     // --- UB memory layout ---
@@ -124,9 +132,9 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Passthrough to MTE3 (no V compute needed)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, mijND);     // mi = mij
-        TSTORE(liGlobalND, lijND);     // li = lij
-        TSTORE(oiGlobal, oiNewTile);   // oi = oi_new
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
 
         if (is_last) {
             // Single block: normalize dst = oi_new / lij
@@ -157,53 +165,53 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
         // pipe_barrier(PIPE_V) required between each dependent vector operation
         // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
+        TMAX(miNewND, miND, mijND);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
+        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
+        TEXP(alphaND, alphaND);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
+        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
+        TEXP(betaND, betaND);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(liND, alphaND, liND);           // li = alpha * li
+        TMUL(liND, alphaND, liND);  // li = alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
+        TMUL(tmpND, betaND, lijND);  // tmp = beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
+        TADD(liND, liND, tmpND);  // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
         // mi_new → mi accumulator, li_new → li accumulator
         // alpha → mij buffer (reuse), beta → lij buffer (reuse)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, miNewND);         // persist mi_new
-        TSTORE(liGlobalND, liND);            // persist li_new
-        TSTORE(mijGlobalND, alphaND);        // temp: alpha to mij buffer
-        TSTORE(lijGlobalND, betaND);         // temp: beta to lij buffer
+        TSTORE(miGlobalND, miNewND);   // persist mi_new
+        TSTORE(liGlobalND, liND);      // persist li_new
+        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
 
         // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        TLOAD(alphaDN, mijGlobalDN);         // alpha from mij buffer as DN
-        TLOAD(betaDN, lijGlobalDN);          // beta from lij buffer as DN
+        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
         if (is_last) {
-            TLOAD(liDN, liGlobalDN);         // li_new from li buffer as DN
+            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
         }
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
 
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
             pipe_barrier(PIPE_V);
-            TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
+            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             TSTORE(dstGlobal, oiTile);
@@ -216,16 +224,16 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* mij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* lij    = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mi     = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* li     = reinterpret_cast<__gm__ uint8_t*>(args[4]);
-    __gm__ uint8_t* oi     = reinterpret_cast<__gm__ uint8_t*>(args[5]);
-    int is_first  = static_cast<int>(args[6]);
-    int is_last   = static_cast<int>(args[7]);
-    __gm__ uint8_t* dst    = reinterpret_cast<__gm__ uint8_t*>(args[8]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *mij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *lij = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *oi_new = reinterpret_cast<__gm__ uint8_t *>(args[2]);
+    __gm__ uint8_t *mi = reinterpret_cast<__gm__ uint8_t *>(args[3]);
+    __gm__ uint8_t *li = reinterpret_cast<__gm__ uint8_t *>(args[4]);
+    __gm__ uint8_t *oi = reinterpret_cast<__gm__ uint8_t *>(args[5]);
+    int is_first = static_cast<int>(args[6]);
+    int is_last = static_cast<int>(args[7]);
+    __gm__ uint8_t *dst = reinterpret_cast<__gm__ uint8_t *>(args[8]);
     int q_tile_size = static_cast<int>(args[9]);
     // args[10] = head_dim (128)
 

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Softmax Preparation Kernel (AIV) with partial block masking
 //
 // Operates on (M, N) tile where M=q_tile_size, N=block_size:
@@ -29,14 +39,14 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
-                                 __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
-                                 __gm__ uint8_t* lij_raw, int valid_len)
-{
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
-    __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
-    __gm__ float*      mij = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float*      lij = reinterpret_cast<__gm__ float*>(lij_raw);
+static __aicore__ void softmax_prepare_impl(
+    __gm__ uint8_t *sij_raw, float scale_value, __gm__ uint8_t *pij_raw, __gm__ uint8_t *mij_raw,
+    __gm__ uint8_t *lij_raw, int valid_len
+) {
+    __gm__ float *sij = reinterpret_cast<__gm__ float *>(sij_raw);
+    __gm__ bfloat16_t *pij = reinterpret_cast<__gm__ bfloat16_t *>(pij_raw);
+    __gm__ float *mij = reinterpret_cast<__gm__ float *>(mij_raw);
+    __gm__ float *lij = reinterpret_cast<__gm__ float *>(lij_raw);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -52,8 +62,7 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
     // Dynamic-cols tile: marks which columns are valid for TFILLPAD boundary
     using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
     // Padded tile: TFILLPAD_INPLACE fills positions [valid_len, N) with -inf
-    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N,
-                            SLayout::NoneBox, 512, PadValue::Min>;
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N, SLayout::NoneBox, 512, PadValue::Min>;
 
     using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
     using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
@@ -104,14 +113,17 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
     TSTORE(pijGlobal, pijBf16Tile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    union { uint64_t u; float f; } scale_conv;
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *sij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[1]);
     float scale_value = scale_conv.f;
-    __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mij = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[4]);
+    __gm__ uint8_t *pij = reinterpret_cast<__gm__ uint8_t *>(args[2]);
+    __gm__ uint8_t *mij = reinterpret_cast<__gm__ uint8_t *>(args[3]);
+    __gm__ uint8_t *lij = reinterpret_cast<__gm__ uint8_t *>(args[4]);
     int q_tile_size = static_cast<int>(args[5]);
     // args[6] = block_size
     int valid_len = static_cast<int>(args[7]);

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -37,19 +37,19 @@
 
 extern "C" {
 
-int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
+int build_paged_attention_graph(Runtime *runtime, const ChipStorageTaskArgs &orch_args) {
     if (orch_args.tensor_count() < 6) {
         std::cerr << "Expected at least 6 tensors, got " << orch_args.tensor_count() << '\n';
         return -1;
     }
 
     // Extract host pointers from tensor metadata
-    void* host_query = orch_args.tensor(0).data_as<void>();
-    void* host_key_cache = orch_args.tensor(1).data_as<void>();
-    void* host_value_cache = orch_args.tensor(2).data_as<void>();
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
-    void* host_out = orch_args.tensor(5).data_as<void>();
+    void *host_query = orch_args.tensor(0).data_as<void>();
+    void *host_key_cache = orch_args.tensor(1).data_as<void>();
+    void *host_value_cache = orch_args.tensor(2).data_as<void>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    void *host_out = orch_args.tensor(5).data_as<void>();
 
     // Extract sizes from tensor metadata
     size_t query_size = orch_args.tensor(0).nbytes();
@@ -85,10 +85,10 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
     std::cout << "q_tile_size=" << q_tile_size << ", num_head_tiles=" << num_head_tiles << '\n';
 
     // Allocate device memory for inputs/outputs
-    void* dev_query = runtime->host_api.device_malloc(query_size);
-    void* dev_key_cache = runtime->host_api.device_malloc(key_cache_size);
-    void* dev_value_cache = runtime->host_api.device_malloc(value_cache_size);
-    void* dev_out = runtime->host_api.device_malloc(out_size);
+    void *dev_query = runtime->host_api.device_malloc(query_size);
+    void *dev_key_cache = runtime->host_api.device_malloc(key_cache_size);
+    void *dev_value_cache = runtime->host_api.device_malloc(value_cache_size);
+    void *dev_out = runtime->host_api.device_malloc(out_size);
 
     if (!dev_query || !dev_key_cache || !dev_value_cache || !dev_out) {
         std::cerr << "Error: Failed to allocate device memory\n";
@@ -109,11 +109,11 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
     // Per-batch-per-block intermediate buffers
     uint32_t total_buffers = batch * max_num_blocks;
-    void** dev_sij_arr = new void*[total_buffers];
-    void** dev_pij_arr = new void*[total_buffers];
-    void** dev_mij_arr = new void*[total_buffers];
-    void** dev_lij_arr = new void*[total_buffers];
-    void** dev_oi_new_arr = new void*[total_buffers];
+    void **dev_sij_arr = new void *[total_buffers];
+    void **dev_pij_arr = new void *[total_buffers];
+    void **dev_mij_arr = new void *[total_buffers];
+    void **dev_lij_arr = new void *[total_buffers];
+    void **dev_oi_new_arr = new void *[total_buffers];
 
     for (uint32_t i = 0; i < total_buffers; i++) {
         dev_sij_arr[i] = runtime->host_api.device_malloc(sij_size);
@@ -129,9 +129,9 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
     size_t li_size = mi_size;
     size_t oi_size = static_cast<size_t>(q_tile_size) * head_dim * sizeof(float);
 
-    void** dev_mi_arr = new void*[total_accums];
-    void** dev_li_arr = new void*[total_accums];
-    void** dev_oi_arr = new void*[total_accums];
+    void **dev_mi_arr = new void *[total_accums];
+    void **dev_li_arr = new void *[total_accums];
+    void **dev_oi_arr = new void *[total_accums];
 
     for (uint32_t i = 0; i < total_accums; i++) {
         dev_mi_arr[i] = runtime->host_api.device_malloc(mi_size);
@@ -153,11 +153,11 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
             // Query: (batch, q_head_num, head_dim) bf16
             // qi points to heads [cur_offset .. cur_offset+q_tile_size) for batch b_idx
-            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query) +
+            uint8_t *qi_ptr = reinterpret_cast<uint8_t *>(dev_query) +
                               static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
 
             // Output: (batch * q_head_num, head_dim) float32
-            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out) +
+            uint8_t *out_ptr = reinterpret_cast<uint8_t *>(dev_out) +
                                static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
 
             // GQA: which kv_head this head tile maps to
@@ -165,9 +165,9 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
             // Per-(batch, head_tile) accumulators
             uint32_t accum_idx = b_idx * num_head_tiles + ht;
-            void* dev_mi = dev_mi_arr[accum_idx];
-            void* dev_li = dev_li_arr[accum_idx];
-            void* dev_oi = dev_oi_arr[accum_idx];
+            void *dev_mi = dev_mi_arr[accum_idx];
+            void *dev_li = dev_li_arr[accum_idx];
+            void *dev_oi = dev_oi_arr[accum_idx];
 
             int t_up_prev = -1;
 
@@ -176,51 +176,41 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
                 int valid_len = std::min(static_cast<int>(block_size), cur_seq - static_cast<int>(bn * block_size));
 
                 // Key: (total_blocks, block_size, kv_head_num, head_dim) bf16
-                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache) +
+                uint8_t *kj_ptr = reinterpret_cast<uint8_t *>(dev_key_cache) +
                                   (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
                                       head_dim * sizeof(uint16_t);
 
                 // Value: (total_blocks, block_size, kv_head_num, head_dim) bf16
-                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache) +
+                uint8_t *vj_ptr = reinterpret_cast<uint8_t *>(dev_value_cache) +
                                   (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
                                       head_dim * sizeof(uint16_t);
 
                 uint32_t buf_idx = b_idx * max_num_blocks + bn;
-                void* dev_sij = dev_sij_arr[buf_idx];
-                void* dev_pij = dev_pij_arr[buf_idx];
-                void* dev_mij = dev_mij_arr[buf_idx];
-                void* dev_lij = dev_lij_arr[buf_idx];
-                void* dev_oi_new = dev_oi_new_arr[buf_idx];
+                void *dev_sij = dev_sij_arr[buf_idx];
+                void *dev_pij = dev_pij_arr[buf_idx];
+                void *dev_mij = dev_mij_arr[buf_idx];
+                void *dev_lij = dev_lij_arr[buf_idx];
+                void *dev_oi_new = dev_oi_new_arr[buf_idx];
 
                 // QK: qi(M, K) @ kj.T(K, N) -> sij(M, N)
-                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),
-                    reinterpret_cast<uint64_t>(kj_ptr),
-                    reinterpret_cast<uint64_t>(dev_sij),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim),
-                    static_cast<uint64_t>(block_size)};
+                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),  reinterpret_cast<uint64_t>(kj_ptr),
+                                       reinterpret_cast<uint64_t>(dev_sij), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(head_dim),     static_cast<uint64_t>(block_size)};
                 int t_qk = runtime->add_task(qk_args, 6, FUNC_QK_MATMUL, CoreType::AIC);
                 total_tasks++;
 
                 // SF: scale, rowmax, exp, rowsum -> pij, mij, lij
-                uint64_t sf_args[8] = {reinterpret_cast<uint64_t>(dev_sij),
-                    scale_value_bits,
-                    reinterpret_cast<uint64_t>(dev_pij),
-                    reinterpret_cast<uint64_t>(dev_mij),
-                    reinterpret_cast<uint64_t>(dev_lij),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(valid_len)};
+                uint64_t sf_args[8] = {reinterpret_cast<uint64_t>(dev_sij), scale_value_bits,
+                                       reinterpret_cast<uint64_t>(dev_pij), reinterpret_cast<uint64_t>(dev_mij),
+                                       reinterpret_cast<uint64_t>(dev_lij), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(block_size),   static_cast<uint64_t>(valid_len)};
                 int t_sf = runtime->add_task(sf_args, 8, FUNC_SOFTMAX_PREPARE, CoreType::AIV);
                 total_tasks++;
 
                 // PV: pij(M, K') @ vj(K', N') -> oi_new(M, N')
-                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),
-                    reinterpret_cast<uint64_t>(vj_ptr),
-                    reinterpret_cast<uint64_t>(dev_oi_new),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(head_dim)};
+                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),    reinterpret_cast<uint64_t>(vj_ptr),
+                                       reinterpret_cast<uint64_t>(dev_oi_new), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(block_size),      static_cast<uint64_t>(head_dim)};
                 int t_pv = runtime->add_task(pv_args, 6, FUNC_PV_MATMUL, CoreType::AIC);
                 total_tasks++;
 
@@ -231,17 +221,12 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
                 int is_first = (bn == 0) ? 1 : 0;
                 int is_last = (bn == bn_this_batch - 1) ? 1 : 0;
 
-                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),
-                    reinterpret_cast<uint64_t>(dev_lij),
-                    reinterpret_cast<uint64_t>(dev_oi_new),
-                    reinterpret_cast<uint64_t>(dev_mi),
-                    reinterpret_cast<uint64_t>(dev_li),
-                    reinterpret_cast<uint64_t>(dev_oi),
-                    static_cast<uint64_t>(is_first),
-                    static_cast<uint64_t>(is_last),
-                    reinterpret_cast<uint64_t>(out_ptr),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim)};
+                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),    reinterpret_cast<uint64_t>(dev_lij),
+                                        reinterpret_cast<uint64_t>(dev_oi_new), reinterpret_cast<uint64_t>(dev_mi),
+                                        reinterpret_cast<uint64_t>(dev_li),     reinterpret_cast<uint64_t>(dev_oi),
+                                        static_cast<uint64_t>(is_first),        static_cast<uint64_t>(is_last),
+                                        reinterpret_cast<uint64_t>(out_ptr),    static_cast<uint64_t>(q_tile_size),
+                                        static_cast<uint64_t>(head_dim)};
                 int t_up = runtime->add_task(up_args, 11, FUNC_ONLINE_UPDATE, CoreType::AIV);
                 total_tasks++;
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Matrix Multiplication Kernel (Cube Core)
  *
@@ -35,28 +45,24 @@ AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
     return (num_1 + num_2 - 1) / num_2 * num_2;
 }
 
-static __aicore__ inline int get_num_tiles(__gm__ Tensor* tensor, uint64_t tile_elems) {
+static __aicore__ inline int get_num_tiles(__gm__ Tensor *tensor, uint64_t tile_elems) {
     uint64_t total_elems = tensor->shapes[0];
     return static_cast<int>(total_elems / tile_elems);
 }
 
 template <int TILE>
-static __aicore__ void matmul_impl(
-    __gm__ float* input_a,
-    __gm__ float* input_b,
-    __gm__ float* output) {
-
+static __aicore__ void matmul_impl(__gm__ float *input_a, __gm__ float *input_b, __gm__ float *output) {
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
     constexpr int M = CeilAlign<int>(TILE, 16);
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);
@@ -104,22 +110,22 @@ static __aicore__ void matmul_impl(
     wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* input_a = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* input_b = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* output  = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_a = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *input_b = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *output = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
     constexpr uint64_t TILE_ELEMS = 128 * 128;
     int num_tiles = get_num_tiles(input_a, TILE_ELEMS);
 
-    __gm__ float* base_a = reinterpret_cast<__gm__ float*>(input_a->buffer.addr) + input_a->start_offset;
-    __gm__ float* base_b = reinterpret_cast<__gm__ float*>(input_b->buffer.addr) + input_b->start_offset;
-    __gm__ float* base_c = reinterpret_cast<__gm__ float*>(output->buffer.addr) + output->start_offset;
+    __gm__ float *base_a = reinterpret_cast<__gm__ float *>(input_a->buffer.addr) + input_a->start_offset;
+    __gm__ float *base_b = reinterpret_cast<__gm__ float *>(input_b->buffer.addr) + input_b->start_offset;
+    __gm__ float *base_c = reinterpret_cast<__gm__ float *>(output->buffer.addr) + output->start_offset;
 
     for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
-        __gm__ float* a_ptr = base_a + (tile_idx * TILE_ELEMS);
-        __gm__ float* b_ptr = base_b + (tile_idx * TILE_ELEMS);
-        __gm__ float* c_ptr = base_c + (tile_idx * TILE_ELEMS);
+        __gm__ float *a_ptr = base_a + (tile_idx * TILE_ELEMS);
+        __gm__ float *b_ptr = base_b + (tile_idx * TILE_ELEMS);
+        __gm__ float *c_ptr = base_c + (tile_idx * TILE_ELEMS);
 
         matmul_impl<128>(a_ptr, b_ptr, c_ptr);
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Tensor Addition Kernel
  *
@@ -25,17 +35,13 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-static __aicore__ inline int get_num_tiles(__gm__ Tensor* tensor, uint64_t tile_elems) {
+static __aicore__ inline int get_num_tiles(__gm__ Tensor *tensor, uint64_t tile_elems) {
     uint64_t total_elems = tensor->shapes[0];
     return static_cast<int>(total_elems / tile_elems);
 }
 
 template <int ROWS, int COLS>
-static __aicore__ void add_impl(
-    __gm__ float* src0,
-    __gm__ float* src1,
-    __gm__ float* out) {
-
+static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ float *out) {
     using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
     using DynStridDim5 = Stride<1, 1, 1, COLS, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
@@ -64,22 +70,22 @@ static __aicore__ void add_impl(
     wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
     constexpr uint64_t TILE_ELEMS = 128 * 128;
     int num_tiles = get_num_tiles(src0_tensor, TILE_ELEMS);
 
-    __gm__ float* base_src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* base_src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* base_out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    __gm__ float *base_src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *base_src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *base_out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
-        __gm__ float* src0_ptr = base_src0 + (tile_idx * TILE_ELEMS);
-        __gm__ float* src1_ptr = base_src1 + (tile_idx * TILE_ELEMS);
-        __gm__ float* out_ptr = base_out + (tile_idx * TILE_ELEMS);
+        __gm__ float *src0_ptr = base_src0 + (tile_idx * TILE_ELEMS);
+        __gm__ float *src1_ptr = base_src1 + (tile_idx * TILE_ELEMS);
+        __gm__ float *out_ptr = base_out + (tile_idx * TILE_ELEMS);
 
         add_impl<128, 128>(src0_ptr, src1_ptr, out_ptr);
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -39,16 +39,16 @@ static constexpr uint64_t ADD_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 11,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     // Tensor args
     Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_B = from_tensor_arg(orch_args.tensor(1));
@@ -65,12 +65,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     int add_batch = static_cast<int>(orch_args.scalar(4));
 
     LOG_ALWAYS("[alternating_orch] thread num: %d, idx: %d", orch_thread_num, orch_thread_index);
-    LOG_INFO("[alternating_orch] Batch: %d, M: %d, N: %d, matmul_batch: %d, add_batch: %d",
-        batch,
-        M,
-        N,
-        matmul_batch,
-        add_batch);
+    LOG_INFO(
+        "[alternating_orch] Batch: %d, M: %d, N: %d, matmul_batch: %d, add_batch: %d", batch, M, N, matmul_batch,
+        add_batch
+    );
 
     int total_matmul_tasks = batch * M;
     int total_add_tasks = batch * N;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_hub.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -11,4 +21,4 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Batched PV Matmul Kernel: for each batch b, pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -26,20 +36,14 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void pv_matmul_batch_impl(
-    __gm__ Tensor* pij_batch,
-    __gm__ Tensor* value_cache,
-    __gm__ Tensor* oi_new_batch,
-    uint64_t block_table_ptr,
-    uint64_t batch_count,
-    uint64_t block_idx,
-    uint64_t block_num,
-    uint64_t batch_start) {
-
-    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_batch->buffer.addr);
-    __gm__ bfloat16_t* val_base = reinterpret_cast<__gm__ bfloat16_t*>(value_cache->buffer.addr);
-    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new_batch->buffer.addr);
+    __gm__ Tensor *pij_batch, __gm__ Tensor *value_cache, __gm__ Tensor *oi_new_batch, uint64_t block_table_ptr,
+    uint64_t batch_count, uint64_t block_idx, uint64_t block_num, uint64_t batch_start
+) {
+    __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_batch->buffer.addr);
+    __gm__ bfloat16_t *val_base = reinterpret_cast<__gm__ bfloat16_t *>(value_cache->buffer.addr);
+    __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_new_batch->buffer.addr);
     // Block table values are always non-negative (physical block indices)
-    __gm__ int32_t* bt = reinterpret_cast<__gm__ int32_t*>(block_table_ptr);
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_ptr);
 
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
@@ -65,10 +69,10 @@ static __aicore__ void pv_matmul_batch_impl(
     TASSIGN(cTile, 0x0);
 
     for (uint64_t b = 0; b < batch_count; b++) {
-        __gm__ bfloat16_t* pij_addr = pij_base + b * M * K;
+        __gm__ bfloat16_t *pij_addr = pij_base + b * M * K;
         int32_t phys_block = bt[(batch_start + b) * block_num + block_idx];
-        __gm__ bfloat16_t* vj_addr = val_base + (uint64_t)phys_block * K * N;
-        __gm__ float* oi_addr = oi_base + b * M * N;
+        __gm__ bfloat16_t *vj_addr = val_base + (uint64_t)phys_block * K * N;
+        __gm__ float *oi_addr = oi_base + b * M * N;
 
         GlobalA pijGlobal(pij_addr);
         GlobalB vjGlobal(vj_addr);
@@ -99,10 +103,10 @@ static __aicore__ void pv_matmul_batch_impl(
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* pij_batch = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* value_cache = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new_batch = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *pij_batch = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *value_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t block_table_ptr = static_cast<uint64_t>(args[3]);
     uint64_t batch_count = static_cast<uint64_t>(args[4]);
     uint64_t block_idx = static_cast<uint64_t>(args[5]);
@@ -113,11 +117,11 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
 
     if (q_tile_size == 16) {
         pv_matmul_batch_impl<16, 128, 128>(
-            pij_batch, value_cache, oi_new_batch,
-            block_table_ptr, batch_count, block_idx, block_num, batch_start);
+            pij_batch, value_cache, oi_new_batch, block_table_ptr, batch_count, block_idx, block_num, batch_start
+        );
     } else {
         pv_matmul_batch_impl<64, 64, 128>(
-            pij_batch, value_cache, oi_new_batch,
-            block_table_ptr, batch_count, block_idx, block_num, batch_start);
+            pij_batch, value_cache, oi_new_batch, block_table_ptr, batch_count, block_idx, block_num, batch_start
+        );
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Batched QK Matmul Kernel: for each batch b, qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -26,22 +36,15 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void qk_matmul_batch_impl(
-    __gm__ Tensor* query,
-    __gm__ Tensor* key_cache,
-    __gm__ Tensor* sij_batch,
-    uint64_t block_table_ptr,
-    uint64_t batch_count,
-    uint64_t block_idx,
-    uint64_t q_offset,
-    uint64_t block_num,
-    uint64_t num_heads,
-    uint64_t batch_start) {
-
-    __gm__ bfloat16_t* query_base = reinterpret_cast<__gm__ bfloat16_t*>(query->buffer.addr);
-    __gm__ bfloat16_t* key_base = reinterpret_cast<__gm__ bfloat16_t*>(key_cache->buffer.addr);
-    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_batch->buffer.addr);
+    __gm__ Tensor *query, __gm__ Tensor *key_cache, __gm__ Tensor *sij_batch, uint64_t block_table_ptr,
+    uint64_t batch_count, uint64_t block_idx, uint64_t q_offset, uint64_t block_num, uint64_t num_heads,
+    uint64_t batch_start
+) {
+    __gm__ bfloat16_t *query_base = reinterpret_cast<__gm__ bfloat16_t *>(query->buffer.addr);
+    __gm__ bfloat16_t *key_base = reinterpret_cast<__gm__ bfloat16_t *>(key_cache->buffer.addr);
+    __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_batch->buffer.addr);
     // Block table values are always non-negative (physical block indices)
-    __gm__ int32_t* bt = reinterpret_cast<__gm__ int32_t*>(block_table_ptr);
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_ptr);
 
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
@@ -67,10 +70,10 @@ static __aicore__ void qk_matmul_batch_impl(
     TASSIGN(cTile, 0x0);
 
     for (uint64_t b = 0; b < batch_count; b++) {
-        __gm__ bfloat16_t* qi_addr = query_base + ((batch_start + b) * num_heads + q_offset) * K;
+        __gm__ bfloat16_t *qi_addr = query_base + ((batch_start + b) * num_heads + q_offset) * K;
         int32_t phys_block = bt[(batch_start + b) * block_num + block_idx];
-        __gm__ bfloat16_t* kj_addr = key_base + (uint64_t)phys_block * N * K;
-        __gm__ float* sij_addr = sij_base + b * M * N;
+        __gm__ bfloat16_t *kj_addr = key_base + (uint64_t)phys_block * N * K;
+        __gm__ float *sij_addr = sij_base + b * M * N;
 
         GlobalA qiGlobal(qi_addr);
         GlobalB kjGlobal(kj_addr);
@@ -102,10 +105,10 @@ static __aicore__ void qk_matmul_batch_impl(
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* query = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* key_cache = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* sij_batch = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *query = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *key_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *sij_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t block_table_ptr = static_cast<uint64_t>(args[3]);
     uint64_t batch_count = static_cast<uint64_t>(args[4]);
     uint64_t block_idx = static_cast<uint64_t>(args[5]);
@@ -118,13 +121,13 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
 
     if (q_tile_size == 16) {
         qk_matmul_batch_impl<16, 128, 128>(
-            query, key_cache, sij_batch,
-            block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
-            batch_start);
+            query, key_cache, sij_batch, block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
+            batch_start
+        );
     } else {
         qk_matmul_batch_impl<64, 128, 64>(
-            query, key_cache, sij_batch,
-            block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
-            batch_start);
+            query, key_cache, sij_batch, block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
+            batch_start
+        );
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_hub.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -11,4 +21,4 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Batched Online Softmax Update + Normalize Kernel (AIV)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -31,27 +41,17 @@ using namespace pto;
 
 template <int M, int N>
 static __aicore__ void online_update_batch_impl(
-    __gm__ Tensor* mij_batch,
-    __gm__ Tensor* lij_batch,
-    __gm__ Tensor* oi_new_batch,
-    __gm__ Tensor* mi_batch,
-    __gm__ Tensor* li_batch,
-    __gm__ Tensor* oi_batch,
-    __gm__ Tensor* out,
-    uint64_t is_first,
-    uint64_t is_last,
-    uint64_t batch_count,
-    uint64_t q_offset,
-    uint64_t num_heads,
-    uint64_t batch_start) {
-
-    __gm__ float* mij_base = reinterpret_cast<__gm__ float*>(mij_batch->buffer.addr);
-    __gm__ float* lij_base = reinterpret_cast<__gm__ float*>(lij_batch->buffer.addr);
-    __gm__ float* oi_new_base = reinterpret_cast<__gm__ float*>(oi_new_batch->buffer.addr);
-    __gm__ float* mi_base = reinterpret_cast<__gm__ float*>(mi_batch->buffer.addr);
-    __gm__ float* li_base = reinterpret_cast<__gm__ float*>(li_batch->buffer.addr);
-    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_batch->buffer.addr);
-    __gm__ float* out_base = reinterpret_cast<__gm__ float*>(out->buffer.addr);
+    __gm__ Tensor *mij_batch, __gm__ Tensor *lij_batch, __gm__ Tensor *oi_new_batch, __gm__ Tensor *mi_batch,
+    __gm__ Tensor *li_batch, __gm__ Tensor *oi_batch, __gm__ Tensor *out, uint64_t is_first, uint64_t is_last,
+    uint64_t batch_count, uint64_t q_offset, uint64_t num_heads, uint64_t batch_start
+) {
+    __gm__ float *mij_base = reinterpret_cast<__gm__ float *>(mij_batch->buffer.addr);
+    __gm__ float *lij_base = reinterpret_cast<__gm__ float *>(lij_batch->buffer.addr);
+    __gm__ float *oi_new_base = reinterpret_cast<__gm__ float *>(oi_new_batch->buffer.addr);
+    __gm__ float *mi_base = reinterpret_cast<__gm__ float *>(mi_batch->buffer.addr);
+    __gm__ float *li_base = reinterpret_cast<__gm__ float *>(li_batch->buffer.addr);
+    __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_batch->buffer.addr);
+    __gm__ float *out_base = reinterpret_cast<__gm__ float *>(out->buffer.addr);
 
     constexpr int kScalarCols = 32 / sizeof(float);
     constexpr int kScalarRows = M / kScalarCols;
@@ -89,13 +89,13 @@ static __aicore__ void online_update_batch_impl(
     TASSIGN(tmpND, 2 * kDataBytes + 7 * kScalarNDBytes);
 
     for (uint64_t b = 0; b < batch_count; b++) {
-        __gm__ float* mij_ptr = mij_base + b * M;
-        __gm__ float* lij_ptr = lij_base + b * M;
-        __gm__ float* oi_new_ptr = oi_new_base + b * M * N;
-        __gm__ float* mi_ptr = mi_base + b * M;
-        __gm__ float* li_ptr = li_base + b * M;
-        __gm__ float* oi_ptr = oi_base + b * M * N;
-        __gm__ float* dst_ptr = out_base + ((batch_start + b) * num_heads + q_offset) * N;
+        __gm__ float *mij_ptr = mij_base + b * M;
+        __gm__ float *lij_ptr = lij_base + b * M;
+        __gm__ float *oi_new_ptr = oi_new_base + b * M * N;
+        __gm__ float *mi_ptr = mi_base + b * M;
+        __gm__ float *li_ptr = li_base + b * M;
+        __gm__ float *oi_ptr = oi_base + b * M * N;
+        __gm__ float *dst_ptr = out_base + ((batch_start + b) * num_heads + q_offset) * N;
 
         GlobalDataMxN oiNewGlobal(oi_new_ptr);
         GlobalDataMxN oiGlobal(oi_ptr);
@@ -189,14 +189,14 @@ static __aicore__ void online_update_batch_impl(
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* mij_batch = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* lij_batch = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new_batch = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mi_batch = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* li_batch = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* oi_batch = reinterpret_cast<__gm__ Tensor*>(args[5]);
-    __gm__ Tensor* out = reinterpret_cast<__gm__ Tensor*>(args[6]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mij_batch = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *lij_batch = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mi_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *li_batch = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *oi_batch = reinterpret_cast<__gm__ Tensor *>(args[5]);
+    __gm__ Tensor *out = reinterpret_cast<__gm__ Tensor *>(args[6]);
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t batch_count = static_cast<uint64_t>(args[9]);
@@ -208,13 +208,13 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
 
     if (q_tile_size == 16) {
         online_update_batch_impl<16, 128>(
-            mij_batch, lij_batch, oi_new_batch,
-            mi_batch, li_batch, oi_batch, out,
-            is_first, is_last, batch_count, q_offset, num_heads, batch_start);
+            mij_batch, lij_batch, oi_new_batch, mi_batch, li_batch, oi_batch, out, is_first, is_last, batch_count,
+            q_offset, num_heads, batch_start
+        );
     } else {
         online_update_batch_impl<64, 128>(
-            mij_batch, lij_batch, oi_new_batch,
-            mi_batch, li_batch, oi_batch, out,
-            is_first, is_last, batch_count, q_offset, num_heads, batch_start);
+            mij_batch, lij_batch, oi_new_batch, mi_batch, li_batch, oi_batch, out, is_first, is_last, batch_count,
+            q_offset, num_heads, batch_start
+        );
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Batched Softmax Preparation Kernel (AIV)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -30,21 +40,14 @@ using namespace pto;
 
 template <int M, int N>
 static __aicore__ void softmax_prepare_batch_impl(
-    __gm__ Tensor* sij_batch,
-    __gm__ Tensor* pij_batch,
-    __gm__ Tensor* mij_batch,
-    __gm__ Tensor* lij_batch,
-    float scale_value,
-    uint64_t context_lens_ptr,
-    uint64_t batch_count,
-    uint64_t block_idx,
-    uint64_t batch_start) {
-
-    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_batch->buffer.addr);
-    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_batch->buffer.addr);
-    __gm__ float* mij_base = reinterpret_cast<__gm__ float*>(mij_batch->buffer.addr);
-    __gm__ float* lij_base = reinterpret_cast<__gm__ float*>(lij_batch->buffer.addr);
-    __gm__ int32_t* ctx_lens = reinterpret_cast<__gm__ int32_t*>(context_lens_ptr);
+    __gm__ Tensor *sij_batch, __gm__ Tensor *pij_batch, __gm__ Tensor *mij_batch, __gm__ Tensor *lij_batch,
+    float scale_value, uint64_t context_lens_ptr, uint64_t batch_count, uint64_t block_idx, uint64_t batch_start
+) {
+    __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_batch->buffer.addr);
+    __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_batch->buffer.addr);
+    __gm__ float *mij_base = reinterpret_cast<__gm__ float *>(mij_batch->buffer.addr);
+    __gm__ float *lij_base = reinterpret_cast<__gm__ float *>(lij_batch->buffer.addr);
+    __gm__ int32_t *ctx_lens = reinterpret_cast<__gm__ int32_t *>(context_lens_ptr);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -84,10 +87,10 @@ static __aicore__ void softmax_prepare_batch_impl(
             valid_len = (remaining < N) ? remaining : N;
         }
 
-        __gm__ float* sij_addr = sij_base + b * M * N;
-        __gm__ bfloat16_t* pij_addr = pij_base + b * M * N;
-        __gm__ float* mij_addr = mij_base + b * M;
-        __gm__ float* lij_addr = lij_base + b * M;
+        __gm__ float *sij_addr = sij_base + b * M * N;
+        __gm__ bfloat16_t *pij_addr = pij_base + b * M * N;
+        __gm__ float *mij_addr = mij_base + b * M;
+        __gm__ float *lij_addr = lij_base + b * M;
 
         GlobalDataMxN sijGlobal(sij_addr);
         GlobalDataMxN_bf16 pijGlobal(pij_addr);
@@ -156,12 +159,15 @@ static __aicore__ void softmax_prepare_batch_impl(
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* sij_batch = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* pij_batch = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* mij_batch = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* lij_batch = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    union { uint64_t u; float f; } scale_conv;
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *sij_batch = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *pij_batch = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *mij_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *lij_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[4]);
     float scale_value = scale_conv.f;
     uint64_t context_lens_ptr = static_cast<uint64_t>(args[5]);
@@ -173,11 +179,13 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
 
     if (q_tile_size == 16) {
         softmax_prepare_batch_impl<16, 128>(
-            sij_batch, pij_batch, mij_batch, lij_batch,
-            scale_value, context_lens_ptr, batch_count, block_idx, batch_start);
+            sij_batch, pij_batch, mij_batch, lij_batch, scale_value, context_lens_ptr, batch_count, block_idx,
+            batch_start
+        );
     } else {
         softmax_prepare_batch_impl<64, 64>(
-            sij_batch, pij_batch, mij_batch, lij_batch,
-            scale_value, context_lens_ptr, batch_count, block_idx, batch_start);
+            sij_batch, pij_batch, mij_batch, lij_batch, scale_value, context_lens_ptr, batch_count, block_idx,
+            batch_start
+        );
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -54,16 +54,16 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     // Read dimensions from tensor metadata
     uint64_t batch = orch_args.tensor(0).shapes[0];
     uint64_t num_heads = orch_args.tensor(0).shapes[1];
@@ -81,13 +81,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
     LOG_INFO("batch_paged_attention: batch=%" PRIu64 ", num_heads=%" PRIu64, batch, num_heads);
 
-    void* query_ptr = orch_args.tensor(0).data_as<void>();
-    void* kc_ptr = orch_args.tensor(1).data_as<void>();
-    void* vc_ptr = orch_args.tensor(2).data_as<void>();
-    void* out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).data_as<void>();
+    void *out_ptr = orch_args.tensor(5).data_as<void>();
 
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
 
     uint64_t max_bn = 0;
     for (uint64_t b = 0; b < batch; b++) {
@@ -133,9 +133,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 params_hub.add_output(scalar_acc_ci);
                 params_hub.add_output(scalar_acc_ci);
                 TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, params_hub);
-                const Tensor& oi_batch = hub_outs.get_ref(0);
-                const Tensor& li_batch = hub_outs.get_ref(1);
-                const Tensor& mi_batch = hub_outs.get_ref(2);
+                const Tensor &oi_batch = hub_outs.get_ref(0);
+                const Tensor &li_batch = hub_outs.get_ref(1);
+                const Tensor &mi_batch = hub_outs.get_ref(2);
 
                 // Inner-loop create infos: shapes are loop-invariant, hoist out of bn loop
                 uint32_t sij_shapes[2] = {static_cast<uint32_t>(chunk_bc * q_tile), static_cast<uint32_t>(block_size)};
@@ -160,7 +160,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                         params_qk.add_scalar(num_heads);
                         params_qk.add_scalar(batch_start);
                         TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
-                        const Tensor& sij_b = qk_outs.get_ref(0);
+                        const Tensor &sij_b = qk_outs.get_ref(0);
 
                         Arg params_sf;
                         params_sf.add_input(sij_b);
@@ -173,9 +173,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                         params_sf.add_scalar(bn);
                         params_sf.add_scalar(batch_start);
                         TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
-                        const Tensor& pij_b = sf_outs.get_ref(0);
-                        const Tensor& mij_b = sf_outs.get_ref(1);
-                        const Tensor& lij_b = sf_outs.get_ref(2);
+                        const Tensor &pij_b = sf_outs.get_ref(0);
+                        const Tensor &mij_b = sf_outs.get_ref(1);
+                        const Tensor &lij_b = sf_outs.get_ref(2);
 
                         Arg params_pv;
                         params_pv.add_input(pij_b);
@@ -187,7 +187,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                         params_pv.add_scalar(block_num);
                         params_pv.add_scalar(batch_start);
                         TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
-                        const Tensor& oi_new_b = pv_outs.get_ref(0);
+                        const Tensor &oi_new_b = pv_outs.get_ref(0);
 
                         uint64_t is_first = (bn == 0) ? 1 : 0;
                         uint64_t is_last = (bn == max_bn - 1) ? 1 : 0;
@@ -212,13 +212,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         }
     }
 
-    LOG_INFO("batch_paged_attention: %" PRIu64 " tasks (batch=%" PRIu64 ", max_bn=%" PRIu64 ", chunks=%" PRIu64
-             ", IN_CORE_BATCH=%" PRIu64 ")",
-        static_cast<uint64_t>(num_chunks * (1 + max_bn * 4)),
-        batch,
-        max_bn,
-        num_chunks,
-        IN_CORE_BATCH);
+    LOG_INFO(
+        "batch_paged_attention: %" PRIu64 " tasks (batch=%" PRIu64 ", max_bn=%" PRIu64 ", chunks=%" PRIu64
+        ", IN_CORE_BATCH=%" PRIu64 ")",
+        static_cast<uint64_t>(num_chunks * (1 + max_bn * 4)), batch, max_bn, num_chunks, IN_CORE_BATCH
+    );
 }
 
 }  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Tile-based Matrix Multiplication Kernel (Cube Core)
  *
@@ -40,22 +50,18 @@ AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
 }
 
 template <int TILE>
-static __aicore__ void gemm_tile_impl(
-    __gm__ float* input_a,
-    __gm__ float* input_b,
-    __gm__ float* output) {
-
+static __aicore__ void gemm_tile_impl(__gm__ float *input_a, __gm__ float *input_b, __gm__ float *output) {
     constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
     constexpr int M = CeilAlign<int>(TILE, 16);
     constexpr int K = CeilAlign<int>(TILE, blockAlign);
     constexpr int N = CeilAlign<int>(TILE, blockAlign);
 
-    using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
-    using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>,
-        Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataA =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC =
+        GlobalTensor<float, Shape<1, 1, 1, TILE, TILE>, Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
 
     GlobalDataA src0Global(input_a);
     GlobalDataB src1Global(input_b);
@@ -106,32 +112,41 @@ static __aicore__ void gemm_tile_impl(
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* input_a = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* input_b = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* output  = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* config  = reinterpret_cast<__gm__ Tensor*>(args[3]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_a = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *input_b = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *output = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *config = reinterpret_cast<__gm__ Tensor *>(args[3]);
 
-    __gm__ int64_t* cfg = reinterpret_cast<__gm__ int64_t*>(config->buffer.addr);
+    __gm__ int64_t *cfg = reinterpret_cast<__gm__ int64_t *>(config->buffer.addr);
     uint64_t tile_size = static_cast<uint64_t>(cfg[0]);
     uint64_t tile_elems = tile_size * tile_size;
     int num_tiles = static_cast<uint64_t>(cfg[3]);
 
-    __gm__ float* base_a = reinterpret_cast<__gm__ float*>(input_a->buffer.addr) + input_a->start_offset;
-    __gm__ float* base_b = reinterpret_cast<__gm__ float*>(input_b->buffer.addr) + input_b->start_offset;
-    __gm__ float* base_c = reinterpret_cast<__gm__ float*>(output->buffer.addr) + output->start_offset;
+    __gm__ float *base_a = reinterpret_cast<__gm__ float *>(input_a->buffer.addr) + input_a->start_offset;
+    __gm__ float *base_b = reinterpret_cast<__gm__ float *>(input_b->buffer.addr) + input_b->start_offset;
+    __gm__ float *base_c = reinterpret_cast<__gm__ float *>(output->buffer.addr) + output->start_offset;
 
     for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
-        __gm__ float* a_ptr = base_a + (tile_idx * tile_elems);
-        __gm__ float* b_ptr = base_b + (tile_idx * tile_elems);
-        __gm__ float* c_ptr = base_c + (tile_idx * tile_elems);
+        __gm__ float *a_ptr = base_a + (tile_idx * tile_elems);
+        __gm__ float *b_ptr = base_b + (tile_idx * tile_elems);
+        __gm__ float *c_ptr = base_c + (tile_idx * tile_elems);
 
         switch (tile_size) {
-            case 16:  gemm_tile_impl<16>(a_ptr, b_ptr, c_ptr);  break;
-            case 32:  gemm_tile_impl<32>(a_ptr, b_ptr, c_ptr);  break;
-            case 64:  gemm_tile_impl<64>(a_ptr, b_ptr, c_ptr);  break;
-            case 128: gemm_tile_impl<128>(a_ptr, b_ptr, c_ptr); break;
-            default: break;
+        case 16:
+            gemm_tile_impl<16>(a_ptr, b_ptr, c_ptr);
+            break;
+        case 32:
+            gemm_tile_impl<32>(a_ptr, b_ptr, c_ptr);
+            break;
+        case 64:
+            gemm_tile_impl<64>(a_ptr, b_ptr, c_ptr);
+            break;
+        case 128:
+            gemm_tile_impl<128>(a_ptr, b_ptr, c_ptr);
+            break;
+        default:
+            break;
         }
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Tile-based Element-wise Addition Kernel (Vector Core) - INOUT Pattern
  *
@@ -30,10 +40,7 @@ using namespace pto;
 #endif
 
 template <int TILE>
-static __aicore__ void tile_add_impl(
-    __gm__ float* c_ptr,
-    __gm__ float* p_ptr) {
-
+static __aicore__ void tile_add_impl(__gm__ float *c_ptr, __gm__ float *p_ptr) {
     using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
     using DynStridDim5 = Stride<1, 1, 1, TILE, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
@@ -65,29 +72,38 @@ static __aicore__ void tile_add_impl(
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* c_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* p_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* config   = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *c_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *p_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *config = reinterpret_cast<__gm__ Tensor *>(args[2]);
 
-    __gm__ int64_t* cfg = reinterpret_cast<__gm__ int64_t*>(config->buffer.addr);
+    __gm__ int64_t *cfg = reinterpret_cast<__gm__ int64_t *>(config->buffer.addr);
     uint64_t tile_size = static_cast<uint64_t>(cfg[0]);
     uint64_t tile_elems = tile_size * tile_size;
     int num_tiles = static_cast<int>(cfg[3]);
 
-    __gm__ float* base_c = reinterpret_cast<__gm__ float*>(c_tensor->buffer.addr) + c_tensor->start_offset;
-    __gm__ float* base_p = reinterpret_cast<__gm__ float*>(p_tensor->buffer.addr) + p_tensor->start_offset;
+    __gm__ float *base_c = reinterpret_cast<__gm__ float *>(c_tensor->buffer.addr) + c_tensor->start_offset;
+    __gm__ float *base_p = reinterpret_cast<__gm__ float *>(p_tensor->buffer.addr) + p_tensor->start_offset;
 
     for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
-        __gm__ float* c_ptr = base_c + (tile_idx * tile_elems);
-        __gm__ float* p_ptr = base_p + (tile_idx * tile_elems);
+        __gm__ float *c_ptr = base_c + (tile_idx * tile_elems);
+        __gm__ float *p_ptr = base_p + (tile_idx * tile_elems);
 
         switch (tile_size) {
-            case 16:  tile_add_impl<16>(c_ptr, p_ptr);  break;
-            case 32:  tile_add_impl<32>(c_ptr, p_ptr);  break;
-            case 64:  tile_add_impl<64>(c_ptr, p_ptr);  break;
-            case 128: tile_add_impl<128>(c_ptr, p_ptr); break;
-            default: break;
+        case 16:
+            tile_add_impl<16>(c_ptr, p_ptr);
+            break;
+        case 32:
+            tile_add_impl<32>(c_ptr, p_ptr);
+            break;
+        case 64:
+            tile_add_impl<64>(c_ptr, p_ptr);
+            break;
+        case 128:
+            tile_add_impl<128>(c_ptr, p_ptr);
+            break;
+        default:
+            break;
         }
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -37,16 +37,16 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 4,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 
@@ -57,7 +57,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     Tensor ext_config = from_tensor_arg(orch_args.tensor(3));
 
     // Read config from tensor data: [tile_size, grid_k, num_groups, incore_loop]
-    int64_t* host_config = orch_args.tensor(3).data_as<int64_t>();
+    int64_t *host_config = orch_args.tensor(3).data_as<int64_t>();
     int tile_size = static_cast<int>(host_config[0]);
     int grid_k = static_cast<int>(host_config[1]);
     int num_groups = static_cast<int>(host_config[2]);
@@ -67,13 +67,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     int grid_m = 1;
     int grid_n = 1;
 
-    LOG_INFO("[bgemm_orch] tile_size: %d, grid_m: %d, grid_n: %d, grid_k: %d, num_groups: %d, incore_loop: %d",
-        tile_size,
-        grid_m,
-        grid_n,
-        grid_k,
-        num_groups,
-        incore_loop);
+    LOG_INFO(
+        "[bgemm_orch] tile_size: %d, grid_m: %d, grid_n: %d, grid_k: %d, num_groups: %d, incore_loop: %d", tile_size,
+        grid_m, grid_n, grid_k, num_groups, incore_loop
+    );
 
     uint32_t tile_shapes[1] = {static_cast<uint32_t>(tile_elems)};
     uint64_t group_tile_elems = static_cast<uint64_t>(incore_loop) * tile_elems;
@@ -119,10 +116,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         }
     }
 
-    LOG_INFO("[bgemm_orch] Submitted %d gemm tasks and %d add tasks (%d total)",
-        total_gemm,
-        total_add,
-        total_gemm + total_add);
+    LOG_INFO(
+        "[bgemm_orch] Submitted %d gemm tasks and %d add tasks (%d total)", total_gemm, total_add,
+        total_gemm + total_add
+    );
 }
 
 }  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_hub.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Supports two tile configurations via runtime dispatch:
@@ -24,10 +34,10 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __gm__ Tensor* oi) {
-    __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
-    __gm__ bfloat16_t* vj_addr = reinterpret_cast<__gm__ bfloat16_t*>(vj->buffer.addr);
-    __gm__ float* oi_addr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
+static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __gm__ Tensor *oi) {
+    __gm__ bfloat16_t *pij_addr = reinterpret_cast<__gm__ bfloat16_t *>(pij->buffer.addr);
+    __gm__ bfloat16_t *vj_addr = reinterpret_cast<__gm__ bfloat16_t *>(vj->buffer.addr);
+    __gm__ float *oi_addr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
 
     // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
@@ -61,9 +71,9 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
 
     // Load pij and vj to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, pijGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, vjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
@@ -87,10 +97,10 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* vj = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *vj = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(pij->shapes[0]);
     // args[4] = block_size, args[5] = head_dim
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Supports two tile configurations via runtime dispatch:
@@ -24,10 +34,10 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm__ Tensor* sij) {
-    __gm__ bfloat16_t* qi_addr = reinterpret_cast<__gm__ bfloat16_t*>(qi->buffer.addr);
-    __gm__ bfloat16_t* kj_addr = reinterpret_cast<__gm__ bfloat16_t*>(kj->buffer.addr);
-    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
+static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm__ Tensor *sij) {
+    __gm__ bfloat16_t *qi_addr = reinterpret_cast<__gm__ bfloat16_t *>(qi->buffer.addr);
+    __gm__ bfloat16_t *kj_addr = reinterpret_cast<__gm__ bfloat16_t *>(kj->buffer.addr);
+    __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
 
     // qi (M, K) bf16 in ND (row-major) layout
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
@@ -62,9 +72,9 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
 
     // Load A and B to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, qiGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, kjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
@@ -88,10 +98,10 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* qi = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* kj = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *qi = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *kj = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *sij = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
     // args[4] = head_dim (128), args[5] = block_size
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_hub.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Operates on full tiles where M=q_tile_size, N=head_dim (128):
@@ -26,22 +36,17 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ Tensor* mij,
-    __gm__ Tensor* lij,
-    __gm__ Tensor* oi_new,
-    __gm__ Tensor* mi,
-    __gm__ Tensor* li,
-    __gm__ Tensor* oi,
-    uint64_t is_first,
-    uint64_t is_last,
-    __gm__ Tensor* dst) {
-    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
-    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
-    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
-    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
-    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+static __aicore__ void online_update_impl(
+    __gm__ Tensor *mij, __gm__ Tensor *lij, __gm__ Tensor *oi_new, __gm__ Tensor *mi, __gm__ Tensor *li,
+    __gm__ Tensor *oi, uint64_t is_first, uint64_t is_last, __gm__ Tensor *dst
+) {
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi->buffer.addr);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li->buffer.addr);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst->buffer.addr);
 
     // Aligned rows for ColMajor DN tiles (32-byte alignment)
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
@@ -126,7 +131,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to the same UB as DN tiles for storing as ND format
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);           // alias same UB as mijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
         TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,21 +178,21 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        TMAX(miNewRow, miRow, mijRow);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        TSUB(alphaRow, miRow, miNewRow);  // alpha_exp = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        TSUB(betaRow, mijRow, miNewRow);  // beta_exp = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        TEXP(betaRow, betaRow);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        TMUL(tmpRow, alphaRow, liRow);  // alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        TMUL(liNewRow, betaRow, lijRow);  // beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         TRESHAPE(alphaDN, alphaRow);
@@ -195,9 +200,9 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
 
         // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
         // Alias ND tiles to the same UB locations as miNewRow and liNewRow
@@ -212,15 +217,15 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }
@@ -228,14 +233,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mi = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* li = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* oi = reinterpret_cast<__gm__ Tensor*>(args[5]);
-    __gm__ Tensor* dst = reinterpret_cast<__gm__ Tensor*>(args[6]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mi = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *li = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *oi = reinterpret_cast<__gm__ Tensor *>(args[5]);
+    __gm__ Tensor *dst = reinterpret_cast<__gm__ Tensor *>(args[6]);
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Softmax Preparation Kernel (AIV) with partial block masking
 //
 // Operates on (M, N) tile where M=q_tile_size, N=block_size:
@@ -31,16 +41,14 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
-    float scale_value,
-    __gm__ Tensor* pij,
-    __gm__ Tensor* mij,
-    __gm__ Tensor* lij) {
+static __aicore__ void softmax_prepare_impl(
+    __gm__ Tensor *sij, float scale_value, __gm__ Tensor *pij, __gm__ Tensor *mij, __gm__ Tensor *lij
+) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
-    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
-    __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
-    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
+    __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
+    __gm__ bfloat16_t *pij_addr = reinterpret_cast<__gm__ bfloat16_t *>(pij->buffer.addr);
+    __gm__ float *mij_addr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_addr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -102,14 +110,14 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     // Truncate pij to bf16 first
     pipe_barrier(PIPE_V);
     TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);        // pij bf16 ready, can store early
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);  // pij bf16 ready, can store early
 
     // Continue computing: bf16 → f32 and rowsum while pij store proceeds in parallel
     pipe_barrier(PIPE_V);
     TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
     pipe_barrier(PIPE_V);
     TROWSUM(sumTile, pijTile, tmpTile);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);        // sum ready
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);  // sum ready
 
     // Store pij (overlaps with TCVT + TROWSUM above)
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -124,11 +132,11 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[3]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *sij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[3]);
     union {
         uint64_t u;
         float f;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -56,16 +56,16 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
     uint64_t prof_param_extract = 0;
@@ -100,18 +100,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     LOG_ALWAYS(">>>>>> batch = %" PRIu64, batch);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void* query_ptr = orch_args.tensor(0).data_as<void>();
-    void* kc_ptr = orch_args.tensor(1).data_as<void>();
-    void* vc_ptr = orch_args.tensor(2).data_as<void>();
-    void* out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).data_as<void>();
+    void *out_ptr = orch_args.tensor(5).data_as<void>();
 
     uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t value_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t out_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type);
     Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type);
@@ -119,8 +121,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
     CYCLE_COUNT_LAP(prof_ext_tensor);
 
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -157,9 +159,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 params_inplace.add_output(scalar_ci);
                 CYCLE_COUNT_LAP(prof_param_setup);
                 TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, params_inplace);
-                const Tensor& oi = hub_outs.get_ref(0);
-                const Tensor& li_update = hub_outs.get_ref(1);
-                const Tensor& mi_update = hub_outs.get_ref(2);
+                const Tensor &oi = hub_outs.get_ref(0);
+                const Tensor &li_update = hub_outs.get_ref(1);
+                const Tensor &mi_update = hub_outs.get_ref(2);
                 prof_submit_count++;
                 CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -183,7 +185,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_qk.add_output(sij_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
-                    const Tensor& sij = qk_outs.get_ref(0);
+                    const Tensor &sij = qk_outs.get_ref(0);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -201,9 +203,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_sf.add_scalar(scale_value);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
-                    const Tensor& pij_f16 = sf_outs.get_ref(0);
-                    const Tensor& mi = sf_outs.get_ref(1);
-                    const Tensor& li = sf_outs.get_ref(2);
+                    const Tensor &pij_f16 = sf_outs.get_ref(0);
+                    const Tensor &mi = sf_outs.get_ref(1);
+                    const Tensor &li = sf_outs.get_ref(2);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -213,7 +215,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_pv.add_output(tile2d_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
-                    const Tensor& oi_tmp = pv_outs.get_ref(0);
+                    const Tensor &oi_tmp = pv_outs.get_ref(0);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -243,35 +245,37 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
     uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
                      prof_submit_task + prof_scope;
-    LOG_ALWAYS("=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
-        prof_submit_count,
-        prof_make_count,
-        prof_view_count,
-        cycles_to_us(total));
+    LOG_ALWAYS(
+        "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===", prof_submit_count,
+        prof_make_count, prof_view_count, cycles_to_us(total)
+    );
     if (total > 0) {
-        LOG_ALWAYS("  param_extract    : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_extract),
-            prof_param_extract * 100.0 / total);
         LOG_ALWAYS(
-            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
-        LOG_ALWAYS("  create_info(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_make_count,
-            cycles_to_us(prof_make_tensor),
+            "  param_extract    : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_extract),
+            prof_param_extract * 100.0 / total
+        );
+        LOG_ALWAYS(
+            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total
+        );
+        LOG_ALWAYS(
+            "  create_info(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_make_count, cycles_to_us(prof_make_tensor),
             prof_make_tensor * 100.0 / total,
-            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
-        LOG_ALWAYS("  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_view_count,
-            cycles_to_us(prof_tensor_view),
-            prof_tensor_view * 100.0 / total,
-            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
+            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0
+        );
         LOG_ALWAYS(
-            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
+            "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_view_count, cycles_to_us(prof_tensor_view),
+            prof_tensor_view * 100.0 / total,
+            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0
+        );
+        LOG_ALWAYS(
+            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total
+        );
         LOG_ALWAYS("  scope            : %7.3fus (%5.1f%%)", cycles_to_us(prof_scope), prof_scope * 100.0 / total);
-        LOG_ALWAYS("  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_submit_count,
-            cycles_to_us(prof_submit_task),
+        LOG_ALWAYS(
+            "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_submit_count, cycles_to_us(prof_submit_task),
             prof_submit_task * 100.0 / total,
-            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
+            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0
+        );
     }
 
 #undef CYCLE_COUNT_START

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_hub.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // SplitK PV Matmul Kernel: Accumulated P @ V across n_blocks
 //
 // Processes n_blocks blocks using SplitK accumulation pattern:
@@ -39,12 +49,9 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void pv_matmul_n_impl(
-    __gm__ bfloat16_t* pij_base,
-    __gm__ bfloat16_t* val_base,
-    __gm__ float* oi_base,
-    uint64_t n_blocks,
-    __gm__ int32_t* block_table) {
-
+    __gm__ bfloat16_t *pij_base, __gm__ bfloat16_t *val_base, __gm__ float *oi_base, uint64_t n_blocks,
+    __gm__ int32_t *block_table
+) {
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
@@ -96,9 +103,9 @@ static __aicore__ void pv_matmul_n_impl(
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
         wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
         TLOAD(aMatTile[cur], pijGlobal);
-        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);   // forward: A in L1 ready
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: A in L1 ready
         TLOAD(bMatTile[cur], vjGlobal);
-        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);   // forward: B in L1 ready
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: B in L1 ready
 
         // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
         // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
@@ -107,17 +114,17 @@ static __aicore__ void pv_matmul_n_impl(
         TMOV(aTile[cur], aMatTile[cur]);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
         TMOV(bTile[cur], bMatTile[cur]);
-        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur); // reverse: release L1[cur]
+        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);  // reverse: release L1[cur]
 
         // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
-        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);   // forward: L0[cur] ready
+        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);  // forward: L0[cur] ready
         wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
         if (i == 0) {
             TMATMUL(cTile, aTile[cur], bTile[cur]);
         } else {
             TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
         }
-        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);   // reverse: release L0[cur]
+        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);  // reverse: release L0[cur]
     }
 
     // Drain outstanding reverse-dependency flags
@@ -134,16 +141,16 @@ static __aicore__ void pv_matmul_n_impl(
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* pij_buf = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* value_cache = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *pij_buf = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *value_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t n_blocks = static_cast<uint64_t>(args[3]);
-    __gm__ int32_t* block_table = reinterpret_cast<__gm__ int32_t*>(args[4]);
+    __gm__ int32_t *block_table = reinterpret_cast<__gm__ int32_t *>(args[4]);
 
-    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_buf->buffer.addr) + pij_buf->start_offset;
-    __gm__ bfloat16_t* val_base = reinterpret_cast<__gm__ bfloat16_t*>(value_cache->buffer.addr);
-    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr) + oi_new->start_offset;
+    __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_buf->buffer.addr) + pij_buf->start_offset;
+    __gm__ bfloat16_t *val_base = reinterpret_cast<__gm__ bfloat16_t *>(value_cache->buffer.addr);
+    __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr) + oi_new->start_offset;
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Multi-block QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N) for each block
 //
 // Processes n_blocks blocks in a single kernel invocation.
@@ -33,12 +43,9 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void qk_matmul_n_impl(
-    __gm__ bfloat16_t* qi_base,
-    __gm__ bfloat16_t* key_base,
-    __gm__ float* sij_base,
-    uint64_t n_blocks,
-    __gm__ int32_t* block_table) {
-
+    __gm__ bfloat16_t *qi_base, __gm__ bfloat16_t *key_base, __gm__ float *sij_base, uint64_t n_blocks,
+    __gm__ int32_t *block_table
+) {
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
@@ -98,16 +105,16 @@ static __aicore__ void qk_matmul_n_impl(
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* qi = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* key_cache = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* sij_buf = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *qi = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *key_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *sij_buf = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t n_blocks = static_cast<uint64_t>(args[3]);
-    __gm__ int32_t* block_table = reinterpret_cast<__gm__ int32_t*>(args[4]);
+    __gm__ int32_t *block_table = reinterpret_cast<__gm__ int32_t *>(args[4]);
 
-    __gm__ bfloat16_t* qi_base = reinterpret_cast<__gm__ bfloat16_t*>(qi->buffer.addr) + qi->start_offset;
-    __gm__ bfloat16_t* key_base = reinterpret_cast<__gm__ bfloat16_t*>(key_cache->buffer.addr);
-    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_buf->buffer.addr) + sij_buf->start_offset;
+    __gm__ bfloat16_t *qi_base = reinterpret_cast<__gm__ bfloat16_t *>(qi->buffer.addr) + qi->start_offset;
+    __gm__ bfloat16_t *key_base = reinterpret_cast<__gm__ bfloat16_t *>(key_cache->buffer.addr);
+    __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_buf->buffer.addr) + sij_buf->start_offset;
 
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_hub.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Operates on full tiles where M=q_tile_size, N=head_dim (128):
@@ -26,22 +36,17 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ Tensor* mij,
-    __gm__ Tensor* lij,
-    __gm__ Tensor* oi_new,
-    __gm__ Tensor* mi,
-    __gm__ Tensor* li,
-    __gm__ Tensor* oi,
-    uint64_t is_first,
-    uint64_t is_last,
-    __gm__ Tensor* dst) {
-    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
-    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
-    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
-    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
-    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+static __aicore__ void online_update_impl(
+    __gm__ Tensor *mij, __gm__ Tensor *lij, __gm__ Tensor *oi_new, __gm__ Tensor *mi, __gm__ Tensor *li,
+    __gm__ Tensor *oi, uint64_t is_first, uint64_t is_last, __gm__ Tensor *dst
+) {
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi->buffer.addr);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li->buffer.addr);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst->buffer.addr);
 
     // Aligned rows for ColMajor DN tiles (32-byte alignment)
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
@@ -126,8 +131,8 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to same UB as DN tiles for ND-format store
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);                    // alias same UB as mijDN
-        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);   // alias same UB as lijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
+        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,21 +178,21 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
+        TMAX(miNewRow, miRow, mijRow);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
+        TSUB(alphaRow, miRow, miNewRow);  // alpha_exp = mi - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
+        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
         pipe_barrier(PIPE_V);
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
+        TSUB(betaRow, mijRow, miNewRow);  // beta_exp = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
+        TEXP(betaRow, betaRow);  // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
+        TMUL(tmpRow, alphaRow, liRow);  // alpha * li
         pipe_barrier(PIPE_V);
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
+        TMUL(liNewRow, betaRow, lijRow);  // beta * lij
         pipe_barrier(PIPE_V);
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         pipe_barrier(PIPE_V);
@@ -195,11 +200,11 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         TRESHAPE(betaDN, betaRow);
 
         // Scale data tiles using row-broadcast multiply
-        TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
+        TROWEXPANDMUL(oiTile, oiTile, alphaDN);  // oi *= alpha
         pipe_barrier(PIPE_V);
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
-        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
+        TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
         // Alias ND tiles to the same UB locations as miNewRow and liNewRow
@@ -214,15 +219,15 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }
@@ -230,14 +235,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mi = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* li = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* oi = reinterpret_cast<__gm__ Tensor*>(args[5]);
-    __gm__ Tensor* dst = reinterpret_cast<__gm__ Tensor*>(args[6]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mi = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *li = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *oi = reinterpret_cast<__gm__ Tensor *>(args[5]);
+    __gm__ Tensor *dst = reinterpret_cast<__gm__ Tensor *>(args[6]);
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Two-Pass Softmax Kernel (AIV) for n_blocks tiles
 //
 // Input:  sij_buf (n_blocks * M, N) fp32 — QK results stacked vertically
@@ -37,14 +47,9 @@ using namespace pto;
 
 template <int M, int N>
 static __aicore__ void softmax_prepare_n_impl(
-    __gm__ float* sij_base,
-    float scale_value,
-    __gm__ bfloat16_t* pij_base,
-    __gm__ float* mij_addr,
-    __gm__ float* lij_addr,
-    uint64_t n_blocks,
-    uint64_t valid_len_last) {
-
+    __gm__ float *sij_base, float scale_value, __gm__ bfloat16_t *pij_base, __gm__ float *mij_addr,
+    __gm__ float *lij_addr, uint64_t n_blocks, uint64_t valid_len_last
+) {
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
     constexpr int kScalarCols = 32 / sizeof(float);
     constexpr int kScalarRows = M / kScalarCols;
@@ -100,10 +105,10 @@ static __aicore__ void softmax_prepare_n_impl(
     TASSIGN(sumAccTile, 4 * kDataBytes);
     int scalarBase = 5 * kDataBytes;
     TASSIGN(localMaxDN, scalarBase);
-    TASSIGN(localMaxRow, scalarBase);                     // alias: same UB as localMaxDN
+    TASSIGN(localMaxRow, scalarBase);  // alias: same UB as localMaxDN
     TASSIGN(globalMaxDN, scalarBase + kScalarDNBytes);
-    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
-    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);    // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);  // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
     TASSIGN(sumDN, scalarBase + 2 * kScalarDNBytes);
     TASSIGN(pijBf16Tile, scalarBase + 3 * kScalarDNBytes);
 
@@ -234,11 +239,11 @@ static __aicore__ void softmax_prepare_n_impl(
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* sij_buf = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* pij_buf = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[3]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *sij_buf = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *pij_buf = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[3]);
     union {
         uint64_t u;
         float f;
@@ -248,10 +253,10 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t n_blocks = static_cast<uint64_t>(args[5]);
     uint64_t valid_len_last = static_cast<uint64_t>(args[6]);
 
-    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_buf->buffer.addr) + sij_buf->start_offset;
-    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_buf->buffer.addr) + pij_buf->start_offset;
-    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr) + mij->start_offset;
-    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr) + lij->start_offset;
+    __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_buf->buffer.addr) + sij_buf->start_offset;
+    __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_buf->buffer.addr) + pij_buf->start_offset;
+    __gm__ float *mij_addr = reinterpret_cast<__gm__ float *>(mij->buffer.addr) + mij->start_offset;
+    __gm__ float *lij_addr = reinterpret_cast<__gm__ float *>(lij->buffer.addr) + lij->start_offset;
 
     uint64_t q_tile_size = static_cast<uint64_t>(sij_buf->shapes[0]);
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -68,16 +68,16 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 #ifdef ENABLE_PROFILING
@@ -116,26 +116,28 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     CYCLE_COUNT_LAP(prof_param_extract);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void* query_ptr = orch_args.tensor(0).data_as<void>();
-    void* kc_ptr = orch_args.tensor(1).data_as<void>();
-    void* vc_ptr = orch_args.tensor(2).data_as<void>();
-    void* out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).data_as<void>();
+    void *out_ptr = orch_args.tensor(5).data_as<void>();
 
     uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t value_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t out_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type, false);
     Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type, false);
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
 
 #ifdef ENABLE_PROFILING
     CYCLE_COUNT_LAP(prof_ext_tensor);
@@ -159,7 +161,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         uint64_t cur_seq = host_context_lens[b_idx];
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         // Pre-compute block table base pointer for this batch
-        int* bt_base = host_block_table + b_idx * block_num;
+        int *bt_base = host_block_table + b_idx * block_num;
 
         // Prefetch next block host_context_lens data while processing current batch
         if (b_idx + 1 < batch) {
@@ -186,9 +188,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 params_inplace.add_output(scalar_noinit_ci);
                 CYCLE_COUNT_LAP(prof_param_setup);
                 TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, params_inplace);
-                const Tensor& oi = hub_outs.get_ref(0);
-                const Tensor& li_update = hub_outs.get_ref(1);
-                const Tensor& mi_update = hub_outs.get_ref(2);
+                const Tensor &oi = hub_outs.get_ref(0);
+                const Tensor &li_update = hub_outs.get_ref(1);
+                const Tensor &mi_update = hub_outs.get_ref(2);
 #ifdef ENABLE_PROFILING
                 prof_submit_count++;
                 CYCLE_COUNT_LAP(prof_submit_task);
@@ -208,7 +210,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
                     // === Task 1: Batched QK matmul ===
                     uint32_t sij_buf_shapes[2] = {
-                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)};
+                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)
+                    };
                     TensorCreateInfo sij_buf_ci(sij_buf_shapes, 2, DataType::FLOAT32);
 #ifdef ENABLE_PROFILING
                     prof_make_count += 1;
@@ -223,7 +226,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_qk.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
-                    const Tensor& sij_buf = qk_outs.get_ref(0);
+                    const Tensor &sij_buf = qk_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -231,7 +234,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
                     // === Task 2: Two-pass softmax over all blocks in group ===
                     uint32_t pij_buf_shapes[2] = {
-                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)};
+                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)
+                    };
                     TensorCreateInfo pij_buf_ci(pij_buf_shapes, 2, data_type);
 #ifdef ENABLE_PROFILING
                     prof_make_count += 1;
@@ -248,9 +252,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_sf.add_scalar(valid_len_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
-                    const Tensor& pij_buf = sf_outs.get_ref(0);
-                    const Tensor& mi = sf_outs.get_ref(1);
-                    const Tensor& li = sf_outs.get_ref(2);
+                    const Tensor &pij_buf = sf_outs.get_ref(0);
+                    const Tensor &mi = sf_outs.get_ref(1);
+                    const Tensor &li = sf_outs.get_ref(2);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -265,7 +269,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     params_pv.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
-                    const Tensor& oi_new = pv_outs.get_ref(0);
+                    const Tensor &oi_new = pv_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -301,37 +305,40 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 #ifdef ENABLE_PROFILING
     uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
                      prof_submit_task + prof_scope_and_loop;
-    LOG_ALWAYS("=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
-        prof_submit_count,
-        prof_make_count,
-        prof_view_count,
-        cycles_to_us(total));
+    LOG_ALWAYS(
+        "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===", prof_submit_count,
+        prof_make_count, prof_view_count, cycles_to_us(total)
+    );
     if (total > 0) {
-        LOG_ALWAYS("  param_extract    : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_extract),
-            prof_param_extract * 100.0 / total);
         LOG_ALWAYS(
-            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
-        LOG_ALWAYS("  create_info(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_make_count,
-            cycles_to_us(prof_make_tensor),
+            "  param_extract    : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_extract),
+            prof_param_extract * 100.0 / total
+        );
+        LOG_ALWAYS(
+            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total
+        );
+        LOG_ALWAYS(
+            "  create_info(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_make_count, cycles_to_us(prof_make_tensor),
             prof_make_tensor * 100.0 / total,
-            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
-        LOG_ALWAYS("  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_view_count,
-            cycles_to_us(prof_tensor_view),
-            prof_tensor_view * 100.0 / total,
-            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
+            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0
+        );
         LOG_ALWAYS(
-            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
-        LOG_ALWAYS("  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_submit_count,
-            cycles_to_us(prof_submit_task),
+            "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_view_count, cycles_to_us(prof_tensor_view),
+            prof_tensor_view * 100.0 / total,
+            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0
+        );
+        LOG_ALWAYS(
+            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total
+        );
+        LOG_ALWAYS(
+            "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_submit_count, cycles_to_us(prof_submit_task),
             prof_submit_task * 100.0 / total,
-            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
-        LOG_ALWAYS("  scope_and_loop   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_scope_and_loop),
-            prof_scope_and_loop * 100.0 / total);
+            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0
+        );
+        LOG_ALWAYS(
+            "  scope_and_loop   : %7.3fus (%5.1f%%)", cycles_to_us(prof_scope_and_loop),
+            prof_scope_and_loop * 100.0 / total
+        );
     }
 #endif
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_add.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_add.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Element-wise Tensor Addition Kernel
  *
@@ -34,14 +44,14 @@ using namespace pto;
  *              args[2] = out pointer (output tensor)
  *              args[3] = size (number of elements)
  */
-extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t* args) {
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     // Unpack arguments (Tensor* pointers from runtime)
-    __gm__ Tensor* src0_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* src1_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ float* src0 = reinterpret_cast<__gm__ float*>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
-    __gm__ float* src1 = reinterpret_cast<__gm__ float*>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
-    __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
     // Configuration: float, 128, 128, 128, 128
     constexpr int kTRows_ = 128;
@@ -73,7 +83,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    
+
     set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_noop.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_noop.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * No-op Kernel
  *
@@ -20,6 +30,4 @@ using namespace pto;
 #define __aicore__ [aicore]
 #endif
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    (void)args;
-}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
@@ -40,16 +40,16 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 4,  // a, b, result, check
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 
@@ -73,7 +73,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     params_c.add_input(ext_b);
     params_c.add_output(inter_ci);
     TaskOutputTensors c_outs = pto2_rt_submit_aiv_task(FUNC_ADD, params_c);
-    const Tensor& c = c_outs.get_ref(0);
+    const Tensor &c = c_outs.get_ref(0);
 
     // =========================================================
     // Step 2: get_tensor_data(c, {0}) → check[0]
@@ -108,7 +108,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     Arg params_scalar;
     params_scalar.add_output(scalar_ci);
     TaskOutputTensors scalar_outs = pto2_rt_submit_aiv_task(FUNC_NOOP, params_scalar);
-    const Tensor& scalar_tensor = scalar_outs.get_ref(0);
+    const Tensor &scalar_tensor = scalar_outs.get_ref(0);
 
     // =========================================================
     // Step 5: get_tensor_data(scalar_tensor, {0}) → check[2]
@@ -146,10 +146,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     //   Tests set_tensor_data write + orchestration arithmetic
     // =========================================================
     float combined = c0_val + s0_val;  // 2.0 + 77.0 = 79.0
-    LOG_INFO("Orchestration arithmetic: %f + %f = %f",
-        static_cast<double>(c0_val),
-        static_cast<double>(s0_val),
-        static_cast<double>(combined));  // NOLINT(whitespace/line_length)
+    LOG_INFO(
+        "Orchestration arithmetic: %f + %f = %f", static_cast<double>(c0_val), static_cast<double>(s0_val),
+        static_cast<double>(combined)
+    );  // NOLINT(whitespace/line_length)
 
     check_idx[0] = 4;
     set_tensor_data(ext_check, 1, check_idx, combined);
@@ -174,7 +174,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     Arg params_d;
     params_d.add_output(inter_ci);
     TaskOutputTensors d_outs = pto2_rt_submit_aiv_task(FUNC_NOOP, params_d);
-    const Tensor& d = d_outs.get_ref(0);
+    const Tensor &d = d_outs.get_ref(0);
 
     idx[0] = 0;
     set_tensor_data(d, 1, idx, 10.0f);
@@ -184,7 +184,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     params_e.add_input(ext_a);
     params_e.add_output(inter_ci);
     TaskOutputTensors e_outs = pto2_rt_submit_aiv_task(FUNC_ADD, params_e);
-    const Tensor& e = e_outs.get_ref(0);
+    const Tensor &e = e_outs.get_ref(0);
 
     float e0_val = get_tensor_data<float>(e, 1, idx);
     LOG_INFO("Orch→AICore RAW: e[0] = %f (expected 12.0)", static_cast<double>(e0_val));
@@ -249,7 +249,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     set_tensor_data(ext_b, 1, idx, 55.0f);
     float ext_war_val = get_tensor_data<float>(ext_b, 1, idx);
     LOG_INFO(
-        "External WAR (INOUT): set_tensor_data(ext_b, 55.0) = %f (expected 55.0)", static_cast<double>(ext_war_val));
+        "External WAR (INOUT): set_tensor_data(ext_b, 55.0) = %f (expected 55.0)", static_cast<double>(ext_war_val)
+    );
 
     check_idx[0] = 8;
     set_tensor_data(ext_check, 1, check_idx, ext_war_val);

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Supports two tile configurations via runtime dispatch:
@@ -22,19 +32,18 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* vj_raw, __gm__ uint8_t* oi_raw)
-{
-    __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
-    __gm__ bfloat16_t* vj  = reinterpret_cast<__gm__ bfloat16_t*>(vj_raw);
-    __gm__ float*      oi  = reinterpret_cast<__gm__ float*>(oi_raw);
+static __aicore__ void pv_matmul_impl(__gm__ uint8_t *pij_raw, __gm__ uint8_t *vj_raw, __gm__ uint8_t *oi_raw) {
+    __gm__ bfloat16_t *pij = reinterpret_cast<__gm__ bfloat16_t *>(pij_raw);
+    __gm__ bfloat16_t *vj = reinterpret_cast<__gm__ bfloat16_t *>(vj_raw);
+    __gm__ float *oi = reinterpret_cast<__gm__ float *>(oi_raw);
 
     // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M*K, M*K, M*K, K, 1>>;
-    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K*N, K*N, K*N, N, 1>>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, N, 1>>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   pijGlobal(pij);
-    GlobalB   vjGlobal(vj);
+    GlobalA pijGlobal(pij);
+    GlobalB vjGlobal(vj);
     GlobalOut oiGlobal(oi);
 
     // L1 Mat tiles: standard ND pattern for both A and B
@@ -42,18 +51,18 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<bfloat16_t, M, K, M, K>;
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -81,11 +90,10 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t* pij_raw, __gm__ uint8_t* v
     TSTORE(oiGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* pij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* vj     = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *pij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *vj = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *oi_new = reinterpret_cast<__gm__ uint8_t *>(args[2]);
     int q_tile_size = static_cast<int>(args[3]);
     // args[4] = block_size, args[5] = head_dim
 

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Supports two tile configurations via runtime dispatch:
@@ -22,20 +32,19 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj_raw, __gm__ uint8_t* sij_raw)
-{
-    __gm__ bfloat16_t* qi  = reinterpret_cast<__gm__ bfloat16_t*>(qi_raw);
-    __gm__ bfloat16_t* kj  = reinterpret_cast<__gm__ bfloat16_t*>(kj_raw);
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
+static __aicore__ void qk_matmul_impl(__gm__ uint8_t *qi_raw, __gm__ uint8_t *kj_raw, __gm__ uint8_t *sij_raw) {
+    __gm__ bfloat16_t *qi = reinterpret_cast<__gm__ bfloat16_t *>(qi_raw);
+    __gm__ bfloat16_t *kj = reinterpret_cast<__gm__ bfloat16_t *>(kj_raw);
+    __gm__ float *sij = reinterpret_cast<__gm__ float *>(sij_raw);
 
     // qi (M, K) bf16 in ND (row-major) layout
-    using GlobalA   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M*K, M*K, M*K, K, 1>>;
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB   = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K*N, K*N, K*N, 1, K>, Layout::DN>;
-    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M*N, M*N, M*N, N, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
 
-    GlobalA   qiGlobal(qi);
-    GlobalB   kjGlobal(kj);
+    GlobalA qiGlobal(qi);
+    GlobalB kjGlobal(kj);
     GlobalOut sijGlobal(sij);
 
     // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
@@ -43,18 +52,18 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
 
     // L0 tiles
-    using LeftTile  = TileLeft<bfloat16_t, M, K, M, K>;
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
-    using AccTile   = TileAcc<float, M, N, M, N>;
+    using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;
     TileMatB bMatTile;
     TASSIGN(aMatTile, 0x0);
     TASSIGN(bMatTile, 0x20000);
 
-    LeftTile  aTile;
+    LeftTile aTile;
     RightTile bTile;
-    AccTile   cTile;
+    AccTile cTile;
     TASSIGN(aTile, 0x0);
     TASSIGN(bTile, 0x0);
     TASSIGN(cTile, 0x0);
@@ -82,11 +91,10 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t* qi_raw, __gm__ uint8_t* kj
     TSTORE(sijGlobal, cTile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args)
-{
-    __gm__ uint8_t* qi  = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* kj  = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *qi = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *kj = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *sij = reinterpret_cast<__gm__ uint8_t *>(args[2]);
     int q_tile_size = static_cast<int>(args[3]);
     // args[4] = head_dim (128), args[5] = block_size
 

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Operates on full tiles where M=q_tile_size, N=head_dim (128):
@@ -24,18 +34,17 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_t* lij_raw,
-                               __gm__ uint8_t* oi_new_raw, __gm__ uint8_t* mi_raw,
-                               __gm__ uint8_t* li_raw, __gm__ uint8_t* oi_raw,
-                               int is_first, int is_last, __gm__ uint8_t* dst_raw)
-{
-    __gm__ float* mij_ptr    = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float* lij_ptr    = reinterpret_cast<__gm__ float*>(lij_raw);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new_raw);
-    __gm__ float* mi_ptr     = reinterpret_cast<__gm__ float*>(mi_raw);
-    __gm__ float* li_ptr     = reinterpret_cast<__gm__ float*>(li_raw);
-    __gm__ float* oi_ptr     = reinterpret_cast<__gm__ float*>(oi_raw);
-    __gm__ float* dst_ptr    = reinterpret_cast<__gm__ float*>(dst_raw);
+static __aicore__ void online_update_impl(
+    __gm__ uint8_t *mij_raw, __gm__ uint8_t *lij_raw, __gm__ uint8_t *oi_new_raw, __gm__ uint8_t *mi_raw,
+    __gm__ uint8_t *li_raw, __gm__ uint8_t *oi_raw, int is_first, int is_last, __gm__ uint8_t *dst_raw
+) {
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij_raw);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij_raw);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new_raw);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi_raw);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li_raw);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi_raw);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst_raw);
 
     // Scalar tile dimensions for RowMajor layout:
     // kScalarCols = 32 bytes / 4 bytes per float = 8 floats per row (one 32-byte block)
@@ -51,12 +60,11 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<1, 1, 1, N, 1>>;
 
     // Scalar ND: M contiguous floats as (kScalarRows, kScalarCols) RowMajor
-    using GlobalScalarND = GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>,
-                                        pto::Stride<1, 1, 1, kScalarCols, 1>>;
+    using GlobalScalarND =
+        GlobalTensor<float, Shape<1, 1, 1, kScalarRows, kScalarCols>, pto::Stride<1, 1, 1, kScalarCols, 1>>;
 
     // Scalar DN: same M contiguous floats as (kAlignedRows, 1) ColMajor
-    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>,
-                                        pto::Stride<1, 1, 1, 1, 1>, Layout::DN>;
+    using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, pto::Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     // --- GlobalTensor instances ---
 
@@ -78,8 +86,8 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     // --- Tile types ---
 
     using TileDataMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
-    using TileScalarND = Tile<TileType::Vec, float, kScalarRows, kScalarCols,
-                              BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     // --- UB memory layout ---
@@ -124,9 +132,9 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
         // Passthrough to MTE3 (no V compute needed)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, mijND);     // mi = mij
-        TSTORE(liGlobalND, lijND);     // li = lij
-        TSTORE(oiGlobal, oiNewTile);   // oi = oi_new
+        TSTORE(miGlobalND, mijND);    // mi = mij
+        TSTORE(liGlobalND, lijND);    // li = lij
+        TSTORE(oiGlobal, oiNewTile);  // oi = oi_new
 
         if (is_last) {
             // Single block: normalize dst = oi_new / lij
@@ -156,44 +164,44 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
 
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
         // to resolve RAW hazards on shared UB tiles.
-        TMAX(miNewND, miND, mijND);          // mi_new = max(mi, mij)
-        TSUB(alphaND, miND, miNewND);        // alpha = mi - mi_new
-        TEXP(alphaND, alphaND);              // alpha = exp(mi - mi_new)
-        TSUB(betaND, mijND, miNewND);        // beta = mij - mi_new
-        TEXP(betaND, betaND);                // beta = exp(mij - mi_new)
-        TMUL(liND, alphaND, liND);           // li = alpha * li
-        TMUL(tmpND, betaND, lijND);          // tmp = beta * lij
-        TADD(liND, liND, tmpND);             // li = alpha * li + beta * lij (= li_new)
+        TMAX(miNewND, miND, mijND);    // mi_new = max(mi, mij)
+        TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new
+        TEXP(alphaND, alphaND);        // alpha = exp(mi - mi_new)
+        TSUB(betaND, mijND, miNewND);  // beta = mij - mi_new
+        TEXP(betaND, betaND);          // beta = exp(mij - mi_new)
+        TMUL(liND, alphaND, liND);     // li = alpha * li
+        TMUL(tmpND, betaND, lijND);    // tmp = beta * lij
+        TADD(liND, liND, tmpND);       // li = alpha * li + beta * lij (= li_new)
 
         // Phase 3: Store scalar results to GM (ND format)
         // mi_new → mi accumulator, li_new → li accumulator
         // alpha → mij buffer (reuse), beta → lij buffer (reuse)
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(miGlobalND, miNewND);         // persist mi_new
-        TSTORE(liGlobalND, liND);            // persist li_new
-        TSTORE(mijGlobalND, alphaND);        // temp: alpha to mij buffer
-        TSTORE(lijGlobalND, betaND);         // temp: beta to lij buffer
+        TSTORE(miGlobalND, miNewND);   // persist mi_new
+        TSTORE(liGlobalND, liND);      // persist li_new
+        TSTORE(mijGlobalND, alphaND);  // temp: alpha to mij buffer
+        TSTORE(lijGlobalND, betaND);   // temp: beta to lij buffer
 
         // Phase 4: Reload alpha, beta (and li if last) as ColMajor DN
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        TLOAD(alphaDN, mijGlobalDN);         // alpha from mij buffer as DN
-        TLOAD(betaDN, lijGlobalDN);          // beta from lij buffer as DN
+        TLOAD(alphaDN, mijGlobalDN);  // alpha from mij buffer as DN
+        TLOAD(betaDN, lijGlobalDN);   // beta from lij buffer as DN
         if (is_last) {
-            TLOAD(liDN, liGlobalDN);         // li_new from li buffer as DN
+            TLOAD(liDN, liGlobalDN);  // li_new from li buffer as DN
         }
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
 
         // Phase 5: Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
-        TADD(oiTile, oiTile, oiNewTile);               // oi = alpha*oi + beta*oi_new
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
+        TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
 
         if (is_last) {
             // Phase 6: Normalize and output
-            TROWEXPANDDIV(oiTile, oiTile, liDN);      // dst = oi / li_new
+            TROWEXPANDDIV(oiTile, oiTile, liDN);  // dst = oi / li_new
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
             TSTORE(dstGlobal, oiTile);
@@ -206,16 +214,16 @@ static __aicore__ void online_update_impl(__gm__ uint8_t* mij_raw, __gm__ uint8_
     }
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* mij    = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    __gm__ uint8_t* lij    = reinterpret_cast<__gm__ uint8_t*>(args[1]);
-    __gm__ uint8_t* oi_new = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mi     = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* li     = reinterpret_cast<__gm__ uint8_t*>(args[4]);
-    __gm__ uint8_t* oi     = reinterpret_cast<__gm__ uint8_t*>(args[5]);
-    int is_first  = static_cast<int>(args[6]);
-    int is_last   = static_cast<int>(args[7]);
-    __gm__ uint8_t* dst    = reinterpret_cast<__gm__ uint8_t*>(args[8]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *mij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    __gm__ uint8_t *lij = reinterpret_cast<__gm__ uint8_t *>(args[1]);
+    __gm__ uint8_t *oi_new = reinterpret_cast<__gm__ uint8_t *>(args[2]);
+    __gm__ uint8_t *mi = reinterpret_cast<__gm__ uint8_t *>(args[3]);
+    __gm__ uint8_t *li = reinterpret_cast<__gm__ uint8_t *>(args[4]);
+    __gm__ uint8_t *oi = reinterpret_cast<__gm__ uint8_t *>(args[5]);
+    int is_first = static_cast<int>(args[6]);
+    int is_last = static_cast<int>(args[7]);
+    __gm__ uint8_t *dst = reinterpret_cast<__gm__ uint8_t *>(args[8]);
     int q_tile_size = static_cast<int>(args[9]);
     // args[10] = head_dim (128)
 

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Softmax Preparation Kernel (AIV) with partial block masking
 //
 // Operates on (M, N) tile where M=q_tile_size, N=block_size:
@@ -29,14 +39,14 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale_value,
-                                 __gm__ uint8_t* pij_raw, __gm__ uint8_t* mij_raw,
-                                 __gm__ uint8_t* lij_raw, int valid_len)
-{
-    __gm__ float*      sij = reinterpret_cast<__gm__ float*>(sij_raw);
-    __gm__ bfloat16_t* pij = reinterpret_cast<__gm__ bfloat16_t*>(pij_raw);
-    __gm__ float*      mij = reinterpret_cast<__gm__ float*>(mij_raw);
-    __gm__ float*      lij = reinterpret_cast<__gm__ float*>(lij_raw);
+static __aicore__ void softmax_prepare_impl(
+    __gm__ uint8_t *sij_raw, float scale_value, __gm__ uint8_t *pij_raw, __gm__ uint8_t *mij_raw,
+    __gm__ uint8_t *lij_raw, int valid_len
+) {
+    __gm__ float *sij = reinterpret_cast<__gm__ float *>(sij_raw);
+    __gm__ bfloat16_t *pij = reinterpret_cast<__gm__ bfloat16_t *>(pij_raw);
+    __gm__ float *mij = reinterpret_cast<__gm__ float *>(mij_raw);
+    __gm__ float *lij = reinterpret_cast<__gm__ float *>(lij_raw);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -52,8 +62,7 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
     // Dynamic-cols tile: marks which columns are valid for TFILLPAD boundary
     using TileSijDyn = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, -1>;
     // Padded tile: TFILLPAD_INPLACE fills positions [valid_len, N) with -inf
-    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N,
-                            SLayout::NoneBox, 512, PadValue::Min>;
+    using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N, SLayout::NoneBox, 512, PadValue::Min>;
 
     using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
     using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
@@ -103,14 +112,17 @@ static __aicore__ void softmax_prepare_impl(__gm__ uint8_t* sij_raw, float scale
     TSTORE(pijGlobal, pijBf16Tile);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ uint8_t* sij = reinterpret_cast<__gm__ uint8_t*>(args[0]);
-    union { uint64_t u; float f; } scale_conv;
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ uint8_t *sij = reinterpret_cast<__gm__ uint8_t *>(args[0]);
+    union {
+        uint64_t u;
+        float f;
+    } scale_conv;
     scale_conv.u = static_cast<uint64_t>(args[1]);
     float scale_value = scale_conv.f;
-    __gm__ uint8_t* pij = reinterpret_cast<__gm__ uint8_t*>(args[2]);
-    __gm__ uint8_t* mij = reinterpret_cast<__gm__ uint8_t*>(args[3]);
-    __gm__ uint8_t* lij = reinterpret_cast<__gm__ uint8_t*>(args[4]);
+    __gm__ uint8_t *pij = reinterpret_cast<__gm__ uint8_t *>(args[2]);
+    __gm__ uint8_t *mij = reinterpret_cast<__gm__ uint8_t *>(args[3]);
+    __gm__ uint8_t *lij = reinterpret_cast<__gm__ uint8_t *>(args[4]);
     int q_tile_size = static_cast<int>(args[5]);
     // args[6] = block_size
     int valid_len = static_cast<int>(args[7]);

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -37,19 +37,19 @@
 
 extern "C" {
 
-int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orch_args) {
+int build_paged_attention_graph(Runtime *runtime, const ChipStorageTaskArgs &orch_args) {
     if (orch_args.tensor_count() < 6) {
         std::cerr << "Expected at least 6 tensors, got " << orch_args.tensor_count() << '\n';
         return -1;
     }
 
     // Extract host pointers from tensor metadata
-    void* host_query = orch_args.tensor(0).data_as<void>();
-    void* host_key_cache = orch_args.tensor(1).data_as<void>();
-    void* host_value_cache = orch_args.tensor(2).data_as<void>();
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
-    void* host_out = orch_args.tensor(5).data_as<void>();
+    void *host_query = orch_args.tensor(0).data_as<void>();
+    void *host_key_cache = orch_args.tensor(1).data_as<void>();
+    void *host_value_cache = orch_args.tensor(2).data_as<void>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    void *host_out = orch_args.tensor(5).data_as<void>();
 
     // Extract sizes from tensor metadata
     size_t query_size = orch_args.tensor(0).nbytes();
@@ -85,10 +85,10 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
     std::cout << "q_tile_size=" << q_tile_size << ", num_head_tiles=" << num_head_tiles << '\n';
 
     // Allocate device memory for inputs/outputs
-    void* dev_query = runtime->host_api.device_malloc(query_size);
-    void* dev_key_cache = runtime->host_api.device_malloc(key_cache_size);
-    void* dev_value_cache = runtime->host_api.device_malloc(value_cache_size);
-    void* dev_out = runtime->host_api.device_malloc(out_size);
+    void *dev_query = runtime->host_api.device_malloc(query_size);
+    void *dev_key_cache = runtime->host_api.device_malloc(key_cache_size);
+    void *dev_value_cache = runtime->host_api.device_malloc(value_cache_size);
+    void *dev_out = runtime->host_api.device_malloc(out_size);
 
     if (!dev_query || !dev_key_cache || !dev_value_cache || !dev_out) {
         std::cerr << "Error: Failed to allocate device memory\n";
@@ -109,11 +109,11 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
     // Per-batch-per-block intermediate buffers
     uint32_t total_buffers = batch * max_num_blocks;
-    void** dev_sij_arr = new void*[total_buffers];
-    void** dev_pij_arr = new void*[total_buffers];
-    void** dev_mij_arr = new void*[total_buffers];
-    void** dev_lij_arr = new void*[total_buffers];
-    void** dev_oi_new_arr = new void*[total_buffers];
+    void **dev_sij_arr = new void *[total_buffers];
+    void **dev_pij_arr = new void *[total_buffers];
+    void **dev_mij_arr = new void *[total_buffers];
+    void **dev_lij_arr = new void *[total_buffers];
+    void **dev_oi_new_arr = new void *[total_buffers];
 
     for (uint32_t i = 0; i < total_buffers; i++) {
         dev_sij_arr[i] = runtime->host_api.device_malloc(sij_size);
@@ -129,9 +129,9 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
     size_t li_size = mi_size;
     size_t oi_size = static_cast<size_t>(q_tile_size) * head_dim * sizeof(float);
 
-    void** dev_mi_arr = new void*[total_accums];
-    void** dev_li_arr = new void*[total_accums];
-    void** dev_oi_arr = new void*[total_accums];
+    void **dev_mi_arr = new void *[total_accums];
+    void **dev_li_arr = new void *[total_accums];
+    void **dev_oi_arr = new void *[total_accums];
 
     for (uint32_t i = 0; i < total_accums; i++) {
         dev_mi_arr[i] = runtime->host_api.device_malloc(mi_size);
@@ -153,11 +153,11 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
             // Query: (batch, q_head_num, head_dim) bf16
             // qi points to heads [cur_offset .. cur_offset+q_tile_size) for batch b_idx
-            uint8_t* qi_ptr = reinterpret_cast<uint8_t*>(dev_query) +
+            uint8_t *qi_ptr = reinterpret_cast<uint8_t *>(dev_query) +
                               static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(uint16_t);
 
             // Output: (batch * q_head_num, head_dim) float32
-            uint8_t* out_ptr = reinterpret_cast<uint8_t*>(dev_out) +
+            uint8_t *out_ptr = reinterpret_cast<uint8_t *>(dev_out) +
                                static_cast<int64_t>(b_idx * num_heads + cur_offset) * head_dim * sizeof(float);
 
             // GQA: which kv_head this head tile maps to
@@ -165,66 +165,57 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
 
             // Per-(batch, head_tile) accumulators
             uint32_t accum_idx = b_idx * num_head_tiles + ht;
-            void* dev_mi = dev_mi_arr[accum_idx];
-            void* dev_li = dev_li_arr[accum_idx];
-            void* dev_oi = dev_oi_arr[accum_idx];
+            void *dev_mi = dev_mi_arr[accum_idx];
+            void *dev_li = dev_li_arr[accum_idx];
+            void *dev_oi = dev_oi_arr[accum_idx];
 
             int t_up_prev = -1;
 
             for (uint32_t bn = 0; bn < bn_this_batch; bn++) {
                 int cur_block_idx = host_block_table[b_idx * max_num_blocks + bn];
                 int valid_len = std::min(
-                    static_cast<int>(block_size), cur_seq - static_cast<int>(bn) * static_cast<int>(block_size));
+                    static_cast<int>(block_size), cur_seq - static_cast<int>(bn) * static_cast<int>(block_size)
+                );
 
                 // Key: (total_blocks, block_size, kv_head_num, head_dim) bf16
                 // Stride to block: cur_block_idx * (block_size * kv_head_num * head_dim)
                 // Then offset to kv_head: kv_head_idx * head_dim (within each token row)
                 // But since we want contiguous (block_size, head_dim), and kv_head_num=1 makes it simple:
-                uint8_t* kj_ptr = reinterpret_cast<uint8_t*>(dev_key_cache) +
+                uint8_t *kj_ptr = reinterpret_cast<uint8_t *>(dev_key_cache) +
                                   (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
                                       head_dim * sizeof(uint16_t);
 
                 // Value: (total_blocks, block_size, kv_head_num, head_dim) bf16 - same layout as key
-                uint8_t* vj_ptr = reinterpret_cast<uint8_t*>(dev_value_cache) +
+                uint8_t *vj_ptr = reinterpret_cast<uint8_t *>(dev_value_cache) +
                                   (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
                                       head_dim * sizeof(uint16_t);
 
                 uint32_t buf_idx = b_idx * max_num_blocks + bn;
-                void* dev_sij = dev_sij_arr[buf_idx];
-                void* dev_pij = dev_pij_arr[buf_idx];
-                void* dev_mij = dev_mij_arr[buf_idx];
-                void* dev_lij = dev_lij_arr[buf_idx];
-                void* dev_oi_new = dev_oi_new_arr[buf_idx];
+                void *dev_sij = dev_sij_arr[buf_idx];
+                void *dev_pij = dev_pij_arr[buf_idx];
+                void *dev_mij = dev_mij_arr[buf_idx];
+                void *dev_lij = dev_lij_arr[buf_idx];
+                void *dev_oi_new = dev_oi_new_arr[buf_idx];
 
                 // QK: qi(M, K) @ kj.T(K, N) -> sij(M, N)
-                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),
-                    reinterpret_cast<uint64_t>(kj_ptr),
-                    reinterpret_cast<uint64_t>(dev_sij),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim),
-                    static_cast<uint64_t>(block_size)};
+                uint64_t qk_args[6] = {reinterpret_cast<uint64_t>(qi_ptr),  reinterpret_cast<uint64_t>(kj_ptr),
+                                       reinterpret_cast<uint64_t>(dev_sij), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(head_dim),     static_cast<uint64_t>(block_size)};
                 int t_qk = runtime->add_task(qk_args, 6, FUNC_QK_MATMUL, CoreType::AIC);
                 total_tasks++;
 
                 // SF: scale, rowmax, exp, rowsum -> pij, mij, lij
-                uint64_t sf_args[8] = {reinterpret_cast<uint64_t>(dev_sij),
-                    scale_value_bits,
-                    reinterpret_cast<uint64_t>(dev_pij),
-                    reinterpret_cast<uint64_t>(dev_mij),
-                    reinterpret_cast<uint64_t>(dev_lij),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(valid_len)};
+                uint64_t sf_args[8] = {reinterpret_cast<uint64_t>(dev_sij), scale_value_bits,
+                                       reinterpret_cast<uint64_t>(dev_pij), reinterpret_cast<uint64_t>(dev_mij),
+                                       reinterpret_cast<uint64_t>(dev_lij), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(block_size),   static_cast<uint64_t>(valid_len)};
                 int t_sf = runtime->add_task(sf_args, 8, FUNC_SOFTMAX_PREPARE, CoreType::AIV);
                 total_tasks++;
 
                 // PV: pij(M, K') @ vj(K', N') -> oi_new(M, N')
-                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),
-                    reinterpret_cast<uint64_t>(vj_ptr),
-                    reinterpret_cast<uint64_t>(dev_oi_new),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(block_size),
-                    static_cast<uint64_t>(head_dim)};
+                uint64_t pv_args[6] = {reinterpret_cast<uint64_t>(dev_pij),    reinterpret_cast<uint64_t>(vj_ptr),
+                                       reinterpret_cast<uint64_t>(dev_oi_new), static_cast<uint64_t>(q_tile_size),
+                                       static_cast<uint64_t>(block_size),      static_cast<uint64_t>(head_dim)};
                 int t_pv = runtime->add_task(pv_args, 6, FUNC_PV_MATMUL, CoreType::AIC);
                 total_tasks++;
 
@@ -235,17 +226,12 @@ int build_paged_attention_graph(Runtime* runtime, const ChipStorageTaskArgs& orc
                 int is_first = (bn == 0) ? 1 : 0;
                 int is_last = (bn == bn_this_batch - 1) ? 1 : 0;
 
-                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),
-                    reinterpret_cast<uint64_t>(dev_lij),
-                    reinterpret_cast<uint64_t>(dev_oi_new),
-                    reinterpret_cast<uint64_t>(dev_mi),
-                    reinterpret_cast<uint64_t>(dev_li),
-                    reinterpret_cast<uint64_t>(dev_oi),
-                    static_cast<uint64_t>(is_first),
-                    static_cast<uint64_t>(is_last),
-                    reinterpret_cast<uint64_t>(out_ptr),
-                    static_cast<uint64_t>(q_tile_size),
-                    static_cast<uint64_t>(head_dim)};
+                uint64_t up_args[11] = {reinterpret_cast<uint64_t>(dev_mij),    reinterpret_cast<uint64_t>(dev_lij),
+                                        reinterpret_cast<uint64_t>(dev_oi_new), reinterpret_cast<uint64_t>(dev_mi),
+                                        reinterpret_cast<uint64_t>(dev_li),     reinterpret_cast<uint64_t>(dev_oi),
+                                        static_cast<uint64_t>(is_first),        static_cast<uint64_t>(is_last),
+                                        reinterpret_cast<uint64_t>(out_ptr),    static_cast<uint64_t>(q_tile_size),
+                                        static_cast<uint64_t>(head_dim)};
                 int t_up = runtime->add_task(up_args, 11, FUNC_ONLINE_UPDATE, CoreType::AIV);
                 total_tasks++;
 

--- a/tests/st/a5/tensormap_and_ringbuffer/bgemm/kernels/mix/kernel_bgemm.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/bgemm/kernels/mix/kernel_bgemm.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * Tile-based BGEMM Kernel — Combined Cube + Vector (TPUSH/TPOP)
  *
@@ -20,282 +30,278 @@
  *   args[2] = C_tile   (INOUT: read + write accumulator)
  */
 
- #include <cstdint>
- #include <pto/pto-inst.hpp>
- #ifndef __CPU_SIM
- #include <pto/common/fifo.hpp>
- #endif
- 
- #include "tensor.h"
- 
- using namespace pto;
- 
- #ifndef __gm__
- #define __gm__
- #endif
- 
- #ifndef __aicore__
- #define __aicore__ [aicore]
- #endif
- 
- #ifdef __DAV_CUBE__
- constexpr bool DAV_CUBE = true;
- #else
- constexpr bool DAV_CUBE = false;
- #endif
- 
- #ifdef __DAV_VEC__
- constexpr bool DAV_VEC = true;
- #else
- constexpr bool DAV_VEC = false;
- #endif
- 
- // Tile dimensions (must match golden.py)
- constexpr int TILE = 64;
- constexpr int M = TILE;
- constexpr int K = TILE;
- constexpr int N = TILE;
- 
- // =============================================================================
- // Simulation: separate AIC/AIV tasks with GM intermediate (no TPUSH/TPOP)
- // =============================================================================
- #ifdef __CPU_SIM
- 
- extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-     // AIC path: args = [A (input), B (input), P (output)]
-     if constexpr (DAV_CUBE) {
-         __gm__ Tensor* input_a_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-         __gm__ Tensor* input_b_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-         __gm__ Tensor* output_tensor  = reinterpret_cast<__gm__ Tensor*>(args[2]);
- 
-         __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
-         __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
-         __gm__ float* output  = reinterpret_cast<__gm__ float*>(output_tensor->buffer.addr)  + output_tensor->start_offset;
- 
-         using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, M, K>,
-             pto::Stride<M * K, M * K, M * K, K, 1>>;
-         using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, K, N>,
-             pto::Stride<K * N, K * N, K * N, N, 1>>;
-         using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, M, N>,
-             pto::Stride<M * N, M * N, M * N, N, 1>>;
- 
-         GlobalDataA src0Global(input_a);
-         GlobalDataB src1Global(input_b);
-         GlobalDataC dstGlobal(output);
- 
-         using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
-         using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
-         using LeftTile = TileLeft<float, M, K, M, K>;
-         using RightTile = TileRight<float, K, N, K, N>;
-         using AccTile = TileAcc<float, M, N, M, N>;
- 
-         TileMatA aMatTile;
-         TileMatB bMatTile;
-         TASSIGN(aMatTile, 0x0);
-         TASSIGN(bMatTile, 0x20000);
- 
-         LeftTile aTile;
-         RightTile bTile;
-         AccTile cTile;
-         TASSIGN(aTile, 0x0);
-         TASSIGN(bTile, 0x0);
-         TASSIGN(cTile, 0x0);
- 
-         TLOAD(aMatTile, src0Global);
-         TLOAD(bMatTile, src1Global);
- 
-         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
-         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
- 
-         TMOV(aTile, aMatTile);
-         TMOV(bTile, bMatTile);
- 
-         set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
-         wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
- 
-         TMATMUL(cTile, aTile, bTile);
- 
-         set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-         wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
- 
-         TSTORE(dstGlobal, cTile);
- 
-         set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-         wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-     }
- 
-     // AIV path: args = [C (inout), P (input)]
-     if constexpr (DAV_VEC) {
-         __gm__ Tensor* c_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-         __gm__ Tensor* p_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
- 
-         __gm__ float* c_ptr = reinterpret_cast<__gm__ float*>(c_tensor->buffer.addr) + c_tensor->start_offset;
-         __gm__ float* p_ptr = reinterpret_cast<__gm__ float*>(p_tensor->buffer.addr) + p_tensor->start_offset;
- 
-         using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
-         using DynStridDim5 = pto::Stride<1, 1, 1, TILE, 1>;
-         using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
-         using TileData = Tile<TileType::Vec, float, TILE, TILE, BLayout::RowMajor, -1, -1>;
- 
-         TileData cTile(TILE, TILE);
-         TileData pTile(TILE, TILE);
-         TileData outTile(TILE, TILE);
-         TASSIGN(cTile, 0x0);
-         TASSIGN(pTile, 0x10000);
-         TASSIGN(outTile, 0x20000);
- 
-         GlobalData cGlobal(c_ptr);
-         GlobalData pGlobal(p_ptr);
-         GlobalData outGlobal(c_ptr);  // write back to same C location
- 
-         TLOAD(cTile, cGlobal);
-         TLOAD(pTile, pGlobal);
-         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-         TADD(outTile, cTile, pTile);
-         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-         TSTORE(outGlobal, outTile);
- 
-         set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-         wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-     }
- }
- 
- // =============================================================================
- // Hardware: MixedKernels with TPUSH/TPOP via VEC_FIFO
- // =============================================================================
- #else  // !__CPU_SIM
- 
- #define VEC_CORES 2
- constexpr int VEC_M = M / VEC_CORES;  // each vector sub-core handles half the rows
- 
- // TPUSH/TPOP pipe configuration
- constexpr uint16_t PP_FLAG_ID = 0;
- constexpr uint8_t PP_FIFO_DEPTH = 2;
- 
- // Cube accumulator (full M×N tile in L0C)
- using AccTileT = TileAcc<float, M, N, M, N>;
- // Vector consumer tile (half tile: VEC_M×N in UB, split across 2 vector sub-cores)
- using VecFifoTileT = Tile<TileType::Vec, float, VEC_M, N, BLayout::RowMajor, VEC_M, N>;
- 
- // Cube→Vector pipe via on-chip VEC_FIFO (bypasses global memory)
- using PipeT = TPipe<PP_FLAG_ID, Direction::DIR_C2V, sizeof(float) * VEC_M * N, PP_FIFO_DEPTH>;
- 
- extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-     __gm__ Tensor* input_a_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
-     __gm__ Tensor* input_b_tensor = reinterpret_cast<__gm__ Tensor*>(args[1]);
-     __gm__ Tensor* c_tensor       = reinterpret_cast<__gm__ Tensor*>(args[2]);
- 
-     // Pipe and FIFO tile are declared in common scope (both sides reference the type)
-     VecFifoTileT vecFifoTile;
-     PipeT mPipe((__gm__ void *)(uint64_t)0x0, (uint32_t)0x0, (uint32_t)0x0);
- 
-     // =========================================================================
-     // Cube side: TLOAD A,B → TMATMUL → TPUSH result to vector via VEC_FIFO
-     // =========================================================================
-     if constexpr (DAV_CUBE) {
-         __gm__ float* input_a = reinterpret_cast<__gm__ float*>(input_a_tensor->buffer.addr)
-                                 + input_a_tensor->start_offset;
-         __gm__ float* input_b = reinterpret_cast<__gm__ float*>(input_b_tensor->buffer.addr)
-                                 + input_b_tensor->start_offset;
- 
-         using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, M, K>,
-             pto::Stride<M * K, M * K, M * K, K, 1>>;
-         using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, K, N>,
-             pto::Stride<K * N, K * N, K * N, N, 1>>;
- 
-         GlobalDataA src0Global(input_a);
-         GlobalDataB src1Global(input_b);
- 
-         using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
-         using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
-         using LeftTile = TileLeft<float, M, K, M, K>;
-         using RightTile = TileRight<float, K, N, K, N>;
- 
-         TileMatA aMatTile;
-         TileMatB bMatTile;
-         TASSIGN(aMatTile, 0x0);
-         TASSIGN(bMatTile, 0x20000);
- 
-         LeftTile aTile;
-         RightTile bTile;
-         AccTileT accTile;
-         TASSIGN(aTile, 0x0);
-         TASSIGN(bTile, 0x0);
-         TASSIGN(accTile, 0x0);
- 
-         // Load A and B from GM to L1
-         TLOAD(aMatTile, src0Global);
-         TLOAD(bMatTile, src1Global);
- 
-         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
-         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
- 
-         // Move from L1 to L0A/L0B
-         TMOV(aTile, aMatTile);
-         TMOV(bTile, bMatTile);
- 
-         set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
-         wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
- 
-         // Matrix multiply
-         TMATMUL(accTile, aTile, bTile);
- 
-         set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-         wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
- 
-         // Push result directly to vector core's UB (replaces TSTORE to GM)
-         TPUSH<PipeT, AccTileT, TileSplitAxis::TILE_UP_DOWN>(mPipe, accTile);
-     }
- 
-     // =========================================================================
-     // Vector side: TPOP result from cube → TLOAD C from GM → TADD → TSTORE
-     // =========================================================================
-     if constexpr (DAV_VEC) {
-         uint32_t subBlockIdx = get_subblockid();
- 
-         __gm__ float* c_ptr = reinterpret_cast<__gm__ float*>(c_tensor->buffer.addr)
-                               + c_tensor->start_offset;
-         // Each vector sub-core handles its half: sub-core 0 → rows [0, VEC_M),
-         //                                       sub-core 1 → rows [VEC_M, M)
-         __gm__ float* c_sub = c_ptr + static_cast<size_t>(subBlockIdx) * VEC_M * N;
- 
-         using GlobalC = GlobalTensor<float, Shape<1, 1, 1, VEC_M, N>,
-             pto::Stride<VEC_M * N, VEC_M * N, VEC_M * N, N, 1>>;
- 
-         GlobalC cGlobal(c_sub);
-         GlobalC outGlobal(c_sub);  // write back to same location
- 
-         using VecTile = Tile<TileType::Vec, float, VEC_M, N, BLayout::RowMajor, VEC_M, N>;
- 
-         VecTile cTile;
-         VecTile outTile;
-         // Place after FIFO buffer: FIFO uses [0x0, FIFO_DEPTH * VEC_M * N * 4)
-         // = [0x0, 2 * 32 * 64 * 4) = [0x0, 0x4000)
-         TASSIGN(cTile, 0x4000);
-         TASSIGN(outTile, 0x6000);
- 
-         // Pop matmul result from cube via VEC_FIFO (replaces TLOAD from GM)
-         TPOP<PipeT, VecFifoTileT, TileSplitAxis::TILE_UP_DOWN>(mPipe, vecFifoTile);
- 
-         // Load current C tile from GM
-         TLOAD(cTile, cGlobal);
- 
-         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
- 
-         // Accumulate: C += P
-         TADD(outTile, cTile, vecFifoTile);
-         TFREE<PipeT, TileSplitAxis::TILE_UP_DOWN>(mPipe);
- 
-         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
- 
-         // Store result back to GM
-         TSTORE(outGlobal, outTile);
-     }
- }
- 
- #endif  // __CPU_SIM
- 
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#ifndef __CPU_SIM
+#include <pto/common/fifo.hpp>
+#endif
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#ifdef __DAV_CUBE__
+constexpr bool DAV_CUBE = true;
+#else
+constexpr bool DAV_CUBE = false;
+#endif
+
+#ifdef __DAV_VEC__
+constexpr bool DAV_VEC = true;
+#else
+constexpr bool DAV_VEC = false;
+#endif
+
+// Tile dimensions (must match golden.py)
+constexpr int TILE = 64;
+constexpr int M = TILE;
+constexpr int K = TILE;
+constexpr int N = TILE;
+
+// =============================================================================
+// Simulation: separate AIC/AIV tasks with GM intermediate (no TPUSH/TPOP)
+// =============================================================================
+#ifdef __CPU_SIM
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    // AIC path: args = [A (input), B (input), P (output)]
+    if constexpr (DAV_CUBE) {
+        __gm__ Tensor *input_a_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+        __gm__ Tensor *input_b_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+        __gm__ Tensor *output_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+
+        __gm__ float *input_a =
+            reinterpret_cast<__gm__ float *>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
+        __gm__ float *input_b =
+            reinterpret_cast<__gm__ float *>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
+        __gm__ float *output =
+            reinterpret_cast<__gm__ float *>(output_tensor->buffer.addr) + output_tensor->start_offset;
+
+        using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
+        using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, N, 1>>;
+        using GlobalDataC = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
+
+        GlobalDataA src0Global(input_a);
+        GlobalDataB src1Global(input_b);
+        GlobalDataC dstGlobal(output);
+
+        using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+        using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
+        using LeftTile = TileLeft<float, M, K, M, K>;
+        using RightTile = TileRight<float, K, N, K, N>;
+        using AccTile = TileAcc<float, M, N, M, N>;
+
+        TileMatA aMatTile;
+        TileMatB bMatTile;
+        TASSIGN(aMatTile, 0x0);
+        TASSIGN(bMatTile, 0x20000);
+
+        LeftTile aTile;
+        RightTile bTile;
+        AccTile cTile;
+        TASSIGN(aTile, 0x0);
+        TASSIGN(bTile, 0x0);
+        TASSIGN(cTile, 0x0);
+
+        TLOAD(aMatTile, src0Global);
+        TLOAD(bMatTile, src1Global);
+
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+        TMOV(aTile, aMatTile);
+        TMOV(bTile, bMatTile);
+
+        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+        TMATMUL(cTile, aTile, bTile);
+
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+        TSTORE(dstGlobal, cTile);
+
+        set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+        wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    }
+
+    // AIV path: args = [C (inout), P (input)]
+    if constexpr (DAV_VEC) {
+        __gm__ Tensor *c_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+        __gm__ Tensor *p_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+
+        __gm__ float *c_ptr = reinterpret_cast<__gm__ float *>(c_tensor->buffer.addr) + c_tensor->start_offset;
+        __gm__ float *p_ptr = reinterpret_cast<__gm__ float *>(p_tensor->buffer.addr) + p_tensor->start_offset;
+
+        using DynShapeDim5 = Shape<1, 1, 1, TILE, TILE>;
+        using DynStridDim5 = pto::Stride<1, 1, 1, TILE, 1>;
+        using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+        using TileData = Tile<TileType::Vec, float, TILE, TILE, BLayout::RowMajor, -1, -1>;
+
+        TileData cTile(TILE, TILE);
+        TileData pTile(TILE, TILE);
+        TileData outTile(TILE, TILE);
+        TASSIGN(cTile, 0x0);
+        TASSIGN(pTile, 0x10000);
+        TASSIGN(outTile, 0x20000);
+
+        GlobalData cGlobal(c_ptr);
+        GlobalData pGlobal(p_ptr);
+        GlobalData outGlobal(c_ptr);  // write back to same C location
+
+        TLOAD(cTile, cGlobal);
+        TLOAD(pTile, pGlobal);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        TADD(outTile, cTile, pTile);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(outGlobal, outTile);
+
+        set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+        wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    }
+}
+
+// =============================================================================
+// Hardware: MixedKernels with TPUSH/TPOP via VEC_FIFO
+// =============================================================================
+#else  // !__CPU_SIM
+
+#define VEC_CORES 2
+constexpr int VEC_M = M / VEC_CORES;  // each vector sub-core handles half the rows
+
+// TPUSH/TPOP pipe configuration
+constexpr uint16_t PP_FLAG_ID = 0;
+constexpr uint8_t PP_FIFO_DEPTH = 2;
+
+// Cube accumulator (full M×N tile in L0C)
+using AccTileT = TileAcc<float, M, N, M, N>;
+// Vector consumer tile (half tile: VEC_M×N in UB, split across 2 vector sub-cores)
+using VecFifoTileT = Tile<TileType::Vec, float, VEC_M, N, BLayout::RowMajor, VEC_M, N>;
+
+// Cube→Vector pipe via on-chip VEC_FIFO (bypasses global memory)
+using PipeT = TPipe<PP_FLAG_ID, Direction::DIR_C2V, sizeof(float) * VEC_M * N, PP_FIFO_DEPTH>;
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_a_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *input_b_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *c_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+
+    // Pipe and FIFO tile are declared in common scope (both sides reference the type)
+    VecFifoTileT vecFifoTile;
+    PipeT mPipe((__gm__ void *)(uint64_t)0x0, (uint32_t)0x0, (uint32_t)0x0);
+
+    // =========================================================================
+    // Cube side: TLOAD A,B → TMATMUL → TPUSH result to vector via VEC_FIFO
+    // =========================================================================
+    if constexpr (DAV_CUBE) {
+        __gm__ float *input_a =
+            reinterpret_cast<__gm__ float *>(input_a_tensor->buffer.addr) + input_a_tensor->start_offset;
+        __gm__ float *input_b =
+            reinterpret_cast<__gm__ float *>(input_b_tensor->buffer.addr) + input_b_tensor->start_offset;
+
+        using GlobalDataA = GlobalTensor<float, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
+        using GlobalDataB = GlobalTensor<float, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, N, 1>>;
+
+        GlobalDataA src0Global(input_a);
+        GlobalDataB src1Global(input_b);
+
+        using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+        using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
+        using LeftTile = TileLeft<float, M, K, M, K>;
+        using RightTile = TileRight<float, K, N, K, N>;
+
+        TileMatA aMatTile;
+        TileMatB bMatTile;
+        TASSIGN(aMatTile, 0x0);
+        TASSIGN(bMatTile, 0x20000);
+
+        LeftTile aTile;
+        RightTile bTile;
+        AccTileT accTile;
+        TASSIGN(aTile, 0x0);
+        TASSIGN(bTile, 0x0);
+        TASSIGN(accTile, 0x0);
+
+        // Load A and B from GM to L1
+        TLOAD(aMatTile, src0Global);
+        TLOAD(bMatTile, src1Global);
+
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+        // Move from L1 to L0A/L0B
+        TMOV(aTile, aMatTile);
+        TMOV(bTile, bMatTile);
+
+        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+        // Matrix multiply
+        TMATMUL(accTile, aTile, bTile);
+
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+        // Push result directly to vector core's UB (replaces TSTORE to GM)
+        TPUSH<PipeT, AccTileT, TileSplitAxis::TILE_UP_DOWN>(mPipe, accTile);
+    }
+
+    // =========================================================================
+    // Vector side: TPOP result from cube → TLOAD C from GM → TADD → TSTORE
+    // =========================================================================
+    if constexpr (DAV_VEC) {
+        uint32_t subBlockIdx = get_subblockid();
+
+        __gm__ float *c_ptr = reinterpret_cast<__gm__ float *>(c_tensor->buffer.addr) + c_tensor->start_offset;
+        // Each vector sub-core handles its half: sub-core 0 → rows [0, VEC_M),
+        //                                       sub-core 1 → rows [VEC_M, M)
+        __gm__ float *c_sub = c_ptr + static_cast<size_t>(subBlockIdx) * VEC_M * N;
+
+        using GlobalC =
+            GlobalTensor<float, Shape<1, 1, 1, VEC_M, N>, pto::Stride<VEC_M * N, VEC_M * N, VEC_M * N, N, 1>>;
+
+        GlobalC cGlobal(c_sub);
+        GlobalC outGlobal(c_sub);  // write back to same location
+
+        using VecTile = Tile<TileType::Vec, float, VEC_M, N, BLayout::RowMajor, VEC_M, N>;
+
+        VecTile cTile;
+        VecTile outTile;
+        // Place after FIFO buffer: FIFO uses [0x0, FIFO_DEPTH * VEC_M * N * 4)
+        // = [0x0, 2 * 32 * 64 * 4) = [0x0, 0x4000)
+        TASSIGN(cTile, 0x4000);
+        TASSIGN(outTile, 0x6000);
+
+        // Pop matmul result from cube via VEC_FIFO (replaces TLOAD from GM)
+        TPOP<PipeT, VecFifoTileT, TileSplitAxis::TILE_UP_DOWN>(mPipe, vecFifoTile);
+
+        // Load current C tile from GM
+        TLOAD(cTile, cGlobal);
+
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // Accumulate: C += P
+        TADD(outTile, cTile, vecFifoTile);
+        TFREE<PipeT, TileSplitAxis::TILE_UP_DOWN>(mPipe);
+
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+        // Store result back to GM
+        TSTORE(outGlobal, outTile);
+    }
+}
+
+#endif  // __CPU_SIM

--- a/tests/st/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -53,16 +53,16 @@ static constexpr uint32_t TILE_ELEMS = TILE * TILE;  // 4096 elements
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 
@@ -80,7 +80,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
             for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
                 PTO2_SCOPE() {
                     uint32_t c_elem_offset = (static_cast<uint32_t>(batch) * GRID_M * GRID_N +
-                                                 static_cast<uint32_t>(m_idx) * GRID_N + static_cast<uint32_t>(n_idx)) *
+                                              static_cast<uint32_t>(m_idx) * GRID_N + static_cast<uint32_t>(n_idx)) *
                                              TILE_ELEMS;
                     uint32_t c_view_offsets[1] = {c_elem_offset};
                     Tensor C_view = ext_C.view(tile_shapes, c_view_offsets);
@@ -88,11 +88,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     for (int k_idx = 0; k_idx < GRID_K; k_idx++) {
                         uint32_t a_elem_offset =
                             (static_cast<uint32_t>(batch) * GRID_M * GRID_K + static_cast<uint32_t>(m_idx) * GRID_K +
-                                static_cast<uint32_t>(k_idx)) *
+                             static_cast<uint32_t>(k_idx)) *
                             TILE_ELEMS;
                         uint32_t b_elem_offset =
                             (static_cast<uint32_t>(batch) * GRID_K * GRID_N + static_cast<uint32_t>(k_idx) * GRID_N +
-                                static_cast<uint32_t>(n_idx)) *
+                             static_cast<uint32_t>(n_idx)) *
                             TILE_ELEMS;
 
                         uint32_t a_view_offsets[1] = {a_elem_offset};
@@ -117,11 +117,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         }
     }
 
-    LOG_INFO("[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each",
-        BATCH,
-        GRID_M,
-        GRID_N,
-        GRID_K);
+    LOG_INFO(
+        "[bgemm_orch] Submitted tasks for %d batches, %dx%d output tiles, %d K steps each", BATCH, GRID_M, GRID_N,
+        GRID_K
+    );
 }
 
 }  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_hub.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Supports two tile configurations via runtime dispatch:
@@ -24,10 +34,10 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __gm__ Tensor* oi) {
-    __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
-    __gm__ bfloat16_t* vj_addr = reinterpret_cast<__gm__ bfloat16_t*>(vj->buffer.addr);
-    __gm__ float* oi_addr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
+static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __gm__ Tensor *oi) {
+    __gm__ bfloat16_t *pij_addr = reinterpret_cast<__gm__ bfloat16_t *>(pij->buffer.addr);
+    __gm__ bfloat16_t *vj_addr = reinterpret_cast<__gm__ bfloat16_t *>(vj->buffer.addr);
+    __gm__ float *oi_addr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
 
     // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
@@ -61,9 +71,9 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
 
     // Load pij and vj to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, pijGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, vjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
@@ -87,10 +97,10 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor* pij, __gm__ Tensor* vj, __g
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* vj = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *vj = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(pij->shapes[0]);
     // args[4] = block_size, args[5] = head_dim
 

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Supports two tile configurations via runtime dispatch:
@@ -24,10 +34,10 @@ using namespace pto;
 #endif
 
 template <int M, int K, int N>
-static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm__ Tensor* sij) {
-    __gm__ bfloat16_t* qi_addr = reinterpret_cast<__gm__ bfloat16_t*>(qi->buffer.addr);
-    __gm__ bfloat16_t* kj_addr = reinterpret_cast<__gm__ bfloat16_t*>(kj->buffer.addr);
-    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
+static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm__ Tensor *sij) {
+    __gm__ bfloat16_t *qi_addr = reinterpret_cast<__gm__ bfloat16_t *>(qi->buffer.addr);
+    __gm__ bfloat16_t *kj_addr = reinterpret_cast<__gm__ bfloat16_t *>(kj->buffer.addr);
+    __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
 
     // qi (M, K) bf16 in ND (row-major) layout
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
@@ -62,9 +72,9 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
 
     // Load A and B to L1 with separate events for pipeline overlap
     TLOAD(aMatTile, qiGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);     // A load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // A load done
     TLOAD(bMatTile, kjGlobal);
-    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);     // B load done
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // B load done
 
     // Move A to L0A as soon as A load completes (B may still be loading)
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
@@ -88,10 +98,10 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor* qi, __gm__ Tensor* kj, __gm
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* qi = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* kj = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *qi = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *kj = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *sij = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
     // args[4] = head_dim (128), args[5] = block_size
 

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_hub.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Operates on full tiles where M=q_tile_size, N=head_dim (128):
@@ -26,22 +36,17 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ Tensor* mij,
-    __gm__ Tensor* lij,
-    __gm__ Tensor* oi_new,
-    __gm__ Tensor* mi,
-    __gm__ Tensor* li,
-    __gm__ Tensor* oi,
-    uint64_t is_first,
-    uint64_t is_last,
-    __gm__ Tensor* dst) {
-    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
-    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
-    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
-    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
-    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+static __aicore__ void online_update_impl(
+    __gm__ Tensor *mij, __gm__ Tensor *lij, __gm__ Tensor *oi_new, __gm__ Tensor *mi, __gm__ Tensor *li,
+    __gm__ Tensor *oi, uint64_t is_first, uint64_t is_last, __gm__ Tensor *dst
+) {
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi->buffer.addr);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li->buffer.addr);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst->buffer.addr);
 
     // Aligned rows for ColMajor DN tiles (32-byte alignment)
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
@@ -126,7 +131,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to the same UB as DN tiles for storing as ND format
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);           // alias same UB as mijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
         TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,14 +178,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TMAX(miNewRow, miRow, mijRow);     // mi_new = max(mi, mij)
+        TSUB(alphaRow, miRow, miNewRow);   // alpha_exp = mi - mi_new
+        TEXP(alphaRow, alphaRow);          // alpha = exp(mi - mi_new)
+        TSUB(betaRow, mijRow, miNewRow);   // beta_exp = mij - mi_new
+        TEXP(betaRow, betaRow);            // beta = exp(mij - mi_new)
+        TMUL(tmpRow, alphaRow, liRow);     // alpha * li
+        TMUL(liNewRow, betaRow, lijRow);   // beta * lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         TRESHAPE(alphaDN, alphaRow);
@@ -188,7 +193,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
 
         // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
@@ -203,15 +208,15 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }
@@ -219,14 +224,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mi = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* li = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* oi = reinterpret_cast<__gm__ Tensor*>(args[5]);
-    __gm__ Tensor* dst = reinterpret_cast<__gm__ Tensor*>(args[6]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mi = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *li = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *oi = reinterpret_cast<__gm__ Tensor *>(args[5]);
+    __gm__ Tensor *dst = reinterpret_cast<__gm__ Tensor *>(args[6]);
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Softmax Preparation Kernel (AIV) with partial block masking
 //
 // Operates on (M, N) tile where M=q_tile_size, N=block_size:
@@ -31,16 +41,14 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
-    float scale_value,
-    __gm__ Tensor* pij,
-    __gm__ Tensor* mij,
-    __gm__ Tensor* lij) {
+static __aicore__ void softmax_prepare_impl(
+    __gm__ Tensor *sij, float scale_value, __gm__ Tensor *pij, __gm__ Tensor *mij, __gm__ Tensor *lij
+) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
-    __gm__ float* sij_addr = reinterpret_cast<__gm__ float*>(sij->buffer.addr);
-    __gm__ bfloat16_t* pij_addr = reinterpret_cast<__gm__ bfloat16_t*>(pij->buffer.addr);
-    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
+    __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
+    __gm__ bfloat16_t *pij_addr = reinterpret_cast<__gm__ bfloat16_t *>(pij->buffer.addr);
+    __gm__ float *mij_addr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_addr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -97,12 +105,12 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     TEXP(pijTile, pijTile);
     // Truncate pij to bf16 first
     TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);        // pij bf16 ready, can store early
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);  // pij bf16 ready, can store early
 
     // Continue computing: bf16 → f32 and rowsum while pij store proceeds in parallel
     TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
     TROWSUM(sumTile, pijTile, tmpTile);
-    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);        // sum ready
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);  // sum ready
 
     // Store pij (overlaps with TCVT + TROWSUM above)
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -117,11 +125,11 @@ static __aicore__ void softmax_prepare_impl(__gm__ Tensor* sij,
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* sij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* pij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[3]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *sij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[3]);
     union {
         uint64_t u;
         float f;

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -56,16 +56,16 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
     uint64_t prof_param_extract = 0;
@@ -100,18 +100,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     LOG_ALWAYS(">>>>>> batch = %" PRIu64, batch);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void* query_ptr = orch_args.tensor(0).data_as<void>();
-    void* kc_ptr = orch_args.tensor(1).data_as<void>();
-    void* vc_ptr = orch_args.tensor(2).data_as<void>();
-    void* out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).data_as<void>();
+    void *out_ptr = orch_args.tensor(5).data_as<void>();
 
     uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t value_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t out_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type);
     Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type);
@@ -119,8 +121,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
     CYCLE_COUNT_LAP(prof_ext_tensor);
 
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -157,9 +159,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 args_inplace.add_output(scalar_ci);
                 CYCLE_COUNT_LAP(prof_param_setup);
                 TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, args_inplace);
-                const Tensor& oi = hub_outs.get_ref(0);
-                const Tensor& li_update = hub_outs.get_ref(1);
-                const Tensor& mi_update = hub_outs.get_ref(2);
+                const Tensor &oi = hub_outs.get_ref(0);
+                const Tensor &li_update = hub_outs.get_ref(1);
+                const Tensor &mi_update = hub_outs.get_ref(2);
                 prof_submit_count++;
                 CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -183,7 +185,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     args_qk.add_output(sij_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, args_qk);
-                    const Tensor& sij = qk_outs.get_ref(0);
+                    const Tensor &sij = qk_outs.get_ref(0);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -201,9 +203,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     args_sf.add_scalar(scale_value);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, args_sf);
-                    const Tensor& pij_f16 = sf_outs.get_ref(0);
-                    const Tensor& mi = sf_outs.get_ref(1);
-                    const Tensor& li = sf_outs.get_ref(2);
+                    const Tensor &pij_f16 = sf_outs.get_ref(0);
+                    const Tensor &mi = sf_outs.get_ref(1);
+                    const Tensor &li = sf_outs.get_ref(2);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -213,7 +215,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     args_pv.add_output(tile2d_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, args_pv);
-                    const Tensor& oi_tmp = pv_outs.get_ref(0);
+                    const Tensor &oi_tmp = pv_outs.get_ref(0);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -243,35 +245,37 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
     uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
                      prof_submit_task + prof_scope;
-    LOG_ALWAYS("=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
-        prof_submit_count,
-        prof_make_count,
-        prof_view_count,
-        cycles_to_us(total));
+    LOG_ALWAYS(
+        "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===", prof_submit_count,
+        prof_make_count, prof_view_count, cycles_to_us(total)
+    );
     if (total > 0) {
-        LOG_ALWAYS("  param_extract    : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_extract),
-            prof_param_extract * 100.0 / total);
         LOG_ALWAYS(
-            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
-        LOG_ALWAYS("  create_info(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_make_count,
-            cycles_to_us(prof_make_tensor),
+            "  param_extract    : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_extract),
+            prof_param_extract * 100.0 / total
+        );
+        LOG_ALWAYS(
+            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total
+        );
+        LOG_ALWAYS(
+            "  create_info(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_make_count, cycles_to_us(prof_make_tensor),
             prof_make_tensor * 100.0 / total,
-            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
-        LOG_ALWAYS("  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_view_count,
-            cycles_to_us(prof_tensor_view),
-            prof_tensor_view * 100.0 / total,
-            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
+            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0
+        );
         LOG_ALWAYS(
-            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
+            "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_view_count, cycles_to_us(prof_tensor_view),
+            prof_tensor_view * 100.0 / total,
+            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0
+        );
+        LOG_ALWAYS(
+            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total
+        );
         LOG_ALWAYS("  scope            : %7.3fus (%5.1f%%)", cycles_to_us(prof_scope), prof_scope * 100.0 / total);
-        LOG_ALWAYS("  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_submit_count,
-            cycles_to_us(prof_submit_task),
+        LOG_ALWAYS(
+            "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_submit_count, cycles_to_us(prof_submit_task),
             prof_submit_task * 100.0 / total,
-            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
+            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0
+        );
     }
 
 #undef CYCLE_COUNT_START

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_hub.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // SplitK PV Matmul Kernel: Accumulated P @ V across n_blocks
 //
 // Processes n_blocks blocks using SplitK accumulation pattern:
@@ -39,12 +49,9 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void pv_matmul_n_impl(
-    __gm__ bfloat16_t* pij_base,
-    __gm__ bfloat16_t* val_base,
-    __gm__ float* oi_base,
-    uint64_t n_blocks,
-    __gm__ int32_t* block_table) {
-
+    __gm__ bfloat16_t *pij_base, __gm__ bfloat16_t *val_base, __gm__ float *oi_base, uint64_t n_blocks,
+    __gm__ int32_t *block_table
+) {
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, N, 1>>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
@@ -96,9 +103,9 @@ static __aicore__ void pv_matmul_n_impl(
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
         wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
         TLOAD(aMatTile[cur], pijGlobal);
-        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);   // forward: A in L1 ready
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: A in L1 ready
         TLOAD(bMatTile[cur], vjGlobal);
-        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);   // forward: B in L1 ready
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: B in L1 ready
 
         // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
         // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
@@ -107,17 +114,17 @@ static __aicore__ void pv_matmul_n_impl(
         TMOV(aTile[cur], aMatTile[cur]);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
         TMOV(bTile[cur], bMatTile[cur]);
-        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur); // reverse: release L1[cur]
+        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);  // reverse: release L1[cur]
 
         // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
-        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);   // forward: L0[cur] ready
+        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);  // forward: L0[cur] ready
         wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
         if (i == 0) {
             TMATMUL(cTile, aTile[cur], bTile[cur]);
         } else {
             TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
         }
-        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);   // reverse: release L0[cur]
+        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);  // reverse: release L0[cur]
     }
 
     // Drain outstanding reverse-dependency flags
@@ -134,16 +141,16 @@ static __aicore__ void pv_matmul_n_impl(
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* pij_buf = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* value_cache = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *pij_buf = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *value_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t n_blocks = static_cast<uint64_t>(args[3]);
-    __gm__ int32_t* block_table = reinterpret_cast<__gm__ int32_t*>(args[4]);
+    __gm__ int32_t *block_table = reinterpret_cast<__gm__ int32_t *>(args[4]);
 
-    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_buf->buffer.addr) + pij_buf->start_offset;
-    __gm__ bfloat16_t* val_base = reinterpret_cast<__gm__ bfloat16_t*>(value_cache->buffer.addr);
-    __gm__ float* oi_base = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr) + oi_new->start_offset;
+    __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_buf->buffer.addr) + pij_buf->start_offset;
+    __gm__ bfloat16_t *val_base = reinterpret_cast<__gm__ bfloat16_t *>(value_cache->buffer.addr);
+    __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr) + oi_new->start_offset;
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
 

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Multi-block QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N) for each block
 //
 // Processes n_blocks blocks in a single kernel invocation.
@@ -33,12 +43,9 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void qk_matmul_n_impl(
-    __gm__ bfloat16_t* qi_base,
-    __gm__ bfloat16_t* key_base,
-    __gm__ float* sij_base,
-    uint64_t n_blocks,
-    __gm__ int32_t* block_table) {
-
+    __gm__ bfloat16_t *qi_base, __gm__ bfloat16_t *key_base, __gm__ float *sij_base, uint64_t n_blocks,
+    __gm__ int32_t *block_table
+) {
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, pto::Stride<M * N, M * N, M * N, N, 1>>;
@@ -98,16 +105,16 @@ static __aicore__ void qk_matmul_n_impl(
     wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* qi = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* key_cache = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* sij_buf = reinterpret_cast<__gm__ Tensor*>(args[2]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *qi = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *key_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *sij_buf = reinterpret_cast<__gm__ Tensor *>(args[2]);
     uint64_t n_blocks = static_cast<uint64_t>(args[3]);
-    __gm__ int32_t* block_table = reinterpret_cast<__gm__ int32_t*>(args[4]);
+    __gm__ int32_t *block_table = reinterpret_cast<__gm__ int32_t *>(args[4]);
 
-    __gm__ bfloat16_t* qi_base = reinterpret_cast<__gm__ bfloat16_t*>(qi->buffer.addr) + qi->start_offset;
-    __gm__ bfloat16_t* key_base = reinterpret_cast<__gm__ bfloat16_t*>(key_cache->buffer.addr);
-    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_buf->buffer.addr) + sij_buf->start_offset;
+    __gm__ bfloat16_t *qi_base = reinterpret_cast<__gm__ bfloat16_t *>(qi->buffer.addr) + qi->start_offset;
+    __gm__ bfloat16_t *key_base = reinterpret_cast<__gm__ bfloat16_t *>(key_cache->buffer.addr);
+    __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_buf->buffer.addr) + sij_buf->start_offset;
 
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
 

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_hub.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_hub.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
@@ -15,4 +25,4 @@ constexpr int M = 16;
 constexpr int K = 16;
 constexpr int N = 16;
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {}
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {}

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
 // Operates on full tiles where M=q_tile_size, N=head_dim (128):
@@ -26,22 +36,17 @@ using namespace pto;
 #endif
 
 template <int M, int N>
-static __aicore__ void online_update_impl(__gm__ Tensor* mij,
-    __gm__ Tensor* lij,
-    __gm__ Tensor* oi_new,
-    __gm__ Tensor* mi,
-    __gm__ Tensor* li,
-    __gm__ Tensor* oi,
-    uint64_t is_first,
-    uint64_t is_last,
-    __gm__ Tensor* dst) {
-    __gm__ float* mij_ptr = reinterpret_cast<__gm__ float*>(mij->buffer.addr);
-    __gm__ float* lij_ptr = reinterpret_cast<__gm__ float*>(lij->buffer.addr);
-    __gm__ float* oi_new_ptr = reinterpret_cast<__gm__ float*>(oi_new->buffer.addr);
-    __gm__ float* mi_ptr = reinterpret_cast<__gm__ float*>(mi->buffer.addr);
-    __gm__ float* li_ptr = reinterpret_cast<__gm__ float*>(li->buffer.addr);
-    __gm__ float* oi_ptr = reinterpret_cast<__gm__ float*>(oi->buffer.addr);
-    __gm__ float* dst_ptr = reinterpret_cast<__gm__ float*>(dst->buffer.addr);
+static __aicore__ void online_update_impl(
+    __gm__ Tensor *mij, __gm__ Tensor *lij, __gm__ Tensor *oi_new, __gm__ Tensor *mi, __gm__ Tensor *li,
+    __gm__ Tensor *oi, uint64_t is_first, uint64_t is_last, __gm__ Tensor *dst
+) {
+    __gm__ float *mij_ptr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
+    __gm__ float *lij_ptr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
+    __gm__ float *oi_new_ptr = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr);
+    __gm__ float *mi_ptr = reinterpret_cast<__gm__ float *>(mi->buffer.addr);
+    __gm__ float *li_ptr = reinterpret_cast<__gm__ float *>(li->buffer.addr);
+    __gm__ float *oi_ptr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
+    __gm__ float *dst_ptr = reinterpret_cast<__gm__ float *>(dst->buffer.addr);
 
     // Aligned rows for ColMajor DN tiles (32-byte alignment)
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
@@ -126,8 +131,8 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         // Store mi = mij, li = lij, oi = oi_new
         // Alias ND tiles to same UB as DN tiles for ND-format store
         TileScalarND mijND, lijND;
-        TASSIGN(mijND, 2 * kDataBytes);                    // alias same UB as mijDN
-        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);   // alias same UB as lijDN
+        TASSIGN(mijND, 2 * kDataBytes);                   // alias same UB as mijDN
+        TASSIGN(lijND, 2 * kDataBytes + kScalarDNBytes);  // alias same UB as lijDN
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -173,14 +178,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
         TASSIGN(liNewRow, 2 * kDataBytes + 7 * kScalarDNBytes);
         TASSIGN(tmpRow, 2 * kDataBytes + 8 * kScalarDNBytes);
 
-        TMAX(miNewRow, miRow, mijRow);        // mi_new = max(mi, mij)
-        TSUB(alphaRow, miRow, miNewRow);      // alpha_exp = mi - mi_new
-        TEXP(alphaRow, alphaRow);             // alpha = exp(mi - mi_new)
-        TSUB(betaRow, mijRow, miNewRow);      // beta_exp = mij - mi_new
-        TEXP(betaRow, betaRow);               // beta = exp(mij - mi_new)
-        TMUL(tmpRow, alphaRow, liRow);        // alpha * li
-        TMUL(liNewRow, betaRow, lijRow);      // beta * lij
-        TADD(liNewRow, tmpRow, liNewRow);     // li_new = alpha*li + beta*lij
+        TMAX(miNewRow, miRow, mijRow);     // mi_new = max(mi, mij)
+        TSUB(alphaRow, miRow, miNewRow);   // alpha_exp = mi - mi_new
+        TEXP(alphaRow, alphaRow);          // alpha = exp(mi - mi_new)
+        TSUB(betaRow, mijRow, miNewRow);   // beta_exp = mij - mi_new
+        TEXP(betaRow, betaRow);            // beta = exp(mij - mi_new)
+        TMUL(tmpRow, alphaRow, liRow);     // alpha * li
+        TMUL(liNewRow, betaRow, lijRow);   // beta * lij
+        TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
 
         // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for TROWEXPANDMUL
         TRESHAPE(alphaDN, alphaRow);
@@ -188,7 +193,7 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
 
         // Scale data tiles using row-broadcast multiply
         TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
-        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);   // oi_new *= beta
+        TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         TADD(oiTile, oiTile, oiNewTile);              // oi = alpha*oi + beta*oi_new
 
         // Store mi_new and li_new to GM (ND format)
@@ -203,15 +208,15 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
             TROWEXPANDDIV(oiTile, oiTile, liNewDN);
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(dstGlobal, oiTile);
         } else {
             // Store updated accumulators
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-            TSTORE(miGlobalND, miNewND);   // persist mi_new
-            TSTORE(liGlobalND, liNewND);   // persist li_new
+            TSTORE(miGlobalND, miNewND);  // persist mi_new
+            TSTORE(liGlobalND, liNewND);  // persist li_new
             TSTORE(oiGlobal, oiTile);
         }
     }
@@ -219,14 +224,14 @@ static __aicore__ void online_update_impl(__gm__ Tensor* mij,
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* oi_new = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* mi = reinterpret_cast<__gm__ Tensor*>(args[3]);
-    __gm__ Tensor* li = reinterpret_cast<__gm__ Tensor*>(args[4]);
-    __gm__ Tensor* oi = reinterpret_cast<__gm__ Tensor*>(args[5]);
-    __gm__ Tensor* dst = reinterpret_cast<__gm__ Tensor*>(args[6]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mi = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *li = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *oi = reinterpret_cast<__gm__ Tensor *>(args[5]);
+    __gm__ Tensor *dst = reinterpret_cast<__gm__ Tensor *>(args[6]);
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 // Two-Pass Softmax Kernel (AIV) for n_blocks tiles
 //
 // Input:  sij_buf (n_blocks * M, N) fp32 — QK results stacked vertically
@@ -37,14 +47,9 @@ using namespace pto;
 
 template <int M, int N>
 static __aicore__ void softmax_prepare_n_impl(
-    __gm__ float* sij_base,
-    float scale_value,
-    __gm__ bfloat16_t* pij_base,
-    __gm__ float* mij_addr,
-    __gm__ float* lij_addr,
-    uint64_t n_blocks,
-    uint64_t valid_len_last) {
-
+    __gm__ float *sij_base, float scale_value, __gm__ bfloat16_t *pij_base, __gm__ float *mij_addr,
+    __gm__ float *lij_addr, uint64_t n_blocks, uint64_t valid_len_last
+) {
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
     constexpr int kScalarCols = 32 / sizeof(float);
     constexpr int kScalarRows = M / kScalarCols;
@@ -100,10 +105,10 @@ static __aicore__ void softmax_prepare_n_impl(
     TASSIGN(sumAccTile, 4 * kDataBytes);
     int scalarBase = 5 * kDataBytes;
     TASSIGN(localMaxDN, scalarBase);
-    TASSIGN(localMaxRow, scalarBase);                     // alias: same UB as localMaxDN
+    TASSIGN(localMaxRow, scalarBase);  // alias: same UB as localMaxDN
     TASSIGN(globalMaxDN, scalarBase + kScalarDNBytes);
-    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
-    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);    // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxRow, scalarBase + kScalarDNBytes);  // alias: same UB as globalMaxDN
+    TASSIGN(globalMaxND, scalarBase + kScalarDNBytes);   // alias: same UB as globalMaxDN
     TASSIGN(sumDN, scalarBase + 2 * kScalarDNBytes);
     TASSIGN(pijBf16Tile, scalarBase + 3 * kScalarDNBytes);
 
@@ -221,11 +226,11 @@ static __aicore__ void softmax_prepare_n_impl(
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
-extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-    __gm__ Tensor* sij_buf = reinterpret_cast<__gm__ Tensor*>(args[0]);
-    __gm__ Tensor* pij_buf = reinterpret_cast<__gm__ Tensor*>(args[1]);
-    __gm__ Tensor* mij = reinterpret_cast<__gm__ Tensor*>(args[2]);
-    __gm__ Tensor* lij = reinterpret_cast<__gm__ Tensor*>(args[3]);
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *sij_buf = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *pij_buf = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[3]);
     union {
         uint64_t u;
         float f;
@@ -235,10 +240,10 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
     uint64_t n_blocks = static_cast<uint64_t>(args[5]);
     uint64_t valid_len_last = static_cast<uint64_t>(args[6]);
 
-    __gm__ float* sij_base = reinterpret_cast<__gm__ float*>(sij_buf->buffer.addr) + sij_buf->start_offset;
-    __gm__ bfloat16_t* pij_base = reinterpret_cast<__gm__ bfloat16_t*>(pij_buf->buffer.addr) + pij_buf->start_offset;
-    __gm__ float* mij_addr = reinterpret_cast<__gm__ float*>(mij->buffer.addr) + mij->start_offset;
-    __gm__ float* lij_addr = reinterpret_cast<__gm__ float*>(lij->buffer.addr) + lij->start_offset;
+    __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_buf->buffer.addr) + sij_buf->start_offset;
+    __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_buf->buffer.addr) + pij_buf->start_offset;
+    __gm__ float *mij_addr = reinterpret_cast<__gm__ float *>(mij->buffer.addr) + mij->start_offset;
+    __gm__ float *lij_addr = reinterpret_cast<__gm__ float *>(lij->buffer.addr) + lij->start_offset;
 
     uint64_t q_tile_size = static_cast<uint64_t>(sij_buf->shapes[0]);
 

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -68,16 +68,16 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(
-    const ChipStorageTaskArgs& orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    const ChipStorageTaskArgs& orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
     (void)orch_thread_num;    // NOLINT(readability/casting)
     (void)orch_thread_index;  // NOLINT(readability/casting)
 #ifdef ENABLE_PROFILING
@@ -116,26 +116,28 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
     CYCLE_COUNT_LAP(prof_param_extract);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void* query_ptr = orch_args.tensor(0).data_as<void>();
-    void* kc_ptr = orch_args.tensor(1).data_as<void>();
-    void* vc_ptr = orch_args.tensor(2).data_as<void>();
-    void* out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).data_as<void>();
+    void *out_ptr = orch_args.tensor(5).data_as<void>();
 
     uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t value_cache_shapes[2] = {
-        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)};
+        static_cast<uint32_t>(total_blocks_count * block_size), static_cast<uint32_t>(head_dim)
+    };
     uint32_t out_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     Tensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type, false);
     Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type, false);
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
-    int* host_block_table = orch_args.tensor(3).data_as<int>();
-    int* host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_block_table = orch_args.tensor(3).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).data_as<int>();
 
 #ifdef ENABLE_PROFILING
     CYCLE_COUNT_LAP(prof_ext_tensor);
@@ -159,7 +161,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
         uint64_t cur_seq = host_context_lens[b_idx];
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         // Pre-compute block table base pointer for this batch
-        int* bt_base = host_block_table + b_idx * block_num;
+        int *bt_base = host_block_table + b_idx * block_num;
 
         // Prefetch next block host_context_lens data while processing current batch
         if (b_idx + 1 < batch) {
@@ -186,9 +188,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                 args_inplace.add_output(scalar_noinit_ci);
                 CYCLE_COUNT_LAP(prof_param_setup);
                 TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, args_inplace);
-                const Tensor& oi = hub_outs.get_ref(0);
-                const Tensor& li_update = hub_outs.get_ref(1);
-                const Tensor& mi_update = hub_outs.get_ref(2);
+                const Tensor &oi = hub_outs.get_ref(0);
+                const Tensor &li_update = hub_outs.get_ref(1);
+                const Tensor &mi_update = hub_outs.get_ref(2);
 #ifdef ENABLE_PROFILING
                 prof_submit_count++;
                 CYCLE_COUNT_LAP(prof_submit_task);
@@ -208,7 +210,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
                     // === Task 1: Batched QK matmul ===
                     uint32_t sij_buf_shapes[2] = {
-                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)};
+                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)
+                    };
                     TensorCreateInfo sij_buf_ci(sij_buf_shapes, 2, DataType::FLOAT32);
 #ifdef ENABLE_PROFILING
                     prof_make_count += 1;
@@ -223,7 +226,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     args_qk.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, args_qk);
-                    const Tensor& sij_buf = qk_outs.get_ref(0);
+                    const Tensor &sij_buf = qk_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -231,7 +234,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 
                     // === Task 2: Two-pass softmax over all blocks in group ===
                     uint32_t pij_buf_shapes[2] = {
-                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)};
+                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)
+                    };
                     TensorCreateInfo pij_buf_ci(pij_buf_shapes, 2, data_type);
 #ifdef ENABLE_PROFILING
                     prof_make_count += 1;
@@ -248,9 +252,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     args_sf.add_scalar(valid_len_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, args_sf);
-                    const Tensor& pij_buf = sf_outs.get_ref(0);
-                    const Tensor& mi = sf_outs.get_ref(1);
-                    const Tensor& li = sf_outs.get_ref(2);
+                    const Tensor &pij_buf = sf_outs.get_ref(0);
+                    const Tensor &mi = sf_outs.get_ref(1);
+                    const Tensor &li = sf_outs.get_ref(2);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -265,7 +269,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
                     args_pv.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, args_pv);
-                    const Tensor& oi_new = pv_outs.get_ref(0);
+                    const Tensor &oi_new = pv_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -301,37 +305,40 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(
 #ifdef ENABLE_PROFILING
     uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
                      prof_submit_task + prof_scope_and_loop;
-    LOG_ALWAYS("=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===",
-        prof_submit_count,
-        prof_make_count,
-        prof_view_count,
-        cycles_to_us(total));
+    LOG_ALWAYS(
+        "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===", prof_submit_count,
+        prof_make_count, prof_view_count, cycles_to_us(total)
+    );
     if (total > 0) {
-        LOG_ALWAYS("  param_extract    : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_param_extract),
-            prof_param_extract * 100.0 / total);
         LOG_ALWAYS(
-            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total);
-        LOG_ALWAYS("  create_info(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_make_count,
-            cycles_to_us(prof_make_tensor),
+            "  param_extract    : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_extract),
+            prof_param_extract * 100.0 / total
+        );
+        LOG_ALWAYS(
+            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total
+        );
+        LOG_ALWAYS(
+            "  create_info(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_make_count, cycles_to_us(prof_make_tensor),
             prof_make_tensor * 100.0 / total,
-            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0);
-        LOG_ALWAYS("  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_view_count,
-            cycles_to_us(prof_tensor_view),
-            prof_tensor_view * 100.0 / total,
-            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0);
+            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0
+        );
         LOG_ALWAYS(
-            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total);
-        LOG_ALWAYS("  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus",
-            prof_submit_count,
-            cycles_to_us(prof_submit_task),
+            "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_view_count, cycles_to_us(prof_tensor_view),
+            prof_tensor_view * 100.0 / total,
+            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0
+        );
+        LOG_ALWAYS(
+            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total
+        );
+        LOG_ALWAYS(
+            "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_submit_count, cycles_to_us(prof_submit_task),
             prof_submit_task * 100.0 / total,
-            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0);
-        LOG_ALWAYS("  scope_and_loop   : %7.3fus (%5.1f%%)",
-            cycles_to_us(prof_scope_and_loop),
-            prof_scope_and_loop * 100.0 / total);
+            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0
+        );
+        LOG_ALWAYS(
+            "  scope_and_loop   : %7.3fus (%5.1f%%)", cycles_to_us(prof_scope_and_loop),
+            prof_scope_and_loop * 100.0 / total
+        );
     }
 #endif
 


### PR DESCRIPTION
- Format all C++ files across examples/, src/, tests/ with clang-format
- Add clang-tidy pre-commit hook with per-target compile databases
- Add tests/lint/clang_tidy.py to drive per-target tidy checks
- Update CI and .pre-commit-config.yaml for new tidy integration