### PR TITLE
Support: require project-local venv for pip install

### DIFF
--- a/.claude/rules/venv-isolation.md
+++ b/.claude/rules/venv-isolation.md
@@ -1,0 +1,55 @@
+# Virtual Environment Isolation
+
+## Why
+
+Multiple AI agents may work on this repo concurrently (parallel sessions, worktrees). Installing directly with `pip install .` into the user's global or base environment causes package conflicts and non-reproducible state.
+
+## Rule
+
+**Always create and use a project-local virtual environment before running `pip install .` or any `pip` command.**
+
+### Steps
+
+1. **Create venv** (once per working directory — skip if `.venv/` already exists and is usable):
+
+   ```bash
+   python3 -m venv --system-site-packages .venv
+   ```
+
+   `--system-site-packages` ensures system-level packages (e.g. driver bindings) remain accessible.
+
+2. **Activate** before any pip or Python command:
+
+   ```bash
+   source .venv/bin/activate
+   ```
+
+3. **Install the project**:
+
+   ```bash
+   pip install .
+   ```
+
+4. **Run tests / examples** inside the activated venv.
+
+### Worktree Scenario
+
+When working in a git worktree (`.claude/worktrees/` or any other worktree path), the same rule applies — create `.venv` **inside the worktree directory**, not in the original repo. Each worktree gets its own independent venv.
+
+### Quick Reference
+
+```bash
+# First time in a directory (or worktree)
+python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
+pip install .
+
+# Subsequent runs — just activate
+source .venv/bin/activate
+```
+
+## Do NOT
+
+- Run `pip install .` without an activated local venv
+- Share a single venv across multiple worktrees
+- Use `--user` installs as a substitute for venv isolation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ See [docs/developer-guide.md](docs/developer-guide.md) for full directory struct
 ## Directory Ownership
 
 | Role | Working directory |
-|------|-------------------|
+| ---- | ----------------- |
 | Platform Developer | `src/{arch}/platform/` |
 | Runtime Developer | `src/{arch}/runtime/` |
 | Codegen Developer | `examples/` |
@@ -14,7 +14,18 @@ See [docs/developer-guide.md](docs/developer-guide.md) for full directory struct
 
 See [docs/testing.md](docs/testing.md) for the full testing guide (st, pyut, cpput) and [docs/ci.md](docs/ci.md) for CI pipeline details.
 
+### Python environment
+
+This repo requires `pip install .` to run. **Always use a project-local venv created with `--system-site-packages`** — never install into the user/global site. Applies equally to git worktrees (create `.venv` inside the worktree). See [.claude/rules/venv-isolation.md](.claude/rules/venv-isolation.md).
+
+```bash
+python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
+pip install .
+```
+
 ### Format C++ code
+
 ```bash
 clang-format -i <file>
 ```


### PR DESCRIPTION
## Summary

- Add `.claude/rules/venv-isolation.md` requiring AI agents to create a project-local `.venv` (with `--system-site-packages`) before running `pip install .`
- Surface the rule in `CLAUDE.md` under a new "Python environment" section
- Each worktree gets its own independent venv to avoid cross-session conflicts

## Testing

- [ ] Verify `.venv/` is already in `.gitignore`
- [ ] Markdownlint passes on both changed files