### PR TITLE
sync(a5): SPMD multi-block dispatch, profiling fixes, and tensor dependency tracking

### DIFF
--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/golden.py
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/golden.py
@@ -1,0 +1,122 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Golden test specification for mixed AIC+AIV example.
+
+Covers all 5 resource shapes per iteration:
+  1. AIC_AIV_X2: C = A@B, F = D+E, I = G*H
+  2. AIC_ONLY:   J = A@B
+  3. AIV_X1:     K = D+E
+  4. AIV_X2:     L = D+E, M = G*H
+  5. AIC_AIV_X1: N = A@B, O = D+E
+
+All use 128x128 float32 tiles, repeated over num_iters slices.
+
+Args layout (15 args): [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+  Shape/dtype/size in ContinuousTensor metadata.
+"""
+
+import torch
+
+__outputs__ = ["C", "F", "I", "J", "K", "L", "M", "N", "O"]
+RTOL = 1e-3
+ATOL = 1e-3
+
+ALL_CASES = {
+    "case1": {"num_iters": 4},
+    "case2": {"num_iters": 1},
+}
+
+DEFAULT_CASE = "case1"
+
+MATMUL_SIZE = 128
+TILE_ELEMS = 128 * 128
+
+
+def generate_inputs(params: dict) -> list:
+    num_iters = params["num_iters"]
+
+    torch.manual_seed(42)
+
+    # Matmul inputs (shared by AIC tasks)
+    A = torch.randn(MATMUL_SIZE, MATMUL_SIZE, dtype=torch.float32) * 0.01
+    B = torch.randn(MATMUL_SIZE, MATMUL_SIZE, dtype=torch.float32) * 0.01
+
+    # Add inputs (shared by AIV add tasks)
+    D = torch.randn(TILE_ELEMS, dtype=torch.float32) * 0.01
+    E = torch.randn(TILE_ELEMS, dtype=torch.float32) * 0.01
+
+    # Mul inputs (shared by AIV mul tasks)
+    G = torch.randn(TILE_ELEMS, dtype=torch.float32) * 0.01
+    H = torch.randn(TILE_ELEMS, dtype=torch.float32) * 0.01
+
+    # Output buffers (num_iters slices each)
+    C = torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)
+    F = torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)
+    I_out = torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)  # noqa: E741
+    J = torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)
+    K = torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)
+    L = torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)
+    M = torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)
+    N = torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)
+    O_out = torch.zeros(num_iters * TILE_ELEMS, dtype=torch.float32)  # noqa: E741
+
+    A_flat = A.flatten()
+    B_flat = B.flatten()
+
+    return [
+        ("A", A_flat),
+        ("B", B_flat),
+        ("C", C),
+        ("D", D),
+        ("E", E),
+        ("F", F),
+        ("G", G),
+        ("H", H),
+        ("I", I_out),
+        ("J", J),
+        ("K", K),
+        ("L", L),
+        ("M", M),
+        ("N", N),
+        ("O", O_out),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    num_iters = params["num_iters"]
+
+    A = torch.as_tensor(tensors["A"]).reshape(MATMUL_SIZE, MATMUL_SIZE)
+    B = torch.as_tensor(tensors["B"]).reshape(MATMUL_SIZE, MATMUL_SIZE)
+    D = torch.as_tensor(tensors["D"])
+    E = torch.as_tensor(tensors["E"])
+    G = torch.as_tensor(tensors["G"])
+    H = torch.as_tensor(tensors["H"])
+
+    golden_matmul = torch.matmul(A, B).flatten()
+    golden_add = D + E
+    golden_mul = G * H
+
+    for name in ["C", "J", "N"]:
+        out = torch.as_tensor(tensors[name]).reshape(num_iters, TILE_ELEMS)
+        for i in range(num_iters):
+            out[i] = golden_matmul
+        tensors[name][:] = out.flatten()
+
+    for name in ["F", "K", "L", "O"]:
+        out = torch.as_tensor(tensors[name]).reshape(num_iters, TILE_ELEMS)
+        for i in range(num_iters):
+            out[i] = golden_add
+        tensors[name][:] = out.flatten()
+
+    for name in ["I", "M"]:
+        out = torch.as_tensor(tensors[name]).reshape(num_iters, TILE_ELEMS)
+        for i in range(num_iters):
+            out[i] = golden_mul
+        tensors[name][:] = out.flatten()

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Matrix Multiplication Kernel (Cube Core)
+ *
+ * Computes: C = A @ B (TILE x TILE x TILE matmul)
+ * Uses TMATMUL instruction
+ *
+ * Args (Tensor*):
+ *   args[0] = A (INPUT)  - TILE x TILE
+ *   args[1] = B (INPUT)  - TILE x TILE
+ *   args[2] = C (OUTPUT) - TILE x TILE
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <typename T>
+AICORE constexpr inline T CeilAlign(T num_1, T num_2) {
+    if (num_2 == 0) {
+        return 0;
+    }
+    return (num_1 + num_2 - 1) / num_2 * num_2;
+}
+
+static __aicore__ inline int get_num_tiles(__gm__ Tensor *tensor, uint64_t tile_elems) {
+    uint64_t total_elems = tensor->shapes[0];
+    return static_cast<int>(total_elems / tile_elems);
+}
+
+template <int TILE>
+static __aicore__ void matmul_impl(__gm__ float *input_a, __gm__ float *input_b, __gm__ float *output) {
+    constexpr int blockAlign = C0_SIZE_BYTE / sizeof(float);
+    constexpr int M = CeilAlign<int>(TILE, 16);
+    constexpr int K = CeilAlign<int>(TILE, blockAlign);
+    constexpr int N = CeilAlign<int>(TILE, blockAlign);
+
+    using GlobalDataA = GlobalTensor<
+        float, Shape<1, 1, 1, TILE, TILE>, pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataB = GlobalTensor<
+        float, Shape<1, 1, 1, TILE, TILE>, pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+    using GlobalDataC = GlobalTensor<
+        float, Shape<1, 1, 1, TILE, TILE>, pto::Stride<1 * TILE * TILE, 1 * TILE * TILE, TILE * TILE, TILE, 1>>;
+
+    GlobalDataA src0Global(input_a);
+    GlobalDataB src1Global(input_b);
+    GlobalDataC dstGlobal(output);
+
+    using TileMatA = Tile<TileType::Mat, float, M, K, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, float, K, N, BLayout::ColMajor, TILE, TILE, SLayout::RowMajor, 512>;
+
+    using LeftTile = TileLeft<float, M, K, TILE, TILE>;
+    using RightTile = TileRight<float, K, N, TILE, TILE>;
+    using AccTile = TileAcc<float, M, N, TILE, TILE>;
+
+    TileMatA aMatTile;
+    TileMatB bMatTile;
+    TASSIGN(aMatTile, 0x0);
+    TASSIGN(bMatTile, 0x20000);
+
+    LeftTile aTile;
+    RightTile bTile;
+    AccTile cTile;
+    TASSIGN(aTile, 0x0);
+    TASSIGN(bTile, 0x0);
+    TASSIGN(cTile, 0x0);
+
+    TLOAD(aMatTile, src0Global);
+    TLOAD(bMatTile, src1Global);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    TMOV(aTile, aMatTile);
+    TMOV(bTile, bMatTile);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    TMATMUL(cTile, aTile, bTile);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TSTORE(dstGlobal, cTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_a = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *input_b = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *output = reinterpret_cast<__gm__ Tensor *>(args[2]);
+
+    constexpr uint64_t TILE_ELEMS = 128 * 128;
+    int num_tiles = get_num_tiles(input_a, TILE_ELEMS);
+
+    __gm__ float *base_a = reinterpret_cast<__gm__ float *>(input_a->buffer.addr) + input_a->start_offset;
+    __gm__ float *base_b = reinterpret_cast<__gm__ float *>(input_b->buffer.addr) + input_b->start_offset;
+    __gm__ float *base_c = reinterpret_cast<__gm__ float *>(output->buffer.addr) + output->start_offset;
+
+    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        __gm__ float *a_ptr = base_a + (tile_idx * TILE_ELEMS);
+        __gm__ float *b_ptr = base_b + (tile_idx * TILE_ELEMS);
+        __gm__ float *c_ptr = base_c + (tile_idx * TILE_ELEMS);
+
+        matmul_impl<128>(a_ptr, b_ptr, c_ptr);
+    }
+}

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Element-wise Tensor Addition Kernel (for mixed task)
+ *
+ * Implements: out[i] = src0[i] + src1[i]
+ * Tile size: 128 x 128
+ *
+ * In the mixed task, this kernel shares the param list with the matmul kernel.
+ * Matmul uses args[0..2], this kernel uses args[3..5].
+ *
+ * Args (Tensor*):
+ *   args[3] = src0 (INPUT)  - 128 x 128
+ *   args[4] = src1 (INPUT)  - 128 x 128
+ *   args[5] = out (OUTPUT)  - 128 x 128
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static __aicore__ inline int get_num_tiles(__gm__ Tensor *tensor, uint64_t tile_elems) {
+    uint64_t total_elems = tensor->shapes[0];
+    return static_cast<int>(total_elems / tile_elems);
+}
+
+template <int ROWS, int COLS>
+static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ float *out) {
+    using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
+    using DynStridDim5 = pto::Stride<1, 1, 1, COLS, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, ROWS, COLS, BLayout::RowMajor, -1, -1>;
+
+    TileData src0Tile(ROWS, COLS);
+    TileData src1Tile(ROWS, COLS);
+    TileData dstTile(ROWS, COLS);
+    TASSIGN(src0Tile, 0x0);
+    TASSIGN(src1Tile, 0x10000);
+    TASSIGN(dstTile, 0x20000);
+
+    GlobalData src0Global(src0);
+    GlobalData src1Global(src1);
+    GlobalData dstGlobal(out);
+
+    TLOAD(src0Tile, src0Global);
+    TLOAD(src1Tile, src1Global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(dstTile, src0Tile, src1Tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, dstTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[5]);
+
+    constexpr uint64_t TILE_ELEMS = 128 * 128;
+    int num_tiles = get_num_tiles(src0_tensor, TILE_ELEMS);
+
+    __gm__ float *base_src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *base_src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *base_out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        __gm__ float *src0_ptr = base_src0 + (tile_idx * TILE_ELEMS);
+        __gm__ float *src1_ptr = base_src1 + (tile_idx * TILE_ELEMS);
+        __gm__ float *out_ptr = base_out + (tile_idx * TILE_ELEMS);
+
+        add_impl<128, 128>(src0_ptr, src1_ptr, out_ptr);
+    }
+}

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Standalone Element-wise Addition Kernel
+ *
+ * Implements: out[i] = src0[i] + src1[i]
+ * Tile size: 128 x 128
+ *
+ * Reads args[0..2] — for standalone AIV_X1 tasks or AIV0 slot in AIV_X2.
+ *
+ * Args (Tensor*):
+ *   args[0] = src0 (INPUT)  - 128 x 128
+ *   args[1] = src1 (INPUT)  - 128 x 128
+ *   args[2] = out (OUTPUT)  - 128 x 128
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int ROWS, int COLS>
+static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ float *out) {
+    using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
+    using DynStridDim5 = pto::Stride<1, 1, 1, COLS, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, ROWS, COLS, BLayout::RowMajor, -1, -1>;
+
+    TileData src0Tile(ROWS, COLS);
+    TileData src1Tile(ROWS, COLS);
+    TileData dstTile(ROWS, COLS);
+    TASSIGN(src0Tile, 0x0);
+    TASSIGN(src1Tile, 0x10000);
+    TASSIGN(dstTile, 0x20000);
+
+    GlobalData src0Global(src0);
+    GlobalData src1Global(src1);
+    GlobalData dstGlobal(out);
+
+    TLOAD(src0Tile, src0Global);
+    TLOAD(src1Tile, src1Global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(dstTile, src0Tile, src1Tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, dstTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    add_impl<128, 128>(src0, src1, out);
+}

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Element-wise Tensor Multiplication Kernel (for mixed task, AIV1 slot)
+ *
+ * Implements: out[i] = src0[i] * src1[i]
+ * Tile size: 128 x 128
+ *
+ * In the mixed task, this kernel occupies the AIV1 slot and shares the param
+ * list with the matmul kernel (args[0..2]) and add kernel (args[3..5]).
+ * This kernel uses args[6..8].
+ *
+ * Args (Tensor*):
+ *   args[6] = src0 (INPUT)  - 128 x 128
+ *   args[7] = src1 (INPUT)  - 128 x 128
+ *   args[8] = out (OUTPUT)  - 128 x 128
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static __aicore__ inline int get_num_tiles(__gm__ Tensor *tensor, uint64_t tile_elems) {
+    uint64_t total_elems = tensor->shapes[0];
+    return static_cast<int>(total_elems / tile_elems);
+}
+
+template <int ROWS, int COLS>
+static __aicore__ void mul_impl(__gm__ float *src0, __gm__ float *src1, __gm__ float *out) {
+    using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
+    using DynStridDim5 = pto::Stride<1, 1, 1, COLS, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, ROWS, COLS, BLayout::RowMajor, -1, -1>;
+
+    TileData src0Tile(ROWS, COLS);
+    TileData src1Tile(ROWS, COLS);
+    TileData dstTile(ROWS, COLS);
+    TASSIGN(src0Tile, 0x0);
+    TASSIGN(src1Tile, 0x10000);
+    TASSIGN(dstTile, 0x20000);
+
+    GlobalData src0Global(src0);
+    GlobalData src1Global(src1);
+    GlobalData dstGlobal(out);
+
+    TLOAD(src0Tile, src0Global);
+    TLOAD(src1Tile, src1Global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TMUL(dstTile, src0Tile, src1Tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, dstTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[6]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[7]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[8]);
+
+    constexpr uint64_t TILE_ELEMS = 128 * 128;
+    int num_tiles = get_num_tiles(src0_tensor, TILE_ELEMS);
+
+    __gm__ float *base_src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *base_src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *base_out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    for (int tile_idx = 0; tile_idx < num_tiles; tile_idx++) {
+        __gm__ float *src0_ptr = base_src0 + (tile_idx * TILE_ELEMS);
+        __gm__ float *src1_ptr = base_src1 + (tile_idx * TILE_ELEMS);
+        __gm__ float *out_ptr = base_out + (tile_idx * TILE_ELEMS);
+
+        mul_impl<128, 128>(src0_ptr, src1_ptr, out_ptr);
+    }
+}

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Standalone Element-wise Multiplication Kernel (AIV1 slot)
+ *
+ * Implements: out[i] = src0[i] * src1[i]
+ * Tile size: 128 x 128
+ *
+ * Reads args[3..5] — for AIV1 slot in AIV_X2 tasks where AIV0 uses args[0..2].
+ *
+ * Args (Tensor*):
+ *   args[3] = src0 (INPUT)  - 128 x 128
+ *   args[4] = src1 (INPUT)  - 128 x 128
+ *   args[5] = out (OUTPUT)  - 128 x 128
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+template <int ROWS, int COLS>
+static __aicore__ void mul_impl(__gm__ float *src0, __gm__ float *src1, __gm__ float *out) {
+    using DynShapeDim5 = Shape<1, 1, 1, ROWS, COLS>;
+    using DynStridDim5 = pto::Stride<1, 1, 1, COLS, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, ROWS, COLS, BLayout::RowMajor, -1, -1>;
+
+    TileData src0Tile(ROWS, COLS);
+    TileData src1Tile(ROWS, COLS);
+    TileData dstTile(ROWS, COLS);
+    TASSIGN(src0Tile, 0x0);
+    TASSIGN(src1Tile, 0x10000);
+    TASSIGN(dstTile, 0x20000);
+
+    GlobalData src0Global(src0);
+    GlobalData src1Global(src1);
+    GlobalData dstGlobal(out);
+
+    TLOAD(src0Tile, src0Global);
+    TLOAD(src1Tile, src1Global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TMUL(dstTile, src0Tile, src1Tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, dstTile);
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[5]);
+
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    mul_impl<128, 128>(src0, src1, out);
+}

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/kernel_config.py
@@ -1,0 +1,74 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Kernel configuration for mixed AIC+AIV example (tensormap_and_ringbuffer Runtime).
+
+Covers all 5 resource shapes:
+  - AIC_ONLY:   standalone matmul
+  - AIV_X1:     standalone add
+  - AIV_X2:     add (AIV0) + mul (AIV1)
+  - AIC_AIV_X1: matmul (AIC) + add (AIV0)
+  - AIC_AIV_X2: matmul (AIC) + add (AIV0) + mul (AIV1)
+"""
+
+from pathlib import Path
+
+from task_interface import ArgDirection as D  # pyright: ignore[reportAttributeAccessIssue]
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "mixed_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+    "signature": [D.IN, D.IN, D.OUT, D.IN, D.IN, D.OUT, D.IN, D.IN, D.OUT, D.OUT, D.OUT, D.OUT, D.OUT, D.OUT, D.OUT],
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "MATMUL",
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_matmul.cpp"),
+        "core_type": "aic",
+        "signature": [D.IN, D.IN, D.OUT],
+    },
+    {
+        "func_id": 1,
+        "name": "ADD",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_add.cpp"),
+        "core_type": "aiv",
+        "signature": [D.IN, D.IN, D.OUT],
+    },
+    {
+        "func_id": 2,
+        "name": "MUL",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_mul.cpp"),
+        "core_type": "aiv",
+        "signature": [D.IN, D.IN, D.OUT],
+    },
+    {
+        "func_id": 3,
+        "name": "ADD_STANDALONE",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_add_standalone.cpp"),
+        "core_type": "aiv",
+        "signature": [D.IN, D.IN, D.OUT],
+    },
+    {
+        "func_id": 4,
+        "name": "MUL_STANDALONE",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_mul_standalone.cpp"),
+        "core_type": "aiv",
+        "signature": [D.IN, D.IN, D.OUT],
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "block_dim": 3,
+}

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Mixed AIC+AIV Orchestration Function (tensormap_and_ringbuffer Runtime)
+ *
+ * Covers all 5 resource shapes per iteration:
+ *   1. AIC_AIV_X2: AIC matmul(A,B->C) + AIV0 add(D,E->F) + AIV1 mul(G,H->I)
+ *   2. AIC_ONLY:   matmul(A,B->J)
+ *   3. AIV_X1:     add(D,E->K)
+ *   4. AIV_X2:     AIV0 add(D,E->L) + AIV1 mul(G,H->M)
+ *   5. AIC_AIV_X1: AIC matmul(A,B->N) + AIV0 add(D,E->O)
+ *
+ * Arg layout (15 args):
+ *   [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+ *   Shape/dtype/size in tensor metadata.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+// Mixed-task kernels (args offset matches param position in mixed param list)
+#define FUNC_MATMUL 0  // AIC: reads args[0..2]
+#define FUNC_ADD 1     // AIV0 in mixed: reads args[3..5]
+#define FUNC_MUL 2     // AIV1 in mixed: reads args[6..8]
+// Standalone kernels (read args[0..2] or args[3..5])
+#define FUNC_ADD_STANDALONE 3  // AIV: reads args[0..2]
+#define FUNC_MUL_STANDALONE 4  // AIV1 in AIV_X2: reads args[3..5]
+
+static constexpr uint32_t TILE_ELEMS = 128 * 128;
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 15,
+    };
+}
+
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
+    (void)orch_thread_num;    // NOLINT(readability/casting)
+    (void)orch_thread_index;  // NOLINT(readability/casting)
+
+    // Input tensors use from_tensor_arg() — golden shape = kernel shape
+    Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
+    Tensor ext_B = from_tensor_arg(orch_args.tensor(1));
+    Tensor ext_D = from_tensor_arg(orch_args.tensor(3));
+    Tensor ext_E = from_tensor_arg(orch_args.tensor(4));
+    Tensor ext_G = from_tensor_arg(orch_args.tensor(6));
+    Tensor ext_H = from_tensor_arg(orch_args.tensor(7));
+
+    // Output tensors — full buffers
+    Tensor ext_C = from_tensor_arg(orch_args.tensor(2));
+    Tensor ext_F = from_tensor_arg(orch_args.tensor(5));
+    Tensor ext_I = from_tensor_arg(orch_args.tensor(8));
+    Tensor ext_J = from_tensor_arg(orch_args.tensor(9));
+    Tensor ext_K = from_tensor_arg(orch_args.tensor(10));
+    Tensor ext_L = from_tensor_arg(orch_args.tensor(11));
+    Tensor ext_M = from_tensor_arg(orch_args.tensor(12));
+    Tensor ext_N = from_tensor_arg(orch_args.tensor(13));
+    Tensor ext_O = from_tensor_arg(orch_args.tensor(14));
+
+    // Derive num_iters from output tensor size
+    uint32_t total_elems = orch_args.tensor(2).shapes[0];
+    int num_iters = static_cast<int>(total_elems / TILE_ELEMS);
+
+    LOG_INFO("[mixed_orch] num_iters=%d", num_iters);
+
+    for (int i = 0; i < num_iters; i++) {
+        PTO2_SCOPE() {
+            uint32_t view_shapes[1] = {TILE_ELEMS};
+            uint32_t view_offsets[1] = {static_cast<uint32_t>(i) * TILE_ELEMS};
+
+            Tensor C_view = ext_C.view(view_shapes, view_offsets);
+            Tensor F_view = ext_F.view(view_shapes, view_offsets);
+            Tensor I_view = ext_I.view(view_shapes, view_offsets);
+            Tensor J_view = ext_J.view(view_shapes, view_offsets);
+            Tensor K_view = ext_K.view(view_shapes, view_offsets);
+            Tensor L_view = ext_L.view(view_shapes, view_offsets);
+            Tensor M_view = ext_M.view(view_shapes, view_offsets);
+            Tensor N_view = ext_N.view(view_shapes, view_offsets);
+            Tensor O_view = ext_O.view(view_shapes, view_offsets);
+
+            // 1. AIC_AIV_X2: matmul + add + mul
+            {
+                MixedKernels mk;
+                mk.aic_kernel_id = FUNC_MATMUL;
+                mk.aiv0_kernel_id = FUNC_ADD;
+                mk.aiv1_kernel_id = FUNC_MUL;
+                Arg args;
+                args.add_input(ext_A);
+                args.add_input(ext_B);
+                args.add_output(C_view);
+                args.add_input(ext_D);
+                args.add_input(ext_E);
+                args.add_output(F_view);
+                args.add_input(ext_G);
+                args.add_input(ext_H);
+                args.add_output(I_view);
+                pto2_rt_submit_task(mk, args);
+            }
+
+            // 2. AIC_ONLY: standalone matmul
+            {
+                Arg args;
+                args.add_input(ext_A);
+                args.add_input(ext_B);
+                args.add_output(J_view);
+                pto2_rt_submit_aic_task(FUNC_MATMUL, args);
+            }
+
+            // 3. AIV_X1: standalone add
+            {
+                Arg args;
+                args.add_input(ext_D);
+                args.add_input(ext_E);
+                args.add_output(K_view);
+                pto2_rt_submit_aiv_task(FUNC_ADD_STANDALONE, args);
+            }
+
+            // 4. AIV_X2: add (AIV0) + mul (AIV1)
+            {
+                MixedKernels mk;
+                mk.aiv0_kernel_id = FUNC_ADD_STANDALONE;
+                mk.aiv1_kernel_id = FUNC_MUL_STANDALONE;
+                Arg args;
+                args.add_input(ext_D);
+                args.add_input(ext_E);
+                args.add_output(L_view);
+                args.add_input(ext_G);
+                args.add_input(ext_H);
+                args.add_output(M_view);
+                pto2_rt_submit_task(mk, args);
+            }
+
+            // 5. AIC_AIV_X1: matmul (AIC) + add (AIV0)
+            {
+                MixedKernels mk;
+                mk.aic_kernel_id = FUNC_MATMUL;
+                mk.aiv0_kernel_id = FUNC_ADD;
+                Arg args;
+                args.add_input(ext_A);
+                args.add_input(ext_B);
+                args.add_output(N_view);
+                args.add_input(ext_D);
+                args.add_input(ext_E);
+                args.add_output(O_view);
+                pto2_rt_submit_task(mk, args);
+            }
+        }
+    }
+
+    LOG_INFO("[mixed_orch] Submitted %d iterations x 5 shapes = %d tasks", num_iters, num_iters * 5);
+}
+
+}  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -163,6 +163,7 @@ static __aicore__ void online_update_impl(
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
+        // pipe_barrier(PIPE_V) required between each dependent vector operation
         // to resolve RAW hazards on shared UB tiles.
         TMAX(miNewND, miND, mijND);    // mi_new = max(mi, mij)
         TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -26,8 +26,9 @@
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
-#include "tensor.h"
+#include "tensor.h"  // NOLINT(build/include_subdir)
 
+// NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
 #ifndef __gm__
@@ -35,7 +36,7 @@ using namespace pto;
 #endif
 
 #ifndef __aicore__
-#define __aicore__ [aicore]
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
 template <int M, int N>
@@ -115,12 +116,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *pij = reinterpret_cast<__gm__ Tensor *>(args[1]);
     __gm__ Tensor *mij = reinterpret_cast<__gm__ Tensor *>(args[2]);
     __gm__ Tensor *lij = reinterpret_cast<__gm__ Tensor *>(args[3]);
-    union {
-        uint64_t u;
-        float f;
-    } scale_conv;
-    scale_conv.u = static_cast<uint64_t>(args[4]);
-    float scale_value = scale_conv.f;
+    float scale_value = from_u64<float>(static_cast<uint64_t>(args[4]));
 
     softmax_prepare_impl<16, 16>(sij, scale_value, pij, mij, lij);
 }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
@@ -88,6 +88,6 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 2,
+    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -126,11 +126,11 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                 uint32_t out_view_offsets[2] = {cur_offset, 0};
                 Tensor out_view = out.view(tile2d_shapes, out_view_offsets);
 
-                Arg args_inplace;
-                args_inplace.add_output(tile2d_ci);
-                args_inplace.add_output(scalar_ci);
-                args_inplace.add_output(scalar_ci);
-                TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, args_inplace);
+                Arg params_inplace;
+                params_inplace.add_output(tile2d_ci);
+                params_inplace.add_output(scalar_ci);
+                params_inplace.add_output(scalar_ci);
+                TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, params_inplace);
                 const Tensor &oi = hub_outs.get_ref(0);
                 const Tensor &li_update = hub_outs.get_ref(1);
                 const Tensor &mi_update = hub_outs.get_ref(2);
@@ -144,48 +144,48 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     Tensor kj = key_cache.view(kv_shapes, kv_offsets);
                     Tensor vj = value_cache.view(kv_shapes, kv_offsets);
 
-                    Arg args_qk;
-                    args_qk.add_input(qi);
-                    args_qk.add_input(kj);
-                    args_qk.add_output(sij_ci);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, args_qk);
+                    Arg params_qk;
+                    params_qk.add_input(qi);
+                    params_qk.add_input(kj);
+                    params_qk.add_output(sij_ci);
+                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij = qk_outs.get_ref(0);
 
                     uint32_t sij_valid_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(valid_len)};
                     uint32_t sij_valid_offsets[2] = {0, 0};
                     Tensor sij_valid = sij.view(sij_valid_shapes, sij_valid_offsets);
-                    Arg args_sf;
-                    args_sf.add_input(sij_valid);
-                    args_sf.add_output(pij_f16_ci);
-                    args_sf.add_output(scalar_ci);
-                    args_sf.add_output(scalar_ci);
-                    args_sf.add_scalar(scale_value);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, args_sf);
+                    Arg params_sf;
+                    params_sf.add_input(sij_valid);
+                    params_sf.add_output(pij_f16_ci);
+                    params_sf.add_output(scalar_ci);
+                    params_sf.add_output(scalar_ci);
+                    params_sf.add_scalar(scale_value);
+                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_f16 = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
 
-                    Arg args_pv;
-                    args_pv.add_input(pij_f16);
-                    args_pv.add_input(vj);
-                    args_pv.add_output(tile2d_ci);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, args_pv);
+                    Arg params_pv;
+                    params_pv.add_input(pij_f16);
+                    params_pv.add_input(vj);
+                    params_pv.add_output(tile2d_ci);
+                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_tmp = pv_outs.get_ref(0);
 
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
 
-                    Arg args_up;
-                    args_up.add_input(mi);
-                    args_up.add_input(li);
-                    args_up.add_input(oi_tmp);
-                    args_up.add_inout(mi_update);
-                    args_up.add_inout(li_update);
-                    args_up.add_inout(oi);
-                    args_up.add_inout(out_view);
-                    args_up.add_scalar(is_first);
-                    args_up.add_scalar(is_last);
-                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, args_up);
+                    Arg params_up;
+                    params_up.add_input(mi);
+                    params_up.add_input(li);
+                    params_up.add_input(oi_tmp);
+                    params_up.add_inout(mi_update);
+                    params_up.add_inout(li_update);
+                    params_up.add_inout(oi);
+                    params_up.add_inout(out_view);
+                    params_up.add_scalar(is_first);
+                    params_up.add_scalar(is_last);
+                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
                 }
             }
         }

--- a/examples/a5/tensormap_and_ringbuffer/spmd_basic/golden.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_basic/golden.py
@@ -1,0 +1,65 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Golden test for SPMD context accessors (Phase 2: block_dim=1).
+
+Verifies that get_block_idx and get_block_num return correct values for all
+three subtask slots (AIC, AIV0, AIV1) in a MIX task, and that AIV
+kernels read the correct sub_block_id from GlobalContext.
+
+Phase 2 invariants: block_idx=0, block_num=1.
+GlobalContext: sub_block_id 0 (AIV0/left), 1 (AIV1/right).
+
+Output layout (float32[48], 3 cache lines):
+  [0..15]  = AIC  slot: [block_idx, block_num, pad x14]
+  [16..31] = AIV0 slot: [block_idx, block_num, sub_block_id=0, pad x13]
+  [32..47] = AIV1 slot: [block_idx, block_num, sub_block_id=1, pad x13]
+
+Args layout: [output]
+"""
+
+import torch
+
+__outputs__ = ["output"]
+RTOL = 0
+ATOL = 0
+
+ALL_CASES = {
+    "Case1": {},
+}
+
+DEFAULT_CASE = "Case1"
+
+# 16 floats per slot = 64 bytes = 1 cache line
+FLOATS_PER_CACHE_LINE = 16
+
+
+def generate_inputs(params: dict) -> list:
+    output = torch.zeros(3 * FLOATS_PER_CACHE_LINE, dtype=torch.float32)
+    return [
+        ("output", output),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    out = torch.as_tensor(tensors["output"])
+    # Cache line 0: AIC (no sub_block_id)
+    out[0] = 0.0  # block_idx
+    out[1] = 1.0  # block_num
+    # Cache line 1: AIV0 (sub_block_id=0)
+    base = 1 * FLOATS_PER_CACHE_LINE
+    out[base + 0] = 0.0  # block_idx
+    out[base + 1] = 1.0  # block_num
+    out[base + 2] = 0.0  # sub_block_id
+    # Cache line 2: AIV1 (sub_block_id=1)
+    base = 2 * FLOATS_PER_CACHE_LINE
+    out[base + 0] = 0.0  # block_idx
+    out[base + 1] = 1.0  # block_num
+    out[base + 2] = 1.0  # sub_block_id
+    tensors["output"][:] = out

--- a/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/aic/kernel_spmd_read.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/aic/kernel_spmd_read.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Context Read Kernel (AIC version)
+ *
+ * Reads SPMD local context (block_idx, block_num) and writes values to
+ * cache line 0 of the shared output tensor.  AIC does not use
+ * get_sub_block_id (sub_block_id is only meaningful for AIV).
+ *
+ * Args:
+ *   args[0] = output Tensor* (OUTPUT, 48 float32 elements)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+// Cache line = 64B = 16 float32.  Each slot owns one cache line.
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+
+// dcci + constants: CCEC provides these as builtins; provide fallbacks for sim.
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    // AIC writes at fixed cache line 0 (no sub_block_id needed)
+    out[0] = static_cast<float>(get_block_idx(args));
+    out[1] = static_cast<float>(get_block_num(args));
+
+    // Flush this cache line to HBM so host can read the output.
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/aiv/kernel_spmd_read.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/aiv/kernel_spmd_read.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Context Read Kernel (AIV version)
+ *
+ * Reads SPMD context via Get* accessors and writes values to the shared
+ * output tensor.  AIV uses get_sub_block_id to determine its lane (0=left,
+ * 1=right) and writes at cache line (1 + sub_block_id) to avoid
+ * overlapping with the AIC slot at cache line 0.
+ *
+ * Args:
+ *   args[0] = output Tensor* (OUTPUT, 48 float32 elements)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+// Cache line = 64B = 16 float32.  Each slot owns one cache line.
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+
+// dcci + constants: CCEC provides these as builtins; provide fallbacks for sim.
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int32_t sub_block_id = get_sub_block_id(args);
+    // AIV writes at cache line (1 + sub_block_id), skipping AIC's cache line 0
+    int32_t offset = (1 + sub_block_id) * FLOATS_PER_CACHE_LINE;
+
+    out[offset + 0] = static_cast<float>(get_block_idx(args));
+    out[offset + 1] = static_cast<float>(get_block_num(args));
+    out[offset + 2] = static_cast<float>(sub_block_id);
+
+    // Flush this cache line to HBM so host can read the output.
+    dcci(&out[offset], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/kernel_config.py
@@ -1,0 +1,51 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Kernel configuration for SPMD basic test (tensormap_and_ringbuffer Runtime).
+
+Submits a single MIX task (AIC + AIV0 + AIV1) so all three sub_block_id
+values are exercised in one dispatch.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "spmd_basic_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "SPMD_READ_AIC",
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_spmd_read.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "SPMD_READ_AIV0",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_spmd_read.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 2,
+        "name": "SPMD_READ_AIV1",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_spmd_read.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "orch_thread_num": 1,
+    "block_dim": 24,
+}

--- a/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Basic Orchestration
+ *
+ * Submits a single MIX task (AIC + AIV0 + AIV1) with a shared output
+ * tensor. Each subtask writes its SPMD context at a sub_block_id-based
+ * offset, so the host can verify all three slots independently.
+ *
+ * Args layout: [output]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_SPMD_READ_AIC 0
+#define FUNC_SPMD_READ_AIV0 1
+#define FUNC_SPMD_READ_AIV1 2
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 1,
+    };
+}
+
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
+    (void)orch_thread_num;  // NOLINT(readability/casting)
+    if (orch_thread_index != 0) return;
+
+    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+
+    MixedKernels mk;
+    mk.aic_kernel_id = FUNC_SPMD_READ_AIC;
+    mk.aiv0_kernel_id = FUNC_SPMD_READ_AIV0;
+    mk.aiv1_kernel_id = FUNC_SPMD_READ_AIV1;
+
+    Arg args;
+    args.add_inout(ext_output);
+
+    pto2_rt_submit_task(mk, args);
+
+    LOG_ALWAYS("[spmd_basic_orch] Submitted 1 MIX task (AIC+AIV0+AIV1)");
+}
+
+}  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/golden.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/golden.py
@@ -1,0 +1,63 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Golden test for SPMD multi-block AIV.
+
+Submits five AIV tasks with block_num = 4, 16, 24, 48, 96 to verify:
+  T0 (block_num=4):  basic multi-block — fits within one sched thread
+  T1 (block_num=16): saturates one sched thread (8 clusters × 2 AIV)
+  T2 (block_num=24): forces cross-thread dispatch via ready_queue re-push
+  T3 (block_num=48): occupies all AIV cores across all 3 sched threads
+  T4 (block_num=96): two full rounds of all AIV cores
+
+Each block writes float(block_idx) at cache line (base_cl + block_idx).
+Output tensor: 188 cache lines = 3008 float32.
+
+Args layout: [output]
+"""
+
+import torch
+
+__outputs__ = ["output"]
+RTOL = 0
+ATOL = 0
+
+ALL_CASES = {
+    "Case1": {},
+}
+
+DEFAULT_CASE = "Case1"
+
+FLOATS_PER_CACHE_LINE = 16
+
+# (block_num, base_cl) for each submitted task
+TASKS = [
+    (4, 0),  # T0: basic
+    (16, 4),  # T1: saturate single thread
+    (24, 20),  # T2: cross-thread
+    (48, 44),  # T3: all AIV cores
+    (96, 92),  # T4: two full rounds
+]
+
+TOTAL_CL = sum(block_num for block_num, _ in TASKS)  # 44
+
+
+def generate_inputs(params: dict) -> list:
+    output = torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)
+    return [
+        ("output", output),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    out = torch.as_tensor(tensors["output"])
+    for block_num, base_cl in TASKS:
+        for block_idx in range(block_num):
+            out[(base_cl + block_idx) * FLOATS_PER_CACHE_LINE] = float(block_idx)
+    tensors["output"][:] = out

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/aiv/kernel_spmd_write.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/aiv/kernel_spmd_write.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Multi-Block Write Kernel (AIV)
+ *
+ * Each block writes float(block_idx) at a cacheline-aligned offset
+ * determined by scalar parameter base_cl:
+ *
+ *   out[(base_cl + block_idx) * FLOATS_PER_CACHE_LINE] = float(block_idx)
+ *
+ * Args:
+ *   args[0] = output Tensor* (INOUT)
+ *   args[1] = scalar: base_cl (starting cache line index for this task)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int32_t base_cl = static_cast<int32_t>(args[1]);
+    int32_t core_idx = get_block_idx(args);
+    int32_t offset = (base_cl + core_idx) * FLOATS_PER_CACHE_LINE;
+
+    out[offset] = static_cast<float>(core_idx);
+
+    dcci(&out[offset], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/kernel_config.py
@@ -1,0 +1,39 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Kernel configuration for SPMD multi-block AIV test (tensormap_and_ringbuffer Runtime).
+
+Submits a single AIV task with block_num=4 so each block writes its
+block_idx at a distinct cacheline-aligned offset.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "spmd_multiblock_aiv_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "SPMD_WRITE_AIV",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_spmd_write.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "orch_thread_num": 1,
+    "block_dim": 24,
+}

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Multi-Block AIV Orchestration
+ *
+ * Submits three AIV tasks with increasing block_num to exercise:
+ *   T0: block_num=4   — fits within a single sched thread
+ *   T1: block_num=16  — saturates one sched thread (8 clusters × 2 AIV)
+ *   T2: block_num=24  — forces cross-thread re-push via ready_queue
+ *
+ * Each task writes to a disjoint region of the output tensor using the
+ * base_cl scalar to offset the block writes.
+ *
+ * Args layout: [output]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_SPMD_WRITE_AIV 0
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 1,
+    };
+}
+
+static void submit_spmd_aiv(int32_t kernel_id, Tensor &out, int16_t block_num, int64_t base_cl) {
+    Arg args;
+    args.add_inout(out);
+    args.add_scalar(base_cl);
+    args.launch_spec.set_core_num(block_num);
+    pto2_rt_submit_aiv_task(kernel_id, args);
+}
+
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
+    (void)orch_thread_num;  // NOLINT(readability/casting)
+    if (orch_thread_index != 0) return;
+
+    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+
+    // T0: 4 blocks — basic multi-block
+    submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 4, 0);
+
+    // T1: 16 blocks — saturate one sched thread's AIV cores (8 clusters × 2 AIV)
+    submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 16, 4);
+
+    // T2: 24 blocks — cross-thread dispatch via ready_queue re-push
+    submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 24, 20);
+
+    // T3: 48 blocks — occupy all AIV cores across all 3 sched threads
+    submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 48, 44);
+
+    // T4: 96 blocks — two full rounds of all AIV cores
+    submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 96, 92);
+
+    LOG_ALWAYS("[spmd_multiblock_aiv] Submitted 5 AIV tasks: block_num=4,16,24,48,96");
+}
+
+}  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/golden.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/golden.py
@@ -1,0 +1,68 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Golden test for SPMD multi-block MIX.
+
+Submits five MIX tasks (AIC + AIV0 + AIV1) with block_num = 2, 8, 12, 24, 48 to verify:
+  T0 (block_num=2):  basic multi-block MIX
+  T1 (block_num=8):  saturates one sched thread (8 clusters)
+  T2 (block_num=12): forces cross-thread dispatch via ready_queue re-push
+  T3 (block_num=24): occupies all clusters across all 3 sched threads
+  T4 (block_num=48): two full rounds of all clusters
+
+Each block occupies 3 cache lines (AIC, AIV0, AIV1).  All three cores
+in the same block write the same float(block_idx) to their respective CL.
+
+Output tensor: 282 cache lines = 4512 float32.
+
+Args layout: [output]
+"""
+
+import torch
+
+__outputs__ = ["output"]
+RTOL = 0
+ATOL = 0
+
+ALL_CASES = {
+    "Case1": {},
+}
+
+DEFAULT_CASE = "Case1"
+
+FLOATS_PER_CACHE_LINE = 16
+SLOTS_PER_BLOCK = 3  # AIC, AIV0, AIV1
+
+# (block_num, base_cl) for each submitted task
+TASKS = [
+    (2, 0),  # T0: basic MIX (6 CL)
+    (8, 6),  # T1: saturate single thread (24 CL)
+    (12, 30),  # T2: cross-thread (36 CL)
+    (24, 66),  # T3: all clusters (72 CL)
+    (48, 138),  # T4: two full rounds (144 CL)
+]
+
+TOTAL_CL = sum(block_num * SLOTS_PER_BLOCK for block_num, _ in TASKS)  # 66
+
+
+def generate_inputs(params: dict) -> list:
+    output = torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)
+    return [
+        ("output", output),
+    ]
+
+
+def compute_golden(tensors: dict, params: dict) -> None:
+    out = torch.as_tensor(tensors["output"])
+    for block_num, base_cl in TASKS:
+        for block_idx in range(block_num):
+            for slot in range(SLOTS_PER_BLOCK):
+                cl = base_cl + block_idx * SLOTS_PER_BLOCK + slot
+                out[cl * FLOATS_PER_CACHE_LINE] = float(block_idx)
+    tensors["output"][:] = out

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Multi-Block MIX Kernel (AIC version)
+ *
+ * AIC writes float(block_idx) at cache line (base_cl + block_idx * 3 + 0).
+ *
+ * Args:
+ *   args[0] = output Tensor* (INOUT)
+ *   args[1] = scalar: base_cl (starting cache line index for this task)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+static constexpr int32_t SLOTS_PER_BLOCK = 3;
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int32_t base_cl = static_cast<int32_t>(args[1]);
+    int32_t core_idx = get_block_idx(args);
+    int32_t offset = (base_cl + core_idx * SLOTS_PER_BLOCK + 0) * FLOATS_PER_CACHE_LINE;
+
+    out[offset] = static_cast<float>(core_idx);
+
+    dcci(&out[offset], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Multi-Block MIX Kernel (AIV version)
+ *
+ * AIV writes float(block_idx) at cache line
+ *   (base_cl + block_idx * 3 + 1 + sub_block_id)
+ * where sub_block_id is 0 for AIV0 and 1 for AIV1.
+ *
+ * Args:
+ *   args[0] = output Tensor* (INOUT)
+ *   args[1] = scalar: base_cl (starting cache line index for this task)
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+static constexpr int32_t SLOTS_PER_BLOCK = 3;
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int32_t base_cl = static_cast<int32_t>(args[1]);
+    int32_t core_idx = get_block_idx(args);
+    int32_t sub_block_id = get_sub_block_id(args);
+    int32_t offset = (base_cl + core_idx * SLOTS_PER_BLOCK + 1 + sub_block_id) * FLOATS_PER_CACHE_LINE;
+
+    out[offset] = static_cast<float>(core_idx);
+
+    dcci(&out[offset], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/kernel_config.py
@@ -1,0 +1,51 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Kernel configuration for SPMD multi-block MIX test (tensormap_and_ringbuffer Runtime).
+
+Submits a single MIX task (AIC + AIV0 + AIV1) with block_num=2 so all
+three subtask slots in both blocks see the correct block_idx.
+"""
+
+from pathlib import Path
+
+_KERNELS_ROOT = Path(__file__).parent
+
+ORCHESTRATION = {
+    "source": str(_KERNELS_ROOT / "orchestration" / "spmd_multiblock_mix_orch.cpp"),
+    "function_name": "aicpu_orchestration_entry",
+}
+
+KERNELS = [
+    {
+        "func_id": 0,
+        "name": "SPMD_MIX_AIC",
+        "source": str(_KERNELS_ROOT / "aic" / "kernel_spmd_mix.cpp"),
+        "core_type": "aic",
+    },
+    {
+        "func_id": 1,
+        "name": "SPMD_MIX_AIV0",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_spmd_mix.cpp"),
+        "core_type": "aiv",
+    },
+    {
+        "func_id": 2,
+        "name": "SPMD_MIX_AIV1",
+        "source": str(_KERNELS_ROOT / "aiv" / "kernel_spmd_mix.cpp"),
+        "core_type": "aiv",
+    },
+]
+
+RUNTIME_CONFIG = {
+    "runtime": "tensormap_and_ringbuffer",
+    "aicpu_thread_num": 4,
+    "orch_thread_num": 1,
+    "block_dim": 24,
+}

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Multi-Block MIX Orchestration
+ *
+ * Submits three MIX tasks (AIC + AIV0 + AIV1) with increasing block_num:
+ *   T0: block_num=2   — basic multi-block MIX
+ *   T1: block_num=8   — saturates one sched thread (8 clusters)
+ *   T2: block_num=12  — forces cross-thread re-push via ready_queue
+ *
+ * Each task writes to a disjoint region of the output tensor using the
+ * base_cl scalar to offset the block writes.
+ *
+ * Args layout: [output]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_SPMD_MIX_AIC 0
+#define FUNC_SPMD_MIX_AIV0 1
+#define FUNC_SPMD_MIX_AIV1 2
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 1,
+    };
+}
+
+static void
+submit_spmd_mix(int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, Tensor &out, int16_t block_num, int64_t base_cl) {
+    MixedKernels mk;
+    mk.aic_kernel_id = aic_id;
+    mk.aiv0_kernel_id = aiv0_id;
+    mk.aiv1_kernel_id = aiv1_id;
+
+    Arg args;
+    args.add_inout(out);
+    args.add_scalar(base_cl);
+    args.launch_spec.set_core_num(block_num);
+    pto2_rt_submit_task(mk, args);
+}
+
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
+    (void)orch_thread_num;  // NOLINT(readability/casting)
+    if (orch_thread_index != 0) return;
+
+    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+
+    // T0: 2 blocks (6 CL) — basic multi-block MIX
+    submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 2, 0);
+
+    // T1: 8 blocks (24 CL) — saturate one sched thread's clusters
+    submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 8, 6);
+
+    // T2: 12 blocks (36 CL) — cross-thread dispatch via ready_queue re-push
+    submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 12, 30);
+
+    // T3: 24 blocks (72 CL) — occupy all clusters across all 3 sched threads
+    submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 24, 66);
+
+    // T4: 48 blocks (144 CL) — two full rounds of all clusters
+    submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 48, 138);
+
+    LOG_ALWAYS("[spmd_multiblock_mix] Submitted 5 MIX tasks: block_num=2,8,12,24,48");
+}
+
+}  // extern "C"

--- a/src/a5/platform/include/common/perf_profiling.h
+++ b/src/a5/platform/include/common/perf_profiling.h
@@ -57,8 +57,8 @@
 #include <cstdint>
 #include <vector>
 
-#include "core_type.h"
-#include "platform_config.h"
+#include "common/core_type.h"
+#include "common/platform_config.h"
 
 // Maximum number of successor tasks per PerfRecord (matches Task::fanout)
 #ifndef RUNTIME_MAX_FANOUT
@@ -286,7 +286,7 @@ struct AicpuOrchSummary {
     uint64_t end_time;         // Orchestrator end timestamp
     uint64_t sync_cycle;       // sync_tensormap phase
     uint64_t alloc_cycle;      // task_ring_alloc phase
-    uint64_t params_cycle;     // param_copy phase
+    uint64_t args_cycle;       // param_copy phase
     uint64_t lookup_cycle;     // lookup+dep phase
     uint64_t heap_cycle;       // heap_alloc phase
     uint64_t insert_cycle;     // tensormap_insert phase

--- a/src/a5/platform/include/host/performance_collector.h
+++ b/src/a5/platform/include/host/performance_collector.h
@@ -78,6 +78,15 @@ using PerfUnregisterCallback = int (*)(void *dev_ptr, int device_id, void *user_
  */
 using PerfFreeCallback = int (*)(void *dev_ptr, void *user_data);
 
+/**
+ * Device context setup callback (called once on mgmt thread startup)
+ *
+ * @param device_id Device ID to set
+ * @param user_data User-provided context pointer
+ * @return 0 on success, error code on failure
+ */
+using PerfSetDeviceCallback = int (*)(int device_id, void *user_data);
+
 // =============================================================================
 // ProfMemoryManager - Dynamic Buffer Memory Management Thread
 // =============================================================================
@@ -140,10 +149,12 @@ public:
      * @param free_cb Device memory free callback
      * @param user_data User context for callbacks
      * @param device_id Device ID for registration
+     * @param set_device_cb Device context setup callback (nullptr to skip)
      */
     void start(
         void *shared_mem_host, int num_cores, int num_phase_threads, PerfAllocCallback alloc_cb,
-        PerfRegisterCallback register_cb, PerfFreeCallback free_cb, void *user_data, int device_id
+        PerfRegisterCallback register_cb, PerfFreeCallback free_cb, void *user_data, int device_id,
+        PerfSetDeviceCallback set_device_cb = nullptr
     );
 
     /**
@@ -194,6 +205,7 @@ private:
     PerfAllocCallback alloc_cb_{nullptr};
     PerfRegisterCallback register_cb_{nullptr};
     PerfFreeCallback free_cb_{nullptr};
+    PerfSetDeviceCallback set_device_cb_{nullptr};
     void *user_data_{nullptr};
     int device_id_{-1};
 
@@ -269,11 +281,12 @@ public:
      * @param register_cb Memory registration callback (can be nullptr for simulation)
      * @param free_cb Memory free callback
      * @param user_data User-provided context pointer passed to callbacks
+     * @param set_device_cb Device context setup callback (nullptr to skip)
      * @return 0 on success, error code on failure
      */
     int initialize(
         Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-        PerfFreeCallback free_cb, void *user_data
+        PerfFreeCallback free_cb, void *user_data, PerfSetDeviceCallback set_device_cb = nullptr
     );
 
     /**
@@ -378,6 +391,7 @@ private:
     PerfAllocCallback alloc_cb_{nullptr};
     PerfRegisterCallback register_cb_{nullptr};
     PerfFreeCallback free_cb_{nullptr};
+    PerfSetDeviceCallback set_device_cb_{nullptr};
     void *user_data_{nullptr};
 
     // Memory manager

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -760,7 +760,13 @@ int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, i
         return allocator->free(dev_ptr);
     };
 
-    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_);
+    auto set_device_cb = [](int device_id, void * /*user_data*/) -> int {
+        return rtSetDevice(device_id);
+    };
+
+    return perf_collector_.initialize(
+        runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_, set_device_cb
+    );
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -579,7 +579,7 @@ int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, i
     };
 
     // Simulation: no registration needed (pass nullptr)
-    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, nullptr, free_cb, nullptr);
+    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, nullptr, free_cb, nullptr, nullptr);
 }
 
 void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {

--- a/src/a5/platform/src/host/performance_collector.cpp
+++ b/src/a5/platform/src/host/performance_collector.cpp
@@ -47,7 +47,8 @@ ProfMemoryManager::~ProfMemoryManager() {
 
 void ProfMemoryManager::start(
     void *shared_mem_host, int num_cores, int num_phase_threads, PerfAllocCallback alloc_cb,
-    PerfRegisterCallback register_cb, PerfFreeCallback free_cb, void *user_data, int device_id
+    PerfRegisterCallback register_cb, PerfFreeCallback free_cb, void *user_data, int device_id,
+    PerfSetDeviceCallback set_device_cb
 ) {
     shared_mem_host_ = shared_mem_host;
     num_cores_ = num_cores;
@@ -57,6 +58,7 @@ void ProfMemoryManager::start(
     free_cb_ = free_cb;
     user_data_ = user_data;
     device_id_ = device_id;
+    set_device_cb_ = set_device_cb;
 
     running_.store(true);
     mgmt_thread_ = std::thread(&ProfMemoryManager::mgmt_loop, this);
@@ -188,6 +190,7 @@ void ProfMemoryManager::process_ready_entry(
         PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
 
         // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
+        // Source priority: recycled pool → drain done_queue → alloc (last resort).
         rmb();
         uint32_t head_val = state->free_queue.head;
         uint32_t tail = state->free_queue.tail;
@@ -337,6 +340,13 @@ void ProfMemoryManager::process_ready_entry(
 }
 
 void ProfMemoryManager::mgmt_loop() {
+    if (set_device_cb_ != nullptr) {
+        int rc = set_device_cb_(device_id_, user_data_);
+        if (rc != 0) {
+            LOG_ERROR("mgmt_loop: set_device_cb(%d) failed: %d", device_id_, rc);
+        }
+    }
+
     PerfDataHeader *header = get_perf_header(shared_mem_host_);
 
     while (running_.load()) {
@@ -442,7 +452,7 @@ void ProfMemoryManager::mgmt_loop() {
                 if (state->free_queue.tail - state->free_queue.head == 0) {
                     void *host_ptr = nullptr;
                     void *dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
-                    if (dev_ptr == nullptr) break;
+                    if (dev_ptr == nullptr) break;  // HBM exhausted, stop trying
                     reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
                     uint32_t t_val = state->free_queue.tail;
                     state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
@@ -450,7 +460,7 @@ void ProfMemoryManager::mgmt_loop() {
                     wmb();
                     state->free_queue.tail = t_val + 1;
                     wmb();
-                    break;
+                    break;  // One alloc per iteration to limit rtMalloc frequency
                 }
             }
         }
@@ -534,7 +544,7 @@ void *PerformanceCollector::alloc_single_buffer(size_t size, void **host_ptr_out
 
 int PerformanceCollector::initialize(
     Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-    PerfFreeCallback free_cb, void *user_data
+    PerfFreeCallback free_cb, void *user_data, PerfSetDeviceCallback set_device_cb
 ) {
     if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
@@ -554,6 +564,7 @@ int PerformanceCollector::initialize(
     register_cb_ = register_cb;
     free_cb_ = free_cb;
     user_data_ = user_data;
+    set_device_cb_ = set_device_cb;
 
     // Step 1: Calculate shared memory size (slot arrays only, no actual buffers)
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
@@ -702,7 +713,7 @@ void PerformanceCollector::start_memory_manager() {
 
     memory_manager_.start(
         perf_shared_mem_host_, num_aicore_, PLATFORM_MAX_AICPU_THREADS, alloc_cb_, register_cb_, free_cb_, user_data_,
-        device_id_
+        device_id_, set_device_cb_
     );
 }
 
@@ -871,6 +882,7 @@ void PerformanceCollector::poll_and_collect(int expected_tasks) {
         } else {
             // Timeout on wait — check for execution complete signal or overall timeout
             if (execution_complete_.load()) {
+                // Device is done. Final non-blocking drain and exit.
                 ReadyBufferInfo drain_info;
                 while (memory_manager_.try_pop_ready(drain_info)) {
                     if (drain_info.type == ProfBufferType::PERF_RECORD) {
@@ -1368,7 +1380,7 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path) {
             outfile << "      \"alloc\": " << std::fixed << std::setprecision(3)
                     << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
             outfile << "      \"params\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.params_cycle) << ",\n";
+                    << cycles_to_us(collected_orch_summary_.args_cycle) << ",\n";
             outfile << "      \"lookup\": " << std::fixed << std::setprecision(3)
                     << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
             outfile << "      \"heap\": " << std::fixed << std::setprecision(3)

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 #include <atomic>
 #include <cstdint>
 #include <cstdio>
@@ -540,7 +541,7 @@ int AicpuExecutor::shutdown_aicore(Runtime *runtime, int thread_idx, const int *
     for (int i = 0; i < thread_cores_num_[thread_idx]; i++) {
         int core_id = cur_thread_cores[i];
         Handshake *hank = &all_handshakes[core_id];
-        LOG_INFO("Thread %d: AICPU hank addr = 0x%lx", thread_idx, (uint64_t)hank);
+        LOG_INFO("Thread %d: AICPU hank addr = 0x%lx", thread_idx, reinterpret_cast<uint64_t>(hank));
 
         uint64_t reg_addr = core_id_to_reg_addr_[core_id];
         if (reg_addr != 0) {
@@ -619,11 +620,35 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 );
 
                 int completed_task_id = pending_task_ids_[core_id];
+                int prev_running_id = running_task_ids_[core_id];
 
-                // Profiling
+                // Profiling: when prev_running_id exists, its AICore record was
+                // written first (at records[count]), so complete it BEFORE the
+                // pending task's record to maintain buffer ordering.
                 if (profiling_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();
                     PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
+
+                    if (prev_running_id != AICPU_TASK_INVALID) {
+                        Task *prev_task = &runtime.tasks[prev_running_id];
+                        uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
+                        for (int i = 0; i < prev_task->fanout_count; i++) {
+                            fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
+                        }
+                        if (perf_aicpu_complete_record(
+                                perf_buf, static_cast<uint32_t>(prev_running_id),
+                                static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
+                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                            ) != 0) {
+                            DEV_ERROR(
+                                "Core %d: perf_aicpu_complete_record failed for implicit task %d", core_id,
+                                prev_running_id
+                            );
+                        }
+                        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    }
+
+                    finish_ts = get_sys_cnt_aicpu();
                     Task *task = &runtime.tasks[completed_task_id];
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     for (int i = 0; i < task->fanout_count; i++) {
@@ -642,7 +667,6 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 cur_thread_completed++;
                 completed_tasks_.fetch_add(1, std::memory_order_release);
 
-                int prev_running_id = running_task_ids_[core_id];
                 pending_task_ids_[core_id] = AICPU_TASK_INVALID;
                 running_task_ids_[core_id] = AICPU_TASK_INVALID;
 
@@ -690,7 +714,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 if (!dispatched && profiling_enabled) {
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
-            } else if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_ACK_STATE) {  // Case 2: ACK
+            } else if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_ACK_STATE) {
+                // Case 2: Pending task received ACK
                 LOG_INFO(
                     "Thread %d: Core %d ACKed task %d (running_id=%d)", thread_idx, core_id, pending_task_ids_[core_id],
                     running_task_ids_[core_id]
@@ -707,6 +732,28 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 // completed (AICore overwrote COND before we could read its FIN).
                 // Count it here to avoid losing completion.
                 if (prev_running_id != AICPU_TASK_INVALID) {
+                    // Profiling: complete the implicit task's AICore record
+                    if (profiling_enabled) {
+                        uint64_t finish_ts = get_sys_cnt_aicpu();
+                        PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
+                        Task *prev_task = &runtime.tasks[prev_running_id];
+                        uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
+                        for (int i = 0; i < prev_task->fanout_count; i++) {
+                            fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
+                        }
+                        if (perf_aicpu_complete_record(
+                                perf_buf, static_cast<uint32_t>(prev_running_id),
+                                static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
+                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                            ) != 0) {
+                            DEV_ERROR(
+                                "Core %d: perf_aicpu_complete_record failed for implicit task %d", core_id,
+                                prev_running_id
+                            );
+                        }
+                        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    }
+
                     cur_thread_completed++;
                     completed_tasks_.fetch_add(1, std::memory_order_release);
 
@@ -721,7 +768,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
                 // Core can accept new task now (pipeline!)
                 // Continue to Case 4 to dispatch next task
-            } else if (reg_task_id == running_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {  // Case 3: FIN
+            } else if (reg_task_id == running_task_ids_[core_id] && reg_state == TASK_FIN_STATE) {
+                // Case 3: Running task finished
                 LOG_INFO(
                     "Thread %d: Core %d completed task %d (pending_id=%d)", thread_idx, core_id,
                     running_task_ids_[core_id], pending_task_ids_[core_id]

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -389,11 +389,10 @@ struct AicpuExecutor {
 
             if (done) {
                 core_exec_state.executing_reg_task_id = AICPU_TASK_INVALID;
-                PTO2SubtaskSlot subslot = core_exec_state.executing_subslot;
                 PTO2TaskSlotState &slot_state = *core_exec_state.executing_slot_state;
 
-                // Two-stage completion: mark subtask done, then handle mixed-task completion
-                bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state, subslot);
+                // Completion: increment atomic counter, trigger task-level completion on last subtask
+                bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state);
                 if (mixed_complete) {
 #if PTO2_SCHED_PROFILING
                     PTO2CompletionStats cstats =
@@ -541,6 +540,40 @@ struct AicpuExecutor {
         return count;
     }
 
+    /**
+     * Build per-core dispatch payload: copy tensor pointers and scalars into
+     * the per-core args[] array, then populate SPMD local context at the tail.
+     *
+     * Reads next_block_idx and block_num directly from the task descriptor
+     * to populate LocalContext.  The caller is responsible for incrementing
+     * next_block_idx AFTER dispatch.
+     *
+     * GlobalContext (sub_block_id) is NOT written here — it is initialized once
+     * at runtime startup by init_global_context().
+     */
+    void build_payload(PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot) {
+        int32_t slot_idx = static_cast<int32_t>(subslot);
+        uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
+        const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
+        dispatch_payload.function_bin_addr = callable->resolved_addr();
+        auto &payload = *slot_state.payload;
+        int n = 0;
+        for (int32_t i = 0; i < payload.tensor_count; i++) {
+            dispatch_payload.args[n++] = reinterpret_cast<uint64_t>(&payload.tensors[i]);
+        }
+        for (int32_t i = 0; i < payload.scalar_count; i++) {
+            dispatch_payload.args[n++] = payload.scalars[i];
+        }
+        // Per-dispatch local context (read from slot state)
+        dispatch_payload.local_context.core_idx = slot_state.next_block_idx;
+        dispatch_payload.local_context.core_num = slot_state.block_num;
+        // Store context pointers at fixed suffix positions in args[]
+        // (GlobalContext content is already set by init_global_context, but the
+        //  pointer must be written each dispatch since args[] is rebuilt entirely)
+        dispatch_payload.args[SPMD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
+        dispatch_payload.args[SPMD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.global_context);
+    }
+
     void dispatch_subtask_to_core(
         Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,
         PTO2SubtaskSlot subslot
@@ -556,11 +589,7 @@ struct AicpuExecutor {
 #endif
         CoreExecState &core_exec_state = core_exec_states_[core_id];
         PTO2DispatchPayload &payload = s_pto2_payload_per_core[core_id];
-        int32_t slot_idx = static_cast<int32_t>(subslot);
-        uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
-        const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
-        payload.function_bin_addr = callable->resolved_addr();
-        payload.args = slot_state.payload->dispatch_args;
+        build_payload(payload, slot_state, subslot);
         core_exec_state.executing_subslot = subslot;
         core_exec_state.executing_slot_state = &slot_state;
 #if PTO2_PROFILING
@@ -905,6 +934,19 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     // Clear per-core dispatch payloads
     memset(s_pto2_payload_per_core, 0, sizeof(s_pto2_payload_per_core));
 
+    // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
+    // This is done once at startup and never modified afterwards.
+    for (int32_t t = 0; t < sched_thread_num_; t++) {
+        CoreTracker &tracker = core_trackers_[t];
+        for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
+            int32_t cluster_offset = c * 3;  // Each cluster = 1 AIC + 2 AIV
+            auto aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
+            auto aiv1_id = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(cluster_offset));
+            s_pto2_payload_per_core[aiv0_id].global_context.sub_block_id = 0;
+            s_pto2_payload_per_core[aiv1_id].global_context.sub_block_id = 1;
+        }
+    }
+
     DEV_INFO("Init: PTO2 mode, task count from shared memory");
 
     finished_count_.store(0, std::memory_order_release);
@@ -1197,29 +1239,61 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                 for (int bi = 0; bi < got; bi++) {
                     PTO2TaskSlotState *slot_state = batch[bi];
                     try_pushed = true;
-#if PTO2_PROFILING
-                    phase_dispatch_count++;
-#endif
 #if PTO2_SCHED_PROFILING
                     uint64_t t_setup_start = get_sys_cnt_aicpu();
 #endif
-                    auto current_valid_cluster_offset = valid_cluster_states.pop_first();
-                    if (shape == PTO2ResourceShape::MIX) {
-                        // Full-cluster scheduling: dispatch only to cores indicated by active_mask.
-                        // Unused cores in the cluster remain idle for single-core tasks.
-                        uint8_t mask = slot_state->active_mask;
-                        if (mask & PTO2_SUBTASK_MASK_AIC) {
-                            auto core_offset = tracker.get_aic_core_offset(current_valid_cluster_offset);
+                    // Dispatch as many blocks as possible for this task using available clusters.
+                    // For block_num=1 the inner body executes exactly once (no overhead).
+                    do {
+                        auto current_valid_cluster_offset = valid_cluster_states.pop_first();
+                        if (shape == PTO2ResourceShape::MIX) {
+                            // Full-cluster: all active subtasks share the same block_idx.
+                            uint8_t mask = slot_state->active_mask;
+                            if (mask & PTO2_SUBTASK_MASK_AIC) {
+                                dispatch_subtask_to_core(
+                                    runtime, thread_idx, tracker.get_aic_core_offset(current_valid_cluster_offset),
+                                    *slot_state, PTO2SubtaskSlot::AIC
+#if PTO2_PROFILING
+                                    ,
+                                    profiling_enabled
+#endif
+                                );
+                            }
+                            if (mask & PTO2_SUBTASK_MASK_AIV0) {
+                                dispatch_subtask_to_core(
+                                    runtime, thread_idx, tracker.get_aiv0_core_offset(current_valid_cluster_offset),
+                                    *slot_state, PTO2SubtaskSlot::AIV0
+#if PTO2_PROFILING
+                                    ,
+                                    profiling_enabled
+#endif
+                                );
+                            }
+                            if (mask & PTO2_SUBTASK_MASK_AIV1) {
+                                dispatch_subtask_to_core(
+                                    runtime, thread_idx, tracker.get_aiv1_core_offset(current_valid_cluster_offset),
+                                    *slot_state, PTO2SubtaskSlot::AIV1
+#if PTO2_PROFILING
+                                    ,
+                                    profiling_enabled
+#endif
+                                );
+                            }
+                            slot_state->next_block_idx++;
+                        } else if (shape == PTO2ResourceShape::AIC) {
                             dispatch_subtask_to_core(
-                                runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIC
+                                runtime, thread_idx, tracker.get_aic_core_offset(current_valid_cluster_offset),
+                                *slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                                 ,
                                 profiling_enabled
 #endif
                             );
-                        }
-                        if (mask & PTO2_SUBTASK_MASK_AIV0) {
-                            auto core_offset = tracker.get_aiv0_core_offset(current_valid_cluster_offset);
+                            slot_state->next_block_idx++;
+                        } else {  // shape == PTO2ResourceShape::AIV
+                            auto core_offset = tracker.is_aiv0_core_idle(current_valid_cluster_offset) ?
+                                                   tracker.get_aiv0_core_offset(current_valid_cluster_offset) :
+                                                   tracker.get_aiv1_core_offset(current_valid_cluster_offset);
                             dispatch_subtask_to_core(
                                 runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
@@ -1227,47 +1301,31 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                                 profiling_enabled
 #endif
                             );
+                            slot_state->next_block_idx++;
+                            // Refresh idle state so the do-while naturally picks up
+                            // the other AIV in the same cluster on the next iteration.
+                            if (slot_state->next_block_idx < slot_state->block_num) {
+                                valid_cluster_states = tracker.get_valid_cluster_offset_states(shape);
+                            }
                         }
-                        if (mask & PTO2_SUBTASK_MASK_AIV1) {
-                            auto core_offset = tracker.get_aiv1_core_offset(current_valid_cluster_offset);
-                            dispatch_subtask_to_core(
-                                runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
-                                ,
-                                profiling_enabled
+                        phase_dispatch_count += __builtin_popcount(slot_state->active_mask);
 #endif
-                            );
-                        }
-                    } else if (shape == PTO2ResourceShape::AIC) {
-                        auto core_offset = tracker.get_aic_core_offset(current_valid_cluster_offset);
-                        dispatch_subtask_to_core(
-                            runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIC
-#if PTO2_PROFILING
-                            ,
-                            profiling_enabled
-#endif
+                        DEV_DEBUG(
+                            "Thread %d: Dispatched %s task %" PRId64 " block %d/%d to cluster_offset %d", thread_idx,
+                            shape_name(shape), static_cast<int64_t>(slot_state->task->task_id.raw),
+                            slot_state->next_block_idx - 1, slot_state->block_num, current_valid_cluster_offset
                         );
-                    } else {  // shape == PTO2ResourceShape::AIV
-                        auto core_offset = tracker.is_aiv0_core_idle(current_valid_cluster_offset) ?
-                                               tracker.get_aiv0_core_offset(current_valid_cluster_offset) :
-                                               tracker.get_aiv1_core_offset(current_valid_cluster_offset);
-                        dispatch_subtask_to_core(
-                            runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV0
-#if PTO2_PROFILING
-                            ,
-                            profiling_enabled
-#endif
-                        );
+                    } while (slot_state->next_block_idx < slot_state->block_num && valid_cluster_states.has_value());
+
+                    // Re-enqueue only if blocks remain after exhausting local clusters
+                    if (slot_state->next_block_idx < slot_state->block_num) {
+                        rt->scheduler.ready_queues[static_cast<int32_t>(shape)].push(slot_state);
                     }
                     made_progress = true;
 #if PTO2_SCHED_PROFILING
                     sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
-                    DEV_DEBUG(
-                        "Thread %d: Dispatching %s task %" PRId64 " to cluster_offset %d", thread_idx,
-                        shape_name(shape), static_cast<int64_t>(slot_state->task->task_id.raw),
-                        current_valid_cluster_offset
-                    );
                 }
 
                 // lazy update valid_cluster_states
@@ -1934,7 +1992,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 orch_summary.end_time = orch_cycle_end;
                 orch_summary.sync_cycle = p.sync_cycle;
                 orch_summary.alloc_cycle = p.alloc_cycle;
-                orch_summary.params_cycle = p.params_cycle;
+                orch_summary.args_cycle = p.args_cycle;
                 orch_summary.lookup_cycle = p.lookup_cycle;
                 orch_summary.heap_cycle = 0;  // Now included in alloc_cycle
                 orch_summary.insert_cycle = p.insert_cycle;

--- a/src/a5/runtime/tensormap_and_ringbuffer/build_config.py
+++ b/src/a5/runtime/tensormap_and_ringbuffer/build_config.py
@@ -1,3 +1,11 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 # Tensormap and Ringbuffer Runtime build configuration
 # All paths are relative to this file's directory (src/runtime/tensormap_and_ringbuffer/)
 #
@@ -11,20 +19,8 @@
 # by the Tensor constructor's validation logic).
 
 BUILD_CONFIG = {
-    "aicore": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicore", "orchestration"]
-    },
-    "aicpu": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["aicpu", "runtime", "orchestration"]
-    },
-    "host": {
-        "include_dirs": ["runtime"],
-        "source_dirs": ["host", "runtime", "orchestration"]
-    },
-    "orchestration": {
-        "include_dirs": ["runtime", "orchestration"],
-        "source_dirs": ["orchestration"]
-    }
+    "aicore": {"include_dirs": ["runtime", "common"], "source_dirs": ["aicore", "orchestration"]},
+    "aicpu": {"include_dirs": ["runtime", "common"], "source_dirs": ["aicpu", "runtime", "orchestration"]},
+    "host": {"include_dirs": ["runtime", "common"], "source_dirs": ["host", "runtime", "orchestration"]},
+    "orchestration": {"include_dirs": ["runtime", "orchestration", "common"], "source_dirs": ["orchestration"]},
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file intrinsic.h
+ * @brief SPMD execution context for AICore user kernels
+ *
+ * Topology data exposed to user kernels has two distinct lifetimes:
+ *
+ *   1. Global topology (per-core, fixed after runtime init):
+ *      - sub_block_id : identifies the AIV lane within a cluster
+ *        (0 = AIV0/left, 1 = AIV1/right).  Initialized once at runtime
+ *        startup based on each core's cluster position; never changes.
+ *        Only meaningful for AIV kernels in MIX tasks.
+ *
+ *   2. Local topology (per-dispatch, changes each dispatch):
+ *      - core_idx : which logical block the current worker is executing
+ *      - core_num : total number of blocks in this task (= block_dim)
+ *      Written by build_payload() before each dispatch.
+ *
+ * Both categories are injected via two pointer slots appended at the tail
+ * of the kernel args[] array:
+ *
+ *   args layout:
+ *     [0 .. tensor_count-1]                 = tensor GM pointers
+ *     [tensor_count .. +scalar_count-1]     = scalar values
+ *     ...
+ *     [SPMD_LOCAL_CONTEXT_INDEX]            = (uint64_t)&LocalContext   (per-dispatch)
+ *     [SPMD_GLOBAL_CONTEXT_INDEX]           = (uint64_t)&GlobalContext  (per-core)
+ *
+ * The suffix positions are compile-time constants and do not depend on the
+ * runtime tensor_count or scalar_count.
+ *
+ * Include this header in AICore kernel source files to use the Get* accessors.
+ * Do NOT depend on the raw index constants; always use the accessor functions.
+ *
+ * On CCEC (real hardware), __gm__ and __aicore__ must be defined before
+ * including this header (e.g. via <pto/pto-inst.hpp> or manual #define).
+ * The #ifndef guards below provide fallbacks for non-kernel builds
+ * (AICPU, HOST) where these qualifiers are not needed.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__
+#endif
+
+/** Number of extra pointer slots appended to the args[] tail (LocalContext + GlobalContext). */
+static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
+
+/**
+ * Args[] suffix indices for context pointers.
+ * Derived from MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(128).
+ * Users should not depend on these values; use the Get* functions below.
+ */
+static constexpr int32_t SPMD_LOCAL_CONTEXT_INDEX = 144;
+static constexpr int32_t SPMD_GLOBAL_CONTEXT_INDEX = 145;
+
+/**
+ * Per-core global context, stored in PTO2DispatchPayload.
+ * Initialized once at runtime startup (init_global_context) based on each
+ * core's cluster position.  Never modified after initialization.
+ */
+struct GlobalContext {
+    // AIV lane within cluster: 0=AIV0(left), 1=AIV1(right).
+    // Used by AIV to select the correct intra-cluster hw instruction.
+    // Not meaningful for AIC kernels or single-AIV tasks.
+    int32_t sub_block_id;
+};
+
+/**
+ * Per-dispatch local context, stored in PTO2DispatchPayload.
+ * Written by build_payload() before each dispatch.  Different blocks of the
+ * same task receive different core_idx values but the same core_num.
+ */
+struct LocalContext {
+    int32_t core_idx;  // Logical block index within the task [0, core_num)
+    int32_t core_num;  // How many logical blocks this task requires.
+                       // Currently fixed to 1 (block_dim > 1 not yet implemented).
+                       // NOT the same as RUNTIME_CONFIG.block_dim in kernel_config.py,
+                       // which controls how many physical cores the runtime launches.
+};
+
+/**
+ * Return the AIV lane index within the cluster.
+ * In a MIX 1C2V task: AIV0(left)=0, AIV1(right)=1.
+ *
+ * This value is only meaningful for AIV kernels in MIX tasks.  It tells
+ * the AIV whether it is the left lane or the right lane within the cluster,
+ * which determines the correct hardware instruction for intra-cluster
+ * communication.
+ *
+ * AIC kernels should NOT call this function.
+ * Single-AIV tasks have no intra-cluster communication, so sub_block_id
+ * has no meaning and should not be used.
+ */
+static __aicore__ inline int32_t get_sub_block_id(__gm__ int64_t *args) {
+    __gm__ GlobalContext *ctx =
+        reinterpret_cast<__gm__ GlobalContext *>(static_cast<uint64_t>(args[SPMD_GLOBAL_CONTEXT_INDEX]));
+    return ctx->sub_block_id;
+}
+
+/**
+ * Return the logical block index assigned to the current worker.
+ * Range: [0, get_block_num(args)).
+ * Within the same task, different blocks receive different indices.
+ */
+static __aicore__ inline int32_t get_block_idx(__gm__ int64_t *args) {
+    __gm__ LocalContext *ctx =
+        reinterpret_cast<__gm__ LocalContext *>(static_cast<uint64_t>(args[SPMD_LOCAL_CONTEXT_INDEX]));
+    return ctx->core_idx;
+}
+
+/**
+ * Return how many logical blocks the current task requires.
+ * All blocks of the same task see the same value.
+ * Currently always returns 1 (block_dim>1 not yet implemented).
+ *
+ * Note: this is NOT the same as RUNTIME_CONFIG.block_dim in
+ * kernel_config.py, which controls how many physical cores are launched.
+ */
+static __aicore__ inline int32_t get_block_num(__gm__ int64_t *args) {
+    __gm__ LocalContext *ctx =
+        reinterpret_cast<__gm__ LocalContext *>(static_cast<uint64_t>(args[SPMD_LOCAL_CONTEXT_INDEX]));
+    return ctx->core_num;
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -9,11 +9,15 @@ During task graph construction, orchestration sometimes needs to read InCore ker
 ## 2. API
 
 ```cpp
-// Blocking read: returns raw uint64_t bit pattern at the given indices
-uint64_t get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
+// Blocking read: returns value at the given indices (default: raw uint64_t bits)
+// Specify T for typed read: float val = get_tensor_data<float>(tensor, 1, idx);
+template<typename T = uint64_t>
+T get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
 
-// Blocking write: stores value at the given indices
-void set_tensor_data(Tensor& tensor, uint32_t ndims, const uint32_t indices[], uint64_t value);
+// Blocking write: stores value at the given indices (type deduced from argument)
+// Typed write: set_tensor_data(tensor, 1, idx, 42.0f);
+template<typename T = uint64_t>
+void set_tensor_data(Tensor& tensor, uint32_t ndims, const uint32_t indices[], T value);
 ```
 
 Both call into the runtime through the ops table — orchestration .so needs no runtime symbol linkage.
@@ -81,7 +85,7 @@ const Tensor& scalar_tensor = outs.get_ref(0);
 
 // Orchestration-side blocking read (waits for kernel completion)
 uint32_t idx[1] = {0};
-uint64_t raw = get_tensor_data(scalar_tensor, 1, idx);
+float val = get_tensor_data<float>(scalar_tensor, 1, idx);
 ```
 
 **Advantage**: Fully reuses existing TensorMap (producer tracking, fanin/fanout dependencies) — no new infrastructure needed.

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -212,19 +212,29 @@ static inline bool pto2_rt_is_fatal() {
 /**
  * Read a value from a tensor at the given multi-dimensional indices.
  *
+ * Default T = uint64_t preserves old behavior (raw bits).
+ * Specify T to get automatic type conversion:
+ *
+ *   uint64_t raw = get_tensor_data(tensor, 1, idx);       // old usage unchanged
+ *   float val = get_tensor_data<float>(tensor, 1, idx);   // typed read
+ *
  * If the tensor has a producer in TensorMap, spin-waits until the producer
  * task completes before reading. External tensors (make_tensor_external)
  * are read immediately without waiting.
- *
- * Returns the raw bits as uint64_t; caller reinterprets via bit_cast.
  */
-static inline uint64_t get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
+template <typename T = uint64_t>
+static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     PTO2Runtime *rt = pto2_current_runtime();
-    return rt->ops->get_tensor_data(rt, tensor, ndims, indices);
+    return from_u64<T>(rt->ops->get_tensor_data(rt, tensor, ndims, indices));
 }
 
 /**
  * Write a value to a tensor at the given multi-dimensional indices.
+ *
+ * Type is deduced from value argument; uint64_t by default:
+ *
+ *   set_tensor_data(tensor, 1, idx, raw_u64);     // old usage unchanged
+ *   set_tensor_data(tensor, 1, idx, 42.0f);       // typed write (T = float)
  *
  * If the tensor has a producer in TensorMap, spin-waits until the producer
  * and all its consumers complete before writing (WAW + WAR safety).
@@ -245,9 +255,10 @@ static inline uint64_t get_tensor_data(const Tensor &tensor, uint32_t ndims, con
  * For runtime-created outputs, call this only on the Tensor returned by
  * add_output(TensorCreateInfo) after submit returns.
  */
-static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value) {
+template <typename T = uint64_t>
+static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {
     PTO2Runtime *rt = pto2_current_runtime();
-    rt->ops->set_tensor_data(rt, tensor, ndims, indices, value);
+    rt->ops->set_tensor_data(rt, tensor, ndims, indices, to_u64(value));
 }
 
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/common.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/common.h
@@ -8,21 +8,23 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 #pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
+
 #include <stdexcept>
 #include <string>
 
 /**
- * Get current stack trace information (including file paths and line numbers).
+ * Get the current stack trace, including file paths and line numbers.
  * Implemented in common.cpp.
  */
 std::string get_stacktrace(int skip_frames = 1);
 
 /**
- * Assertion failure exception, containing file, line number, condition, and stack trace information.
+ * Assertion failure exception with condition, file, line, and stack trace.
  */
 class AssertionError : public std::runtime_error {
 public:
@@ -39,14 +41,15 @@ private:
 };
 
 /**
- * Handler function for assertion failures.
+ * Assertion failure handler.
  * Implemented in common.cpp.
  */
 [[noreturn]] void assert_impl(const char *condition, const char *file, int line);
 
 /**
- * debug_assert macro - checks condition in debug mode; throws exception and prints stack trace on failure.
- * No-op in release mode (NDEBUG).
+ * debug_assert macro:
+ * checks the condition in debug builds and throws with a stack trace on failure.
+ * It is a no-op in release builds (NDEBUG).
  */
 #ifdef NDEBUG
 #define debug_assert(cond) ((void)0)
@@ -60,7 +63,8 @@ private:
 #endif
 
 /**
- * always_assert macro - checks condition in both debug and release modes.
+ * always_assert macro:
+ * checks the condition in both debug and release builds.
  */
 #define always_assert(cond)                         \
     do {                                            \
@@ -68,3 +72,22 @@ private:
             assert_impl(#cond, __FILE__, __LINE__); \
         }                                           \
     } while (0)
+
+#define PTO_PRAGMA(x) _Pragma(#x)
+
+#if defined(__clang__)
+#define MAYBE_UNINITIALIZED_BEGIN                          \
+    PTO_PRAGMA(clang diagnostic push)                      \
+    PTO_PRAGMA(clang diagnostic ignored "-Wuninitialized") \
+    PTO_PRAGMA(clang diagnostic ignored "-Wsometimes-uninitialized")
+#define MAYBE_UNINITIALIZED_END PTO_PRAGMA(clang diagnostic pop)
+#elif defined(__GNUC__)
+#define MAYBE_UNINITIALIZED_BEGIN                        \
+    PTO_PRAGMA(GCC diagnostic push)                      \
+    PTO_PRAGMA(GCC diagnostic ignored "-Wuninitialized") \
+    PTO_PRAGMA(GCC diagnostic ignored "-Wmaybe-uninitialized")
+#define MAYBE_UNINITIALIZED_END PTO_PRAGMA(GCC diagnostic pop)
+#else
+#define MAYBE_UNINITIALIZED_BEGIN
+#define MAYBE_UNINITIALIZED_END
+#endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -8,48 +8,83 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 /**
  * @file pto2_dispatch_payload.h
  * @brief Per-core dispatch payload for AICore kernel execution
  *
- * PTO2DispatchPayload holds the kernel function address and a pointer to the
- * pre-built args[] array in the task payload. AICPU maintains a static array
- * of these (one per core) and writes both fields before each dispatch. AICore
- * caches a pointer to its per-core slot at startup and reads from it on each
- * dispatch. The struct is cache-line aligned to avoid false sharing across
- * concurrently dispatched cores.
+ * PTO2DispatchPayload holds the kernel function address, a per-core args[]
+ * array, and embedded SPMD context (LocalContext + GlobalContext).  AICPU
+ * maintains a static array of these (one per core).
  *
- * The args[] array (tensor GM pointers followed by scalar values) is built once
- * by the Orchestrator at submit time in PTO2TaskPayload::init().
+ * GlobalContext (sub_block_id) is initialized once at runtime startup via
+ * init_global_context() and never modified afterwards.
+ *
+ * LocalContext (block_idx, block_num) and args[] are rebuilt by
+ * build_payload() before each dispatch.  Both context struct pointers are
+ * written into the args[] suffix on every dispatch (since args[] is rebuilt
+ * entirely each time).
+ *
+ * AICore caches a pointer to its per-core slot at startup and reads from
+ * it on each dispatch.  The struct is cache-line aligned to avoid false
+ * sharing across concurrently dispatched cores.
  *
  * The DATA_MAIN_BASE register protocol is unchanged from the base runtime:
  * a monotonically increasing reg_task_id signals new work to AICore.
  */
 
-#ifndef RT2_PTO2_DISPATCH_PAYLOAD_H_
-#define RT2_PTO2_DISPATCH_PAYLOAD_H_
+#pragma once
 
 #include <stdint.h>
-#include "pto_types.h"
-#include "common/qualifier.h"
 
-/** Max dispatch arguments: 128 scalars + up to 16 tensor pointers */
+#include "intrinsic.h"
+#include "pto_types.h"
+
+/** Max dispatch arguments: 128 scalars + up to 16 tensor pointers + ext params */
 #ifndef PTO2_DISPATCH_MAX_ARGS
-#define PTO2_DISPATCH_MAX_ARGS (MAX_SCALAR_ARGS + MAX_TENSOR_ARGS)
+#define PTO2_DISPATCH_MAX_ARGS (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS + PTO2_EXT_PARAMS_COUNT)
 #endif
 
+#ifndef PTO2_ALIGN_UP
+#define PTO2_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
+#endif
+
+// Verify hardcoded indices in intrinsic.h match the computed values.
+static_assert(
+    (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) == SPMD_LOCAL_CONTEXT_INDEX, "LOCAL_CONTEXT_INDEX out of sync with intrinsic.h"
+);
+static_assert(
+    (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS + 1) == SPMD_GLOBAL_CONTEXT_INDEX,
+    "GLOBAL_CONTEXT_INDEX out of sync with intrinsic.h"
+);
+
 /**
- * Per-core dispatch payload: function address + args pointer.
+ * Per-core dispatch payload: function address + args[] + SPMD context.
  *
  * AICPU maintains a static array s_pto2_payload_per_core[RUNTIME_MAX_WORKER].
- * Before each dispatch, AICPU writes function_bin_addr (looked up from
- * func_id_to_addr_[kernel_id]) and args (pointer to pre-built dispatch_args[]
- * in PTO2TaskPayload). AICore caches a pointer to its slot at startup (via
- * Handshake.task) and reads both fields after each DATA_MAIN_BASE change.
+ * AICore caches a pointer to its per-core slot at startup (via Handshake.task)
+ * and reads from it on each dispatch.
+ *
+ * The struct is cache-line aligned to prevent false sharing across
+ * concurrently dispatched cores.
  */
 struct alignas(64) PTO2DispatchPayload {
-    uint64_t function_bin_addr; /**< Kernel entry address in GM (set by Scheduler) */
-    __gm__ uint64_t *args;      /**< Pre-built args in task payload GM (set by Scheduler) */
-};
+    uint64_t function_bin_addr;            /**< Kernel entry address in GM (set by Scheduler) */
+    uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers + scalars + ext params) */
 
-#endif  // RT2_PTO2_DISPATCH_PAYLOAD_H_
+    /** Per-dispatch context: block_idx and block_num.
+     *  Written by build_payload() before each dispatch.
+     *  args[SPMD_LOCAL_CONTEXT_INDEX] points here. */
+    LocalContext local_context;
+
+    /** Per-core global context: sub_block_id (AIV lane identity).
+     *  Initialized once by init_global_context() at runtime startup.
+     *  args[SPMD_GLOBAL_CONTEXT_INDEX] points here. */
+    GlobalContext global_context;
+
+    static_assert(sizeof(args[0]) == 8);
+    static_assert(
+        PTO2_ALIGN_UP((MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0]), 64) ==
+        (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0])
+    );
+};

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -17,7 +17,7 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#include "pto_orchestrator.h"  // NOLINT(build/include_subdir)
+#include "pto_orchestrator.h"
 
 #include <assert.h>
 #include <inttypes.h>
@@ -26,11 +26,11 @@
 #include <string.h>
 
 #include "common/unified_log.h"
-#include "pto_runtime2_types.h"  // NOLINT(build/include_subdir)
-#include "pto_shared_memory.h"   // NOLINT(build/include_subdir)
-#include "pto_tensormap.h"       // NOLINT(build/include_subdir)
-#include "pto_types.h"           // NOLINT(build/include_subdir)
-#include "tensor.h"              // NOLINT(build/include_subdir)
+#include "pto_runtime2_types.h"
+#include "pto_shared_memory.h"
+#include "pto_tensormap.h"
+#include "pto_types.h"
+#include "tensor.h"
 
 // =============================================================================
 // Orchestrator Profiling (compile-time toggle)
@@ -58,7 +58,7 @@ perf_aicpu_record_orch_phase(AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_
 // Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // unified task+heap alloc
-static uint64_t g_orch_params_cycle = 0;     // param copy
+static uint64_t g_orch_args_cycle = 0;       // param copy
 static uint64_t g_orch_lookup_cycle = 0;     // tensormap lookup + dep building
 static uint64_t g_orch_insert_cycle = 0;     // tensormap insert
 static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
@@ -68,7 +68,7 @@ static uint32_t g_orch_submit_idx = 0;
 uint64_t g_orch_alloc_wait_cycle = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
 uint64_t g_orch_alloc_atomic_count = 0;
-uint64_t g_orch_params_atomic_count = 0;
+uint64_t g_orch_args_atomic_count = 0;
 uint64_t g_orch_fanin_atomic_count = 0;
 uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
@@ -113,6 +113,37 @@ static uint32_t g_orch_submit_idx = 0;
 #define CYCLE_COUNT_LAP(acc)
 #define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)
 #endif
+
+static bool pto2_append_fanin_or_fail(
+    PTO2OrchestratorState *orch, PTO2TaskId task_id, int32_t tensor_arg_index, TensorArgType ptype,
+    PTO2TaskSlotState *prod_state, PTO2TaskSlotState *fanin_states[], int32_t *fanin_count, const char *reason
+) {
+    for (int32_t j = 0; j < *fanin_count; j++) {
+        if (fanin_states[j] == prod_state) {
+            return true;
+        }
+    }
+
+    if (*fanin_count >= PTO2_MAX_INPUTS) {
+        LOG_ERROR("========================================");
+        LOG_ERROR("FATAL: Dependency Overflow Detected!");
+        LOG_ERROR("========================================");
+        LOG_ERROR("Task requires more than PTO2_MAX_INPUTS unique fanin dependencies.");
+        LOG_ERROR("  task_id.raw:        %" PRIu64, task_id.raw);
+        LOG_ERROR("  tensor_arg_index:   %d", tensor_arg_index);
+        LOG_ERROR("  tensor_arg_type:    %d", static_cast<int>(ptype));
+        LOG_ERROR("  fanin_count:        %d / %d", *fanin_count, PTO2_MAX_INPUTS);
+        LOG_ERROR("  reason:             %s", reason);
+        LOG_ERROR("This is a runtime dependency-tracking limit.");
+        LOG_ERROR("========================================");
+        orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_DEPENDENCY_OVERFLOW, std::memory_order_release);
+        orch->fatal = true;
+        return false;
+    }
+
+    fanin_states[(*fanin_count)++] = prod_state;
+    return true;
+}
 
 // =============================================================================
 // Orchestrator Initialization
@@ -297,6 +328,9 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
     always_assert(active_mask != 0 && "MixedKernels must have at least one active slot");
 
+    int16_t block_num = args.launch_spec.core_num();
+    always_assert(block_num >= 1 && "block_num must be >= 1");
+
     // Normalize single-AIV tasks: if only aiv1 is set (no aic, no aiv0), move
     // it to the aiv0 slot.  This guarantees the dispatch path can always use
     // PTO2SubtaskSlot::AIV0 for single-AIV shapes without inspecting active_mask.
@@ -351,13 +385,14 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     }
 
     // === Calculate output size (from runtime-created OUTPUT args) ===
-    bool needs_alloc[MAX_TENSOR_ARGS] = {};
+    uint64_t offsets[MAX_TENSOR_ARGS] = {};
+    uint64_t buffer_sizes[MAX_TENSOR_ARGS] = {};
     int32_t total_output_size = 0;
     for (int i = 0; i < args.tensor_count(); i++) {
         if (args.tag(i) == TensorArgType::OUTPUT) {
-            needs_alloc[i] = true;
-            total_output_size +=
-                PTO2_ALIGN_UP(args.tensor(i).create_info.buffer_size_bytes(), PTO2_PACKED_OUTPUT_ALIGN);
+            offsets[i] = total_output_size;
+            buffer_sizes[i] = PTO2_ALIGN_UP(args.tensor(i).create_info->buffer_size_bytes(), PTO2_PACKED_OUTPUT_ALIGN);
+            total_output_size += buffer_sizes[i];
         }
     }
 
@@ -370,7 +405,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
 
     int32_t local_id = alloc_result.task_id;
     int32_t slot = alloc_result.slot;
-    PTO2TaskId task_id = pto2_make_task_id(ring_id, static_cast<uint32_t>(local_id));
+    PTO2TaskId task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(local_id));
 
     PTO2TaskDescriptor &task = allocator.task_by_slot(slot);
     PTO2TaskPayload *payload = &orch->sm_handle->task_payloads[ring_id][slot];
@@ -383,8 +418,8 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         __builtin_prefetch(&payload->tensors[i], 1, 3);
         __builtin_prefetch(reinterpret_cast<char *>(&payload->tensors[i]) + 64, 1, 3);
     }
-    for (int32_t i = 0; i < args.tensor_count() + args.scalar_count(); i += 8) {
-        __builtin_prefetch(&payload->dispatch_args[i], 1, 3);
+    for (int32_t i = 0; i < args.scalar_count(); i += 8) {
+        __builtin_prefetch(&payload->scalars[i], 1, 3);
     }
     __builtin_prefetch(payload, 1, 3);
     __builtin_prefetch(reinterpret_cast<char *>(payload) + 64, 1, 3);
@@ -437,83 +472,52 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, task_id.raw);
 
     // === STEP 3: Lookup inputs + materialize runtime-created outputs ===
-    auto fill_initial_value = [](void *addr, uint64_t buffer_size, DataType dtype, uint64_t initial_value) {
-        uint64_t elem_size = get_element_size(dtype);
-        char *dst = reinterpret_cast<char *>(addr);
-        constexpr uint64_t BLK = 64;
-        uint64_t blk = (buffer_size < BLK) ? buffer_size : BLK;
-        for (uint64_t b = 0; b < blk; b += elem_size) {
-            memcpy(dst + b, &initial_value, elem_size);
-        }
-        uint64_t off = blk;
-        for (; off + blk <= buffer_size; off += blk) {
-            memcpy(dst + off, dst, blk);
-        }
-        if (off < buffer_size) {
-            memcpy(dst + off, dst, buffer_size - off);
-        }
-    };
-
-    int32_t offset = 0;
     for (int i = 0; i < args.tensor_count(); i++) {
         TensorArgType ptype = args.tag(i);
-
-        switch (ptype) {
-        case TensorArgType::INOUT:
-        case TensorArgType::INPUT: {
-            if (args.tensor(i).ptr->manual_dep) break;
-            // Look up producer via TensorMap (reads from cached stack tensor)
-            PTO2LookupResult lookup_result;
-            orch->tensor_map.lookup(*args.tensor(i).ptr, lookup_result);
-
-            for (int r = 0; r < lookup_result.count; r++) {
-                PTO2TensorMapEntry &entry = *lookup_result.entries[r].entry;
-                auto overlap_status = lookup_result.entries[r].overlap_status;
-                // Check if this producer is already in fanin list (avoid duplicates)
-                auto prod_ring = entry.producer_task_id.ring();
-                auto prod_local = entry.producer_task_id.local();
-                PTO2TaskSlotState *prod_state =
-                    &sched->ring_sched_states[prod_ring].get_slot_state_by_task_id(prod_local);
-                bool already_added = false;
-                for (int j = 0; j < fanin_count; j++) {
-                    if (fanin_states[j] == prod_state) {
-                        already_added = true;
-                        break;
-                    }
-                }
-
-                if (!already_added) {
-                    // Add to fanin list (this task depends on producer)
-                    if (fanin_count < PTO2_MAX_INPUTS) {
-                        fanin_states[fanin_count++] = prod_state;
-                    }
-                }
-                if (ptype == TensorArgType::INOUT && overlap_status == OverlapStatus::COVERED) {
-                    if (!entry.with_alloc) {
-                        orch->tensor_map.remove_entry(entry);
-                    }
-                }
-            }
-            break;
+        if (ptype == TensorArgType::OUTPUT) {
+            // Runtime-created OUTPUT tensors are not looked up in the TensorMap since they have no dependencies.
+            continue;
         }
 
-        case TensorArgType::OUTPUT: {
-            const TensorCreateInfo &ci = args.tensor(i).create_info;
-            uint64_t buffer_size = ci.buffer_size_bytes();
-            uint64_t alloc_addr =
-                reinterpret_cast<uint64_t>(reinterpret_cast<char *>(alloc_result.packed_base) + offset);
-            offset += PTO2_ALIGN_UP(buffer_size, PTO2_PACKED_OUTPUT_ALIGN);
-            result.output_ptr(result.output_count)
-                ->init_from_create_info(ci, reinterpret_cast<void *>(alloc_addr), /*version=*/0);
-            if (ci.has_initial_value) {
-                fill_initial_value(reinterpret_cast<void *>(alloc_addr), buffer_size, ci.dtype, ci.initial_value);
+        const Tensor *tensor = args.tensor(i).ptr;
+
+        // Step A: creator retention — all existing tensors extend their creator lifetime.
+        PTO2TaskId owner = tensor->owner_task_id;
+        if (owner.is_valid() && sched != nullptr) {
+            PTO2TaskSlotState *prod_state =
+                &sched->ring_sched_states[owner.ring()].get_slot_state_by_task_id(owner.local());
+            if (!pto2_append_fanin_or_fail(
+                    orch, task_id, i, ptype, prod_state, fanin_states, &fanin_count, "creator retention"
+                )) {
+                return result;
             }
-            result.output_count++;
-            break;
         }
 
-        default:
-            break;
+        // Step B: only INPUT/INOUT need modifier dependency lookup.
+        if (ptype != TensorArgType::INPUT && ptype != TensorArgType::INOUT) {
+            continue;
+        }
+        if (tensor->manual_dep) {
+            continue;
+        }
+
+        PTO2LookupResult lookup_result;
+        orch->tensor_map.lookup(*tensor, lookup_result);
+
+        for (int r = 0; r < lookup_result.count; r++) {
+            PTO2TensorMapEntry &entry = *lookup_result.entries[r].entry;
+            auto overlap_status = lookup_result.entries[r].overlap_status;
+            auto prod_ring = entry.producer_task_id.ring();
+            auto prod_local = entry.producer_task_id.local();
+            PTO2TaskSlotState *prod_state = &sched->ring_sched_states[prod_ring].get_slot_state_by_task_id(prod_local);
+            if (!pto2_append_fanin_or_fail(
+                    orch, task_id, i, ptype, prod_state, fanin_states, &fanin_count, "overlap lookup"
+                )) {
+                return result;
+            }
+            if (ptype == TensorArgType::INOUT && overlap_status == OverlapStatus::COVERED) {
+                orch->tensor_map.remove_entry(entry);
+            }
         }
     }
 
@@ -521,20 +525,12 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
 
     // === STEP 4: Register outputs/inouts in TensorMap (must be separate from lookup) ===
     {
-        int32_t out_idx = 0;
         for (int i = 0; i < args.tensor_count(); i++) {
             TensorArgType ptype = args.tag(i);
-            if (ptype == TensorArgType::OUTPUT || ptype == TensorArgType::INOUT) {
-                bool skip_dep = (ptype == TensorArgType::OUTPUT) ? args.tensor(i).create_info.manual_dep :
-                                                                   args.tensor(i).ptr->manual_dep;
-                if (!skip_dep) {
-                    const Tensor &t =
-                        (ptype == TensorArgType::OUTPUT) ? *result.output_ptr(out_idx) : *args.tensor(i).ptr;
-                    orch->tensor_map.insert(t, task_id, needs_alloc[i]);
+            if (ptype == TensorArgType::INOUT || ptype == TensorArgType::OUTPUT_EXISTING) {
+                if (!args.tensor(i).ptr->manual_dep) {
+                    orch->tensor_map.insert(*args.tensor(i).ptr, task_id);
                 }
-            }
-            if (ptype == TensorArgType::OUTPUT) {
-                out_idx++;
             }
         }
     }
@@ -562,11 +558,19 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         }
     }
 
-    payload->init(args, result);
+    payload->init(args, result, alloc_result.packed_base, offsets, buffer_sizes);
 
-    CYCLE_COUNT_LAP_RECORD(g_orch_params_cycle, AicpuPhaseId::ORCH_PARAMS, task_id.raw);
+    // Write owner_task_id into materialized OUTPUT tensors so creator-only dependency
+    // tracking remains available even when manual_dep skips OverlapMap publication.
+    for (int i = 0; i < args.tensor_count(); i++) {
+        if (args.tag(i) == TensorArgType::OUTPUT) {
+            payload->tensors[i].owner_task_id = task_id;
+        }
+    }
+
+    CYCLE_COUNT_LAP_RECORD(g_orch_args_cycle, AicpuPhaseId::ORCH_PARAMS, task_id.raw);
 #if PTO2_ORCH_PROFILING
-    g_orch_params_atomic_count += 2;  // fanout_lock.store + fanout_count.store
+    g_orch_args_atomic_count += 2;  // fanout_lock.store + fanout_count.store
 #endif
 
     // === STEP 6: Finalize fanin list ===
@@ -578,6 +582,10 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         // so concurrent on_mixed_task_complete can safely access task_state/fanout_refcount.
         cur_slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
         cur_slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
+        cur_slot_state.completed_subtasks.store(0, std::memory_order_relaxed);
+        cur_slot_state.total_required_subtasks = static_cast<int16_t>(block_num * __builtin_popcount(active_mask));
+        cur_slot_state.block_num = block_num;
+        cur_slot_state.next_block_idx = 0;
 
         auto &dep_pool = orch->rings[ring_id].dep_pool;
         // Ensure dep pool has space: fanin_count entries + 1 pre-alloc
@@ -712,7 +720,7 @@ PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     PTO2OrchProfilingData d;
     d.sync_cycle = g_orch_sync_cycle;
     d.alloc_cycle = g_orch_alloc_cycle;
-    d.params_cycle = g_orch_params_cycle;
+    d.args_cycle = g_orch_args_cycle;
     d.lookup_cycle = g_orch_lookup_cycle;
     d.insert_cycle = g_orch_insert_cycle;
     d.fanin_cycle = g_orch_fanin_cycle;
@@ -721,13 +729,13 @@ PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     d.alloc_wait_cycle = g_orch_alloc_wait_cycle;
     d.fanin_wait_cycle = g_orch_fanin_wait_cycle;
     d.alloc_atomic_count = g_orch_alloc_atomic_count;
-    d.params_atomic_count = g_orch_params_atomic_count;
+    d.args_atomic_count = g_orch_args_atomic_count;
     d.fanin_atomic_count = g_orch_fanin_atomic_count;
     d.finalize_atomic_count = g_orch_finalize_atomic_count;
     d.scope_end_atomic_count = g_orch_scope_end_atomic_count;
 
     // Reset
-    g_orch_sync_cycle = g_orch_alloc_cycle = g_orch_params_cycle = 0;
+    g_orch_sync_cycle = g_orch_alloc_cycle = g_orch_args_cycle = 0;
     g_orch_lookup_cycle = g_orch_insert_cycle = 0;
     g_orch_fanin_cycle = g_orch_scope_end_cycle = 0;
     g_orch_submit_count = 0;
@@ -735,7 +743,7 @@ PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     g_orch_alloc_wait_cycle = 0;
     g_orch_fanin_wait_cycle = 0;
     g_orch_alloc_atomic_count = 0;
-    g_orch_params_atomic_count = 0;
+    g_orch_args_atomic_count = 0;
     g_orch_fanin_atomic_count = 0;
     g_orch_finalize_atomic_count = 0;
     g_orch_scope_end_atomic_count = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 /**
  * PTO Runtime2 - Main Implementation
  *
@@ -17,11 +18,15 @@
  */
 
 #include "pto_runtime2.h"
+
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include "common/unified_log.h"
+
+#include <algorithm>
+
 #include "aicpu/device_time.h"
+#include "common/unified_log.h"
 
 // Weak fallback for HOST .so builds (never called, but satisfies linker).
 // The AICPU build links the strong symbol from platform/.../device_time.cpp.
@@ -52,25 +57,53 @@ void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->o
 
 static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrators[pto2_current_orch_idx].fatal; }
 
-// Wait for TensorMap producers of this tensor to be safe for data access.
-// For reads: wait until producer COMPLETED (done writing).
+// Wait for all producers of this tensor to be safe for data access.
+// Checks owner metadata (lifecycle anchor) and OverlapMap (modifier writers).
+// For reads: wait until each producer COMPLETED (done writing).
 // For writes: also wait until all consumers done reading
 //   (fanout_refcount >= fanout_count - 1, excluding scope reference).
 // Uses cycle-based timeout (checked every 1024 spins).
 // Returns false on timeout (sets orch.fatal).
+MAYBE_UNINITIALIZED_BEGIN
 static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wait_for_consumers, const char *caller) {
     PTO2OrchestratorState &orch = rt->orchestrators[pto2_current_orch_idx];
+
+    // Collect producer slot states from both maps, deduplicated by pointer.
+    // +1: one creator slot + up to PTO2_LOOKUP_MAX_RESULTS modifier slots.
+    constexpr int kMaxWait = PTO2_LOOKUP_MAX_RESULTS + 1;
+    PTO2TaskSlotState *slots[kMaxWait];
+    int slot_count = 0;
+
+    // Step A: creator retention — read owner directly from tensor metadata
+    PTO2TaskId owner = tensor.owner_task_id;
+    if (owner.is_valid()) {
+        slots[slot_count++] = &rt->scheduler.ring_sched_states[owner.ring()].get_slot_state_by_task_id(owner.local());
+    }
+
+    // Step B: modifier writer lookup (OverlapMap)
     PTO2LookupResult lookup_result;
     orch.tensor_map.lookup(tensor, lookup_result);
-
     for (int r = 0; r < lookup_result.count; r++) {
-        PTO2TensorMapEntry &entry = *lookup_result.entries[r].entry;
-        PTO2TaskId producer_id = entry.producer_task_id;
-        uint8_t ring_id = producer_id.ring();
-        int32_t local_id = producer_id.local();
-        PTO2TaskSlotState &slot = rt->scheduler.ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
+        PTO2TaskId pid = lookup_result.entries[r].entry->producer_task_id;
+        PTO2TaskSlotState *s = &rt->scheduler.ring_sched_states[pid.ring()].get_slot_state_by_task_id(pid.local());
+        bool already = false;
+        for (int j = 0; j < slot_count; j++) {
+            if (slots[j] == s) {
+                already = true;
+                break;
+            }
+        }
+        if (!already && slot_count < kMaxWait) {
+            slots[slot_count++] = s;
+        }
+    }
 
-        // Wait for producer to complete (WAW safety)
+    // Wait for each producer
+    for (int p = 0; p < slot_count; p++) {
+        PTO2TaskSlotState &slot = *slots[p];
+        uint8_t ring_id = slot.ring_id;
+        int32_t local_id = static_cast<int32_t>(slot.task->task_id.local());
+
         uint64_t t0 = get_sys_cnt_aicpu();
         int32_t spin_count = 0;
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
@@ -79,15 +112,13 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
                 orch.fatal = true;
                 unified_log_error(
                     caller, "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
-                    (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
+                    (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES,  // NOLINT(runtime/int)
+                    ring_id, local_id
                 );
                 return false;
             }
         }
 
-        // For writes: also wait for all consumers to finish reading (WAR safety).
-        // fanout_count includes 1 scope reference that won't release until scope_end,
-        // so wait until fanout_refcount >= fanout_count - 1.
         if (wait_for_consumers) {
             t0 = get_sys_cnt_aicpu();
             spin_count = 0;
@@ -97,7 +128,8 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
                     orch.fatal = true;
                     unified_log_error(
                         caller, "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
-                        (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
+                        (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES,  // NOLINT(runtime/int)
+                        ring_id, local_id
                     );
                     return false;
                 }
@@ -106,6 +138,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     }
     return true;
 }
+MAYBE_UNINITIALIZED_END
 
 uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     if (tensor.buffer.addr == 0) {
@@ -177,7 +210,7 @@ PTO2Runtime *pto2_runtime_create_custom(
     PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity
 ) {
     // Allocate runtime context
-    PTO2Runtime *rt = (PTO2Runtime *)calloc(1, sizeof(PTO2Runtime));
+    PTO2Runtime *rt = static_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) {
         return NULL;
     }
@@ -241,7 +274,7 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     if (orch_count < 1) orch_count = 1;
     if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
 
-    PTO2Runtime *rt = (PTO2Runtime *)calloc(1, sizeof(PTO2Runtime));
+    PTO2Runtime *rt = static_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) return NULL;
 
     rt->ops = &s_runtime_ops;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -31,9 +31,10 @@
 
 #include <atomic>
 
-#include "pto2_dispatch_payload.h"  // NOLINT(build/include_subdir)
-#include "pto_submit_types.h"       // NOLINT(build/include_subdir)
-#include "pto_types.h"              // NOLINT(build/include_subdir)
+#include "pto2_dispatch_payload.h"
+#include "pto_submit_types.h"
+#include "pto_task_id.h"
+#include "pto_types.h"
 
 // =============================================================================
 // Profiling Configuration
@@ -77,7 +78,8 @@
 #define PTO2_ERROR_HEAP_RING_DEADLOCK 2
 #define PTO2_ERROR_FLOW_CONTROL_DEADLOCK 3
 #define PTO2_ERROR_DEP_POOL_OVERFLOW 4
-#define PTO2_ERROR_INVALID_ARGS 5  // Arg construction error (invalid args)
+#define PTO2_ERROR_INVALID_ARGS 5         // Arg construction error (invalid args)
+#define PTO2_ERROR_DEPENDENCY_OVERFLOW 6  // Too many unique fanin dependencies for one task
 
 // Scheduler errors (100+): detected in scheduler threads
 #define PTO2_ERROR_SCHEDULER_TIMEOUT 100
@@ -127,33 +129,8 @@ constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES = 15 * 1000 * 1000 * 1000ULL;
 // =============================================================================
 
 /**
- * TaskId: 64-bit encoding used across Runtime2.
- *
- * raw encoding: (ring_id << 32) | local_id
- *
- * ring_id:  which ring layer (0..PTO2_MAX_RING_DEPTH-1)
- * local_id: per-ring monotonic counter
+ * TaskId: defined in pto_task_id.h (included above).
  */
-struct PTO2TaskId {
-    uint64_t raw;
-
-    constexpr PTO2TaskId() :
-        raw(0) {}
-    constexpr explicit PTO2TaskId(uint64_t v) :
-        raw(v) {}
-
-    constexpr uint8_t ring() const { return static_cast<uint8_t>(raw >> 32); }
-    constexpr uint32_t local() const { return static_cast<uint32_t>(raw & 0xFFFFFFFFu); }
-
-    constexpr bool operator==(const PTO2TaskId &other) const { return raw == other.raw; }
-    constexpr bool operator!=(const PTO2TaskId &other) const { return raw != other.raw; }
-};
-
-static_assert(sizeof(PTO2TaskId) == 8, "PTO2TaskId must stay 8 bytes (shared memory ABI)");
-
-static inline PTO2TaskId pto2_make_task_id(uint8_t ring_id, uint32_t local_id) {
-    return PTO2TaskId{(static_cast<uint64_t>(ring_id) << 32) | static_cast<uint64_t>(local_id)};
-}
 
 // =============================================================================
 // Worker Types
@@ -364,59 +341,66 @@ struct PTO2TaskDescriptor {
  * Task payload data (cold path - only accessed during orchestration and dispatch)
  *
  * Layout: metadata (counts, fanin pointers) packed in the first 3 cache lines,
- * followed by pre-built dispatch args and bulk tensor data. Scalar values are
- * written directly into dispatch_args[] (after tensor pointers), eliminating
- * the separate scalars[] array.
- *
- * The Scheduler writes function_bin_addr and a pointer to dispatch_args[] into
- * PTO2DispatchPayload, then signals AICore via DATA_MAIN_BASE register.
+ * followed by bulk tensor and scalar data. This gives sequential write access
+ * during orchestration and groups scheduler-hot fields (fanin_actual_count +
+ * fanin_slot_states) together for on_task_release.
  */
 struct PTO2TaskPayload {
-    // === Cache line 0 (64B) — metadata ===
+    // === Cache lines 0-2 (192B) — metadata ===
     int32_t tensor_count{0};
     int32_t scalar_count{0};
     int32_t fanin_actual_count{0};  // Actual fanin count (without the +1 redundance)
     int32_t _reserved{0};           // Reserved (dep_pool_mark moved to SlotState for local access)
     PTO2TaskSlotState *fanin_slot_states[PTO2_MAX_INPUTS];  // Producer slot states (used by on_task_release)
-    // === Tensors (2048B) — alignas(64) Tensor forces alignment ===
+    // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
-    // === Pre-built args for AICore dispatch (1152B = 16 tensor ptrs + 128 scalars) ===
-    uint64_t dispatch_args[PTO2_DISPATCH_MAX_ARGS];
+    // === Cache lines 35-50 (1024B) — scalars ===
+    uint64_t scalars[MAX_SCALAR_ARGS];
+
+    // Layout verification (size checks that don't need offsetof).
+    static_assert(sizeof(Tensor) == 128, "Tensor must be 2 cache lines");
+    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 1024, "scalar region must be 1024B (16 cache lines)");
 
     /**
-     * Initialize payload: copy tensors, build dispatch args.
+     * Initialize payload: copy tensors, store scalars.
      *
      * For each param slot, the tensor source is determined by TensorArgType:
-     * - OUTPUT → use materialized_outputs.output_ptr(out_idx++)
-     * - INPUT / INOUT → use refs[i].tensor
+     * - OUTPUT -> use materialized_outputs.output_ptr(out_idx++)
+     * - INPUT / INOUT -> use refs[i].tensor
      *
      * @param args                Task arguments (tensors + scalars)
      * @param materialized_outputs  Materialized output tensors (from TensorCreateInfo path)
      */
-    void init(const Arg &args, const TaskOutputTensors &materialized_outputs) {
+    void
+    init(const Arg &args, TaskOutputTensors &result, void *base_addr, uint64_t offsets[], uint64_t buffer_sizes[]) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
-        int32_t out_idx = 0;
+        // int32_t out_idx = 0;
         for (int32_t i = 0; i < args.tensor_count(); i++) {
-            const Tensor *src;
-            if (args.tag(i) == TensorArgType::OUTPUT) {
-                src = materialized_outputs.output_ptr(out_idx++);
+            if (args.tag(i) != TensorArgType::OUTPUT) {
+                tensors[i].copy(*args.tensor(i).ptr);
             } else {
-                src = args.tensor(i).ptr;
+                tensors[i].init_from_create_info(
+                    *args.tensor(i).create_info,
+                    reinterpret_cast<void *>(reinterpret_cast<char *>(base_addr) + offsets[i]), buffer_sizes[i]
+                );
+                result.materialize_output(tensors[i]);
             }
-            tensors[i].copy(*src);
             tensors[i].update_start_offset();
-            dispatch_args[i] = reinterpret_cast<uint64_t>(&tensors[i]);
         }
-        // Bulk-copy scalars into dispatch_args[tensor_count..], rounded up to
-        // cache-line boundary (extra bytes within the same CL cost nothing).
-        memcpy(
-            &dispatch_args[args.tensor_count()], args.scalar_data(),
-            PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64)
-        );
+        // Round up to cache line boundary. Both arrays are 1024B so no overrun.
+        // Eliminates branches; extra bytes within the same CL have zero additional cost.
+        memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
     }
 };
+
+// PTO2TaskPayload layout verification (offsetof requires complete type).
+static_assert(offsetof(PTO2TaskPayload, tensors) == 192, "tensors must start at byte 192 (cache line 3)");
+static_assert(
+    offsetof(PTO2TaskPayload, scalars) == 192 + MAX_TENSOR_ARGS * sizeof(Tensor),
+    "scalars must immediately follow tensors"
+);
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
@@ -453,9 +437,15 @@ struct alignas(64) PTO2TaskSlotState {
 
     // Hot-path completion fields (moved from TaskDescriptor to avoid cross-struct access)
     uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
-    std::atomic<uint8_t> subtask_done_mask;  // Each subtask sets its done bit on completion
+    std::atomic<uint8_t> subtask_done_mask;  // Deprecated: superseded by completed_subtasks
     uint8_t ring_id;                         // Ring layer this task belongs to (for per-ring reclamation)
     int32_t dep_pool_mark{0};  // Dep pool top after this task's submission (orchestrator-only, local memory)
+
+    // SPMD multi-block (occupies the 8 tail bytes previously implicit padding)
+    std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
+    int16_t total_required_subtasks{0};          // = block_num * popcount(active_mask)
+    int16_t block_num{1};                        // Total logical blocks (set by orchestrator)
+    int16_t next_block_idx{0};                   // Next block to dispatch (scheduler state)
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);
@@ -501,7 +491,7 @@ typedef void (*PTO2InCoreFunc)(void **args, int32_t num_args);
 // This header is also compiled into the Host .so (for struct definitions only),
 // where the hint is never called — the fallback no-op keeps Host builds clean.
 #if __has_include("spin_hint.h")
-#include "spin_hint.h"  // NOLINT(build/include_subdir)
+#include "spin_hint.h"
 #else
 #define SPIN_WAIT_HINT() ((void)0)
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 /**
  * PTO Runtime2 - Scheduler Interface
  *
@@ -26,16 +27,14 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#ifndef PTO_SCHEDULER_H
-#define PTO_SCHEDULER_H
+#pragma once
 
 #include <atomic>
 
+#include "common/core_type.h"
+#include "pto_ring_buffer.h"
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
-#include "pto_ring_buffer.h"
-
-#include "common/core_type.h"
 
 #if PTO2_SCHED_PROFILING
 #include "aicpu/device_time.h"
@@ -131,7 +130,7 @@ struct alignas(64) PTO2ReadyQueue {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
-            int64_t diff = seq - (int64_t)pos;
+            int64_t diff = seq - static_cast<int64_t>(pos);
             if (diff == 0) {
                 if (enqueue_pos.compare_exchange_weak(
                         pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
@@ -144,7 +143,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         slot->slot_state = slot_state;
-        slot->sequence.store((int64_t)(pos + 1), std::memory_order_release);
+        slot->sequence.store(static_cast<int64_t>(pos + 1), std::memory_order_release);
         return true;
     }
 
@@ -160,7 +159,7 @@ struct alignas(64) PTO2ReadyQueue {
             for (int i = 0; i < count; i++) {
                 PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
-                int64_t diff = seq - (int64_t)(pos + i);
+                int64_t diff = seq - static_cast<int64_t>(pos + i);
                 if (diff != 0) {
                     ready = false;
                     break;
@@ -179,7 +178,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             slot->slot_state = items[i];
-            slot->sequence.store((int64_t)(pos + i + 1), std::memory_order_release);
+            slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
     }
 
@@ -194,7 +193,7 @@ struct alignas(64) PTO2ReadyQueue {
             pos = enqueue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
-            int64_t diff = seq - (int64_t)pos;
+            int64_t diff = seq - static_cast<int64_t>(pos);
             atomic_ops += 2;  // enqueue_pos.load + sequence.load
             if (diff == 0) {
                 if (enqueue_pos.compare_exchange_weak(
@@ -218,7 +217,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         slot->slot_state = slot_state;
-        slot->sequence.store((int64_t)(pos + 1), std::memory_order_release);
+        slot->sequence.store(static_cast<int64_t>(pos + 1), std::memory_order_release);
         return true;
     }
 #endif
@@ -237,7 +236,7 @@ struct alignas(64) PTO2ReadyQueue {
             pos = dequeue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
-            int64_t diff = seq - (int64_t)(pos + 1);
+            int64_t diff = seq - static_cast<int64_t>(pos + 1);
             if (diff == 0) {
                 if (dequeue_pos.compare_exchange_weak(
                         pos, pos + 1, std::memory_order_relaxed, std::memory_order_relaxed
@@ -249,7 +248,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         PTO2TaskSlotState *result = slot->slot_state;
-        slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
+        slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
 
@@ -272,7 +271,7 @@ struct alignas(64) PTO2ReadyQueue {
             pos = dequeue_pos.load(std::memory_order_relaxed);
             slot = &slots[pos & mask];
             int64_t seq = slot->sequence.load(std::memory_order_acquire);
-            int64_t diff = seq - (int64_t)(pos + 1);
+            int64_t diff = seq - static_cast<int64_t>(pos + 1);
             atomic_ops += 2;  // dequeue_pos.load + sequence.load
             if (diff == 0) {
                 if (dequeue_pos.compare_exchange_weak(
@@ -297,7 +296,7 @@ struct alignas(64) PTO2ReadyQueue {
         }
 
         PTO2TaskSlotState *result = slot->slot_state;
-        slot->sequence.store((int64_t)(pos + mask + 1), std::memory_order_release);
+        slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
 #endif
@@ -313,7 +312,7 @@ struct alignas(64) PTO2ReadyQueue {
             while (count < max_count) {
                 PTO2ReadyQueueSlot *slot = &slots[(pos + count) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
-                int64_t diff = seq - (int64_t)(pos + count + 1);
+                int64_t diff = seq - static_cast<int64_t>(pos + count + 1);
                 if (diff == 0) {
                     count++;
                     continue;
@@ -336,7 +335,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
-            slot->sequence.store((int64_t)(pos + i + mask + 1), std::memory_order_release);
+            slot->sequence.store(static_cast<int64_t>(pos + i + mask + 1), std::memory_order_release);
         }
         return count;
     }
@@ -355,7 +354,7 @@ struct alignas(64) PTO2ReadyQueue {
             while (count < max_count) {
                 PTO2ReadyQueueSlot *slot = &slots[(pos + count) & mask];
                 int64_t seq = slot->sequence.load(std::memory_order_acquire);
-                int64_t diff = seq - (int64_t)(pos + count + 1);
+                int64_t diff = seq - static_cast<int64_t>(pos + count + 1);
                 atomic_ops++;  // sequence.load
                 if (diff == 0) {
                     count++;
@@ -388,7 +387,7 @@ struct alignas(64) PTO2ReadyQueue {
         for (int i = 0; i < count; i++) {
             PTO2ReadyQueueSlot *slot = &slots[(pos + i) & mask];
             out[i] = slot->slot_state;
-            slot->sequence.store((int64_t)(pos + i + mask + 1), std::memory_order_release);
+            slot->sequence.store(static_cast<int64_t>(pos + i + mask + 1), std::memory_order_release);
             atomic_ops++;  // sequence.store
         }
         atomic_count += atomic_ops;
@@ -655,18 +654,16 @@ struct PTO2SchedulerState {
     }
 
     /**
-     * Two-stage completion: first stage.
-     * Called when a single subtask (AIC, AIV0, or AIV1) finishes.
-     * Sets the corresponding done bit in subtask_done_mask.
+     * Subtask completion: atomic counter model.
+     * Called when a single subtask (AIC, AIV0, or AIV1) finishes on any block.
+     * Atomically increments completed_subtasks and checks whether all subtasks
+     * across all blocks are done.
      *
-     * @return true if this subtask was the last one, completing the mixed task.
+     * @return true if this was the last subtask, completing the entire task.
      */
-    bool on_subtask_complete(PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot) {
-        uint8_t done_bit = (1u << static_cast<uint8_t>(subslot));
-        uint8_t prev_mask = slot_state.subtask_done_mask.fetch_or(done_bit, std::memory_order_acq_rel);
-        uint8_t new_mask = prev_mask | done_bit;
-
-        return new_mask == slot_state.active_mask;
+    bool on_subtask_complete(PTO2TaskSlotState &slot_state) {
+        int16_t prev = slot_state.completed_subtasks.fetch_add(1, std::memory_order_acq_rel);
+        return (prev + 1) == slot_state.total_required_subtasks;
     }
 
     /**
@@ -782,7 +779,7 @@ struct PTO2SchedulerState {
 #endif
         return fanin_edges;
     }
-};
+};  // NOLINT(readability/braces)
 
 // =============================================================================
 // Scheduler API (cold path, defined in pto_scheduler.cpp)
@@ -832,5 +829,3 @@ struct PTO2SchedProfilingData {
  */
 PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
 #endif
-
-#endif  // PTO_SCHEDULER_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 /**
  * PTO Submit Types - Shared submit-contract definitions
  *
@@ -15,8 +16,7 @@
  * headers. Keeps orchestration slim (no dependency on pto_runtime2_types.h).
  */
 
-#ifndef PTO_SUBMIT_TYPES_H
-#define PTO_SUBMIT_TYPES_H
+#pragma once
 
 #include <stdint.h>
 
@@ -100,4 +100,20 @@ static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels &mk) 
     return mask;
 }
 
-#endif  // PTO_SUBMIT_TYPES_H
+/**
+ * SPMD launch parameters carried inside Arg.
+ *
+ * Controls how many logical blocks (SPMD dimension) a single task
+ * is expanded into at dispatch time.  Each block receives a unique
+ * core_idx in [0, core_num) via the per-dispatch LocalContext.
+ */
+class PTO2LaunchSpec {
+public:
+    constexpr PTO2LaunchSpec() = default;
+
+    int16_t core_num() const { return core_num_; }
+    void set_core_num(int16_t n) { core_num_ = n; }
+
+private:
+    int16_t core_num_{1};
+};

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_task_id.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_task_id.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * PTO2TaskId — minimal standalone header.
+ *
+ * Factored out of pto_runtime2_types.h so that tensor.h can include it
+ * without pulling in scheduler-internal constants (heap sizes, timeouts, etc.).
+ */
+
+#pragma once
+
+#include <cstdint>
+
+/**
+ * TaskId: 64-bit encoding used across Runtime2.
+ *
+ * raw encoding: (ring_id << 32) | local_id
+ *
+ * ring_id:  which ring layer (0..PTO2_MAX_RING_DEPTH-1)
+ * local_id: per-ring monotonic counter
+ *
+ * Invalid sentinel: raw == UINT64_MAX (no valid task has this encoding).
+ */
+struct PTO2TaskId {
+    uint64_t raw;
+
+    static constexpr PTO2TaskId make(uint8_t ring_id, uint32_t local_id) {
+        return PTO2TaskId{(static_cast<uint64_t>(ring_id) << 32) | static_cast<uint64_t>(local_id)};
+    }
+
+    static constexpr PTO2TaskId invalid() { return PTO2TaskId{UINT64_MAX}; }
+
+    constexpr uint8_t ring() const { return static_cast<uint8_t>(raw >> 32); }
+    constexpr uint32_t local() const { return static_cast<uint32_t>(raw & 0xFFFFFFFFu); }
+    constexpr bool is_valid() const { return raw != UINT64_MAX; }
+
+    constexpr bool operator==(const PTO2TaskId &other) const { return raw == other.raw; }
+    constexpr bool operator!=(const PTO2TaskId &other) const { return raw != other.raw; }
+};
+
+static_assert(sizeof(PTO2TaskId) == 8, "PTO2TaskId must stay 8 bytes (shared memory ABI)");

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 /**
  * PTO Runtime2 - TensorMap Interface
  *
@@ -41,9 +42,9 @@
 
 #pragma once
 
-#include "common.h"
-#include "pto_runtime2_types.h"
-#include "tensor.h"
+#include "common.h"              // NOLINT(build/include_subdir)
+#include "pto_runtime2_types.h"  // NOLINT(build/include_subdir)
+#include "tensor.h"              // NOLINT(build/include_subdir)
 
 struct PTO2OrchestratorState;  // forward declare
 
@@ -72,7 +73,7 @@ extern uint64_t g_insert_count;
  *
  * Cache line 1 (64B, lookup hot path):
  *   next_in_bucket, producer_task_id, buffer_addr — chain traversal + validity + hash match
- *   version, ndims, is_all_offset_zero, with_alloc, bucket_index — overlap fast path
+ *   version, ndims, is_all_offset_zero, bucket_index — overlap fast path
  *   shapes[5] — overlap comparison
  *
  * Cache line 2 (64B, insert/remove/slow-path only):
@@ -84,17 +85,17 @@ extern uint64_t g_insert_count;
  */
 struct alignas(64) PTO2TensorMapEntry {
     // === Cache line 1 (64B) — lookup hot path ===
+    uint64_t buffer_addr;                // 8B: tensor base address (hash key)
     PTO2TensorMapEntry *next_in_bucket;  // 8B: next entry in hash bucket chain
     PTO2TaskId producer_task_id;         // 8B: raw (ring_id << 32) | local_id
-    uint64_t buffer_addr;                // 8B: tensor base address (hash key)
+    int32_t bucket_index;                // 4B: bucket index (-1 if unlinked)
+    uint32_t __padding0__;               // 4B: occupies Tensor::start_offset high half
     int32_t version;                     // 4B: tensor version for overlap detection
     uint32_t ndims;                      // 4B: number of dimensions
-    int32_t bucket_index;                // 4B: bucket index (-1 if unlinked)
+    DataType __padding_dtype__;          // 1B: occupies Tensor::dtype
     bool is_all_offset_zero;             // 1B: fast-path flag
-    bool with_alloc;                     // 1B: true=OUTPUT, false=INOUT
-    // padding: 2B
+    uint8_t __padding1__[2];
     uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // 20B: shape per dimension
-    // padding: 4B to fill 64B
 
     // === Cache line 2 (64B) — insert/remove/slow-path ===
     PTO2TensorMapEntry *prev_in_bucket;         // 8B: prev in hash bucket chain
@@ -106,19 +107,18 @@ struct alignas(64) PTO2TensorMapEntry {
     /**
      * Copy overlap-relevant fields from a Tensor into this entry.
      */
-    void copy_from_tensor(const Tensor &t) {
-        buffer_addr = t.buffer.addr;
-        version = t.version;
-        ndims = t.ndims;
-        is_all_offset_zero = t.is_all_offset_zero;
-        for (uint32_t i = 0; i < t.ndims; i++) {
-            shapes[i] = t.shapes[i];
-        }
-        if (!t.is_all_offset_zero) {
-            for (uint32_t i = 0; i < t.ndims; i++) {
-                offsets[i] = t.offsets[i];
+    void copy_from_tensor(const Tensor &tensor) {
+        memcpy(this, &tensor, 64);
+        if (!tensor.is_all_offset_zero) {
+            for (uint32_t i = 0; i < tensor.ndims; i++) {
+                offsets[i] = tensor.offsets[i];
             }
         }
+    }
+
+    void copy_tensor_create_info(const TensorCreateInfo &tensor_create_info, uint64_t addr) {
+        memcpy(this, &tensor_create_info, 64);
+        buffer_addr = addr;
     }
 
     /**
@@ -147,8 +147,8 @@ struct alignas(64) PTO2TensorMapEntry {
         for (uint32_t i = 0; i < ndims; i++) {
             uint64_t in_off = input.is_all_offset_zero ? 0 : input.offsets[i];
             uint64_t ent_off = is_all_offset_zero ? 0 : offsets[i];
-            Segment in_range{in_off, in_off + (uint64_t)input.shapes[i]};
-            Segment ent_range{ent_off, ent_off + (uint64_t)shapes[i]};
+            Segment in_range{in_off, in_off + static_cast<uint64_t>(input.shapes[i])};
+            Segment ent_range{ent_off, ent_off + static_cast<uint64_t>(shapes[i])};
             if (!in_range.line_segment_intersection(ent_range)) {
                 return OverlapStatus::NO_OVERLAP;
             } else if (!in_range.contains(ent_range)) {
@@ -160,6 +160,14 @@ struct alignas(64) PTO2TensorMapEntry {
 };
 
 static_assert(sizeof(PTO2TensorMapEntry) == 128, "TensorMapEntry must be exactly 2 cache lines (128 bytes)");
+static_assert(offsetof(PTO2TensorMapEntry, buffer_addr) == offsetof(Tensor, buffer.addr));
+static_assert(offsetof(PTO2TensorMapEntry, version) == offsetof(Tensor, version));
+static_assert(offsetof(PTO2TensorMapEntry, ndims) == offsetof(Tensor, ndims));
+static_assert(offsetof(PTO2TensorMapEntry, is_all_offset_zero) == offsetof(Tensor, is_all_offset_zero));
+static_assert(offsetof(PTO2TensorMapEntry, shapes) == offsetof(Tensor, shapes));
+static_assert(
+    offsetof(PTO2TensorMapEntry, prev_in_bucket) == 64, "TensorMapEntry must be exactly 2 cache lines (128 bytes)"
+);
 
 /**
  * Stack-allocated lookup result (avoids heap allocation per lookup)
@@ -213,7 +221,7 @@ struct PTO2TensorMap {
 
     PTO2OrchestratorState *orch{nullptr};
 
-    // new_entry currently only allocates memory, not attributes
+    // new_entry only allocates memory, does not assign attributes
     PTO2TensorMapEntry *new_entry() {
         if (free_num > 0) {
             PTO2TensorMapEntry *res = free_entry_list[--free_num];
@@ -227,7 +235,7 @@ struct PTO2TensorMap {
     }
 
     void free_entry(PTO2TensorMapEntry &entry) {
-        always_assert(entry.bucket_index != -1);  // Must ensure entry is still in a bucket
+        always_assert(entry.bucket_index != -1);  // must still be in a bucket
 
         // Update predecessor's next pointer (O(1) via prev_in_bucket)
         if (entry.prev_in_bucket == nullptr) {
@@ -350,43 +358,10 @@ struct PTO2TensorMap {
      * @param tensor            Tensor produced
      * @param producer_task_id  Task ID of producer
      */
-    void insert(const Tensor &tensor, PTO2TaskId producer_task_id, bool with_alloc) {
-#if PTO2_TENSORMAP_PROFILING
-        g_insert_count++;
-#endif
-        // Prefetch bucket head and task_entry_head early; new_entry() + field
-        // initialization below provides hide time for these RFOs.
-        uint32_t bucket_index = hash(tensor.buffer.addr);
-        auto ring_id = producer_task_id.ring();
-        auto local_id = producer_task_id.local();
-        int32_t task_slot = local_id & (task_window_sizes[ring_id] - 1);
-
-        // Allocate entry from ring buffer pool
+    void insert(const Tensor &tensor, PTO2TaskId producer_task_id) {
         PTO2TensorMapEntry *entry = new_entry();
-
-        // Initialize new entry
         entry->copy_from_tensor(tensor);
-        entry->producer_task_id = producer_task_id;
-        entry->with_alloc = with_alloc;
-
-        // Insert at head of hash bucket (maintains task_id descending order)
-        entry->bucket_index = bucket_index;
-        entry->next_in_bucket = buckets[bucket_index];
-        // Update old head's prev pointer
-        if (entry->next_in_bucket != nullptr) {
-            entry->next_in_bucket->prev_in_bucket = entry;
-        }
-        buckets[entry->bucket_index] = entry;
-        entry->prev_in_bucket = nullptr;  // New head has no predecessor
-
-        // Link to task's entry list (for cleanup), indexed by ring and local slot
-        entry->next_in_task = task_entry_heads[ring_id][task_slot];
-        entry->prev_in_task = nullptr;  // New head has no predecessor
-        // Update old head's prev pointer
-        if (entry->next_in_task != nullptr) {
-            entry->next_in_task->prev_in_task = entry;
-        }
-        task_entry_heads[ring_id][task_slot] = entry;
+        link_entry(entry, tensor.buffer.addr, producer_task_id);
     }
 
     /**
@@ -410,7 +385,7 @@ struct PTO2TensorMap {
                 // (slot may have been reused by a newer task)
                 debug_assert(
                     cur_entry->producer_task_id ==
-                    pto2_make_task_id(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id))
+                    PTO2TaskId::make(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id))
                 );
                 free_entry(*cur_entry);
                 cur_entry = next_entry;
@@ -439,6 +414,38 @@ struct PTO2TensorMap {
     }
 
     /**
+     * Link an initialized entry into bucket and task chains.
+     */
+    void link_entry(PTO2TensorMapEntry *entry, uint64_t addr, PTO2TaskId producer_task_id) {
+#if PTO2_TENSORMAP_PROFILING
+        g_insert_count++;
+#endif
+        uint32_t bucket_index = hash(addr);
+        auto ring_id = producer_task_id.ring();
+        auto local_id = producer_task_id.local();
+        int32_t task_slot = local_id & (task_window_sizes[ring_id] - 1);
+
+        entry->producer_task_id = producer_task_id;
+
+        // Insert at head of hash bucket
+        entry->bucket_index = bucket_index;
+        entry->next_in_bucket = buckets[bucket_index];
+        if (entry->next_in_bucket != nullptr) {
+            entry->next_in_bucket->prev_in_bucket = entry;
+        }
+        buckets[bucket_index] = entry;
+        entry->prev_in_bucket = nullptr;
+
+        // Link to task's entry list
+        entry->next_in_task = task_entry_heads[ring_id][task_slot];
+        entry->prev_in_task = nullptr;
+        if (entry->next_in_task != nullptr) {
+            entry->next_in_task->prev_in_task = entry;
+        }
+        task_entry_heads[ring_id][task_slot] = entry;
+    }
+
+    /**
      * Check if entry is valid (producer has not retired)
      */
     bool entry_valid(const PTO2TensorMapEntry &entry) const {
@@ -455,7 +462,7 @@ struct PTO2TensorMap {
      * Called during pool wrap-around to unlink reused entries.
      */
     void remove_from_task(PTO2TensorMapEntry &entry) {
-        always_assert(entry.bucket_index != -1);  // Must ensure entry is still in a bucket
+        always_assert(entry.bucket_index != -1);  // must still be in a bucket
         // Update predecessor's next pointer (O(1) via prev_in_task)
         if (entry.prev_in_task == nullptr) {
             // Entry is the head of its task chain, update task_entry_heads

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -32,9 +32,10 @@
 #include <arm_neon.h>
 #endif
 
-#include "task_args.h"   // NOLINT(build/include_subdir) -- TaskArgs base class
-#include "tensor.h"      // NOLINT(build/include_subdir)
-#include "tensor_arg.h"  // NOLINT(build/include_subdir) -- canonical TensorArgType definition
+#include "pto_submit_types.h"  // NOLINT(build/include_subdir) -- PTO2LaunchSpec
+#include "task_args.h"         // NOLINT(build/include_subdir) -- TaskArgs base class
+#include "tensor.h"            // NOLINT(build/include_subdir)
+#include "tensor_arg.h"        // NOLINT(build/include_subdir) -- canonical TensorArgType definition
 
 // Task arguments
 #define MAX_TENSOR_ARGS 16   // Maximum tensor arguments per task
@@ -62,28 +63,27 @@
 class TaskOutputTensors {
 public:  // NOLINT(whitespace/indent)
     TaskOutputTensors() :
-        output_count(0) {}
+        output_count_(0) {}
 
-    uint32_t output_count;
-
-    bool empty() const { return output_count == 0; }
-    uint32_t size() const { return output_count; }
+    bool empty() const { return output_count_ == 0; }
+    uint32_t size() const { return output_count_; }
 
     /// Borrow a materialized output tensor by index (lvalue only).
     const Tensor &get_ref(uint32_t index) const & {
-        always_assert(index < output_count);
-        return *reinterpret_cast<const Tensor *>(_storage + index * sizeof(Tensor));
+        always_assert(index < output_count_);
+        return *tensors_[index];
     }
     const Tensor &get_ref(uint32_t index) const && = delete;
 
-    /// Runtime-internal: writable pointer for materialization.
-    Tensor *output_ptr(uint32_t index) { return reinterpret_cast<Tensor *>(_storage + index * sizeof(Tensor)); }
-    const Tensor *output_ptr(uint32_t index) const {
-        return reinterpret_cast<const Tensor *>(_storage + index * sizeof(Tensor));
+    /// Runtime-internal: append one materialized output Tensor.
+    void materialize_output(const Tensor &tensor) {
+        always_assert(output_count_ < PTO2_MAX_OUTPUTS);
+        tensors_[output_count_++] = &tensor;
     }
 
 private:  // NOLINT(whitespace/indent)
-    alignas(Tensor) unsigned char _storage[PTO2_MAX_OUTPUTS * sizeof(Tensor)];
+    uint32_t output_count_;
+    const Tensor *tensors_[PTO2_MAX_OUTPUTS];
 };
 
 // =============================================================================
@@ -98,7 +98,7 @@ private:  // NOLINT(whitespace/indent)
  */
 union TensorRef {
     const Tensor *ptr;
-    TensorCreateInfo create_info;
+    const TensorCreateInfo *create_info;
     TensorRef() :
         ptr(nullptr) {}
 };
@@ -118,7 +118,7 @@ union TensorRef {
  *
  * Example:
  *   Tensor x = make_tensor_external(dev_a, shapes, 2);
- *   TensorCreateInfo ci(shapes, 2);
+ *   TensorCreateInfo ci(shapes, 2);  // must outlive submit
  *   Arg args;
  *   args.add_input(x);
  *   args.add_output(ci);
@@ -129,6 +129,7 @@ union TensorRef {
 struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType> {
     bool has_error{false};
     const char *error_msg{nullptr};
+    PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
 
     void reset() {
         clear();
@@ -169,26 +170,18 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
 
     /// Standard future-output path: runtime allocates buffer from heap,
     /// materializes Tensor into TaskOutputTensors.
+    /// The TensorCreateInfo must outlive the submit call (pointer is stored).
     void add_output(const TensorCreateInfo &ci) {
         if (!check_add_tensor_valid()) {
             return;
         }
-        tensors_[tensor_count_].create_info = ci;
+        tensors_[tensor_count_].create_info = &ci;
         tags_[tensor_count_] = TensorArgType::OUTPUT;
         tensor_count_++;
     }
 
-    /// Runtime-allocated output with an initial element value replicated
-    /// across the full buffer after HeapRing allocation.
-    void add_output(const TensorCreateInfo &ci, uint64_t initial_value) {
-        if (!check_add_tensor_valid()) {
-            return;
-        }
-        tensors_[tensor_count_].create_info = ci;
-        tensors_[tensor_count_].create_info.set_initial_value(initial_value);
-        tags_[tensor_count_] = TensorArgType::OUTPUT;
-        tensor_count_++;
-    }
+    /// Prevent passing temporaries — the pointer would dangle before submit.
+    void add_output(TensorCreateInfo &&) = delete;
 
     void add_inout(const Tensor &t) {
         if (!check_add_tensor_valid()) {
@@ -199,12 +192,37 @@ struct Arg : TaskArgs<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, Ten
         tensor_count_++;
     }
 
-    void add_scalar(uint64_t v) {
+    /// Write-only existing tensor: skips OverlapMap lookup, depends on creator.
+    void add_output(const Tensor &t) {
+        if (!check_add_tensor_valid()) return;
+        tensors_[tensor_count_].ptr = &t;
+        tags_[tensor_count_] = TensorArgType::OUTPUT_EXISTING;
+        tensor_count_++;
+    }
+
+    /// No-dependency existing tensor: skips OverlapMap lookup, depends on creator only.
+    void add_no_dep(const Tensor &t) {
+        if (!check_add_tensor_valid()) return;
+        tensors_[tensor_count_].ptr = &t;
+        tags_[tensor_count_] = TensorArgType::NO_DEP;
+        tensor_count_++;
+    }
+
+    /**
+     * Add a scalar value. Type is deduced from the argument;
+     * the value is bit-cast to uint64_t for storage.
+     *
+     *   args.add_scalar(uint64_val);      // existing usage unchanged
+     *   args.add_scalar(3.14f);           // float, auto bit-cast
+     *   args.add_scalar(int32_t(42));     // int32, auto bit-cast
+     */
+    template <typename T = uint64_t>
+    void add_scalar(T value) {
         if (scalar_count_ >= MAX_SCALAR_ARGS) {
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
             return;
         }
-        scalars_[scalar_count_++] = v;
+        scalars_[scalar_count_++] = to_u64(value);
     }
 
     void add_scalars(const uint64_t *values, int count) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -21,8 +21,9 @@
  * - Function address mapping (func_id_to_addr_)
  *
  * Task dispatch uses a per-core PTO2DispatchPayload written by the scheduler.
- * The Orchestrator pre-builds dispatch_args[] in each task payload; the
- * scheduler only fills function_bin_addr + args before signaling AICore.
+ * At dispatch time, build_payload() copies tensor pointers and scalars from
+ * the task payload into the per-core args[], populates SPMD context, then
+ * signals AICore via DATA_MAIN_BASE.
  */
 
 #ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_
@@ -36,8 +37,8 @@
 #include "common/core_type.h"
 #include "common/perf_profiling.h"
 #include "common/platform_config.h"
-#include "pto2_dispatch_payload.h"  // NOLINT(build/include_subdir)
-#include "task_args.h"              // NOLINT(build/include_subdir)
+#include "pto2_dispatch_payload.h"
+#include "task_args.h"
 
 // =============================================================================
 // Configuration Macros

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -18,8 +18,9 @@
 #include <string>
 #include <utility>
 
-#include "common.h"     // NOLINT(build/include_subdir)
-#include "data_type.h"  // NOLINT(build/include_subdir)
+#include "common.h"       // NOLINT(build/include_subdir)
+#include "data_type.h"    // NOLINT(build/include_subdir)
+#include "pto_task_id.h"  // NOLINT(build/include_subdir)
 
 constexpr int RUNTIME_MAX_TENSOR_DIMS = 5;
 
@@ -55,33 +56,37 @@ struct Segment {
  * dtype, ndims, raw_shapes (== shapes), manual_dep, and an optional
  * initial value fill.
  *
- * Arg::add_output() copies this value into Arg immediately, so the
- * original stack object does not need to outlive the add_output() call.
+ * Layout (64B) is aligned with Tensor cacheline 1 so that
+ * init_from_create_info() can copy the entire cacheline with a single memcpy,
+ * then overwrite buffer/owner metadata and refresh start_offset later.
+ *
+ * Arg::add_output() stores a pointer to this object, so the original
+ * must remain valid (not a temporary) until after the submit call.
  */
-struct TensorCreateInfo {
-    DataType dtype;
-    uint32_t ndims;
-    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];
-    bool manual_dep;
-    bool has_initial_value;
-    uint64_t initial_value;
-
+class alignas(64) TensorCreateInfo {
+public:  // NOLINT(whitespace/indent)
     TensorCreateInfo(
         const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false
     ) :
-        dtype(dtype),
-        ndims(ndims),
-        manual_dep(manual_dep),
+        initial_value(0),
         has_initial_value(false),
-        initial_value(0) {
+        version(0),
+        ndims(ndims),
+        dtype(dtype),
+        is_all_offset_zero(true),
+        is_raw_eq_shapes(true),
+        manual_dep(manual_dep) {
         for (uint32_t i = 0; i < ndims; i++) {
             raw_shapes[i] = shapes[i];
         }
     }
 
-    void set_initial_value(uint64_t value) {
+    void copy(const TensorCreateInfo &other) { memcpy(this, &other, sizeof(other)); }
+
+    template <typename T = uint64_t>
+    void set_initial_value(T value) {
         has_initial_value = true;
-        initial_value = value;
+        initial_value = to_u64(value);
     }
 
     uint64_t buffer_size_bytes() const {
@@ -91,7 +96,33 @@ struct TensorCreateInfo {
         }
         return total * get_element_size(dtype);
     }
+
+public:  // NOLINT(whitespace/indent)
+    // --- Bytes [0, 32): TensorCreateInfo-only fields ---
+    // These occupy the same positions as Tensor::buffer, Tensor::owner_task_id,
+    // and Tensor::start_offset. The runtime overwrites owner metadata after the
+    // memcpy and refreshes start_offset during payload materialization.
+    uint64_t initial_value;
+    bool has_initial_value;
+    uint8_t __pad1__[7];
+    uint64_t __pad2__;  // → Tensor::owner_task_id
+    uint64_t __pad3__;  // → Tensor::start_offset (zeroed)
+
+    // --- Bytes [32, 64): Matches Tensor cacheline 1 layout ---
+    int32_t version;  // Always 0 for create-info outputs
+    uint32_t ndims;
+    DataType dtype;
+    bool is_all_offset_zero;  // Always true for create-info outputs
+    bool is_raw_eq_shapes;    // Always true for create-info outputs
+    bool manual_dep;
+    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // → Tensor::shapes
+
+    TensorCreateInfo() = default;
+
+    friend struct Arg;
 };
+
+static_assert(sizeof(TensorCreateInfo) == 64);
 
 /**
  * Tensor descriptor for Task input/output (128B = 2 cache lines)
@@ -108,12 +139,12 @@ struct TensorCreateInfo {
  * - is_all_offset_zero: when true, offsets[] are implicitly zero — skip offset read/write
  * - is_raw_eq_shapes: when true, raw_shapes[] == shapes[] — skip raw_shapes read/write,
  *   use shapes[] wherever raw_shapes would be needed
- * - manual_dep: when true, dependency tracking is managed manually
+ * - manual_dep: when true, keep creator retention only and skip OverlapMap dependency tracking
  *
  * When BOTH flags are true, cache line 2 is never accessed.
  *
- * Layout: cache line 1 holds hot-path fields (buffer, start_offset, version,
- * dtype, ndims, flags, shapes); cache line 2 holds warm-path fields (raw_shapes, offsets).
+ * Layout: cache line 1 holds hot-path fields (buffer, owner_task_id, start_offset,
+ * version, ndims, dtype, flags, shapes); cache line 2 holds warm-path fields (raw_shapes, offsets).
  *
  * Construction:
  * Users cannot default-construct or directly construct a Tensor.
@@ -125,21 +156,21 @@ struct TensorCreateInfo {
  */
 struct alignas(64) Tensor {
     // === Cache line 1 (64B) — hot path ===
-    PTOBufferHandle buffer;   // Underlying memory buffer (addr in bytes, size in bytes)
-    uint64_t start_offset;    // Cached 1D element offset (precomputed from raw_shapes + offsets), only calc before
-                              // incore, useless in orch
-    int32_t version;          // Tensor version for overlap detection
-    DataType dtype;           // Data type of tensor elements
-    uint32_t ndims;           // Number of dimensions used
-    bool is_all_offset_zero;  // True when all offsets[] are zero (skip offset read/write)
-    bool is_raw_eq_shapes;    // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
-    bool manual_dep;          // True when dependency is managed manually (skip tensormap lookup/insert)
+    PTOBufferHandle buffer;    // Underlying memory buffer (addr in bytes, size in bytes)
+    PTO2TaskId owner_task_id;  // Creator task; PTO2TaskId::invalid() for external tensors
+    uint64_t start_offset;     // Cached 1D element offset (precomputed from raw_shapes + offsets)
+    int32_t version;           // Tensor version for overlap detection
+    uint32_t ndims;            // Number of dimensions used
+    DataType dtype;            // Data type of tensor elements
+    bool is_all_offset_zero;   // True when all offsets[] are zero (skip offset read/write)
+    bool is_raw_eq_shapes;     // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
+    bool manual_dep;           // True when dependency tracking is creator-only (skip OverlapMap lookup/insert)
     uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // Current view shape per dimension
-    uint32_t __padding__;
 
     // === Cache line 2 (64B) — warm path ===
     uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
     uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
+    uint8_t _pad_cl2[24];                          // Tail padding (bytes 104–127)
 
     // --- Copy / move / destroy are public (valid tensors can be freely copied) ---
     Tensor(const Tensor &) = default;
@@ -178,17 +209,18 @@ struct alignas(64) Tensor {
                 offsets[i] = in_offsets[i];
             }
         }
+        owner_task_id = PTO2TaskId::invalid();
     }
 
     void init(const Tensor &other) {
         memcpy(this, &other, 64);  // fast copy cache line 1
         if (!other.is_raw_eq_shapes) {
-            for (uint32_t i = 0; i < ndims; i++) {
+            for (uint32_t i = 0; i < other.ndims; i++) {
                 raw_shapes[i] = other.raw_shapes[i];
             }
         }
         if (!other.is_all_offset_zero) {
-            for (uint32_t i = 0; i < ndims; i++) {
+            for (uint32_t i = 0; i < other.ndims; i++) {
                 offsets[i] = other.offsets[i];
             }
         }
@@ -231,6 +263,7 @@ struct alignas(64) Tensor {
             }
         }
         is_all_offset_zero = all_zero;
+        owner_task_id = other.owner_task_id;
     }
 
     /// Compute 1D flat element offset from multi-dimensional indices.
@@ -250,12 +283,31 @@ struct alignas(64) Tensor {
     }
 
     /// Materialize a TensorCreateInfo into this Tensor (fresh contiguous output).
-    void init_from_create_info(const TensorCreateInfo &ci, void *addr, int32_t version_val) {
-        init(
-            addr, ci.buffer_size_bytes(), ci.raw_shapes, ci.raw_shapes, nullptr, ci.ndims, ci.dtype, version_val,
-            /*is_all_offset_zero=*/true,
-            /*is_raw_eq_shapes=*/true, ci.manual_dep
-        );
+    /// Single 64B memcpy covers the entire cacheline 1, then buffer is overwritten.
+    void init_from_create_info(const TensorCreateInfo &ci, void *addr, uint64_t buffer_size) {
+        memcpy(this, &ci, 64);
+        buffer = {reinterpret_cast<uint64_t>(addr), buffer_size};
+        owner_task_id = PTO2TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
+        if (ci.has_initial_value) {
+            fill_initial_value(ci.initial_value);
+        }
+    }
+
+    void fill_initial_value(uint64_t initial_value) {
+        always_assert(reinterpret_cast<char *>(buffer.addr) != nullptr);
+        uint64_t elem_size = get_element_size(dtype);
+        char *dst = reinterpret_cast<char *>(buffer.addr);
+        constexpr uint64_t BLK = 64;
+        uint64_t blk = (buffer.size < BLK) ? buffer.size : BLK;
+        for (uint64_t b = 0; b < blk; b += elem_size) {
+            memcpy(dst + b, &initial_value, elem_size);
+        }
+        uint64_t filled = blk;
+        while (filled < buffer.size) {
+            uint64_t copy_size = ((buffer.size - filled) < filled) ? (buffer.size - filled) : filled;
+            memcpy(dst + filled, dst, copy_size);
+            filled += copy_size;
+        }
     }
 
     // --- Operations ---
@@ -413,3 +465,15 @@ private:
 
 static_assert(sizeof(Tensor) == 128, "Tensor must be exactly 2 cache lines (128 bytes)");
 static_assert(offsetof(Tensor, raw_shapes) == 64);
+static_assert(offsetof(Tensor, owner_task_id) == 16, "owner_task_id must be at bytes 16-23 (cacheline 1)");
+static_assert(offsetof(Tensor, start_offset) == 24, "start_offset must be at bytes 24-31 (cacheline 1)");
+
+// TensorCreateInfo layout must match Tensor cacheline 1 for memcpy optimization
+static_assert(sizeof(TensorCreateInfo) == 64, "TensorCreateInfo must match Tensor cacheline 1 size (64 bytes)");
+static_assert(offsetof(TensorCreateInfo, version) == offsetof(Tensor, version));
+static_assert(offsetof(TensorCreateInfo, ndims) == offsetof(Tensor, ndims));
+static_assert(offsetof(TensorCreateInfo, dtype) == offsetof(Tensor, dtype));
+static_assert(offsetof(TensorCreateInfo, is_all_offset_zero) == offsetof(Tensor, is_all_offset_zero));
+static_assert(offsetof(TensorCreateInfo, is_raw_eq_shapes) == offsetof(Tensor, is_raw_eq_shapes));
+static_assert(offsetof(TensorCreateInfo, manual_dep) == offsetof(Tensor, manual_dep));
+static_assert(offsetof(TensorCreateInfo, raw_shapes) == offsetof(Tensor, shapes));

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -163,6 +163,7 @@ static __aicore__ void online_update_impl(
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
         // Phase 2: Scalar arithmetic in RowMajor (kScalarRows, kScalarCols)
+        // pipe_barrier(PIPE_V) required between each dependent vector operation
         // to resolve RAW hazards on shared UB tiles.
         TMAX(miNewND, miND, mijND);    // mi_new = max(mi, mij)
         TSUB(alphaND, miND, miNewND);  // alpha = mi - mi_new

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -173,19 +173,14 @@ int build_paged_attention_graph(Runtime *runtime, const ChipStorageTaskArgs &orc
 
             for (uint32_t bn = 0; bn < bn_this_batch; bn++) {
                 int cur_block_idx = host_block_table[b_idx * max_num_blocks + bn];
-                int valid_len = std::min(
-                    static_cast<int>(block_size), cur_seq - static_cast<int>(bn) * static_cast<int>(block_size)
-                );
+                int valid_len = std::min(static_cast<int>(block_size), cur_seq - static_cast<int>(bn * block_size));
 
                 // Key: (total_blocks, block_size, kv_head_num, head_dim) bf16
-                // Stride to block: cur_block_idx * (block_size * kv_head_num * head_dim)
-                // Then offset to kv_head: kv_head_idx * head_dim (within each token row)
-                // But since we want contiguous (block_size, head_dim), and kv_head_num=1 makes it simple:
                 uint8_t *kj_ptr = reinterpret_cast<uint8_t *>(dev_key_cache) +
                                   (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
                                       head_dim * sizeof(uint16_t);
 
-                // Value: (total_blocks, block_size, kv_head_num, head_dim) bf16 - same layout as key
+                // Value: (total_blocks, block_size, kv_head_num, head_dim) bf16
                 uint8_t *vj_ptr = reinterpret_cast<uint8_t *>(dev_value_cache) +
                                   (static_cast<int64_t>(cur_block_idx) * block_size * kv_head_num + kv_head_idx) *
                                       head_dim * sizeof(uint16_t);

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -92,9 +92,6 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __g
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(oiGlobal, cTile);
-
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -93,9 +93,6 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(sijGlobal, cTile);
-
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -220,8 +220,6 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -120,9 +120,6 @@ static __aicore__ void softmax_prepare_impl(
     TSTORE(mijGlobal, maxTile);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
     TSTORE(lijGlobal, sumTile);
-
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -153,12 +153,12 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                 prof_view_count += 2;
                 CYCLE_COUNT_LAP(prof_tensor_view);
 
-                Arg args_inplace;
-                args_inplace.add_output(tile2d_ci);
-                args_inplace.add_output(scalar_ci);
-                args_inplace.add_output(scalar_ci);
+                Arg params_inplace;
+                params_inplace.add_output(tile2d_ci);
+                params_inplace.add_output(scalar_ci);
+                params_inplace.add_output(scalar_ci);
                 CYCLE_COUNT_LAP(prof_param_setup);
-                TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, args_inplace);
+                TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, params_inplace);
                 const Tensor &oi = hub_outs.get_ref(0);
                 const Tensor &li_update = hub_outs.get_ref(1);
                 const Tensor &mi_update = hub_outs.get_ref(2);
@@ -179,12 +179,12 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     prof_view_count += 2;
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
-                    Arg args_qk;
-                    args_qk.add_input(qi);
-                    args_qk.add_input(kj);
-                    args_qk.add_output(sij_ci);
+                    Arg params_qk;
+                    params_qk.add_input(qi);
+                    params_qk.add_input(kj);
+                    params_qk.add_output(sij_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, args_qk);
+                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij = qk_outs.get_ref(0);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -195,26 +195,26 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     prof_view_count += 1;
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
-                    Arg args_sf;
-                    args_sf.add_input(sij_valid);
-                    args_sf.add_output(pij_f16_ci);
-                    args_sf.add_output(scalar_ci);
-                    args_sf.add_output(scalar_ci);
-                    args_sf.add_scalar(scale_value);
+                    Arg params_sf;
+                    params_sf.add_input(sij_valid);
+                    params_sf.add_output(pij_f16_ci);
+                    params_sf.add_output(scalar_ci);
+                    params_sf.add_output(scalar_ci);
+                    params_sf.add_scalar(scale_value);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, args_sf);
+                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_f16 = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
-                    Arg args_pv;
-                    args_pv.add_input(pij_f16);
-                    args_pv.add_input(vj);
-                    args_pv.add_output(tile2d_ci);
+                    Arg params_pv;
+                    params_pv.add_input(pij_f16);
+                    params_pv.add_input(vj);
+                    params_pv.add_output(tile2d_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, args_pv);
+                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_tmp = pv_outs.get_ref(0);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -223,18 +223,18 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
                     CYCLE_COUNT_LAP(prof_param_extract);
 
-                    Arg args_up;
-                    args_up.add_input(mi);
-                    args_up.add_input(li);
-                    args_up.add_input(oi_tmp);
-                    args_up.add_inout(mi_update);
-                    args_up.add_inout(li_update);
-                    args_up.add_inout(oi);
-                    args_up.add_inout(out_view);
-                    args_up.add_scalar(is_first);
-                    args_up.add_scalar(is_last);
+                    Arg params_up;
+                    params_up.add_input(mi);
+                    params_up.add_input(li);
+                    params_up.add_input(oi_tmp);
+                    params_up.add_inout(mi_update);
+                    params_up.add_inout(li_update);
+                    params_up.add_inout(oi);
+                    params_up.add_inout(out_view);
+                    params_up.add_scalar(is_first);
+                    params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, args_up);
+                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
                 }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -136,9 +136,6 @@ static __aicore__ void pv_matmul_n_impl(
     set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     TSTORE(oiGlobal, cTile);
-
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -101,8 +101,6 @@ static __aicore__ void qk_matmul_n_impl(
             pipe_barrier(PIPE_ALL);
         }
     }
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -220,8 +220,6 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -221,9 +221,6 @@ static __aicore__ void softmax_prepare_n_impl(
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(lijGlobalDN, sumDN);
-
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -177,17 +177,17 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                 Tensor qi = query.view(qi_shapes, qi_offsets);
                 uint32_t out_view_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
                 uint32_t out_view_offsets[2] = {static_cast<uint32_t>(cur_offset), 0};
-                Tensor out_view = out.view(out_view_shapes, out_view_offsets);
+                Tensor out_view = out.view(out_view_shapes, out_view_offsets, true);
 #ifdef ENABLE_PROFILING
                 prof_view_count += 2;
                 CYCLE_COUNT_LAP(prof_tensor_view);
 #endif
-                Arg args_inplace;
-                args_inplace.add_output(tile2d_ci);
-                args_inplace.add_output(scalar_noinit_ci);
-                args_inplace.add_output(scalar_noinit_ci);
+                Arg params_inplace;
+                params_inplace.add_output(tile2d_ci);
+                params_inplace.add_output(scalar_noinit_ci);
+                params_inplace.add_output(scalar_noinit_ci);
                 CYCLE_COUNT_LAP(prof_param_setup);
-                TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, args_inplace);
+                TaskOutputTensors hub_outs = pto2_rt_submit_aiv_task(FUNC_AIV_HUB, params_inplace);
                 const Tensor &oi = hub_outs.get_ref(0);
                 const Tensor &li_update = hub_outs.get_ref(1);
                 const Tensor &mi_update = hub_outs.get_ref(2);
@@ -198,7 +198,7 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
 
                 // Reusable Arg objects — reset() before each use avoids
                 // repeated stack-frame construction in the inner loop.
-                Arg args_qk, args_sf, args_pv, args_up;
+                Arg params_qk, params_sf, params_pv, params_up;
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
                     uint64_t n_blocks = std::min(static_cast<uint64_t>(N_UNROLL), bn_this_batch - bn);
@@ -218,14 +218,14 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     CYCLE_COUNT_LAP(prof_make_tensor);
 #endif
 
-                    args_qk.reset();
-                    args_qk.add_input(qi);
-                    args_qk.add_input(key_cache);
-                    args_qk.add_output(sij_buf_ci);
-                    args_qk.add_scalar(n_blocks);
-                    args_qk.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
+                    params_qk.reset();
+                    params_qk.add_input(qi);
+                    params_qk.add_input(key_cache);
+                    params_qk.add_output(sij_buf_ci);
+                    params_qk.add_scalar(n_blocks);
+                    params_qk.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, args_qk);
+                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij_buf = qk_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
@@ -242,16 +242,16 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     CYCLE_COUNT_LAP(prof_make_tensor);
 #endif
 
-                    args_sf.reset();
-                    args_sf.add_input(sij_buf);
-                    args_sf.add_output(pij_buf_ci);
-                    args_sf.add_output(scalar_ci);
-                    args_sf.add_output(scalar_ci);
-                    args_sf.add_scalar(scale_value);
-                    args_sf.add_scalar(n_blocks);
-                    args_sf.add_scalar(valid_len_last);
+                    params_sf.reset();
+                    params_sf.add_input(sij_buf);
+                    params_sf.add_output(pij_buf_ci);
+                    params_sf.add_output(scalar_ci);
+                    params_sf.add_output(scalar_ci);
+                    params_sf.add_scalar(scale_value);
+                    params_sf.add_scalar(n_blocks);
+                    params_sf.add_scalar(valid_len_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, args_sf);
+                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_buf = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
@@ -261,14 +261,14 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
 #endif
 
                     // === Task 3: SplitK PV matmul (accumulated P @ V) ===
-                    args_pv.reset();
-                    args_pv.add_input(pij_buf);
-                    args_pv.add_input(value_cache);
-                    args_pv.add_output(tile2d_ci);
-                    args_pv.add_scalar(n_blocks);
-                    args_pv.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
+                    params_pv.reset();
+                    params_pv.add_input(pij_buf);
+                    params_pv.add_input(value_cache);
+                    params_pv.add_output(tile2d_ci);
+                    params_pv.add_scalar(n_blocks);
+                    params_pv.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, args_pv);
+                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_new = pv_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
@@ -279,18 +279,18 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     uint64_t is_first = (bn == 0) ? 1 : 0;
                     uint64_t is_last = (bn + n_blocks >= bn_this_batch) ? 1 : 0;
 
-                    args_up.reset();
-                    args_up.add_input(mi);
-                    args_up.add_input(li);
-                    args_up.add_input(oi_new);
-                    args_up.add_inout(mi_update);
-                    args_up.add_inout(li_update);
-                    args_up.add_inout(oi);
-                    args_up.add_inout(out_view);
-                    args_up.add_scalar(is_first);
-                    args_up.add_scalar(is_last);
+                    params_up.reset();
+                    params_up.add_input(mi);
+                    params_up.add_input(li);
+                    params_up.add_input(oi_new);
+                    params_up.add_inout(mi_update);
+                    params_up.add_inout(li_update);
+                    params_up.add_inout(oi);
+                    params_up.add_inout(out_view);
+                    params_up.add_scalar(is_first);
+                    params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, args_up);
+                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);


### PR DESCRIPTION

Synchronize A5 platform, runtimes, and tests with a2a3 improvements. Follows the established sync pattern.

Platform (src/a5/platform/):
- 012675a (#419): Add PerfSetDeviceCallback for device context setup in mgmt_loop, buffer recycling improvements
- fe63325 (#403): Fix include paths in perf_profiling.h, rename params_cycle to args_cycle

Runtime host_build_graph (src/a5/runtime/host_build_graph/):
- 012675a (#419): Add implicit task profiling records in Case 1/Case 2, reinterpret_cast cleanup, license header

Runtime tensormap_and_ringbuffer (src/a5/runtime/tensormap_and_ringbuffer/):
- 7059fff (#389): Encapsulate TaskOutputTensors materialization in orchestrator
- 27a85c8 (#390): Const-qualify set_tensor_data Tensor parameter
- 1d97ac5 (#395): Arg inherits TaskArgs, simplify orchestrator arg passing
- 121a1d5 (#387): Add to_u64/from_u64 type-safe conversion utilities in orchestration API
- fe63325 (#403): Defer output tensor materialization, TensorCreateInfo pointer, tensormap link_entry
- cd59b47 (#404): Add SPMD context accessors, intrinsic.h, build_payload with LocalContext/GlobalContext
- 4917d12 (#415): Refine tensor dependency tracking, TensorCreateInfo alignment, owner tracking
- 34a6e1c (#417): SPMD multi-block dispatch, scheduler dual-queue, submit_types extensions

Tests (examples/a5/, tests/st/a5/):
- be765f1 (#392): Migrate paged_attention orchestration to ChipStorageTaskArgs API
- 121a1d5 (#387): Use from_u64<float> in softmax_prepare kernels
- fe63325 (#403): Add license headers, NOLINT annotations, output tensor view(true)
- cd59b47 (#404): Add spmd_basic example (AIC+AIV SPMD read test)
- 34a6e1c (#417): Add spmd_multiblock_aiv and spmd_multiblock_mix examples
- Remove redundant end-of-kernel sync barriers in paged_attention test kernels
- Adjust paged_attention orch_thread_num (2→1), paged_attention_unroll block_dim (36→24)