### PR TITLE
Refactor: remove multi-orchestrator support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,4 +290,4 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           source ${ASCEND_HOME_PATH}/bin/setenv.bash
           DEVICE_LIST=$(python -c "s,e='${DEVICE_RANGE}'.split('-'); print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          task-submit --device "$DEVICE_LIST" --run "python ci.py -p a5 -d ${DEVICE_RANGE} -c 882c4db -t 1200 --clone-protocol https"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python ci.py -p a5 -d ${DEVICE_RANGE} -c 882c4db -t 1200 --clone-protocol https"

--- a/ci.py
+++ b/ci.py
@@ -459,7 +459,6 @@ def run_single_task(
         config = CallConfig()
         config.block_dim = runtime_config.get("block_dim", 24)
         config.aicpu_thread_num = runtime_config.get("aicpu_thread_num", 3)
-        config.orch_thread_num = runtime_config.get("orch_thread_num", 1)
 
         with _temporary_env(run_env):
             worker.run(task.chip_callable, orch_args, config)

--- a/examples/a2a3/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -62,12 +62,8 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index
-) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
-
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args) {
     Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_B = from_tensor_arg(orch_args.tensor(1));
     Tensor ext_C = from_tensor_arg(orch_args.tensor(2));

--- a/examples/a2a3/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
+++ b/examples/a2a3/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
@@ -37,12 +37,8 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index
-) {
-    (void)orch_thread_num;
-    (void)orch_thread_index;
-
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args) {
     // golden shape = kernel shape, use from_tensor_arg() directly
     Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_b = from_tensor_arg(orch_args.tensor(1));

--- a/examples/a2a3/host_build_graph/matmul/kernels/kernel_config.py
+++ b/examples/a2a3/host_build_graph/matmul/kernels/kernel_config.py
@@ -56,6 +56,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "host_build_graph",
     "aicpu_thread_num": 3,
-    "orch_thread_num": 0,
     "block_dim": 3,
 }

--- a/examples/a2a3/host_build_graph/paged_attention/kernels/kernel_config.py
+++ b/examples/a2a3/host_build_graph/paged_attention/kernels/kernel_config.py
@@ -72,6 +72,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "host_build_graph",
     "aicpu_thread_num": 3,
-    "orch_thread_num": 0,
     "block_dim": 3,
 }

--- a/examples/a2a3/host_build_graph/vector_example/kernels/kernel_config.py
+++ b/examples/a2a3/host_build_graph/vector_example/kernels/kernel_config.py
@@ -52,6 +52,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "host_build_graph",
     "aicpu_thread_num": 3,
-    "orch_thread_num": 0,
     "block_dim": 3,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/kernel_config.py
@@ -88,6 +88,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -45,8 +45,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // Read dimensions from tensor metadata
     uint64_t batch = orch_args.tensor(0).shapes[0];
     uint64_t num_heads = orch_args.tensor(0).shapes[1];
@@ -105,7 +104,7 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
         uint64_t q_offset = q_idx * q_tile;
 
-        for (uint64_t chunk_idx = orch_thread_index; chunk_idx < num_chunks; chunk_idx += orch_thread_num) {
+        for (uint64_t chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
             uint64_t chunk_bc = batch - chunk_idx * IN_CORE_BATCH;
             if (chunk_bc > IN_CORE_BATCH) chunk_bc = IN_CORE_BATCH;
             uint64_t batch_start = chunk_idx * IN_CORE_BATCH;

--- a/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -60,11 +60,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // 1D external tensors for the full A, B, C arrays
     Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_B = from_tensor_arg(orch_args.tensor(1));

--- a/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
@@ -1,37 +1,43 @@
 # InCore Orchestration Guide: tensormap_and_ringbuffer
 
 ## Goal
+
 In tensormap_and_ringbuffer, the orchestration function runs on AICPU and builds the graph directly on device. Dependencies are discovered automatically by TensorMap based on tensor overlap, and task memory is allocated from ring buffers.
 
 ## Where To Put Orchestration Code
+
 - Each example keeps orchestration sources under `examples/tensormap_and_ringbuffer/<example>/kernels/orchestration/`.
 - `examples/tensormap_and_ringbuffer/<example>/kernels/kernel_config.py` selects the orchestration source and the runtime `tensormap_and_ringbuffer`.
 
 ## Required Exports
+
 Your orchestration shared object must export:
 
 ```cpp
-extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count);
-extern "C" void aicpu_orchestration_entry(uint64_t* args, int arg_count, int orch_thread_num, int orch_thread_index);
+extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args);
+extern "C" void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args);
 ```
 
 Both symbols are loaded by AICPU via `dlopen` in `src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp`.
 
 ## Argument Layout
+
 Arguments are constructed by `examples/scripts/code_runner.py` and passed through host init into `Runtime::orch_args` as device pointers or scalars. For the default `TENSOR_ORDER` flow, the layout is:
 
-```
+```text
 [ptr_0, ptr_1, ..., ptr_n, nbytes_0, nbytes_1, ..., nbytes_n, element_count]
 ```
 
 Validate `arg_count` in `aicpu_orchestration_config` and interpret pointers as device addresses.
 
 ## Building The Graph
+
 1. Wrap orchestration in scopes with `PTO2_SCOPE()` to control tensor lifetimes.
 2. Use `make_tensor_external` for existing device buffers and `TensorCreateInfo` + `add_output(...)` for runtime-created intermediates.
 3. Use `add_inout(...)` for existing tensors that a kernel writes.
 4. Build `Arg` with `add_input`, `add_output`, `add_inout` for tensors and `add_scalar` for scalars.
    > **Constraint**: All tensor parameters (`add_input` / `add_output` / `add_inout`) **must** be added before any scalar parameters (`add_scalar` / `add_scalars`). Violating this order will trigger an assertion failure. This is because the runtime dispatches tensor arguments first in kernel args, followed by scalars, and the layout must match.
+
    ```cpp
    // Correct
    Arg p;
@@ -44,6 +50,7 @@ Validate `arg_count` in `aicpu_orchestration_config` and interpret pointers as d
    p.add_scalar(val);    // scalar added too early
    p.add_input(a);       // assertion: "scalar must add after all tensor added"
    ```
+
 5. Submit tasks with one of:
    - `pto2_rt_submit_aic_task(kernel_id, args)` — AIC (CUBE) task
    - `pto2_rt_submit_aiv_task(kernel_id, args)` — AIV (VECTOR) task
@@ -52,20 +59,25 @@ Validate `arg_count` in `aicpu_orchestration_config` and interpret pointers as d
 Dependencies are inferred by TensorMap from input/inout/output tensors, so you do not add explicit edges.
 
 ## Submit API And Kernel IDs
+
 - Submit helpers are defined in `pto_orchestration_api.h`.
 - `pto2_rt_submit_aic_task` and `pto2_rt_submit_aiv_task` are convenience wrappers around `pto2_rt_submit_task` with a `MixedKernels` struct.
 - For mixed AIC+AIV tasks, construct a `MixedKernels` struct directly:
+
   ```cpp
   MixedKernels mk;
   mk.aic_kernel_id = FUNC_QK;
   mk.aiv0_kernel_id = FUNC_SF;
   pto2_rt_submit_task(mk, args);
   ```
+
 - Kernel `func_id` values are defined in `kernels/kernel_config.py` under `KERNELS`.
 
 ## Completion Semantics
+
 Do not call `pto2_rt_orchestration_done` yourself in device mode. The executor wraps the entry call in an outer scope and signals completion after `aicpu_orchestration_entry` returns.
 
 ## Examples
+
 - `examples/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp` (AIV-only tasks)
 - `examples/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp` (mixed AIC + AIV tasks)

--- a/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -48,11 +48,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // Input tensors use from_tensor_arg() — golden shape = kernel shape
     Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_B = from_tensor_arg(orch_args.tensor(1));

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
@@ -88,6 +88,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -47,8 +47,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // Read dimensions from tensor metadata
     // query: shape=[batch, num_heads, head_dim]
     uint64_t batch = orch_args.tensor(0).shapes[0];
@@ -69,15 +68,6 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     uint64_t q_tile = 16;
     uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;
     uint64_t elem_size = get_element_size(data_type);
-
-    // Partition batch across orchestrators
-    uint64_t b_start = batch * orch_thread_index / orch_thread_num;
-    uint64_t b_end = batch * (orch_thread_index + 1) / orch_thread_num;
-
-    LOG_INFO(
-        "orch_idx=%d/%d batch=%" PRIu64 " b_range=[%" PRIu64 ",%" PRIu64 ")", orch_thread_index, orch_thread_num, batch,
-        b_start, b_end
-    );
 
     // Reshape tensors for kernel consumption (2D flattened)
     void *query_ptr = orch_args.tensor(0).data_as<void>();
@@ -118,7 +108,7 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     TensorCreateInfo sij_ci(sij_shapes, 2, DataType::FLOAT32);
     TensorCreateInfo pij_f16_ci(sij_shapes, 2, data_type);
 
-    for (uint64_t b_idx = b_start; b_idx < b_end; b_idx++) {
+    for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
         uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};
         uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
@@ -197,10 +187,7 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
         }
     }
 
-    LOG_INFO(
-        "orch_idx=%d: tasks submitted for batch=[%" PRIu64 ",%" PRIu64 "), num_heads=%" PRIu64, orch_thread_index,
-        b_start, b_end, num_heads
-    );
+    LOG_INFO("tasks submitted for batch=%" PRIu64 ", num_heads=%" PRIu64, batch, num_heads);
 }
 
 }  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/kernel_config.py
@@ -46,6 +46,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -38,11 +38,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     MixedKernels mk;

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/kernel_config.py
@@ -34,6 +34,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -48,11 +48,7 @@ static void submit_spmd_aiv(int32_t kernel_id, Tensor &out, int16_t block_num, i
     pto2_rt_submit_aiv_task(kernel_id, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     // T0: 4 blocks — basic multi-block

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/kernel_config.py
@@ -46,6 +46,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -56,11 +56,7 @@ submit_spmd_mix(int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, Tensor &out, i
     pto2_rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     // T0: 2 blocks (6 CL) — basic multi-block MIX

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_starvation/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_starvation/kernels/kernel_config.py
@@ -48,6 +48,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
@@ -65,11 +65,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     pto2_rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     int64_t cl = 0;

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start/kernels/kernel_config.py
@@ -47,6 +47,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
@@ -60,11 +60,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     pto2_rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     // T0: 2 blocks, sync_start=true  (6 CL)

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/kernel_config.py
@@ -36,6 +36,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
@@ -54,11 +54,7 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     pto2_rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     // T0: 4 blocks, sync_start=true (fast path: 4 <= idle AIV cores on one thread)

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/kernel_config.py
@@ -48,6 +48,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
@@ -58,11 +58,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     pto2_rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     // T0: block_num=1, sync_start=true (degenerate: always fast path, 3 CL)

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/kernel_config.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/kernel_config.py
@@ -57,6 +57,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
@@ -76,11 +76,7 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     pto2_rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     int64_t cl = 0;

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -52,11 +52,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
  * The executor wraps this call in PTO2_SCOPE, so we are already inside
  * the outer scope on entry.
  */
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // golden shape = kernel shape, use from_tensor_arg() directly
     Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_b = from_tensor_arg(orch_args.tensor(1));

--- a/examples/a5/host_build_graph/paged_attention/kernels/kernel_config.py
+++ b/examples/a5/host_build_graph/paged_attention/kernels/kernel_config.py
@@ -72,6 +72,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "host_build_graph",
     "aicpu_thread_num": 3,
-    "orch_thread_num": 0,
     "block_dim": 3,
 }

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -61,11 +61,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // 1D external tensors for the full A, B, C arrays
     Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_B = from_tensor_arg(orch_args.tensor(1));

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -48,11 +48,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // Input tensors use from_tensor_arg() — golden shape = kernel shape
     Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_B = from_tensor_arg(orch_args.tensor(1));

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/kernel_config.py
@@ -88,6 +88,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -47,8 +47,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // Read dimensions from tensor metadata
     // query: shape=[batch, num_heads, head_dim]
     uint64_t batch = orch_args.tensor(0).shapes[0];
@@ -69,15 +68,6 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     uint64_t q_tile = 16;
     uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;
     uint64_t elem_size = get_element_size(data_type);
-
-    // Partition batch across orchestrators
-    uint64_t b_start = batch * orch_thread_index / orch_thread_num;
-    uint64_t b_end = batch * (orch_thread_index + 1) / orch_thread_num;
-
-    LOG_INFO(
-        "orch_idx=%d/%d batch=%" PRIu64 " b_range=[%" PRIu64 ",%" PRIu64 ")", orch_thread_index, orch_thread_num, batch,
-        b_start, b_end
-    );
 
     // Reshape tensors for kernel consumption (2D flattened)
     void *query_ptr = orch_args.tensor(0).data_as<void>();
@@ -118,7 +108,7 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     TensorCreateInfo sij_ci(sij_shapes, 2, DataType::FLOAT32);
     TensorCreateInfo pij_f16_ci(sij_shapes, 2, data_type);
 
-    for (uint64_t b_idx = b_start; b_idx < b_end; b_idx++) {
+    for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
         uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};
         uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
@@ -197,10 +187,7 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
         }
     }
 
-    LOG_INFO(
-        "orch_idx=%d: tasks submitted for batch=[%" PRIu64 ",%" PRIu64 "), num_heads=%" PRIu64, orch_thread_index,
-        b_start, b_end, num_heads
-    );
+    LOG_INFO("tasks submitted for batch=%" PRIu64 ", num_heads=%" PRIu64, batch, num_heads);
 }
 
 }  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/kernel_config.py
@@ -46,6 +46,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -38,11 +38,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     MixedKernels mk;

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/kernel_config.py
@@ -34,6 +34,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -48,11 +48,7 @@ static void submit_spmd_aiv(int32_t kernel_id, Tensor &out, int16_t block_num, i
     pto2_rt_submit_aiv_task(kernel_id, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     // T0: 4 blocks — basic multi-block

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/kernel_config.py
@@ -46,6 +46,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -56,11 +56,7 @@ submit_spmd_mix(int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, Tensor &out, i
     pto2_rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     // T0: 2 blocks (6 CL) — basic multi-block MIX

--- a/examples/a5/tensormap_and_ringbuffer/spmd_starvation/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_starvation/kernels/kernel_config.py
@@ -48,6 +48,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a5/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
@@ -65,11 +65,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     pto2_rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     int64_t cl = 0;

--- a/examples/a5/tensormap_and_ringbuffer/spmd_sync_start/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_sync_start/kernels/kernel_config.py
@@ -47,6 +47,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a5/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
@@ -60,11 +60,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     pto2_rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     // T0: 2 blocks, sync_start=true  (6 CL)

--- a/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/kernel_config.py
@@ -36,6 +36,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
@@ -54,11 +54,7 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     pto2_rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     // T0: 4 blocks, sync_start=true (fast path: 4 <= idle AIV cores on one thread)

--- a/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/kernel_config.py
@@ -47,6 +47,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
@@ -58,11 +58,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     pto2_rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;  // NOLINT(readability/casting)
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     // T0: block_num=1, sync_start=true (degenerate: always fast path, 3 CL)

--- a/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/kernel_config.py
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/kernel_config.py
@@ -57,6 +57,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
@@ -76,11 +76,7 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     pto2_rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;
-    if (orch_thread_index != 0) return;
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
 
     int64_t cl = 0;

--- a/examples/scripts/code_runner.py
+++ b/examples/scripts/code_runner.py
@@ -532,7 +532,6 @@ class CodeRunner:
         # Runtime configuration - read from kernel_config or use defaults
         runtime_config = getattr(self._kernel_config, "RUNTIME_CONFIG", {})
         self.aicpu_thread_num = runtime_config.get("aicpu_thread_num", 3)
-        self.orch_thread_num = runtime_config.get("orch_thread_num", 1)
         self.block_dim = runtime_config.get("block_dim", 24)
         self.runtime_name = runtime_config.get("runtime", "host_build_graph")
         self.repeat_rounds = repeat_rounds if repeat_rounds is not None else runtime_config.get("rounds", 1)
@@ -887,7 +886,6 @@ class CodeRunner:
                 config = CallConfig()
                 config.block_dim = self.block_dim
                 config.aicpu_thread_num = self.aicpu_thread_num
-                config.orch_thread_num = self.orch_thread_num
                 if self.enable_profiling and round_idx == 0:
                     config.enable_profiling = True
                     logger.info("Profiling enabled")

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -570,12 +570,10 @@ NB_MODULE(_task_interface, m) {
         .def(nb::init<>())
         .def_rw("block_dim", &CallConfig::block_dim)
         .def_rw("aicpu_thread_num", &CallConfig::aicpu_thread_num)
-        .def_rw("orch_thread_num", &CallConfig::orch_thread_num)
         .def_rw("enable_profiling", &CallConfig::enable_profiling)
         .def("__repr__", [](const CallConfig &self) -> std::string {
             std::ostringstream os;
             os << "CallConfig(block_dim=" << self.block_dim << ", aicpu_thread_num=" << self.aicpu_thread_num
-               << ", orch_thread_num=" << self.orch_thread_num
                << ", enable_profiling=" << (self.enable_profiling ? "True" : "False") << ")";
             return os.str();
         });

--- a/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
@@ -102,9 +102,8 @@ void perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks);
  *
  * @param runtime Runtime instance pointer
  * @param num_sched_threads Number of scheduler threads
- * @param num_orch_threads Number of orchestrator threads (may become schedulers after transition)
  */
-void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, int num_orch_threads = 1);
+void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads);
 
 /**
  * Record a single scheduler phase

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -351,15 +351,7 @@ int DeviceRunner::run(
         return -1;
     }
 
-    // Validate orchestrator configuration
-    int scheduler_thread_num = launch_aicpu_num - runtime.orch_thread_num;
-
-    if (runtime.orch_thread_num > launch_aicpu_num) {
-        LOG_ERROR(
-            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num
-        );
-        return -1;
-    }
+    int scheduler_thread_num = runtime.get_orch_built_on_host() ? launch_aicpu_num : launch_aicpu_num - 1;
 
     // Validate even core distribution for initial scheduler threads
     if (scheduler_thread_num > 0) {

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -100,9 +100,9 @@ int set_device(int device_id) {
 }
 
 int run_runtime(
-    RuntimeHandle runtime, const void *callable, const void *args, int block_dim, int aicpu_thread_num,
-    int orch_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_profiling
+    RuntimeHandle runtime, const void *callable, const void *args, int block_dim, int aicpu_thread_num, int device_id,
+    const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size,
+    int enable_profiling
 ) {
     if (runtime == NULL) return -1;
     if (aicpu_binary == NULL || aicpu_size == 0 || aicore_binary == NULL || aicore_size == 0) return -1;
@@ -135,7 +135,6 @@ int run_runtime(
         }
 
         // Phase 3: launch
-        r->orch_thread_num = orch_thread_num;
         DeviceRunner &runner = DeviceRunner::get();
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -229,15 +229,7 @@ int DeviceRunner::run(
         return -1;
     }
 
-    // Validate orchestrator configuration
-    int scheduler_thread_num = launch_aicpu_num - runtime.orch_thread_num;
-
-    if (runtime.orch_thread_num > launch_aicpu_num) {
-        LOG_ERROR(
-            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num
-        );
-        return -1;
-    }
+    int scheduler_thread_num = runtime.get_orch_built_on_host() ? launch_aicpu_num : launch_aicpu_num - 1;
 
     // Validate even core distribution for initial scheduler threads
     if (scheduler_thread_num > 0) {

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -98,9 +98,9 @@ int set_device(int device_id) {
 }
 
 int run_runtime(
-    RuntimeHandle runtime, const void *callable, const void *args, int block_dim, int aicpu_thread_num,
-    int orch_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_profiling
+    RuntimeHandle runtime, const void *callable, const void *args, int block_dim, int aicpu_thread_num, int device_id,
+    const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size,
+    int enable_profiling
 ) {
     if (runtime == NULL) return -1;
 
@@ -130,7 +130,6 @@ int run_runtime(
         }
 
         // Phase 3: launch
-        r->orch_thread_num = orch_thread_num;
         DeviceRunner &runner = DeviceRunner::get();
         std::vector<uint8_t> aicpu_vec;
         std::vector<uint8_t> aicore_vec;

--- a/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -38,7 +38,7 @@ static PerfBufferState *s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
 static PhaseBufferState *s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
 static PhaseBuffer *s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
-static __thread int s_orch_thread_idx = -1;
+static int s_orch_thread_idx = -1;
 
 /**
  * Enqueue ready buffer to per-thread queue
@@ -279,7 +279,7 @@ void perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks) {
     wmb();
 }
 
-void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, int num_orch_threads) {
+void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
     void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize phase profiling");
@@ -299,7 +299,7 @@ void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, in
 
     // Cache per-thread record pointers and clear buffers
     // Include all threads: scheduler + orchestrator (orchestrators may become schedulers)
-    int total_threads = num_sched_threads + num_orch_threads;
+    int total_threads = num_sched_threads + 1;
     if (total_threads > PLATFORM_MAX_AICPU_THREADS) {
         total_threads = PLATFORM_MAX_AICPU_THREADS;
     }
@@ -342,8 +342,8 @@ void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, in
     wmb();
 
     LOG_INFO(
-        "Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread", num_sched_threads,
-        num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD
+        "Phase profiling initialized: %d scheduler + 1 orch thread, %d records/thread", num_sched_threads,
+        PLATFORM_PHASE_RECORDS_PER_THREAD
     );
 }
 

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -67,9 +67,7 @@
 // Device orchestration function signature (loaded via dlopen).
 // The orchestration .so receives a PTO2Runtime* (with ops table populated)
 // instead of a raw shared-memory pointer.
-typedef void (*DeviceOrchestrationFunc)(
-    PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args, int32_t orch_thread_num, int32_t orch_thread_index
-);
+typedef void (*DeviceOrchestrationFunc)(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args);
 
 // Config function exported by orchestration .so
 typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs &orch_args);
@@ -169,7 +167,6 @@ struct CoreStateTracker {
 };
 
 struct AicpuExecutor {
-    int32_t orch_thread_num_;
     int32_t sched_thread_num_;
     bool orch_to_sched_{false};
 
@@ -230,7 +227,6 @@ struct AicpuExecutor {
     std::atomic<bool> pto2_init_done_{false};
     std::atomic<bool> runtime_init_ready_{false};
     std::atomic<bool> pto2_init_complete_{false};  // init block finished; others wait for this
-    std::atomic<int32_t> orch_finished_count_{0};  // Number of orchestrator threads that have finished
 
     // ===== Dynamic core transition state =====
     std::atomic<bool> transition_requested_{false};
@@ -667,11 +663,6 @@ void AicpuExecutor::assign_cores_to_threads() {
         core_count_per_thread_[i] = 0;
     }
 
-    // Mark orchestrator threads explicitly (no cores).
-    for (int32_t t = divisor; t < thread_num_; t++) {
-        DEV_INFO("Thread %d: orchestrator (0 cores)", t);
-    }
-
     // Per-sched-thread running core index used while filling core_assignments_.
     int32_t core_idx[MAX_AICPU_THREADS] = {};
 
@@ -795,19 +786,9 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
 
     // Read execution parameters from runtime
     thread_num_ = runtime->sche_cpu_num;
-    orch_thread_num_ = runtime->orch_thread_num;
-    sched_thread_num_ = thread_num_ - orch_thread_num_;
-    orch_to_sched_ = runtime->orch_to_sched;
     if (thread_num_ == 0) thread_num_ = 1;
-
-    if (!orch_to_sched_ && sched_thread_num_ == 0) {
-        DEV_ERROR(
-            "no scheduler and orch not trans to schedulers when finished, maybe you need set env PTO2_ORCH_TO_SCHED=1 "
-            "or scale down orch number."
-        );
-        init_failed_.store(true, std::memory_order_release);
-        return -1;
-    }
+    sched_thread_num_ = thread_num_ - 1;
+    orch_to_sched_ = runtime->orch_to_sched;
 
     if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
         DEV_ERROR("Invalid thread_num: %d", thread_num_);
@@ -933,7 +914,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         if (runtime->enable_profiling) {
             perf_aicpu_init_profiling(runtime);
             // Initialize phase profiling for scheduler threads + orchestrator threads
-            perf_aicpu_init_phase_profiling(runtime, sched_thread_num_, orch_thread_num_);
+            perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
             perf_aicpu_set_orch_thread_idx(sched_thread_num_);
         }
 #endif
@@ -1602,201 +1583,173 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Orchestrator check
     if (thread_idx >= sched_thread_num_) {
-        int32_t orch_idx = thread_idx - sched_thread_num_;
         if (runtime->get_orch_built_on_host()) {
-            DEV_INFO("Thread %d: Host orchestration mode, no-op (orch_idx=%d)", thread_idx, orch_idx);
+            DEV_INFO("Thread %d: Host orchestration mode, no-op", thread_idx);
         } else {
-            // First orchestrator thread (orch_idx == 0): load SO, create runtime
-            if (orch_idx == 0) {
-                DEV_INFO("Thread %d: Primary orchestrator, loading SO via dlopen", thread_idx);
+            DEV_INFO("Thread %d: Orchestrator, loading SO via dlopen", thread_idx);
 
-                const void *so_data = runtime->get_device_orch_so_data();
-                size_t so_size = runtime->get_device_orch_so_size();
+            const void *so_data = runtime->get_device_orch_so_data();
+            size_t so_size = runtime->get_device_orch_so_size();
 
-                if (so_data == nullptr || so_size == 0) {
-                    DEV_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
-                    return -1;
-                }
-
-                // Try multiple paths that may allow execution on AICPU
-                char so_path[256];
-                bool file_created = false;
-                const char *candidate_dirs[] = {
-                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
-                };
-                const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
-
-                for (int32_t i = 0; i < num_candidates && !file_created; i++) {
-                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
-                    int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
-                    if (fd < 0) {
-                        DEV_INFO(
-                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
-                        );
-                        continue;
-                    }
-                    ssize_t written = write(fd, so_data, so_size);
-                    close(fd);
-                    if (written != static_cast<ssize_t>(so_size)) {
-                        DEV_INFO(
-                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
-                        );
-                        unlink(so_path);
-                        continue;
-                    }
-                    file_created = true;
-                    DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
-                }
-
-                if (!file_created) {
-                    DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
-                    return -1;
-                }
-
-                dlerror();
-                void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
-                const char *dlopen_err = dlerror();
-                if (handle == nullptr) {
-                    DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
-                    unlink(so_path);
-                    return -1;
-                }
-                DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
-
-                dlerror();
-                auto config_func =
-                    reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
-
-                dlerror();
-                DeviceOrchestrationFunc orch_func =
-                    reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
-                const char *dlsym_error = dlerror();
-                if (dlsym_error != nullptr) {
-                    DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-                if (orch_func == nullptr) {
-                    DEV_ERROR("Thread %d: dlsym returned NULL for aicpu_orchestration_entry", thread_idx);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-                const ChipStorageTaskArgs &args = runtime->get_orch_args();
-                int32_t arg_count = args.tensor_count() + args.scalar_count();
-                DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
-                for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
-                    const ContinuousTensor &t = args.tensor(i);
-                    DEV_INFO(
-                        "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
-                        static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
-                    );
-                }
-                for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
-                    DEV_INFO(
-                        "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
-                        static_cast<uint64_t>(args.scalar(i))
-                    );
-                }
-
-                uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
-                uint64_t heap_size = PTO2_HEAP_SIZE;
-                int32_t expected_arg_count = 0;
-                if (config_func) {
-                    PTO2OrchestrationConfig cfg = config_func(args);
-                    expected_arg_count = cfg.expected_arg_count;
-                    DEV_INFO("Thread %d: Config: expected_args=%d", thread_idx, expected_arg_count);
-                } else {
-                    DEV_INFO("Thread %d: No config function, using defaults", thread_idx);
-                }
-
-                if (expected_arg_count > 0 && arg_count < expected_arg_count) {
-                    DEV_ERROR("Thread %d: arg_count %d < expected %d", thread_idx, arg_count, expected_arg_count);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-                if (runtime->pto2_task_window_size > 0) {
-                    task_window_size = runtime->pto2_task_window_size;
-                }
-                if (runtime->pto2_heap_size > 0) {
-                    heap_size = runtime->pto2_heap_size;
-                }
-                int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
-                if (runtime->pto2_dep_pool_size > 0) {
-                    dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
-                }
-                DEV_INFO(
-                    "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
-                    static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
-                );
-
-                void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
-                void *gm_heap = runtime->get_pto2_gm_heap_ptr();
-
-                uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
-                PTO2SharedMemoryHandle *sm_handle =
-                    pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
-                if (!sm_handle) {
-                    DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-                rt = pto2_runtime_create_from_sm(
-                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity
-                );
-                if (!rt) {
-                    DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
-                    pto2_sm_destroy(sm_handle);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-#if PTO2_PROFILING
-                for (int i = 0; i < orch_thread_num_; i++) {
-                    rt->orchestrators[i].enable_profiling = runtime->enable_profiling;
-                }
-#endif
-
-                // With multi-ring, slot_states are per-ring inside the scheduler.
-                runtime->set_pto2_slot_states_ptr(nullptr);
-
-                // Store shared state for other orchestrator threads
-                orch_func_ = orch_func;
-                orch_args_cached_ = &args;
-                orch_so_handle_ = handle;
-                snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
-
-                // All-orchestrator mode: primary orchestrator does one-time init
-                if (sched_thread_num_ == 0) {
-                    DEV_INFO("Thread %d: All-orchestrator mode, doing one-time init", thread_idx);
-                    if (runtime->enable_profiling) {
-                        perf_aicpu_init_profiling(runtime);
-                        // After transition, all threads become schedulers
-                        perf_aicpu_init_phase_profiling(runtime, thread_num_, orch_thread_num_);
-                        perf_aicpu_set_orch_thread_idx(0);
-                    }
-                    pto2_init_done_.store(true, std::memory_order_release);
-                    pto2_init_complete_.store(true, std::memory_order_release);
-                    DEV_INFO("Thread %d: One-time init done", thread_idx);
-                }
-
-                runtime_init_ready_.store(true, std::memory_order_release);
-            } else {
-                // Non-primary orchestrator: wait for primary to finish setup
-                while (!runtime_init_ready_.load(std::memory_order_acquire)) {
-                    SPIN_WAIT_HINT();
-                }
+            if (so_data == nullptr || so_size == 0) {
+                DEV_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
+                return -1;
             }
 
+            // Try multiple paths that may allow execution on AICPU
+            char so_path[256];
+            bool file_created = false;
+            const char *candidate_dirs[] = {
+                "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
+            };
+            const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
+
+            for (int32_t i = 0; i < num_candidates && !file_created; i++) {
+                snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
+                int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+                if (fd < 0) {
+                    DEV_INFO(
+                        "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
+                    );
+                    continue;
+                }
+                ssize_t written = write(fd, so_data, so_size);
+                close(fd);
+                if (written != static_cast<ssize_t>(so_size)) {
+                    DEV_INFO(
+                        "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
+                    );
+                    unlink(so_path);
+                    continue;
+                }
+                file_created = true;
+                DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+            }
+
+            if (!file_created) {
+                DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
+                return -1;
+            }
+
+            dlerror();
+            void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+            const char *dlopen_err = dlerror();
+            if (handle == nullptr) {
+                DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
+                unlink(so_path);
+                return -1;
+            }
+            DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
+
+            dlerror();
+            auto config_func =
+                reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
+
+            dlerror();
+            DeviceOrchestrationFunc orch_func =
+                reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
+            const char *dlsym_error = dlerror();
+            if (dlsym_error != nullptr) {
+                DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+            if (orch_func == nullptr) {
+                DEV_ERROR("Thread %d: dlsym returned NULL for aicpu_orchestration_entry", thread_idx);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+            const ChipStorageTaskArgs &args = runtime->get_orch_args();
+            int32_t arg_count = args.tensor_count() + args.scalar_count();
+            DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
+            for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
+                const ContinuousTensor &t = args.tensor(i);
+                DEV_INFO(
+                    "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
+                    static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
+                );
+            }
+            for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
+                DEV_INFO(
+                    "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
+                    static_cast<uint64_t>(args.scalar(i))
+                );
+            }
+
+            uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
+            uint64_t heap_size = PTO2_HEAP_SIZE;
+            int32_t expected_arg_count = 0;
+            if (config_func) {
+                PTO2OrchestrationConfig cfg = config_func(args);
+                expected_arg_count = cfg.expected_arg_count;
+                DEV_INFO("Thread %d: Config: expected_args=%d", thread_idx, expected_arg_count);
+            } else {
+                DEV_INFO("Thread %d: No config function, using defaults", thread_idx);
+            }
+
+            if (expected_arg_count > 0 && arg_count < expected_arg_count) {
+                DEV_ERROR("Thread %d: arg_count %d < expected %d", thread_idx, arg_count, expected_arg_count);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+            if (runtime->pto2_task_window_size > 0) {
+                task_window_size = runtime->pto2_task_window_size;
+            }
+            if (runtime->pto2_heap_size > 0) {
+                heap_size = runtime->pto2_heap_size;
+            }
+            int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
+            if (runtime->pto2_dep_pool_size > 0) {
+                dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
+            }
+            DEV_INFO(
+                "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
+                static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
+            );
+
+            void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
+            void *gm_heap = runtime->get_pto2_gm_heap_ptr();
+
+            uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+            PTO2SharedMemoryHandle *sm_handle =
+                pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
+            if (!sm_handle) {
+                DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+            rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
+            if (!rt) {
+                DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
+                pto2_sm_destroy(sm_handle);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+#if PTO2_PROFILING
+            rt->orchestrator.enable_profiling = runtime->enable_profiling;
+#endif
+
+            // With multi-ring, slot_states are per-ring inside the scheduler.
+            runtime->set_pto2_slot_states_ptr(nullptr);
+
+            // Store shared state for orchestrator thread
+            orch_func_ = orch_func;
+            orch_args_cached_ = &args;
+            orch_so_handle_ = handle;
+            snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
+
+            runtime_init_ready_.store(true, std::memory_order_release);
+
             // Wait for scheduler's one-time init to complete
-            // (or primary orchestrator's init in all-orchestrator mode)
             while (!pto2_init_complete_.load(std::memory_order_acquire)) {
                 SPIN_WAIT_HINT();
             }
@@ -1809,19 +1762,16 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 
             // Call orchestration function wrapped in an outer scope
-            DEV_ALWAYS(
-                "Thread %d: Calling aicpu_orchestration_entry from SO (orch_idx=%d/(0~%d))", thread_idx, orch_idx,
-                orch_thread_num_ - 1
-            );
+            DEV_ALWAYS("Thread %d: Calling aicpu_orchestration_entry from SO", thread_idx);
 #if PTO2_PROFILING
             uint64_t orch_cycle_start = get_sys_cnt_aicpu();
 #endif
-            PTO2_SCOPE(rt) { orch_func_(rt, *orch_args_cached_, orch_thread_num_, orch_idx); }
+            PTO2_SCOPE(rt) { orch_func_(rt, *orch_args_cached_); }
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
             DEV_ALWAYS(
-                "Thread %d: orch_start=%" PRIu64 " orch_func_cost=%.3fus (orch_idx=%d)", thread_idx,
-                static_cast<uint64_t>(orch_cycle_start), cycles_to_us(orch_cycle_end - orch_cycle_start), orch_idx
+                "Thread %d: orch_start=%" PRIu64 " orch_func_cost=%.3fus", thread_idx,
+                static_cast<uint64_t>(orch_cycle_start), cycles_to_us(orch_cycle_end - orch_cycle_start)
             );
 #endif
 
@@ -1893,107 +1843,88 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 #endif
 
-            // Coordinate orchestrator completion
-            int32_t finished = orch_finished_count_.fetch_add(1, std::memory_order_acq_rel) + 1;
-            if (finished == orch_thread_num_) {
-                // Last orchestrator: signal completion and trigger core transition
-                pto2_rt_orchestration_done(rt);
+            // Signal completion and trigger core transition
+            pto2_rt_orchestration_done(rt);
 
+            void *sm = runtime->get_pto2_gm_sm_ptr();
+            PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
+            int32_t pto2_task_count = 0;
+            if (sm_header) {
+                for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                    pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
+                }
+            }
+#if PTO2_PROFILING
+            DEV_ALWAYS(
+                "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_task_count,
+                completed_tasks_.load(std::memory_order_acquire)
+            );
+#endif
+            total_tasks_ = pto2_task_count;
+            if (runtime->enable_profiling && pto2_task_count > 0) {
+                perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
+            }
+            orchestrator_done_ = true;
+            {
+                int32_t orch_err = 0;
                 void *sm = runtime->get_pto2_gm_sm_ptr();
-                PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
-                int32_t pto2_task_count = 0;
-                if (sm_header) {
-                    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                        pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
-                    }
+                if (sm) {
+                    orch_err =
+                        static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
                 }
-#if PTO2_PROFILING
-                DEV_ALWAYS(
-                    "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_task_count,
-                    completed_tasks_.load(std::memory_order_acquire)
-                );
-#endif
-                total_tasks_ = pto2_task_count;
-                if (runtime->enable_profiling && pto2_task_count > 0) {
-                    perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
-                }
-                orchestrator_done_ = true;
-                {
-                    int32_t orch_err = 0;
-                    void *sm = runtime->get_pto2_gm_sm_ptr();
-                    if (sm) {
-                        orch_err =
-                            static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
-                    }
 
-                    // Fatal error: shutdown AICore immediately before core transition.
-                    if (orch_err != PTO2_ERROR_NONE) {
-                        emergency_shutdown(runtime);
-                        completed_.store(true, std::memory_order_release);
-                    }
+                // Fatal error: shutdown AICore immediately before core transition.
+                if (orch_err != PTO2_ERROR_NONE) {
+                    emergency_shutdown(runtime);
+                    completed_.store(true, std::memory_order_release);
                 }
+            }
 
 #if PTO2_ORCH_PROFILING
-                uint64_t reassign_cycle_start = get_sys_cnt_aicpu();
+            uint64_t reassign_cycle_start = get_sys_cnt_aicpu();
 #endif
 
-                // Skip core transition on fatal error — cores already shut down above
-                if (completed_.load(std::memory_order_acquire)) {
-                    // Signal transition to unblock scheduler threads waiting at core transition
-                    transition_requested_.store(true, std::memory_order_release);
-                    reassigned_.store(true, std::memory_order_release);
-                } else if (orch_to_sched_) {
-                    // Compute new core assignments for all threads and initialize donated slots
-                    DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
+            // Skip core transition on fatal error — cores already shut down above
+            if (completed_.load(std::memory_order_acquire)) {
+                // Signal transition to unblock scheduler threads waiting at core transition
+                transition_requested_.store(true, std::memory_order_release);
+                reassigned_.store(true, std::memory_order_release);
+            } else if (orch_to_sched_) {
+                // Compute new core assignments for all threads and initialize donated slots
+                DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
 #if PTO2_PROFILING
-                    uint64_t orch_stage_end_ts = get_sys_cnt_aicpu();
+                uint64_t orch_stage_end_ts = get_sys_cnt_aicpu();
 #endif
-                    transition_requested_.store(true, std::memory_order_release);
+                transition_requested_.store(true, std::memory_order_release);
 #if PTO2_PROFILING
-                    DEV_ALWAYS(
-                        "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
-                    );
-#endif
-
-                    // Wait for scheduler threads to acknowledge transition request
-                    // All-orchestrator mode (sched_thread_num_ == 0): skip the wait
-                    if (sched_thread_num_ > 0) {
-                        while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
-                            if (completed_.load(std::memory_order_acquire)) {
-                                break;
-                            }
-                            SPIN_WAIT_HINT();
-                        }
-                    }
-                    if (!completed_.load(std::memory_order_acquire)) {
-                        reassign_cores_for_all_threads();
-                        reassigned_.store(true, std::memory_order_release);
-                    }
-                }
-
-#if PTO2_ORCH_PROFILING
-                uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
                 DEV_ALWAYS(
-                    "Thread %d: reassign, cost %.3fus (orch_idx=%d)", thread_idx,
-                    cycles_to_us(reassign_cycle_end - reassign_cycle_start), orch_idx
+                    "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
                 );
 #endif
-            } else {
-                // Non-last orchestrator: wait for last orchestrator to finish setup
-                if (orch_to_sched_) {
-                    while (!transition_requested_.load(std::memory_order_acquire)) {
-                        SPIN_WAIT_HINT();
-                    }
-                    while (!reassigned_.load(std::memory_order_acquire)) {
+
+                // Wait for scheduler threads to acknowledge transition request
+                if (sched_thread_num_ > 0) {
+                    while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
                         if (completed_.load(std::memory_order_acquire)) {
                             break;
                         }
                         SPIN_WAIT_HINT();
                     }
                 }
+                if (!completed_.load(std::memory_order_acquire)) {
+                    reassign_cores_for_all_threads();
+                    reassigned_.store(true, std::memory_order_release);
+                }
             }
+
+#if PTO2_ORCH_PROFILING
+            uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
+            DEV_ALWAYS(
+                "Thread %d: reassign, cost %.3fus", thread_idx, cycles_to_us(reassign_cycle_end - reassign_cycle_start)
+            );
+#endif
         }
-        DEV_INFO("Thread %d: Orchestrator completed (orch_idx=%d)", thread_idx, orch_idx);
+        DEV_INFO("Thread %d: Orchestrator completed", thread_idx);
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
@@ -2079,14 +2010,12 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     wait_reassign_.store(0, std::memory_order_release);
     reassigned_.store(false, std::memory_order_release);
     completed_.store(false, std::memory_order_release);
-    orch_finished_count_.store(0, std::memory_order_release);
 
     // Reset core discovery and assignment state
     aic_count_ = 0;
     aiv_count_ = 0;
     cores_total_num_ = 0;
     thread_num_ = 0;
-    orch_thread_num_ = 0;
     sched_thread_num_ = 0;
     thread_cores_num_ = 0;
     orch_to_sched_ = false;

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.cpp
@@ -30,20 +30,20 @@
 // =============================================================================
 
 static SubmitResult submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
-    return pto2_submit_mixed_task(&rt->orchestrators[0], mixed_kernels, args);
+    return pto2_submit_mixed_task(&rt->orchestrator, mixed_kernels, args);
 }
 
 static void add_dependency_impl(PTO2Runtime *rt, PTO2TaskId producer, PTO2TaskId consumer) {
-    pto2_add_dependency(&rt->orchestrators[0], producer, consumer);
+    pto2_add_dependency(&rt->orchestrator, producer, consumer);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrators[0]); }
+void pto2_rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrator); }
 
-void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrators[0]); }
+void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrator); }
 
-void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrators[0]); }
+void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrator); }
 
-static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrators[0].fatal; }
+static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
 
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
@@ -78,7 +78,6 @@ PTO2Runtime *pto2_runtime_create_custom(
 
     rt->ops = &s_runtime_ops;
     rt->mode = mode;
-    rt->orch_count = 1;
     rt->sm_handle = pto2_sm_create(task_window_size, heap_size);
     if (!rt->sm_handle) {
         free(rt);
@@ -104,8 +103,8 @@ PTO2Runtime *pto2_runtime_create_custom(
 #endif
     rt->gm_heap_owned = true;
 
-    // Initialize first orchestrator
-    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
+    // Initialize orchestrator
+    if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
         free(rt);
@@ -114,7 +113,7 @@ PTO2Runtime *pto2_runtime_create_custom(
 
     // Initialize scheduler (heap_size = per-ring heap size)
     if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, rt->gm_heap, heap_size)) {
-        pto2_orchestrator_destroy(&rt->orchestrators[0]);
+        pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
         free(rt);
@@ -122,18 +121,16 @@ PTO2Runtime *pto2_runtime_create_custom(
     }
 
     // Connect orchestrator to scheduler (for simulated mode)
-    pto2_orchestrator_set_scheduler(&rt->orchestrators[0], &rt->scheduler);
+    pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
 
     return rt;
 }
 
 PTO2Runtime *pto2_runtime_create_from_sm(
-    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count,
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity
 ) {
     if (!sm_handle) return NULL;
-    if (orch_count < 1) orch_count = 1;
-    if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
 
     PTO2Runtime *rt = reinterpret_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) return NULL;
@@ -144,32 +141,20 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     rt->gm_heap = gm_heap;
     rt->gm_heap_size = heap_size > 0 ? heap_size * PTO2_MAX_RING_DEPTH : 0;
     rt->gm_heap_owned = false;
-    rt->orch_count = orch_count;
 
-    // Initialize all orchestrator states
-    for (int i = 0; i < orch_count; i++) {
-        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
-            for (int j = 0; j < i; j++) {
-                pto2_orchestrator_destroy(&rt->orchestrators[j]);
-            }
-            free(rt);
-            return NULL;
-        }
-    }
-
-    // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, rt->gm_heap, heap_size)) {
-        for (int i = 0; i < orch_count; i++) {
-            pto2_orchestrator_destroy(&rt->orchestrators[i]);
-        }
+    if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt);
         return NULL;
     }
 
-    // Connect all orchestrators to scheduler
-    for (int i = 0; i < orch_count; i++) {
-        pto2_orchestrator_set_scheduler(&rt->orchestrators[i], &rt->scheduler);
+    // Initialize scheduler (heap_size = per-ring heap size)
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, rt->gm_heap, heap_size)) {
+        pto2_orchestrator_destroy(&rt->orchestrator);
+        free(rt);
+        return NULL;
     }
+
+    pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
 
     return rt;
 }
@@ -178,9 +163,7 @@ void pto2_runtime_destroy(PTO2Runtime *rt) {
     if (!rt) return;
 
     pto2_scheduler_destroy(&rt->scheduler);
-    for (int i = 0; i < rt->orch_count; i++) {
-        pto2_orchestrator_destroy(&rt->orchestrators[i]);
-    }
+    pto2_orchestrator_destroy(&rt->orchestrator);
 
     if (rt->gm_heap_owned && rt->gm_heap) {
         free(rt->gm_heap);

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.h
@@ -43,9 +43,6 @@
 #include "pto_shared_memory.h"   // NOLINT(build/include_subdir)
 #include "pto_submit_types.h"    // NOLINT(build/include_subdir)
 
-// Maximum number of orchestrator threads supported
-constexpr int PTO2_MAX_ORCH_THREADS = 4;
-
 // =============================================================================
 // Runtime Context
 // =============================================================================
@@ -96,8 +93,7 @@ struct PTO2Runtime {
 
     // Components
     PTO2SharedMemoryHandle *sm_handle;
-    PTO2OrchestratorState orchestrators[PTO2_MAX_ORCH_THREADS];
-    int orch_count;  // Number of active orchestrator states
+    PTO2OrchestratorState orchestrator;
     PTO2SchedulerState scheduler;
 
     // GM Heap for output buffers
@@ -148,7 +144,7 @@ PTO2Runtime *pto2_runtime_create_custom(
  * @return Runtime context, or NULL on failure
  */
 PTO2Runtime *pto2_runtime_create_from_sm(
-    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count = 1,
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
 

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
@@ -33,7 +33,6 @@ Runtime::Runtime() {
     memset(workers, 0, sizeof(workers));
     worker_count = 0;
     sche_cpu_num = 1;
-    orch_thread_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
     pto2_task_window_size = 0;
     pto2_heap_size = 0;

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
@@ -155,7 +155,6 @@ public:  // NOLINT(whitespace/indent)
 
     // Execution parameters for AICPU scheduling
     int sche_cpu_num;        // Number of AICPU threads for scheduling
-    int orch_thread_num;     // Number of orchestrator threads (default 1)
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -45,7 +45,6 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     sche_cpu_num = 1;
-    orch_thread_num = 1;
     enable_profiling = false;
     perf_data_base = 0;
     tensor_pair_count = 0;

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -199,8 +199,7 @@ public:
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int sche_cpu_num;     // Number of AICPU threads for scheduling
-    int orch_thread_num;  // Number of orchestrator threads (unused, for API compatibility)
+    int sche_cpu_num;  // Number of AICPU threads for scheduling
 
     // Profiling support
     bool enable_profiling;    // Enable profiling flag
@@ -232,6 +231,9 @@ public:
      * Constructor - zero-initialize all arrays
      */
     Runtime();
+
+    // Orchestration is always built on the host for this runtime
+    bool get_orch_built_on_host() const { return true; }
 
     // =========================================================================
     // Task Management

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -68,9 +68,7 @@
 // Device orchestration function signature (loaded via dlopen).
 // The executor binds the current thread's PTO2Runtime into orchestration TLS
 // before calling the user entry.
-typedef void (*DeviceOrchestrationFunc)(
-    const ChipStorageTaskArgs &orch_args, int32_t orch_thread_num, int32_t orch_thread_index
-);
+typedef void (*DeviceOrchestrationFunc)(const ChipStorageTaskArgs &orch_args);
 typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 
 // Config function exported by orchestration .so
@@ -275,7 +273,6 @@ private:
 };
 
 struct AicpuExecutor {
-    int32_t orch_thread_num_;
     int32_t sched_thread_num_;
     int32_t active_sched_threads_{0};  // Threads currently in dispatch loop (initially sched_thread_num_, becomes
                                        // thread_num_ after orch→sched transition)
@@ -334,7 +331,6 @@ struct AicpuExecutor {
     std::atomic<bool> pto2_init_done_{false};
     std::atomic<bool> runtime_init_ready_{false};
     std::atomic<bool> pto2_init_complete_{false};  // init block finished; others wait for this
-    std::atomic<int32_t> orch_finished_count_{0};  // Number of orchestrator threads that have finished
 
     // ===== Dynamic core transition state =====
     std::atomic<bool> transition_requested_{false};
@@ -1001,12 +997,6 @@ bool AicpuExecutor::assign_cores_to_threads() {
         core_count_per_thread_[i] = 0;
     }
 
-    // Mark orchestrator threads explicitly (no cores).
-    for (int32_t t = divisor; t < thread_num_; t++) {
-        core_trackers_[t].init(0);
-        DEV_INFO("Thread %d: orchestrator (0 cores)", t);
-    }
-
     // Per-sched-thread running core index used while filling core_assignments_.
     int32_t core_idx[MAX_AICPU_THREADS] = {};
     int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
@@ -1127,19 +1117,9 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
 
     // Read execution parameters from runtime
     thread_num_ = runtime->sche_cpu_num;
-    orch_thread_num_ = runtime->orch_thread_num;
-    sched_thread_num_ = thread_num_ - orch_thread_num_;
+    sched_thread_num_ = thread_num_ - 1;
     orch_to_sched_ = runtime->orch_to_sched;
     if (thread_num_ == 0) thread_num_ = 1;
-
-    if (!orch_to_sched_ && sched_thread_num_ == 0) {
-        DEV_ERROR(
-            "no scheduler and orch not trans to schedulers when finished, maybe you need set env PTO2_ORCH_TO_SCHED=1 "
-            "or scale down orch number."
-        );
-        init_failed_.store(true, std::memory_order_release);
-        return -1;
-    }
 
     if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
         DEV_ERROR("Invalid thread_num: %d", thread_num_);
@@ -1269,7 +1249,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         if (runtime->enable_profiling) {
             perf_aicpu_init_profiling(runtime);
             // Initialize phase profiling for scheduler threads + orchestrator threads
-            perf_aicpu_init_phase_profiling(runtime, sched_thread_num_, orch_thread_num_);
+            perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
             perf_aicpu_set_orch_thread_idx(sched_thread_num_);
         }
 #endif
@@ -1931,223 +1911,191 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         uint64_t orch_cycle_start = 0;
         int32_t pto2_submitted_tasks = -1;
 #endif
-        int32_t orch_idx = thread_idx - sched_thread_num_;
         if (runtime->get_orch_built_on_host()) {
-            DEV_INFO("Thread %d: Host orchestration mode, no-op (orch_idx=%d)", thread_idx, orch_idx);
+            DEV_INFO("Thread %d: Host orchestration mode, no-op", thread_idx);
         } else {
-            // First orchestrator thread (orch_idx == 0): load SO, create runtime
-            if (orch_idx == 0) {
-                DEV_INFO("Thread %d: Primary orchestrator, loading SO via dlopen", thread_idx);
+            DEV_INFO("Thread %d: Orchestrator, loading SO via dlopen", thread_idx);
 
-                const void *so_data = runtime->get_device_orch_so_data();
-                size_t so_size = runtime->get_device_orch_so_size();
+            const void *so_data = runtime->get_device_orch_so_data();
+            size_t so_size = runtime->get_device_orch_so_size();
 
-                if (so_data == nullptr || so_size == 0) {
-                    DEV_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
-                    return -1;
-                }
-
-                // Try multiple paths that may allow execution on AICPU
-                char so_path[256];
-                bool file_created = false;
-                const char *candidate_dirs[] = {
-                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
-                };
-                const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
-
-                for (int32_t i = 0; i < num_candidates && !file_created; i++) {
-                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
-                    int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
-                    if (fd < 0) {
-                        DEV_INFO(
-                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
-                        );
-                        continue;
-                    }
-                    ssize_t written = write(fd, so_data, so_size);
-                    close(fd);
-                    if (written != static_cast<ssize_t>(so_size)) {
-                        DEV_INFO(
-                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
-                        );
-                        unlink(so_path);
-                        continue;
-                    }
-                    file_created = true;
-                    DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
-                }
-
-                if (!file_created) {
-                    DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
-                    return -1;
-                }
-
-                dlerror();
-                void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
-                const char *dlopen_err = dlerror();
-                if (handle == nullptr) {
-                    DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
-                    unlink(so_path);
-                    return -1;
-                }
-                DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
-
-                dlerror();
-                auto config_func =
-                    reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
-
-                dlerror();
-                DeviceOrchestrationFunc orch_func =
-                    reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
-                const char *dlsym_error = dlerror();
-                if (dlsym_error != nullptr) {
-                    DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-                if (orch_func == nullptr) {
-                    DEV_ERROR("Thread %d: dlsym returned NULL for aicpu_orchestration_entry", thread_idx);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-                dlerror();
-                auto bind_runtime_func =
-                    reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
-                const char *bind_runtime_error = dlerror();
-                if (bind_runtime_error != nullptr) {
-                    DEV_INFO("Thread %d: Optional TLS runtime binder not found: %s", thread_idx, bind_runtime_error);
-                    bind_runtime_func = nullptr;
-                }
-
-                const ChipStorageTaskArgs &args = runtime->get_orch_args();
-                int32_t arg_count = args.tensor_count() + args.scalar_count();
-                DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
-                for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
-                    const ContinuousTensor &t = args.tensor(i);
-                    DEV_INFO(
-                        "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
-                        static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
-                    );
-                }
-                for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
-                    DEV_INFO(
-                        "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
-                        static_cast<uint64_t>(args.scalar(i))
-                    );
-                }
-
-                uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
-                uint64_t heap_size = PTO2_HEAP_SIZE;
-                int32_t expected_arg_count = 0;
-                if (config_func) {
-                    PTO2OrchestrationConfig cfg = config_func(args);
-                    expected_arg_count = cfg.expected_arg_count;
-                    DEV_INFO("Thread %d: Config: expected_args=%d", thread_idx, expected_arg_count);
-                } else {
-                    DEV_INFO("Thread %d: No config function, using defaults", thread_idx);
-                }
-
-                if (expected_arg_count > 0 && arg_count < expected_arg_count) {
-                    DEV_ERROR("Thread %d: arg_count %d < expected %d", thread_idx, arg_count, expected_arg_count);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-                if (runtime->pto2_task_window_size > 0) {
-                    task_window_size = runtime->pto2_task_window_size;
-                }
-                if (runtime->pto2_heap_size > 0) {
-                    heap_size = runtime->pto2_heap_size;
-                }
-                int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
-                if (runtime->pto2_dep_pool_size > 0) {
-                    dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
-                }
-                DEV_INFO(
-                    "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
-                    static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
-                );
-
-                void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
-                void *gm_heap = runtime->get_pto2_gm_heap_ptr();
-
-                uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
-                PTO2SharedMemoryHandle *sm_handle =
-                    pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
-                if (!sm_handle) {
-                    DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-                rt = pto2_runtime_create_from_sm(
-                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity
-                );
-                if (!rt) {
-                    DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
-                    pto2_sm_destroy(sm_handle);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-#if PTO2_PROFILING
-                for (int i = 0; i < orch_thread_num_; i++) {
-                    rt->orchestrators[i].enable_profiling = runtime->enable_profiling;
-                }
-#endif
-
-                // Total core counts = aic_count_ / aiv_count_ (set once at runtime init).
-                for (int i = 0; i < orch_thread_num_; i++) {
-                    rt->orchestrators[i].total_cluster_count = aic_count_;
-                    rt->orchestrators[i].total_aiv_count = aiv_count_;
-                }
-
-                // With multi-ring, slot_states are per-ring inside the scheduler.
-                runtime->set_pto2_slot_states_ptr(nullptr);
-
-                // Store shared state for other orchestrator threads
-                orch_func_ = orch_func;
-                orch_bind_runtime_ = bind_runtime_func;
-                orch_args_cached_ = &args;
-                orch_so_handle_ = handle;
-                snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
-
-                // All-orchestrator mode: primary orchestrator does one-time init
-                if (sched_thread_num_ == 0) {
-                    DEV_INFO("Thread %d: All-orchestrator mode, doing one-time init", thread_idx);
-                    if (runtime->enable_profiling) {
-                        perf_aicpu_init_profiling(runtime);
-                        // After transition, all threads become schedulers
-                        perf_aicpu_init_phase_profiling(runtime, thread_num_, orch_thread_num_);
-                        perf_aicpu_set_orch_thread_idx(0);
-                    }
-                    pto2_init_done_.store(true, std::memory_order_release);
-                    pto2_init_complete_.store(true, std::memory_order_release);
-                    DEV_INFO("Thread %d: One-time init done", thread_idx);
-                }
-
-                runtime_init_ready_.store(true, std::memory_order_release);
-            } else {
-                // Non-primary orchestrator: wait for primary to finish setup
-                while (!runtime_init_ready_.load(std::memory_order_acquire)) {
-                    SPIN_WAIT_HINT();
-                }
+            if (so_data == nullptr || so_size == 0) {
+                DEV_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
+                return -1;
             }
 
+            // Try multiple paths that may allow execution on AICPU
+            char so_path[256];
+            bool file_created = false;
+            const char *candidate_dirs[] = {
+                "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
+            };
+            const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
+
+            for (int32_t i = 0; i < num_candidates && !file_created; i++) {
+                snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
+                int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+                if (fd < 0) {
+                    DEV_INFO(
+                        "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
+                    );
+                    continue;
+                }
+                ssize_t written = write(fd, so_data, so_size);
+                close(fd);
+                if (written != static_cast<ssize_t>(so_size)) {
+                    DEV_INFO(
+                        "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
+                    );
+                    unlink(so_path);
+                    continue;
+                }
+                file_created = true;
+                DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+            }
+
+            if (!file_created) {
+                DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
+                return -1;
+            }
+
+            dlerror();
+            void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+            const char *dlopen_err = dlerror();
+            if (handle == nullptr) {
+                DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
+                unlink(so_path);
+                return -1;
+            }
+            DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
+
+            dlerror();
+            auto config_func =
+                reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
+
+            dlerror();
+            DeviceOrchestrationFunc orch_func =
+                reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
+            const char *dlsym_error = dlerror();
+            if (dlsym_error != nullptr) {
+                DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+            if (orch_func == nullptr) {
+                DEV_ERROR("Thread %d: dlsym returned NULL for aicpu_orchestration_entry", thread_idx);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+            dlerror();
+            auto bind_runtime_func =
+                reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
+            const char *bind_runtime_error = dlerror();
+            if (bind_runtime_error != nullptr) {
+                DEV_INFO("Thread %d: Optional TLS runtime binder not found: %s", thread_idx, bind_runtime_error);
+                bind_runtime_func = nullptr;
+            }
+
+            const ChipStorageTaskArgs &args = runtime->get_orch_args();
+            int32_t arg_count = args.tensor_count() + args.scalar_count();
+            DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
+            for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
+                const ContinuousTensor &t = args.tensor(i);
+                DEV_INFO(
+                    "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
+                    static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
+                );
+            }
+            for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
+                DEV_INFO(
+                    "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
+                    static_cast<uint64_t>(args.scalar(i))
+                );
+            }
+
+            uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
+            uint64_t heap_size = PTO2_HEAP_SIZE;
+            int32_t expected_arg_count = 0;
+            if (config_func) {
+                PTO2OrchestrationConfig cfg = config_func(args);
+                expected_arg_count = cfg.expected_arg_count;
+                DEV_INFO("Thread %d: Config: expected_args=%d", thread_idx, expected_arg_count);
+            } else {
+                DEV_INFO("Thread %d: No config function, using defaults", thread_idx);
+            }
+
+            if (expected_arg_count > 0 && arg_count < expected_arg_count) {
+                DEV_ERROR("Thread %d: arg_count %d < expected %d", thread_idx, arg_count, expected_arg_count);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+            if (runtime->pto2_task_window_size > 0) {
+                task_window_size = runtime->pto2_task_window_size;
+            }
+            if (runtime->pto2_heap_size > 0) {
+                heap_size = runtime->pto2_heap_size;
+            }
+            int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
+            if (runtime->pto2_dep_pool_size > 0) {
+                dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
+            }
+            DEV_INFO(
+                "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
+                static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
+            );
+
+            void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
+            void *gm_heap = runtime->get_pto2_gm_heap_ptr();
+
+            uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+            PTO2SharedMemoryHandle *sm_handle =
+                pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
+            if (!sm_handle) {
+                DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+            rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
+            if (!rt) {
+                DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
+                pto2_sm_destroy(sm_handle);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+#if PTO2_PROFILING
+            rt->orchestrator.enable_profiling = runtime->enable_profiling;
+#endif
+
+            // Total core counts = aic_count_ / aiv_count_ (set once at runtime init).
+            rt->orchestrator.total_cluster_count = aic_count_;
+            rt->orchestrator.total_aiv_count = aiv_count_;
+
+            // With multi-ring, slot_states are per-ring inside the scheduler.
+            runtime->set_pto2_slot_states_ptr(nullptr);
+
+            orch_func_ = orch_func;
+            orch_bind_runtime_ = bind_runtime_func;
+            orch_args_cached_ = &args;
+            orch_so_handle_ = handle;
+            snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
+
+            runtime_init_ready_.store(true, std::memory_order_release);
+
             // Wait for scheduler's one-time init to complete
-            // (or primary orchestrator's init in all-orchestrator mode)
             while (!pto2_init_complete_.load(std::memory_order_acquire)) {
                 SPIN_WAIT_HINT();
             }
 
 #if PTO2_PROFILING
-            // Each orchestrator thread sets its own phase buffer index (thread-local)
             if (runtime->enable_profiling) {
                 perf_aicpu_set_orch_thread_idx(thread_idx);
             }
@@ -2160,7 +2108,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 orch_bind_runtime_(rt);
             }
             pto2_rt_scope_begin(rt);
-            orch_func_(*orch_args_cached_, orch_thread_num_, orch_idx);
+            orch_func_(*orch_args_cached_);
             pto2_rt_scope_end(rt);
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
@@ -2262,102 +2210,81 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 #endif
 
-            // Coordinate orchestrator completion
-            int32_t finished = orch_finished_count_.fetch_add(1, std::memory_order_acq_rel) + 1;
-            if (finished == orch_thread_num_) {
-                // Last orchestrator: signal completion and trigger core transition
-                pto2_rt_orchestration_done(rt);
+            // Signal completion and trigger core transition
+            pto2_rt_orchestration_done(rt);
 
-                void *sm = runtime->get_pto2_gm_sm_ptr();
-                PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
-                int32_t pto2_task_count = 0;
-                if (sm_header) {
-                    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                        pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
-                    }
-                }
-#if PTO2_PROFILING
-                pto2_submitted_tasks = pto2_task_count;
-#endif
-                total_tasks_ = pto2_task_count;
-                if (runtime->enable_profiling && pto2_task_count > 0) {
-                    perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
-                }
-                orchestrator_done_ = true;
-                {
-                    int32_t orch_err = 0;
-                    void *sm = runtime->get_pto2_gm_sm_ptr();
-                    if (sm) {
-                        orch_err =
-                            static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
-                    }
-
-                    // Fatal error: shutdown AICore immediately before core transition.
-                    if (orch_err != PTO2_ERROR_NONE) {
-                        emergency_shutdown(runtime);
-                        completed_.store(true, std::memory_order_release);
-                    }
-                }
-
-#if PTO2_ORCH_PROFILING
-                uint64_t reassign_cycle_start = get_sys_cnt_aicpu();
-#endif
-
-                // Skip core transition on fatal error — cores already shut down above
-                if (completed_.load(std::memory_order_acquire)) {
-                    // Signal transition to unblock scheduler threads waiting at core transition
-                    transition_requested_.store(true, std::memory_order_release);
-                    reassigned_.store(true, std::memory_order_release);
-                } else if (orch_to_sched_) {
-                    // Compute new core assignments for all threads and initialize donated slots
-                    DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
-#if PTO2_PROFILING
-                    uint64_t orch_stage_end_ts = get_sys_cnt_aicpu();
-#endif
-                    transition_requested_.store(true, std::memory_order_release);
-#if PTO2_PROFILING
-                    DEV_ALWAYS(
-                        "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
-                    );
-#endif
-
-                    // Wait for scheduler threads to acknowledge transition request
-                    // All-orchestrator mode (sched_thread_num_ == 0): skip the wait
-                    if (sched_thread_num_ > 0) {
-                        while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
-                            if (completed_.load(std::memory_order_acquire)) {
-                                break;
-                            }
-                            SPIN_WAIT_HINT();
-                        }
-                    }
-                    if (!completed_.load(std::memory_order_acquire)) {
-                        reassign_cores_for_all_threads();
-                        reassigned_.store(true, std::memory_order_release);
-                    }
-                }
-
-#if PTO2_ORCH_PROFILING
-                uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
-                DEV_ALWAYS(
-                    "Thread %d: reassign, cost %.3fus (orch_idx=%d)", thread_idx,
-                    cycles_to_us(reassign_cycle_end - reassign_cycle_start), orch_idx
-                );
-#endif
-            } else {
-                // Non-last orchestrator: wait for last orchestrator to finish setup
-                if (orch_to_sched_) {
-                    while (!transition_requested_.load(std::memory_order_acquire)) {
-                        SPIN_WAIT_HINT();
-                    }
-                    while (!reassigned_.load(std::memory_order_acquire)) {
-                        if (completed_.load(std::memory_order_acquire)) {
-                            break;
-                        }
-                        SPIN_WAIT_HINT();
-                    }
+            void *sm = runtime->get_pto2_gm_sm_ptr();
+            PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
+            int32_t pto2_task_count = 0;
+            if (sm_header) {
+                for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                    pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                 }
             }
+#if PTO2_PROFILING
+            pto2_submitted_tasks = pto2_task_count;
+#endif
+            total_tasks_ = pto2_task_count;
+            if (runtime->enable_profiling && pto2_task_count > 0) {
+                perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
+            }
+            orchestrator_done_ = true;
+            {
+                int32_t orch_err = 0;
+                void *sm = runtime->get_pto2_gm_sm_ptr();
+                if (sm) {
+                    orch_err =
+                        static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
+                }
+
+                // Fatal error: shutdown AICore immediately before core transition.
+                if (orch_err != PTO2_ERROR_NONE) {
+                    emergency_shutdown(runtime);
+                    completed_.store(true, std::memory_order_release);
+                }
+            }
+
+#if PTO2_ORCH_PROFILING
+            uint64_t reassign_cycle_start = get_sys_cnt_aicpu();
+#endif
+
+            // Skip core transition on fatal error — cores already shut down above
+            if (completed_.load(std::memory_order_acquire)) {
+                // Signal transition to unblock scheduler threads waiting at core transition
+                transition_requested_.store(true, std::memory_order_release);
+                reassigned_.store(true, std::memory_order_release);
+            } else if (orch_to_sched_) {
+                // Compute new core assignments for all threads and initialize donated slots
+                DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
+#if PTO2_PROFILING
+                uint64_t orch_stage_end_ts = get_sys_cnt_aicpu();
+#endif
+                transition_requested_.store(true, std::memory_order_release);
+#if PTO2_PROFILING
+                DEV_ALWAYS(
+                    "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
+                );
+#endif
+
+                // Wait for scheduler threads to acknowledge transition request
+                while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
+                    if (completed_.load(std::memory_order_acquire)) {
+                        break;
+                    }
+                    SPIN_WAIT_HINT();
+                }
+                if (!completed_.load(std::memory_order_acquire)) {
+                    reassign_cores_for_all_threads();
+                    reassigned_.store(true, std::memory_order_release);
+                }
+            }
+
+#if PTO2_ORCH_PROFILING
+            uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
+            DEV_ALWAYS(
+                "Thread %d: reassign, cost %.3fus", thread_idx, cycles_to_us(reassign_cycle_end - reassign_cycle_start)
+            );
+#endif
         }
 #if PTO2_PROFILING
         uint64_t orch_end_ts = get_sys_cnt_aicpu();
@@ -2373,7 +2300,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             );
         }
 #endif
-        DEV_INFO("Thread %d: Orchestrator completed (orch_idx=%d)", thread_idx, orch_idx);
+        DEV_INFO("Thread %d: Orchestrator completed", thread_idx);
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
@@ -2453,14 +2380,12 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     wait_reassign_.store(0, std::memory_order_release);
     reassigned_.store(false, std::memory_order_release);
     completed_.store(false, std::memory_order_release);
-    orch_finished_count_.store(0, std::memory_order_release);
 
     // Reset core discovery and assignment state
     aic_count_ = 0;
     aiv_count_ = 0;
     cores_total_num_ = 0;
     thread_num_ = 0;
-    orch_thread_num_ = 0;
     sched_thread_num_ = 0;
     thread_cores_num_ = 0;
     orch_to_sched_ = false;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -9,7 +9,7 @@ PTO2 (Parallel Task Orchestration v2) is a runtime system for executing task gra
 - **AICore** (AI compute cores): executes kernel functions dispatched by the scheduler.
 - **Shared Memory** (Global Memory): ring buffers, task descriptors, heap, and TensorMap shared between orchestrator and schedulers.
 
-```
+```text
 ┌───────────────────────────────────────────────────────────────────────┐
 │                            Host (CPU)                                 │
 │  golden.py → code_runner.py → compile kernels → init Runtime          │
@@ -73,7 +73,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 ### 2.1 a2a3 (Real Ascend Hardware)
 
 | Component | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | `device_runner.cpp` | Uses CANN APIs: `rtMalloc`, `rtMemcpy`, `rtLaunchKernel` |
 | `memory_allocator.cpp` | Wraps `rtMalloc`/`rtFree` with allocation tracking |
 | `aicore/kernel.cpp` | `KERNEL_ENTRY(aicore_kernel)` → `aicore_execute` |
@@ -83,7 +83,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 ### 2.2 a2a3sim (Thread Simulation)
 
 | Component | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | `device_runner.cpp` | Uses `std::thread` to simulate AICPU/AICore |
 | `memory_allocator.cpp` | Wraps `malloc`/`free` |
 | `aicore/kernel.cpp` | `aicore_execute_wrapper` sets `g_sim_reg_base` per core |
@@ -92,7 +92,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 ### 2.3 Platform Constants (`platform_config.h`)
 
 | Constant | Value | Description |
-|----------|-------|-------------|
+| -------- | ----- | ----------- |
 | `PLATFORM_MAX_BLOCKDIM` | 24 | Maximum blocks (each = 1 AIC + 2 AIV) |
 | `PLATFORM_MAX_AICPU_THREADS` | 4 | AICPU thread count (3 schedulers + 1 orchestrator) |
 | `PLATFORM_MAX_AIC_PER_THREAD` | 24 | Max AIC cores per scheduler thread |
@@ -105,7 +105,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 
 The orchestrator and schedulers communicate through a contiguous shared memory region in Global Memory (GM). Each ring level has its own TaskDescriptor and DepListPool sections. See [MULTI_RING.md §4.3–4.4](MULTI_RING.md) for the per-ring shared memory header and handle layout.
 
-```
+```text
 ┌─────────────────────────────┐  offset 0
 │  PTO2SharedMemoryHeader     │  (flow control, config, sync flags)
 ├─────────────────────────────┤  aligned
@@ -118,7 +118,7 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 ### 3.1 SharedMemoryHeader Fields
 
 | Field | Writer | Reader | Purpose |
-|-------|--------|--------|---------|
+| ----- | ------ | ------ | ------- |
 | `current_task_index` | Orchestrator | Scheduler | Next task ID to allocate (task ring head) |
 | `last_task_alive` | Scheduler | Orchestrator | Oldest still-active task (task ring tail) |
 | `heap_top` | Orchestrator | Scheduler | Heap ring allocation pointer |
@@ -136,7 +136,7 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 
 ### 3.2 Size Calculation
 
-```
+```text
 total = ALIGN(Header) + ALIGN(window_size * sizeof(TaskDescriptor))
       + ALIGN((dep_pool_size + 1) * sizeof(DepListEntry))
 ```
@@ -154,6 +154,7 @@ Alignment is 64 bytes (`PTO2_ALIGN_SIZE`).
 The task ring manages task slot allocation with back-pressure flow control.
 
 **Structure** (`PTO2TaskRing`):
+
 - `descriptors`: pointer to `TaskDescriptor[]` in shared memory
 - `window_size`: number of slots (power of 2)
 - `current_index`: next task ID to allocate (monotonically increasing)
@@ -162,7 +163,8 @@ The task ring manages task slot allocation with back-pressure flow control.
 **Slot mapping**: `slot = task_id & (window_size - 1)`
 
 **Allocation** (`pto2_task_ring_alloc`):
-```
+
+```text
 active_count = current_index - *last_alive_ptr
 if active_count < window_size - 1:
     allocate slot, advance current_index
@@ -179,6 +181,7 @@ else:
 The heap ring manages output buffer allocation from a circular GM heap.
 
 **Structure** (`PTO2HeapRing`):
+
 - `base`: GM heap base address
 - `size`: total heap size (default 1 GB)
 - `top`: allocation pointer (local to orchestrator)
@@ -212,7 +215,7 @@ This back-pressure is essential for correctness with small ring sizes — for ex
 
 A ring that is **too small** can cause a **deadlock**. The root cause is the scope mechanism: each task's `fanout_count` includes a reference from its owning scope. The scope reference is only released when `scope_end()` runs — but `scope_end()` is called by the orchestrator, which is blocked waiting for ring space. This creates a circular dependency:
 
-```
+```text
 Orchestrator blocked on task_ring_alloc (ring full)
     → needs scheduler to advance last_task_alive
     → needs tasks to reach CONSUMED state (fanout_count == 0)
@@ -224,13 +227,15 @@ Orchestrator blocked on task_ring_alloc (ring full)
 The runtime detects this automatically by counting spin iterations in the allocation functions:
 
 **Periodic BLOCKED warnings** (every 10,000 spins):
-```
+
+```text
 [TaskRing] BLOCKED (Flow Control): current=208, last_alive=192, active=16/16 (100.0%), spins=10000
 [HeapRing] BLOCKED: requesting 4096 bytes, available=0, top=65536, tail=0, spins=10000
 ```
 
 **Deadlock detection** (after 100,000 spins with no progress):
-```
+
+```text
 FATAL: Flow Control Deadlock Detected!
 Task Ring is FULL and no progress after 100000 spins.
   - Active tasks:  16
@@ -275,6 +280,7 @@ This design avoids the complexity of ring-based wrapping while still being bound
 ### 5.4 Stale Entry Cleanup: Three-Layer Defense
 
 TensorMap must ensure entries for retired tasks (`producer_task_id < last_task_alive`) are removed, so that:
+
 - The pool does not grow unboundedly (capacity is finite)
 - Lookup performance does not degrade as stale entries accumulate in bucket chains
 
@@ -301,7 +307,7 @@ This forms a back-pressure mechanism analogous to the Task Ring's flow control.
 **Summary**:
 
 | Layer | Trigger | Method | Guarantees |
-|-------|---------|--------|------------|
+| ----- | ------- | ------ | ---------- |
 | Chain Truncation | Every lookup | Truncate stale tail of bucket chain | Lookup only visits valid entries |
 | Periodic Cleanup | Every 64 retired tasks | Walk per-task chains, free entries | Pool capacity reclaimed in bounded time |
 | Pool Back-Pressure | Pool exhausted | Block until scheduler advances watermark | Hard capacity bound, no OOM |
@@ -324,8 +330,8 @@ When `pto2_submit_task` processes parameters:
 ### 6.1 PTO2TaskDescriptor (Hot Path)
 
 | Field | Description |
-|-------|-------------|
-| `task_id` | Canonical mixed-task ID (64-bit: `ring_id << 32 | local_id`). See [MULTI_RING.md §3](MULTI_RING.md). |
+| ----- | ----------- |
+| `task_id` | Canonical mixed-task ID (64-bit: `ring_id << 32 \| local_id`). See [MULTI_RING.md §3](MULTI_RING.md). |
 | `kernel_id[3]` | Per-slot kernel IDs: `[AIC, AIV0, AIV1]`; `INVALID_KERNEL_ID` = inactive |
 | `active_mask` | Bitmask of active subtask slots: `bit0=AIC`, `bit1=AIV0`, `bit2=AIV1` |
 | `subtask_done_mask` | Atomic bitmask; each subtask sets its done bit on completion |
@@ -339,7 +345,7 @@ When `pto2_submit_task` processes parameters:
 ### 6.1b PTO2TaskPayload (Cold Path)
 
 | Field | Description |
-|-------|-------------|
+| ----- | ----------- |
 | `tensors[16]` | Tensor descriptors for parameters |
 | `scalar_value[16]` | Scalar parameter values |
 | `is_tensor[16]` | Whether each parameter is tensor or scalar |
@@ -349,7 +355,7 @@ When `pto2_submit_task` processes parameters:
 
 ### 6.2 Task State Machine
 
-```
+```text
   [0] PENDING ──fanin satisfied──► [1] READY ──dispatch──► [2] RUNNING
       ▲                                                         │
       │                                                         ▼
@@ -357,6 +363,7 @@ When `pto2_submit_task` processes parameters:
 ```
 
 In the scheduler's `task_state[]` array (`std::atomic<PTO2TaskState>`):
+
 - **0 (PENDING)**: waiting for dependencies (`fanin_refcount < fanin_count`)
 - **1 (READY)**: all dependencies satisfied, waiting in ready queue
 - **2 (RUNNING)**: currently executing on a worker
@@ -372,6 +379,7 @@ In the scheduler's `task_state[]` array (`std::atomic<PTO2TaskState>`):
 The orchestrator runs on AICPU Thread 3 and builds the task graph by calling the user-provided orchestration function.
 
 Key members:
+
 - `rings[PTO2_MAX_RING_DEPTH]`: per-ring `PTO2RingSet` (HeapRing + TaskRing + DepPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
 - `tensor_map`, `tensor_pool`: dependency tracking
 - `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
@@ -381,7 +389,7 @@ Key members:
 ### 7.2 Task Submission Flow (`pto2_submit_task`)
 
 | Step | Operation |
-|------|-----------|
+| ---- | --------- |
 | 0 | `pto2_orchestrator_sync_tensormap` — prune stale TensorMap entries |
 | 1 | `pto2_task_ring_alloc` — allocate task slot (may block on flow control) |
 | 2 | Initialize task descriptor, copy parameters |
@@ -401,6 +409,7 @@ The orchestrator and scheduler run concurrently. When adding a consumer to a pro
 3. **Release** `fanout_lock`
 
 The scheduler's completion handler mirrors this:
+
 1. Mark `task_state[slot] = COMPLETED`
 2. **Acquire** `fanout_lock`, read `fanout_head`, **release** lock
 3. Traverse fanout list, incrementing each consumer's `fanin_refcount`
@@ -411,6 +420,7 @@ This lock protocol guarantees every consumer is accounted for exactly once.
 ### 7.4 Scope Mechanism (`PTO2_SCOPE`)
 
 Scopes control the lifetime of intermediate buffers. Each scope:
+
 - Tracks tasks submitted within it via a flat `scope_tasks[]` buffer partitioned by `scope_begins[]`
 - On `scope_end`: increments `fanout_refcount` for scope tasks; when it reaches `fanout_count`, the task's packed buffer can be reclaimed
 
@@ -432,7 +442,7 @@ PTO2_SCOPE(rt) {
 With `aicpu_thread_num=4`, the AICPU runs 4 threads:
 
 | Thread | Role | Cores |
-|--------|------|-------|
+| ------ | ---- | ----- |
 | 0 | Scheduler | 6 AIC + ~13 AIV |
 | 1 | Scheduler | 6 AIC + ~13 AIV |
 | 2 | Scheduler | 6 AIC + ~13 AIV |
@@ -445,10 +455,12 @@ Core assignment: AICs and AIVs are divided equally among the 3 scheduler threads
 Each scheduler thread runs a tight loop with two main phases:
 
 **Phase 1 — Completion Handling**:
+
 - Poll register `COND` on each managed core
 - When `TASK_FIN_STATE` detected: record completion timestamps, call `on_subtask_complete(task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, trigger `on_mixed_task_complete(task_id)` which marks `task_state[slot] = COMPLETED`, acquires fanout lock, traverses fanout list (incrementing consumers' `fanin_refcount`), marks `task_state[slot] = CONSUMED`, and advances `last_task_alive` watermark
 
 **Phase 2 — Dispatch**:
+
 - For each idle core: pop a task from the matching shape-based ready queue (lock-free MPMC Vyukov queue, one per resource shape)
 - Build `PTO2DispatchPayload` from `TaskDescriptor` with `task_id`, `subslot`, `kernel_id`, and `core_type`
 - Write task pointer to `Handshake.task`, signal AICore via register `DATA_MAIN_BASE`
@@ -469,7 +481,7 @@ Ready queues use a lock-free bounded MPMC (Vyukov) design:
 
 After a task reaches state CONSUMED (4), the scheduler tries to advance `last_task_alive`:
 
-```
+```text
 while la < current_task_index:
     if task_state[la & mask] < CONSUMED: break
     reset fanin_refcount[la & mask] = 0
@@ -489,7 +501,7 @@ This is lock-free (CAS-based) and multiple scheduler threads can attempt it conc
 Each AICore worker has a `Handshake` struct in shared memory:
 
 | Field | Direction | Purpose |
-|-------|-----------|---------|
+| ----- | --------- | ------- |
 | `task` | AICPU→AICore | Pointer to `PTO2DispatchPayload` |
 | `control` | AICPU→AICore | 0=normal, 1=shutdown |
 | `perf_records_addr` | AICPU→AICore | Performance buffer address |
@@ -501,11 +513,12 @@ Instead of polling `Handshake.task_status`, the production protocol uses hardwar
 > **Multi-ring note**: `task_id` is 64-bit but registers are 32-bit. A per-core monotonic dispatch counter (`s_dispatch_seq`) replaces `task_id` in register writes to prevent collisions. See [MULTI_RING.md §6](MULTI_RING.md).
 
 | Register | Direction | Usage |
-|----------|-----------|-------|
+| -------- | --------- | ----- |
 | `DATA_MAIN_BASE` | AICPU→AICore | Write `task_id` to dispatch (idle=0x7FFFFFFD); `EXIT_SIGNAL` to shut down |
 | `COND` | AICore→AICPU | `[bit31=state, bits30:0=task_id]`: ACK (state=0) or FIN (state=1) |
 
 **AICore execution loop**:
+
 1. Poll `DATA_MAIN_BASE` for value != AICPU_IDLE_TASK_ID
 2. Read payload from `Handshake.task`
 3. Write ACK to `COND`
@@ -517,7 +530,7 @@ Instead of polling `Handshake.task_status`, the production protocol uses hardwar
 Built by the scheduler from `PTO2TaskDescriptor`:
 
 | Field | Description |
-|-------|-------------|
+| ----- | ----------- |
 | `task_id` | Mixed-task identifier (for completion aggregation) |
 | `subslot` | Which subtask slot this dispatch represents (`AIC`, `AIV0`, or `AIV1`) |
 | `kernel_id` | Function ID for this subtask slot |
@@ -550,12 +563,13 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 ### 10.3 Thread Startup Synchronization
 
 | Flag | Set by | Waited by | Purpose |
-|------|--------|-----------|---------|
+| ---- | ------ | --------- | ------- |
 | `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
 | `pto2_init_done_` | First init thread | Others | One-time memset of arrays started (exchange guard) |
 | `pto2_init_complete_` | Init thread | Thread 3 + others | One-time init of per-task arrays done |
 
 Startup sequence:
+
 1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
 2. Scheduler threads: wait for `runtime_init_ready_` → one thread wins `pto2_init_done_` exchange → memset per-task arrays → set `pto2_init_complete_`; other threads wait for `pto2_init_complete_`
 3. Thread 3: wait for `pto2_init_complete_` → configure orchestrator-scheduler pointers
@@ -571,7 +585,7 @@ The orchestration API is defined in `pto_orchestration_api.h`. Orchestration cod
 ### 11.1 Core API
 
 | Function/Macro | Purpose |
-|----------------|---------|
+| -------------- | ------- |
 | `pto2_rt_submit_task(mixed_kernels, args)` | Submit a mixed task with `MixedKernels` struct |
 | `pto2_rt_submit_aic_task(kernel_id, args)` | Convenience: submit AIC-only task |
 | `pto2_rt_submit_aiv_task(kernel_id, args)` | Convenience: submit AIV-only task |
@@ -581,7 +595,7 @@ The orchestration API is defined in `pto_orchestration_api.h`. Orchestration cod
 ### 11.2 Parameter Construction
 
 | Function | Description |
-|----------|-------------|
+| -------- | ----------- |
 | `make_tensor_external(ptr, shapes, ndim, dtype)` | Wrap an existing device pointer as a tensor |
 | `TensorCreateInfo(shapes, ndim, dtype)` | Describe a runtime-created output buffer |
 | `Arg::add_input(tensor)` | INPUT parameter — read by the task |
@@ -594,7 +608,7 @@ The orchestration API is defined in `pto_orchestration_api.h`. Orchestration cod
 Tasks are queued by resource shape, which is derived from the `active_mask` in the `MixedKernels` struct:
 
 | Shape | Active Mask | Description |
-|-------|-------------|-------------|
+| ----- | ----------- | ----------- |
 | `AIC_ONLY` | AIC only | AIC cores (matrix multiplication) |
 | `AIV_X1` | AIV0 or AIV1 only | Single AIV core (vector operations) |
 | `AIV_X2` | AIV0 + AIV1 | Two AIV cores |
@@ -607,7 +621,7 @@ Each orchestration `.so` must export:
 
 ```cpp
 extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count);
-extern "C" void aicpu_orchestration_entry(uint64_t* args, int arg_count, int orch_thread_num, int orch_thread_index);
+extern "C" void aicpu_orchestration_entry(uint64_t* args, int arg_count);
 ```
 
 ---
@@ -640,7 +654,7 @@ RUNTIME_CONFIG = {
 ### 12.2 Orchestration Structure
 
 ```cpp
-void aicpu_orchestration_entry(uint64_t* args, int arg_count, int orch_thread_num, int orch_thread_index) {
+void aicpu_orchestration_entry(uint64_t* args, int arg_count) {
     // Unpack args: query, key_cache, value_cache, block_table, context_lens, out, config
     for (q_idx = 0; q_idx < q_loop; q_idx++) {
         for (batch_start = 0; batch_start < batch; batch_start += IN_CORE_BATCH) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -36,9 +36,8 @@ Legacy per-task submit (`kernel_id + worker_type`) cannot express atomic co-disp
 
 Design must preserve the current main runtime architecture:
 
-1. Multi-orchestrator runtime wiring (`orchestrators[]`, `orch_count`, thread-local `pto2_current_orch_idx`).
-2. Executor threading split (orchestrator threads vs scheduler threads), and post-orchestrator transition (`transition_requested_` + `reassign_cores_for_all_threads()`).
-3. Shared-memory hot/cold split (`PTO2TaskDescriptor` hot + `PTO2TaskPayload` cold).
+1. Executor threading split (orchestrator thread vs scheduler threads), and post-orchestrator transition (`transition_requested_` + `reassign_cores_for_all_threads()`).
+2. Shared-memory hot/cold split (`PTO2TaskDescriptor` hot + `PTO2TaskPayload` cold).
 
 ## 5. Terminology
 
@@ -197,7 +196,7 @@ Recommended validation coverage:
 2. Atomic dispatch for multi-slot shapes.
 3. Dependency gating and completion aggregation (`done_mask == active_mask`).
 4. Lane-occupancy co-residency behavior for compatible shapes.
-5. Multi-orchestrator and core-transition ownership stability.
+5. Core-transition ownership stability.
 6. Invalid submit handling (`always_assert` path).
 7. Regression coverage for existing examples/tests.
 
@@ -223,4 +222,3 @@ Final validation:
 3. Per-cluster concurrent capacity is lane-occupancy-driven, not a fixed constant.
 4. Submit-contract types live in one shared header-only surface.
 5. Resource-aware dispatch heuristics are allowed without a strict starvation-free guarantee.
-

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -38,16 +38,16 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // =============================================================================
 
 static TaskOutputTensors submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
-    return pto2_submit_mixed_task(&rt->orchestrators[0], mixed_kernels, args);
+    return pto2_submit_mixed_task(&rt->orchestrator, mixed_kernels, args);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrators[0]); }
+void pto2_rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrator); }
 
-void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrators[0]); }
+void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrator); }
 
-void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrators[0]); }
+void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrator); }
 
-static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrators[0].fatal; }
+static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
 
 // Wait for all producers of this tensor to be safe for data access.
 // Checks owner metadata (lifecycle anchor) and OverlapMap (modifier writers).
@@ -58,7 +58,7 @@ static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrators[0].fatal; 
 // Returns false on timeout (sets orch.fatal).
 MAYBE_UNINITIALIZED_BEGIN
 static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wait_for_consumers, const char *caller) {
-    PTO2OrchestratorState &orch = rt->orchestrators[0];
+    PTO2OrchestratorState &orch = rt->orchestrator;
 
     // Collect producer slot states from both maps, deduplicated by pointer.
     // +1: one creator slot + up to PTO2_LOOKUP_MAX_RESULTS modifier slots.
@@ -209,7 +209,6 @@ PTO2Runtime *pto2_runtime_create_custom(
 
     rt->ops = &s_runtime_ops;
     rt->mode = mode;
-    rt->orch_count = 1;
     rt->sm_handle = pto2_sm_create(task_window_size, heap_size);
     if (!rt->sm_handle) {
         free(rt);
@@ -235,8 +234,8 @@ PTO2Runtime *pto2_runtime_create_custom(
 #endif
     rt->gm_heap_owned = true;
 
-    // Initialize first orchestrator
-    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
+    // Initialize orchestrator
+    if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
         free(rt);
@@ -245,7 +244,7 @@ PTO2Runtime *pto2_runtime_create_custom(
 
     // Initialize scheduler (heap_size = per-ring heap size)
     if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
-        pto2_orchestrator_destroy(&rt->orchestrators[0]);
+        pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
         free(rt);
@@ -253,18 +252,16 @@ PTO2Runtime *pto2_runtime_create_custom(
     }
 
     // Connect orchestrator to scheduler (for simulated mode)
-    pto2_orchestrator_set_scheduler(&rt->orchestrators[0], &rt->scheduler);
+    pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
 
     return rt;
 }
 
 PTO2Runtime *pto2_runtime_create_from_sm(
-    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count,
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity
 ) {
     if (!sm_handle) return NULL;
-    if (orch_count < 1) orch_count = 1;
-    if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
 
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) return NULL;
@@ -275,32 +272,20 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     rt->gm_heap = gm_heap;
     rt->gm_heap_size = heap_size > 0 ? heap_size * PTO2_MAX_RING_DEPTH : 0;
     rt->gm_heap_owned = false;
-    rt->orch_count = orch_count;
 
-    // Initialize all orchestrator states
-    for (int i = 0; i < orch_count; i++) {
-        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
-            for (int j = 0; j < i; j++) {
-                pto2_orchestrator_destroy(&rt->orchestrators[j]);
-            }
-            free(rt);
-            return NULL;
-        }
-    }
-
-    // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
-        for (int i = 0; i < orch_count; i++) {
-            pto2_orchestrator_destroy(&rt->orchestrators[i]);
-        }
+    if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt);
         return NULL;
     }
 
-    // Connect all orchestrators to scheduler
-    for (int i = 0; i < orch_count; i++) {
-        pto2_orchestrator_set_scheduler(&rt->orchestrators[i], &rt->scheduler);
+    // Initialize scheduler (heap_size = per-ring heap size)
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
+        pto2_orchestrator_destroy(&rt->orchestrator);
+        free(rt);
+        return NULL;
     }
+
+    pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
 
     return rt;
 }
@@ -309,9 +294,7 @@ void pto2_runtime_destroy(PTO2Runtime *rt) {
     if (!rt) return;
 
     pto2_scheduler_destroy(&rt->scheduler);
-    for (int i = 0; i < rt->orch_count; i++) {
-        pto2_orchestrator_destroy(&rt->orchestrators[i]);
-    }
+    pto2_orchestrator_destroy(&rt->orchestrator);
 
     if (rt->gm_heap_owned && rt->gm_heap) {
         free(rt->gm_heap);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -43,9 +43,6 @@
 #include "pto_scheduler.h"
 #include "pto_orchestrator.h"
 
-// Maximum number of orchestrator threads supported
-constexpr int PTO2_MAX_ORCH_THREADS = 4;
-
 // =============================================================================
 // Runtime Context
 // =============================================================================
@@ -102,8 +99,7 @@ struct PTO2Runtime {
 
     // Components
     PTO2SharedMemoryHandle *sm_handle;
-    PTO2OrchestratorState orchestrators[PTO2_MAX_ORCH_THREADS];
-    int orch_count;  // Number of active orchestrator states
+    PTO2OrchestratorState orchestrator;
     PTO2SchedulerState scheduler;
 
     // GM Heap for output buffers
@@ -154,7 +150,7 @@ PTO2Runtime *pto2_runtime_create_custom(
  * @return Runtime context, or NULL on failure
  */
 PTO2Runtime *pto2_runtime_create_from_sm(
-    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count = 1,
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -33,7 +33,6 @@ Runtime::Runtime() {
     memset(workers, 0, sizeof(workers));
     worker_count = 0;
     sche_cpu_num = 1;
-    orch_thread_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
     pto2_task_window_size = 0;
     pto2_heap_size = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -158,7 +158,6 @@ public:  // NOLINT(whitespace/indent)
 
     // Execution parameters for AICPU scheduling
     int sche_cpu_num;        // Number of AICPU threads for scheduling
-    int orch_thread_num;     // Number of orchestrator threads (default 1)
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)

--- a/src/a5/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/performance_collector_aicpu.h
@@ -102,9 +102,8 @@ void perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks);
  *
  * @param runtime Runtime instance pointer
  * @param num_sched_threads Number of scheduler threads
- * @param num_orch_threads Number of orchestrator threads (may become schedulers after transition)
  */
-void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, int num_orch_threads = 1);
+void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads);
 
 /**
  * Record a single scheduler phase

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -309,15 +309,7 @@ int DeviceRunner::run(
         return -1;
     }
 
-    // Validate orchestrator configuration
-    int scheduler_thread_num = launch_aicpu_num - runtime.orch_thread_num;
-
-    if (runtime.orch_thread_num > launch_aicpu_num) {
-        LOG_ERROR(
-            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num
-        );
-        return -1;
-    }
+    int scheduler_thread_num = runtime.get_orch_built_on_host() ? launch_aicpu_num : launch_aicpu_num - 1;
 
     // Validate even core distribution for initial scheduler threads
     if (scheduler_thread_num > 0) {

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -100,9 +100,9 @@ int set_device(int device_id) {
 }
 
 int run_runtime(
-    RuntimeHandle runtime, const void *callable, const void *args, int block_dim, int aicpu_thread_num,
-    int orch_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_profiling
+    RuntimeHandle runtime, const void *callable, const void *args, int block_dim, int aicpu_thread_num, int device_id,
+    const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size,
+    int enable_profiling
 ) {
     if (runtime == NULL) return -1;
     if (aicpu_binary == NULL || aicpu_size == 0 || aicore_binary == NULL || aicore_size == 0) return -1;
@@ -135,7 +135,6 @@ int run_runtime(
         }
 
         // Phase 3: launch
-        r->orch_thread_num = orch_thread_num;
         DeviceRunner &runner = DeviceRunner::get();
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -229,15 +229,7 @@ int DeviceRunner::run(
         return -1;
     }
 
-    // Validate orchestrator configuration
-    int scheduler_thread_num = launch_aicpu_num - runtime.orch_thread_num;
-
-    if (runtime.orch_thread_num > launch_aicpu_num) {
-        LOG_ERROR(
-            "orch_thread_num (%d) cannot exceed aicpu_thread_num (%d)", runtime.orch_thread_num, launch_aicpu_num
-        );
-        return -1;
-    }
+    int scheduler_thread_num = runtime.get_orch_built_on_host() ? launch_aicpu_num : launch_aicpu_num - 1;
 
     // Validate even core distribution for initial scheduler threads
     if (scheduler_thread_num > 0) {

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -98,9 +98,9 @@ int set_device(int device_id) {
 }
 
 int run_runtime(
-    RuntimeHandle runtime, const void *callable, const void *args, int block_dim, int aicpu_thread_num,
-    int orch_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_profiling
+    RuntimeHandle runtime, const void *callable, const void *args, int block_dim, int aicpu_thread_num, int device_id,
+    const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size,
+    int enable_profiling
 ) {
     if (runtime == NULL) return -1;
 
@@ -130,7 +130,6 @@ int run_runtime(
         }
 
         // Phase 3: launch
-        r->orch_thread_num = orch_thread_num;
         DeviceRunner &runner = DeviceRunner::get();
         std::vector<uint8_t> aicpu_vec;
         std::vector<uint8_t> aicore_vec;

--- a/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -38,7 +38,7 @@ static PerfBufferState *s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
 static PhaseBufferState *s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
 static PhaseBuffer *s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
-static __thread int s_orch_thread_idx = -1;
+static int s_orch_thread_idx = -1;
 
 /**
  * Enqueue ready buffer to per-thread queue
@@ -279,7 +279,7 @@ void perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks) {
     wmb();
 }
 
-void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, int num_orch_threads) {
+void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
     void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         LOG_ERROR("perf_data_base is NULL, cannot initialize phase profiling");
@@ -298,8 +298,8 @@ void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, in
     memset(&s_phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
 
     // Cache per-thread record pointers and clear buffers
-    // Include all threads: scheduler + orchestrator (orchestrators may become schedulers)
-    int total_threads = num_sched_threads + num_orch_threads;
+    // Include all threads: scheduler + orchestrator (orchestrator may become scheduler)
+    int total_threads = num_sched_threads + 1;
     if (total_threads > PLATFORM_MAX_AICPU_THREADS) {
         total_threads = PLATFORM_MAX_AICPU_THREADS;
     }
@@ -342,8 +342,8 @@ void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads, in
     wmb();
 
     LOG_INFO(
-        "Phase profiling initialized: %d scheduler + %d orch threads, %d records/thread", num_sched_threads,
-        num_orch_threads, PLATFORM_PHASE_RECORDS_PER_THREAD
+        "Phase profiling initialized: %d scheduler + 1 orch thread, %d records/thread", num_sched_threads,
+        PLATFORM_PHASE_RECORDS_PER_THREAD
     );
 }
 

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -45,7 +45,6 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     sche_cpu_num = 1;
-    orch_thread_num = 1;
     enable_profiling = false;
     perf_data_base = 0;
     tensor_pair_count = 0;

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -199,8 +199,7 @@ public:
     int worker_count;                       // Number of active workers
 
     // Execution parameters for AICPU scheduling
-    int sche_cpu_num;     // Number of AICPU threads for scheduling
-    int orch_thread_num;  // Number of orchestrator threads (unused, for API compatibility)
+    int sche_cpu_num;  // Number of AICPU threads for scheduling
 
     // Profiling support
     bool enable_profiling;    // Enable profiling flag
@@ -232,6 +231,9 @@ public:
      * Constructor - zero-initialize all arrays
      */
     Runtime();
+
+    // Orchestration is always built on the host for this runtime
+    bool get_orch_built_on_host() const { return true; }
 
     // =========================================================================
     // Task Management

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -68,9 +68,7 @@
 // Device orchestration function signature (loaded via dlopen).
 // The executor binds the current thread's PTO2Runtime into orchestration TLS
 // before calling the user entry.
-typedef void (*DeviceOrchestrationFunc)(
-    const ChipStorageTaskArgs &orch_args, int32_t orch_thread_num, int32_t orch_thread_index
-);
+typedef void (*DeviceOrchestrationFunc)(const ChipStorageTaskArgs &orch_args);
 typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 
 // Config function exported by orchestration .so
@@ -275,7 +273,6 @@ private:
 };
 
 struct AicpuExecutor {
-    int32_t orch_thread_num_;
     int32_t sched_thread_num_;
     int32_t active_sched_threads_{0};  // Threads currently in dispatch loop (initially sched_thread_num_, becomes
                                        // thread_num_ after orch→sched transition)
@@ -334,8 +331,6 @@ struct AicpuExecutor {
     std::atomic<bool> pto2_init_done_{false};
     std::atomic<bool> runtime_init_ready_{false};
     std::atomic<bool> pto2_init_complete_{false};  // init block finished; others wait for this
-    std::atomic<int32_t> orch_finished_count_{0};  // Number of orchestrator threads that have finished
-
     // ===== Dynamic core transition state =====
     std::atomic<bool> transition_requested_{false};
     std::atomic<int32_t> wait_reassign_{0};
@@ -1012,11 +1007,6 @@ bool AicpuExecutor::assign_cores_to_threads() {
         core_count_per_thread_[i] = 0;
     }
 
-    // Mark orchestrator threads explicitly (no cores).
-    for (int32_t t = divisor; t < thread_num_; t++) {
-        DEV_INFO("Thread %d: orchestrator (0 cores)", t);
-    }
-
     // Per-sched-thread running core index used while filling core_assignments_.
     int32_t core_idx[MAX_AICPU_THREADS] = {};
     int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
@@ -1137,19 +1127,9 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
 
     // Read execution parameters from runtime
     thread_num_ = runtime->sche_cpu_num;
-    orch_thread_num_ = runtime->orch_thread_num;
-    sched_thread_num_ = thread_num_ - orch_thread_num_;
+    sched_thread_num_ = thread_num_ - 1;
     orch_to_sched_ = runtime->orch_to_sched;
     if (thread_num_ == 0) thread_num_ = 1;
-
-    if (!orch_to_sched_ && sched_thread_num_ == 0) {
-        DEV_ERROR(
-            "no scheduler and orch not trans to schedulers when finished, maybe you need set env PTO2_ORCH_TO_SCHED=1 "
-            "or scale down orch number."
-        );
-        init_failed_.store(true, std::memory_order_release);
-        return -1;
-    }
 
     if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
         DEV_ERROR("Invalid thread_num: %d", thread_num_);
@@ -1279,7 +1259,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         if (runtime->enable_profiling) {
             perf_aicpu_init_profiling(runtime);
             // Initialize phase profiling for scheduler threads + orchestrator threads
-            perf_aicpu_init_phase_profiling(runtime, sched_thread_num_, orch_thread_num_);
+            perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
             perf_aicpu_set_orch_thread_idx(sched_thread_num_);
         }
 #endif
@@ -1991,222 +1971,191 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         uint64_t orch_cycle_start = 0;
         int32_t pto2_submitted_tasks = -1;
 #endif
-        int32_t orch_idx = thread_idx - sched_thread_num_;
         if (runtime->get_orch_built_on_host()) {
-            DEV_INFO("Thread %d: Host orchestration mode, no-op (orch_idx=%d)", thread_idx, orch_idx);
+            DEV_INFO("Thread %d: Host orchestration mode, no-op", thread_idx);
         } else {
-            // First orchestrator thread (orch_idx == 0): load SO, create runtime
-            if (orch_idx == 0) {
-                DEV_INFO("Thread %d: Primary orchestrator, loading SO via dlopen", thread_idx);
+            DEV_INFO("Thread %d: Orchestrator, loading SO via dlopen", thread_idx);
 
-                const void *so_data = runtime->get_device_orch_so_data();
-                size_t so_size = runtime->get_device_orch_so_size();
+            const void *so_data = runtime->get_device_orch_so_data();
+            size_t so_size = runtime->get_device_orch_so_size();
 
-                if (so_data == nullptr || so_size == 0) {
-                    DEV_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
-                    return -1;
-                }
-
-                // Try multiple paths that may allow execution on AICPU
-                char so_path[256];
-                bool file_created = false;
-                const char *candidate_dirs[] = {
-                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
-                };
-                const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
-
-                for (int32_t i = 0; i < num_candidates && !file_created; i++) {
-                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
-                    int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
-                    if (fd < 0) {
-                        DEV_INFO(
-                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
-                        );
-                        continue;
-                    }
-                    ssize_t written = write(fd, so_data, so_size);
-                    close(fd);
-                    if (written != static_cast<ssize_t>(so_size)) {
-                        DEV_INFO(
-                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
-                        );
-                        unlink(so_path);
-                        continue;
-                    }
-                    file_created = true;
-                    DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
-                }
-
-                if (!file_created) {
-                    DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
-                    return -1;
-                }
-
-                dlerror();
-                void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
-                const char *dlopen_err = dlerror();
-                if (handle == nullptr) {
-                    DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
-                    unlink(so_path);
-                    return -1;
-                }
-                DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
-
-                dlerror();
-                auto config_func =
-                    reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
-
-                dlerror();
-                DeviceOrchestrationFunc orch_func =
-                    reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
-                const char *dlsym_error = dlerror();
-                if (dlsym_error != nullptr) {
-                    DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-                if (orch_func == nullptr) {
-                    DEV_ERROR("Thread %d: dlsym returned NULL for aicpu_orchestration_entry", thread_idx);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-                dlerror();
-                auto bind_runtime_func =
-                    reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
-                const char *bind_runtime_error = dlerror();
-                if (bind_runtime_error != nullptr) {
-                    DEV_INFO("Thread %d: Optional TLS runtime binder not found: %s", thread_idx, bind_runtime_error);
-                    bind_runtime_func = nullptr;
-                }
-
-                const ChipStorageTaskArgs &args = runtime->get_orch_args();
-                int32_t arg_count = args.tensor_count() + args.scalar_count();
-                DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
-                for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
-                    const ContinuousTensor &t = args.tensor(i);
-                    DEV_INFO(
-                        "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
-                        static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
-                    );
-                }
-                for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
-                    DEV_INFO(
-                        "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
-                        static_cast<uint64_t>(args.scalar(i))
-                    );
-                }
-
-                uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
-                uint64_t heap_size = PTO2_HEAP_SIZE;
-                int32_t expected_arg_count = 0;
-                if (config_func) {
-                    PTO2OrchestrationConfig cfg = config_func(args);
-                    expected_arg_count = cfg.expected_arg_count;
-                    DEV_INFO("Thread %d: Config: expected_args=%d", thread_idx, expected_arg_count);
-                } else {
-                    DEV_INFO("Thread %d: No config function, using defaults", thread_idx);
-                }
-
-                if (expected_arg_count > 0 && arg_count < expected_arg_count) {
-                    DEV_ERROR("Thread %d: arg_count %d < expected %d", thread_idx, arg_count, expected_arg_count);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-                if (runtime->pto2_task_window_size > 0) {
-                    task_window_size = runtime->pto2_task_window_size;
-                }
-                if (runtime->pto2_heap_size > 0) {
-                    heap_size = runtime->pto2_heap_size;
-                }
-                int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
-                if (runtime->pto2_dep_pool_size > 0) {
-                    dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
-                }
-                DEV_INFO(
-                    "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
-                    static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
-                );
-
-                void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
-                void *gm_heap = runtime->get_pto2_gm_heap_ptr();
-
-                uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
-                PTO2SharedMemoryHandle *sm_handle =
-                    pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
-                if (!sm_handle) {
-                    DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-                rt = pto2_runtime_create_from_sm(
-                    PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, orch_thread_num_, dep_pool_capacity
-                );
-                if (!rt) {
-                    DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
-                    pto2_sm_destroy(sm_handle);
-                    dlclose(handle);
-                    unlink(so_path);
-                    return -1;
-                }
-
-                // Total core counts for submit-time deadlock detection.
-                for (int i = 0; i < orch_thread_num_; i++) {
-                    rt->orchestrators[i].total_cluster_count = aic_count_;
-                    rt->orchestrators[i].total_aiv_count = aiv_count_;
-                }
-#if PTO2_PROFILING
-                for (int i = 0; i < orch_thread_num_; i++) {
-                    rt->orchestrators[i].enable_profiling = runtime->enable_profiling;
-                }
-#endif
-
-                // With multi-ring, slot_states are per-ring inside the scheduler.
-                runtime->set_pto2_slot_states_ptr(nullptr);
-
-                // Store shared state for other orchestrator threads
-                orch_func_ = orch_func;
-                orch_bind_runtime_ = bind_runtime_func;
-                orch_args_cached_ = &args;
-                orch_so_handle_ = handle;
-                snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
-
-                // All-orchestrator mode: primary orchestrator does one-time init
-                if (sched_thread_num_ == 0) {
-                    DEV_INFO("Thread %d: All-orchestrator mode, doing one-time init", thread_idx);
-                    if (runtime->enable_profiling) {
-                        perf_aicpu_init_profiling(runtime);
-                        // After transition, all threads become schedulers
-                        perf_aicpu_init_phase_profiling(runtime, thread_num_, orch_thread_num_);
-                        perf_aicpu_set_orch_thread_idx(0);
-                    }
-                    pto2_init_done_.store(true, std::memory_order_release);
-                    pto2_init_complete_.store(true, std::memory_order_release);
-                    DEV_INFO("Thread %d: One-time init done", thread_idx);
-                }
-
-                runtime_init_ready_.store(true, std::memory_order_release);
-            } else {
-                // Non-primary orchestrator: wait for primary to finish setup
-                while (!runtime_init_ready_.load(std::memory_order_acquire)) {
-                    SPIN_WAIT_HINT();
-                }
+            if (so_data == nullptr || so_size == 0) {
+                DEV_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
+                return -1;
             }
 
+            // Try multiple paths that may allow execution on AICPU
+            char so_path[256];
+            bool file_created = false;
+            const char *candidate_dirs[] = {
+                "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
+            };
+            const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
+
+            for (int32_t i = 0; i < num_candidates && !file_created; i++) {
+                snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
+                int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+                if (fd < 0) {
+                    DEV_INFO(
+                        "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
+                    );
+                    continue;
+                }
+                ssize_t written = write(fd, so_data, so_size);
+                close(fd);
+                if (written != static_cast<ssize_t>(so_size)) {
+                    DEV_INFO(
+                        "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
+                    );
+                    unlink(so_path);
+                    continue;
+                }
+                file_created = true;
+                DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+            }
+
+            if (!file_created) {
+                DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
+                return -1;
+            }
+
+            dlerror();
+            void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+            const char *dlopen_err = dlerror();
+            if (handle == nullptr) {
+                DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
+                unlink(so_path);
+                return -1;
+            }
+            DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
+
+            dlerror();
+            auto config_func =
+                reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
+
+            dlerror();
+            DeviceOrchestrationFunc orch_func =
+                reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
+            const char *dlsym_error = dlerror();
+            if (dlsym_error != nullptr) {
+                DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+            if (orch_func == nullptr) {
+                DEV_ERROR("Thread %d: dlsym returned NULL for aicpu_orchestration_entry", thread_idx);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+            dlerror();
+            auto bind_runtime_func =
+                reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
+            const char *bind_runtime_error = dlerror();
+            if (bind_runtime_error != nullptr) {
+                DEV_INFO("Thread %d: Optional TLS runtime binder not found: %s", thread_idx, bind_runtime_error);
+                bind_runtime_func = nullptr;
+            }
+
+            const ChipStorageTaskArgs &args = runtime->get_orch_args();
+            int32_t arg_count = args.tensor_count() + args.scalar_count();
+            DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
+            for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
+                const ContinuousTensor &t = args.tensor(i);
+                DEV_INFO(
+                    "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
+                    static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
+                );
+            }
+            for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
+                DEV_INFO(
+                    "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
+                    static_cast<uint64_t>(args.scalar(i))
+                );
+            }
+
+            uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
+            uint64_t heap_size = PTO2_HEAP_SIZE;
+            int32_t expected_arg_count = 0;
+            if (config_func) {
+                PTO2OrchestrationConfig cfg = config_func(args);
+                expected_arg_count = cfg.expected_arg_count;
+                DEV_INFO("Thread %d: Config: expected_args=%d", thread_idx, expected_arg_count);
+            } else {
+                DEV_INFO("Thread %d: No config function, using defaults", thread_idx);
+            }
+
+            if (expected_arg_count > 0 && arg_count < expected_arg_count) {
+                DEV_ERROR("Thread %d: arg_count %d < expected %d", thread_idx, arg_count, expected_arg_count);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+            if (runtime->pto2_task_window_size > 0) {
+                task_window_size = runtime->pto2_task_window_size;
+            }
+            if (runtime->pto2_heap_size > 0) {
+                heap_size = runtime->pto2_heap_size;
+            }
+            int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
+            if (runtime->pto2_dep_pool_size > 0) {
+                dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
+            }
+            DEV_INFO(
+                "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
+                static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
+            );
+
+            void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
+            void *gm_heap = runtime->get_pto2_gm_heap_ptr();
+
+            uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+            PTO2SharedMemoryHandle *sm_handle =
+                pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
+            if (!sm_handle) {
+                DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+            rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
+            if (!rt) {
+                DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
+                pto2_sm_destroy(sm_handle);
+                dlclose(handle);
+                unlink(so_path);
+                return -1;
+            }
+
+            // Core counts for submit-time deadlock detection.
+            rt->orchestrator.total_cluster_count = aic_count_;
+            rt->orchestrator.total_aiv_count = aiv_count_;
+#if PTO2_PROFILING
+            rt->orchestrator.enable_profiling = runtime->enable_profiling;
+#endif
+
+            // With multi-ring, slot_states are per-ring inside the scheduler.
+            runtime->set_pto2_slot_states_ptr(nullptr);
+
+            // Store shared state
+            orch_func_ = orch_func;
+            orch_bind_runtime_ = bind_runtime_func;
+            orch_args_cached_ = &args;
+            orch_so_handle_ = handle;
+            snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
+
+            runtime_init_ready_.store(true, std::memory_order_release);
+
             // Wait for scheduler's one-time init to complete
-            // (or primary orchestrator's init in all-orchestrator mode)
             while (!pto2_init_complete_.load(std::memory_order_acquire)) {
                 SPIN_WAIT_HINT();
             }
 
 #if PTO2_PROFILING
-            // Each orchestrator thread sets its own phase buffer index (thread-local)
             if (runtime->enable_profiling) {
                 perf_aicpu_set_orch_thread_idx(thread_idx);
             }
@@ -2219,7 +2168,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 orch_bind_runtime_(rt);
             }
             pto2_rt_scope_begin(rt);
-            orch_func_(*orch_args_cached_, orch_thread_num_, orch_idx);
+            orch_func_(*orch_args_cached_);
             pto2_rt_scope_end(rt);
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
@@ -2321,102 +2270,81 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 #endif
 
-            // Coordinate orchestrator completion
-            int32_t finished = orch_finished_count_.fetch_add(1, std::memory_order_acq_rel) + 1;
-            if (finished == orch_thread_num_) {
-                // Last orchestrator: signal completion and trigger core transition
-                pto2_rt_orchestration_done(rt);
+            // Signal orchestration completion and trigger core transition
+            pto2_rt_orchestration_done(rt);
 
-                void *sm = runtime->get_pto2_gm_sm_ptr();
-                PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
-                int32_t pto2_task_count = 0;
-                if (sm_header) {
-                    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                        pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
-                    }
-                }
-#if PTO2_PROFILING
-                pto2_submitted_tasks = pto2_task_count;
-#endif
-                total_tasks_ = pto2_task_count;
-                if (runtime->enable_profiling && pto2_task_count > 0) {
-                    perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
-                }
-                orchestrator_done_ = true;
-                {
-                    int32_t orch_err = 0;
-                    void *sm = runtime->get_pto2_gm_sm_ptr();
-                    if (sm) {
-                        orch_err =
-                            static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
-                    }
-
-                    // Fatal error: shutdown AICore immediately before core transition.
-                    if (orch_err != PTO2_ERROR_NONE) {
-                        emergency_shutdown(runtime);
-                        completed_.store(true, std::memory_order_release);
-                    }
-                }
-
-#if PTO2_ORCH_PROFILING
-                uint64_t reassign_cycle_start = get_sys_cnt_aicpu();
-#endif
-
-                // Skip core transition on fatal error — cores already shut down above
-                if (completed_.load(std::memory_order_acquire)) {
-                    // Signal transition to unblock scheduler threads waiting at core transition
-                    transition_requested_.store(true, std::memory_order_release);
-                    reassigned_.store(true, std::memory_order_release);
-                } else if (orch_to_sched_) {
-                    // Compute new core assignments for all threads and initialize donated slots
-                    DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
-#if PTO2_PROFILING
-                    uint64_t orch_stage_end_ts = get_sys_cnt_aicpu();
-#endif
-                    transition_requested_.store(true, std::memory_order_release);
-#if PTO2_PROFILING
-                    DEV_ALWAYS(
-                        "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
-                    );
-#endif
-
-                    // Wait for scheduler threads to acknowledge transition request
-                    // All-orchestrator mode (sched_thread_num_ == 0): skip the wait
-                    if (sched_thread_num_ > 0) {
-                        while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
-                            if (completed_.load(std::memory_order_acquire)) {
-                                break;
-                            }
-                            SPIN_WAIT_HINT();
-                        }
-                    }
-                    if (!completed_.load(std::memory_order_acquire)) {
-                        reassign_cores_for_all_threads();
-                        reassigned_.store(true, std::memory_order_release);
-                    }
-                }
-
-#if PTO2_ORCH_PROFILING
-                uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
-                DEV_ALWAYS(
-                    "Thread %d: reassign, cost %.3fus (orch_idx=%d)", thread_idx,
-                    cycles_to_us(reassign_cycle_end - reassign_cycle_start), orch_idx
-                );
-#endif
-            } else {
-                // Non-last orchestrator: wait for last orchestrator to finish setup
-                if (orch_to_sched_) {
-                    while (!transition_requested_.load(std::memory_order_acquire)) {
-                        SPIN_WAIT_HINT();
-                    }
-                    while (!reassigned_.load(std::memory_order_acquire)) {
-                        if (completed_.load(std::memory_order_acquire)) {
-                            break;
-                        }
-                        SPIN_WAIT_HINT();
-                    }
+            void *sm = runtime->get_pto2_gm_sm_ptr();
+            PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
+            int32_t pto2_task_count = 0;
+            if (sm_header) {
+                for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                    pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                 }
             }
+#if PTO2_PROFILING
+            pto2_submitted_tasks = pto2_task_count;
+#endif
+            total_tasks_ = pto2_task_count;
+            if (runtime->enable_profiling && pto2_task_count > 0) {
+                perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
+            }
+            orchestrator_done_ = true;
+            {
+                int32_t orch_err = 0;
+                void *sm = runtime->get_pto2_gm_sm_ptr();
+                if (sm) {
+                    orch_err =
+                        static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
+                }
+
+                // Fatal error: shutdown AICore immediately before core transition.
+                if (orch_err != PTO2_ERROR_NONE) {
+                    emergency_shutdown(runtime);
+                    completed_.store(true, std::memory_order_release);
+                }
+            }
+
+#if PTO2_ORCH_PROFILING
+            uint64_t reassign_cycle_start = get_sys_cnt_aicpu();
+#endif
+
+            // Skip core transition on fatal error — cores already shut down above
+            if (completed_.load(std::memory_order_acquire)) {
+                // Signal transition to unblock scheduler threads waiting at core transition
+                transition_requested_.store(true, std::memory_order_release);
+                reassigned_.store(true, std::memory_order_release);
+            } else if (orch_to_sched_) {
+                // Compute new core assignments for all threads and initialize donated slots
+                DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
+#if PTO2_PROFILING
+                uint64_t orch_stage_end_ts = get_sys_cnt_aicpu();
+#endif
+                transition_requested_.store(true, std::memory_order_release);
+#if PTO2_PROFILING
+                DEV_ALWAYS(
+                    "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
+                );
+#endif
+
+                // Wait for scheduler threads to acknowledge transition request
+                while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
+                    if (completed_.load(std::memory_order_acquire)) {
+                        break;
+                    }
+                    SPIN_WAIT_HINT();
+                }
+                if (!completed_.load(std::memory_order_acquire)) {
+                    reassign_cores_for_all_threads();
+                    reassigned_.store(true, std::memory_order_release);
+                }
+            }
+
+#if PTO2_ORCH_PROFILING
+            uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
+            DEV_ALWAYS(
+                "Thread %d: reassign, cost %.3fus", thread_idx, cycles_to_us(reassign_cycle_end - reassign_cycle_start)
+            );
+#endif
         }
 #if PTO2_PROFILING
         uint64_t orch_end_ts = get_sys_cnt_aicpu();
@@ -2432,7 +2360,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             );
         }
 #endif
-        DEV_INFO("Thread %d: Orchestrator completed (orch_idx=%d)", thread_idx, orch_idx);
+        DEV_INFO("Thread %d: Orchestrator completed", thread_idx);
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
@@ -2512,14 +2440,11 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     wait_reassign_.store(0, std::memory_order_release);
     reassigned_.store(false, std::memory_order_release);
     completed_.store(false, std::memory_order_release);
-    orch_finished_count_.store(0, std::memory_order_release);
-
     // Reset core discovery and assignment state
     aic_count_ = 0;
     aiv_count_ = 0;
     cores_total_num_ = 0;
     thread_num_ = 0;
-    orch_thread_num_ = 0;
     sched_thread_num_ = 0;
     thread_cores_num_ = 0;
     orch_to_sched_ = false;

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -9,7 +9,7 @@ PTO2 (Parallel Task Orchestration v2) is a runtime system for executing task gra
 - **AICore** (AI compute cores): executes kernel functions dispatched by the scheduler.
 - **Shared Memory** (Global Memory): ring buffers, task descriptors, heap, and TensorMap shared between orchestrator and schedulers.
 
-```
+```text
 ┌───────────────────────────────────────────────────────────────────────┐
 │                            Host (CPU)                                 │
 │  golden.py → code_runner.py → compile kernels → init Runtime          │
@@ -73,7 +73,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 ### 2.1 a2a3 (Real Ascend Hardware)
 
 | Component | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | `device_runner.cpp` | Uses CANN APIs: `rtMalloc`, `rtMemcpy`, `rtLaunchKernel` |
 | `memory_allocator.cpp` | Wraps `rtMalloc`/`rtFree` with allocation tracking |
 | `aicore/kernel.cpp` | `KERNEL_ENTRY(aicore_kernel)` → `aicore_execute` |
@@ -83,7 +83,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 ### 2.2 a2a3sim (Thread Simulation)
 
 | Component | Description |
-|-----------|-------------|
+| --------- | ----------- |
 | `device_runner.cpp` | Uses `std::thread` to simulate AICPU/AICore |
 | `memory_allocator.cpp` | Wraps `malloc`/`free` |
 | `aicore/kernel.cpp` | `aicore_execute_wrapper` sets `g_sim_reg_base` per core |
@@ -92,7 +92,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 ### 2.3 Platform Constants (`platform_config.h`)
 
 | Constant | Value | Description |
-|----------|-------|-------------|
+| -------- | ----- | ----------- |
 | `PLATFORM_MAX_BLOCKDIM` | 24 | Maximum blocks (each = 1 AIC + 2 AIV) |
 | `PLATFORM_MAX_AICPU_THREADS` | 4 | AICPU thread count (3 schedulers + 1 orchestrator) |
 | `PLATFORM_MAX_AIC_PER_THREAD` | 24 | Max AIC cores per scheduler thread |
@@ -105,7 +105,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 
 The orchestrator and schedulers communicate through a contiguous shared memory region in Global Memory (GM). Each ring level has its own TaskDescriptor and DepListPool sections. See [MULTI_RING.md §4.3–4.4](MULTI_RING.md) for the per-ring shared memory header and handle layout.
 
-```
+```text
 ┌─────────────────────────────┐  offset 0
 │  PTO2SharedMemoryHeader     │  (flow control, config, sync flags)
 ├─────────────────────────────┤  aligned
@@ -118,7 +118,7 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 ### 3.1 SharedMemoryHeader Fields
 
 | Field | Writer | Reader | Purpose |
-|-------|--------|--------|---------|
+| ----- | ------ | ------ | ------- |
 | `current_task_index` | Orchestrator | Scheduler | Next task ID to allocate (task ring head) |
 | `last_task_alive` | Scheduler | Orchestrator | Oldest still-active task (task ring tail) |
 | `heap_top` | Orchestrator | Scheduler | Heap ring allocation pointer |
@@ -136,7 +136,7 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 
 ### 3.2 Size Calculation
 
-```
+```text
 total = ALIGN(Header) + ALIGN(window_size * sizeof(TaskDescriptor))
       + ALIGN((dep_pool_size + 1) * sizeof(DepListEntry))
 ```
@@ -154,6 +154,7 @@ Alignment is 64 bytes (`PTO2_ALIGN_SIZE`).
 The task ring manages task slot allocation with back-pressure flow control.
 
 **Structure** (`PTO2TaskRing`):
+
 - `descriptors`: pointer to `TaskDescriptor[]` in shared memory
 - `window_size`: number of slots (power of 2)
 - `current_index`: next task ID to allocate (monotonically increasing)
@@ -162,7 +163,8 @@ The task ring manages task slot allocation with back-pressure flow control.
 **Slot mapping**: `slot = task_id & (window_size - 1)`
 
 **Allocation** (`pto2_task_ring_alloc`):
-```
+
+```text
 active_count = current_index - *last_alive_ptr
 if active_count < window_size - 1:
     allocate slot, advance current_index
@@ -179,6 +181,7 @@ else:
 The heap ring manages output buffer allocation from a circular GM heap.
 
 **Structure** (`PTO2HeapRing`):
+
 - `base`: GM heap base address
 - `size`: total heap size (default 1 GB)
 - `top`: allocation pointer (local to orchestrator)
@@ -212,7 +215,7 @@ This back-pressure is essential for correctness with small ring sizes — for ex
 
 A ring that is **too small** can cause a **deadlock**. The root cause is the scope mechanism: each task's `fanout_count` includes a reference from its owning scope. The scope reference is only released when `scope_end()` runs — but `scope_end()` is called by the orchestrator, which is blocked waiting for ring space. This creates a circular dependency:
 
-```
+```text
 Orchestrator blocked on task_ring_alloc (ring full)
     → needs scheduler to advance last_task_alive
     → needs tasks to reach CONSUMED state (fanout_count == 0)
@@ -224,13 +227,15 @@ Orchestrator blocked on task_ring_alloc (ring full)
 The runtime detects this automatically by counting spin iterations in the allocation functions:
 
 **Periodic BLOCKED warnings** (every 10,000 spins):
-```
+
+```text
 [TaskRing] BLOCKED (Flow Control): current=208, last_alive=192, active=16/16 (100.0%), spins=10000
 [HeapRing] BLOCKED: requesting 4096 bytes, available=0, top=65536, tail=0, spins=10000
 ```
 
 **Deadlock detection** (after 100,000 spins with no progress):
-```
+
+```text
 FATAL: Flow Control Deadlock Detected!
 Task Ring is FULL and no progress after 100000 spins.
   - Active tasks:  16
@@ -275,6 +280,7 @@ This design avoids the complexity of ring-based wrapping while still being bound
 ### 5.4 Stale Entry Cleanup: Three-Layer Defense
 
 TensorMap must ensure entries for retired tasks (`producer_task_id < last_task_alive`) are removed, so that:
+
 - The pool does not grow unboundedly (capacity is finite)
 - Lookup performance does not degrade as stale entries accumulate in bucket chains
 
@@ -301,7 +307,7 @@ This forms a back-pressure mechanism analogous to the Task Ring's flow control.
 **Summary**:
 
 | Layer | Trigger | Method | Guarantees |
-|-------|---------|--------|------------|
+| ----- | ------- | ------ | ---------- |
 | Chain Truncation | Every lookup | Truncate stale tail of bucket chain | Lookup only visits valid entries |
 | Periodic Cleanup | Every 64 retired tasks | Walk per-task chains, free entries | Pool capacity reclaimed in bounded time |
 | Pool Back-Pressure | Pool exhausted | Block until scheduler advances watermark | Hard capacity bound, no OOM |
@@ -324,8 +330,8 @@ When `pto2_submit_task` processes parameters:
 ### 6.1 PTO2TaskDescriptor (Hot Path)
 
 | Field | Description |
-|-------|-------------|
-| `task_id` | Canonical mixed-task ID (64-bit: `ring_id << 32 | local_id`). See [MULTI_RING.md §3](MULTI_RING.md). |
+| ----- | ----------- |
+| `task_id` | Canonical mixed-task ID (64-bit: `ring_id << 32 \| local_id`). See [MULTI_RING.md §3](MULTI_RING.md). |
 | `kernel_id[3]` | Per-slot kernel IDs: `[AIC, AIV0, AIV1]`; `INVALID_KERNEL_ID` = inactive |
 | `active_mask` | Bitmask of active subtask slots: `bit0=AIC`, `bit1=AIV0`, `bit2=AIV1` |
 | `subtask_done_mask` | Atomic bitmask; each subtask sets its done bit on completion |
@@ -339,7 +345,7 @@ When `pto2_submit_task` processes parameters:
 ### 6.1b PTO2TaskPayload (Cold Path)
 
 | Field | Description |
-|-------|-------------|
+| ----- | ----------- |
 | `tensors[16]` | Tensor descriptors for parameters |
 | `scalar_value[16]` | Scalar parameter values |
 | `is_tensor[16]` | Whether each parameter is tensor or scalar |
@@ -349,7 +355,7 @@ When `pto2_submit_task` processes parameters:
 
 ### 6.2 Task State Machine
 
-```
+```text
   [0] PENDING ──fanin satisfied──► [1] READY ──dispatch──► [2] RUNNING
       ▲                                                         │
       │                                                         ▼
@@ -357,6 +363,7 @@ When `pto2_submit_task` processes parameters:
 ```
 
 In the scheduler's `task_state[]` array (`std::atomic<PTO2TaskState>`):
+
 - **0 (PENDING)**: waiting for dependencies (`fanin_refcount < fanin_count`)
 - **1 (READY)**: all dependencies satisfied, waiting in ready queue
 - **2 (RUNNING)**: currently executing on a worker
@@ -372,6 +379,7 @@ In the scheduler's `task_state[]` array (`std::atomic<PTO2TaskState>`):
 The orchestrator runs on AICPU Thread 3 and builds the task graph by calling the user-provided orchestration function.
 
 Key members:
+
 - `rings[PTO2_MAX_RING_DEPTH]`: per-ring `PTO2RingSet` (HeapRing + TaskRing + DepPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
 - `tensor_map`, `tensor_pool`: dependency tracking
 - `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
@@ -381,7 +389,7 @@ Key members:
 ### 7.2 Task Submission Flow (`pto2_submit_task`)
 
 | Step | Operation |
-|------|-----------|
+| ---- | --------- |
 | 0 | `pto2_orchestrator_sync_tensormap` — prune stale TensorMap entries |
 | 1 | `pto2_task_ring_alloc` — allocate task slot (may block on flow control) |
 | 2 | Initialize task descriptor, copy parameters |
@@ -401,6 +409,7 @@ The orchestrator and scheduler run concurrently. When adding a consumer to a pro
 3. **Release** `fanout_lock`
 
 The scheduler's completion handler mirrors this:
+
 1. Mark `task_state[slot] = COMPLETED`
 2. **Acquire** `fanout_lock`, read `fanout_head`, **release** lock
 3. Traverse fanout list, incrementing each consumer's `fanin_refcount`
@@ -411,6 +420,7 @@ This lock protocol guarantees every consumer is accounted for exactly once.
 ### 7.4 Scope Mechanism (`PTO2_SCOPE`)
 
 Scopes control the lifetime of intermediate buffers. Each scope:
+
 - Tracks tasks submitted within it via a flat `scope_tasks[]` buffer partitioned by `scope_begins[]`
 - On `scope_end`: increments `fanout_refcount` for scope tasks; when it reaches `fanout_count`, the task's packed buffer can be reclaimed
 
@@ -432,7 +442,7 @@ PTO2_SCOPE(rt) {
 With `aicpu_thread_num=4`, the AICPU runs 4 threads:
 
 | Thread | Role | Cores |
-|--------|------|-------|
+| ------ | ---- | ----- |
 | 0 | Scheduler | 6 AIC + ~13 AIV |
 | 1 | Scheduler | 6 AIC + ~13 AIV |
 | 2 | Scheduler | 6 AIC + ~13 AIV |
@@ -445,10 +455,12 @@ Core assignment: AICs and AIVs are divided equally among the 3 scheduler threads
 Each scheduler thread runs a tight loop with two main phases:
 
 **Phase 1 — Completion Handling**:
+
 - Poll register `COND` on each managed core
 - When `TASK_FIN_STATE` detected: record completion timestamps, call `on_subtask_complete(task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, trigger `on_mixed_task_complete(task_id)` which marks `task_state[slot] = COMPLETED`, acquires fanout lock, traverses fanout list (incrementing consumers' `fanin_refcount`), marks `task_state[slot] = CONSUMED`, and advances `last_task_alive` watermark
 
 **Phase 2 — Dispatch**:
+
 - For each idle core: pop a task from the matching shape-based ready queue (lock-free MPMC Vyukov queue, one per resource shape)
 - Build `PTO2DispatchPayload` from `TaskDescriptor` with `task_id`, `subslot`, `kernel_id`, and `core_type`
 - Write task pointer to `Handshake.task`, signal AICore via register `DATA_MAIN_BASE`
@@ -469,7 +481,7 @@ Ready queues use a lock-free bounded MPMC (Vyukov) design:
 
 After a task reaches state CONSUMED (4), the scheduler tries to advance `last_task_alive`:
 
-```
+```text
 while la < current_task_index:
     if task_state[la & mask] < CONSUMED: break
     reset fanin_refcount[la & mask] = 0
@@ -489,7 +501,7 @@ This is lock-free (CAS-based) and multiple scheduler threads can attempt it conc
 Each AICore worker has a `Handshake` struct in shared memory:
 
 | Field | Direction | Purpose |
-|-------|-----------|---------|
+| ----- | --------- | ------- |
 | `task` | AICPU→AICore | Pointer to `PTO2DispatchPayload` |
 | `control` | AICPU→AICore | 0=normal, 1=shutdown |
 | `perf_records_addr` | AICPU→AICore | Performance buffer address |
@@ -501,11 +513,12 @@ Instead of polling `Handshake.task_status`, the production protocol uses hardwar
 > **Multi-ring note**: `task_id` is 64-bit but registers are 32-bit. A per-core monotonic dispatch counter (`s_dispatch_seq`) replaces `task_id` in register writes to prevent collisions. See [MULTI_RING.md §6](MULTI_RING.md).
 
 | Register | Direction | Usage |
-|----------|-----------|-------|
+| -------- | --------- | ----- |
 | `DATA_MAIN_BASE` | AICPU→AICore | Write `task_id` to dispatch (idle=0x7FFFFFFD); `EXIT_SIGNAL` to shut down |
 | `COND` | AICore→AICPU | `[bit31=state, bits30:0=task_id]`: ACK (state=0) or FIN (state=1) |
 
 **AICore execution loop**:
+
 1. Poll `DATA_MAIN_BASE` for value != AICPU_IDLE_TASK_ID
 2. Read payload from `Handshake.task`
 3. Write ACK to `COND`
@@ -517,7 +530,7 @@ Instead of polling `Handshake.task_status`, the production protocol uses hardwar
 Built by the scheduler from `PTO2TaskDescriptor`:
 
 | Field | Description |
-|-------|-------------|
+| ----- | ----------- |
 | `task_id` | Mixed-task identifier (for completion aggregation) |
 | `subslot` | Which subtask slot this dispatch represents (`AIC`, `AIV0`, or `AIV1`) |
 | `kernel_id` | Function ID for this subtask slot |
@@ -550,12 +563,13 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 ### 10.3 Thread Startup Synchronization
 
 | Flag | Set by | Waited by | Purpose |
-|------|--------|-----------|---------|
+| ---- | ------ | --------- | ------- |
 | `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
 | `pto2_init_done_` | First init thread | Others | One-time memset of arrays started (exchange guard) |
 | `pto2_init_complete_` | Init thread | Thread 3 + others | One-time init of per-task arrays done |
 
 Startup sequence:
+
 1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
 2. Scheduler threads: wait for `runtime_init_ready_` → one thread wins `pto2_init_done_` exchange → memset per-task arrays → set `pto2_init_complete_`; other threads wait for `pto2_init_complete_`
 3. Thread 3: wait for `pto2_init_complete_` → configure orchestrator-scheduler pointers
@@ -571,7 +585,7 @@ The orchestration API is defined in `pto_orchestration_api.h`. Orchestration cod
 ### 11.1 Core API
 
 | Function/Macro | Purpose |
-|----------------|---------|
+| -------------- | ------- |
 | `pto2_rt_submit_task(mixed_kernels, args)` | Submit a mixed task with `MixedKernels` struct |
 | `pto2_rt_submit_aic_task(kernel_id, args)` | Convenience: submit AIC-only task |
 | `pto2_rt_submit_aiv_task(kernel_id, args)` | Convenience: submit AIV-only task |
@@ -581,7 +595,7 @@ The orchestration API is defined in `pto_orchestration_api.h`. Orchestration cod
 ### 11.2 Parameter Construction
 
 | Function | Description |
-|----------|-------------|
+| -------- | ----------- |
 | `make_tensor_external(ptr, shapes, ndim, dtype)` | Wrap an existing device pointer as a tensor |
 | `TensorCreateInfo(shapes, ndim, dtype)` | Describe a runtime-created output buffer |
 | `Arg::add_input(tensor)` | INPUT parameter — read by the task |
@@ -594,7 +608,7 @@ The orchestration API is defined in `pto_orchestration_api.h`. Orchestration cod
 Tasks are queued by resource shape, which is derived from the `active_mask` in the `MixedKernels` struct:
 
 | Shape | Active Mask | Description |
-|-------|-------------|-------------|
+| ----- | ----------- | ----------- |
 | `AIC_ONLY` | AIC only | AIC cores (matrix multiplication) |
 | `AIV_X1` | AIV0 or AIV1 only | Single AIV core (vector operations) |
 | `AIV_X2` | AIV0 + AIV1 | Two AIV cores |
@@ -607,7 +621,7 @@ Each orchestration `.so` must export:
 
 ```cpp
 extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count);
-extern "C" void aicpu_orchestration_entry(uint64_t* args, int arg_count, int orch_thread_num, int orch_thread_index);
+extern "C" void aicpu_orchestration_entry(uint64_t* args, int arg_count);
 ```
 
 ---
@@ -640,7 +654,7 @@ RUNTIME_CONFIG = {
 ### 12.2 Orchestration Structure
 
 ```cpp
-void aicpu_orchestration_entry(uint64_t* args, int arg_count, int orch_thread_num, int orch_thread_index) {
+void aicpu_orchestration_entry(uint64_t* args, int arg_count) {
     // Unpack args: query, key_cache, value_cache, block_table, context_lens, out, config
     for (q_idx = 0; q_idx < q_loop; q_idx++) {
         for (batch_start = 0; batch_start < batch; batch_start += IN_CORE_BATCH) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -36,9 +36,8 @@ Legacy per-task submit (`kernel_id + worker_type`) cannot express atomic co-disp
 
 Design must preserve the current main runtime architecture:
 
-1. Multi-orchestrator runtime wiring (`orchestrators[]`, `orch_count`, thread-local `pto2_current_orch_idx`).
-2. Executor threading split (orchestrator threads vs scheduler threads), and post-orchestrator transition (`transition_requested_` + `reassign_cores_for_all_threads()`).
-3. Shared-memory hot/cold split (`PTO2TaskDescriptor` hot + `PTO2TaskPayload` cold).
+1. Executor threading split (orchestrator thread vs scheduler threads), and post-orchestrator transition (`transition_requested_` + `reassign_cores_for_all_threads()`).
+2. Shared-memory hot/cold split (`PTO2TaskDescriptor` hot + `PTO2TaskPayload` cold).
 
 ## 5. Terminology
 
@@ -197,7 +196,7 @@ Recommended validation coverage:
 2. Atomic dispatch for multi-slot shapes.
 3. Dependency gating and completion aggregation (`done_mask == active_mask`).
 4. Lane-occupancy co-residency behavior for compatible shapes.
-5. Multi-orchestrator and core-transition ownership stability.
+5. Core-transition ownership stability.
 6. Invalid submit handling (`always_assert` path).
 7. Regression coverage for existing examples/tests.
 
@@ -223,4 +222,3 @@ Final validation:
 3. Per-cluster concurrent capacity is lane-occupancy-driven, not a fixed constant.
 4. Submit-contract types live in one shared header-only surface.
 5. Resource-aware dispatch heuristics are allowed without a strict starvation-free guarantee.
-

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -38,16 +38,16 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // =============================================================================
 
 static TaskOutputTensors submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
-    return pto2_submit_mixed_task(&rt->orchestrators[0], mixed_kernels, args);
+    return pto2_submit_mixed_task(&rt->orchestrator, mixed_kernels, args);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrators[0]); }
+void pto2_rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrator); }
 
-void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrators[0]); }
+void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrator); }
 
-void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrators[0]); }
+void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrator); }
 
-static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrators[0].fatal; }
+static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
 
 // Wait for all producers of this tensor to be safe for data access.
 // Checks owner metadata (lifecycle anchor) and OverlapMap (modifier writers).
@@ -58,7 +58,7 @@ static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrators[0].fatal; 
 // Returns false on timeout (sets orch.fatal).
 MAYBE_UNINITIALIZED_BEGIN
 static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wait_for_consumers, const char *caller) {
-    PTO2OrchestratorState &orch = rt->orchestrators[0];
+    PTO2OrchestratorState &orch = rt->orchestrator;
 
     // Collect producer slot states from both maps, deduplicated by pointer.
     // +1: one creator slot + up to PTO2_LOOKUP_MAX_RESULTS modifier slots.
@@ -209,7 +209,6 @@ PTO2Runtime *pto2_runtime_create_custom(
 
     rt->ops = &s_runtime_ops;
     rt->mode = mode;
-    rt->orch_count = 1;
     rt->sm_handle = pto2_sm_create(task_window_size, heap_size);
     if (!rt->sm_handle) {
         free(rt);
@@ -235,8 +234,8 @@ PTO2Runtime *pto2_runtime_create_custom(
 #endif
     rt->gm_heap_owned = true;
 
-    // Initialize first orchestrator
-    if (!pto2_orchestrator_init(&rt->orchestrators[0], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
+    // Initialize orchestrator
+    if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
         free(rt);
@@ -245,7 +244,7 @@ PTO2Runtime *pto2_runtime_create_custom(
 
     // Initialize scheduler (heap_size = per-ring heap size)
     if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
-        pto2_orchestrator_destroy(&rt->orchestrators[0]);
+        pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
         free(rt);
@@ -253,18 +252,16 @@ PTO2Runtime *pto2_runtime_create_custom(
     }
 
     // Connect orchestrator to scheduler (for simulated mode)
-    pto2_orchestrator_set_scheduler(&rt->orchestrators[0], &rt->scheduler);
+    pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
 
     return rt;
 }
 
 PTO2Runtime *pto2_runtime_create_from_sm(
-    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count,
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity
 ) {
     if (!sm_handle) return NULL;
-    if (orch_count < 1) orch_count = 1;
-    if (orch_count > PTO2_MAX_ORCH_THREADS) orch_count = PTO2_MAX_ORCH_THREADS;
 
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) return NULL;
@@ -275,32 +272,20 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     rt->gm_heap = gm_heap;
     rt->gm_heap_size = heap_size > 0 ? heap_size * PTO2_MAX_RING_DEPTH : 0;
     rt->gm_heap_owned = false;
-    rt->orch_count = orch_count;
 
-    // Initialize all orchestrator states
-    for (int i = 0; i < orch_count; i++) {
-        if (!pto2_orchestrator_init(&rt->orchestrators[i], rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
-            for (int j = 0; j < i; j++) {
-                pto2_orchestrator_destroy(&rt->orchestrators[j]);
-            }
-            free(rt);
-            return NULL;
-        }
-    }
-
-    // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
-        for (int i = 0; i < orch_count; i++) {
-            pto2_orchestrator_destroy(&rt->orchestrators[i]);
-        }
+    if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt);
         return NULL;
     }
 
-    // Connect all orchestrators to scheduler
-    for (int i = 0; i < orch_count; i++) {
-        pto2_orchestrator_set_scheduler(&rt->orchestrators[i], &rt->scheduler);
+    // Initialize scheduler (heap_size = per-ring heap size)
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
+        pto2_orchestrator_destroy(&rt->orchestrator);
+        free(rt);
+        return NULL;
     }
+
+    pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
 
     return rt;
 }
@@ -309,9 +294,7 @@ void pto2_runtime_destroy(PTO2Runtime *rt) {
     if (!rt) return;
 
     pto2_scheduler_destroy(&rt->scheduler);
-    for (int i = 0; i < rt->orch_count; i++) {
-        pto2_orchestrator_destroy(&rt->orchestrators[i]);
-    }
+    pto2_orchestrator_destroy(&rt->orchestrator);
 
     if (rt->gm_heap_owned && rt->gm_heap) {
         free(rt->gm_heap);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -43,9 +43,6 @@
 #include "pto_scheduler.h"
 #include "pto_orchestrator.h"
 
-// Maximum number of orchestrator threads supported
-constexpr int PTO2_MAX_ORCH_THREADS = 4;
-
 // =============================================================================
 // Runtime Context
 // =============================================================================
@@ -102,8 +99,7 @@ struct PTO2Runtime {
 
     // Components
     PTO2SharedMemoryHandle *sm_handle;
-    PTO2OrchestratorState orchestrators[PTO2_MAX_ORCH_THREADS];
-    int orch_count;  // Number of active orchestrator states
+    PTO2OrchestratorState orchestrator;
     PTO2SchedulerState scheduler;
 
     // GM Heap for output buffers
@@ -154,7 +150,7 @@ PTO2Runtime *pto2_runtime_create_custom(
  * @return Runtime context, or NULL on failure
  */
 PTO2Runtime *pto2_runtime_create_from_sm(
-    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size, int orch_count = 1,
+    PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.cpp
@@ -33,7 +33,6 @@ Runtime::Runtime() {
     memset(workers, 0, sizeof(workers));
     worker_count = 0;
     sche_cpu_num = 1;
-    orch_thread_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
     pto2_task_window_size = 0;
     pto2_heap_size = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -158,7 +158,6 @@ public:  // NOLINT(whitespace/indent)
 
     // Execution parameters for AICPU scheduling
     int sche_cpu_num;        // Number of AICPU threads for scheduling
-    int orch_thread_num;     // Number of orchestrator threads (default 1)
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -107,9 +107,8 @@ void ChipWorker::run(const void *callable, const void *args, const CallConfig &c
     void *rt = runtime_buf_.data();
 
     int rc = run_runtime_fn_(
-        rt, callable, args, config.block_dim, config.aicpu_thread_num, config.orch_thread_num, device_id_,
-        aicpu_binary_.data(), aicpu_binary_.size(), aicore_binary_.data(), aicore_binary_.size(),
-        config.enable_profiling ? 1 : 0
+        rt, callable, args, config.block_dim, config.aicpu_thread_num, device_id_, aicpu_binary_.data(),
+        aicpu_binary_.size(), aicore_binary_.data(), aicore_binary_.size(), config.enable_profiling ? 1 : 0
     );
     if (rc != 0) {
         throw std::runtime_error("run_runtime failed with code " + std::to_string(rc));

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -19,7 +19,6 @@
 struct CallConfig {
     int block_dim = 24;
     int aicpu_thread_num = 3;
-    int orch_thread_num = 1;
     bool enable_profiling = false;
 };
 
@@ -47,7 +46,7 @@ private:
     using SetDeviceFn = int (*)(int);
     using GetRuntimeSizeFn = size_t (*)();
     using RunRuntimeFn = int (*)(
-        void *, const void *, const void *, int, int, int, int, const uint8_t *, size_t, const uint8_t *, size_t, int
+        void *, const void *, const void *, int, int, int, const uint8_t *, size_t, const uint8_t *, size_t, int
     );
     using FinalizeDeviceFn = int (*)();
 

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -47,12 +47,26 @@ int set_device(int device_id);
 /**
  * Build the task graph, execute on device, copy results back, and clean up.
  *
- * Combines init_runtime + launch_runtime + finalize_runtime into one call.
+ * Combines the former init_runtime + enable_runtime_profiling +
+ * launch_runtime + finalize_runtime into a single call.
+ *
+ * @param runtime           Caller-allocated buffer (size from get_runtime_size())
+ * @param callable          Opaque ChipCallable pointer (orchestration + kernel binaries)
+ * @param args              Opaque ChipStorageTaskArgs pointer (tensor/scalar arguments)
+ * @param block_dim         Number of AICore blocks
+ * @param aicpu_thread_num  Number of AICPU scheduler threads
+ * @param device_id         Target device
+ * @param aicpu_binary      AICPU executor binary blob
+ * @param aicpu_size        Size of AICPU binary
+ * @param aicore_binary     AICore executor binary blob
+ * @param aicore_size       Size of AICore binary
+ * @param enable_profiling  1 to enable profiling, 0 to disable
+ * @return 0 on success, negative on error
  */
 int run_runtime(
-    RuntimeHandle runtime, const void *callable, const void *args, int block_dim, int aicpu_thread_num,
-    int orch_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_profiling
+    RuntimeHandle runtime, const void *callable, const void *args, int block_dim, int aicpu_thread_num, int device_id,
+    const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size,
+    int enable_profiling
 );
 
 /**

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -48,12 +48,8 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index
-) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
-
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args) {
     // Read dimensions from tensor metadata
     // query: shape=[batch, num_heads, head_dim]
     uint64_t batch = orch_args.tensor(0).shapes[0];

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -78,11 +78,8 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(
-    PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index
-) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
+__attribute__((visibility("default"))) void
+aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args) {
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/kernel_config.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/kernel_config.py
@@ -44,6 +44,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -47,8 +47,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // Tensor args
     Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_B = from_tensor_arg(orch_args.tensor(1));
@@ -64,7 +63,6 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     int matmul_batch = static_cast<int>(orch_args.scalar(3));
     int add_batch = static_cast<int>(orch_args.scalar(4));
 
-    LOG_ALWAYS("[alternating_orch] thread num: %d, idx: %d", orch_thread_num, orch_thread_index);
     LOG_INFO(
         "[alternating_orch] Batch: %d, M: %d, N: %d, matmul_batch: %d, add_batch: %d", batch, M, N, matmul_batch,
         add_batch
@@ -81,7 +79,7 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     int max_groups = num_matmul_groups > num_add_groups ? num_matmul_groups : num_add_groups;
 
     // Interleaved submit: matmul and add groups alternate
-    for (int group_idx = orch_thread_index; group_idx < max_groups; group_idx += orch_thread_num) {
+    for (int group_idx = 0; group_idx < max_groups; group_idx++) {
         if (group_idx < num_matmul_groups) {
             int start_task_idx = group_idx * matmul_batch;
             uint64_t offset = static_cast<uint64_t>(start_task_idx) * MATMUL_ELEMS;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/kernel_config.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/kernel_config.py
@@ -86,6 +86,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -62,8 +62,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // Read dimensions from tensor metadata
     uint64_t batch = orch_args.tensor(0).shapes[0];
     uint64_t num_heads = orch_args.tensor(0).shapes[1];
@@ -120,7 +119,7 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
         uint64_t q_offset = q_idx * q_tile;
 
-        for (uint64_t chunk_idx = orch_thread_index; chunk_idx < num_chunks; chunk_idx += orch_thread_num) {
+        for (uint64_t chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
             uint64_t chunk_bc = batch - chunk_idx * IN_CORE_BATCH;
             if (chunk_bc > IN_CORE_BATCH) chunk_bc = IN_CORE_BATCH;
             uint64_t batch_start = chunk_idx * IN_CORE_BATCH;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -45,11 +45,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // Tensor args
     Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_B = from_tensor_arg(orch_args.tensor(1));

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -64,10 +64,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;
-    (void)orch_thread_index;
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
     uint64_t prof_scope = 0;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
@@ -88,6 +88,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 24,
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -76,10 +76,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;
-    (void)orch_thread_index;
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
@@ -48,11 +48,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
-
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     // External tensors from golden.py
     Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_b = from_tensor_arg(orch_args.tensor(1));

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -64,10 +64,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
     uint64_t prof_scope = 0;

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/kernel_config.py
@@ -88,6 +88,5 @@ KERNELS = [
 RUNTIME_CONFIG = {
     "runtime": "tensormap_and_ringbuffer",
     "aicpu_thread_num": 4,
-    "orch_thread_num": 1,
     "block_dim": 36,
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -76,10 +76,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
     };
 }
 
-__attribute__((visibility("default"))) void
-aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;

--- a/tests/ut/test_chip_worker.py
+++ b/tests/ut/test_chip_worker.py
@@ -31,18 +31,15 @@ class TestCallConfig:
         config = CallConfig()
         assert config.block_dim == 24
         assert config.aicpu_thread_num == 3
-        assert config.orch_thread_num == 1
         assert config.enable_profiling is False
 
     def test_setters(self):
         config = CallConfig()
         config.block_dim = 32
         config.aicpu_thread_num = 4
-        config.orch_thread_num = 2
         config.enable_profiling = True
         assert config.block_dim == 32
         assert config.aicpu_thread_num == 4
-        assert config.orch_thread_num == 2
         assert config.enable_profiling is True
 
     def test_repr(self):


### PR DESCRIPTION
Multi-orchestrator capability (orch_thread_num > 1) is no longer needed. All runtimes now hardcode a single orchestrator thread.

Runtime layer:
- PTO2Runtime: replace orchestrators[PTO2_MAX_ORCH_THREADS] + orch_count with a single orchestrator field; remove PTO2_MAX_ORCH_THREADS constant
- pto2_runtime_create_from_sm(): drop orch_count parameter
- AicpuExecutor: remove orch_thread_num_, orch_finished_count_ and all multi-orchestrator coordination logic (non-primary wait, last-orch barrier, all-orch mode); simplify sched_thread_num_ = thread_num_ - 1
- DeviceOrchestrationFunc: remove orch_thread_num/orch_thread_index params
- perf_aicpu_init_phase_profiling(): remove num_orch_threads param; replace __thread s_orch_thread_idx with plain static

Host/platform layer:
- CallConfig: remove orch_thread_num field
- run_runtime() C API: remove orch_thread_num parameter (all 4 platforms)
- device_runner: use runtime.get_orch_built_on_host() to determine scheduler_thread_num (host_build_graph = all threads schedule)
- host_build_graph Runtime: add get_orch_built_on_host() returning true
- runtime.h / runtime.cpp: remove orch_thread_num field from all runtimes

Python/config layer:
- Remove CallConfig.orch_thread_num nanobind binding
- Remove orch_thread_num from code_runner.py, ci.py, and all kernel_config.py RUNTIME_CONFIG dicts (27 files)
- Update test_chip_worker.py assertions accordingly

Orchestration .so interface:
- Remove orch_thread_num/orch_thread_index from aicpu_orchestration_entry signatures across all 36 orchestration files (examples + tests)
- Adapt files that used params for work partitioning to single-thread

Validated: a2a3sim CI 20/20 passed