### PR TITLE
feat(platform): pass KernelArgs to AICore kernel via device memory

### DIFF
--- a/src/a2a3/platform/include/common/kernel_args.h
+++ b/src/a2a3/platform/include/common/kernel_args.h
@@ -60,15 +60,16 @@ extern "C" {
  * - runtime_args: Written by host, read by AICPU (task runtime, includes
  *   handshake buffers)
  *
- * Note: AICore kernels receive Runtime* directly, not KernelArgs
- *       - AICPU: accesses runtime_args->workers directly
- *       - AICore: receives Runtime* pointer with workers at offset 0
+ * Field Access Patterns:
+ *       - AICPU: receives KernelArgs* via DynTileFwkBackendKernelServer
+ *       - AICore: receives KernelArgs* via KERNEL_ENTRY
  */
 struct KernelArgs {
-    uint64_t unused[5] = {0};          // Alignment padding (required by CANN runtime offset)
-    DeviceArgs *device_args{nullptr};  // Device arguments (AICPU reads, contains SO info)
-    Runtime *runtime_args{nullptr};    // Task runtime in device memory
-    uint64_t regs{0};                  // Per-core register base address array (platform-specific)
+    uint64_t unused[5] = {0};                               // Alignment padding (required by CANN runtime offset)
+    DeviceArgs *device_args{nullptr};                       // Device arguments (AICPU reads, contains SO info)
+    __may_used_by_aicore__ Runtime *runtime_args{nullptr};  // Task runtime in device memory
+    uint64_t regs{0};                                       // Per-core register base address array (platform-specific)
+    uint64_t ffts_base_addr{0};                             // FFTS base address for AICore
 };
 
 #ifdef __cplusplus

--- a/src/a2a3/platform/onboard/aicore/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicore/kernel.cpp
@@ -13,8 +13,7 @@
  */
 #include "aicore/aicore.h"
 #include "common/core_type.h"
-
-class Runtime;
+#include "common/kernel_args.h"
 
 #ifdef __DAV_VEC__
 #define KERNEL_ENTRY(x) \
@@ -48,7 +47,7 @@ extern __aicore__ void aicore_execute(__gm__ Runtime *runtime, int block_idx, Co
  *
  * @param runtime Address of Runtime structure in device memory
  */
-extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime *runtime) {
+extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ KernelArgs *k_args) {
     // Calculate block_idx for this core
 #ifdef __DAV_VEC__
     block_idx = get_block_idx() * get_subblockdim() + get_subblockid() + get_block_num();
@@ -58,5 +57,6 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime
     core_type = CoreType::AIC;
 #endif
 
-    aicore_execute(runtime, block_idx, core_type);
+    set_ffts_base_addr((uint64_t)k_args->ffts_base_addr);
+    aicore_execute(k_args->runtime_args, block_idx, core_type);
 }

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -136,6 +136,48 @@ int KernelArgsHelper::finalize_runtime_args() {
     return 0;
 }
 
+int KernelArgsHelper::init_ffts_base_addr() {
+    uint64_t ffts_base_addr{0};
+    uint32_t ffts_len{0};
+    int rc = rtGetC2cCtrlAddr(&ffts_base_addr, &ffts_len);
+    if (rc != 0) {
+        LOG_ERROR("rtGetC2cCtrlAddr failed: %d", rc);
+        return rc;
+    }
+    args.ffts_base_addr = ffts_base_addr;
+    return 0;
+}
+
+int KernelArgsHelper::init_device_kernel_args(MemoryAllocator &allocator) {
+    allocator_ = &allocator;
+
+    if (device_k_args_ == nullptr) {
+        void *dev_ptr = allocator_->alloc(sizeof(KernelArgs));
+        if (dev_ptr == nullptr) {
+            LOG_ERROR("Alloc for device KernelArgs failed");
+            return -1;
+        }
+        device_k_args_ = reinterpret_cast<KernelArgs *>(dev_ptr);
+    }
+    int rc = rtMemcpy(device_k_args_, sizeof(KernelArgs), &args, sizeof(KernelArgs), RT_MEMCPY_HOST_TO_DEVICE);
+    if (rc != 0) {
+        LOG_ERROR("rtMemcpy for KernelArgs failed: %d", rc);
+        allocator_->free(device_k_args_);
+        device_k_args_ = nullptr;
+        return rc;
+    }
+    return 0;
+}
+
+int KernelArgsHelper::finalize_device_kernel_args() {
+    if (device_k_args_ != nullptr && allocator_ != nullptr) {
+        int rc = allocator_->free(device_k_args_);
+        device_k_args_ = nullptr;
+        return rc;
+    }
+    return 0;
+}
+
 // =============================================================================
 // AicpuSoInfo Implementation
 // =============================================================================
@@ -406,6 +448,7 @@ int DeviceRunner::run(
     });
 
     auto runtime_args_cleanup = RAIIScopeGuard([this]() {
+        kernel_args_.finalize_device_kernel_args();
         kernel_args_.finalize_runtime_args();
     });
 
@@ -435,6 +478,19 @@ int DeviceRunner::run(
         return rc;
     }
 
+    rc = kernel_args_.init_ffts_base_addr();
+    if (rc != 0) {
+        LOG_ERROR("init_ffts_base_addr failed: %d", rc);
+        return rc;
+    }
+
+    // Copy KernelArgs to device memory for AICore
+    rc = kernel_args_.init_device_kernel_args(mem_alloc_);
+    if (rc != 0) {
+        LOG_ERROR("init_device_kernel_args failed: %d", rc);
+        return rc;
+    }
+
     std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServerInit===" << '\n';
     // Launch AICPU init kernel
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServerInit", 1);
@@ -454,8 +510,8 @@ int DeviceRunner::run(
     }
 
     std::cout << "\n=== launch_aicore_kernel===" << '\n';
-    // Launch AICore kernel
-    rc = launch_aicore_kernel(stream_aicore_, kernel_args_.args.runtime_args);
+    // Launch AICore kernel (pass device copy of KernelArgs)
+    rc = launch_aicore_kernel(stream_aicore_, kernel_args_.device_k_args_);
     if (rc != 0) {
         LOG_ERROR("launch_aicore_kernel failed: %d", rc);
         return rc;
@@ -618,7 +674,7 @@ int DeviceRunner::launch_aicpu_kernel(rtStream_t stream, KernelArgs *k_args, con
     );
 }
 
-int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime *runtime) {
+int DeviceRunner::launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args) {
     if (aicore_kernel_binary_.empty()) {
         LOG_ERROR("AICore kernel binary is empty");
         return -1;
@@ -641,10 +697,9 @@ int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime *runtime) {
     }
 
     struct Args {
-        Runtime *runtime;
+        KernelArgs *k_args;
     };
-    // Pass device address of Runtime to AICore
-    Args args = {runtime};
+    Args args = {k_args};
     rtArgsEx_t rt_args;
     std::memset(&rt_args, 0, sizeof(rt_args));
     rt_args.args = &args;

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -70,6 +70,7 @@ struct DeviceArgs {
 struct KernelArgsHelper {
     KernelArgs args;
     MemoryAllocator *allocator_{nullptr};
+    KernelArgs *device_k_args_{nullptr};  // Device copy of KernelArgs for AICore
 
     /**
      * Initialize device arguments by allocating device memory and copying data
@@ -102,6 +103,30 @@ struct KernelArgsHelper {
      * @return 0 on success, error code on failure
      */
     int finalize_runtime_args();
+
+    /**
+     * Retrieve FFTS base address via rtGetC2cCtrlAddr and store in KernelArgs
+     *
+     * @return 0 on success, error code on failure
+     */
+    int init_ffts_base_addr();
+
+    /**
+     * Copy KernelArgs to device memory for AICore kernel parameter passing
+     *
+     * Must be called after init_runtime_args and init_ffts_base_addr.
+     *
+     * @param allocator  Memory allocator to use
+     * @return 0 on success, error code on failure
+     */
+    int init_device_kernel_args(MemoryAllocator &allocator);
+
+    /**
+     * Free device memory allocated for KernelArgs copy
+     *
+     * @return 0 on success, error code on failure
+     */
+    int finalize_device_kernel_args();
 
     /**
      * Implicit conversion operators for seamless use with runtime APIs
@@ -286,10 +311,10 @@ public:
      * workflows.
      *
      * @param stream  AICore stream
-     * @param runtime   Pointer to device runtime
+     * @param k_args  Pointer to kernel arguments (includes runtime, ffts_base_addr, etc.)
      * @return 0 on success, error code on failure
      */
-    int launch_aicore_kernel(rtStream_t stream, Runtime *runtime);
+    int launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args);
 
     /**
      * Upload a kernel binary to device memory


### PR DESCRIPTION
Unify AICore kernel entry to receive KernelArgs* (like AICPU's
DynTileFwkBackendKernelServer), enabling ffts_base_addr passthrough.

- Add ffts_base_addr field to KernelArgs struct
- Add KernelArgsHelper::init_ffts_base_addr() to retrieve via rtGetC2cCtrlAddr
- Add KernelArgsHelper::init_device_kernel_args() to copy KernelArgs to device
- Change AICore KERNEL_ENTRY parameter from Runtime* to KernelArgs*
- Change launch_aicore_kernel to pass device KernelArgs pointer
Platform a2a3 only