### PR TITLE
[WIP] Fix: two ring-buffer allocator defects in pto_ring_buffer.h

### DIFF
--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.h
@@ -217,7 +217,7 @@ struct PTO2HeapRing {
                 if (space_at_end >= alloc_size) {
                     new_top = top + alloc_size;
                     result = (char *)base + top;
-                } else if (tail > alloc_size) {
+                } else if (tail >= alloc_size) {
                     // Wrap to beginning
                     new_top = alloc_size;
                     result = base;
@@ -545,7 +545,7 @@ struct PTO2DepListPool {
      */
     PTO2DepListEntry *alloc() {
         int32_t used = top - tail;
-        if (used >= capacity) {
+        if (used >= capacity - 1) {
             LOG_ERROR("========================================");
             LOG_ERROR("FATAL: Dependency Pool Overflow!");
             LOG_ERROR("========================================");
@@ -563,7 +563,7 @@ struct PTO2DepListPool {
             }
             return nullptr;
         }
-        int32_t idx = top % capacity;
+        int32_t idx = static_cast<int32_t>((static_cast<uint32_t>(top) - 1) % (capacity - 1)) + 1;
         top++;
         used++;
         if (used > high_water) high_water = used;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -272,7 +272,7 @@ private:
             if (space_at_end >= alloc_size) {
                 result = static_cast<char *>(heap_base_) + top;
                 heap_top_ = top + alloc_size;
-            } else if (tail > alloc_size) {
+            } else if (tail >= alloc_size) {
                 result = heap_base_;
                 heap_top_ = alloc_size;
             } else {
@@ -426,7 +426,7 @@ struct PTO2DepListPool {
      */
     PTO2DepListEntry *alloc() {
         int32_t used = top - tail;
-        if (used >= capacity) {
+        if (used >= capacity - 1) {
             LOG_ERROR("========================================");
             LOG_ERROR("FATAL: Dependency Pool Overflow!");
             LOG_ERROR("========================================");
@@ -444,7 +444,7 @@ struct PTO2DepListPool {
             }
             return nullptr;
         }
-        int32_t idx = top % capacity;
+        int32_t idx = static_cast<int32_t>((static_cast<uint32_t>(top) - 1) % (capacity - 1)) + 1;
         top++;
         used++;
         if (used > high_water) high_water = used;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -272,7 +272,7 @@ private:
             if (space_at_end >= alloc_size) {
                 result = static_cast<char *>(heap_base_) + top;
                 heap_top_ = top + alloc_size;
-            } else if (tail > alloc_size) {
+            } else if (tail >= alloc_size) {
                 result = heap_base_;
                 heap_top_ = alloc_size;
             } else {
@@ -426,7 +426,7 @@ struct PTO2DepListPool {
      */
     PTO2DepListEntry *alloc() {
         int32_t used = top - tail;
-        if (used >= capacity) {
+        if (used >= capacity - 1) {
             LOG_ERROR("========================================");
             LOG_ERROR("FATAL: Dependency Pool Overflow!");
             LOG_ERROR("========================================");
@@ -444,7 +444,7 @@ struct PTO2DepListPool {
             }
             return nullptr;
         }
-        int32_t idx = top % capacity;
+        int32_t idx = static_cast<int32_t>((static_cast<uint32_t>(top) - 1) % (capacity - 1)) + 1;
         top++;
         used++;
         if (used > high_water) high_water = used;


### PR DESCRIPTION
## Summary

- **Bug 1 (heap wrap-around)**: `try_bump_heap` used `tail > alloc_size` (strict greater-than), causing deadlock when `tail == alloc_size` — exactly enough space exists at `[0, alloc_size)` but the condition incorrectly rejected it. Fixed to `tail >= alloc_size`.
- **Bug 2 (DepListPool sentinel collision)**: `alloc()` computed `idx = top % capacity`, which returns 0 (the NULL sentinel slot) when `top` is a multiple of `capacity`. Fixed to `idx = ((top - 1) % (capacity - 1)) + 1` so the index always stays in `[1, capacity-1]`. Overflow check tightened from `used >= capacity` to `used >= capacity - 1` to match the reduced usable range.
- Both fixes applied to all three affected runtimes: `a2a3/tensormap_and_ringbuffer`, `a2a3/aicpu_build_graph`, `a5/tensormap_and_ringbuffer`.

## Testing

- [x] All 113 Python unit tests pass (`pytest tests -m "not requires_hardware"`)
- [ ] Simulation tests (`./ci.sh -p a2a3sim`)
- [ ] Hardware tests (`ctest -R test_ring_buffer` once test infrastructure is available)

Fixes #429