### PR TITLE
Fix: correct dispatch timestamp recording in host_build_graph aicpu executor

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -146,7 +146,7 @@ inline void AicpuExecutor::resolve_task_dependencies(
                     cur_aic_tail = (cur_aic_tail + 1) % MAX_CORES_PER_THREAD;
                     cur_aic_ready_count++;
                 } else {
-                    std::lock_guard<std::mutex> lock(ready_queue_aic_mutex_);
+                    std::scoped_lock lock(ready_queue_aic_mutex_);
                     ready_queue_aic_[ready_queue_aic_tail_] = dep_id;
                     ready_queue_aic_tail_ = (ready_queue_aic_tail_ + 1) % RUNTIME_MAX_TASKS;
                     ready_count_aic_.fetch_add(1, std::memory_order_release);
@@ -157,7 +157,7 @@ inline void AicpuExecutor::resolve_task_dependencies(
                     cur_aiv_tail = (cur_aiv_tail + 1) % MAX_CORES_PER_THREAD;
                     cur_aiv_ready_count++;
                 } else {
-                    std::lock_guard<std::mutex> lock(ready_queue_aiv_mutex_);
+                    std::scoped_lock lock(ready_queue_aiv_mutex_);
                     ready_queue_aiv_[ready_queue_aiv_tail_] = dep_id;
                     ready_queue_aiv_tail_ = (ready_queue_aiv_tail_ + 1) % RUNTIME_MAX_TASKS;
                     ready_count_aiv_.fetch_add(1, std::memory_order_release);
@@ -181,13 +181,14 @@ inline bool AicpuExecutor::try_dispatch_task(
     head = (head + 1) % MAX_CORES_PER_THREAD;
     ready_count--;
 
-    // Profiling: buffer switch check
+    // Profiling: buffer switch check. Then record the real AICPU dispatch point for this core.
     if (profiling_enabled) {
         core_dispatch_counts_[core_id]++;
         if (core_dispatch_counts_[core_id] >= PLATFORM_PROF_BUFFER_SIZE - 1) {
             perf_aicpu_switch_buffer(&runtime, core_id, thread_idx);
             core_dispatch_counts_[core_id] = 0;
         }
+        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
     }
 
     const char *core_type_str = (core_type == CoreType::AIC) ? "AIC" : "AIV";
@@ -848,7 +849,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
         // Refill local queues from shared queues
         if (cur_aic_ready_count == 0) {
             if (ready_count_aic_.load(std::memory_order_acquire) > 0) {
-                std::lock_guard<std::mutex> lock(ready_queue_aic_mutex_);
+                std::scoped_lock lock(ready_queue_aic_mutex_);
                 int available = ready_count_aic_.load(std::memory_order_relaxed);
                 int to_grab = (available < aic_per_thread_) ? available : aic_per_thread_;
 
@@ -869,7 +870,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
         if (cur_aiv_ready_count == 0) {
             if (ready_count_aiv_.load(std::memory_order_acquire) > 0) {
-                std::lock_guard<std::mutex> lock(ready_queue_aiv_mutex_);
+                std::scoped_lock lock(ready_queue_aiv_mutex_);
                 int available = ready_count_aiv_.load(std::memory_order_relaxed);
                 int to_grab = (available < aiv_per_thread_) ? available : aiv_per_thread_;
 

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -120,7 +120,7 @@ struct AicpuExecutor {
 
     inline bool try_dispatch_task(
         int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head,
-        int &ready_count
+        int &ready_count, bool profiling_enabled
     );
 };
 
@@ -145,7 +145,7 @@ inline void AicpuExecutor::resolve_task_dependencies(
                     cur_aic_tail = (cur_aic_tail + 1) % MAX_CORES_PER_THREAD;
                     cur_aic_ready_count++;
                 } else {
-                    std::lock_guard<std::mutex> lock(ready_queue_aic_mutex_);
+                    std::scoped_lock lock(ready_queue_aic_mutex_);
                     ready_queue_aic_[ready_queue_aic_tail_] = dep_id;
                     ready_queue_aic_tail_ = (ready_queue_aic_tail_ + 1) % RUNTIME_MAX_TASKS;
                     ready_count_aic_.fetch_add(1, std::memory_order_release);
@@ -156,7 +156,7 @@ inline void AicpuExecutor::resolve_task_dependencies(
                     cur_aiv_tail = (cur_aiv_tail + 1) % MAX_CORES_PER_THREAD;
                     cur_aiv_ready_count++;
                 } else {
-                    std::lock_guard<std::mutex> lock(ready_queue_aiv_mutex_);
+                    std::scoped_lock lock(ready_queue_aiv_mutex_);
                     ready_queue_aiv_[ready_queue_aiv_tail_] = dep_id;
                     ready_queue_aiv_tail_ = (ready_queue_aiv_tail_ + 1) % RUNTIME_MAX_TASKS;
                     ready_count_aiv_.fetch_add(1, std::memory_order_release);
@@ -168,7 +168,8 @@ inline void AicpuExecutor::resolve_task_dependencies(
 
 // Try to dispatch a task from thread-local queue to a core
 inline bool AicpuExecutor::try_dispatch_task(
-    int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head, int &ready_count
+    int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head, int &ready_count,
+    bool profiling_enabled
 ) {
     if (ready_count <= 0) {
         return false;
@@ -187,6 +188,11 @@ inline bool AicpuExecutor::try_dispatch_task(
 
     // Set state before writing register to avoid race with AICore ACK
     pending_task_ids_[core_id] = task_id;
+
+    // Record the real AICPU dispatch point for this core.
+    if (profiling_enabled) {
+        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+    }
 
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(task_id));
 
@@ -660,12 +666,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
                     dispatched = try_dispatch_task(
                         core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
-                        cur_aic_ready_count
+                        cur_aic_ready_count, profiling_enabled
                     );
                 } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
                     dispatched = try_dispatch_task(
                         core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
-                        cur_aiv_ready_count
+                        cur_aiv_ready_count, profiling_enabled
                     );
                 }
 
@@ -789,12 +795,12 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
                         dispatched = try_dispatch_task(
                             core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
-                            cur_aic_ready_count
+                            cur_aic_ready_count, profiling_enabled
                         );
                     } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
                         dispatched = try_dispatch_task(
                             core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
-                            cur_aiv_ready_count
+                            cur_aiv_ready_count, profiling_enabled
                         );
                     }
                 }
@@ -818,14 +824,14 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
                     if (try_dispatch_task(
                             core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
-                            cur_aic_ready_count
+                            cur_aic_ready_count, profiling_enabled
                         )) {
                         made_progress = true;
                     }
                 } else if (h->core_type == CoreType::AIV && cur_aiv_ready_count > 0) {
                     if (try_dispatch_task(
                             core_id, reg_addr, CoreType::AIV, thread_idx, cur_ready_queue_aiv, cur_aiv_head,
-                            cur_aiv_ready_count
+                            cur_aiv_ready_count, profiling_enabled
                         )) {
                         made_progress = true;
                     }
@@ -836,7 +842,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
         // Refill local queues from shared queues
         if (cur_aic_ready_count == 0) {
             if (ready_count_aic_.load(std::memory_order_acquire) > 0) {
-                std::lock_guard<std::mutex> lock(ready_queue_aic_mutex_);
+                std::scoped_lock lock(ready_queue_aic_mutex_);
                 int available = ready_count_aic_.load(std::memory_order_relaxed);
                 int to_grab = (available < aic_per_thread_) ? available : aic_per_thread_;
 
@@ -857,7 +863,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
         if (cur_aiv_ready_count == 0) {
             if (ready_count_aiv_.load(std::memory_order_acquire) > 0) {
-                std::lock_guard<std::mutex> lock(ready_queue_aiv_mutex_);
+                std::scoped_lock lock(ready_queue_aiv_mutex_);
                 int available = ready_count_aiv_.load(std::memory_order_relaxed);
                 int to_grab = (available < aiv_per_thread_) ? available : aiv_per_thread_;
 

--- a/tools/swimlane_converter.py
+++ b/tools/swimlane_converter.py
@@ -45,20 +45,20 @@ except ImportError:
 
 
 def _func_id_to_letter(func_id):
-    """Map a non-negative integer func_id to a base-26 letter label.
+    """Map a non-negative integer func_id to a numeric+letter label.
 
-    0 → 'a', 1 → 'b', …, 25 → 'z', 26 → 'aa', 27 → 'ab', …
+    0 → '0_a', 1 → '1_b', …, 25 → '25_z', 26 → '26_aa', 27 → '27_ab', …
     """
     try:
         n = int(func_id)
     except (TypeError, ValueError):
         return str(func_id)
     letters = []
-    n += 1  # shift so that 0 maps to 'a' (1-based bijective base-26)
-    while n > 0:
-        n, rem = divmod(n - 1, 26)
+    m = n + 1  # shift so that 0 maps to 'a' (1-based bijective base-26)
+    while m > 0:
+        m, rem = divmod(m - 1, 26)
         letters.append(chr(ord("a") + rem))
-    return "".join(reversed(letters))
+    return str(n) + "_" + "".join(reversed(letters))
 
 
 def normalize_pto2_task_id_int(v):
@@ -445,7 +445,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
     events.append({"args": {"sort_index": 4}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 1})
 
     # Check if any task has AICPU timestamps
-    has_aicpu_data = any(task.get("dispatch_time_us", 0) > 0 and task.get("finish_time_us", 0) > 0 for task in tasks)
+    has_aicpu_data = any(task.get("dispatch_time_us", 0) >= 0 and task.get("finish_time_us", 0) > 0 for task in tasks)
 
     if has_aicpu_data:
         events.append(
@@ -534,7 +534,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
         for task in tasks:
             dispatch_us = task.get("dispatch_time_us", 0)
             finish_us = task.get("finish_time_us", 0)
-            if dispatch_us <= 0 or finish_us <= 0:
+            # 0us is a valid timestamp (base-time aligned); only reject negative/invalid values.
+            if dispatch_us < 0 or finish_us <= 0:
                 continue
 
             tid = core_to_tid[task["core_id"]]
@@ -803,7 +804,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
     if has_aicpu_data:
         for task in tasks:
             src_finish_us = task.get("finish_time_us", 0)
-            if src_finish_us <= 0:
+            # 0us is valid for the first task; keep it for dependency visualization.
+            if src_finish_us < 0:
                 continue
 
             src_tid = core_to_tid[task["core_id"]]
@@ -814,7 +816,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
 
                 succ_task = task_map[succ_task_id]
                 dst_dispatch_us = succ_task.get("dispatch_time_us", 0)
-                if dst_dispatch_us <= 0:
+                if dst_dispatch_us < 0:
                     continue
 
                 dst_tid = core_to_tid[succ_task["core_id"]]
@@ -868,7 +870,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
             core_thread_votes = defaultdict(lambda: defaultdict(int))
             for task in tasks:
                 dispatch_us = task.get("dispatch_time_us", 0)
-                if dispatch_us <= 0:
+                if dispatch_us < 0:
                     continue
                 core_id = task["core_id"]
                 for thread_idx, dispatch_records in dispatch_phases_by_thread.items():
@@ -884,7 +886,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
 
         for task in tasks:
             dispatch_us = task.get("dispatch_time_us", 0)
-            if dispatch_us <= 0:
+            if dispatch_us < 0:
                 continue
 
             matched_thread = core_to_sched_thread.get(task["core_id"])
@@ -972,7 +974,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
                     continue
 
                 dispatch_us = task.get("dispatch_time_us", 0)
-                if dispatch_us <= 0:
+                if dispatch_us < 0:
                     continue
 
                 matched_thread = core_to_sched_thread.get(task["core_id"])


### PR DESCRIPTION
Record dispatch_timestamps_ at the actual dispatch point in
try_dispatch_task (a2a3/a5), fixing previously missing or misplaced
profiling timestamps. Also fix swimlane_converter rejecting 0us
dispatch timestamps as invalid — 0 is a valid base-aligned value.
Together these fix corrupted swimlane/Perfetto trace output.