### PR TITLE
Support: pass FFTS base address through AICore launch

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -471,16 +471,20 @@ int DeviceRunner::run(
     });
 
     std::cout << "\n=== Initialize runtime args ===" << '\n';
-    // Initialize runtime args
-    rc = kernel_args_.init_runtime_args(runtime, mem_alloc_);
-    if (rc != 0) {
-        LOG_ERROR("init_runtime_args failed: %d", rc);
-        return rc;
-    }
 
+    // Get FFTS base address and store in Runtime (for AICPU → AICore dispatch payload)
     rc = kernel_args_.init_ffts_base_addr();
     if (rc != 0) {
         LOG_ERROR("init_ffts_base_addr failed: %d", rc);
+        return rc;
+    }
+    runtime.ffts_base_addr = kernel_args_.args.ffts_base_addr;
+    LOG_INFO("ffts_base_addr = 0x%lx", runtime.ffts_base_addr);
+
+    // Copy Runtime to device (includes ffts_base_addr)
+    rc = kernel_args_.init_runtime_args(runtime, mem_alloc_);
+    if (rc != 0) {
+        LOG_ERROR("init_runtime_args failed: %d", rc);
         return rc;
     }
 

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
@@ -39,6 +39,8 @@ Runtime::Runtime() {
     pto2_heap_size = 0;
     pto2_dep_pool_size = 0;
     orch_to_sched = false;
+    perf_data_base = 0;
+    ffts_base_addr = 0;
 
     // Initialize tensor pairs
     tensor_pair_count = 0;

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
@@ -176,6 +176,7 @@ public:  // NOLINT(whitespace/indent)
     // Controlled via PTO2_ORCH_TO_SCHED environment variable.
     bool orch_to_sched;
     uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
+    uint64_t ffts_base_addr;  // FFTS base address for AICore set_ffts_base_addr() (cross-core pipe)
 
 private:  // NOLINT(whitespace/indent)
     // Tensor pairs for host-device memory tracking

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -48,6 +48,7 @@ Runtime::Runtime() {
     orch_thread_num = 1;
     enable_profiling = false;
     perf_data_base = 0;
+    ffts_base_addr = 0;
     tensor_pair_count = 0;
 
     // Initialize kernel binary tracking

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -205,6 +205,7 @@ public:
     // Profiling support
     bool enable_profiling;    // Enable profiling flag
     uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
+    uint64_t ffts_base_addr;  // FFTS base address for AICore set_ffts_base_addr() (cross-core pipe)
 
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -88,6 +88,16 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
     __gm__ PTO2DispatchPayload *payload = reinterpret_cast<__gm__ PTO2DispatchPayload *>(my_hank->task);
 
+#ifndef __CPU_SIM
+    // FFTS base address is initialized once by AICPU and remains constant for
+    // the lifetime of this AICore kernel. Cache it once outside the hot loop.
+    dcci(&payload->ffts_base_addr, SINGLE_CACHE_LINE);
+    uint64_t ffts_base_addr = payload->ffts_base_addr;
+    if (ffts_base_addr != 0) {
+        set_ffts_base_addr(ffts_base_addr);
+    }
+#endif
+
     bool profiling_enabled = runtime->enable_profiling;
 
     // Phase 4: Main execution loop - poll register for tasks until exit signal

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1188,6 +1188,12 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     // Clear per-core dispatch payloads
     memset(s_pto2_payload_per_core, 0, sizeof(s_pto2_payload_per_core));
 
+    // Propagate ffts_base_addr from Runtime to all dispatch payloads
+    // so AICore can call set_ffts_base_addr before each per-task kernel.
+    for (int32_t i = 0; i < RUNTIME_MAX_WORKER; i++) {
+        s_pto2_payload_per_core[i].ffts_base_addr = runtime->ffts_base_addr;
+    }
+
     // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
     // This is done once at startup and never modified afterwards.
     for (int32_t t = 0; t < sched_thread_num_; t++) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -70,6 +70,7 @@ static_assert(
 struct alignas(64) PTO2DispatchPayload {
     uint64_t function_bin_addr;            /**< Kernel entry address in GM (set by Scheduler) */
     uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers + scalars + ext params) */
+    uint64_t ffts_base_addr;               /**< FFTS base address for cross-core pipe (set once at init) */
 
     /** Per-dispatch context: block_idx and block_num.
      *  Written by build_payload() before each dispatch.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -39,6 +39,8 @@ Runtime::Runtime() {
     pto2_heap_size = 0;
     pto2_dep_pool_size = 0;
     orch_to_sched = false;
+    perf_data_base = 0;
+    ffts_base_addr = 0;
 
     // Initialize tensor pairs
     tensor_pair_count = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -179,6 +179,7 @@ public:  // NOLINT(whitespace/indent)
     // Controlled via PTO2_ORCH_TO_SCHED environment variable.
     bool orch_to_sched;
     uint64_t perf_data_base;  // Performance data shared memory base address (device-side)
+    uint64_t ffts_base_addr;  // FFTS base address for AICore set_ffts_base_addr() (cross-core pipe)
 
 private:  // NOLINT(whitespace/indent)
     // Tensor pairs for host-device memory tracking


### PR DESCRIPTION
Support: pass FFTS base address through AICore launch

- Add FFTS base address fields to KernelArgs, Runtime, and PTO2 payloads
- Initialize the address on host and propagate it into AICore dispatch
- Set the FFTS base before AICore task execution for cross-core pipe
- Keep shared host device runner compatible with all runtime variants