### PR TITLE
fix(tools): inject python/ into sys.path before loading kernel_config

### DIFF
--- a/tools/perf_to_mermaid.py
+++ b/tools/perf_to_mermaid.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 """
 Performance Data to Mermaid Diagram Converter
 
@@ -13,12 +21,13 @@ Usage:
     python3 perf_to_mermaid.py perf_swimlane_20260210_143526.json --style compact
 """
 
-import json
 import argparse
-import sys
-from pathlib import Path
-from datetime import datetime
 import importlib.util
+import json
+import sys
+import traceback
+from datetime import datetime
+from pathlib import Path
 
 
 def read_perf_data(filepath):
@@ -35,18 +44,18 @@ def read_perf_data(filepath):
     Raises:
         ValueError: If JSON format is invalid
     """
-    with open(filepath, 'r') as f:
+    with open(filepath) as f:
         data = json.load(f)
 
     # Validate required fields
-    required_fields = ['version', 'tasks']
+    required_fields = ["version", "tasks"]
     for field in required_fields:
         if field not in data:
             raise ValueError(f"Missing required field: {field}")
 
     # Validate version
-    if data['version'] != 1:
-        raise ValueError(f"Unsupported version: {data['version']} (expected 1)")
+    if data["version"] not in [1, 2]:
+        raise ValueError(f"Unsupported version: {data['version']} (expected 1 or 2)")
 
     return data
 
@@ -68,7 +77,13 @@ def load_kernel_config(config_path):
     if not config_path.exists():
         raise ValueError(f"Kernel config file not found: {config_path}")
 
-    # Load the Python module dynamically
+    # Load the Python module dynamically.
+    # kernel_config.py may import `task_interface` from the project's python/ directory,
+    # so ensure it's on sys.path before executing the module.
+    python_dir = str(Path(__file__).resolve().parent.parent / "python")
+    if python_dir not in sys.path:
+        sys.path.insert(0, python_dir)
+
     spec = importlib.util.spec_from_file_location("kernel_config", config_path)
     if spec is None or spec.loader is None:
         raise ValueError(f"Cannot load module from: {config_path}")
@@ -77,22 +92,25 @@ def load_kernel_config(config_path):
     spec.loader.exec_module(module)
 
     # Extract func_id to name mapping from KERNELS list
-    if not hasattr(module, 'KERNELS'):
-        raise ValueError(f"kernel_config.py missing KERNELS definition")
+    if not hasattr(module, "KERNELS"):
+        raise ValueError("kernel_config.py missing KERNELS definition")
 
     func_id_to_name = {}
     for kernel in module.KERNELS:
-        if 'func_id' not in kernel:
+        if "func_id" not in kernel:
             print(f"Warning: Kernel entry missing 'func_id', skipping: {kernel}", file=sys.stderr)
             continue
 
-        func_id = kernel['func_id']
+        func_id = kernel["func_id"]
 
-        if 'name' not in kernel:
-            print(f"Warning: Kernel entry for func_id={func_id} missing 'name', will use default naming", file=sys.stderr)
+        if "name" not in kernel:
+            print(
+                f"Warning: Kernel entry for func_id={func_id} missing 'name', will use default naming",
+                file=sys.stderr,
+            )
             continue
 
-        func_id_to_name[str(func_id)] = kernel['name']
+        func_id_to_name[str(func_id)] = kernel["name"]
 
     return func_id_to_name
 
@@ -121,8 +139,8 @@ def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", di
 
     # Generate node definitions
     for task in tasks:
-        task_id = task['task_id']
-        func_id = task['func_id']
+        task_id = task["task_id"]
+        func_id = task["func_id"]
 
         # Get function name
         if func_id_to_name and str(func_id) in func_id_to_name:
@@ -139,21 +157,21 @@ def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", di
             label = f"{func_name}({task_id})"
 
         # Node definition with label
-        lines.append(f"    Task{task_id}[\"{label}\"]")
+        lines.append(f'    Task{task_id}["{label}"]')
 
     lines.append("")
 
     # Generate edges (dependencies)
     for task in tasks:
-        task_id = task['task_id']
-        for succ_task_id in task['fanout']:
+        task_id = task["task_id"]
+        for succ_task_id in task["fanout"]:
             lines.append(f"    Task{task_id} --> Task{succ_task_id}")
 
     lines.append("")
 
     # Generate styling based on core_type using classDef and class
     # Build set of unique core_types
-    unique_core_types = set(task['core_type'] for task in tasks)
+    unique_core_types = set(task["core_type"] for task in tasks)
 
     # Define color palette for core types
     core_type_colors = {
@@ -173,7 +191,7 @@ def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", di
     # Apply classes to nodes
     for core_type in sorted(unique_core_types):
         # Find all tasks with this core_type
-        task_ids = [str(task['task_id']) for task in tasks if task['core_type'] == core_type]
+        task_ids = [str(task["task_id"]) for task in tasks if task["core_type"] == core_type]
         task_list = ",".join(f"Task{tid}" for tid in task_ids)
         lines.append(f"    class {task_list} {core_type}Style")
 
@@ -182,126 +200,149 @@ def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", di
     return "\n".join(lines)
 
 
-def main():
+def _build_parser():
     parser = argparse.ArgumentParser(
-        description='Convert swimlane performance JSON to Mermaid flowchart',
+        description="Convert swimlane performance JSON to Mermaid flowchart",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-示例：
-  %(prog)s                                       # 使用 outputs/ 中最新的 .json 文件
-  %(prog)s perf_swimlane_20260210_143526.json   # 输出：outputs/mermaid_diagram_20260210_143526.md
+Examples:
+  %(prog)s                                       # latest perf_swimlane_*.json under outputs/
+  %(prog)s perf_swimlane_20260210_143526.json   # -> outputs/mermaid_diagram_20260210_143526.md
   %(prog)s perf_swimlane_20260210_143526.json -o custom_diagram.md
   %(prog)s perf_swimlane_20260210_143526.json -k kernel_config.py
   %(prog)s perf_swimlane_20260210_143526.json --style compact
   %(prog)s perf_swimlane_20260210_143526.json -v
 
-生成的 Mermaid 图可以：
-  1. 直接在 GitHub/GitLab Markdown 中渲染
-  2. 在 https://mermaid.live/ 中可视化
-  3. 在支持 Mermaid 的编辑器中查看（如 VS Code + Mermaid 插件）
-        """
+View the Mermaid diagram:
+  1. GitHub/GitLab Markdown preview
+  2. https://mermaid.live/
+  3. Editors with a Mermaid extension (e.g. VS Code)
+        """,
     )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        help="Input JSON (.json). If omitted, use the newest perf_swimlane_*.json under outputs/",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output Markdown path (default: outputs/mermaid_diagram_<timestamp>.md)",
+    )
+    parser.add_argument(
+        "-k",
+        "--kernel-config",
+        help="Path to kernel_config.py for func_id -> name mapping",
+    )
+    parser.add_argument(
+        "--style",
+        choices=["detailed", "compact"],
+        default="detailed",
+        help="Node detail: detailed (full) or compact (minimal)",
+    )
+    parser.add_argument(
+        "--direction",
+        choices=["TD", "LR"],
+        default="TD",
+        help="Flowchart direction: TD (top-down, default) or LR (left-right)",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    return parser
 
-    parser.add_argument('input', nargs='?', help='输入 JSON 文件 (.json)。如果未指定，使用 outputs/ 目录中最新的 perf_swimlane_*.json 文件')
-    parser.add_argument('-o', '--output', help='输出 Markdown 文件（默认：outputs/mermaid_diagram_<timestamp>.md）')
-    parser.add_argument('-k', '--kernel-config', help='kernel_config.py 文件路径，用于 func_id 到函数名的映射')
-    parser.add_argument('--style', choices=['detailed', 'compact'], default='detailed',
-                        help='节点信息密度：detailed（详细，包含核心和时间）或 compact（紧凑，仅函数名）')
-    parser.add_argument('--direction', choices=['TD', 'LR'], default='TD',
-                        help='流程图方向：TD（从上到下，默认）或 LR（从左到右）')
-    parser.add_argument('-v', '--verbose', action='store_true', help='详细输出')
 
-    args = parser.parse_args()
-
-    # If no input file specified, find the latest .json file in outputs/ directory
-    if args.input is None:
-        outputs_dir = Path(__file__).parent.parent / "outputs"
-        json_files = list(outputs_dir.glob("perf_swimlane_*.json"))
-
-        if not json_files:
-            print(f"错误：在 {outputs_dir} 中未找到 perf_swimlane_*.json 文件", file=sys.stderr)
-            print("请指定输入文件或确保 outputs/ 中存在 .json 文件", file=sys.stderr)
-            return 1
-
-        # Get the most recently modified file
-        input_path = max(json_files, key=lambda p: p.stat().st_mtime)
-
-        if args.verbose:
-            print(f"自动选择最新文件：{input_path.name}")
-    else:
+def _resolve_input_path(args):
+    """Resolve input path, auto-selecting latest perf_swimlane_*.json if not specified."""
+    if args.input is not None:
         input_path = Path(args.input)
+        if not input_path.exists():
+            print(f"Error: input file not found: {input_path}", file=sys.stderr)
+            return None
+        return input_path
 
-    # Check input file exists
-    if not input_path.exists():
-        print(f"错误：输入文件不存在：{input_path}", file=sys.stderr)
+    outputs_dir = Path(__file__).parent.parent / "outputs"
+    json_files = list(outputs_dir.glob("perf_swimlane_*.json"))
+    if not json_files:
+        print(f"Error: no perf_swimlane_*.json under {outputs_dir}", file=sys.stderr)
+        print("Specify an input file or add .json files under outputs/", file=sys.stderr)
+        return None
+
+    input_path = max(json_files, key=lambda p: p.stat().st_mtime)
+    if args.verbose:
+        print(f"Auto-selected latest file: {input_path.name}")
+    return input_path
+
+
+def _resolve_output_path(args, input_path):
+    """Determine output path from args or derive from input filename."""
+    if args.output:
+        return Path(args.output)
+
+    input_stem = input_path.stem
+    if input_stem.startswith("perf_swimlane_"):
+        timestamp_part = input_stem[len("perf_swimlane_") :]
+    else:
+        timestamp_part = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    outputs_dir = Path(__file__).parent.parent / "outputs"
+    outputs_dir.mkdir(exist_ok=True)
+    return outputs_dir / f"mermaid_diagram_{timestamp_part}.md"
+
+
+def main():
+    args = _build_parser().parse_args()
+
+    input_path = _resolve_input_path(args)
+    if input_path is None:
         return 1
 
     try:
-        # Read performance data JSON
         if args.verbose:
-            print(f"读取性能数据：{input_path}")
-
+            print(f"Reading performance data: {input_path}")
         data = read_perf_data(input_path)
-
         if args.verbose:
-            print(f"\n=== 性能数据 ===")
-            print(f"  版本：{data['version']}")
-            print(f"  任务数量：{len(data['tasks'])}")
+            print("\n=== Performance data ===")
+            print(f"  Version: {data['version']}")
+            print(f"  Tasks: {len(data['tasks'])}")
             print()
 
-        # Load function name mapping from kernel_config.py if provided
         func_names = {}
         if args.kernel_config:
             if args.verbose:
-                print(f"加载 kernel config：{args.kernel_config}")
+                print(f"Loading kernel config: {args.kernel_config}")
             func_names = load_kernel_config(args.kernel_config)
             if args.verbose:
-                print(f"  加载了 {len(func_names)} 个函数名映射")
+                print(f"  Loaded {len(func_names)} func_id name mappings")
                 for func_id, name in sorted(func_names.items(), key=lambda x: int(x[0])):
                     print(f"    func_id={func_id}: {name}")
                 print()
 
-        # Determine output path
-        if args.output:
-            output_path = Path(args.output)
-        else:
-            # Extract timestamp from input filename
-            input_stem = input_path.stem  # filename without extension
+        output_path = _resolve_output_path(args, input_path)
 
-            # Try to extract timestamp from filename
-            if input_stem.startswith("perf_swimlane_"):
-                timestamp_part = input_stem[len("perf_swimlane_"):]  # e.g., "20260210_143526"
-            else:
-                # Fallback: use current timestamp
-                timestamp_part = datetime.now().strftime("%Y%m%d_%H%M%S")
+        mermaid_text = generate_mermaid_flowchart(
+            data["tasks"],
+            func_names,
+            args.style,
+            args.direction,
+            args.verbose,
+        )
 
-            # Generate output filename and save to outputs/ directory
-            outputs_dir = Path(__file__).parent.parent / "outputs"
-            outputs_dir.mkdir(exist_ok=True)  # Ensure outputs directory exists
-            output_path = outputs_dir / f"mermaid_diagram_{timestamp_part}.md"
-
-        # Generate Mermaid diagram
-        mermaid_text = generate_mermaid_flowchart(data['tasks'], func_names, args.style, args.direction, args.verbose)
-
-        # Write to file
-        with open(output_path, 'w', encoding='utf-8') as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             f.write("# Task Dependency Graph\n\n")
-            f.write(f"生成自：`{input_path.name}`\n\n")
+            f.write(f"Generated from: `{input_path.name}`\n\n")
             f.write(mermaid_text)
 
-        print(f"\n✓ 转换完成")
-        print(f"  输入：{input_path}")
-        print(f"  输出：{output_path}")
+        print("\nConversion complete")
+        print(f"  Input:  {input_path}")
+        print(f"  Output: {output_path}")
 
         return 0
 
     except Exception as e:
-        print(f"错误：{e}", file=sys.stderr)
+        print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
-            import traceback
             traceback.print_exc()
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/tools/swimlane_converter.py
+++ b/tools/swimlane_converter.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 """
 Swimlane JSON to Perfetto JSON Converter
 
@@ -13,12 +21,15 @@ Usage:
     python3 swimlane_converter.py perf_swimlane_20260210_143526.json -v
 """
 
-import json
 import argparse
-import sys
-from pathlib import Path
-from datetime import datetime
 import importlib.util
+import json
+import sys
+import traceback
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any
 
 try:
     from device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
@@ -26,9 +37,11 @@ except ImportError:
     from tools.device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
 
 try:
-    from sched_overhead_analysis import parse_scheduler_threads, run_analysis as run_sched_overhead_analysis
+    from sched_overhead_analysis import parse_scheduler_threads
+    from sched_overhead_analysis import run_analysis as run_sched_overhead_analysis
 except ImportError:
-    from tools.sched_overhead_analysis import parse_scheduler_threads, run_analysis as run_sched_overhead_analysis
+    from tools.sched_overhead_analysis import parse_scheduler_threads
+    from tools.sched_overhead_analysis import run_analysis as run_sched_overhead_analysis
 
 
 def normalize_pto2_task_id_int(v):
@@ -80,17 +93,17 @@ def read_perf_data(filepath):
     Raises:
         ValueError: If JSON format is invalid
     """
-    with open(filepath, 'r') as f:
+    with open(filepath) as f:
         data = json.load(f)
 
     # Validate required fields
-    required_fields = ['version', 'tasks']
+    required_fields = ["version", "tasks"]
     for field in required_fields:
         if field not in data:
             raise ValueError(f"Missing required field: {field}")
 
     # Validate version
-    if data['version'] not in [1, 2]:
+    if data["version"] not in [1, 2]:
         raise ValueError(f"Unsupported version: {data['version']} (expected 1 or 2)")
 
     return data
@@ -115,7 +128,13 @@ def load_kernel_config(config_path):
     if not config_path.exists():
         raise ValueError(f"Kernel config file not found: {config_path}")
 
-    # Load the Python module dynamically
+    # Load the Python module dynamically.
+    # kernel_config.py may import `task_interface` from the project's python/ directory,
+    # so ensure it's on sys.path before executing the module.
+    python_dir = str(Path(__file__).resolve().parent.parent / "python")
+    if python_dir not in sys.path:
+        sys.path.insert(0, python_dir)
+
     spec = importlib.util.spec_from_file_location("kernel_config", config_path)
     if spec is None or spec.loader is None:
         raise ValueError(f"Cannot load module from: {config_path}")
@@ -124,25 +143,28 @@ def load_kernel_config(config_path):
     spec.loader.exec_module(module)
 
     # Extract func_id to name mapping from KERNELS list
-    if not hasattr(module, 'KERNELS'):
-        raise ValueError(f"kernel_config.py missing KERNELS definition")
+    if not hasattr(module, "KERNELS"):
+        raise ValueError("kernel_config.py missing KERNELS definition")
 
     func_id_to_name = {}
     for kernel in module.KERNELS:
         # Skip entries without func_id
-        if 'func_id' not in kernel:
+        if "func_id" not in kernel:
             print(f"Warning: Kernel entry missing 'func_id', skipping: {kernel}", file=sys.stderr)
             continue
 
-        func_id = kernel['func_id']
+        func_id = kernel["func_id"]
 
         # If name is missing, we'll fall back to default naming (Func_{func_id})
-        if 'name' not in kernel:
-            print(f"Warning: Kernel entry for func_id={func_id} missing 'name', will use default naming", file=sys.stderr)
+        if "name" not in kernel:
+            print(
+                f"Warning: Kernel entry for func_id={func_id} missing 'name', will use default naming",
+                file=sys.stderr,
+            )
             continue
 
         # Store as string to match JSON format
-        func_id_to_name[str(func_id)] = kernel['name']
+        func_id_to_name[str(func_id)] = kernel["name"]
 
     return func_id_to_name
 
@@ -168,20 +190,23 @@ def parse_sched_cpu_from_device_log(log_path, task_count):
     if not threads:
         return None
 
-    total_sched_cpu_us = sum(t.get('total_us', 0.0) for t in threads.values())
+    total_sched_cpu_us = sum(t.get("total_us", 0.0) for t in threads.values())
     if total_sched_cpu_us <= 0:
         return None
 
-    total_completed = sum(t.get('completed', 0) for t in threads.values())
+    total_completed = sum(t.get("completed", 0) for t in threads.values())
     if task_count > 0 and total_completed > 0 and abs(total_completed - task_count) / task_count > 0.5:
-        print(f"Warning: device log has {total_completed} completed tasks "
-              f"but perf JSON has {task_count}; skipping Sched CPU metric "
-              f"(device log may be from a different run)", file=sys.stderr)
+        print(
+            f"Warning: device log has {total_completed} completed tasks "
+            f"but perf JSON has {task_count}; skipping Sched CPU metric "
+            f"(device log may be from a different run)",
+            file=sys.stderr,
+        )
         return None
 
     return {
-        'us_per_task': total_sched_cpu_us / task_count,
-        'num_sched_threads': len(threads),
+        "us_per_task": total_sched_cpu_us / task_count,
+        "num_sched_threads": len(threads),
     }
 
 
@@ -200,49 +225,49 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
         sched_info: Optional dict with 'us_per_task' (float) and 'num_sched_threads' (int),
             parsed from device log by parse_sched_cpu_from_device_log()
     """
-    from collections import defaultdict
-
     # Group tasks by func_id with extended metrics
-    func_stats = defaultdict(lambda: {
-        'durations': [],
-        'head_overheads': [],
-        'tail_overheads': [],
-        'latencies': [],
-        'total_exec_time': 0.0,
-        'total_latency': 0.0
-    })
+    func_stats: defaultdict[Any, dict[str, Any]] = defaultdict(
+        lambda: {
+            "durations": [],
+            "head_overheads": [],
+            "tail_overheads": [],
+            "latencies": [],
+            "total_exec_time": 0.0,
+            "total_latency": 0.0,
+        }
+    )
 
     # Track global min dispatch and max finish times
-    min_dispatch_time = float('inf')
-    max_finish_time = float('-inf')
+    min_dispatch_time = float("inf")
+    max_finish_time = float("-inf")
 
     for task in tasks:
-        func_id = task['func_id']
-        duration = task['duration_us']
-        func_stats[func_id]['durations'].append(duration)
+        func_id = task["func_id"]
+        duration = task["duration_us"]
+        func_stats[func_id]["durations"].append(duration)
 
         # Calculate new metrics if dispatch_time_us and finish_time_us are available
-        if 'dispatch_time_us' in task and 'finish_time_us' in task:
-            dispatch_time = task['dispatch_time_us']
-            finish_time = task['finish_time_us']
-            start_time = task['start_time_us']
-            end_time = task['end_time_us']
+        if "dispatch_time_us" in task and "finish_time_us" in task:
+            dispatch_time = task["dispatch_time_us"]
+            finish_time = task["finish_time_us"]
+            start_time = task["start_time_us"]
+            end_time = task["end_time_us"]
 
             # Head overhead: start_time_us - dispatch_time_us
             head_overhead = start_time - dispatch_time
-            func_stats[func_id]['head_overheads'].append(head_overhead)
+            func_stats[func_id]["head_overheads"].append(head_overhead)
 
             # Tail overhead: finish_time_us - end_time_us
             tail_overhead = finish_time - end_time
-            func_stats[func_id]['tail_overheads'].append(tail_overhead)
+            func_stats[func_id]["tail_overheads"].append(tail_overhead)
 
             # Latency: finish_time_us - dispatch_time_us
             latency = finish_time - dispatch_time
-            func_stats[func_id]['latencies'].append(latency)
+            func_stats[func_id]["latencies"].append(latency)
 
             # Accumulate execution time and latency for ratio calculation
-            func_stats[func_id]['total_exec_time'] += duration
-            func_stats[func_id]['total_latency'] += latency
+            func_stats[func_id]["total_exec_time"] += duration
+            func_stats[func_id]["total_latency"] += latency
 
             # Track global times
             min_dispatch_time = min(min_dispatch_time, dispatch_time)
@@ -253,7 +278,10 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
     print("Task Statistics by Function")
     print("  Exec = kernel time on AICore; Latency = dispatch->finish (incl. head OH + Exec + tail OH)")
     print("=" * 110)
-    print(f"{'Func_ID':<8} {'Func_Name':<12} {'Count':>5}   {'Avg Exec(us)':>12}  {'Avg Latency(us)':>15}  {'Exec%':>6}   {'Avg Head OH(us)':>15}  {'Avg Tail OH(us)':>15}")
+    print(
+        f"{'Func_ID':<8} {'Func_Name':<12} {'Count':>5}   {'Avg Exec(us)':>12}  "
+        f"{'Avg Latency(us)':>15}  {'Exec%':>6}   {'Avg Head OH(us)':>15}  {'Avg Tail OH(us)':>15}"
+    )
     print("-" * 110)
 
     # Sort by func_id for consistent output
@@ -262,7 +290,7 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
 
     for func_id in sorted(func_stats.keys()):
         stats = func_stats[func_id]
-        durations = stats['durations']
+        durations = stats["durations"]
         count = len(durations)
         sum_duration = sum(durations)
         avg_duration = sum_duration / count
@@ -278,24 +306,31 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
             func_name = f"Func_{func_id}"
 
         # Calculate averages
-        avg_head_overhead = sum(stats['head_overheads']) / len(stats['head_overheads']) if stats['head_overheads'] else 0
-        avg_tail_overhead = sum(stats['tail_overheads']) / len(stats['tail_overheads']) if stats['tail_overheads'] else 0
-        avg_latency = stats['total_latency'] / count if count > 0 else 0
+        avg_head_overhead = (
+            sum(stats["head_overheads"]) / len(stats["head_overheads"]) if stats["head_overheads"] else 0
+        )
+        avg_tail_overhead = (
+            sum(stats["tail_overheads"]) / len(stats["tail_overheads"]) if stats["tail_overheads"] else 0
+        )
+        avg_latency = stats["total_latency"] / count if count > 0 else 0
 
         # Calculate execution ratio: total_exec_time / total_latency
-        exec_ratio = (stats['total_exec_time'] / stats['total_latency'] * 100) if stats['total_latency'] > 0 else 0
+        exec_ratio = (stats["total_exec_time"] / stats["total_latency"] * 100) if stats["total_latency"] > 0 else 0
 
-        print(f"{func_id:<8} {func_name:<12} {count:>5}   {avg_duration:>12.2f}  {avg_latency:>15.2f}  {exec_ratio:>5.1f}%   {avg_head_overhead:>15.2f}  {avg_tail_overhead:>15.2f}")
+        print(
+            f"{func_id:<8} {func_name:<12} {count:>5}   {avg_duration:>12.2f}  {avg_latency:>15.2f}  "
+            f"{exec_ratio:>5.1f}%   {avg_head_overhead:>15.2f}  {avg_tail_overhead:>15.2f}"
+        )
 
     # Print total row
     print("-" * 110)
 
     # Calculate total latency (sum of all latencies)
-    total_latency_sum = sum(stats['total_latency'] for stats in func_stats.values())
+    total_latency_sum = sum(stats["total_latency"] for stats in func_stats.values())
     print(f"{'TOTAL':<21} {total_count:>5}   {total_duration:>12.2f}  {total_latency_sum:>15.2f}")
 
     # Print total test execution time
-    if min_dispatch_time != float('inf') and max_finish_time != float('-inf'):
+    if min_dispatch_time != float("inf") and max_finish_time != float("-inf"):
         total_test_time = max_finish_time - min_dispatch_time
         print(f"\nTotal Test Time: {total_test_time:.2f} us (from earliest dispatch to latest finish)")
 
@@ -305,27 +340,42 @@ def print_task_statistics(tasks, func_id_to_name=None, sched_info=None):
         avg_latency_us = total_latency_sum / total_count
         exec_latency_ratio_pct = total_duration / total_latency_sum * 100
         print("\n--- Task execution vs Scheduler overhead ---")
-        print(f"  Per-task (all):  Avg Exec = {avg_exec_us:.2f} us,  Avg Latency (dispatch->finish) = {avg_latency_us:.2f} us,  Exec/Latency = {exec_latency_ratio_pct:.2f}%")
+        print(
+            f"  Per-task (all):  Avg Exec = {avg_exec_us:.2f} us,  "
+            f"Avg Latency (dispatch->finish) = {avg_latency_us:.2f} us,  "
+            f"Exec/Latency = {exec_latency_ratio_pct:.2f}%"
+        )
         if sched_info is not None:
-            sched_cpu = sched_info['us_per_task']
-            num_cores = len(set(t['core_id'] for t in tasks))
+            sched_cpu = sched_info["us_per_task"]
+            num_cores = len(set(t["core_id"] for t in tasks))
             exec_sched_ratio = (avg_exec_us / sched_cpu * 100) if sched_cpu > 0 else 0
             per_core_exec = avg_exec_us / num_cores if num_cores > 0 else 0
             per_core_ratio = (per_core_exec / sched_cpu * 100) if sched_cpu > 0 else 0
-            num_threads = sched_info['num_sched_threads']
-            print(f"  Sched CPU (from device log): {sched_cpu:.2f} us/task  (Exec/Sched = {exec_sched_ratio:.1f}%, PerCore/Sched = {per_core_ratio:.1f}%)")
-            print(f"  (Latency = dispatch→finish; Sched CPU = scheduler thread CPU per task; PerCore = avg_exec/{num_cores}_cores vs sched_cpu, {num_threads} sched threads)")
+            num_threads = sched_info["num_sched_threads"]
+            print(
+                f"  Sched CPU (from device log): {sched_cpu:.2f} us/task  "
+                f"(Exec/Sched = {exec_sched_ratio:.1f}%, PerCore/Sched = {per_core_ratio:.1f}%)"
+            )
+            print(
+                f"  (Latency = dispatch→finish; Sched CPU = scheduler thread CPU per task; "
+                f"PerCore = avg_exec/{num_cores}_cores vs sched_cpu, {num_threads} sched threads)"
+            )
         else:
             print("  (Latency = dispatch→finish; Sched CPU = scheduler thread CPU per task)")
 
     print("=" * 110)
 
 
-
-
-def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose=False,
-                                scheduler_phases=None, orchestrator_data=None,
-                                orchestrator_phases=None, core_to_thread=None):
+def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
+    tasks,
+    output_path,
+    func_id_to_name=None,
+    verbose=False,
+    scheduler_phases=None,
+    orchestrator_data=None,
+    orchestrator_phases=None,
+    core_to_thread=None,
+):
     """Generate Chrome Trace Event Format JSON from task data.
 
     Args:
@@ -350,7 +400,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
         - pid=4 "AICPU Orchestrator": orchestrator phase bars or summary (version 2)
     """
     if verbose:
-        print(f"Generating Chrome Trace JSON...")
+        print("Generating Chrome Trace JSON...")
         print(f"  Tasks: {len(tasks)}")
         if func_id_to_name:
             print(f"  Function names: {len(func_id_to_name)} entries")
@@ -358,7 +408,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
     # Step 1: Build core_to_tid mapping (using only core_id, not core_type)
     unique_cores = set()
     for task in tasks:
-        unique_cores.add(task['core_id'])
+        unique_cores.add(task["core_id"])
 
     core_to_tid = {}
     tid_counter = 1000
@@ -374,74 +424,48 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
     # Metadata event: Process names and sort order
     # Display order: Orchestrator (pid=4) → Scheduler (pid=3) → AICPU View (pid=2) → AICore View (pid=1)
-    events.append({
-        "args": {"name": "AICore View"},
-        "cat": "__metadata",
-        "name": "process_name",
-        "ph": "M",
-        "pid": 1
-    })
-    events.append({
-        "args": {"sort_index": 4},
-        "cat": "__metadata",
-        "name": "process_sort_index",
-        "ph": "M",
-        "pid": 1
-    })
+    events.append({"args": {"name": "AICore View"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 1})
+    events.append({"args": {"sort_index": 4}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 1})
 
     # Check if any task has AICPU timestamps
-    has_aicpu_data = any(
-        task.get('dispatch_time_us', 0) > 0 and task.get('finish_time_us', 0) > 0
-        for task in tasks
-    )
+    has_aicpu_data = any(task.get("dispatch_time_us", 0) > 0 and task.get("finish_time_us", 0) > 0 for task in tasks)
 
     if has_aicpu_data:
-        events.append({
-            "args": {"name": "AICPU View"},
-            "cat": "__metadata",
-            "name": "process_name",
-            "ph": "M",
-            "pid": 2
-        })
-        events.append({
-            "args": {"sort_index": 3},
-            "cat": "__metadata",
-            "name": "process_sort_index",
-            "ph": "M",
-            "pid": 2
-        })
+        events.append(
+            {"args": {"name": "AICPU View"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 2}
+        )
+        events.append(
+            {"args": {"sort_index": 3}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 2}
+        )
 
     # Metadata events: Thread names (one per core)
     for core_id, tid in core_to_tid.items():
         # Find first task with this core_id to get core_type
         core_type = None
         for task in tasks:
-            if task['core_id'] == core_id:
-                core_type = task['core_type']
+            if task["core_id"] == core_id:
+                core_type = task["core_type"]
                 break
 
         # core_type is now a string ("aic" or "aiv")
-        core_type_str = core_type.upper()
+        core_type_str = (core_type or "unknown").upper()
         thread_name = f"{core_type_str}_{core_id}"
-        events.append({
-            "args": {"name": thread_name},
-            "cat": "__metadata",
-            "name": "thread_name",
-            "ph": "M",
-            "pid": 1,
-            "tid": tid
-        })
+        events.append(
+            {"args": {"name": thread_name}, "cat": "__metadata", "name": "thread_name", "ph": "M", "pid": 1, "tid": tid}
+        )
 
         # Also add thread name for AICPU View if data exists
         if has_aicpu_data:
-            events.append({
-                "args": {"name": thread_name},
-                "cat": "__metadata",
-                "name": "thread_name",
-                "ph": "M",
-                "pid": 2,
-                "tid": tid
-            })
+            events.append(
+                {
+                    "args": {"name": thread_name},
+                    "cat": "__metadata",
+                    "name": "thread_name",
+                    "ph": "M",
+                    "pid": 2,
+                    "tid": tid,
+                }
+            )
 
     # Duration events (Complete events "X")
     # Build task_id -> event_id mapping for flow events
@@ -449,91 +473,95 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
     event_id = 0
 
     for task in tasks:
-        tid = core_to_tid[task['core_id']]
-        ts = task['start_time_us']
-        dur = task['duration_us']
+        tid = core_to_tid[task["core_id"]]
+        ts = task["start_time_us"]
+        dur = task["duration_us"]
 
         # Build fanout hint string (packed ids → rXtY / tY for readability)
-        fanout_str = "[" + ", ".join(format_task_display(x) for x in task['fanout']) + "]"
+        fanout_str = "[" + ", ".join(format_task_display(x) for x in task["fanout"]) + "]"
 
         # Get function name if available
-        func_id = task['func_id']
-        tdisp = format_task_display(task['task_id'])
+        func_id = task["func_id"]
+        tdisp = format_task_display(task["task_id"])
         if func_id_to_name and str(func_id) in func_id_to_name:
             func_name = func_id_to_name[str(func_id)]
             task_name = f"{func_name}({tdisp})"
         else:
             task_name = f"Func_{func_id}({tdisp})"
 
-        events.append({
-            "args": {
-                "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
-                "fanout-hint": fanout_str,
-                "duration-us": dur,
-                "taskId": task['task_id']
-            },
-            "cat": "event",
-            "id": event_id,
-            "name": task_name,
-            "ph": "X",
-            "pid": 1,
-            "tid": tid,
-            "ts": ts,
-            "dur": dur
-        })
+        events.append(
+            {
+                "args": {
+                    "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
+                    "fanout-hint": fanout_str,
+                    "duration-us": dur,
+                    "taskId": task["task_id"],
+                },
+                "cat": "event",
+                "id": event_id,
+                "name": task_name,
+                "ph": "X",
+                "pid": 1,
+                "tid": tid,
+                "ts": ts,
+                "dur": dur,
+            }
+        )
 
         # Record mapping for flow events
-        task_to_event_id[task['task_id']] = event_id
+        task_to_event_id[task["task_id"]] = event_id
         event_id += 1
 
     # AICPU View duration events (dispatch_time to finish_time)
     if has_aicpu_data:
         for task in tasks:
-            dispatch_us = task.get('dispatch_time_us', 0)
-            finish_us = task.get('finish_time_us', 0)
+            dispatch_us = task.get("dispatch_time_us", 0)
+            finish_us = task.get("finish_time_us", 0)
             if dispatch_us <= 0 or finish_us <= 0:
                 continue
 
-            tid = core_to_tid[task['core_id']]
+            tid = core_to_tid[task["core_id"]]
             aicpu_dur = finish_us - dispatch_us
 
             # Get function name if available
-            func_id = task['func_id']
-            tdisp = format_task_display(task['task_id'])
+            func_id = task["func_id"]
+            tdisp = format_task_display(task["task_id"])
             if func_id_to_name and str(func_id) in func_id_to_name:
                 func_name = func_id_to_name[str(func_id)]
                 task_name = f"{func_name}({tdisp})"
             else:
                 task_name = f"Func_{func_id}({tdisp})"
 
-            events.append({
-                "args": {
-                    "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
-                    "dispatch-time-us": dispatch_us,
-                    "finish-time-us": finish_us,
-                    "aicpu-duration-us": aicpu_dur,
-                    "taskId": task['task_id']
-                },
-                "cat": "event",
-                "id": event_id,
-                "name": task_name,
-                "ph": "X",
-                "pid": 2,
-                "tid": tid,
-                "ts": dispatch_us,
-                "dur": aicpu_dur
-            })
+            events.append(
+                {
+                    "args": {
+                        "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
+                        "dispatch-time-us": dispatch_us,
+                        "finish-time-us": finish_us,
+                        "aicpu-duration-us": aicpu_dur,
+                        "taskId": task["task_id"],
+                    },
+                    "cat": "event",
+                    "id": event_id,
+                    "name": task_name,
+                    "ph": "X",
+                    "pid": 2,
+                    "tid": tid,
+                    "ts": dispatch_us,
+                    "dur": aicpu_dur,
+                }
+            )
             event_id += 1
 
     # Flow events (Flow events "s" and "f" for dependencies)
-    task_map = {t['task_id']: t for t in tasks}
+    task_map = {t["task_id"]: t for t in tasks}
     flow_id = 0
 
     for task in tasks:
-        src_tid = core_to_tid[task['core_id']]
-        src_ts_end = task['end_time_us']
+        src_tid = core_to_tid[task["core_id"]]
+        src_ts_end = task["end_time_us"]
 
-        for succ_task_id in task['fanout']:
+        for succ_task_id in task["fanout"]:
             if succ_task_id not in task_map:
                 if verbose:
                     print(
@@ -543,66 +571,62 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                 continue
 
             succ_task = task_map[succ_task_id]
-            dst_tid = core_to_tid[succ_task['core_id']]
-            dst_ts_start = succ_task['start_time_us']
+            dst_tid = core_to_tid[succ_task["core_id"]]
+            dst_ts_start = succ_task["start_time_us"]
 
             # Get event IDs for source and destination tasks
-            src_event_id = task_to_event_id[task['task_id']]
-            dst_event_id = task_to_event_id[succ_task['task_id']]
+            src_event_id = task_to_event_id[task["task_id"]]
+            dst_event_id = task_to_event_id[succ_task["task_id"]]
 
             # Flow start timestamp (at end of source task, slightly before)
             # Use a small offset (0.01 us) for visual clarity
             flow_start_us = src_ts_end - 0.01
 
             # Flow start event (at end of source task)
-            events.append({
-                "cat": "flow",
-                "id": flow_id,
-                "name": "dependency",
-                "ph": "s",
-                "pid": 1,
-                "tid": src_tid,
-                "ts": flow_start_us,
-                "bind_id": src_event_id
-            })
+            events.append(
+                {
+                    "cat": "flow",
+                    "id": flow_id,
+                    "name": "dependency",
+                    "ph": "s",
+                    "pid": 1,
+                    "tid": src_tid,
+                    "ts": flow_start_us,
+                    "bind_id": src_event_id,
+                }
+            )
 
             # Flow finish event (at start of destination task)
-            events.append({
-                "cat": "flow",
-                "id": flow_id,
-                "name": "dependency",
-                "ph": "f",
-                "pid": 1,
-                "tid": dst_tid,
-                "ts": dst_ts_start,
-                "bp": "e",
-                "bind_id": dst_event_id
-            })
+            events.append(
+                {
+                    "cat": "flow",
+                    "id": flow_id,
+                    "name": "dependency",
+                    "ph": "f",
+                    "pid": 1,
+                    "tid": dst_tid,
+                    "ts": dst_ts_start,
+                    "bp": "e",
+                    "bind_id": dst_event_id,
+                }
+            )
 
             flow_id += 1
 
     # AICPU Scheduler phase events (version 2)
     if scheduler_phases:
         # Process metadata
-        events.append({
-            "args": {"name": "AICPU Scheduler"},
-            "cat": "__metadata",
-            "name": "process_name",
-            "ph": "M",
-            "pid": 3
-        })
-        events.append({
-            "args": {"sort_index": 2},
-            "cat": "__metadata",
-            "name": "process_sort_index",
-            "ph": "M",
-            "pid": 3
-        })
+        events.append(
+            {"args": {"name": "AICPU Scheduler"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 3}
+        )
+        events.append(
+            {"args": {"sort_index": 2}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 3}
+        )
 
         # Phase color mapping
         phase_colors = {
-            "complete": "good",       # green
-            "dispatch": "terrible",   # red
+            "complete": "good",  # green
+            "dispatch": "terrible",  # red
             "scan": "thread_state_running",  # blue
             "idle": "yellow",  # yellow
         }
@@ -611,14 +635,16 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
             tid = 3000 + thread_idx
 
             # Thread name metadata
-            events.append({
-                "args": {"name": f"Sched_{thread_idx}"},
-                "cat": "__metadata",
-                "name": "thread_name",
-                "ph": "M",
-                "pid": 3,
-                "tid": tid
-            })
+            events.append(
+                {
+                    "args": {"name": f"Sched_{thread_idx}"},
+                    "cat": "__metadata",
+                    "name": "thread_name",
+                    "ph": "M",
+                    "pid": 3,
+                    "tid": tid,
+                }
+            )
 
             for record in thread_records:
                 phase = record.get("phase", "unknown")
@@ -631,7 +657,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     "args": {
                         "phase": phase,
                         "loop_iter": record.get("loop_iter", 0),
-                        "tasks_processed": tasks_processed
+                        "tasks_processed": tasks_processed,
                     },
                     "cat": "scheduler",
                     "cname": phase_colors.get(phase, "generic_work"),
@@ -640,27 +666,19 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     "pid": 3,
                     "tid": tid,
                     "ts": start_us,
-                    "dur": dur
+                    "dur": dur,
                 }
                 events.append(event)
 
     # AICPU Orchestrator event (version 2)
     if orchestrator_phases or orchestrator_data:
         # Process metadata
-        events.append({
-            "args": {"name": "AICPU Orchestrator"},
-            "cat": "__metadata",
-            "name": "process_name",
-            "ph": "M",
-            "pid": 4
-        })
-        events.append({
-            "args": {"sort_index": 1},
-            "cat": "__metadata",
-            "name": "process_sort_index",
-            "ph": "M",
-            "pid": 4
-        })
+        events.append(
+            {"args": {"name": "AICPU Orchestrator"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 4}
+        )
+        events.append(
+            {"args": {"sort_index": 1}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 4}
+        )
 
         # Normalize orchestrator_phases: support both per-thread nested format
         # (list of lists) and legacy flat format (list of dicts)
@@ -670,31 +688,28 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
         for orch_idx in range(len(orch_threads)):
             tid = 4000 + orch_idx
             name = f"Orch_{orch_idx}"
-            events.append({
-                "args": {"name": name},
-                "cat": "__metadata",
-                "name": "thread_name",
-                "ph": "M",
-                "pid": 4,
-                "tid": tid
-            })
+            events.append(
+                {"args": {"name": name}, "cat": "__metadata", "name": "thread_name", "ph": "M", "pid": 4, "tid": tid}
+            )
         if not orch_threads and orchestrator_data:
-            events.append({
-                "args": {"name": "Orchestrator"},
-                "cat": "__metadata",
-                "name": "thread_name",
-                "ph": "M",
-                "pid": 4,
-                "tid": 4000
-            })
+            events.append(
+                {
+                    "args": {"name": "Orchestrator"},
+                    "cat": "__metadata",
+                    "name": "thread_name",
+                    "ph": "M",
+                    "pid": 4,
+                    "tid": 4000,
+                }
+            )
 
     if orchestrator_phases:
         # Per-task orchestrator phase bars
         orch_phase_colors = {
-            "orch_sync": "thread_state_iowait",      # orange
-            "orch_alloc": "terrible",                  # red
-            "orch_params": "good",                     # green
-            "orch_lookup": "thread_state_running",     # blue
+            "orch_sync": "thread_state_iowait",  # orange
+            "orch_alloc": "terrible",  # red
+            "orch_params": "good",  # green
+            "orch_lookup": "thread_state_running",  # blue
             "orch_heap": "yellow",
             "orch_insert": "olive",
             "orch_fanin": "rail_animation",
@@ -722,11 +737,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     label = f"{display_name}({submit_idx})"
 
                 event = {
-                    "args": {
-                        "phase": phase,
-                        "submit_idx": submit_idx,
-                        "task_id": task_id
-                    },
+                    "args": {"phase": phase, "submit_idx": submit_idx, "task_id": task_id},
                     "cat": "orchestrator",
                     "cname": orch_phase_colors.get(phase, "generic_work"),
                     "name": label,
@@ -734,7 +745,7 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     "pid": 4,
                     "tid": tid,
                     "ts": start_us,
-                    "dur": dur
+                    "dur": dur,
                 }
                 events.append(event)
 
@@ -758,56 +769,62 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                     orch_args[f"{phase_name}_%"] = round(pct, 1)
 
         # Total orchestrator bar
-        events.append({
-            "args": orch_args,
-            "cat": "orchestrator",
-            "name": f"Orchestrator({orchestrator_data.get('submit_count', 0)} tasks)",
-            "ph": "X",
-            "pid": 4,
-            "tid": 4000,
-            "ts": orch_start,
-            "dur": orch_dur
-        })
+        events.append(
+            {
+                "args": orch_args,
+                "cat": "orchestrator",
+                "name": f"Orchestrator({orchestrator_data.get('submit_count', 0)} tasks)",
+                "ph": "X",
+                "pid": 4,
+                "tid": 4000,
+                "ts": orch_start,
+                "dur": orch_dur,
+            }
+        )
 
     # AICPU View fanout arrows (duplicate AICore View flow events using AICPU timestamps)
     if has_aicpu_data:
         for task in tasks:
-            src_finish_us = task.get('finish_time_us', 0)
+            src_finish_us = task.get("finish_time_us", 0)
             if src_finish_us <= 0:
                 continue
 
-            src_tid = core_to_tid[task['core_id']]
+            src_tid = core_to_tid[task["core_id"]]
 
-            for succ_task_id in task['fanout']:
+            for succ_task_id in task["fanout"]:
                 if succ_task_id not in task_map:
                     continue
 
                 succ_task = task_map[succ_task_id]
-                dst_dispatch_us = succ_task.get('dispatch_time_us', 0)
+                dst_dispatch_us = succ_task.get("dispatch_time_us", 0)
                 if dst_dispatch_us <= 0:
                     continue
 
-                dst_tid = core_to_tid[succ_task['core_id']]
+                dst_tid = core_to_tid[succ_task["core_id"]]
 
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dependency",
-                    "ph": "s",
-                    "pid": 2,
-                    "tid": src_tid,
-                    "ts": src_finish_us - 0.01
-                })
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dependency",
-                    "ph": "f",
-                    "pid": 2,
-                    "tid": dst_tid,
-                    "ts": dst_dispatch_us,
-                    "bp": "e"
-                })
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dependency",
+                        "ph": "s",
+                        "pid": 2,
+                        "tid": src_tid,
+                        "ts": src_finish_us - 0.01,
+                    }
+                )
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dependency",
+                        "ph": "f",
+                        "pid": 2,
+                        "tid": dst_tid,
+                        "ts": dst_dispatch_us,
+                        "bp": "e",
+                    }
+                )
                 flow_id += 1
 
     # Scheduler DISPATCH → task execution arrows
@@ -831,13 +848,12 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                 if dispatch_records:
                     dispatch_phases_by_thread[thread_idx] = dispatch_records
 
-            from collections import defaultdict
             core_thread_votes = defaultdict(lambda: defaultdict(int))
             for task in tasks:
-                dispatch_us = task.get('dispatch_time_us', 0)
+                dispatch_us = task.get("dispatch_time_us", 0)
                 if dispatch_us <= 0:
                     continue
-                core_id = task['core_id']
+                core_id = task["core_id"]
                 for thread_idx, dispatch_records in dispatch_phases_by_thread.items():
                     for dr in dispatch_records:
                         if dr["start_time_us"] <= dispatch_us <= dr["end_time_us"]:
@@ -845,63 +861,71 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
                             break
 
             for core_id, votes in core_thread_votes.items():
-                core_to_sched_thread[core_id] = max(votes, key=votes.get)
+                core_to_sched_thread[core_id] = max(votes.items(), key=lambda kv: kv[1])[0]
             if verbose:
                 print(f"  Core-to-thread mapping: {len(core_to_sched_thread)} cores (inferred via voting)")
 
         for task in tasks:
-            dispatch_us = task.get('dispatch_time_us', 0)
+            dispatch_us = task.get("dispatch_time_us", 0)
             if dispatch_us <= 0:
                 continue
 
-            matched_thread = core_to_sched_thread.get(task['core_id'])
+            matched_thread = core_to_sched_thread.get(task["core_id"])
 
             if matched_thread is not None:
                 sched_tid = 3000 + matched_thread
-                core_tid = core_to_tid[task['core_id']]
+                core_tid = core_to_tid[task["core_id"]]
 
                 # Flow: scheduler DISPATCH → AICore View task start
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dispatch",
-                    "ph": "s",
-                    "pid": 3,
-                    "tid": sched_tid,
-                    "ts": dispatch_us
-                })
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dispatch",
-                    "ph": "f",
-                    "pid": 1,
-                    "tid": core_tid,
-                    "ts": task['start_time_us'],
-                    "bp": "e"
-                })
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dispatch",
+                        "ph": "s",
+                        "pid": 3,
+                        "tid": sched_tid,
+                        "ts": dispatch_us,
+                    }
+                )
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dispatch",
+                        "ph": "f",
+                        "pid": 1,
+                        "tid": core_tid,
+                        "ts": task["start_time_us"],
+                        "bp": "e",
+                    }
+                )
                 flow_id += 1
 
                 # Flow: scheduler DISPATCH → AICPU View task start
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dispatch",
-                    "ph": "s",
-                    "pid": 3,
-                    "tid": sched_tid,
-                    "ts": dispatch_us
-                })
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": "dispatch",
-                    "ph": "f",
-                    "pid": 2,
-                    "tid": core_tid,
-                    "ts": dispatch_us,
-                    "bp": "e"
-                })
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dispatch",
+                        "ph": "s",
+                        "pid": 3,
+                        "tid": sched_tid,
+                        "ts": dispatch_us,
+                    }
+                )
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": "dispatch",
+                        "ph": "f",
+                        "pid": 2,
+                        "tid": core_tid,
+                        "ts": dispatch_us,
+                        "bp": "e",
+                    }
+                )
                 flow_id += 1
 
     # Orchestrator → scheduler dispatch:
@@ -926,15 +950,15 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
         if has_aicpu_data and (orch_fanin_by_task or orch_params_by_task):
             for task in tasks:
-                tid = normalize_pto2_task_id_int(task.get('task_id'))
+                tid = normalize_pto2_task_id_int(task.get("task_id"))
                 if tid is None:
                     continue
 
-                dispatch_us = task.get('dispatch_time_us', 0)
+                dispatch_us = task.get("dispatch_time_us", 0)
                 if dispatch_us <= 0:
                     continue
 
-                matched_thread = core_to_sched_thread.get(task['core_id'])
+                matched_thread = core_to_sched_thread.get(task["core_id"])
                 if matched_thread is None:
                     continue
 
@@ -954,25 +978,29 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
 
                 orch_tid = 4000 + orch_idx
 
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": flow_name,
-                    "ph": "s",
-                    "pid": 4,
-                    "tid": orch_tid,
-                    "ts": anchor_us
-                })
-                events.append({
-                    "cat": "flow",
-                    "id": flow_id,
-                    "name": flow_name,
-                    "ph": "f",
-                    "pid": 3,
-                    "tid": sched_tid,
-                    "ts": dispatch_us,
-                    "bp": "e"
-                })
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": flow_name,
+                        "ph": "s",
+                        "pid": 4,
+                        "tid": orch_tid,
+                        "ts": anchor_us,
+                    }
+                )
+                events.append(
+                    {
+                        "cat": "flow",
+                        "id": flow_id,
+                        "name": flow_name,
+                        "ph": "f",
+                        "pid": 3,
+                        "tid": sched_tid,
+                        "ts": dispatch_us,
+                        "bp": "e",
+                    }
+                )
                 flow_id += 1
 
     if verbose:
@@ -980,16 +1008,16 @@ def generate_chrome_trace_json(tasks, output_path, func_id_to_name=None, verbose
         print(f"  Flow events: {flow_id}")
 
     # Step 3: Write JSON file (with traceEvents wrapper to match C++ output)
-    with open(output_path, 'w') as f:
+    with open(output_path, "w") as f:
         json.dump({"traceEvents": events}, f, indent=2)
 
     if verbose:
         print(f"JSON written to: {output_path}")
 
 
-def main():
+def _build_parser():
     parser = argparse.ArgumentParser(
-        description='Convert swimlane performance JSON to Chrome Trace Event JSON',
+        description="Convert swimlane performance JSON to Chrome Trace Event JSON",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -999,63 +1027,121 @@ Examples:
   %(prog)s perf_swimlane_20260210_143526.json -k examples/host_build_graph/paged_attention/kernels/kernel_config.py
   %(prog)s perf_swimlane_20260210_143526.json -d 0
   %(prog)s perf_swimlane_20260210_143526.json -v
-        """
+        """,
     )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        help="Input JSON file (.json). If not specified, uses the latest perf_swimlane_*.json in outputs/",
+    )
+    parser.add_argument("-o", "--output", help="Output JSON file (default: outputs/merged_swimlane_<timestamp>.json)")
+    parser.add_argument(
+        "-k",
+        "--kernel-config",
+        help="Path to kernel_config.py file for func_id to function name mapping",
+    )
+    parser.add_argument("--device-log", help="Device log file/path/glob override used for scheduler analysis")
+    parser.add_argument("-d", "--device-id", help="Device id for auto-selection from device-<id>")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    return parser
 
-    parser.add_argument('input', nargs='?', help='Input JSON file (.json). If not specified, uses the latest perf_swimlane_*.json file in outputs/ directory')
-    parser.add_argument('-o', '--output', help='Output JSON file (default: outputs/merged_swimlane_<timestamp>.json)')
-    parser.add_argument('-k', '--kernel-config', help='Path to kernel_config.py file for func_id to function name mapping')
-    parser.add_argument('--device-log', help='Device log file/path/glob override used for scheduler analysis')
-    parser.add_argument('-d', '--device-id', help='Device id for auto-selection from device-<id>')
-    parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
 
-    args = parser.parse_args()
-
-    # If no input file specified, find the latest .json file in outputs/ directory
-    if args.input is None:
-        outputs_dir = Path(__file__).parent.parent / "outputs"
-        json_files = list(outputs_dir.glob("perf_swimlane_*.json"))
-
-        if not json_files:
-            print(f"Error: No perf_swimlane_*.json files found in {outputs_dir}", file=sys.stderr)
-            print("Please specify an input file or ensure .json files exist in outputs/", file=sys.stderr)
-            return 1
-
-        # Get the most recently modified file
-        input_path = max(json_files, key=lambda p: p.stat().st_mtime)
-
-        if args.verbose:
-            print(f"Auto-selected latest file: {input_path.name}")
-    else:
+def _resolve_input_path(args):
+    """Resolve input path, auto-selecting latest perf_swimlane_*.json if not specified."""
+    if args.input is not None:
         input_path = Path(args.input)
+        if not input_path.exists():
+            print(f"Error: Input file not found: {input_path}", file=sys.stderr)
+            return None
+        return input_path
 
-    # Check input file exists
-    if not input_path.exists():
-        print(f"Error: Input file not found: {input_path}", file=sys.stderr)
+    outputs_dir = Path(__file__).parent.parent / "outputs"
+    json_files = list(outputs_dir.glob("perf_swimlane_*.json"))
+    if not json_files:
+        print(f"Error: No perf_swimlane_*.json files found in {outputs_dir}", file=sys.stderr)
+        print("Please specify an input file or ensure .json files exist in outputs/", file=sys.stderr)
+        return None
+
+    input_path = max(json_files, key=lambda p: p.stat().st_mtime)
+    if args.verbose:
+        print(f"Auto-selected latest file: {input_path.name}")
+    return input_path
+
+
+def _resolve_output_path(args, input_path):
+    """Determine output path from args or derive from input filename."""
+    if args.output:
+        return Path(args.output)
+
+    input_stem = input_path.stem
+    if input_stem.startswith("perf_swimlane_"):
+        timestamp_part = input_stem[len("perf_swimlane_") :]
+    else:
+        timestamp_part = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    outputs_dir = Path(__file__).parent.parent / "outputs"
+    outputs_dir.mkdir(exist_ok=True)
+    return outputs_dir / f"merged_swimlane_{timestamp_part}.json"
+
+
+def _print_verbose_data_info(data, verbose):
+    """Print verbose summary of loaded performance data including v2 phase counts."""
+    if not verbose:
+        return
+    print("\n=== Performance Data ===")
+    print(f"  Version: {data['version']}")
+    print(f"  Task Count: {len(data['tasks'])}")
+    if data["tasks"]:
+        start_times = [t["start_time_us"] for t in data["tasks"]]
+        end_times = [t["end_time_us"] for t in data["tasks"]]
+        min_time = min(start_times)
+        max_time = max(end_times)
+        print(f"  Time Range: {min_time:.3f} us - {max_time:.3f} us (span: {max_time - min_time:.3f} us)")
+    print()
+    if data["version"] != 2:
+        return
+    scheduler_phases = data.get("aicpu_scheduler_phases")
+    orchestrator_data = data.get("aicpu_orchestrator")
+    orchestrator_phases = data.get("aicpu_orchestrator_phases")
+    core_to_thread = data.get("core_to_thread")
+    if scheduler_phases:
+        print(f"  Scheduler threads: {len(scheduler_phases)}")
+        print(f"  Total phase records: {sum(len(t) for t in scheduler_phases)}")
+    if orchestrator_data:
+        print(f"  Orchestrator: {orchestrator_data.get('submit_count', 0)} tasks")
+    if orchestrator_phases:
+        print(f"  Orchestrator threads: {len(orchestrator_phases)}")
+        print(f"  Total orchestrator phase records: {sum(len(t) for t in orchestrator_phases)}")
+    if core_to_thread:
+        print(f"  Core-to-thread mapping: {len(core_to_thread)} cores")
+
+
+def _report_device_log(resolved_device_log, log_strategy):
+    """Print device log resolution result."""
+    if resolved_device_log is not None:
+        print(f"\nDevice log: {resolved_device_log}")
+        print(f"Selection: {log_strategy}")
+        inferred_device_id = infer_device_id_from_log_path(resolved_device_log)
+        if inferred_device_id is not None:
+            print(f"Inferred Device ID: {inferred_device_id}")
+    else:
+        print("\nDevice log: (not resolved)")
+        print(f"Selection: {log_strategy}")
+
+
+def main():
+    args = _build_parser().parse_args()
+
+    input_path = _resolve_input_path(args)
+    if input_path is None:
         return 1
 
     try:
-        # Read performance data JSON
         if args.verbose:
             print(f"Reading performance data from: {input_path}")
-
         data = read_perf_data(input_path)
+        _print_verbose_data_info(data, args.verbose)
 
-        if args.verbose:
-            print("\n=== Performance Data ===")
-            print(f"  Version: {data['version']}")
-            print(f"  Task Count: {len(data['tasks'])}")
-
-            # Calculate time range
-            if data['tasks']:
-                start_times = [t['start_time_us'] for t in data['tasks']]
-                end_times = [t['end_time_us'] for t in data['tasks']]
-                min_time = min(start_times)
-                max_time = max(end_times)
-                print(f"  Time Range: {min_time:.3f} us - {max_time:.3f} us (span: {max_time - min_time:.3f} us)")
-            print()
-
-        # Load function name mapping from kernel_config.py if provided
         func_names = {}
         if args.kernel_config:
             if args.verbose:
@@ -1067,86 +1153,40 @@ Examples:
                     print(f"    func_id={func_id}: {name}")
                 print()
 
-        # Determine output path
-        if args.output:
-            output_path = Path(args.output)
-        else:
-            # Extract timestamp from input filename
-            # Expected format: perf_swimlane_YYYYMMDD_HHMMSS.json
-            input_stem = input_path.stem  # filename without extension
+        output_path = _resolve_output_path(args, input_path)
 
-            # Try to extract timestamp from filename
-            if input_stem.startswith("perf_swimlane_"):
-                timestamp_part = input_stem[len("perf_swimlane_"):]  # e.g., "20260210_143526"
-            else:
-                # Fallback: use current timestamp
-                timestamp_part = datetime.now().strftime("%Y%m%d_%H%M%S")
-
-            # Generate output filename and save to outputs/ directory
-            outputs_dir = Path(__file__).parent.parent / "outputs"
-            outputs_dir.mkdir(exist_ok=True)  # Ensure outputs directory exists
-            output_path = outputs_dir / f"merged_swimlane_{timestamp_part}.json"
-
-        # Resolve device log path for scheduler analysis
         resolved_device_log, log_strategy = resolve_device_log_path(
             device_id=args.device_id,
             device_log=args.device_log,
             perf_path=input_path,
         )
 
-        # Extract version 2 data if available
-        scheduler_phases = data.get('aicpu_scheduler_phases')
-        orchestrator_data = data.get('aicpu_orchestrator')
-        orchestrator_phases = data.get('aicpu_orchestrator_phases')
-        core_to_thread = data.get('core_to_thread')
+        generate_chrome_trace_json(
+            data["tasks"],
+            str(output_path),
+            func_names,
+            args.verbose,
+            scheduler_phases=data.get("aicpu_scheduler_phases"),
+            orchestrator_data=data.get("aicpu_orchestrator"),
+            orchestrator_phases=data.get("aicpu_orchestrator_phases"),
+            core_to_thread=data.get("core_to_thread"),
+        )
 
-        if args.verbose and data['version'] == 2:
-            if scheduler_phases:
-                total_phase_records = sum(len(t) for t in scheduler_phases)
-                print(f"  Scheduler threads: {len(scheduler_phases)}")
-                print(f"  Total phase records: {total_phase_records}")
-            if orchestrator_data:
-                print(f"  Orchestrator: {orchestrator_data.get('submit_count', 0)} tasks")
-            if orchestrator_phases:
-                total_orch = sum(len(t) for t in orchestrator_phases)
-                print(f"  Orchestrator threads: {len(orchestrator_phases)}")
-                print(f"  Total orchestrator phase records: {total_orch}")
-            if core_to_thread:
-                print(f"  Core-to-thread mapping: {len(core_to_thread)} cores")
-
-        # Generate Perfetto JSON
-        generate_chrome_trace_json(data['tasks'], str(output_path), func_names, args.verbose,
-                                   scheduler_phases=scheduler_phases,
-                                   orchestrator_data=orchestrator_data,
-                                   orchestrator_phases=orchestrator_phases,
-                                   core_to_thread=core_to_thread)
-
-        print(f"\n✓ Conversion complete")
+        print("\n✓ Conversion complete")
         print(f"  Input:  {input_path}")
         print(f"  Output: {output_path}")
         print(f"\nTo visualize: Open https://ui.perfetto.dev/ and drag in {output_path}")
 
-        if resolved_device_log is not None:
-            print(f"\nDevice log: {resolved_device_log}")
-            print(f"Selection: {log_strategy}")
-            inferred_device_id = infer_device_id_from_log_path(resolved_device_log)
-            if inferred_device_id is not None:
-                print(f"Inferred Device ID: {inferred_device_id}")
-        else:
-            print(f"\nDevice log: (not resolved)")
-            print(f"Selection: {log_strategy}")
+        _report_device_log(resolved_device_log, log_strategy)
 
-        # Optional: parse sched CPU from device log
         sched_info = None
         if resolved_device_log is not None:
-            sched_info = parse_sched_cpu_from_device_log(resolved_device_log, len(data['tasks']))
+            sched_info = parse_sched_cpu_from_device_log(resolved_device_log, len(data["tasks"]))
             if args.verbose and sched_info is not None:
                 print(f"  Parsed sched CPU from device log: {sched_info['us_per_task']:.2f} us/task")
 
-        # Print task statistics (incl. task execution vs scheduler overhead)
-        print_task_statistics(data['tasks'], func_names, sched_info=sched_info)
+        print_task_statistics(data["tasks"], func_names, sched_info=sched_info)
 
-        # Integrated deep-dive overhead analysis
         if resolved_device_log is not None:
             print("\n=== Scheduler Overhead Deep Dive ===")
             deep_dive_rc = run_sched_overhead_analysis(
@@ -1170,10 +1210,9 @@ Examples:
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
-            import traceback
             traceback.print_exc()
         return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Both perf_to_mermaid.py and swimlane_converter.py failed when
kernel_config.py imported `task_interface` from the project's python/
directory, because that directory was not on sys.path at load time.
Fix by inserting the resolved python/ path before executing the module.

Also apply ruff formatting to pass pre-commit checks.
