### PR TITLE
Update: adapt simpler to pto-isa bfloat16 CPU-sim support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Set up C++ compiler
         run: |
           if [[ "${{ runner.os }}" == "Linux" ]]; then
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
             sudo apt-get update
             sudo apt-get install -y ninja-build
             sudo apt-get install -y g++-15 || sudo apt-get install -y g++
@@ -131,7 +132,7 @@ jobs:
         run: pip install .
 
       - name: Run simulation examples (a2a3sim)
-        run: python ci.py -p a2a3sim -c 882c4db -t 600 --clone-protocol https
+        run: python ci.py -p a2a3sim -c 8830244b -t 600 --clone-protocol https
 
   st-sim-a5:
     runs-on: ${{ matrix.os }}
@@ -148,6 +149,7 @@ jobs:
       - name: Set up C++ compiler
         run: |
           if [[ "${{ runner.os }}" == "Linux" ]]; then
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
             sudo apt-get update
             sudo apt-get install -y ninja-build
             sudo apt-get install -y g++-15 || sudo apt-get install -y g++
@@ -181,7 +183,7 @@ jobs:
         run: pip install .
 
       - name: Run simulation examples (a5sim)
-        run: python ci.py -p a5sim -c 882c4db -t 600 --clone-protocol https
+        run: python ci.py -p a5sim -c 8830244b -t 600 --clone-protocol https
 
   # ---------- Python unit tests (a2a3 hardware) ----------
   ut-py-a2a3:
@@ -215,7 +217,7 @@ jobs:
       - name: Run on-device examples (a2a3)
         run: |
           export PATH="$HOME/.local/bin:$PATH"
-          source ${ASCEND_HOME_PATH}/bin/setenv.bash && python ci.py -p a2a3 -d ${DEVICE_RANGE} -c 882c4db -t 600 --clone-protocol https
+          source ${ASCEND_HOME_PATH}/bin/setenv.bash && python ci.py -p a2a3 -d ${DEVICE_RANGE} -c 8830244b -t 600 --clone-protocol https
 
 
   # ---------- Detect A5 changes (runs on GitHub server, not A5 machine) ----------
@@ -290,4 +292,4 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           source ${ASCEND_HOME_PATH}/bin/setenv.bash
           DEVICE_LIST=$(python -c "s,e='${DEVICE_RANGE}'.split('-'); print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python ci.py -p a5 -d ${DEVICE_RANGE} -c 882c4db -t 1200 --clone-protocol https"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python ci.py -p a5 -d ${DEVICE_RANGE} -c 8830244b -t 1200 --clone-protocol https"

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/golden.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/golden.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Paged Attention Golden - tensormap_and_ringbuffer example (small scale, float16)."""
+"""Paged Attention Golden - tensormap_and_ringbuffer example (small scale, bfloat16)."""
 
 from paged_attention_golden import (
     compute_golden,  # noqa: F401
@@ -28,7 +28,7 @@ ALL_CASES = {
         "block_size": 16,
         "context_len": 33,
         "max_model_len": 256,
-        "dtype": "float16",
+        "dtype": "bfloat16",
     },
     "Case2": {
         "batch": 1,
@@ -38,7 +38,7 @@ ALL_CASES = {
         "block_size": 16,
         "context_len": 128,
         "max_model_len": 256,
-        "dtype": "float16",
+        "dtype": "bfloat16",
     },
     "CaseVarSeq2": {
         "batch": 2,
@@ -49,7 +49,7 @@ ALL_CASES = {
         "context_len": 33,
         "context_lens_list": [33, 17],
         "max_model_len": 256,
-        "dtype": "float16",
+        "dtype": "bfloat16",
     },
     "CaseVarSeq4": {
         "batch": 4,
@@ -60,7 +60,7 @@ ALL_CASES = {
         "context_len": 128,
         "context_lens_list": [33, 64, 128, 15],
         "max_model_len": 256,
-        "dtype": "float16",
+        "dtype": "bfloat16",
     },
 }
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -12,7 +12,7 @@
 //
 // Fixed tile size: (16, 16) @ (16, 16) -> (16, 16)
 //
-// pij is float16 (converted from fp32 in softmax_prepare via TCVT).
+// pij is bfloat16 (converted from fp32 in softmax_prepare via TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
 // Standard non-transposed B pattern: ND GlobalB + ColMajor/RowMajor TileMatB.
 
@@ -33,13 +33,13 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __gm__ Tensor *oi) {
-    __gm__ half *pij_addr = reinterpret_cast<__gm__ half *>(pij->buffer.addr);
-    __gm__ half *vj_addr = reinterpret_cast<__gm__ half *>(vj->buffer.addr);
+    __gm__ bfloat16_t *pij_addr = reinterpret_cast<__gm__ bfloat16_t *>(pij->buffer.addr);
+    __gm__ bfloat16_t *vj_addr = reinterpret_cast<__gm__ bfloat16_t *>(vj->buffer.addr);
     __gm__ float *oi_addr = reinterpret_cast<__gm__ float *>(oi->buffer.addr);
 
-    // pij (M, K) fp16, vj (K, N) fp16 in ND (row-major), oi_new (M, N) fp32
-    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
-    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
+    // pij (M, K) bf16, vj (K, N) bf16 in ND (row-major), oi_new (M, N) fp32
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
 
     GlobalA pijGlobal(pij_addr + pij->start_offset);
@@ -47,12 +47,12 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __g
     GlobalOut oiGlobal(oi_addr + oi->start_offset);
 
     // L1 Mat tiles: standard ND pattern for both A and B
-    using TileMatA = Tile<TileType::Mat, half, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
-    using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
+    using TileMatA = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::ColMajor, K, N, SLayout::RowMajor, 512>;
 
     // L0 tiles
-    using LeftTile = TileLeft<half, M, K, M, K>;
-    using RightTile = TileRight<half, K, N, K, N>;
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile = TileRight<bfloat16_t, K, N, K, N>;
     using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -33,14 +33,14 @@ using namespace pto;
 
 template <int M, int K, int N>
 static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm__ Tensor *sij) {
-    __gm__ half *qi_addr = reinterpret_cast<__gm__ half *>(qi->buffer.addr);
-    __gm__ half *kj_addr = reinterpret_cast<__gm__ half *>(kj->buffer.addr);
+    __gm__ bfloat16_t *qi_addr = reinterpret_cast<__gm__ bfloat16_t *>(qi->buffer.addr);
+    __gm__ bfloat16_t *kj_addr = reinterpret_cast<__gm__ bfloat16_t *>(kj->buffer.addr);
     __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
 
-    // qi (M, K) fp16 in ND (row-major) layout
-    using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
+    // qi (M, K) bf16 in ND (row-major) layout
+    using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     // kj stored as (N, K) row-major = (K, N) column-major -> DN layout
-    using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
     using GlobalOut = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<M * N, M * N, M * N, N, 1>>;
 
     GlobalA qiGlobal(qi_addr + qi->start_offset);
@@ -48,12 +48,12 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm
     GlobalOut sijGlobal(sij_addr + sij->start_offset);
 
     // L1 Mat tiles: A is standard ND, B uses transposed-B pattern (RowMajor/ColMajor)
-    using TileMatA = Tile<TileType::Mat, half, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
-    using TileMatB = Tile<TileType::Mat, half, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
+    using TileMatA = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
 
     // L0 tiles
-    using LeftTile = TileLeft<half, M, K, M, K>;
-    using RightTile = TileRight<half, K, N, K, N>;
+    using LeftTile = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile = TileRight<bfloat16_t, K, N, K, N>;
     using AccTile = TileAcc<float, M, N, M, N>;
 
     TileMatA aMatTile;

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -46,18 +46,18 @@ static __aicore__ void softmax_prepare_impl(
 ) {
     uint64_t valid_len = static_cast<uint64_t>(sij->shapes[1]);
     __gm__ float *sij_addr = reinterpret_cast<__gm__ float *>(sij->buffer.addr);
-    __gm__ half *pij_addr = reinterpret_cast<__gm__ half *>(pij->buffer.addr);
+    __gm__ bfloat16_t *pij_addr = reinterpret_cast<__gm__ bfloat16_t *>(pij->buffer.addr);
     __gm__ float *mij_addr = reinterpret_cast<__gm__ float *>(mij->buffer.addr);
     __gm__ float *lij_addr = reinterpret_cast<__gm__ float *>(lij->buffer.addr);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
     using GlobalDataMxN = GlobalTensor<float, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
-    using GlobalDataMxN_f16 = GlobalTensor<half, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
+    using GlobalDataMxN_bf16 = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, N>, Stride<1, 1, 1, N, 1>>;
     using GlobalScalarDN = GlobalTensor<float, Shape<1, 1, 1, kAlignedRows, 1>, Stride<1, 1, 1, 1, 1>, Layout::DN>;
 
     GlobalDataMxN sijGlobal(sij_addr + sij->start_offset);
-    GlobalDataMxN_f16 pijGlobal(pij_addr + pij->start_offset);
+    GlobalDataMxN_bf16 pijGlobal(pij_addr + pij->start_offset);
     GlobalScalarDN mijGlobal(mij_addr + mij->start_offset);
     GlobalScalarDN lijGlobal(lij_addr + lij->start_offset);
 
@@ -67,7 +67,7 @@ static __aicore__ void softmax_prepare_impl(
     using TileSijPad = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N, SLayout::NoneBox, 512, PadValue::Min>;
 
     using TileVecMxN = Tile<TileType::Vec, float, M, N, BLayout::RowMajor, M, N>;
-    using TileVecMxN_f16 = Tile<TileType::Vec, half, M, N, BLayout::RowMajor, M, N>;
+    using TileVecMxN_bf16 = Tile<TileType::Vec, bfloat16_t, M, N, BLayout::RowMajor, M, N>;
     using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, M, 1>;
 
     TileVecMxN sijTile;
@@ -77,7 +77,7 @@ static __aicore__ void softmax_prepare_impl(
     TileVecMxN tmpTile;
     TileScalarDN maxTile;
     TileScalarDN sumTile;
-    TileVecMxN_f16 pijF16Tile;
+    TileVecMxN_bf16 pijBf16Tile;
 
     TASSIGN(sijTile, 0x0);
     TASSIGN(sijDynTile, 0x0);
@@ -86,7 +86,7 @@ static __aicore__ void softmax_prepare_impl(
     TASSIGN(tmpTile, 2 * M * N * sizeof(float));
     TASSIGN(maxTile, 3 * M * N * sizeof(float));
     TASSIGN(sumTile, 3 * M * N * sizeof(float) + kAlignedRows * sizeof(float));
-    TASSIGN(pijF16Tile, 3 * M * N * sizeof(float) + 2 * kAlignedRows * sizeof(float));
+    TASSIGN(pijBf16Tile, 3 * M * N * sizeof(float) + 2 * kAlignedRows * sizeof(float));
 
     // Load full sij (M, N) tile from GM - all N columns including garbage for partial blocks
     TLOAD(sijTile, sijGlobal);
@@ -104,16 +104,16 @@ static __aicore__ void softmax_prepare_impl(
     TROWEXPANDSUB(pijTile, sijTile, maxTile);
     pipe_barrier(PIPE_V);
     TEXP(pijTile, pijTile);
-    // Truncate pij to fp16 first, then compute lij from truncated values (matches golden)
-    TCVT(pijF16Tile, pijTile, RoundMode::CAST_ROUND);
-    TCVT(pijTile, pijF16Tile, RoundMode::CAST_ROUND);
+    // Truncate pij to bf16 first, then compute lij from truncated values (matches golden)
+    TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
+    TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
     TROWSUM(sumTile, pijTile, tmpTile);
 
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(mijGlobal, maxTile);
     TSTORE(lijGlobal, sumTile);
-    TSTORE(pijGlobal, pijF16Tile);
+    TSTORE(pijGlobal, pijBf16Tile);
 
     set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
     wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -15,9 +15,9 @@
  * Each block processes a single 16x16 matmul operation.
  *
  * Memory Layout:
- *   Query: (batch, 16, 16) - one 16x16 tile per batch fp16
- *   Key:   (total_blocks, 16, 16) - stored as K^T for direct matmul fp16
- *   Value: (total_blocks, 16, 16) - direct format fp16
+ *   Query: (batch, 16, 16) - one 16x16 tile per batch bf16
+ *   Key:   (total_blocks, 16, 16) - stored as K^T for direct matmul bf16
+ *   Value: (total_blocks, 16, 16) - direct format bf16
  *
  * This file compiles as a standalone .so with zero runtime link dependencies.
  * All runtime calls go through the PTO2RuntimeOps function-pointer table.
@@ -106,7 +106,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     TensorCreateInfo tile2d_ci(tile2d_shapes, 2, DataType::FLOAT32);
     TensorCreateInfo scalar_ci(scalar_shapes, 1, DataType::FLOAT32);
     TensorCreateInfo sij_ci(sij_shapes, 2, DataType::FLOAT32);
-    TensorCreateInfo pij_f16_ci(sij_shapes, 2, data_type);
+    TensorCreateInfo pij_bf16_ci(sij_shapes, 2, data_type);
 
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
         uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};
@@ -152,17 +152,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     Tensor sij_valid = sij.view(sij_valid_shapes, sij_valid_offsets);
                     Arg params_sf;
                     params_sf.add_input(sij_valid);
-                    params_sf.add_output(pij_f16_ci);
+                    params_sf.add_output(pij_bf16_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_scalar(scale_value);
                     TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
-                    const Tensor &pij_f16 = sf_outs.get_ref(0);
+                    const Tensor &pij_bf16 = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
 
                     Arg params_pv;
-                    params_pv.add_input(pij_f16);
+                    params_pv.add_input(pij_bf16);
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
                     TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/mix/kernel_bgemm.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/mix/kernel_bgemm.cpp
@@ -93,6 +93,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     // Pipe and FIFO tile are declared in common scope (both sides reference the type)
     VecFifoTileT vecFifoTile;
+    TASSIGN(vecFifoTile, 0x0);
     PipeT mPipe(nullptr, 0U, 0U);
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- Pin pto-isa to 8830244b for BF16 CPU-sim support (TMATMUL, TCVT, etc.)
- Convert a2a3 paged_attention example from float16 to bfloat16 as validation
- Fix a5 bgemm deadlock: add TASSIGN for vecFifoTile (required by new
  NPUMemoryModel at 8830244b)
- Fix CI: add ubuntu-toolchain-r/test PPA so ubuntu sim jobs install
  g++-15 instead of falling back to g++-13 (broken bfloat16 on x86_64)