### PR TITLE
Perf(paged_attention_unroll): four kernel optimizations for QK matmul, softmax Pass 1, scale multiply, and online update barriers

### DIFF
--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -20,6 +20,7 @@
 //
 // Optimizations:
 //   - qi TLOAD hoisted before the loop (constant across all iterations)
+//   - Double-buffered L1 B tiles: prefetch next kj during current TMATMUL+TSTORE
 //
 // Supports two tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
@@ -60,10 +61,14 @@ static __aicore__ void qk_matmul_n_impl(
     using RightTile = TileRight<bfloat16_t, K, N, K, N>;
     using AccTile = TileAcc<float, M, N, M, N>;
 
+    // Double-buffered L1 B tiles for kj prefetching
+    constexpr int kBBytes = K * N * static_cast<int>(sizeof(bfloat16_t));
     TileMatA aMatTile;
-    TileMatB bMatTile;
+    TileMatB bMatTile_A;
+    TileMatB bMatTile_B;
     TASSIGN(aMatTile, 0x0);
-    TASSIGN(bMatTile, 0x20000);
+    TASSIGN(bMatTile_A, 0x20000);
+    TASSIGN(bMatTile_B, 0x20000 + kBBytes);
 
     LeftTile aTile;
     RightTile bTile;
@@ -76,19 +81,34 @@ static __aicore__ void qk_matmul_n_impl(
     GlobalA qiGlobal(qi_base);
     TLOAD(aMatTile, qiGlobal);
 
+    // Pre-load first kj into buffer A
+    GlobalB kjGlobal_0(key_base + bt[bt_offset + 0] * N * K);
+    TLOAD(bMatTile_A, kjGlobal_0);
+
     for (uint64_t i = 0; i < n_blocks; i++) {
-        GlobalB kjGlobal(key_base + bt[bt_offset + i] * N * K);
         GlobalOut sijGlobal(sij_base + i * M * N);
 
-        // Load only B each iteration (qi already in L1 from hoist)
-        TLOAD(bMatTile, kjGlobal);
-
+        // Wait for current kj TLOAD to complete
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
 
-        // TMOV qi from L1→L0A (re-copy since TMATMUL consumed L0A) and kj from L1→L0B
+        // TMOV qi L1→L0A and kj L1→L0B from current buffer
         TMOV(aTile, aMatTile);
-        TMOV(bTile, bMatTile);
+        if (i % 2 == 0) {
+            TMOV(bTile, bMatTile_A);
+        } else {
+            TMOV(bTile, bMatTile_B);
+        }
+
+        // Prefetch next kj into alternate L1 buffer (overlaps with MTE1→M→FIX)
+        if (i + 1 < n_blocks) {
+            GlobalB kjGlobal_next(key_base + bt[bt_offset + i + 1] * N * K);
+            if (i % 2 == 0) {
+                TLOAD(bMatTile_B, kjGlobal_next);
+            } else {
+                TLOAD(bMatTile_A, kjGlobal_next);
+            }
+        }
 
         set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
         wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
@@ -101,6 +121,10 @@ static __aicore__ void qk_matmul_n_impl(
         TSTORE(sijGlobal, cTile);
 
         if (i + 1 < n_blocks) {
+            // Drain all pipes before next iteration:
+            //   - FIX/MTE3: ensures TSTORE data path (L0C→UB→GM) fully completes
+            //   - MTE2: prefetch TLOAD likely already done (ran during TMATMUL+TSTORE)
+            // The prefetch TLOAD overlaps with compute, so barrier cost is minimal.
             pipe_barrier(PIPE_ALL);
         }
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -180,16 +180,16 @@ static __aicore__ void online_update_impl(
 
         TMAX(miNewRow, miRow, mijRow);  // mi_new = max(mi, mij)
         pipe_barrier(PIPE_V);
+        // alphaRow and betaRow write to independent UB addresses; both only read miNewRow
         TSUB(alphaRow, miRow, miNewRow);  // alpha_exp = mi - mi_new
-        pipe_barrier(PIPE_V);
-        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
-        pipe_barrier(PIPE_V);
         TSUB(betaRow, mijRow, miNewRow);  // beta_exp = mij - mi_new
         pipe_barrier(PIPE_V);
-        TEXP(betaRow, betaRow);  // beta = exp(mij - mi_new)
+        // TEXP on independent UB addresses
+        TEXP(alphaRow, alphaRow);  // alpha = exp(mi - mi_new)
+        TEXP(betaRow, betaRow);    // beta = exp(mij - mi_new)
         pipe_barrier(PIPE_V);
-        TMUL(tmpRow, alphaRow, liRow);  // alpha * li
-        pipe_barrier(PIPE_V);
+        // tmpRow and liNewRow write to independent UB addresses
+        TMUL(tmpRow, alphaRow, liRow);    // alpha * li
         TMUL(liNewRow, betaRow, lijRow);  // beta * lij
         pipe_barrier(PIPE_V);
         TADD(liNewRow, tmpRow, liNewRow);  // li_new = alpha*li + beta*lij
@@ -200,8 +200,7 @@ static __aicore__ void online_update_impl(
         TRESHAPE(betaDN, betaRow);
 
         // Scale data tiles using row-broadcast multiply
-        TROWEXPANDMUL(oiTile, oiTile, alphaDN);  // oi *= alpha
-        pipe_barrier(PIPE_V);
+        TROWEXPANDMUL(oiTile, oiTile, alphaDN);       // oi *= alpha
         TROWEXPANDMUL(oiNewTile, oiNewTile, betaDN);  // oi_new *= beta
         pipe_barrier(PIPE_V);
         TADD(oiTile, oiTile, oiNewTile);  // oi = alpha*oi + beta*oi_new

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -15,10 +15,10 @@
 //         mij (M,) fp32 — global row max across all blocks
 //         lij (M,) fp32 — total row sum across all blocks
 //
-// Pass 1: Iterate over n_blocks tiles, apply scale, mask last block,
-//         find global m = max over all blocks of rowmax(S_i * scale)
-//         Uses TRESHAPE for DN↔Row conversion to keep globalMax in UB
-//         (eliminates 63 × 4 GM round-trip operations).
+// Pass 1: Iterate over n_blocks tiles, mask last block,
+//         find global m = scale * max over all blocks of rowmax(S_i)
+//         Defers scale to after the loop (single M-element TMULS vs n_blocks M×N).
+//         Uses double-buffered sij tiles and TRESHAPE for DN↔Row conversion.
 // Pass 2: Iterate again, compute P_i = exp(S_i * scale - m) -> bf16,
 //         accumulate l = sum over all blocks of rowsum(P_i)
 //         Uses double-buffered sij tiles to overlap TLOAD with computation.
@@ -116,24 +116,44 @@ static __aicore__ void softmax_prepare_n_impl(
     GlobalScalarND mijGlobalND(mij_addr);
     GlobalScalarDN lijGlobalDN(lij_addr);
 
-    // ======== Pass 1: Find global row max via TRESHAPE (no GM round-trip) ========
+    // ======== Pass 1: Find global row max (unscaled) with double-buffered sij ========
+    // rowmax(S*scale) = scale * rowmax(S) since scale > 0, so defer scale to after loop.
+    GlobalDataMxN sijGlobal_p1_0(sij_base);
+    TLOAD(sijTile_A, sijGlobal_p1_0);
+
     for (uint64_t i = 0; i < n_blocks; i++) {
-        GlobalDataMxN sijGlobal(sij_base + i * M * N);
-        TLOAD(sijTile_A, sijGlobal);
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
         if (i == n_blocks - 1 && valid_len_last < static_cast<uint64_t>(N)) {
             TileSijDyn sijDynTile(static_cast<size_t>(valid_len_last));
-            TASSIGN(sijDynTile, 0x0);
-            TFILLPAD_INPLACE(sijPadTile_A, sijDynTile);
+            if (i % 2 == 0) {
+                TASSIGN(sijDynTile, 0x0);
+                TFILLPAD_INPLACE(sijPadTile_A, sijDynTile);
+            } else {
+                TASSIGN(sijDynTile, static_cast<int>(kDataBytes));
+                TFILLPAD_INPLACE(sijPadTile_B, sijDynTile);
+            }
             pipe_barrier(PIPE_V);
         }
 
-        TMULS(sijTile_A, sijTile_A, scale_value);
+        // Compute unscaled TROWMAX on current buffer
+        if (i % 2 == 0) {
+            TROWMAX(localMaxDN, sijTile_A, tmpTile);
+        } else {
+            TROWMAX(localMaxDN, sijTile_B, tmpTile);
+        }
         pipe_barrier(PIPE_V);
-        TROWMAX(localMaxDN, sijTile_A, tmpTile);
-        pipe_barrier(PIPE_V);
+
+        // Prefetch next sij into alternate buffer (overlaps with V pipe scalar ops)
+        if (i + 1 < n_blocks) {
+            GlobalDataMxN sijGlobal_next(sij_base + (i + 1) * M * N);
+            if (i % 2 == 0) {
+                TLOAD(sijTile_B, sijGlobal_next);
+            } else {
+                TLOAD(sijTile_A, sijGlobal_next);
+            }
+        }
 
         // TRESHAPE: ColMajor(M,1) → RowMajor(1,M) for element-wise TMAX
         TRESHAPE(localMaxRow, localMaxDN);
@@ -144,6 +164,10 @@ static __aicore__ void softmax_prepare_n_impl(
         }
         pipe_barrier(PIPE_V);
     }
+
+    // Apply scale once to the global max vector (M elements, not n_blocks × M × N)
+    TMULS(globalMaxRow, globalMaxRow, scale_value);
+    pipe_barrier(PIPE_V);
 
     // TRESHAPE back: RowMajor(1,M) → ColMajor(M,1) for Pass 2's TROWEXPANDSUB
     TRESHAPE(globalMaxDN, globalMaxRow);


### PR DESCRIPTION
### Summary

This PR applies four targeted kernel-level optimizations to the `paged_attention_unroll` example, reducing pipeline stalls and redundant compute in the critical path.

---

### Optimization 1 — QK Matmul: Double-Buffered L1 B Tiles

**File:** `tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp`

**Problem:** Each iteration stalled on `TLOAD(kj)` before proceeding to `TMOV+TMATMUL`, serializing HBM fetch with compute.

**Fix:** Allocate two L1 B tile buffers (`bMatTile_A`, `bMatTile_B`) at staggered L1 offsets. The first `kj` is pre-loaded before the loop. Inside the loop, `TLOAD` for `kj[i+1]` is issued immediately after `TMOV` into L0B, so the prefetch runs concurrently with `TMATMUL+TSTORE`. The `pipe_barrier(PIPE_ALL)` at the end of each iteration drains FIX/MTE3 for the store; by that point the prefetch TLOAD is already complete (it ran during compute), so barrier cost is minimal.

---

### Optimization 2 — Softmax Pass 1: Double-Buffered `sij` + Deferred Scale

**File:** `tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp`

**Problem (latency):** Each Pass 1 iteration issued `TLOAD(sij[i])`, waited for MTE2→V, then computed — fully serialized.

**Fix:** Pre-load `sij[0]` before the loop. Inside the loop, after consuming the current buffer via `TROWMAX`, issue `TLOAD(sij[i+1])` into the alternate buffer. The TLOAD overlaps with V-pipe scalar ops (`TRESHAPE`, `TMAX`).

**Problem (throughput):** `TMULS(scale)` was applied element-wise to every `M×N` tile on each of the `n_blocks` iterations.

**Fix:** `rowmax(S·scale) = scale · rowmax(S)` for `scale > 0`, so the scale is deferred to a single `TMULS(globalMaxRow, scale)` on the `M`-element vector after the loop — `n_blocks` times fewer multiply operations.

---

### Optimization 3 — Online Update: Eliminate Redundant Barriers

**File:** `tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp`

**Problem:** Sequential `TSUB → pipe_barrier → TEXP → pipe_barrier` for `alpha` was immediately followed by another `TSUB → pipe_barrier → TEXP → pipe_barrier` for `beta`, even though both only read `miNewRow` (which is ready after the first `pipe_barrier(PIPE_V)`) and write to independent UB addresses.

**Fix:** Batch both `TSUB` ops together (one barrier for both reads of `miNewRow`), then batch both `TEXP` ops together (one barrier before). Removes two `pipe_barrier(PIPE_V)` calls. Similarly, the two `TROWEXPANDMUL` ops write to independent tiles (`oiTile` vs `oiNewTile`), so the barrier between them is unnecessary — merged into a single drain after both.