### PR TITLE
Refactor(a5): replace shared-memory profiling with memcpy-based collection

### DIFF
--- a/src/a5/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/performance_collector_aicpu.h
@@ -13,7 +13,10 @@
  * @brief AICPU performance data collection interface
  *
  * Provides performance profiling management interface for AICPU side.
- * Handles buffer initialization, switching, and flushing.
+ * Handles buffer initialization and per-record completion. In the memcpy-based
+ * collection design, Host pre-allocates one PerfBuffer per core and one
+ * PhaseBuffer per thread; AICPU writes directly into them until full, after
+ * which further records are silently dropped.
  */
 
 #ifndef PLATFORM_AICPU_PERFORMANCE_COLLECTOR_AICPU_H_
@@ -42,8 +45,10 @@ void perf_aicpu_init_profiling(Runtime *runtime);
  * Complete a PerfRecord with AICPU-side metadata after AICore task completion
  *
  * Reads perf_buf->count, validates task_id match against the latest record,
- * and fills all AICPU-side fields. Callers must pre-extract fanout into a
- * plain uint64_t array (platform layer cannot depend on runtime linked-list types).
+ * and fills all AICPU-side fields. Returns -1 and silently drops the record
+ * when the buffer is full (count >= PLATFORM_PROF_BUFFER_SIZE). Callers must
+ * pre-extract fanout into a plain uint64_t array (platform layer cannot depend
+ * on runtime linked-list types).
  *
  * @param perf_buf              PerfBuffer pointer (from handshake perf_records_addr)
  * @param expected_reg_task_id  Register dispatch token (low 32 bits) to validate
@@ -59,29 +64,6 @@ int perf_aicpu_complete_record(
     PerfBuffer *perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
     uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
 );
-
-/**
- * Switch performance buffer when current buffer is full
- *
- * Checks buffer capacity and switches to alternate buffer if needed.
- *
- * @param runtime Runtime instance pointer
- * @param core_id Core ID
- * @param thread_idx Thread index
- */
-void perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx);
-
-/**
- * Flush remaining performance data
- *
- * Marks non-empty buffers as ready and enqueues them for host collection.
- *
- * @param runtime Runtime instance pointer
- * @param thread_idx Thread index
- * @param cur_thread_cores Array of core IDs managed by this thread
- * @param core_num Number of cores managed by this thread
- */
-void perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cur_thread_cores, int core_num);
 
 /**
  * Update total task count in performance header
@@ -178,15 +160,5 @@ void perf_aicpu_write_core_assignments(
     const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
     int total_cores
 );
-
-/**
- * Flush remaining phase records for a thread
- *
- * Marks the current WRITING phase buffer as READY and enqueues it
- * for host collection. Called at thread exit (analogous to perf_aicpu_flush_buffers).
- *
- * @param thread_idx Thread index (scheduler thread or orchestrator)
- */
-void perf_aicpu_flush_phase_buffers(int thread_idx);
 
 #endif  // PLATFORM_AICPU_PERFORMANCE_COLLECTOR_AICPU_H_

--- a/src/a5/platform/include/common/perf_profiling.h
+++ b/src/a5/platform/include/common/perf_profiling.h
@@ -13,42 +13,20 @@
  * @file perf_profiling.h
  * @brief Performance profiling data structures
  *
- * Architecture: Fixed header + per-core/thread buffer states + optional phase profiling region
+ * Architecture: per-core PerfBuffer + per-thread PhaseBuffer + a single
+ * PerfSetupHeader, all allocated on device by Host.
  *
- * Memory layout (shared memory between Host and Device):
- * ┌─────────────────────────────────────────────────────────────┐
- * │ PerfDataHeader (fixed header)                               │
- * │  - ReadyQueue (FIFO, capacity=PLATFORM_PROF_READYQUEUE_SIZE)│
- * │  - Metadata (num_cores, flags)                              │
- * ├─────────────────────────────────────────────────────────────┤
- * │ PerfBufferState[0] (Core 0)                                 │
- * │  - free_queue: SPSC queue of available buffer pointers      │
- * │  - current_buf_ptr, current_buf_seq                         │
- * ├─────────────────────────────────────────────────────────────┤
- * │ PerfBufferState[1] (Core 1)                                 │
- * ├─────────────────────────────────────────────────────────────┤
- * │ ...                                                         │
- * ├─────────────────────────────────────────────────────────────┤
- * │ PerfBufferState[num_cores-1]                                │
- * ├─────────────────────────────────────────────────────────────┤
- * │ AicpuPhaseHeader (optional, present when phase profiling)   │
- * │  - magic, num_sched_threads, records_per_thread             │
- * │  - orch_summary                                             │
- * ├─────────────────────────────────────────────────────────────┤
- * │ PhaseBufferState[thread0]                                   │
- * │  - free_queue: SPSC queue of available buffer pointers      │
- * │  - current_buf_ptr, current_buf_seq                         │
- * ├─────────────────────────────────────────────────────────────┤
- * │ PhaseBufferState[thread1]                                   │
- * ├─────────────────────────────────────────────────────────────┤
- * │ ...                                                         │
- * └─────────────────────────────────────────────────────────────┘
+ * Layout (count-first + flexible array):
+ *   PerfBuffer  = 64B header (count + padding) + records[capacity]
+ *   PhaseBuffer = 64B header (count + padding) + records[capacity]
  *
- * Actual PerfBuffer / PhaseBuffer are allocated dynamically by Host
- * and pushed into the per-core/thread free_queue.
- *
- * Base size = sizeof(PerfDataHeader) + num_cores * sizeof(PerfBufferState)
- * With phases = Base + sizeof(AicpuPhaseHeader) + num_threads * sizeof(PhaseBufferState)
+ * Buffer device pointers + total_tasks + AicpuPhaseHeader (with orch_summary
+ * and core_to_thread) are consolidated in PerfSetupHeader. Host copies
+ * PerfSetupHeader to device once before execution; AICPU reads pointers in
+ * its profiling init. After execution, Host copies PerfSetupHeader back, then
+ * does a two-step memcpy (header → count → records) on each PerfBuffer /
+ * PhaseBuffer to reduce transfer to "actual records" instead of full
+ * capacity.
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_COMMON_PERF_PROFILING_H_
@@ -98,134 +76,22 @@ struct PerfRecord {
 static_assert(sizeof(PerfRecord) % 64 == 0, "PerfRecord must be 64-byte aligned for optimal cache performance");
 
 // =============================================================================
-// PerfBuffer - Fixed-Size Record Buffer
+// PerfBuffer - Record Buffer with Count-First Layout
 // =============================================================================
 
 /**
- * Fixed-size performance record buffer
+ * Performance record buffer (count-first + flexible array)
  *
- * Capacity: PLATFORM_PROF_BUFFER_SIZE (defined in platform_config.h)
- * Allocated dynamically by Host, pushed into per-core free_queue.
+ * Layout: 64B header (count + padding) followed by records[].
+ * Actual allocation: 64 + capacity * sizeof(PerfRecord).
+ *
+ * Count-first enables two-step collection: Host copies 64B to read count,
+ * then copies only count * sizeof(PerfRecord) of actual data.
  */
 struct PerfBuffer {
-    PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Record array
-    volatile uint32_t count;                        // Current record count
-} __attribute__((aligned(64)));
-
-// =============================================================================
-// PerfFreeQueue - SPSC Lock-Free Queue for Free Buffers
-// =============================================================================
-
-/**
- * Single Producer Single Consumer (SPSC) lock-free queue for free buffer management
- *
- * Producer: Host (ProfMemoryManager thread) pushes newly allocated buffers
- * Consumer: Device (AICPU thread) pops buffers when switching
- *
- * Queue semantics:
- * - Empty: head == tail
- * - Full: (tail - head) >= PLATFORM_PROF_SLOT_COUNT
- * - Capacity: PLATFORM_PROF_SLOT_COUNT buffers
- *
- * Memory ordering:
- * - Device pop: rmb() → read tail → read buffer_ptrs[head % COUNT] → rmb() → write head → wmb()
- * - Host push: write buffer_ptrs[tail % COUNT] → wmb() → write tail → wmb()
- */
-struct PerfFreeQueue {
-    volatile uint64_t buffer_ptrs[PLATFORM_PROF_SLOT_COUNT];  // Free buffer addresses
-    volatile uint32_t head;                                   // Consumer read position (Device increments)
-    volatile uint32_t tail;                                   // Producer write position (Host increments)
-    uint32_t pad[13];                                         // Pad to 128 bytes (aligned to cache line)
-} __attribute__((aligned(64)));
-
-static_assert(sizeof(PerfFreeQueue) == 128, "PerfFreeQueue must be 128 bytes for cache alignment");
-
-// =============================================================================
-// PerfBufferState - Per-Core/Thread Buffer State (Unified for PerfRecord and Phase)
-// =============================================================================
-
-/**
- * Per-core or per-thread buffer state for dynamic profiling
- *
- * Contains:
- * - free_queue: SPSC queue of available buffer addresses
- * - current_buf_ptr: Currently active buffer being written (0 = no active buffer)
- * - current_buf_seq: Monotonic sequence number for ordering
- *
- * Used in two contexts:
- * - Per-core PerfRecord profiling (current_buf_ptr → PerfBuffer)
- * - Per-thread Phase profiling (current_buf_ptr → PhaseBuffer)
- *
- * Writers:
- * - free_queue.tail: Host writes (pushes new buffers)
- * - free_queue.head: Device writes (pops buffers)
- * - current_buf_ptr: Device writes (after pop), Host reads (for flush/collect)
- * - current_buf_seq: Device writes (monotonic counter)
- */
-struct PerfBufferState {
-    PerfFreeQueue free_queue;           // SPSC queue of free buffer addresses
-    volatile uint64_t current_buf_ptr;  // Current active buffer (0 = none)
-    volatile uint32_t current_buf_seq;  // Sequence number for ordering
-    uint32_t pad[13];                   // Pad to 192 bytes (aligned to cache line)
-} __attribute__((aligned(64)));
-
-static_assert(sizeof(PerfBufferState) == 192, "PerfBufferState must be 192 bytes for cache alignment");
-
-// Type alias for semantic clarity in Phase profiling context
-using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
-
-// =============================================================================
-// ReadyQueueEntry - Queue Entry for Ready Buffers
-// =============================================================================
-
-/**
- * Ready queue entry
- *
- * When a buffer on a core/thread is full, AICPU adds this entry to the queue.
- * Host memory manager retrieves entries from the queue.
- *
- * Entry types (distinguished by is_phase flag):
- * - PerfRecord entry: core_index = core ID, is_phase = 0
- * - Phase entry:      core_index = thread_idx, is_phase = 1
- */
-struct ReadyQueueEntry {
-    uint32_t core_index;  // Core index (0 ~ num_cores-1), or thread_idx for phase entries
-    uint32_t is_phase;    // 0 = PerfRecord, 1 = Phase
-    uint64_t buffer_ptr;  // Device pointer to the full buffer
-    uint32_t buffer_seq;  // Sequence number for ordering
-    uint32_t pad;         // Alignment padding
-} __attribute__((aligned(32)));
-
-// =============================================================================
-// PerfDataHeader - Fixed Header
-// =============================================================================
-
-/**
- * Performance data fixed header
- *
- * Located at the start of shared memory, contains:
- * 1. Per-thread ready queues (FIFO Circular Buffers)
- * 2. Metadata (core count)
- *
- * Ready queue design:
- * - Per-thread queues: Avoid lock contention between AICPU threads
- * - Capacity per queue: PLATFORM_PROF_READYQUEUE_SIZE (full capacity for each thread)
- * - Implementation: Circular Buffer
- * - Producer: AICPU thread (adds full buffers to its own queue)
- * - Consumer: Host memory manager thread (reads from all queues)
- * - Queue empty: head == tail
- * - Queue full: (tail + 1) % capacity == head
- */
-struct PerfDataHeader {
-    // Per-thread ready queues (FIFO Circular Buffers)
-    // Each AICPU thread has its own queue to avoid lock contention
-    ReadyQueueEntry queues[PLATFORM_MAX_AICPU_THREADS][PLATFORM_PROF_READYQUEUE_SIZE];
-    volatile uint32_t queue_heads[PLATFORM_MAX_AICPU_THREADS];  // Consumer read positions (Host modifies)
-    volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // Producer write positions (AICPU modifies)
-
-    // Metadata (Host initializes, Device read-only)
-    uint32_t num_cores;             // Actual number of cores launched
-    volatile uint32_t total_tasks;  // Total tasks (AICPU writes after orchestration)
+    volatile uint32_t count;  // Current record count (at offset 0 for cache-line read)
+    uint32_t pad[15];         // Pad to 64B cache line boundary
+    PerfRecord records[];     // Flexible array member (not counted in sizeof)
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -297,25 +163,26 @@ struct AicpuOrchSummary {
     uint32_t padding;          // Alignment padding
 } __attribute__((aligned(64)));
 
-constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;        // "ACPH"
-constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per thread
+constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"
 
 /**
- * Fixed-size phase record buffer (analogous to PerfBuffer)
+ * Phase record buffer (count-first + flexible array)
  *
  * Capacity: PLATFORM_PHASE_RECORDS_PER_THREAD
- * Allocated dynamically by Host, pushed into per-thread free_queue.
+ * Actual allocation: 64 + capacity * sizeof(AicpuPhaseRecord).
  */
 struct PhaseBuffer {
-    AicpuPhaseRecord records[PLATFORM_PHASE_RECORDS_PER_THREAD];
-    volatile uint32_t count;
+    volatile uint32_t count;     // Current record count (at offset 0 for cache-line read)
+    uint32_t pad[15];            // Pad to 64B cache line boundary
+    AicpuPhaseRecord records[];  // Flexible array member
 } __attribute__((aligned(64)));
 
 /**
  * AICPU phase profiling header
  *
- * Located after the PerfBufferState array in shared memory.
- * Contains metadata and per-thread tracking.
+ * Embedded in PerfSetupHeader. Contains the magic, per-thread metadata, the
+ * core_id → scheduler thread mapping, and the orchestrator's cumulative
+ * cycle summary.
  */
 struct AicpuPhaseHeader {
     uint32_t magic;                             // Validation magic (AICPU_PHASE_MAGIC)
@@ -327,6 +194,38 @@ struct AicpuPhaseHeader {
 } __attribute__((aligned(64)));
 
 // =============================================================================
+// PerfSetupHeader - Host/Device Metadata Exchange
+// =============================================================================
+
+/**
+ * Performance setup header
+ *
+ * Allocated on device by Host. Host writes buffer pointers and metadata,
+ * then copies this struct to device once before execution. AICPU reads
+ * buffer pointers during init. After execution completes, Host copies
+ * this struct back to read total_tasks and phase_header.
+ *
+ * Memory layout: runtime.perf_data_base points to this struct on device.
+ */
+struct PerfSetupHeader {
+    // Host writes, AICPU reads (init)
+    uint32_t num_cores;          // Number of AICore instances
+    uint32_t num_phase_threads;  // Number of phase profiling threads
+    uint32_t pad0[14];           // Pad to 64B
+
+    // Host writes, AICPU reads: per-core / per-thread buffer device pointers
+    uint64_t core_buffer_ptrs[PLATFORM_MAX_CORES];           // PerfBuffer* on device
+    uint64_t phase_buffer_ptrs[PLATFORM_MAX_AICPU_THREADS];  // PhaseBuffer* on device
+
+    // AICPU writes, host reads back
+    volatile uint32_t total_tasks;  // Updated by orchestrator
+    uint32_t pad1[15];              // Pad to 64B
+
+    // AICPU writes, host reads back (via collect_all)
+    AicpuPhaseHeader phase_header;  // Contains orch_summary and core_to_thread
+} __attribute__((aligned(64)));
+
+// =============================================================================
 // Helper Functions - Memory Layout
 // =============================================================================
 
@@ -335,92 +234,36 @@ extern "C" {
 #endif
 
 /**
- * Calculate total memory size for performance data (buffer states only, no buffers)
+ * Get PerfSetupHeader pointer from base address
  *
- * Formula: Total size = Fixed header + Dynamic tail
- *                     = sizeof(PerfDataHeader) + num_cores × sizeof(PerfBufferState)
- *
- * @param num_cores Number of cores (block_dim × PLATFORM_CORES_PER_BLOCKDIM)
- * @return Total bytes for header + buffer states
+ * @param base_ptr Device base address (runtime.perf_data_base)
+ * @return PerfSetupHeader pointer
  */
-inline size_t calc_perf_data_size(int num_cores) {
-    return sizeof(PerfDataHeader) + num_cores * sizeof(PerfBufferState);
+inline PerfSetupHeader *get_perf_setup_header(void *base_ptr) { return reinterpret_cast<PerfSetupHeader *>(base_ptr); }
+
+/**
+ * Calculate PerfSetupHeader allocation size
+ */
+inline size_t calc_perf_setup_size() { return sizeof(PerfSetupHeader); }
+
+/**
+ * Calculate total bytes for a PerfBuffer with the given capacity
+ *
+ * @param capacity Number of PerfRecord slots (e.g. PLATFORM_PROF_BUFFER_SIZE)
+ * @return 64B header + capacity * sizeof(PerfRecord)
+ */
+inline size_t calc_perf_buffer_size(int capacity) {
+    return sizeof(PerfBuffer) + static_cast<size_t>(capacity) * sizeof(PerfRecord);
 }
 
 /**
- * Get header pointer
+ * Calculate total bytes for a PhaseBuffer with the given capacity
  *
- * @param base_ptr Shared memory base address (device_ptr or host_ptr)
- * @return PerfDataHeader pointer
+ * @param capacity Number of AicpuPhaseRecord slots (e.g. PLATFORM_PHASE_RECORDS_PER_THREAD)
+ * @return 64B header + capacity * sizeof(AicpuPhaseRecord)
  */
-inline PerfDataHeader *get_perf_header(void *base_ptr) { return reinterpret_cast<PerfDataHeader *>(base_ptr); }
-
-/**
- * Get PerfBufferState array start address
- *
- * @param base_ptr Shared memory base address
- * @return PerfBufferState array pointer
- */
-inline PerfBufferState *get_perf_buffer_states(void *base_ptr) {
-    return reinterpret_cast<PerfBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(PerfDataHeader));
-}
-
-/**
- * Get PerfBufferState for specified core
- *
- * @param base_ptr Shared memory base address
- * @param core_index Core index (0 ~ num_cores-1)
- * @return PerfBufferState pointer
- */
-inline PerfBufferState *get_perf_buffer_state(void *base_ptr, int core_index) {
-    return &get_perf_buffer_states(base_ptr)[core_index];
-}
-
-/**
- * Calculate total memory size including phase profiling region (buffer states only)
- *
- * @param num_cores Number of AICore instances
- * @param num_sched_threads Number of phase profiling threads (scheduler + orchestrator)
- * @return Total bytes needed for header + all buffer states
- */
-inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threads) {
-    return calc_perf_data_size(num_cores) + sizeof(AicpuPhaseHeader) + num_sched_threads * sizeof(PhaseBufferState);
-}
-
-/**
- * Get AicpuPhaseHeader pointer (located after PerfBufferState array)
- *
- * @param base_ptr Shared memory base address
- * @param num_cores Number of AICore instances
- * @return AicpuPhaseHeader pointer
- */
-inline AicpuPhaseHeader *get_phase_header(void *base_ptr, int num_cores) {
-    return reinterpret_cast<AicpuPhaseHeader *>(reinterpret_cast<char *>(base_ptr) + calc_perf_data_size(num_cores));
-}
-
-/**
- * Get PhaseBufferState array start address (located after AicpuPhaseHeader)
- *
- * @param base_ptr Shared memory base address
- * @param num_cores Number of AICore instances
- * @return PhaseBufferState array pointer
- */
-inline PhaseBufferState *get_phase_buffer_states(void *base_ptr, int num_cores) {
-    return reinterpret_cast<PhaseBufferState *>(
-        reinterpret_cast<char *>(get_phase_header(base_ptr, num_cores)) + sizeof(AicpuPhaseHeader)
-    );
-}
-
-/**
- * Get PhaseBufferState for specified thread
- *
- * @param base_ptr Shared memory base address
- * @param num_cores Number of AICore instances
- * @param thread_idx Thread index
- * @return PhaseBufferState pointer
- */
-inline PhaseBufferState *get_phase_buffer_state(void *base_ptr, int num_cores, int thread_idx) {
-    return &get_phase_buffer_states(base_ptr, num_cores)[thread_idx];
+inline size_t calc_phase_buffer_size(int capacity) {
+    return sizeof(PhaseBuffer) + static_cast<size_t>(capacity) * sizeof(AicpuPhaseRecord);
 }
 
 #ifdef __cplusplus

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -88,55 +88,24 @@ constexpr int PLATFORM_MAX_CORES_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD + PLAT
 constexpr int PLATFORM_MAX_CORES = PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 108
 
 /**
- * Performance buffer capacity per buffer
- * Number of PerfRecord entries per dynamically allocated PerfBuffer
+ * Performance buffer capacity per core
+ * Maximum number of PerfRecord entries per PerfBuffer.
+ * Each core gets one PerfBuffer; when full, AICPU silently stops recording.
  */
-constexpr int PLATFORM_PROF_BUFFER_SIZE = 1000;
+constexpr int PLATFORM_PROF_BUFFER_SIZE = 10000;
 
 /**
- * Number of buffer slots per core/thread for dynamic profiling
- * Host dynamically allocates buffers and writes addresses into these slots.
- * Device reads slot addresses when switching buffers.
- * Using slots: provides full pipeline depth for buffer recycling.
- * No runtime rtMalloc — all buffers are pre-allocated and recycled in a closed loop.
+ * Performance buffer capacity per AICPU thread
+ * Maximum number of AicpuPhaseRecord entries per PhaseBuffer.
+ * Each thread gets one PhaseBuffer; when full, records are silently dropped.
  */
-constexpr int PLATFORM_PROF_SLOT_COUNT = 4;
-
-/**
- * PerfBuffer pre-allocation count per AICore.
- * 1 goes into the free_queue at init, the rest into the recycled pool.
- */
-constexpr int PLATFORM_PROF_BUFFERS_PER_CORE = 8;
-
-/**
- * PhaseBuffer pre-allocation count per AICPU thread.
- * 1 goes into the free_queue at init, the rest into the recycled pool.
- */
-constexpr int PLATFORM_PROF_BUFFERS_PER_THREAD = 16;
-
-/**
- * Ready queue capacity for performance data collection
- * Queue holds ReadyQueueEntry structs for buffers ready to be read by Host.
- * Sized to match pre-allocation total across all cores and threads.
- */
-constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
-    PLATFORM_MAX_CORES * PLATFORM_PROF_BUFFERS_PER_CORE + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_BUFFERS_PER_THREAD;
+constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 500000;
 
 /**
  * System counter frequency (get_sys_cnt)
  * Used to convert timestamps to microseconds.
  */
 constexpr uint64_t PLATFORM_PROF_SYS_CNT_FREQ = 1000000000;  // 1000 MHz
-
-/**
- * Timeout duration for performance data collection (seconds)
- */
-constexpr int PLATFORM_PROF_TIMEOUT_SECONDS = 30;
-
-/**
- * Number of empty polling iterations before checking timeout
- */
-constexpr int PLATFORM_PROF_EMPTY_POLLS_CHECK_NUM = 1000;
 
 inline double cycles_to_us(uint64_t cycles) {
     return (static_cast<double>(cycles) / PLATFORM_PROF_SYS_CNT_FREQ) * 1000000.0;

--- a/src/a5/platform/include/host/performance_collector.h
+++ b/src/a5/platform/include/host/performance_collector.h
@@ -11,27 +11,29 @@
 
 /**
  * @file performance_collector.h
- * @brief Platform-agnostic performance data collector with dynamic memory management
+ * @brief Host-side performance data collector (memcpy-based)
  *
- * Architecture:
- * - ProfMemoryManager: Dedicated thread that polls ReadyQueue, allocates new
- *   device buffers, and replaces full buffers in slot arrays.
- * - PerformanceCollector: Main thread collects data from ProfMemoryManager's
- *   internal queue, copies records to host vectors, and exports results.
+ * Design:
+ *   1. Host pre-allocates one PerfBuffer per core and one PhaseBuffer per
+ *      AICPU thread on device, plus a single PerfSetupHeader that stores
+ *      all buffer pointers, total_tasks, and the AicpuPhaseHeader.
+ *   2. During execution, AICore writes timing into PerfBuffers and AICPU
+ *      completes records + writes phase data directly into device memory.
+ *      When a buffer fills up, records are silently dropped (AICPU-side
+ *      early return).
+ *   3. After stream sync, Host copies PerfSetupHeader, each PerfBuffer, and
+ *      each PhaseBuffer back via rtMemcpy (two-step: 64B header → read
+ *      count → copy count*sizeof(record) actual data).
  *
- * Design Pattern: Dependency Injection via Callbacks for memory operations.
+ * This replaces the previous shared-memory + ProfMemoryManager design that
+ * depended on halHostRegister, which A5 hardware does not support.
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_
 #define SRC_A5_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_
 
-#include <atomic>
-#include <condition_variable>
-#include <mutex>
-#include <queue>
+#include <cstddef>
 #include <string>
-#include <thread>
-#include <unordered_map>
 #include <vector>
 
 #include "common/perf_profiling.h"
@@ -39,380 +41,151 @@
 #include "runtime.h"
 
 /**
- * Memory allocation callback for performance profiling
+ * Device memory allocation callback.
  *
- * @param size Memory size in bytes
+ * @param size      Memory size in bytes
  * @param user_data User-provided context pointer
  * @return Allocated device memory pointer, or nullptr on failure
  */
 using PerfAllocCallback = void *(*)(size_t size, void *user_data);
 
 /**
- * Memory registration callback (for Host-Device shared memory)
+ * Device memory free callback.
  *
- * @param dev_ptr Device memory pointer
- * @param size Memory size in bytes
- * @param device_id Device ID
- * @param user_data User-provided context pointer
- * @param[out] host_ptr Host-mapped pointer
- * @return 0 on success, error code on failure
- */
-using PerfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void *user_data, void **host_ptr);
-
-/**
- * Memory unregister callback
- *
- * @param dev_ptr Device memory pointer
- * @param device_id Device ID
- * @param user_data User-provided context pointer
- * @return 0 on success, error code on failure
- */
-using PerfUnregisterCallback = int (*)(void *dev_ptr, int device_id, void *user_data);
-
-/**
- * Memory free callback
- *
- * @param dev_ptr Device memory pointer
+ * @param dev_ptr   Device memory pointer
  * @param user_data User-provided context pointer
  * @return 0 on success, error code on failure
  */
 using PerfFreeCallback = int (*)(void *dev_ptr, void *user_data);
 
 /**
- * Device context setup callback (called once on mgmt thread startup)
+ * Host → Device copy callback (rtMemcpy HOST_TO_DEVICE / memcpy in sim).
  *
- * @param device_id Device ID to set
+ * @param dev_dst   Device destination pointer
+ * @param host_src  Host source pointer
+ * @param size      Number of bytes to copy
  * @param user_data User-provided context pointer
  * @return 0 on success, error code on failure
  */
-using PerfSetDeviceCallback = int (*)(int device_id, void *user_data);
-
-// =============================================================================
-// ProfMemoryManager - Dynamic Buffer Memory Management Thread
-// =============================================================================
+using PerfCopyToDeviceCallback = int (*)(void *dev_dst, const void *host_src, size_t size, void *user_data);
 
 /**
- * Buffer type identifier for ReadyBufferInfo
- */
-enum class ProfBufferType { PERF_RECORD, PHASE };
-
-/**
- * Information about a ready (full) buffer, passed from mgmt thread to main thread
- */
-struct ReadyBufferInfo {
-    ProfBufferType type;
-    uint32_t index;         // core_index (PERF_RECORD) or thread_idx (PHASE)
-    uint32_t slot_idx;      // Reserved (unused in free queue design)
-    void *dev_buffer_ptr;   // Device address of the full buffer
-    void *host_buffer_ptr;  // Host-mapped address (sim: same as dev)
-    uint32_t buffer_seq;    // Sequence number for ordering
-};
-
-/**
- * Notification that a buffer has been copied and can be freed
- */
-struct CopyDoneInfo {
-    void *dev_buffer_ptr;  // Device buffer to free
-    ProfBufferType type;   // Buffer type (for recycling)
-};
-
-/**
- * Dynamic profiling buffer memory manager
+ * Device → Host copy callback (rtMemcpy DEVICE_TO_HOST / memcpy in sim).
  *
- * Runs a dedicated thread that:
- * 1. Polls ReadyQueue in shared memory for full buffer entries
- * 2. Allocates new device buffers via callback
- * 3. Writes new buffer addresses into slots (for device to pick up)
- * 4. Pushes old (full) buffer info to internal queue for main thread to copy
- * 5. Frees device buffers after main thread confirms copy is done
+ * @param host_dst  Host destination pointer
+ * @param dev_src   Device source pointer
+ * @param size      Number of bytes to copy
+ * @param user_data User-provided context pointer
+ * @return 0 on success, error code on failure
  */
-class ProfMemoryManager {
-public:
-    ProfMemoryManager() = default;
-    ~ProfMemoryManager();
-
-    // Disable copy
-    ProfMemoryManager(const ProfMemoryManager &) = delete;
-    ProfMemoryManager &operator=(const ProfMemoryManager &) = delete;
-
-    // Allow PerformanceCollector to register initial buffer mappings
-    friend class PerformanceCollector;
-
-    /**
-     * Start the memory management thread
-     *
-     * @param shared_mem_host Host-mapped shared memory base address
-     * @param num_cores Number of AICore instances (PerfBufferState count)
-     * @param num_phase_threads Number of phase profiling threads (PhaseBufferState count)
-     * @param alloc_cb Device memory allocation callback
-     * @param register_cb Host-device mapping callback (nullptr for simulation)
-     * @param free_cb Device memory free callback
-     * @param user_data User context for callbacks
-     * @param device_id Device ID for registration
-     * @param set_device_cb Device context setup callback (nullptr to skip)
-     */
-    void start(
-        void *shared_mem_host, int num_cores, int num_phase_threads, PerfAllocCallback alloc_cb,
-        PerfRegisterCallback register_cb, PerfFreeCallback free_cb, void *user_data, int device_id,
-        PerfSetDeviceCallback set_device_cb = nullptr
-    );
-
-    /**
-     * Stop the memory management thread
-     * Blocks until the thread exits.
-     */
-    void stop();
-
-    /**
-     * Try to pop a ready buffer info (non-blocking)
-     *
-     * @param[out] info Ready buffer info
-     * @return true if an item was available, false otherwise
-     */
-    bool try_pop_ready(ReadyBufferInfo &info);
-
-    /**
-     * Wait for a ready buffer info with timeout
-     *
-     * @param[out] info Ready buffer info
-     * @param timeout Maximum wait time
-     * @return true if an item was available, false on timeout
-     */
-    bool wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout);
-
-    /**
-     * Notify that a buffer has been copied and can be freed
-     *
-     * @param info Copy done notification
-     */
-    void notify_copy_done(const CopyDoneInfo &info);
-
-    /**
-     * Check if the manager thread is running
-     */
-    bool is_running() const { return running_.load(); }
-
-private:
-    std::thread mgmt_thread_;
-    std::atomic<bool> running_{false};
-
-    // Shared memory references
-    void *shared_mem_host_{nullptr};
-    int num_cores_{0};
-    int num_phase_threads_{0};
-
-    // Callbacks
-    PerfAllocCallback alloc_cb_{nullptr};
-    PerfRegisterCallback register_cb_{nullptr};
-    PerfFreeCallback free_cb_{nullptr};
-    PerfSetDeviceCallback set_device_cb_{nullptr};
-    void *user_data_{nullptr};
-    int device_id_{-1};
-
-    // Management thread → main thread (ready buffers)
-    std::mutex ready_mutex_;
-    std::condition_variable ready_cv_;
-    std::queue<ReadyBufferInfo> ready_queue_;
-
-    // Main thread → management thread (buffers to free)
-    std::mutex done_mutex_;
-    std::queue<CopyDoneInfo> done_queue_;
-
-    // Device-to-host pointer mapping (populated during alloc_and_register)
-    std::unordered_map<void *, void *> dev_to_host_;
-
-    // Recycled buffer pools (avoids alloc/free churn in mgmt_loop)
-    std::vector<void *> recycled_perf_buffers_;
-    std::vector<void *> recycled_phase_buffers_;
-
-    // Management thread main loop
-    void mgmt_loop();
-
-    // Allocate a new buffer and optionally register for host access
-    void *alloc_and_register(size_t size, void **host_ptr_out);
-
-    // Free a previously allocated buffer
-    void free_buffer(void *dev_ptr);
-
-    // Resolve device pointer to host pointer
-    void *resolve_host_ptr(void *dev_ptr);
-
-    // Register an external dev→host mapping (for initial buffers)
-    void register_mapping(void *dev_ptr, void *host_ptr);
-
-    // Process one ReadyQueue entry
-    void process_ready_entry(PerfDataHeader *header, int thread_idx, const ReadyQueueEntry &entry);
-};
-
-// =============================================================================
-// PerformanceCollector - Main Collector
-// =============================================================================
+using PerfCopyFromDeviceCallback = int (*)(void *host_dst, const void *dev_src, size_t size, void *user_data);
 
 /**
- * Performance data collector
+ * Host-side performance data collector.
  *
- * Manages performance profiling lifecycle:
- * 1. Initialize shared memory (Header + SlotArrays) and allocate initial buffers
- * 2. Start ProfMemoryManager thread
- * 3. Collect records from ProfMemoryManager's queue (main thread)
- * 4. Export swimlane visualization
- *
- * Platform-agnostic: Memory management delegated to callbacks
+ * Lifecycle:
+ *   1. initialize() — allocate PerfSetupHeader and all per-core/per-thread
+ *      buffers on device, publish pointers into runtime.perf_data_base
+ *   2. (AICore/AICPU run, writing directly into device buffers)
+ *   3. collect_all() — after stream sync, copy PerfSetupHeader back,
+ *      then copy each PerfBuffer / PhaseBuffer back using two-step
+ *      count-first memcpy. Fills collected_*_records_ vectors.
+ *   4. export_swimlane_json() — serialize collected data to Chrome Trace
+ *      Event Format JSON. Logic unchanged from previous design.
+ *   5. finalize() — free all device buffers.
  */
 class PerformanceCollector {
 public:
     PerformanceCollector() = default;
     ~PerformanceCollector();
 
-    // Disable copy and move
     PerformanceCollector(const PerformanceCollector &) = delete;
     PerformanceCollector &operator=(const PerformanceCollector &) = delete;
 
     /**
-     * Initialize performance profiling
+     * Allocate device buffers and publish PerfSetupHeader.
      *
-     * Allocates shared memory for slot arrays, allocates initial buffers,
-     * and writes buffer addresses into slots.
-     *
-     * @param runtime Runtime instance to configure
-     * @param num_aicore Number of AICore instances
-     * @param device_id Device ID
-     * @param alloc_cb Memory allocation callback
-     * @param register_cb Memory registration callback (can be nullptr for simulation)
-     * @param free_cb Memory free callback
-     * @param user_data User-provided context pointer passed to callbacks
-     * @param set_device_cb Device context setup callback (nullptr to skip)
+     * @param runtime          Runtime to configure (sets runtime.perf_data_base)
+     * @param num_aicore       Number of AICore instances to profile
+     * @param device_id        Device ID (stored for later callbacks)
+     * @param alloc_cb         Device memory alloc
+     * @param free_cb          Device memory free
+     * @param copy_to_dev_cb   Host→device copy (used during init to publish header)
+     * @param copy_from_dev_cb Device→host copy (used during collect_all)
+     * @param user_data        Opaque context passed back to callbacks
      * @return 0 on success, error code on failure
      */
     int initialize(
-        Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-        PerfFreeCallback free_cb, void *user_data, PerfSetDeviceCallback set_device_cb = nullptr
+        Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfFreeCallback free_cb,
+        PerfCopyToDeviceCallback copy_to_dev_cb, PerfCopyFromDeviceCallback copy_from_dev_cb, void *user_data
     );
 
     /**
-     * Start the memory management thread
+     * Copy all profiling data back from device and parse it into
+     * collected_perf_records_ / collected_phase_records_ /
+     * collected_orch_summary_ / core_to_thread_.
      *
-     * Must be called after initialize() and before device execution starts.
-     */
-    void start_memory_manager();
-
-    /**
-     * Poll and collect performance data from the memory manager's queue
+     * Must be called after the execution stream has been fully synchronized.
      *
-     * Runs on the main thread (or a dedicated collector thread in sim mode).
-     * Pulls ready buffers from ProfMemoryManager, copies records to host vectors,
-     * and notifies the manager to free old device buffers.
-     *
-     * @param expected_tasks Expected total number of tasks (0 = auto-detect)
-     */
-    void poll_and_collect(int expected_tasks = 0);
-
-    /**
-     * Export performance data to Chrome Trace Event Format
-     *
-     * @param output_path Output directory path
      * @return 0 on success, error code on failure
+     */
+    int collect_all();
+
+    /**
+     * Export collected data to Chrome Trace Event Format JSON.
+     *
+     * @param output_path Output directory
+     * @return 0 on success, -1 on failure
      */
     int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
-     * Stop the memory management thread and clean up remaining data
+     * Free all device buffers and clear host-side state.
      *
-     * Must be called after device execution completes.
-     */
-    void stop_memory_manager();
-
-    /**
-     * Cleanup all resources
-     *
-     * @param unregister_cb Memory unregister callback (can be nullptr)
-     * @param free_cb Memory free callback
-     * @param user_data User-provided context pointer
      * @return 0 on success, error code on failure
      */
-    int finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void *user_data);
+    int finalize();
 
     /**
-     * Check if collector is initialized
+     * Check if the collector has been initialized.
      */
-    bool is_initialized() const { return perf_shared_mem_host_ != nullptr; }
+    bool is_initialized() const { return setup_header_dev_ != nullptr; }
 
     /**
-     * Drain remaining buffers from the memory manager's ready queue
-     *
-     * After poll_and_collect() exits (all PERF records collected) and
-     * the memory manager is stopped, Phase buffers may still be in the
-     * ready queue. This method drains them into the collected vectors.
-     *
-     * Must be called after stop_memory_manager() and before collect_phase_data().
-     */
-    void drain_remaining_buffers();
-
-    /**
-     * Collect AICPU phase profiling data from shared memory
-     *
-     * Reads scheduler phase records and orchestrator summary from the
-     * phase profiling region. Must be called after AICPU threads have joined.
-     */
-    void collect_phase_data();
-
-    /**
-     * Scan PerfBufferState::current_buf_ptr for all cores to recover
-     * partial records not delivered through the pipeline.
-     *
-     * Must be called after device execution completes and after
-     * stop_memory_manager(). Follows the same pattern as collect_phase_data()
-     * for PhaseBufferStates.
-     */
-    void scan_remaining_perf_buffers();
-
-    /**
-     * Signal that device execution is complete (streams synchronized).
-     * poll_and_collect() will drain remaining pipeline data and exit.
-     */
-    void signal_execution_complete();
-
-    /**
-     * Get collected records (for testing)
+     * Accessor used by tests.
      */
     const std::vector<std::vector<PerfRecord>> &get_records() const { return collected_perf_records_; }
 
 private:
-    // Shared memory pointers
-    void *perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
-    void *perf_shared_mem_host_{nullptr};  // Host-mapped pointer (slot arrays)
-    bool was_registered_{false};           // True if register_cb was called successfully
-    int device_id_{-1};
+    // Device-side allocations
+    void *setup_header_dev_{nullptr};
+    std::vector<void *> core_buffers_dev_;
+    std::vector<void *> phase_buffers_dev_;
 
     // Configuration
     int num_aicore_{0};
+    int num_phase_threads_{0};
+    int device_id_{-1};
 
-    // Callbacks (stored for memory manager)
+    // Sizes (computed once in initialize)
+    size_t perf_buffer_bytes_{0};
+    size_t phase_buffer_bytes_{0};
+
+    // Callbacks
     PerfAllocCallback alloc_cb_{nullptr};
-    PerfRegisterCallback register_cb_{nullptr};
     PerfFreeCallback free_cb_{nullptr};
-    PerfSetDeviceCallback set_device_cb_{nullptr};
+    PerfCopyToDeviceCallback copy_to_dev_cb_{nullptr};
+    PerfCopyFromDeviceCallback copy_from_dev_cb_{nullptr};
     void *user_data_{nullptr};
 
-    // Memory manager
-    ProfMemoryManager memory_manager_;
-
-    // Collected data (per-core vectors, indexed by core_index)
+    // Host-side collected data (indexed by core / thread)
     std::vector<std::vector<PerfRecord>> collected_perf_records_;
-
-    // AICPU phase profiling data (per-thread, mixed sched + orch records)
     std::vector<std::vector<AicpuPhaseRecord>> collected_phase_records_;
     AicpuOrchSummary collected_orch_summary_{};
     bool has_phase_data_{false};
 
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
     std::vector<int8_t> core_to_thread_;
-
-    // Signal from device_runner that execution is complete
-    std::atomic<bool> execution_complete_{false};
-
-    // Allocate a single buffer (PerfBuffer or PhaseBuffer) and register it
-    void *alloc_single_buffer(size_t size, void **host_ptr_out);
 };
 
 #endif  // SRC_A5_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -17,55 +17,15 @@
 
 #include "device_runner.h"
 
-#include <dlfcn.h>
-
 #include <cassert>
+#include <cstring>
 #include <iostream>
 #include <string>
 #include <vector>
 
-// Include HAL constants from CANN (header only, library loaded dynamically)
-#include "ascend_hal.h"
 #include "callable.h"
 #include "host/host_regs.h"  // Register address retrieval
 #include "host/raii_scope_guard.h"
-
-// =============================================================================
-// Lazy-loaded HAL (ascend_hal) for profiling host-register only
-// =============================================================================
-
-namespace {
-void *g_hal_handle = nullptr;
-
-using HalHostRegisterFn = int (*)(void *dev_ptr, size_t size, unsigned int flags, int device_id, void **host_ptr);
-using HalHostUnregisterFn = int (*)(void *host_ptr, int device_id);
-
-int load_hal_if_needed() {
-    if (g_hal_handle != nullptr) {
-        return 0;
-    }
-    g_hal_handle = dlopen("libascend_hal.so", RTLD_NOW | RTLD_LOCAL);
-    if (g_hal_handle == nullptr) {
-        return -1;
-    }
-    return 0;
-}
-
-HalHostRegisterFn get_halHostRegister() {
-    if (g_hal_handle == nullptr) {
-        return nullptr;
-    }
-    return reinterpret_cast<HalHostRegisterFn>(dlsym(g_hal_handle, "halHostRegister"));
-}
-
-HalHostUnregisterFn get_halHostUnregister() {
-    if (g_hal_handle == nullptr) {
-        return nullptr;
-    }
-    return reinterpret_cast<HalHostUnregisterFn>(dlsym(g_hal_handle, "halHostUnregister"));
-}
-
-}  // namespace
 
 // =============================================================================
 // KernelArgsHelper Implementation
@@ -408,16 +368,7 @@ int DeviceRunner::run(
             LOG_ERROR("init_performance_profiling failed: %d", rc);
             return rc;
         }
-        // Start memory management thread
-        perf_collector_.start_memory_manager();
     }
-
-    auto perf_cleanup = RAIIScopeGuard([this]() {
-        bool was_initialized = perf_collector_.is_initialized();
-        if (was_initialized) {
-            perf_collector_.stop_memory_manager();
-        }
-    });
 
     std::cout << "\n=== Initialize runtime args ===" << '\n';
     // Initialize runtime args
@@ -454,19 +405,6 @@ int DeviceRunner::run(
     }
 
     {
-        // Poll and collect performance data in a separate collector thread
-        std::thread collector_thread;
-        if (runtime.enable_profiling) {
-            collector_thread = std::thread([this, &runtime]() {
-                poll_and_collect_performance_data(runtime.get_task_count());
-            });
-        }
-        auto thread_guard = RAIIScopeGuard([&]() {
-            if (runtime.enable_profiling && collector_thread.joinable()) {
-                collector_thread.join();
-            }
-        });
-
         std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
         // Synchronize streams
         rc = rtStreamSynchronize(stream_aicpu_);
@@ -481,19 +419,12 @@ int DeviceRunner::run(
             LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
             return rc;
         }
-
-        // Signal collector that device execution is complete
-        if (runtime.enable_profiling) {
-            perf_collector_.signal_execution_complete();
-        }
     }
 
-    // Stop memory management, drain remaining buffers, collect phase data, export
+    // After streams are synchronized, pull profiling data back in one batch
+    // (memcpy-based: two-step count-first copy per buffer).
     if (runtime.enable_profiling) {
-        perf_collector_.stop_memory_manager();
-        perf_collector_.drain_remaining_buffers();
-        perf_collector_.scan_remaining_perf_buffers();
-        perf_collector_.collect_phase_data();
+        perf_collector_.collect_all();
         export_swimlane_json();
     }
 
@@ -556,23 +487,9 @@ int DeviceRunner::finalize() {
         stream_aicore_ = nullptr;
     }
 
-    // Cleanup performance profiling
+    // Cleanup performance profiling (frees PerfSetupHeader + all per-core/per-thread buffers)
     if (perf_collector_.is_initialized()) {
-        auto unregister_cb = [](void *dev_ptr, int device_id, void *user_data) -> int {
-            (void)user_data;
-            HalHostUnregisterFn fn = get_halHostUnregister();
-            if (fn != nullptr) {
-                return fn(dev_ptr, device_id);
-            }
-            return 0;
-        };
-
-        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-            auto *allocator = static_cast<MemoryAllocator *>(user_data);
-            return allocator->free(dev_ptr);
-        };
-
-        perf_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+        perf_collector_.finalize();
     }
 
     // Free all remaining allocations (including handshake buffer and binGmAddr)
@@ -726,25 +643,10 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
 }
 
 int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, int device_id) {
-    // Define allocation callback (a5: use MemoryAllocator)
+    // Device memory allocation via MemoryAllocator
     auto alloc_cb = [](size_t size, void *user_data) -> void * {
         auto *allocator = static_cast<MemoryAllocator *>(user_data);
         return allocator->alloc(size);
-    };
-
-    // Define registration callback (a5: use halHostRegister for shared memory)
-    auto register_cb = [](void *dev_ptr, size_t size, int device_id, void *user_data, void **host_ptr) -> int {
-        (void)user_data;  // Not needed for registration
-        if (load_hal_if_needed() != 0) {
-            LOG_ERROR("Failed to load ascend_hal for profiling: %s", dlerror());
-            return -1;
-        }
-        HalHostRegisterFn fn = get_halHostRegister();
-        if (fn == nullptr) {
-            LOG_ERROR("halHostRegister symbol not found: %s", dlerror());
-            return -1;
-        }
-        return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
 
     auto free_cb = [](void *dev_ptr, void *user_data) -> int {
@@ -752,17 +654,18 @@ int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, i
         return allocator->free(dev_ptr);
     };
 
-    auto set_device_cb = [](int device_id, void * /*user_data*/) -> int {
-        return rtSetDevice(device_id);
+    // Host→device and device→host copies via rtMemcpy
+    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size, void * /*user_data*/) -> int {
+        return rtMemcpy(dev_dst, size, host_src, size, RT_MEMCPY_HOST_TO_DEVICE);
+    };
+
+    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size, void * /*user_data*/) -> int {
+        return rtMemcpy(host_dst, size, dev_src, size, RT_MEMCPY_DEVICE_TO_HOST);
     };
 
     return perf_collector_.initialize(
-        runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_, set_device_cb
+        runtime, num_aicore, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb, &mem_alloc_
     );
-}
-
-void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
-    perf_collector_.poll_and_collect(expected_tasks);
 }
 
 int DeviceRunner::export_swimlane_json(const std::string &output_path) {

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -233,17 +233,6 @@ public:
     void print_handshake_results();
 
     /**
-     * Poll and collect performance data from device
-     *
-     * Polls the ready queue and collects performance records from full buffers.
-     * This is a synchronous polling function that should be called after
-     * launching kernels but before stream synchronization.
-     *
-     * @param expected_tasks Expected total number of tasks (used for exit condition)
-     */
-    void poll_and_collect_performance_data(int expected_tasks);
-
-    /**
      * Export performance data to merged_swimlane.json
      *
      * Converts collected performance records to Chrome Trace Event Format
@@ -397,14 +386,14 @@ private:
     );
 
     /**
-     * Initialize performance profiling shared memory
+     * Initialize performance profiling device buffers
      *
-     * Allocates device memory, maps to host for shared access, and initializes
-     * performance data structures (header and double buffers).
+     * Allocates PerfSetupHeader and per-core/per-thread buffers on device,
+     * publishes pointers via runtime.perf_data_base.
      *
      * @param runtime Runtime instance to configure
      * @param num_aicore Number of AICore instances
-     * @param device_id Device ID for host registration
+     * @param device_id Device ID
      * @return 0 on success, error code on failure
      */
     int init_performance_profiling(Runtime &runtime, int num_aicore, int device_id);

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -310,16 +310,7 @@ int DeviceRunner::run(
             LOG_ERROR("init_performance_profiling failed: %d", rc);
             return rc;
         }
-        // Start memory management thread
-        perf_collector_.start_memory_manager();
     }
-
-    auto perf_cleanup = RAIIScopeGuard([this]() {
-        bool was_initialized = perf_collector_.is_initialized();
-        if (was_initialized) {
-            perf_collector_.stop_memory_manager();
-        }
-    });
 
     // Allocate simulated register blocks for all AICore cores
     // Using sparse mapping: 2 x 4KB pages per core instead of 24KB contiguous block
@@ -393,14 +384,6 @@ int DeviceRunner::run(
         });
     }
 
-    // Poll and collect performance data during execution (if enabled)
-    std::thread collector_thread;
-    if (runtime.enable_profiling) {
-        collector_thread = std::thread([this, &runtime]() {
-            poll_and_collect_performance_data(runtime.get_task_count());
-        });
-    }
-
     // Wait for all threads to complete
     LOG_INFO("Waiting for threads to complete");
     for (auto &t : aicpu_threads) {
@@ -410,24 +393,11 @@ int DeviceRunner::run(
         t.join();
     }
 
-    // Signal collector that device execution is complete
-    if (runtime.enable_profiling) {
-        perf_collector_.signal_execution_complete();
-    }
-
-    // Wait for collector thread if it was launched
-    if (runtime.enable_profiling && collector_thread.joinable()) {
-        collector_thread.join();
-    }
-
     LOG_INFO("All threads completed");
 
-    // Stop memory management, drain remaining buffers, collect phase data, export
+    // Collect performance data and export
     if (runtime.enable_profiling) {
-        perf_collector_.stop_memory_manager();
-        perf_collector_.drain_remaining_buffers();
-        perf_collector_.scan_remaining_perf_buffers();
-        perf_collector_.collect_phase_data();
+        perf_collector_.collect_all();
         export_swimlane_json();
     }
 
@@ -488,13 +458,7 @@ int DeviceRunner::finalize() {
 
     // Cleanup performance profiling
     if (perf_collector_.is_initialized()) {
-        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-            (void)user_data;
-            free(dev_ptr);
-            return 0;
-        };
-
-        perf_collector_.finalize(nullptr, free_cb, nullptr);
+        perf_collector_.finalize();
     }
 
     // Kernel binaries should have been removed by validate_runtime_impl()
@@ -621,25 +585,30 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
 // =============================================================================
 
 int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, int device_id) {
-    // Define allocation callback (a5sim: use malloc)
-    auto alloc_cb = [](size_t size, void *user_data) -> void * {
-        (void)user_data;  // Not needed for malloc
+    // Simulation: "device" memory is just host memory, so use malloc/free and
+    // std::memcpy for the copy callbacks.
+    auto alloc_cb = [](size_t size, void * /*user_data*/) -> void * {
         return malloc(size);
     };
 
-    // Define free callback (a5sim: use free)
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        (void)user_data;  // Not needed for free
+    auto free_cb = [](void *dev_ptr, void * /*user_data*/) -> int {
         free(dev_ptr);
         return 0;
     };
 
-    // Simulation: no registration needed (pass nullptr)
-    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, nullptr, free_cb, nullptr, nullptr);
-}
+    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size, void * /*user_data*/) -> int {
+        std::memcpy(dev_dst, host_src, size);
+        return 0;
+    };
 
-void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
-    perf_collector_.poll_and_collect(expected_tasks);
+    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size, void * /*user_data*/) -> int {
+        std::memcpy(host_dst, dev_src, size);
+        return 0;
+    };
+
+    return perf_collector_.initialize(
+        runtime, num_aicore, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb, nullptr
+    );
 }
 
 int DeviceRunner::export_swimlane_json(const std::string &output_path) {

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -142,17 +142,6 @@ public:
     void print_handshake_results();
 
     /**
-     * Poll and collect performance data from shared memory
-     *
-     * Polls the ready queue and collects performance records from full buffers.
-     * This is a synchronous polling function that should be called after
-     * launching kernels but before thread synchronization.
-     *
-     * @param expected_tasks Expected total number of tasks (used for exit condition)
-     */
-    void poll_and_collect_performance_data(int expected_tasks);
-
-    /**
      * Export performance data to merged_swimlane.json
      *
      * Converts collected performance records to Chrome Trace Event Format

--- a/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -11,11 +11,12 @@
 
 /**
  * @file performance_collector_aicpu.cpp
- * @brief AICPU performance data collection implementation (SPSC free queue)
+ * @brief AICPU performance data collection implementation (memcpy-based)
  *
- * Uses per-core PerfBufferState with SPSC free queues for O(1) buffer switching.
- * Host memory manager dynamically allocates replacement buffers and pushes
- * them into the free_queue. Device pops from free_queue when switching.
+ * Host pre-allocates one PerfBuffer per core and one PhaseBuffer per thread
+ * on the device. AICPU writes records directly into them via cached pointers.
+ * When a buffer fills up, subsequent records are silently dropped — there is
+ * no buffer switching or flushing.
  */
 
 #include "aicpu/performance_collector_aicpu.h"
@@ -28,51 +29,12 @@
 #include "common/unified_log.h"
 
 // Cached pointers for hot-path access (set during init)
-static AicpuPhaseHeader *s_phase_header = nullptr;
-static PerfDataHeader *s_perf_header = nullptr;
+static PerfSetupHeader *s_setup_header = nullptr;
 
-// Per-core PerfBufferState cache
-static PerfBufferState *s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
-
-// Per-thread PhaseBufferState cache
-static PhaseBufferState *s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
+// Per-thread PhaseBuffer cache
 static PhaseBuffer *s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
 static int s_orch_thread_idx = -1;
-
-/**
- * Enqueue ready buffer to per-thread queue
- *
- * @param header PerfDataHeader pointer
- * @param thread_idx Thread index
- * @param core_index Core index (or thread_idx for phase entries)
- * @param buffer_ptr Device pointer to the full buffer
- * @param buffer_seq Sequence number for ordering
- * @param is_phase 0 = PerfRecord, 1 = Phase
- * @return 0 on success, -1 if queue full
- */
-static int enqueue_ready_buffer(
-    PerfDataHeader *header, int thread_idx, uint32_t core_index, uint64_t buffer_ptr, uint32_t buffer_seq,
-    uint32_t is_phase
-) {
-    uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
-    uint32_t current_tail = header->queue_tails[thread_idx];
-    uint32_t current_head = header->queue_heads[thread_idx];
-
-    // Check if queue is full
-    uint32_t next_tail = (current_tail + 1) % capacity;
-    if (next_tail == current_head) {
-        return -1;
-    }
-
-    header->queues[thread_idx][current_tail].core_index = core_index;
-    header->queues[thread_idx][current_tail].is_phase = is_phase;
-    header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
-    header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
-    header->queue_tails[thread_idx] = next_tail;
-
-    return 0;
-}
 
 void perf_aicpu_init_profiling(Runtime *runtime) {
     void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
@@ -81,43 +43,29 @@ void perf_aicpu_init_profiling(Runtime *runtime) {
         return;
     }
 
-    s_perf_header = get_perf_header(perf_base);
+    s_setup_header = get_perf_setup_header(perf_base);
 
     int32_t task_count = runtime->get_task_count();
-    s_perf_header->total_tasks = static_cast<uint32_t>(task_count);
+    s_setup_header->total_tasks = static_cast<uint32_t>(task_count);
 
-    LOG_INFO("Initializing performance profiling for %d cores (free queue)", runtime->worker_count);
+    LOG_INFO("Initializing performance profiling for %d cores (memcpy-based)", runtime->worker_count);
 
-    // Pop first buffer from free_queue for each core
+    // Initialize each core's PerfBuffer and publish the pointer to the handshake
     for (int i = 0; i < runtime->worker_count; i++) {
         Handshake *h = &runtime->workers[i];
-        PerfBufferState *state = get_perf_buffer_state(perf_base, i);
+        uint64_t buf_ptr = s_setup_header->core_buffer_ptrs[i];
 
-        s_perf_buffer_states[i] = state;
-
-        // Pop first buffer from free_queue
-        rmb();
-        uint32_t head = state->free_queue.head;
-        uint32_t tail = state->free_queue.tail;
-
-        if (head != tail) {
-            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-            rmb();
-            state->free_queue.head = head + 1;
-            state->current_buf_ptr = buf_ptr;
-            state->current_buf_seq = 0;
-            wmb();
-
-            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(buf_ptr);
-            buf->count = 0;
-            h->perf_records_addr = buf_ptr;
-
-            LOG_DEBUG("Core %d: popped initial buffer (addr=0x%lx)", i, buf_ptr);
-        } else {
-            LOG_ERROR("Core %d: free_queue is empty during init!", i);
-            state->current_buf_ptr = 0;
+        if (buf_ptr == 0) {
+            LOG_ERROR("Core %d: core_buffer_ptrs[%d] is NULL during init!", i, i);
             h->perf_records_addr = 0;
+            continue;
         }
+
+        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(buf_ptr);
+        buf->count = 0;
+        h->perf_records_addr = buf_ptr;
+
+        LOG_DEBUG("Core %d: PerfBuffer at 0x%lx", i, buf_ptr);
     }
 
     wmb();
@@ -131,6 +79,8 @@ int perf_aicpu_complete_record(
 ) {
     rmb();
     uint32_t count = perf_buf->count;
+    // Buffer-full check lives here (AICore does not branch on capacity); return -1
+    // silently drops the record, caller ignores the failure.
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
 
     PerfRecord *record = &perf_buf->records[count];
@@ -157,124 +107,13 @@ int perf_aicpu_complete_record(
     return 0;
 }
 
-void perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx) {
-    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
-    if (perf_base == nullptr) {
-        return;
-    }
-
-    PerfBufferState *state = s_perf_buffer_states[core_id];
-    if (state == nullptr) {
-        return;
-    }
-
-    PerfBuffer *full_buf = reinterpret_cast<PerfBuffer *>(state->current_buf_ptr);
-    if (full_buf == nullptr) {
-        return;
-    }
-
-    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)", thread_idx, core_id, full_buf->count);
-
-    // Check free_queue before committing the full buffer
-    rmb();
-    uint32_t head = state->free_queue.head;
-    uint32_t tail = state->free_queue.tail;
-
-    if (head == tail) {
-        // No replacement buffer available — overwrite current buffer to keep AICore alive
-        LOG_WARN("Thread %d: Core %d no free buffer, overwriting current buffer (data lost)", thread_idx, core_id);
-        full_buf->count = 0;
-        wmb();
-        return;
-    }
-
-    // Enqueue full buffer to ReadyQueue
-    uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, state->current_buf_ptr, seq, 0);
-    if (rc != 0) {
-        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
-        // Revert: discard data and keep writing
-        full_buf->count = 0;
-        wmb();
-        return;
-    }
-
-    // Pop next buffer from free_queue
-    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-    rmb();
-    state->free_queue.head = head + 1;
-    state->current_buf_ptr = new_buf_ptr;
-    state->current_buf_seq = seq + 1;
-    wmb();
-
-    PerfBuffer *new_buf = reinterpret_cast<PerfBuffer *>(new_buf_ptr);
-    new_buf->count = 0;
-
-    // Update handshake for AICore
-    Handshake *h = &runtime->workers[core_id];
-    h->perf_records_addr = new_buf_ptr;
-    wmb();
-
-    LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
-}
-
-void perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cur_thread_cores, int core_num) {
-    if (!runtime->enable_profiling) {
-        return;
-    }
-
-    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
-    if (perf_base == nullptr) {
-        return;
-    }
-
-    rmb();
-
-    LOG_INFO("Thread %d: Flushing performance buffers for %d cores", thread_idx, core_num);
-
-    int flushed_count = 0;
-
-    for (int i = 0; i < core_num; i++) {
-        int core_id = cur_thread_cores[i];
-        PerfBufferState *state = s_perf_buffer_states[core_id];
-        if (state == nullptr) continue;
-
-        rmb();
-        uint64_t buf_ptr = state->current_buf_ptr;
-        if (buf_ptr == 0) {
-            // No active buffer
-            continue;
-        }
-
-        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(buf_ptr);
-        if (buf->count == 0) {
-            continue;
-        }
-
-        uint32_t seq = state->current_buf_seq;
-        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, buf_ptr, seq, 0);
-        if (rc == 0) {
-            LOG_INFO("Thread %d: Core %d flushed buffer with %u records", thread_idx, core_id, buf->count);
-            flushed_count++;
-            state->current_buf_ptr = 0;
-            wmb();
-        } else {
-            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
-        }
-    }
-
-    wmb();
-
-    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
-}
-
 void perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks) {
     void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
 
-    PerfDataHeader *header = get_perf_header(perf_base);
+    PerfSetupHeader *header = get_perf_setup_header(perf_base);
     header->total_tasks = total_tasks;
     wmb();
 }
@@ -286,56 +125,40 @@ void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
         return;
     }
 
-    s_phase_header = get_phase_header(perf_base, runtime->worker_count);
-    s_perf_header = get_perf_header(perf_base);
+    s_setup_header = get_perf_setup_header(perf_base);
 
-    s_phase_header->magic = AICPU_PHASE_MAGIC;
-    s_phase_header->num_sched_threads = num_sched_threads;
-    s_phase_header->records_per_thread = PLATFORM_PHASE_RECORDS_PER_THREAD;
-    s_phase_header->num_cores = 0;
+    AicpuPhaseHeader *phase_header = &s_setup_header->phase_header;
+    phase_header->magic = AICPU_PHASE_MAGIC;
+    phase_header->num_sched_threads = num_sched_threads;
+    phase_header->records_per_thread = PLATFORM_PHASE_RECORDS_PER_THREAD;
+    phase_header->num_cores = 0;
 
-    memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
-    memset(&s_phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
+    memset(phase_header->core_to_thread, -1, sizeof(phase_header->core_to_thread));
+    memset(&phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
 
-    // Cache per-thread record pointers and clear buffers
-    // Include all threads: scheduler + orchestrator (orchestrator may become scheduler)
+    // Cache per-thread PhaseBuffer pointers. Include all threads: scheduler +
+    // orchestrator (orchestrator may become scheduler).
     int total_threads = num_sched_threads + 1;
     if (total_threads > PLATFORM_MAX_AICPU_THREADS) {
         total_threads = PLATFORM_MAX_AICPU_THREADS;
     }
     for (int t = 0; t < total_threads; t++) {
-        PhaseBufferState *state = get_phase_buffer_state(perf_base, runtime->worker_count, t);
-
-        s_phase_buffer_states[t] = state;
-
-        // Pop first buffer from free_queue
-        rmb();
-        uint32_t head = state->free_queue.head;
-        uint32_t tail = state->free_queue.tail;
-
-        if (head != tail) {
-            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-            rmb();
-            state->free_queue.head = head + 1;
-            state->current_buf_ptr = buf_ptr;
-            state->current_buf_seq = 0;
-            wmb();
-
-            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
-            buf->count = 0;
-            s_current_phase_buf[t] = buf;
-
-            LOG_DEBUG("Thread %d: popped initial phase buffer (addr=0x%lx)", t, buf_ptr);
-        } else {
-            LOG_ERROR("Thread %d: phase free_queue is empty during init!", t);
-            state->current_buf_ptr = 0;
+        uint64_t buf_ptr = s_setup_header->phase_buffer_ptrs[t];
+        if (buf_ptr == 0) {
+            LOG_ERROR("Thread %d: phase_buffer_ptrs[%d] is NULL during init!", t, t);
             s_current_phase_buf[t] = nullptr;
+            continue;
         }
+
+        PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
+        buf->count = 0;
+        s_current_phase_buf[t] = buf;
+
+        LOG_DEBUG("Thread %d: PhaseBuffer at 0x%lx", t, buf_ptr);
     }
 
     // Clear remaining slots
     for (int t = total_threads; t < PLATFORM_MAX_AICPU_THREADS; t++) {
-        s_phase_buffer_states[t] = nullptr;
         s_current_phase_buf[t] = nullptr;
     }
 
@@ -347,106 +170,21 @@ void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
     );
 }
 
-/**
- * Switch phase buffer when current buffer is full (free queue version)
- *
- * Enqueues the full buffer to ReadyQueue and pops the next buffer from free_queue.
- * If no free buffer is available, sets s_current_phase_buf to nullptr so subsequent
- * records are dropped (preserving already-enqueued data).
- */
-static void switch_phase_buffer(int thread_idx) {
-    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
-    if (state == nullptr) return;
-
-    PhaseBuffer *full_buf = s_current_phase_buf[thread_idx];
-    if (full_buf == nullptr) return;
-
-    LOG_INFO("Thread %d: phase buffer is full (count=%u)", thread_idx, full_buf->count);
-
-    // Enqueue to ReadyQueue
-    uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, state->current_buf_ptr, seq, 1);
-    if (rc != 0) {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data", thread_idx);
-        full_buf->count = 0;
-        wmb();
-        return;
-    }
-
-    // Pop next buffer from free_queue
-    rmb();
-    uint32_t head = state->free_queue.head;
-    uint32_t tail = state->free_queue.tail;
-
-    if (head != tail) {
-        uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-        rmb();
-        state->free_queue.head = head + 1;
-        state->current_buf_ptr = new_buf_ptr;
-        state->current_buf_seq = seq + 1;
-        wmb();
-
-        PhaseBuffer *new_buf = reinterpret_cast<PhaseBuffer *>(new_buf_ptr);
-        new_buf->count = 0;
-        s_current_phase_buf[thread_idx] = new_buf;
-
-        LOG_INFO("Thread %d: switched to new phase buffer", thread_idx);
-    } else {
-        // No free buffer available, drop subsequent records
-        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up", thread_idx);
-        s_current_phase_buf[thread_idx] = nullptr;
-        state->current_buf_ptr = 0;
-        wmb();
-    }
-}
-
 void perf_aicpu_record_phase(
     int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
     uint64_t tasks_processed
 ) {
-    if (s_phase_header == nullptr) {
+    if (s_setup_header == nullptr) {
         return;
     }
 
     PhaseBuffer *buf = s_current_phase_buf[thread_idx];
-
-    // Try to recover from nullptr (no buffer was available on previous switch)
-    if (buf == nullptr) {
-        PhaseBufferState *state = s_phase_buffer_states[thread_idx];
-        if (state == nullptr) return;
-
-        rmb();
-        uint32_t head = state->free_queue.head;
-        uint32_t tail = state->free_queue.tail;
-
-        if (head != tail) {
-            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-            rmb();
-            state->free_queue.head = head + 1;
-            state->current_buf_ptr = buf_ptr;
-            state->current_buf_seq = state->current_buf_seq + 1;
-            wmb();
-
-            buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
-            buf->count = 0;
-            s_current_phase_buf[thread_idx] = buf;
-
-            LOG_INFO("Thread %d: recovered phase buffer", thread_idx);
-        }
-        if (buf == nullptr) return;  // Still no buffer available
-    }
+    if (buf == nullptr) return;
 
     uint32_t idx = buf->count;
-
     if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
-        // Buffer full, switch to next buffer
-        switch_phase_buffer(thread_idx);
-        buf = s_current_phase_buf[thread_idx];
-        if (buf == nullptr) return;  // No buffer available
-        idx = buf->count;
-        if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
-            return;  // Switch failed; drop this record
-        }
+        // Buffer full; silently drop.
+        return;
     }
 
     AicpuPhaseRecord *record = &buf->records[idx];
@@ -460,11 +198,11 @@ void perf_aicpu_record_phase(
 }
 
 void perf_aicpu_write_orch_summary(const AicpuOrchSummary *src) {
-    if (s_phase_header == nullptr) {
+    if (s_setup_header == nullptr) {
         return;
     }
 
-    AicpuOrchSummary *dst = &s_phase_header->orch_summary;
+    AicpuOrchSummary *dst = &s_setup_header->phase_header.orch_summary;
 
     memcpy(dst, src, sizeof(AicpuOrchSummary));
     dst->magic = AICPU_PHASE_MAGIC;
@@ -483,60 +221,27 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread
 void perf_aicpu_record_orch_phase(
     AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id
 ) {
-    if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
+    if (s_orch_thread_idx < 0 || s_setup_header == nullptr) return;
     perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
-}
-
-void perf_aicpu_flush_phase_buffers(int thread_idx) {
-    if (s_phase_header == nullptr || s_perf_header == nullptr) {
-        return;
-    }
-
-    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
-    if (state == nullptr) return;
-
-    rmb();
-    uint64_t buf_ptr = state->current_buf_ptr;
-    if (buf_ptr == 0) {
-        // No active buffer
-        return;
-    }
-
-    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
-    if (buf->count == 0) {
-        return;
-    }
-
-    uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, buf_ptr, seq, 1);
-    if (rc == 0) {
-        LOG_INFO("Thread %d: flushed phase buffer with %u records", thread_idx, buf->count);
-        state->current_buf_ptr = 0;
-        s_current_phase_buf[thread_idx] = nullptr;
-        wmb();
-    } else {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!", thread_idx);
-    }
-
-    wmb();
 }
 
 void perf_aicpu_write_core_assignments(
     const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
     int total_cores
 ) {
-    if (s_phase_header == nullptr) {
+    if (s_setup_header == nullptr) {
         return;
     }
 
-    memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
-    s_phase_header->num_cores = static_cast<uint32_t>(total_cores);
+    AicpuPhaseHeader *phase_header = &s_setup_header->phase_header;
+    memset(phase_header->core_to_thread, -1, sizeof(phase_header->core_to_thread));
+    phase_header->num_cores = static_cast<uint32_t>(total_cores);
 
     for (int t = 0; t < num_threads; t++) {
         for (int i = 0; i < core_counts[t]; i++) {
             int core_id = core_assignments[t][i];
             if (core_id >= 0 && core_id < PLATFORM_MAX_CORES) {
-                s_phase_header->core_to_thread[core_id] = static_cast<int8_t>(t);
+                phase_header->core_to_thread[core_id] = static_cast<int8_t>(t);
             }
         }
     }

--- a/src/a5/platform/src/host/performance_collector.cpp
+++ b/src/a5/platform/src/host/performance_collector.cpp
@@ -11,10 +11,7 @@
 
 /**
  * @file performance_collector.cpp
- * @brief Platform-agnostic performance data collector implementation
- *
- * Implements ProfMemoryManager (dynamic buffer management thread) and
- * PerformanceCollector (data collection and export).
+ * @brief Host-side performance data collector (memcpy-based) implementation
  */
 
 #include "host/performance_collector.h"
@@ -23,482 +20,19 @@
 #include <sys/types.h>
 
 #include <algorithm>
-#include <chrono>
 #include <cinttypes>
+#include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
-#include <optional>
 #include <string>
 #include <vector>
 
-#include "common/memory_barrier.h"
 #include "common/unified_log.h"
 
 // =============================================================================
-// ProfMemoryManager Implementation
-// =============================================================================
-
-ProfMemoryManager::~ProfMemoryManager() {
-    if (running_.load()) {
-        stop();
-    }
-}
-
-void ProfMemoryManager::start(
-    void *shared_mem_host, int num_cores, int num_phase_threads, PerfAllocCallback alloc_cb,
-    PerfRegisterCallback register_cb, PerfFreeCallback free_cb, void *user_data, int device_id,
-    PerfSetDeviceCallback set_device_cb
-) {
-    shared_mem_host_ = shared_mem_host;
-    num_cores_ = num_cores;
-    num_phase_threads_ = num_phase_threads;
-    alloc_cb_ = alloc_cb;
-    register_cb_ = register_cb;
-    free_cb_ = free_cb;
-    user_data_ = user_data;
-    device_id_ = device_id;
-    set_device_cb_ = set_device_cb;
-
-    running_.store(true);
-    mgmt_thread_ = std::thread(&ProfMemoryManager::mgmt_loop, this);
-
-    LOG_INFO("ProfMemoryManager started: %d cores, %d phase threads", num_cores, num_phase_threads);
-}
-
-void ProfMemoryManager::stop() {
-    running_.store(false);
-    if (mgmt_thread_.joinable()) {
-        mgmt_thread_.join();
-    }
-
-    // Drain remaining done_queue and free buffers
-    {
-        std::lock_guard<std::mutex> lock(done_mutex_);
-        while (!done_queue_.empty()) {
-            CopyDoneInfo info = done_queue_.front();
-            done_queue_.pop();
-            free_buffer(info.dev_buffer_ptr);
-        }
-    }
-
-    // Free recycled buffers
-    for (void *ptr : recycled_perf_buffers_) {
-        free_buffer(ptr);
-    }
-    recycled_perf_buffers_.clear();
-    for (void *ptr : recycled_phase_buffers_) {
-        free_buffer(ptr);
-    }
-    recycled_phase_buffers_.clear();
-
-    LOG_INFO("ProfMemoryManager stopped");
-}
-
-bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo &info) {
-    std::lock_guard<std::mutex> lock(ready_mutex_);
-    if (ready_queue_.empty()) {
-        return false;
-    }
-    info = ready_queue_.front();
-    ready_queue_.pop();
-    return true;
-}
-
-bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout) {
-    std::unique_lock<std::mutex> lock(ready_mutex_);
-    if (ready_cv_.wait_for(lock, timeout, [this] {
-            return !ready_queue_.empty();
-        })) {
-        info = ready_queue_.front();
-        ready_queue_.pop();
-        return true;
-    }
-    return false;
-}
-
-void ProfMemoryManager::notify_copy_done(const CopyDoneInfo &info) {
-    std::lock_guard<std::mutex> lock(done_mutex_);
-    done_queue_.push(info);
-}
-
-void *ProfMemoryManager::alloc_and_register(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size, user_data_);
-    if (dev_ptr == nullptr) {
-        const char *hint = (size == sizeof(PerfBuffer)) ?
-                               "increase PLATFORM_PROF_BUFFERS_PER_CORE to reduce profiling data loss" :
-                               "increase PLATFORM_PROF_BUFFERS_PER_THREAD to reduce profiling data loss";
-        LOG_WARN("ProfMemoryManager: alloc failed for %zu bytes, %s", size, hint);
-        *host_ptr_out = nullptr;
-        return nullptr;
-    }
-
-    if (register_cb_ != nullptr) {
-        void *host_ptr = nullptr;
-        int rc = register_cb_(dev_ptr, size, device_id_, user_data_, &host_ptr);
-        if (rc != 0 || host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: register failed: %d", rc);
-            free_buffer(dev_ptr);
-            *host_ptr_out = nullptr;
-            return nullptr;
-        }
-        *host_ptr_out = host_ptr;
-    } else {
-        // Simulation mode: dev_ptr == host_ptr
-        *host_ptr_out = dev_ptr;
-    }
-
-    dev_to_host_[dev_ptr] = *host_ptr_out;
-    return dev_ptr;
-}
-
-void ProfMemoryManager::free_buffer(void *dev_ptr) {
-    if (dev_ptr != nullptr && free_cb_ != nullptr) {
-        dev_to_host_.erase(dev_ptr);
-        free_cb_(dev_ptr, user_data_);
-    }
-}
-
-void *ProfMemoryManager::resolve_host_ptr(void *dev_ptr) {
-    if (register_cb_ == nullptr) {
-        return dev_ptr;  // Simulation mode: dev_ptr == host_ptr
-    }
-    auto it = dev_to_host_.find(dev_ptr);
-    if (it != dev_to_host_.end()) {
-        return it->second;
-    }
-    LOG_ERROR("ProfMemoryManager: no host mapping for dev_ptr=%p", dev_ptr);
-    return nullptr;
-}
-
-void ProfMemoryManager::register_mapping(void *dev_ptr, void *host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
-
-void ProfMemoryManager::process_ready_entry(
-    PerfDataHeader * /*header*/, int /*thread_idx*/, const ReadyQueueEntry &entry
-) {
-    bool is_phase = (entry.is_phase != 0);
-    uint64_t old_dev_ptr = entry.buffer_ptr;
-    uint32_t seq = entry.buffer_seq;
-
-    if (is_phase) {
-        uint32_t tidx = entry.core_index;
-        if (tidx >= static_cast<uint32_t>(PLATFORM_MAX_AICPU_THREADS)) {
-            LOG_ERROR("ProfMemoryManager: invalid phase entry: thread=%u", tidx);
-            return;
-        }
-
-        PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
-
-        // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
-        // Source priority: recycled pool → drain done_queue → alloc (last resort).
-        rmb();
-        uint32_t head_val = state->free_queue.head;
-        uint32_t tail = state->free_queue.tail;
-        uint32_t available = tail - head_val;
-
-        int to_push = PLATFORM_PROF_SLOT_COUNT;
-        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
-            void *host_ptr = nullptr;
-            void *new_dev_ptr = nullptr;
-
-            if (!recycled_phase_buffers_.empty()) {
-                new_dev_ptr = recycled_phase_buffers_.back();
-                recycled_phase_buffers_.pop_back();
-                host_ptr = resolve_host_ptr(new_dev_ptr);
-            }
-            if (new_dev_ptr == nullptr) {
-                std::lock_guard<std::mutex> lock(done_mutex_);
-                while (!done_queue_.empty()) {
-                    CopyDoneInfo dinfo = done_queue_.front();
-                    done_queue_.pop();
-                    if (dinfo.type == ProfBufferType::PERF_RECORD)
-                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
-                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
-                }
-            }
-            if (new_dev_ptr == nullptr && !recycled_phase_buffers_.empty()) {
-                new_dev_ptr = recycled_phase_buffers_.back();
-                recycled_phase_buffers_.pop_back();
-                host_ptr = resolve_host_ptr(new_dev_ptr);
-            }
-            if (new_dev_ptr == nullptr) {
-                new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
-            }
-            if (new_dev_ptr == nullptr) break;
-
-            reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
-            uint32_t cur_tail = tail + p;
-            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
-                reinterpret_cast<uint64_t>(new_dev_ptr);
-            wmb();
-            state->free_queue.tail = cur_tail + 1;
-            wmb();
-        }
-
-        // Resolve host pointer of old buffer
-        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
-        if (old_host_ptr == nullptr) {
-            LOG_ERROR(
-                "ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p",
-                reinterpret_cast<void *>(old_dev_ptr)
-            );
-            return;
-        }
-
-        // Push old buffer to ready queue for main thread to copy
-        ReadyBufferInfo info;
-        info.type = ProfBufferType::PHASE;
-        info.index = tidx;
-        info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
-        info.host_buffer_ptr = old_host_ptr;
-        info.buffer_seq = seq;
-
-        {
-            std::lock_guard<std::mutex> lock(ready_mutex_);
-            ready_queue_.push(info);
-        }
-        ready_cv_.notify_one();
-
-    } else {
-        uint32_t core_index = entry.core_index;
-        if (core_index >= static_cast<uint32_t>(num_cores_)) {
-            LOG_ERROR("ProfMemoryManager: invalid perf entry: core=%u", core_index);
-            return;
-        }
-
-        PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, core_index);
-
-        // Replenish free_queue with up to 2 buffers (1 active + 1 spare).
-        rmb();
-        uint32_t head_val = state->free_queue.head;
-        uint32_t tail = state->free_queue.tail;
-        uint32_t available = tail - head_val;
-
-        int to_push = PLATFORM_PROF_SLOT_COUNT;
-        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
-            void *host_ptr = nullptr;
-            void *new_dev_ptr = nullptr;
-
-            if (!recycled_perf_buffers_.empty()) {
-                new_dev_ptr = recycled_perf_buffers_.back();
-                recycled_perf_buffers_.pop_back();
-                host_ptr = resolve_host_ptr(new_dev_ptr);
-            }
-            if (new_dev_ptr == nullptr) {
-                std::lock_guard<std::mutex> lock(done_mutex_);
-                while (!done_queue_.empty()) {
-                    CopyDoneInfo dinfo = done_queue_.front();
-                    done_queue_.pop();
-                    if (dinfo.type == ProfBufferType::PERF_RECORD)
-                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
-                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
-                }
-            }
-            if (new_dev_ptr == nullptr && !recycled_perf_buffers_.empty()) {
-                new_dev_ptr = recycled_perf_buffers_.back();
-                recycled_perf_buffers_.pop_back();
-                host_ptr = resolve_host_ptr(new_dev_ptr);
-            }
-            if (new_dev_ptr == nullptr) {
-                new_dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
-            }
-            if (new_dev_ptr == nullptr) break;
-
-            reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
-            uint32_t cur_tail = tail + p;
-            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
-                reinterpret_cast<uint64_t>(new_dev_ptr);
-            wmb();
-            state->free_queue.tail = cur_tail + 1;
-            wmb();
-        }
-
-        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
-        if (old_host_ptr == nullptr) {
-            LOG_ERROR(
-                "ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p",
-                reinterpret_cast<void *>(old_dev_ptr)
-            );
-            return;
-        }
-
-        ReadyBufferInfo info;
-        info.type = ProfBufferType::PERF_RECORD;
-        info.index = core_index;
-        info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
-        info.host_buffer_ptr = old_host_ptr;
-        info.buffer_seq = seq;
-
-        {
-            std::lock_guard<std::mutex> lock(ready_mutex_);
-            ready_queue_.push(info);
-        }
-        ready_cv_.notify_one();
-    }
-}
-
-void ProfMemoryManager::mgmt_loop() {
-    if (set_device_cb_ != nullptr) {
-        int rc = set_device_cb_(device_id_, user_data_);
-        if (rc != 0) {
-            LOG_ERROR("mgmt_loop: set_device_cb(%d) failed: %d", device_id_, rc);
-        }
-    }
-
-    PerfDataHeader *header = get_perf_header(shared_mem_host_);
-
-    while (running_.load()) {
-        // 1. Recycle done queue: move completed buffers to recycled pools for reuse
-        {
-            std::lock_guard<std::mutex> lock(done_mutex_);
-            while (!done_queue_.empty()) {
-                CopyDoneInfo info = done_queue_.front();
-                done_queue_.pop();
-                if (info.type == ProfBufferType::PERF_RECORD) {
-                    recycled_perf_buffers_.push_back(info.dev_buffer_ptr);
-                } else {
-                    recycled_phase_buffers_.push_back(info.dev_buffer_ptr);
-                }
-            }
-        }
-
-        // 2. Poll ReadyQueues from all AICPU threads
-        bool found_any = false;
-        for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
-            rmb();
-            uint32_t head = header->queue_heads[t];
-            uint32_t tail = header->queue_tails[t];
-
-            // Validate indices to prevent OOB access from corrupted shared memory
-            if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-                LOG_ERROR(
-                    "mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)", t, head, tail,
-                    PLATFORM_PROF_READYQUEUE_SIZE
-                );
-                continue;
-            }
-
-            while (head != tail) {
-                ReadyQueueEntry entry = header->queues[t][head];
-
-                process_ready_entry(header, t, entry);
-
-                head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
-                header->queue_heads[t] = head;
-                wmb();
-
-                found_any = true;
-
-                // Re-read tail in case more entries arrived
-                rmb();
-                tail = header->queue_tails[t];
-                if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-                    LOG_ERROR("mgmt_loop: invalid tail for thread %d: %u", t, tail);
-                    break;
-                }
-            }
-        }
-
-        // 3. Proactive replenishment: push buffers to cores/threads whose free_queue
-        //    is completely empty (avail == 0). Try recycled pool first, alloc as fallback.
-        if (!recycled_perf_buffers_.empty() || !recycled_phase_buffers_.empty()) {
-            for (int i = 0; i < num_cores_ && !recycled_perf_buffers_.empty(); i++) {
-                PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
-                rmb();
-                uint32_t avail = state->free_queue.tail - state->free_queue.head;
-                if (avail == 0) {
-                    void *dev_ptr = recycled_perf_buffers_.back();
-                    recycled_perf_buffers_.pop_back();
-                    void *host_ptr = resolve_host_ptr(dev_ptr);
-                    if (host_ptr != nullptr) {
-                        reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
-                        uint32_t t_val = state->free_queue.tail;
-                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
-                            reinterpret_cast<uint64_t>(dev_ptr);
-                        wmb();
-                        state->free_queue.tail = t_val + 1;
-                        wmb();
-                    }
-                }
-            }
-            for (int t = 0; t < num_phase_threads_ && !recycled_phase_buffers_.empty(); t++) {
-                PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, t);
-                rmb();
-                uint32_t avail = state->free_queue.tail - state->free_queue.head;
-                if (avail == 0) {
-                    void *dev_ptr = recycled_phase_buffers_.back();
-                    recycled_phase_buffers_.pop_back();
-                    void *host_ptr = resolve_host_ptr(dev_ptr);
-                    if (host_ptr != nullptr) {
-                        reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
-                        uint32_t t_val = state->free_queue.tail;
-                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
-                            reinterpret_cast<uint64_t>(dev_ptr);
-                        wmb();
-                        state->free_queue.tail = t_val + 1;
-                        wmb();
-                    }
-                }
-            }
-        }
-        // Alloc fallback: if recycled pools are both empty, scan for depleted cores and alloc.
-        // This only triggers when ALL pre-allocated buffers are in-flight (extreme workloads).
-        if (recycled_perf_buffers_.empty() && recycled_phase_buffers_.empty()) {
-            for (int i = 0; i < num_cores_; i++) {
-                PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
-                rmb();
-                if (state->free_queue.tail - state->free_queue.head == 0) {
-                    void *host_ptr = nullptr;
-                    void *dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
-                    if (dev_ptr == nullptr) break;  // HBM exhausted, stop trying
-                    reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
-                    uint32_t t_val = state->free_queue.tail;
-                    state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
-                        reinterpret_cast<uint64_t>(dev_ptr);
-                    wmb();
-                    state->free_queue.tail = t_val + 1;
-                    wmb();
-                    break;  // One alloc per iteration to limit rtMalloc frequency
-                }
-            }
-        }
-
-        // 4. If nothing found, yield briefly to avoid busy-spinning
-        if (!found_any) {
-            std::this_thread::sleep_for(std::chrono::microseconds(10));
-        }
-    }
-
-    // Final drain: process any remaining entries
-    PerfDataHeader *hdr = get_perf_header(shared_mem_host_);
-    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
-        rmb();
-        uint32_t head = hdr->queue_heads[t];
-        uint32_t tail = hdr->queue_tails[t];
-        if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u", t, head, tail);
-            continue;
-        }
-        while (head != tail) {
-            ReadyQueueEntry entry = hdr->queues[t][head];
-            process_ready_entry(hdr, t, entry);
-            head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
-            hdr->queue_heads[t] = head;
-            wmb();
-            rmb();
-            tail = hdr->queue_tails[t];
-            if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-                LOG_ERROR("mgmt_loop drain: invalid tail for thread %d: %u", t, tail);
-                break;
-            }
-        }
-    }
-}
-
-// =============================================================================
-// PerformanceCollector Implementation
+// Helpers
 // =============================================================================
 
 /**
@@ -510,659 +44,281 @@ static bool is_scheduler_phase(AicpuPhaseId id) {
     return static_cast<uint32_t>(id) < static_cast<uint32_t>(AicpuPhaseId::SCHED_PHASE_COUNT);
 }
 
+// =============================================================================
+// PerformanceCollector Implementation
+// =============================================================================
+
 PerformanceCollector::~PerformanceCollector() {
-    if (perf_shared_mem_host_ != nullptr) {
+    if (setup_header_dev_ != nullptr) {
         LOG_WARN("PerformanceCollector destroyed without finalize()");
     }
 }
 
-void *PerformanceCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size, user_data_);
-    if (dev_ptr == nullptr) {
-        LOG_ERROR("Failed to allocate buffer (%zu bytes)", size);
-        *host_ptr_out = nullptr;
-        return nullptr;
-    }
-
-    if (register_cb_ != nullptr) {
-        void *host_ptr = nullptr;
-        int rc = register_cb_(dev_ptr, size, device_id_, user_data_, &host_ptr);
-        if (rc != 0 || host_ptr == nullptr) {
-            LOG_ERROR("Buffer registration failed: %d", rc);
-            *host_ptr_out = nullptr;
-            return nullptr;
-        }
-        *host_ptr_out = host_ptr;
-    } else {
-        *host_ptr_out = dev_ptr;
-    }
-
-    // Register mapping so ProfMemoryManager can resolve dev→host
-    memory_manager_.register_mapping(dev_ptr, *host_ptr_out);
-    return dev_ptr;
-}
-
 int PerformanceCollector::initialize(
-    Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
-    PerfFreeCallback free_cb, void *user_data, PerfSetDeviceCallback set_device_cb
+    Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfFreeCallback free_cb,
+    PerfCopyToDeviceCallback copy_to_dev_cb, PerfCopyFromDeviceCallback copy_from_dev_cb, void *user_data
 ) {
-    if (perf_shared_mem_host_ != nullptr) {
+    if (setup_header_dev_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
         return -1;
     }
-
-    LOG_INFO("Initializing performance profiling");
 
     if (num_aicore <= 0 || num_aicore > PLATFORM_MAX_CORES) {
         LOG_ERROR("Invalid number of AICores: %d (max=%d)", num_aicore, PLATFORM_MAX_CORES);
         return -1;
     }
+    if (alloc_cb == nullptr || free_cb == nullptr || copy_to_dev_cb == nullptr || copy_from_dev_cb == nullptr) {
+        LOG_ERROR("PerformanceCollector::initialize: null callback");
+        return -1;
+    }
+
+    LOG_INFO("Initializing performance profiling (memcpy-based)");
 
     device_id_ = device_id;
     num_aicore_ = num_aicore;
+    num_phase_threads_ = PLATFORM_MAX_AICPU_THREADS;
     alloc_cb_ = alloc_cb;
-    register_cb_ = register_cb;
     free_cb_ = free_cb;
+    copy_to_dev_cb_ = copy_to_dev_cb;
+    copy_from_dev_cb_ = copy_from_dev_cb;
     user_data_ = user_data;
-    set_device_cb_ = set_device_cb;
 
-    // Step 1: Calculate shared memory size (slot arrays only, no actual buffers)
-    int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
-    size_t total_size = calc_perf_data_size_with_phases(num_aicore, num_phase_threads);
+    perf_buffer_bytes_ = calc_perf_buffer_size(PLATFORM_PROF_BUFFER_SIZE);
+    phase_buffer_bytes_ = calc_phase_buffer_size(PLATFORM_PHASE_RECORDS_PER_THREAD);
 
-    LOG_DEBUG("Shared memory allocation plan:");
-    LOG_DEBUG("  Number of cores:      %d", num_aicore);
-    LOG_DEBUG("  Header size:          %zu bytes", sizeof(PerfDataHeader));
-    LOG_DEBUG("  PerfBufferState size: %zu bytes each", sizeof(PerfBufferState));
-    LOG_DEBUG("  PhaseBufferState size:%zu bytes each", sizeof(PhaseBufferState));
-    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
+    LOG_DEBUG("  PerfSetupHeader size: %zu bytes", calc_perf_setup_size());
+    LOG_DEBUG("  PerfBuffer size:      %zu bytes (capacity=%d)", perf_buffer_bytes_, PLATFORM_PROF_BUFFER_SIZE);
+    LOG_DEBUG(
+        "  PhaseBuffer size:     %zu bytes (capacity=%d)", phase_buffer_bytes_, PLATFORM_PHASE_RECORDS_PER_THREAD
+    );
+    LOG_DEBUG("  num_aicore:           %d", num_aicore_);
+    LOG_DEBUG("  num_phase_threads:    %d", num_phase_threads_);
 
-    // Step 2: Allocate shared memory for slot arrays
-    void *perf_dev_ptr = alloc_cb(total_size, user_data);
-    if (perf_dev_ptr == nullptr) {
-        LOG_ERROR("Failed to allocate shared memory (%zu bytes)", total_size);
+    // Step 1: Allocate PerfSetupHeader on device
+    setup_header_dev_ = alloc_cb_(calc_perf_setup_size(), user_data_);
+    if (setup_header_dev_ == nullptr) {
+        LOG_ERROR("Failed to allocate PerfSetupHeader (%zu bytes)", calc_perf_setup_size());
         return -1;
     }
-    LOG_DEBUG("Allocated shared memory: %p", perf_dev_ptr);
 
-    // Step 3: Register to host mapping (optional)
-    void *perf_host_ptr = nullptr;
-    if (register_cb != nullptr) {
-        int rc = register_cb(perf_dev_ptr, total_size, device_id, user_data, &perf_host_ptr);
-        if (rc != 0) {
-            LOG_ERROR("Memory registration failed: %d", rc);
-            return rc;
-        }
-        was_registered_ = true;
-        if (perf_host_ptr == nullptr) {
-            LOG_ERROR("register_cb succeeded but returned null host_ptr");
+    // Step 2: Allocate one PerfBuffer per core on device
+    core_buffers_dev_.assign(num_aicore_, nullptr);
+    for (int i = 0; i < num_aicore_; i++) {
+        void *buf = alloc_cb_(perf_buffer_bytes_, user_data_);
+        if (buf == nullptr) {
+            LOG_ERROR("Failed to allocate PerfBuffer for core %d (%zu bytes)", i, perf_buffer_bytes_);
+            finalize();
             return -1;
         }
-        LOG_DEBUG("Mapped to host memory: %p", perf_host_ptr);
-    } else {
-        perf_host_ptr = perf_dev_ptr;
-        LOG_DEBUG("Simulation mode: host_ptr = dev_ptr = %p", perf_host_ptr);
+        core_buffers_dev_[i] = buf;
     }
 
-    // Step 4: Initialize header
-    PerfDataHeader *header = get_perf_header(perf_host_ptr);
-
-    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
-        memset(header->queues[t], 0, sizeof(header->queues[t]));
-        header->queue_heads[t] = 0;
-        header->queue_tails[t] = 0;
-    }
-
-    header->num_cores = num_aicore;
-    header->total_tasks = 0;
-
-    LOG_DEBUG("Initialized PerfDataHeader:");
-    LOG_DEBUG("  num_cores:        %d", header->num_cores);
-    LOG_DEBUG("  buffer_capacity:  %d", PLATFORM_PROF_BUFFER_SIZE);
-    LOG_DEBUG("  queue capacity:   %d", PLATFORM_PROF_READYQUEUE_SIZE);
-
-    // Step 5: Initialize PerfBufferStates — 1 buffer per core in free_queue, rest to recycled pool
-    for (int i = 0; i < num_aicore; i++) {
-        PerfBufferState *state = get_perf_buffer_state(perf_host_ptr, i);
-        memset(state, 0, sizeof(PerfBufferState));
-
-        state->free_queue.head = 0;
-        state->free_queue.tail = 0;
-        state->current_buf_ptr = 0;
-        state->current_buf_seq = 0;
-
-        for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_CORE; s++) {
-            void *host_buf_ptr = nullptr;
-            void *dev_buf_ptr = alloc_single_buffer(sizeof(PerfBuffer), &host_buf_ptr);
-            if (dev_buf_ptr == nullptr) {
-                LOG_ERROR("Failed to allocate PerfBuffer for core %d, buffer %d", i, s);
-                return -1;
-            }
-            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(host_buf_ptr);
-            memset(buf, 0, sizeof(PerfBuffer));
-            buf->count = 0;
-
-            if (s == 0) {
-                state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
-            } else {
-                memory_manager_.recycled_perf_buffers_.push_back(dev_buf_ptr);
-            }
+    // Step 3: Allocate one PhaseBuffer per AICPU thread on device
+    phase_buffers_dev_.assign(num_phase_threads_, nullptr);
+    for (int t = 0; t < num_phase_threads_; t++) {
+        void *buf = alloc_cb_(phase_buffer_bytes_, user_data_);
+        if (buf == nullptr) {
+            LOG_ERROR("Failed to allocate PhaseBuffer for thread %d (%zu bytes)", t, phase_buffer_bytes_);
+            finalize();
+            return -1;
         }
-        wmb();
-        state->free_queue.tail = 1;
-        wmb();
+        phase_buffers_dev_[t] = buf;
     }
-    LOG_DEBUG(
-        "Initialized %d PerfBufferStates: 1 buffer/core, %d in recycled pool", num_aicore,
-        num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1)
-    );
 
-    // Step 6: Initialize PhaseBufferStates — 1 buffer per thread in free_queue, rest to recycled pool
-    for (int t = 0; t < num_phase_threads; t++) {
-        PhaseBufferState *state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
-        memset(state, 0, sizeof(PhaseBufferState));
-
-        state->free_queue.head = 0;
-        state->free_queue.tail = 0;
-        state->current_buf_ptr = 0;
-        state->current_buf_seq = 0;
-
-        for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_THREAD; s++) {
-            void *host_buf_ptr = nullptr;
-            void *dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
-            if (dev_buf_ptr == nullptr) {
-                LOG_ERROR("Failed to allocate PhaseBuffer for thread %d, buffer %d", t, s);
-                return -1;
-            }
-            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(host_buf_ptr);
-            memset(buf, 0, sizeof(PhaseBuffer));
-            buf->count = 0;
-
-            if (s == 0) {
-                state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
-            } else {
-                memory_manager_.recycled_phase_buffers_.push_back(dev_buf_ptr);
-            }
-        }
-        wmb();
-        state->free_queue.tail = 1;
-        wmb();
+    // Step 4: Build PerfSetupHeader on host and copy to device
+    PerfSetupHeader host_header;
+    memset(&host_header, 0, sizeof(host_header));
+    host_header.num_cores = static_cast<uint32_t>(num_aicore_);
+    host_header.num_phase_threads = static_cast<uint32_t>(num_phase_threads_);
+    host_header.total_tasks = 0;
+    for (int i = 0; i < num_aicore_; i++) {
+        host_header.core_buffer_ptrs[i] = reinterpret_cast<uint64_t>(core_buffers_dev_[i]);
     }
-    LOG_DEBUG(
-        "Initialized %d PhaseBufferStates: 1 buffer/thread, %d in recycled pool", num_phase_threads,
-        num_phase_threads * (PLATFORM_PROF_BUFFERS_PER_THREAD - 1)
+    for (int t = 0; t < num_phase_threads_; t++) {
+        host_header.phase_buffer_ptrs[t] = reinterpret_cast<uint64_t>(phase_buffers_dev_[t]);
+    }
+    // phase_header is zero-initialized; AICPU sets magic during init.
+
+    int rc = copy_to_dev_cb_(setup_header_dev_, &host_header, sizeof(host_header), user_data_);
+    if (rc != 0) {
+        LOG_ERROR("Failed to copy PerfSetupHeader to device: %d", rc);
+        finalize();
+        return rc;
+    }
+
+    // Step 5: Publish the device-side header pointer via runtime.perf_data_base.
+    // AICPU reads this on init_profiling to discover per-core / per-thread buffer pointers.
+    runtime.perf_data_base = reinterpret_cast<uint64_t>(setup_header_dev_);
+    LOG_DEBUG("runtime.perf_data_base = 0x%lx", runtime.perf_data_base);
+
+    LOG_INFO(
+        "Performance profiling initialized: %d cores × %zuB PerfBuffer, %d threads × %zuB PhaseBuffer", num_aicore_,
+        perf_buffer_bytes_, num_phase_threads_, phase_buffer_bytes_
     );
-
-    wmb();
-
-    // Step 7: Pass base address to Runtime
-    runtime.perf_data_base = reinterpret_cast<uint64_t>(perf_dev_ptr);
-    LOG_DEBUG("Set runtime.perf_data_base = 0x%lx", runtime.perf_data_base);
-
-    perf_shared_mem_dev_ = perf_dev_ptr;
-    perf_shared_mem_host_ = perf_host_ptr;
-
-    LOG_INFO("Performance profiling initialized (dynamic buffer mode)");
     return 0;
 }
 
-void PerformanceCollector::start_memory_manager() {
-    if (perf_shared_mem_host_ == nullptr) {
-        return;
+int PerformanceCollector::collect_all() {
+    if (setup_header_dev_ == nullptr) {
+        LOG_ERROR("PerformanceCollector::collect_all called before initialize");
+        return -1;
     }
 
-    memory_manager_.start(
-        perf_shared_mem_host_, num_aicore_, PLATFORM_MAX_AICPU_THREADS, alloc_cb_, register_cb_, free_cb_, user_data_,
-        device_id_, set_device_cb_
-    );
-}
+    LOG_INFO("Collecting performance data via device→host memcpy");
 
-void PerformanceCollector::stop_memory_manager() {
-    if (memory_manager_.is_running()) {
-        memory_manager_.stop();
-    }
-}
-
-void PerformanceCollector::signal_execution_complete() { execution_complete_.store(true); }
-
-void PerformanceCollector::poll_and_collect(int expected_tasks) {
-    if (perf_shared_mem_host_ == nullptr) {
-        return;
+    // Step 1: Copy back PerfSetupHeader (contains total_tasks and phase_header)
+    PerfSetupHeader host_header;
+    memset(&host_header, 0, sizeof(host_header));
+    int rc = copy_from_dev_cb_(&host_header, setup_header_dev_, sizeof(host_header), user_data_);
+    if (rc != 0) {
+        LOG_ERROR("Failed to copy PerfSetupHeader from device: %d", rc);
+        return rc;
     }
 
-    execution_complete_.store(false);
+    uint32_t total_tasks = host_header.total_tasks;
+    LOG_DEBUG("PerfSetupHeader: total_tasks=%u", total_tasks);
 
-    LOG_INFO("Collecting performance data");
-
-    PerfDataHeader *header = get_perf_header(perf_shared_mem_host_);
-
-    const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);
-    std::optional<std::chrono::steady_clock::time_point> idle_start;
-
-    // Initialize collection storage before the waiting loop so buffers
-    // can be processed immediately, preventing device memory leaks.
-    int total_records_collected = 0;
-    int buffers_processed = 0;
-
+    // Step 2: Prepare host-side storage
     collected_perf_records_.clear();
     collected_perf_records_.resize(num_aicore_);
     collected_phase_records_.clear();
-    collected_phase_records_.resize(PLATFORM_MAX_AICPU_THREADS);
+    collected_phase_records_.resize(num_phase_threads_);
 
-    if (expected_tasks <= 0) {
-        LOG_INFO("Waiting for AICPU to write total_tasks in PerfDataHeader...");
-        idle_start = std::chrono::steady_clock::now();
+    // Step 3: Two-step copy each PerfBuffer back.
+    //   - First copy 64B header → read count
+    //   - Then copy count * sizeof(PerfRecord) of actual data
+    uint64_t total_perf_records = 0;
+    {
+        // Reusable header buffer (aligned to 64B to match PerfBuffer layout)
+        alignas(64) unsigned char header_buf[sizeof(PerfBuffer)];
+        for (int i = 0; i < num_aicore_; i++) {
+            void *dev_ptr = core_buffers_dev_[i];
+            if (dev_ptr == nullptr) continue;
 
-        while (true) {
-            rmb();
-            uint32_t raw_total_tasks = header->total_tasks;
-
-            if (raw_total_tasks > 0) {
-                expected_tasks = static_cast<int>(raw_total_tasks);
-                LOG_INFO("AICPU reported task count: %d", expected_tasks);
-                break;
-            }
-
-            auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
-            if (elapsed >= timeout_duration) {
-                LOG_ERROR(
-                    "Timeout waiting for AICPU task count after %ld seconds",
-                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
-                );
-                return;
-            }
-
-            // Process ready buffers while waiting to free device memory
-            ReadyBufferInfo info;
-            if (memory_manager_.try_pop_ready(info)) {
-                if (info.type == ProfBufferType::PERF_RECORD) {
-                    PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
-                    rmb();
-                    uint32_t count = buf->count;
-                    if (count > PLATFORM_PROF_BUFFER_SIZE) {
-                        count = PLATFORM_PROF_BUFFER_SIZE;
-                    }
-                    uint32_t core_index = info.index;
-                    if (core_index < static_cast<uint32_t>(num_aicore_)) {
-                        for (uint32_t i = 0; i < count; i++) {
-                            collected_perf_records_[core_index].push_back(buf->records[i]);
-                        }
-                        total_records_collected += count;
-                    }
-                } else {
-                    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
-                    rmb();
-                    uint32_t count = buf->count;
-                    if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                        count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-                    }
-                    uint32_t tidx = info.index;
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_phase_records_[tidx].push_back(buf->records[i]);
-                    }
-                }
-                memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
-                buffers_processed++;
-            }
-        }
-    }
-
-    LOG_DEBUG("Initial expected tasks: %d", expected_tasks);
-
-    // Check phase header for scheduler thread info
-    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
-    int num_sched_for_poll = 0;
-    if (phase_header->magic == AICPU_PHASE_MAGIC) {
-        num_sched_for_poll = phase_header->num_sched_threads;
-        if (num_sched_for_poll > PLATFORM_MAX_AICPU_THREADS) {
-            num_sched_for_poll = PLATFORM_MAX_AICPU_THREADS;
-        }
-    }
-
-    idle_start.reset();
-    int last_logged_expected = -1;
-
-    while (total_records_collected < expected_tasks) {
-        // Check for updated expected_tasks
-        rmb();
-        int current_expected = static_cast<int>(header->total_tasks);
-        if (current_expected > expected_tasks) {
-            expected_tasks = current_expected;
-            if (last_logged_expected < 0) {
-                LOG_INFO("Updated expected_tasks to %d (orchestrator progress)", expected_tasks);
-                last_logged_expected = expected_tasks;
-            }
-        }
-
-        ReadyBufferInfo info;
-        if (memory_manager_.wait_pop_ready(info, std::chrono::milliseconds(100))) {
-            idle_start.reset();
-
-            if (info.type == ProfBufferType::PERF_RECORD) {
-                PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
-                rmb();
-                uint32_t count = buf->count;
-                if (count > PLATFORM_PROF_BUFFER_SIZE) {
-                    count = PLATFORM_PROF_BUFFER_SIZE;
-                }
-
-                uint32_t core_index = info.index;
-                if (core_index < static_cast<uint32_t>(num_aicore_)) {
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_perf_records_[core_index].push_back(buf->records[i]);
-                    }
-                    total_records_collected += count;
-                }
-
-                LOG_DEBUG(
-                    "Collected %u perf records from core %u (total: %d/%d)", count, core_index, total_records_collected,
-                    expected_tasks
-                );
-
-            } else {
-                PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
-                rmb();
-                uint32_t count = buf->count;
-                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-                }
-
-                uint32_t tidx = info.index;
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_phase_records_[tidx].push_back(buf->records[i]);
-                }
-
-                LOG_DEBUG("Collected %u phase records from thread %u", count, tidx);
-            }
-
-            // Notify memory manager to recycle old buffer
-            memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
-            buffers_processed++;
-
-        } else {
-            // Timeout on wait — check for execution complete signal or overall timeout
-            if (execution_complete_.load()) {
-                // Device is done. Final non-blocking drain and exit.
-                ReadyBufferInfo drain_info;
-                while (memory_manager_.try_pop_ready(drain_info)) {
-                    if (drain_info.type == ProfBufferType::PERF_RECORD) {
-                        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(drain_info.host_buffer_ptr);
-                        rmb();
-                        uint32_t count = buf->count;
-                        if (count > PLATFORM_PROF_BUFFER_SIZE) count = PLATFORM_PROF_BUFFER_SIZE;
-                        uint32_t ci = drain_info.index;
-                        if (ci < static_cast<uint32_t>(num_aicore_)) {
-                            for (uint32_t i = 0; i < count; i++) {
-                                collected_perf_records_[ci].push_back(buf->records[i]);
-                            }
-                            total_records_collected += count;
-                        }
-                    } else {
-                        PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(drain_info.host_buffer_ptr);
-                        rmb();
-                        uint32_t count = buf->count;
-                        if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD))
-                            count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-                        uint32_t tidx = drain_info.index;
-                        for (uint32_t i = 0; i < count; i++) {
-                            collected_phase_records_[tidx].push_back(buf->records[i]);
-                        }
-                    }
-                    memory_manager_.notify_copy_done({drain_info.dev_buffer_ptr, drain_info.type});
-                    buffers_processed++;
-                }
-                LOG_INFO(
-                    "Execution complete signal received, exiting with %d/%d records", total_records_collected,
-                    expected_tasks
-                );
-                break;
-            }
-            if (!idle_start.has_value()) {
-                idle_start = std::chrono::steady_clock::now();
-            }
-            auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
-            if (elapsed >= timeout_duration) {
-                LOG_ERROR(
-                    "Performance data collection idle timeout after %ld seconds",
-                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
-                );
-                LOG_ERROR("Collected %d / %d records before timeout", total_records_collected, expected_tasks);
-                break;
-            }
-        }
-    }
-
-    LOG_INFO("Total buffers processed: %d", buffers_processed);
-    LOG_INFO("Total records collected: %d", total_records_collected);
-
-    if (total_records_collected < expected_tasks) {
-        LOG_WARN("Incomplete collection (%d / %d records)", total_records_collected, expected_tasks);
-    }
-
-    LOG_INFO("Performance data collection complete");
-}
-
-void PerformanceCollector::drain_remaining_buffers() {
-    if (perf_shared_mem_host_ == nullptr) {
-        return;
-    }
-
-    // Ensure phase record storage is initialized
-    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
-    rmb();
-    int num_sched = 0;
-    if (phase_header->magic == AICPU_PHASE_MAGIC) {
-        num_sched = phase_header->num_sched_threads;
-        if (num_sched > PLATFORM_MAX_AICPU_THREADS) {
-            num_sched = PLATFORM_MAX_AICPU_THREADS;
-        }
-    }
-
-    int drained_perf = 0;
-    int drained_phase = 0;
-
-    ReadyBufferInfo info;
-    while (memory_manager_.try_pop_ready(info)) {
-        if (info.type == ProfBufferType::PERF_RECORD) {
-            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
-            rmb();
-            uint32_t count = buf->count;
-            if (count > PLATFORM_PROF_BUFFER_SIZE) {
-                count = PLATFORM_PROF_BUFFER_SIZE;
-            }
-            uint32_t core_index = info.index;
-            if (core_index < static_cast<uint32_t>(num_aicore_)) {
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_perf_records_[core_index].push_back(buf->records[i]);
-                }
-                drained_perf += count;
-            }
-        } else {
-            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
-            rmb();
-            uint32_t count = buf->count;
-            if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-            }
-            uint32_t tidx = info.index;
-            for (uint32_t i = 0; i < count; i++) {
-                collected_phase_records_[tidx].push_back(buf->records[i]);
-            }
-            drained_phase += count;
-        }
-
-        memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
-    }
-
-    if (drained_perf > 0 || drained_phase > 0) {
-        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records", drained_perf, drained_phase);
-    }
-
-    if (drained_phase > 0) {
-        has_phase_data_ = true;
-    }
-}
-
-void PerformanceCollector::scan_remaining_perf_buffers() {
-    if (perf_shared_mem_host_ == nullptr) {
-        return;
-    }
-
-    rmb();
-
-    int total_recovered = 0;
-
-    for (int core_index = 0; core_index < num_aicore_; core_index++) {
-        PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, core_index);
-
-        rmb();
-        uint64_t buf_ptr = state->current_buf_ptr;
-        if (buf_ptr == 0) {
-            continue;
-        }
-
-        void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
-        if (host_ptr == nullptr) {
-            LOG_ERROR(
-                "scan_remaining_perf_buffers: no host mapping for dev_ptr=%p (core %d)",
-                reinterpret_cast<void *>(buf_ptr), core_index
-            );
-            continue;
-        }
-
-        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(host_ptr);
-        uint32_t count = buf->count;
-        if (count == 0) {
-            continue;
-        }
-        if (count > PLATFORM_PROF_BUFFER_SIZE) {
-            count = PLATFORM_PROF_BUFFER_SIZE;
-        }
-
-        for (uint32_t i = 0; i < count; i++) {
-            collected_perf_records_[core_index].push_back(buf->records[i]);
-        }
-        total_recovered += count;
-    }
-
-    if (total_recovered > 0) {
-        LOG_INFO("scan_remaining_perf_buffers: recovered %d records from active buffers", total_recovered);
-    }
-}
-
-void PerformanceCollector::collect_phase_data() {
-    if (perf_shared_mem_host_ == nullptr) {
-        return;
-    }
-
-    rmb();
-
-    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
-
-    // Validate magic
-    if (phase_header->magic != AICPU_PHASE_MAGIC) {
-        LOG_INFO(
-            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC
-        );
-        return;
-    }
-
-    int num_sched_threads = phase_header->num_sched_threads;
-    if (num_sched_threads > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR(
-            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS
-        );
-        return;
-    }
-    LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
-
-    int total_slots = PLATFORM_MAX_AICPU_THREADS;
-
-    // Scan remaining PhaseBufferStates for active buffers with partial data.
-    // READY buffers were already enqueued to the ReadyQueue and collected via
-    // poll_and_collect() or drain_remaining_buffers(). Only current_buf_ptr
-    // contains partial data that was never enqueued (the active buffer when execution ended).
-    int total_phase_records = 0;
-    for (int t = 0; t < total_slots; t++) {
-        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
-
-        rmb();
-        uint64_t buf_ptr = state->current_buf_ptr;
-        if (buf_ptr != 0) {
-            void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
-            if (host_ptr == nullptr) {
-                LOG_ERROR(
-                    "collect_phase_data: no host mapping for dev_ptr=%p (thread %d)", reinterpret_cast<void *>(buf_ptr),
-                    t
-                );
+            rc = copy_from_dev_cb_(header_buf, dev_ptr, sizeof(PerfBuffer), user_data_);
+            if (rc != 0) {
+                LOG_ERROR("Failed to copy PerfBuffer header for core %d: %d", i, rc);
                 continue;
             }
-            PhaseBuffer *pbuf = reinterpret_cast<PhaseBuffer *>(host_ptr);
-            if (pbuf->count > 0) {
-                uint32_t count = pbuf->count;
-                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-                }
 
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_phase_records_[t].push_back(pbuf->records[i]);
-                }
-                total_phase_records += count;
+            uint32_t count = reinterpret_cast<PerfBuffer *>(header_buf)->count;
+            if (count > static_cast<uint32_t>(PLATFORM_PROF_BUFFER_SIZE)) {
+                LOG_WARN(
+                    "Core %d: PerfBuffer count=%u exceeds capacity=%d, clamping", i, count, PLATFORM_PROF_BUFFER_SIZE
+                );
+                count = PLATFORM_PROF_BUFFER_SIZE;
             }
+            if (count == 0) {
+                LOG_DEBUG("Core %d: empty PerfBuffer", i);
+                continue;
+            }
+
+            collected_perf_records_[i].resize(count);
+            size_t records_bytes = static_cast<size_t>(count) * sizeof(PerfRecord);
+            void *dev_records = static_cast<unsigned char *>(dev_ptr) + sizeof(PerfBuffer);
+            rc = copy_from_dev_cb_(collected_perf_records_[i].data(), dev_records, records_bytes, user_data_);
+            if (rc != 0) {
+                LOG_ERROR("Failed to copy PerfBuffer records for core %d: %d", i, rc);
+                collected_perf_records_[i].clear();
+                continue;
+            }
+            total_perf_records += count;
+            LOG_DEBUG("Core %d: collected %u perf records", i, count);
         }
     }
 
-    // Log per-thread totals
-    for (size_t t = 0; t < collected_phase_records_.size(); t++) {
-        if (!collected_phase_records_[t].empty()) {
+    // Step 4: Two-step copy each PhaseBuffer back.
+    uint64_t total_phase_records = 0;
+    {
+        alignas(64) unsigned char header_buf[sizeof(PhaseBuffer)];
+        for (int t = 0; t < num_phase_threads_; t++) {
+            void *dev_ptr = phase_buffers_dev_[t];
+            if (dev_ptr == nullptr) continue;
+
+            rc = copy_from_dev_cb_(header_buf, dev_ptr, sizeof(PhaseBuffer), user_data_);
+            if (rc != 0) {
+                LOG_ERROR("Failed to copy PhaseBuffer header for thread %d: %d", t, rc);
+                continue;
+            }
+
+            uint32_t count = reinterpret_cast<PhaseBuffer *>(header_buf)->count;
+            if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                LOG_WARN(
+                    "Thread %d: PhaseBuffer count=%u exceeds capacity=%d, clamping", t, count,
+                    PLATFORM_PHASE_RECORDS_PER_THREAD
+                );
+                count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+            }
+            if (count == 0) {
+                continue;
+            }
+
+            collected_phase_records_[t].resize(count);
+            size_t records_bytes = static_cast<size_t>(count) * sizeof(AicpuPhaseRecord);
+            void *dev_records = static_cast<unsigned char *>(dev_ptr) + sizeof(PhaseBuffer);
+            rc = copy_from_dev_cb_(collected_phase_records_[t].data(), dev_records, records_bytes, user_data_);
+            if (rc != 0) {
+                LOG_ERROR("Failed to copy PhaseBuffer records for thread %d: %d", t, rc);
+                collected_phase_records_[t].clear();
+                continue;
+            }
+            total_phase_records += count;
+        }
+    }
+
+    // Step 5: Extract phase header fields (orch summary + core-to-thread mapping)
+    const AicpuPhaseHeader &phase_header = host_header.phase_header;
+    bool phase_header_valid = (phase_header.magic == AICPU_PHASE_MAGIC);
+
+    if (phase_header_valid) {
+        collected_orch_summary_ = phase_header.orch_summary;
+        int num_cores_mapping = static_cast<int>(phase_header.num_cores);
+        if (num_cores_mapping > 0 && num_cores_mapping <= PLATFORM_MAX_CORES) {
+            core_to_thread_.assign(phase_header.core_to_thread, phase_header.core_to_thread + num_cores_mapping);
+            LOG_DEBUG("Core-to-thread mapping: %d cores", num_cores_mapping);
+        }
+    } else {
+        memset(&collected_orch_summary_, 0, sizeof(collected_orch_summary_));
+    }
+
+    bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
+    has_phase_data_ = (total_phase_records > 0) || orch_valid;
+
+    // Step 6: Log per-thread totals (sched vs orch breakdown)
+    if (has_phase_data_) {
+        for (size_t t = 0; t < collected_phase_records_.size(); t++) {
+            if (collected_phase_records_[t].empty()) continue;
             size_t sched_count = 0, orch_count = 0;
             for (const auto &r : collected_phase_records_[t]) {
                 if (is_scheduler_phase(r.phase_id)) sched_count++;
                 else orch_count++;
             }
             LOG_INFO(
-                "  Thread %zu: %zu records (sched=%zu, orch=%zu)", t, collected_phase_records_[t].size(), sched_count,
-                orch_count
+                "  Thread %zu: %zu phase records (sched=%zu, orch=%zu)", t, collected_phase_records_[t].size(),
+                sched_count, orch_count
+            );
+        }
+        if (orch_valid) {
+            LOG_INFO(
+                "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
+                cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time)
             );
         }
     }
 
-    // Read orchestrator summary
-    collected_orch_summary_ = phase_header->orch_summary;
-    bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
-
-    if (orch_valid) {
-        LOG_INFO(
-            "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
-            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time)
-        );
-    } else {
-        LOG_INFO("  Orchestrator: no summary data");
-    }
-
-    // Check if drain_remaining_buffers() already accumulated some Phase records
-    bool has_accumulated = has_phase_data_;
-    if (!has_accumulated) {
-        for (const auto &v : collected_phase_records_) {
-            if (!v.empty()) {
-                has_accumulated = true;
-                break;
-            }
-        }
-    }
-    has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
-
-    // Read core-to-thread mapping
-    int num_cores = static_cast<int>(phase_header->num_cores);
-    if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
-        core_to_thread_.assign(phase_header->core_to_thread, phase_header->core_to_thread + num_cores);
-        LOG_INFO("  Core-to-thread mapping: %d cores", num_cores);
-    }
-
     LOG_INFO(
-        "Phase data collection complete: %d remaining records, orch_summary=%s", total_phase_records,
-        orch_valid ? "yes" : "no"
+        "Collection complete: %" PRIu64 " perf records, %" PRIu64 " phase records, orch_summary=%s", total_perf_records,
+        total_phase_records, orch_valid ? "yes" : "no"
     );
+
+    if (total_tasks > 0 && total_perf_records < total_tasks) {
+        LOG_WARN(
+            "Incomplete collection: %" PRIu64 " / %u records (some cores may have filled their PerfBuffer)",
+            total_perf_records, total_tasks
+        );
+    }
+
+    return 0;
 }
 
 int PerformanceCollector::export_swimlane_json(const std::string &output_path) {
@@ -1454,98 +610,55 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path) {
     return 0;
 }
 
-int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb, void *user_data) {
-    if (perf_shared_mem_host_ == nullptr) {
+int PerformanceCollector::finalize() {
+    if (setup_header_dev_ == nullptr && core_buffers_dev_.empty() && phase_buffers_dev_.empty()) {
         return 0;
     }
 
-    // Stop memory manager if still running
-    stop_memory_manager();
-
     LOG_DEBUG("Cleaning up performance profiling resources");
 
-    // Free initial buffers that are still in the slot arrays
-    // (These were not freed by the memory manager because they were never replaced)
-    // The memory manager frees old buffers after copy; initial buffers in free_queues remain.
-    // Free all buffers in the free_queues and current_buf_ptr.
-    for (int i = 0; i < num_aicore_; i++) {
-        PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, i);
-
-        // Free current buffer if any
-        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            free_cb(reinterpret_cast<void *>(state->current_buf_ptr), user_data);
-        }
-
-        // Free all buffers in free_queue (limit iterations to max capacity)
-        rmb();
-        uint32_t head = state->free_queue.head;
-        uint32_t tail = state->free_queue.tail;
-        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
-        while (head != tail && max_iters-- > 0) {
-            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-            if (buf_ptr != 0 && free_cb != nullptr) {
-                free_cb(reinterpret_cast<void *>(buf_ptr), user_data);
+    // Free per-core PerfBuffers
+    if (free_cb_ != nullptr) {
+        for (void *ptr : core_buffers_dev_) {
+            if (ptr != nullptr) {
+                free_cb_(ptr, user_data_);
             }
-            head++;
-        }
-        if (head != tail) {
-            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)", i, head, tail);
         }
     }
+    core_buffers_dev_.clear();
 
-    int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
-    for (int t = 0; t < num_phase_threads; t++) {
-        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
-
-        // Free current buffer if any
-        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            free_cb(reinterpret_cast<void *>(state->current_buf_ptr), user_data);
-        }
-
-        // Free all buffers in free_queue (limit iterations to max capacity)
-        rmb();
-        uint32_t head = state->free_queue.head;
-        uint32_t tail = state->free_queue.tail;
-        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
-        while (head != tail && max_iters-- > 0) {
-            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-            if (buf_ptr != 0 && free_cb != nullptr) {
-                free_cb(reinterpret_cast<void *>(buf_ptr), user_data);
+    // Free per-thread PhaseBuffers
+    if (free_cb_ != nullptr) {
+        for (void *ptr : phase_buffers_dev_) {
+            if (ptr != nullptr) {
+                free_cb_(ptr, user_data_);
             }
-            head++;
-        }
-        if (head != tail) {
-            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)", t, head, tail);
         }
     }
+    phase_buffers_dev_.clear();
 
-    // Unregister host mapping (optional)
-    if (unregister_cb != nullptr && was_registered_) {
-        int rc = unregister_cb(perf_shared_mem_dev_, device_id_, user_data);
-        if (rc != 0) {
-            LOG_ERROR("halHostUnregister failed: %d", rc);
-            return rc;
-        }
-        LOG_DEBUG("Host mapping unregistered");
+    // Free PerfSetupHeader
+    if (free_cb_ != nullptr && setup_header_dev_ != nullptr) {
+        free_cb_(setup_header_dev_, user_data_);
     }
+    setup_header_dev_ = nullptr;
 
-    // Free shared memory (slot arrays)
-    if (free_cb != nullptr && perf_shared_mem_dev_ != nullptr) {
-        free_cb(perf_shared_mem_dev_, user_data);
-        LOG_DEBUG("Shared memory freed");
-    }
-
-    perf_shared_mem_dev_ = nullptr;
-    perf_shared_mem_host_ = nullptr;
-    was_registered_ = false;
+    // Clear host-side state
     collected_perf_records_.clear();
     collected_phase_records_.clear();
+    memset(&collected_orch_summary_, 0, sizeof(collected_orch_summary_));
     core_to_thread_.clear();
     has_phase_data_ = false;
+
+    num_aicore_ = 0;
+    num_phase_threads_ = 0;
     device_id_ = -1;
+    perf_buffer_bytes_ = 0;
+    phase_buffer_bytes_ = 0;
     alloc_cb_ = nullptr;
-    register_cb_ = nullptr;
     free_cb_ = nullptr;
+    copy_to_dev_cb_ = nullptr;
+    copy_from_dev_cb_ = nullptr;
     user_data_ = nullptr;
 
     LOG_DEBUG("Performance profiling cleanup complete");

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -97,8 +97,7 @@ struct AicpuExecutor {
     std::atomic<int> finished_count_{0};
 
     // ===== Performance profiling state =====
-    uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];   // Per-core AICPU dispatch timestamp
-    uint32_t core_dispatch_counts_[RUNTIME_MAX_WORKER];  // Per-core total dispatched task counter
+    uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];  // Per-core AICPU dispatch timestamp
 
     // ===== Methods =====
     int init(Runtime *runtime);
@@ -121,7 +120,7 @@ struct AicpuExecutor {
 
     inline bool try_dispatch_task(
         int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head,
-        int &ready_count, bool profiling_enabled, Runtime &runtime
+        int &ready_count
     );
 };
 
@@ -169,8 +168,7 @@ inline void AicpuExecutor::resolve_task_dependencies(
 
 // Try to dispatch a task from thread-local queue to a core
 inline bool AicpuExecutor::try_dispatch_task(
-    int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head, int &ready_count,
-    bool profiling_enabled, Runtime &runtime
+    int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head, int &ready_count
 ) {
     if (ready_count <= 0) {
         return false;
@@ -180,15 +178,6 @@ inline bool AicpuExecutor::try_dispatch_task(
     int task_id = local_queue[head];
     head = (head + 1) % MAX_CORES_PER_THREAD;
     ready_count--;
-
-    // Profiling: buffer switch check
-    if (profiling_enabled) {
-        core_dispatch_counts_[core_id]++;
-        if (core_dispatch_counts_[core_id] >= PLATFORM_PROF_BUFFER_SIZE - 1) {
-            perf_aicpu_switch_buffer(&runtime, core_id, thread_idx);
-            core_dispatch_counts_[core_id] = 0;
-        }
-    }
 
     const char *core_type_str = (core_type == CoreType::AIC) ? "AIC" : "AIV";
     LOG_INFO(
@@ -260,7 +249,6 @@ int AicpuExecutor::init(Runtime *runtime) {
 
     for (int i = 0; i < RUNTIME_MAX_WORKER; i++) {
         dispatch_timestamps_[i] = 0;
-        core_dispatch_counts_[i] = 0;
     }
     if (runtime->enable_profiling) {
         perf_aicpu_init_profiling(runtime);
@@ -672,12 +660,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
                     dispatched = try_dispatch_task(
                         core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
-                        cur_aic_ready_count, profiling_enabled, runtime
+                        cur_aic_ready_count
                     );
                 } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
                     dispatched = try_dispatch_task(
                         core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
-                        cur_aiv_ready_count, profiling_enabled, runtime
+                        cur_aiv_ready_count
                     );
                 }
 
@@ -801,12 +789,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
                         dispatched = try_dispatch_task(
                             core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
-                            cur_aic_ready_count, profiling_enabled, runtime
+                            cur_aic_ready_count
                         );
                     } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
                         dispatched = try_dispatch_task(
                             core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
-                            cur_aiv_ready_count, profiling_enabled, runtime
+                            cur_aiv_ready_count
                         );
                     }
                 }
@@ -830,14 +818,14 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
                     if (try_dispatch_task(
                             core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
-                            cur_aic_ready_count, profiling_enabled, runtime
+                            cur_aic_ready_count
                         )) {
                         made_progress = true;
                     }
                 } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
                     if (try_dispatch_task(
                             core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
-                            cur_aiv_ready_count, profiling_enabled, runtime
+                            cur_aiv_ready_count
                         )) {
                         made_progress = true;
                     }
@@ -979,11 +967,6 @@ int AicpuExecutor::run(Runtime *runtime) {
         return rc;
     }
 
-    // Flush performance buffers for cores managed by this thread
-    if (runtime->enable_profiling) {
-        perf_aicpu_flush_buffers(runtime, thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
-    }
-
     LOG_INFO("Thread %d: Completed", thread_idx);
 
     int prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
@@ -1014,7 +997,6 @@ void AicpuExecutor::deinit(Runtime *runtime) {
 
     for (int i = 0; i < RUNTIME_MAX_WORKER; i++) {
         dispatch_timestamps_[i] = 0;
-        core_dispatch_counts_[i] = 0;
         pending_task_ids_[i] = AICPU_TASK_INVALID;
         running_task_ids_[i] = AICPU_TASK_INVALID;
         core_first_dispatch_[i] = true;

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -103,7 +103,6 @@ struct alignas(64) CoreExecState {
     uint8_t pad_[3];                          // offset 25: alignment padding
 #if PTO2_PROFILING
     // --- Profiling fields (dispatch path, compile-time gated) ---
-    uint32_t dispatch_count;      // offset 28: dispatched task count (buffer mgmt)
     uint64_t dispatch_timestamp;  // offset 32: AICPU dispatch timestamp
 #endif
     // --- Cold fields (init/diagnostics only, never in hot path) ---
@@ -595,8 +594,7 @@ struct AicpuExecutor {
     }
 
     void dispatch_subtask_to_core(
-        Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,
-        PTO2SubtaskSlot subslot
+        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot
 #if PTO2_PROFILING
         ,
         bool profiling_enabled
@@ -604,9 +602,6 @@ struct AicpuExecutor {
     ) {
         CoreTracker &tracker = core_trackers_[thread_idx];
         auto core_id = tracker.get_core_id_by_offset(core_offset);
-#if !PTO2_PROFILING
-        (void)runtime;  // NOLINT(readability/casting)
-#endif
         CoreExecState &core_exec_state = core_exec_states_[core_id];
         PTO2DispatchPayload &payload = s_pto2_payload_per_core[core_id];
         build_payload(payload, slot_state, subslot);
@@ -615,11 +610,6 @@ struct AicpuExecutor {
 #if PTO2_PROFILING
         if (profiling_enabled) {
             core_exec_state.dispatch_timestamp = get_sys_cnt_aicpu();
-            if (core_exec_state.dispatch_count >= PLATFORM_PROF_BUFFER_SIZE) {
-                perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
-                core_exec_state.dispatch_count = 0;
-            }
-            core_exec_state.dispatch_count++;
         }
 #endif
         // Per-core monotonic counter for register protocol uniqueness (32-bit).
@@ -646,7 +636,7 @@ struct AicpuExecutor {
     // Dispatch one SPMD block of a MIX task to the cluster at cluster_offset.
     // Reads slot_state.next_block_idx as block_idx; caller increments it afterwards.
     void dispatch_mix_block_to_cluster(
-        Runtime *runtime, int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state
+        int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state
 #if PTO2_PROFILING
         ,
         bool profiling_enabled
@@ -656,7 +646,7 @@ struct AicpuExecutor {
         uint8_t core_mask = pto2_core_mask(slot_state.active_mask);
         if (core_mask & PTO2_SUBTASK_MASK_AIC) {
             dispatch_subtask_to_core(
-                runtime, thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC
+                thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                 ,
                 profiling_enabled
@@ -665,7 +655,7 @@ struct AicpuExecutor {
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV0) {
             dispatch_subtask_to_core(
-                runtime, thread_idx, tracker.get_aiv0_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV0
+                thread_idx, tracker.get_aiv0_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                 ,
                 profiling_enabled
@@ -674,7 +664,7 @@ struct AicpuExecutor {
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV1) {
             dispatch_subtask_to_core(
-                runtime, thread_idx, tracker.get_aiv1_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV1
+                thread_idx, tracker.get_aiv1_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
                 ,
                 profiling_enabled
@@ -713,8 +703,7 @@ struct AicpuExecutor {
     // based on shape.  For AIV, picks whichever AIV core in the cluster is currently idle.
     // Caller is responsible for incrementing slot_state.next_block_idx after this returns.
     void dispatch_block_to_cluster(
-        Runtime *runtime, int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state,
-        PTO2ResourceShape shape
+        int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape
 #if PTO2_PROFILING
         ,
         bool profiling_enabled, uint32_t &phase_dispatch_count
@@ -723,7 +712,7 @@ struct AicpuExecutor {
         CoreTracker &tracker = core_trackers_[thread_idx];
         if (shape == PTO2ResourceShape::MIX) {
             dispatch_mix_block_to_cluster(
-                runtime, thread_idx, cluster_offset, slot_state
+                thread_idx, cluster_offset, slot_state
 #if PTO2_PROFILING
                 ,
                 profiling_enabled
@@ -731,7 +720,7 @@ struct AicpuExecutor {
             );
         } else if (shape == PTO2ResourceShape::AIC) {
             dispatch_subtask_to_core(
-                runtime, thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC
+                thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                 ,
                 profiling_enabled
@@ -742,7 +731,7 @@ struct AicpuExecutor {
                                    tracker.get_aiv0_core_offset(cluster_offset) :
                                    tracker.get_aiv1_core_offset(cluster_offset);
             dispatch_subtask_to_core(
-                runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIV0
+                thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                 ,
                 profiling_enabled
@@ -771,7 +760,7 @@ struct AicpuExecutor {
     // Called only when global resources >= block_num, so one pass always suffices.
     // All other threads are spinning — the drain worker has exclusive tracker access.
     void drain_worker_dispatch(
-        Runtime *runtime, int32_t block_num
+        int32_t block_num
 #if PTO2_PROFILING
         ,
         bool profiling_enabled, uint32_t &phase_dispatch_count
@@ -788,7 +777,7 @@ struct AicpuExecutor {
             auto valid = core_trackers_[t].get_valid_cluster_offset_states(shape);
             while (valid.has_value() && slot_state->next_block_idx < block_num) {
                 dispatch_block_to_cluster(
-                    runtime, t, valid.pop_first(), *slot_state, shape
+                    t, valid.pop_first(), *slot_state, shape
 #if PTO2_PROFILING
                     ,
                     profiling_enabled, phase_dispatch_count
@@ -822,7 +811,7 @@ struct AicpuExecutor {
     //      Non-elected threads spin-wait until sync_start_pending == 0.
     //      During dispatch the elected thread has exclusive tracker access.
     void handle_drain_mode(
-        Runtime *runtime, int32_t thread_idx
+        int32_t thread_idx
 #if PTO2_PROFILING
         ,
         bool profiling_enabled, uint32_t &phase_dispatch_count
@@ -871,7 +860,7 @@ struct AicpuExecutor {
 
         // Phase 3: Dispatch — all other threads are spinning, exclusive tracker access.
         drain_worker_dispatch(
-            runtime, block_num
+            block_num
 #if PTO2_PROFILING
             ,
             profiling_enabled, phase_dispatch_count
@@ -1464,7 +1453,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         // pause normal dispatch and let the drain protocol run.
         if (drain_state_.sync_start_pending.load(std::memory_order_acquire) != 0) {
             handle_drain_mode(
-                runtime, thread_idx
+                thread_idx
 #if PTO2_PROFILING
                 ,
                 profiling_enabled, phase_dispatch_count
@@ -1534,8 +1523,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                             uint8_t mask = pto2_core_mask(slot_state->active_mask);
                             if (mask & PTO2_SUBTASK_MASK_AIC) {
                                 dispatch_subtask_to_core(
-                                    runtime, thread_idx, tracker.get_aic_core_offset(current_valid_cluster_offset),
-                                    *slot_state, PTO2SubtaskSlot::AIC
+                                    thread_idx, tracker.get_aic_core_offset(current_valid_cluster_offset), *slot_state,
+                                    PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                                     ,
                                     profiling_enabled
@@ -1544,8 +1533,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                             }
                             if (mask & PTO2_SUBTASK_MASK_AIV0) {
                                 dispatch_subtask_to_core(
-                                    runtime, thread_idx, tracker.get_aiv0_core_offset(current_valid_cluster_offset),
-                                    *slot_state, PTO2SubtaskSlot::AIV0
+                                    thread_idx, tracker.get_aiv0_core_offset(current_valid_cluster_offset), *slot_state,
+                                    PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                                     ,
                                     profiling_enabled
@@ -1554,8 +1543,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                             }
                             if (mask & PTO2_SUBTASK_MASK_AIV1) {
                                 dispatch_subtask_to_core(
-                                    runtime, thread_idx, tracker.get_aiv1_core_offset(current_valid_cluster_offset),
-                                    *slot_state, PTO2SubtaskSlot::AIV1
+                                    thread_idx, tracker.get_aiv1_core_offset(current_valid_cluster_offset), *slot_state,
+                                    PTO2SubtaskSlot::AIV1
 #if PTO2_PROFILING
                                     ,
                                     profiling_enabled
@@ -1565,8 +1554,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                             slot_state->next_block_idx++;
                         } else if (shape == PTO2ResourceShape::AIC) {
                             dispatch_subtask_to_core(
-                                runtime, thread_idx, tracker.get_aic_core_offset(current_valid_cluster_offset),
-                                *slot_state, PTO2SubtaskSlot::AIC
+                                thread_idx, tracker.get_aic_core_offset(current_valid_cluster_offset), *slot_state,
+                                PTO2SubtaskSlot::AIC
 #if PTO2_PROFILING
                                 ,
                                 profiling_enabled
@@ -1578,7 +1567,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                                                    tracker.get_aiv0_core_offset(current_valid_cluster_offset) :
                                                    tracker.get_aiv1_core_offset(current_valid_cluster_offset);
                             dispatch_subtask_to_core(
-                                runtime, thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV0
+                                thread_idx, core_offset, *slot_state, PTO2SubtaskSlot::AIV0
 #if PTO2_PROFILING
                                 ,
                                 profiling_enabled
@@ -1950,14 +1939,6 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     );
 #endif
 
-#if PTO2_PROFILING
-    // Flush performance buffers for cores managed by this thread
-    if (profiling_enabled) {
-        perf_aicpu_flush_buffers(runtime, thread_idx, core_assignments_[thread_idx], core_num);
-        perf_aicpu_flush_phase_buffers(thread_idx);
-    }
-#endif
-
     return cur_thread_completed;
 }
 
@@ -2265,8 +2246,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 perf_aicpu_write_core_assignments(
                     core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
                 );
-                // Flush orchestrator's phase record buffer
-                perf_aicpu_flush_phase_buffers(thread_idx);
             }
 #endif
 


### PR DESCRIPTION

A5 hardware does not support halHostRegister. Replace the ProfMemoryManager + ReadyQueue + SPSC free-queue pipeline with a simpler design: Host pre-allocates fixed PerfBuffer/PhaseBuffer on device, AICPU writes directly (silently drops when full), Host copies back after stream sync via two-step count-first rtMemcpy.

- Remove ProfMemoryManager thread, ReadyQueue, PerfFreeQueue, PerfBufferState, PerfDataHeader and halHostRegister dependency
- Add PerfSetupHeader for Host/AICPU metadata exchange
- Use flexible array members (count-first layout) for PerfBuffer and PhaseBuffer
- Add copy-to-device and copy-from-device callbacks, replace register/unregister callbacks
- Increase PLATFORM_PROF_BUFFER_SIZE from 1000 to 10000, PLATFORM_PHASE_RECORDS_PER_THREAD from 16384 to 500000
- Simplify DeviceRunner: remove collector thread, signal_execution_complete, drain/scan/flush calls; replace with single collect_all() after sync