### PR TITLE
Support: align sim clang checks and harden runtime startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
 
   # ---------- Python unit tests (no hardware) ----------
   ut-py:
-    needs: pre-commit
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -85,7 +84,6 @@ jobs:
 
   # ---------- Simulation scene tests ----------
   st-sim-a2a3:
-    needs: pre-commit
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -108,11 +106,6 @@ jobs:
           else
             brew install ninja
             brew install gcc@15 || brew install gcc
-            if command -v g++-15; then
-              echo "CXX=g++-15" >> $GITHUB_ENV
-            else
-              echo "CXX=g++" >> $GITHUB_ENV
-            fi
           fi
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -142,7 +135,6 @@ jobs:
         run: ./ci.sh -p a2a3sim -r ${{ matrix.runtime }} -c 6622890 -t 600 --clone-protocol https
 
   st-sim-a5:
-    needs: pre-commit
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -165,11 +157,6 @@ jobs:
           else
             brew install ninja
             brew install gcc@15 || brew install gcc
-            if command -v g++-15; then
-              echo "CXX=g++-15" >> $GITHUB_ENV
-            else
-              echo "CXX=g++" >> $GITHUB_ENV
-            fi
           fi
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -200,7 +187,6 @@ jobs:
 
   # ---------- Python unit tests (a2a3 hardware) ----------
   ut-py-a2a3:
-    needs: pre-commit
     runs-on: [self-hosted, a2a3]
     timeout-minutes: 30
 
@@ -218,7 +204,6 @@ jobs:
 
   # ---------- Scene tests (a2a3 hardware) ----------
   st-onboard-a2a3:
-    needs: pre-commit
     runs-on: [self-hosted, a2a3]
     timeout-minutes: 60
 
@@ -270,7 +255,7 @@ jobs:
   #       Add the "a5" label to the runner, matching [self-hosted, a5] below.
   #
   # ut-py-a5:
-  #   needs: pre-commit detect-changes
+  #   needs: detect-changes
   #   runs-on: [self-hosted, a5]
   #   timeout-minutes: 30
   #
@@ -288,7 +273,7 @@ jobs:
   #
 
   st-onboard-a5:
-    needs: [pre-commit, detect-changes]
+    needs: detect-changes
     if: needs.detect-changes.outputs.a5_changed == 'true'
     runs-on: [self-hosted, a5]
     timeout-minutes: 60

--- a/python/runtime_compiler.py
+++ b/python/runtime_compiler.py
@@ -329,7 +329,26 @@ class RuntimeCompiler:
             cmake_source_dir,
             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
         ] + cmake_args
-        self._run_build_step(cmake_cmd, build_dir, platform, "CMake configuration")
+        try:
+            self._run_build_step(cmake_cmd, build_dir, platform, "CMake configuration")
+        except RuntimeError as exc:
+            # Persistent CMake cache dirs under build/cache can become invalid when the
+            # selected compiler or command-line cache entries change. In that case, wipe
+            # the target build dir and retry once with a clean configure.
+            build_path = Path(build_dir)
+            if not any(build_path.iterdir()):
+                raise
+            logger.warning(
+                "[%s] CMake configuration failed in cached build dir %s; clearing cache and retrying once",
+                platform,
+                build_dir,
+            )
+            shutil.rmtree(build_path)
+            build_path.mkdir(parents=True, exist_ok=True)
+            try:
+                self._run_build_step(cmake_cmd, build_dir, platform, "CMake configuration")
+            except RuntimeError:
+                raise exc
 
         build_cmd = [
             "cmake",

--- a/src/a2a3/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/sim/aicpu/CMakeLists.txt
@@ -61,7 +61,7 @@ target_compile_options(aicpu_kernel
         -Wall
         -Wextra
         -Werror
-        -Wno-error=class-memaccess
+        $<$<CXX_COMPILER_ID:GNU>:-Wno-error=class-memaccess>
         -fPIC
         -O3
         -g

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -437,27 +437,6 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime *runtime) {
     ready_queue_aic_tail_ = 0;
     ready_queue_aiv_head_ = 0;
     ready_queue_aiv_tail_ = 0;
-    int initial_ready[RUNTIME_MAX_TASKS];
-    int initial_count = runtime->get_initial_ready_tasks(initial_ready);
-
-    LOG_INFO("Init: Found %d initially ready tasks", initial_count);
-
-    // Classify initial ready tasks by type
-    int initial_aic[RUNTIME_MAX_TASKS];
-    int initial_aiv[RUNTIME_MAX_TASKS];
-    int initial_aic_count = 0;
-    int initial_aiv_count = 0;
-
-    for (int i = 0; i < initial_count; i++) {
-        Task *task = runtime->get_task(initial_ready[i]);
-        if (task->core_type == CoreType::AIC) {
-            initial_aic[initial_aic_count++] = initial_ready[i];
-        } else {
-            initial_aiv[initial_aiv_count++] = initial_ready[i];
-        }
-    }
-
-    LOG_INFO("Init: Initial ready tasks by type: AIC=%d, AIV=%d", initial_aic_count, initial_aiv_count);
 
     for (int t = 0; t < MAX_AICPU_THREADS; t++) {
         cur_ready_queue_aic_head_[t] = 0;
@@ -466,50 +445,67 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime *runtime) {
         cur_ready_queue_aiv_tail_[t] = 0;
     }
 
+    int initial_count = 0;
+    int initial_aic_count = 0;
+    int initial_aiv_count = 0;
     int aic_shared_count = 0;
-    int thread_idx = 0;
-    for (int i = 0; i < initial_aic_count; i++) {
-        int task_id = initial_aic[i];
+    int aiv_shared_count = 0;
+    int next_aic_thread = 0;
+    int next_aiv_thread = 0;
 
-        int head = cur_ready_queue_aic_head_[thread_idx];
-        int tail = cur_ready_queue_aic_tail_[thread_idx];
-        int cur_size = (tail - head + MAX_CORES_PER_THREAD) % MAX_CORES_PER_THREAD;
+    auto enqueue_initial_task = [&](int task_id, CoreType core_type, int &next_thread_idx, int &shared_count) {
+        int thread_idx = next_thread_idx;
+        int *head_ptr = (core_type == CoreType::AIC) ? &cur_ready_queue_aic_head_[thread_idx] :
+                                                       &cur_ready_queue_aiv_head_[thread_idx];
+        int *tail_ptr = (core_type == CoreType::AIC) ? &cur_ready_queue_aic_tail_[thread_idx] :
+                                                       &cur_ready_queue_aiv_tail_[thread_idx];
+        int cur_size = (*tail_ptr - *head_ptr + MAX_CORES_PER_THREAD) % MAX_CORES_PER_THREAD;
+        int local_capacity = (core_type == CoreType::AIC) ? aic_per_thread_ : aiv_per_thread_;
 
-        if (cur_size < aic_per_thread_) {
-            cur_ready_queue_aic_[thread_idx][tail] = task_id;
-            cur_ready_queue_aic_tail_[thread_idx] = (tail + 1) % MAX_CORES_PER_THREAD;
-            LOG_INFO("Init: AIC task %d -> Thread %d local queue (size=%d)", task_id, thread_idx, cur_size + 1);
-        } else {
+        if (cur_size < local_capacity) {
+            if (core_type == CoreType::AIC) {
+                cur_ready_queue_aic_[thread_idx][*tail_ptr] = task_id;
+            } else {
+                cur_ready_queue_aiv_[thread_idx][*tail_ptr] = task_id;
+            }
+            *tail_ptr = (*tail_ptr + 1) % MAX_CORES_PER_THREAD;
+            LOG_INFO(
+                "Init: %s task %d -> Thread %d local queue (size=%d)", core_type == CoreType::AIC ? "AIC" : "AIV",
+                task_id, thread_idx, cur_size + 1
+            );
+        } else if (core_type == CoreType::AIC) {
             ready_queue_aic_[ready_queue_aic_tail_] = task_id;
             ready_queue_aic_tail_ = (ready_queue_aic_tail_ + 1) % RUNTIME_MAX_TASKS;
-            aic_shared_count++;
-        }
-
-        thread_idx = (thread_idx + 1) % thread_num_;
-    }
-    ready_count_aic_.store(aic_shared_count, std::memory_order_release);
-
-    int aiv_shared_count = 0;
-    thread_idx = 0;
-    for (int i = 0; i < initial_aiv_count; i++) {
-        int task_id = initial_aiv[i];
-
-        int head = cur_ready_queue_aiv_head_[thread_idx];
-        int tail = cur_ready_queue_aiv_tail_[thread_idx];
-        int cur_size = (tail - head + MAX_CORES_PER_THREAD) % MAX_CORES_PER_THREAD;
-
-        if (cur_size < aiv_per_thread_) {
-            cur_ready_queue_aiv_[thread_idx][tail] = task_id;
-            cur_ready_queue_aiv_tail_[thread_idx] = (tail + 1) % MAX_CORES_PER_THREAD;
-            LOG_INFO("Init: AIV task %d -> Thread %d local queue (size=%d)", task_id, thread_idx, cur_size + 1);
+            shared_count++;
         } else {
             ready_queue_aiv_[ready_queue_aiv_tail_] = task_id;
             ready_queue_aiv_tail_ = (ready_queue_aiv_tail_ + 1) % RUNTIME_MAX_TASKS;
-            aiv_shared_count++;
+            shared_count++;
         }
 
-        thread_idx = (thread_idx + 1) % thread_num_;
+        next_thread_idx = (thread_idx + 1) % thread_num_;
+    };
+
+    int task_count = runtime->get_task_count();
+    for (int task_id = 0; task_id < task_count; task_id++) {
+        Task *task = runtime->get_task(task_id);
+        if (task == nullptr || task->fanin.load(std::memory_order_acquire) != 0) {
+            continue;
+        }
+
+        initial_count++;
+        if (task->core_type == CoreType::AIC) {
+            initial_aic_count++;
+            enqueue_initial_task(task_id, CoreType::AIC, next_aic_thread, aic_shared_count);
+        } else {
+            initial_aiv_count++;
+            enqueue_initial_task(task_id, CoreType::AIV, next_aiv_thread, aiv_shared_count);
+        }
     }
+
+    LOG_INFO("Init: Found %d initially ready tasks", initial_count);
+    LOG_INFO("Init: Initial ready tasks by type: AIC=%d, AIV=%d", initial_aic_count, initial_aiv_count);
+    ready_count_aic_.store(aic_shared_count, std::memory_order_release);
     ready_count_aiv_.store(aiv_shared_count, std::memory_order_release);
 
     LOG_INFO(

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -25,6 +25,8 @@ Runtime::Runtime() {
     // NOTE: host_api is initialized in InitRuntime() (host-only code)
     // because the CApi functions don't exist when compiled for device.
 
+    memset(workers, 0, sizeof(workers));
+
     // Initialize task array (cannot use memset with atomic members)
     for (int i = 0; i < RUNTIME_MAX_TASKS; i++) {
         tasks[i].task_id = 0;
@@ -43,6 +45,9 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     sche_cpu_num = 1;
+    orch_thread_num = 1;
+    enable_profiling = false;
+    perf_data_base = 0;
     tensor_pair_count = 0;
 
     // Initialize kernel binary tracking

--- a/src/a5/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a5/platform/sim/aicpu/CMakeLists.txt
@@ -61,7 +61,7 @@ target_compile_options(aicpu_kernel
         -Wall
         -Wextra
         -Werror
-        -Wno-error=class-memaccess
+        $<$<CXX_COMPILER_ID:GNU>:-Wno-error=class-memaccess>
         -fPIC
         -O3
         -g

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -437,27 +437,6 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime *runtime) {
     ready_queue_aic_tail_ = 0;
     ready_queue_aiv_head_ = 0;
     ready_queue_aiv_tail_ = 0;
-    int initial_ready[RUNTIME_MAX_TASKS];
-    int initial_count = runtime->get_initial_ready_tasks(initial_ready);
-
-    LOG_INFO("Init: Found %d initially ready tasks", initial_count);
-
-    // Classify initial ready tasks by type
-    int initial_aic[RUNTIME_MAX_TASKS];
-    int initial_aiv[RUNTIME_MAX_TASKS];
-    int initial_aic_count = 0;
-    int initial_aiv_count = 0;
-
-    for (int i = 0; i < initial_count; i++) {
-        Task *task = runtime->get_task(initial_ready[i]);
-        if (task->core_type == CoreType::AIC) {
-            initial_aic[initial_aic_count++] = initial_ready[i];
-        } else {
-            initial_aiv[initial_aiv_count++] = initial_ready[i];
-        }
-    }
-
-    LOG_INFO("Init: Initial ready tasks by type: AIC=%d, AIV=%d", initial_aic_count, initial_aiv_count);
 
     for (int t = 0; t < MAX_AICPU_THREADS; t++) {
         cur_ready_queue_aic_head_[t] = 0;
@@ -466,50 +445,67 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime *runtime) {
         cur_ready_queue_aiv_tail_[t] = 0;
     }
 
+    int initial_count = 0;
+    int initial_aic_count = 0;
+    int initial_aiv_count = 0;
     int aic_shared_count = 0;
-    int thread_idx = 0;
-    for (int i = 0; i < initial_aic_count; i++) {
-        int task_id = initial_aic[i];
+    int aiv_shared_count = 0;
+    int next_aic_thread = 0;
+    int next_aiv_thread = 0;
 
-        int head = cur_ready_queue_aic_head_[thread_idx];
-        int tail = cur_ready_queue_aic_tail_[thread_idx];
-        int cur_size = (tail - head + MAX_CORES_PER_THREAD) % MAX_CORES_PER_THREAD;
+    auto enqueue_initial_task = [&](int task_id, CoreType core_type, int &next_thread_idx, int &shared_count) {
+        int thread_idx = next_thread_idx;
+        int *head_ptr = (core_type == CoreType::AIC) ? &cur_ready_queue_aic_head_[thread_idx] :
+                                                       &cur_ready_queue_aiv_head_[thread_idx];
+        int *tail_ptr = (core_type == CoreType::AIC) ? &cur_ready_queue_aic_tail_[thread_idx] :
+                                                       &cur_ready_queue_aiv_tail_[thread_idx];
+        int cur_size = (*tail_ptr - *head_ptr + MAX_CORES_PER_THREAD) % MAX_CORES_PER_THREAD;
+        int local_capacity = (core_type == CoreType::AIC) ? aic_per_thread_ : aiv_per_thread_;
 
-        if (cur_size < aic_per_thread_) {
-            cur_ready_queue_aic_[thread_idx][tail] = task_id;
-            cur_ready_queue_aic_tail_[thread_idx] = (tail + 1) % MAX_CORES_PER_THREAD;
-            LOG_INFO("Init: AIC task %d -> Thread %d local queue (size=%d)", task_id, thread_idx, cur_size + 1);
-        } else {
+        if (cur_size < local_capacity) {
+            if (core_type == CoreType::AIC) {
+                cur_ready_queue_aic_[thread_idx][*tail_ptr] = task_id;
+            } else {
+                cur_ready_queue_aiv_[thread_idx][*tail_ptr] = task_id;
+            }
+            *tail_ptr = (*tail_ptr + 1) % MAX_CORES_PER_THREAD;
+            LOG_INFO(
+                "Init: %s task %d -> Thread %d local queue (size=%d)", core_type == CoreType::AIC ? "AIC" : "AIV",
+                task_id, thread_idx, cur_size + 1
+            );
+        } else if (core_type == CoreType::AIC) {
             ready_queue_aic_[ready_queue_aic_tail_] = task_id;
             ready_queue_aic_tail_ = (ready_queue_aic_tail_ + 1) % RUNTIME_MAX_TASKS;
-            aic_shared_count++;
-        }
-
-        thread_idx = (thread_idx + 1) % thread_num_;
-    }
-    ready_count_aic_.store(aic_shared_count, std::memory_order_release);
-
-    int aiv_shared_count = 0;
-    thread_idx = 0;
-    for (int i = 0; i < initial_aiv_count; i++) {
-        int task_id = initial_aiv[i];
-
-        int head = cur_ready_queue_aiv_head_[thread_idx];
-        int tail = cur_ready_queue_aiv_tail_[thread_idx];
-        int cur_size = (tail - head + MAX_CORES_PER_THREAD) % MAX_CORES_PER_THREAD;
-
-        if (cur_size < aiv_per_thread_) {
-            cur_ready_queue_aiv_[thread_idx][tail] = task_id;
-            cur_ready_queue_aiv_tail_[thread_idx] = (tail + 1) % MAX_CORES_PER_THREAD;
-            LOG_INFO("Init: AIV task %d -> Thread %d local queue (size=%d)", task_id, thread_idx, cur_size + 1);
+            shared_count++;
         } else {
             ready_queue_aiv_[ready_queue_aiv_tail_] = task_id;
             ready_queue_aiv_tail_ = (ready_queue_aiv_tail_ + 1) % RUNTIME_MAX_TASKS;
-            aiv_shared_count++;
+            shared_count++;
         }
 
-        thread_idx = (thread_idx + 1) % thread_num_;
+        next_thread_idx = (thread_idx + 1) % thread_num_;
+    };
+
+    int task_count = runtime->get_task_count();
+    for (int task_id = 0; task_id < task_count; task_id++) {
+        Task *task = runtime->get_task(task_id);
+        if (task == nullptr || task->fanin.load(std::memory_order_acquire) != 0) {
+            continue;
+        }
+
+        initial_count++;
+        if (task->core_type == CoreType::AIC) {
+            initial_aic_count++;
+            enqueue_initial_task(task_id, CoreType::AIC, next_aic_thread, aic_shared_count);
+        } else {
+            initial_aiv_count++;
+            enqueue_initial_task(task_id, CoreType::AIV, next_aiv_thread, aiv_shared_count);
+        }
     }
+
+    LOG_INFO("Init: Found %d initially ready tasks", initial_count);
+    LOG_INFO("Init: Initial ready tasks by type: AIC=%d, AIV=%d", initial_aic_count, initial_aiv_count);
+    ready_count_aic_.store(aic_shared_count, std::memory_order_release);
     ready_count_aiv_.store(aiv_shared_count, std::memory_order_release);
 
     LOG_INFO(

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -25,6 +25,8 @@ Runtime::Runtime() {
     // NOTE: host_api is initialized in InitRuntime() (host-only code)
     // because the CApi functions don't exist when compiled for device.
 
+    memset(workers, 0, sizeof(workers));
+
     // Initialize task array (cannot use memset with atomic members)
     for (int i = 0; i < RUNTIME_MAX_TASKS; i++) {
         tasks[i].task_id = 0;
@@ -43,6 +45,9 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     sche_cpu_num = 1;
+    orch_thread_num = 1;
+    enable_profiling = false;
+    perf_data_base = 0;
     tensor_pair_count = 0;
 
     // Initialize kernel binary tracking


### PR DESCRIPTION
## Summary
- Align sim clang CI/build settings with the split lint pipeline
- Retry cached CMake configure after clearing stale build directories
- Initialize host_build_graph runtime worker state before launch
- Remove large initial-task stack buffers that can crash sim AICPU threads

## Testing
- python examples/scripts/run_example.py -k examples/a2a3/host_build_graph/vector_example/kernels -g examples/a2a3/host_build_graph/vector_example/golden.py -p a2a3sim -c 6622890


🤖 Generated with [Claude Code](https://claude.com/claude-code)