### PR TITLE
Perf(runtime): defer fanout wiring to scheduler via wiring queue

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,9 +68,10 @@ The PTO Runtime consists of **three separate programs** that communicate through
 **Key Responsibilities:**
 
 - Initialize handshake protocol with AICore cores
-- Identify initially ready tasks (fanin=0)
+- Wire fanout dependency edges from orchestrator's wiring queue (scheduler thread 0)
+- Identify ready tasks (fanin satisfied) and enqueue to ready queues
 - Dispatch ready tasks to idle AICore cores
-- Track task completion and update dependencies
+- Track task completion and notify downstream consumers
 - Continue until all tasks complete
 
 ### 3. AICore Kernel (`src/{arch}/platform/*/aicore/`)

--- a/docs/distributed_level_runtime.md
+++ b/docs/distributed_level_runtime.md
@@ -41,9 +41,12 @@ User code ──►  DistOrchestrator                   DistScheduler
                │                                   │
                │ submit(callable, args, config)     │
                │   1. alloc ring slot               │
-               │   2. TensorMap: build deps         │
-               │   3. fanin wiring                  │
-               │   4. if ready → push ready_queue ─►│
+               │   2. TensorMap: lookup deps        │
+               │   3. record fanin metadata         │
+               │   4. push wiring_queue ───────────►│
+               │                                    │ Phase 0: drain wiring_queue
+               │                                    │   wire fanout edges (lock + dep_pool)
+               │                                    │   if ready → push ready_queue
                │                                    │ pop ready_queue
                │                                    │ pick idle WorkerThread
                │                                    │ dispatch(payload) ──────► IWorker::run()
@@ -60,12 +63,13 @@ User code ──►  DistOrchestrator                   DistScheduler
 **Orchestrator** (main thread, single-threaded):
 
 - Owns TensorMap, Scope, Ring alloc side — no locks needed
-- Builds the DAG: for each submit, looks up input tensors to find producers, wires fanin/fanout edges
-- Pushes READY tasks to the ready queue
+- Builds the dependency metadata: for each submit, looks up input tensors to find producers, records fanin pointers in payload, increments producers' `fanout_count`
+- Pushes tasks to scheduler's wiring queue for asynchronous fanout edge construction
 
 **Scheduler** (dedicated C++ thread):
 
-- Pops tasks from ready queue, finds idle WorkerThreads, dispatches
+- **Wiring**: drains wiring queue, wires fanout edges (acquires `fanout_lock`, allocates dep_pool entries), determines task readiness
+- Pops ready tasks from ready queue, finds idle WorkerThreads, dispatches
 - Receives completion callbacks from WorkerThreads
 - Releases fanout refs, wakes downstream consumers, retires consumed slots
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
@@ -30,8 +30,8 @@ class TestPagedAttentionRingbuffer(SceneTestCase):
     RTOL = 1e-3
     ATOL = 1e-3
     RUNTIME_ENV = {
-        "PTO2_RING_TASK_WINDOW": "128",
-        "PTO2_RING_HEAP": "262144",
+        "PTO2_RING_TASK_WINDOW": "64",
+        "PTO2_RING_HEAP": "2621440",
         "PTO2_RING_DEP_POOL": "256",
     }
 

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -1782,7 +1782,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // Print orchestrator profiling data
 #if PTO2_ORCH_PROFILING
             PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
-            uint64_t total = p.alloc_cycle + p.params_cycle + p.heap_cycle + p.fanin_cycle;
+            uint64_t total = p.alloc_cycle + p.args_cycle + p.heap_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
             DEV_ALWAYS(
                 "Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===", thread_idx,
@@ -1802,8 +1802,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             );
             DEV_ALWAYS(
                 "Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
-                cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total,
-                static_cast<uint64_t>(p.params_atomic_count)
+                cycles_to_us(p.args_cycle), p.args_cycle * 100.0 / total, static_cast<uint64_t>(p.args_atomic_count)
             );
             DEV_ALWAYS(
                 "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
@@ -1824,7 +1823,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 orch_summary.end_time = orch_cycle_end;
                 orch_summary.sync_cycle = 0;
                 orch_summary.alloc_cycle = p.alloc_cycle;
-                orch_summary.params_cycle = p.args_cycle;
+                orch_summary.args_cycle = p.args_cycle;
                 orch_summary.lookup_cycle = 0;
                 orch_summary.heap_cycle = p.heap_cycle;
                 orch_summary.insert_cycle = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1503,11 +1503,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     uint64_t sched_scan_cycle = 0;
     uint64_t sched_complete_cycle = 0;
     uint64_t sched_dispatch_cycle = 0;
+    uint64_t sched_wiring_cycle = 0;
     uint64_t sched_idle_cycle = 0;
     uint64_t sched_loop_count = 0;
     uint32_t phase_complete_count = 0;
     uint32_t phase_dispatch_count = 0;
 #if PTO2_SCHED_PROFILING
+    uint32_t phase_wiring_count = 0;
     uint64_t complete_probe_count = 0;
     uint64_t complete_hit_count = 0;
     uint64_t notify_edges_total = 0;
@@ -1693,6 +1695,22 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             continue;
         }
 
+        // Phase 3: Drain wiring queue — wire fanout edges for newly submitted tasks.
+        // Only thread 0 does wiring to keep dep_pool single-threaded.
+        if (thread_idx == 0) {
+            int wired = rt->scheduler.drain_wiring_queue();
+            if (wired > 0) {
+                made_progress = true;
+#if PTO2_SCHED_PROFILING
+                phase_wiring_count += wired;
+#endif
+            }
+        }
+#if PTO2_PROFILING
+        CYCLE_COUNT_LAP(sched_wiring_cycle);
+#endif
+
+        // Phase 4: Dispatch
         const PTO2ResourceShape *dispatch_order = get_dispatch_order(thread_idx);
         bool entered_drain = false;
 
@@ -2039,7 +2057,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     );
 
     // Scheduler summary logging (always print when PTO2_PROFILING=1)
-    uint64_t sched_total = sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
+    uint64_t sched_total =
+        sched_wiring_cycle + sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
 
 #if PTO2_SCHED_PROFILING
@@ -2151,6 +2170,19 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_scan_cycle),
             sched_scan_cycle * 100.0 / sched_total
         );
+
+        // Level 1: wiring
+#if PTO2_SCHED_PROFILING
+        DEV_ALWAYS(
+            "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx, cycles_to_us(sched_wiring_cycle),
+            sched_wiring_cycle * 100.0 / sched_total, phase_wiring_count
+        );
+#else
+        DEV_ALWAYS(
+            "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_wiring_cycle),
+            sched_wiring_cycle * 100.0 / sched_total
+        );
+#endif
 
         // Level 1: idle
         DEV_ALWAYS(
@@ -2403,7 +2435,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #if PTO2_ORCH_PROFILING
             PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
             uint64_t total =
-                p.sync_cycle + p.alloc_cycle + p.params_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
+                p.sync_cycle + p.alloc_cycle + p.args_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
             DEV_ALWAYS(
                 "Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===", thread_idx,
@@ -2429,8 +2461,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             );
             DEV_ALWAYS(
                 "Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
-                cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total,
-                static_cast<uint64_t>(p.params_atomic_count)
+                cycles_to_us(p.args_cycle), p.args_cycle * 100.0 / total, static_cast<uint64_t>(p.args_atomic_count)
             );
             DEV_ALWAYS(
                 "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -10,7 +10,7 @@ The single-ring design uses one `last_task_alive` watermark shared by HeapRing, 
 
 Split HeapRing, TaskRing, and DepPool into arrays of `PTO2_MAX_RING_DEPTH` (4) independent instances. Each scope depth maps to its own ring, with an independent `last_task_alive` watermark.
 
-```
+```text
 Scope depth 0  ──►  rings[0] = { HeapRing, TaskRing, DepPool }
 Scope depth 1  ──►  rings[1] = { HeapRing, TaskRing, DepPool }
 Scope depth 2  ──►  rings[2] = { HeapRing, TaskRing, DepPool }
@@ -23,14 +23,14 @@ Inner-scope tasks can now be reclaimed independently without waiting for outer-s
 
 Task IDs are widened from 32-bit to 64-bit to carry the ring identity:
 
-```
+```text
 task_id.raw = (ring_id << 32) | local_id
 ```
 
 `PTO2TaskId` exposes direct accessors in `pto_runtime2_types.h`:
 
 | API | Purpose |
-|-----|---------|
+| --- | ------- |
 | `pto2_make_task_id(ring_id, local_id)` | Compose a 64-bit task ID (`PTO2TaskId`) |
 | `task_id.ring()` | Extract `ring_id` (bits 63-32) |
 | `task_id.local()` | Extract `local_id` (bits 31-0) |
@@ -39,7 +39,7 @@ task_id.raw = (ring_id << 32) | local_id
 Type changes:
 
 | Field | Before | After |
-|-------|--------|-------|
+| ----- | ------ | ----- |
 | `PTO2TaskDescriptor.task_id` | `int32_t` | `PTO2TaskId` |
 | `PTO2TensorMapEntry.producer_task_id` | `int32_t` | `PTO2TaskId` |
 | `PTO2TaskSlotState.ring_id` | N/A | `uint8_t` (new, denormalized for fast access) |
@@ -54,7 +54,7 @@ Bundles the three per-ring resources into a single aggregate (`pto_ring_buffer.h
 struct PTO2RingSet {
     PTO2HeapRing   heap_ring;
     PTO2TaskRing   task_ring;
-    PTO2DepListPool dep_pool;
+    PTO2FaninPool fanin_pool;
 };
 ```
 
@@ -66,9 +66,8 @@ PTO2HeapRing heap_ring;
 PTO2TaskRing task_ring;
 PTO2DepListPool dep_pool;
 
-// After: per-ring array
+// After: per-ring array (dep_pool moved to scheduler, see §4.5)
 PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
-int32_t dep_pool_last_reclaimed[PTO2_MAX_RING_DEPTH];
 ```
 
 Ring selection: `current_ring_id() = min(scope_stack_top, PTO2_MAX_RING_DEPTH - 1)`.
@@ -115,9 +114,11 @@ struct RingSchedState {
     int32_t task_window_size;
     int32_t task_window_mask;
     std::atomic<int32_t> advance_lock;
+    PTO2DepListPool dep_pool;  // fanout wiring dep pool (exclusively managed by scheduler thread 0)
 };
 
 RingSchedState ring_sched_states[PTO2_MAX_RING_DEPTH];
+PTO2ReadyQueue wiring_queue;  // deferred fanout wiring from orchestrator
 ```
 
 ### 4.6 PTO2TensorMap (modified)
@@ -140,7 +141,7 @@ bool entry_valid(const PTO2TensorMapEntry& e) {
 ### 4.7 Unchanged Structures
 
 | Structure | Reason |
-|-----------|--------|
+| --------- | ------ |
 | `PTO2DepListEntry` | Stores `PTO2TaskSlotState*` pointer — naturally crosses ring boundaries |
 | `PTO2TaskPayload` | `fanin_slot_states[]` are pointers — no ring coupling |
 | `PTO2ReadyQueue` | Global ready queues shared across all rings (tasks ready to dispatch regardless of origin ring) |
@@ -152,7 +153,7 @@ bool entry_valid(const PTO2TensorMapEntry& e) {
 
 Each ring's `last_task_alive` advances independently:
 
-```
+```text
 advance_ring_pointers(ring_id):
     la = rings[ring_id].fc.last_task_alive
     while task_state[la & mask] >= CONSUMED:
@@ -174,13 +175,16 @@ Dependency edges use `PTO2TaskSlotState*` pointers, which naturally span rings:
 
 ### 5.3 DepPool Reclamation
 
-```
-pto2_dep_pool_reclaim(ring_id):
+DepPool is exclusively managed by scheduler thread 0 (allocation during wiring, reclamation during watermark advancement):
+
+```text
+// Called by scheduler thread 0 during wiring_queue drain:
+dep_pool_reclaim(ring_id):
     la = rings[ring_id].fc.last_task_alive
     newest_consumed = la - 1
-    mark = task_payloads[ring_id][slot(newest_consumed)].dep_pool_mark
+    mark = slot_states[slot(newest_consumed)].dep_pool_mark
     if mark > 0:
-        rings[ring_id].dep_pool.advance_tail(mark)
+        ring_sched_states[ring_id].dep_pool.advance_tail(mark)
 ```
 
 Note: dep entries from ring N's pool may appear in ring M's fanout lists. Reclamation is safe because the entries are accessed during fanout traversal (completion time), which always happens before the consumer task — and therefore the dep entry — becomes eligible for reclamation.
@@ -189,7 +193,7 @@ Note: dep entries from ring N's pool may appear in ring M's fanout lists. Reclam
 
 The AICore dispatch protocol uses 32-bit registers. With multi-ring, `task_id` truncation to 32-bit loses the `ring_id`, causing collisions:
 
-```
+```text
 Ring 0, local_id=0  →  DATA_MAIN_BASE = 0 + 1 = 1
 Ring 1, local_id=0  →  DATA_MAIN_BASE = 0 + 1 = 1  (collision!)
 ```
@@ -203,7 +207,7 @@ AICore uses `last_reg_val` to detect new dispatches — identical values cause s
 ### 7.1 Compile-Time Defaults (per ring)
 
 | Constant | Default | Total (×4 rings) |
-|----------|---------|-------------------|
+| -------- | ------- | ---------------- |
 | `PTO2_TASK_WINDOW_SIZE` | 16384 | 65536 |
 | `PTO2_HEAP_SIZE` | 256 MB | 1 GB |
 | `PTO2_DEP_LIST_POOL_SIZE` | 16384 | 65536 |
@@ -212,7 +216,7 @@ AICore uses `last_reg_val` to detect new dispatches — identical values cause s
 
 Uniform (applies to all rings):
 
-```
+```bash
 PTO2_RING_TASK_WINDOW=1024
 PTO2_RING_HEAP=1048576
 PTO2_RING_DEP_POOL=1024

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -335,8 +335,8 @@ When `pto2_submit_task` processes parameters:
 | `kernel_id[3]` | Per-slot kernel IDs: `[AIC, AIV0, AIV1]`; `INVALID_KERNEL_ID` = inactive |
 | `active_mask` | Bitmask of active subtask slots: `bit0=AIC`, `bit1=AIV0`, `bit2=AIV1` |
 | `subtask_done_mask` | Atomic bitmask; each subtask sets its done bit on completion |
-| `fanin_count` | Number of producer dependencies |
-| `fanout_lock` | Per-task spinlock for concurrent fanout modification |
+| `fanin_count` | Number of producer dependencies (set by scheduler during wiring) |
+| `fanout_lock` | Per-task spinlock for concurrent fanout modification (used by scheduler wiring + completion) |
 | `fanout_head` | Head of fanout consumer list (pointer, protected by `fanout_lock`) |
 | `fanout_count` | 1 (scope ref) + number of consumers |
 | `packed_buffer_base` | Start of packed buffer in GM Heap |
@@ -380,42 +380,49 @@ The orchestrator runs on AICPU Thread 3 and builds the task graph by calling the
 
 Key members:
 
-- `rings[PTO2_MAX_RING_DEPTH]`: per-ring `PTO2RingSet` (HeapRing + TaskRing + DepPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
+- `rings[PTO2_MAX_RING_DEPTH]`: per-ring `PTO2RingSet` (HeapRing + TaskRing + FaninPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
 - `tensor_map`, `tensor_pool`: dependency tracking
 - `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
-- `scheduler`: pointer to scheduler state (for simulated mode or `init_task_on_submit`)
+- `scheduler`: pointer to scheduler state (for wiring queue and ready queue access)
 - `gm_heap_base`, `gm_heap_size`: GM heap for output buffers
 
-### 7.2 Task Submission Flow (`pto2_submit_task`)
+### 7.2 Task Submission Flow (`pto2_submit_mixed_task`)
 
 | Step | Operation |
 | ---- | --------- |
 | 0 | `pto2_orchestrator_sync_tensormap` — prune stale TensorMap entries |
 | 1 | `pto2_task_ring_alloc` — allocate task slot (may block on flow control) |
-| 2 | Initialize task descriptor, copy parameters |
-| 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers |
-| 4 | **Dependency**: `pto2_add_consumer_to_producer` for each producer found |
-| 5 | **Heap alloc**: `pto2_alloc_packed_buffer` for OUTPUT args (addr=0) |
-| 6 | **Insert**: register OUTPUT/INOUT args in TensorMap |
-| 7 | **Fanin**: finalize `fanin_count`; if `init_task_on_submit`, call scheduler's `init_task` |
-| 8 | **Publish**: `STORE_RELEASE(current_task_index)` makes task visible to scanners |
+| 2 | Initialize task descriptor + slot state, copy parameters |
+| 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers; collect producer pointers in `PTO2FaninBuilder` |
+| 4 | **Insert**: register OUTPUT/INOUT args in TensorMap |
+| 5 | **Record fanin metadata**: store producer pointers in `payload->fanin_inline_slot_states[]` (+ spill pool if >16); increment each producer's `fanout_count` (no lock needed — single writer) |
+| 6 | **Push to wiring queue**: scheduler thread 0 asynchronously wires fanout edges (lock + dep_pool + early_finished check + ready push) |
 
-### 7.3 Lock Protocol for Concurrent Dependency Setup
+> **Note**: Fanout wiring (Steps 4–7 in earlier versions) has been moved from the
+> orchestrator submit hot path to the scheduler's `wiring_queue`. This reduces the
+> orchestrator's shared L2 cache / memory bus pressure, as the orchestrator no longer
+> acquires `fanout_lock` or allocates from `dep_pool` during submission.
 
-The orchestrator and scheduler run concurrently. When adding a consumer to a producer's fanout list:
+### 7.3 Deferred Fanout Wiring (Scheduler Wiring Queue)
 
-1. **Orchestrator acquires** the producer's `fanout_lock` via `pto2_fanout_lock(task)` (CAS spin-lock)
-2. **Normal path**: prepend consumer to the producer's fanout list, increment `fanout_count`
-3. **Release** `fanout_lock`
+The orchestrator pushes each submitted task to `scheduler->wiring_queue`. Scheduler thread 0 drains this queue and, for each task:
+
+1. Sets `fanin_count = N + 1` (+1 redundance to prevent premature readiness)
+2. For each producer in `payload->fanin_slot_states[]`:
+   - **Acquires** the producer's `fanout_lock`
+   - Checks `task_state >= COMPLETED` (early-finished optimization)
+   - If not completed: prepends consumer to producer's `fanout_head` via `dep_pool.prepend`
+   - **Releases** `fanout_lock`
+3. Atomically releases the +1 redundance + early_finished count via `fanin_refcount.fetch_add`
+4. If all deps satisfied: pushes task to ready queue
 
 The scheduler's completion handler mirrors this:
 
-1. Mark `task_state[slot] = COMPLETED`
-2. **Acquire** `fanout_lock`, read `fanout_head`, **release** lock
-3. Traverse fanout list, incrementing each consumer's `fanin_refcount`
-4. Mark `task_state[slot] = CONSUMED` when `fanout_refcount` reaches `fanout_count`
+1. **Acquire** `fanout_lock`, mark `task_state = COMPLETED`, read `fanout_head`, **release** lock
+2. Traverse fanout list, incrementing each consumer's `fanin_refcount`
+3. Mark `task_state = CONSUMED` when `fanout_refcount` reaches `fanout_count`
 
-This lock protocol guarantees every consumer is accounted for exactly once.
+This protocol guarantees every consumer is accounted for exactly once.
 
 ### 7.4 Scope Mechanism (`PTO2_SCOPE`)
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -163,9 +163,9 @@ This project-defined flattened numbering is kept unchanged.
 ### 10.2 Runtime Behavior per Submit
 
 1. Validate submit arguments.
-2. Allocate mixed-task ID and initialize descriptor/payload once.
-3. Build fanin/fanout at mixed-task granularity.
-4. Enqueue by shape when ready.
+2. Allocate mixed-task ID and initialize descriptor/payload/slot_state once.
+3. Lookup producers via TensorMap; collect fanin metadata and increment producers' `fanout_count`.
+4. Push task to scheduler's wiring queue (scheduler thread 0 asynchronously wires fanout edges and determines readiness).
 5. Dispatch all active lanes atomically when resources allow.
 6. Aggregate completion and release downstream once.
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -301,17 +301,24 @@ static bool pto2_prepare_task(
         auto &rs = out->sched->ring_sched_states[ring_id];
         out->slot_state = &rs.get_slot_state_by_slot(out->alloc_result.slot);
         PTO2TaskSlotState &slot_state = *out->slot_state;
-        slot_state.fanin_count = 0;
         slot_state.fanout_head = nullptr;
         slot_state.fanout_lock.store(0, std::memory_order_relaxed);
         slot_state.fanout_count = 1;
-        slot_state.fanout_refcount.store(0, std::memory_order_release);
-        slot_state.fanin_refcount.store(0, std::memory_order_release);
+        slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
+        slot_state.fanin_refcount.store(0, std::memory_order_relaxed);
+        slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
+        slot_state.completed_subtasks.store(0, std::memory_order_relaxed);
+        slot_state.subtask_done_mask.store(0, std::memory_order_relaxed);
+        int16_t block_num = args.launch_spec.block_num();
+        slot_state.total_required_subtasks =
+            static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
+        slot_state.block_num = block_num;
+        slot_state.next_block_idx = 0;
         slot_state.payload = out->payload;
         slot_state.task = out->task;
         slot_state.active_mask = active_mask;
-        slot_state.subtask_done_mask.store(0, std::memory_order_relaxed);
         slot_state.ring_id = ring_id;
+        // fanin_count is set by scheduler during wiring
         scope_tasks_push(orch, &slot_state);
     } else {
         scope_tasks_push(orch, nullptr);
@@ -353,25 +360,10 @@ bool pto2_orchestrator_init(
         if (!fanin_entries) {
             for (int j = 0; j < r; j++) {
                 free(orch->rings[j].fanin_pool.base);
-                free(orch->rings[j].dep_pool.base);
             }
             return false;
         }
         orch->rings[r].fanin_pool.init(fanin_entries, dep_pool_capacity, &sm_handle->header->orch_error_code);
-
-        // Allocate and initialize dependency list pool (per-ring)
-        PTO2DepListEntry *dep_entries =
-            reinterpret_cast<PTO2DepListEntry *>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
-        if (!dep_entries) {
-            // Cleanup previously allocated rings
-            for (int j = 0; j < r; j++) {
-                free(orch->rings[j].fanin_pool.base);
-                free(orch->rings[j].dep_pool.base);
-            }
-            free(orch->rings[r].fanin_pool.base);
-            return false;
-        }
-        orch->rings[r].dep_pool.init(dep_entries, dep_pool_capacity, &sm_handle->header->orch_error_code);
     }
 
     // Initialize TensorMap with per-ring task window sizes
@@ -382,7 +374,6 @@ bool pto2_orchestrator_init(
     if (!orch->tensor_map.init_default(task_window_sizes)) {
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             free(orch->rings[r].fanin_pool.base);
-            free(orch->rings[r].dep_pool.base);
         }
         return false;
     }
@@ -398,7 +389,6 @@ bool pto2_orchestrator_init(
         free(orch->scope_begins);
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             free(orch->rings[r].fanin_pool.base);
-            free(orch->rings[r].dep_pool.base);
         }
         orch->tensor_map.destroy();
         return false;
@@ -417,8 +407,6 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState *orch) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         free(orch->rings[r].fanin_pool.base);
         orch->rings[r].fanin_pool.base = NULL;
-        free(orch->rings[r].dep_pool.base);
-        orch->rings[r].dep_pool.base = NULL;
     }
 
     free(orch->scope_tasks);
@@ -579,11 +567,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     // Read current last_task_alive from shared memory for this ring
     int32_t sm_last_task_alive = fc.last_task_alive.load(std::memory_order_acquire);
 
-    orch->tensor_map.sync_tensormap(ring_id, sm_last_task_alive);
-
-    if (sched) {
-        orch->rings[ring_id].dep_pool.reclaim(*sched, ring_id, sm_last_task_alive);
-    }
+    orch->tensor_map.sync_tensormap(task_id, sm_last_task_alive);
 
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, task_id.raw);
 
@@ -664,24 +648,13 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     task.packed_buffer_base = prepared.alloc_result.packed_base;
     task.packed_buffer_end = prepared.alloc_result.packed_end;
 
-    // Prefetch producer slot_states and cur_slot_state (written at init but likely
-    // evicted by lookup/insert/heap). param_copy below provides hide time.
-    if (sched) {
-        auto &rs = sched->ring_sched_states[ring_id];
-        __builtin_prefetch(&rs.get_slot_state_by_slot(slot), 1, 0);
-        fanin_builder.for_each([](PTO2TaskSlotState *producer_slot_state) {
-            __builtin_prefetch(producer_slot_state, 1, 0);
-            return true;
-        });
-    }
-
     payload->init(args, result, prepared.alloc_result.packed_base, layout.offsets, layout.buffer_sizes);
 
     // Write owner_task_id into materialized OUTPUT tensors so creator-only dependency
     // tracking remains available even when manual_dep skips OverlapMap publication.
     for (int i = 0; i < args.tensor_count(); i++) {
         if (args.tag(i) == TensorArgType::OUTPUT) {
-            payload->tensors[i].owner_task_id = task_id;
+            payload->tensors[i].owner_task_id = prepared.task_id;
         }
     }
 
@@ -690,69 +663,37 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     g_orch_args_atomic_count += 2;  // fanout_lock.store + fanout_count.store
 #endif
 
-    // === STEP 6: Finalize fanin list ===
-    // First build the fanin list
+    // === STEP 6: Record fanin metadata + push to wiring queue ===
+    // Deferred wiring: orchestrator only stores dependency metadata and increments
+    // fanout_count. The actual fanout_head wiring (lock + dep_pool + early_finished)
+    // is handled asynchronously by scheduler thread 0 via the wiring queue.
     if (sched) {
         auto &rs = sched->ring_sched_states[ring_id];
         PTO2TaskSlotState &cur_slot_state = rs.get_slot_state_by_slot(slot);
-        // Initialize scheduler state BEFORE adding to producer fanout lists,
-        // so concurrent on_mixed_task_complete can safely access task_state/fanout_refcount.
-        cur_slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
-        cur_slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
-        cur_slot_state.completed_subtasks.store(0, std::memory_order_relaxed);
-        cur_slot_state.total_required_subtasks =
-            static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
-        cur_slot_state.block_num = block_num;
-        cur_slot_state.next_block_idx = 0;
-
-        auto &dep_pool = orch->rings[ring_id].dep_pool;
         int32_t fanin_count = fanin_builder.count;
         int32_t inline_count = std::min(fanin_count, PTO2_FANIN_INLINE_CAP);
         int32_t spill_count = fanin_count - inline_count;
-        dep_pool.ensure_space(*sched, fc, ring_id, fanin_count + 1);
 
-        int32_t early_finished = 0;
-        cur_slot_state.fanin_count = fanin_count + 1;  // +1 redundance for not being ready too early
+        // Store fanin metadata in payload for scheduler to iterate
         payload->fanin_actual_count = fanin_count;
         payload->fanin_spill_start = (spill_count > 0) ? fanin_builder.spill_start : 0;
         payload->fanin_spill_pool = (spill_count > 0) ? fanin_builder.spill_pool : nullptr;
         for (int i = 0; i < inline_count; i++) {
             payload->fanin_inline_slot_states[i] = fanin_builder.inline_slots[i];
         }
-        pto2_for_each_fanin_slot_state(*payload, [&](PTO2TaskSlotState *producer_slot) {
-            PTO2TaskSlotState &producer_slot_state = *producer_slot;
-#if PTO2_ORCH_PROFILING
-            pto2_fanout_lock(producer_slot_state, g_orch_fanin_atomic_count, g_orch_fanin_wait_cycle);
-#else
-            pto2_fanout_lock(producer_slot_state);
-#endif
-            producer_slot_state.fanout_count += 1;
-            int32_t prod_state = producer_slot_state.task_state.load(std::memory_order_acquire);
-            if (prod_state >= PTO2_TASK_COMPLETED) {
-                early_finished++;
-            } else {
-                producer_slot_state.fanout_head = dep_pool.prepend(producer_slot_state.fanout_head, &cur_slot_state);
-            }
-            pto2_fanout_unlock(producer_slot_state);
+
+        // Increment fanout_count on each producer (no lock — only orch writes this field).
+        // Prevents premature CONSUMED: scope_end's release_producer checks fanout_refcount == fanout_count.
+        pto2_for_each_fanin_slot_state(*payload, [](PTO2TaskSlotState *producer) {
+            producer->fanout_count += 1;
         });
-        // Combined release: merge early_finished batch with the +1 init release
-        // into a single atomic fetch_add (saves one acq_rel cache-line bounce per task).
-        int32_t initial_refcount = early_finished + 1;  // +1 for the init release
-        int32_t new_rc =
-            cur_slot_state.fanin_refcount.fetch_add(initial_refcount, std::memory_order_acq_rel) + initial_refcount;
-        if (new_rc >= fanin_count + 1) {
-            PTO2ResourceShape shape = pto2_active_mask_to_shape(active_mask);
-            sched->ready_queues[static_cast<int32_t>(shape)].push(&cur_slot_state);
+
+        // Push to per-ring wiring queue — scheduler sets fanin_count, wires fanout, checks readiness
+        while (!sched->ring_sched_states[ring_id].wiring_queue.push(&cur_slot_state)) {
+            SPIN_WAIT_HINT();
         }
-        // Record dep pool watermark in local slot state (used by tail reclamation)
-        cur_slot_state.dep_pool_mark = orch->rings[ring_id].dep_pool.top;
 #if PTO2_ORCH_PROFILING
-        // Per producer: fetch_add(fanout_count) + load(task_state) + store(unlock) = 3 atomics
-        // Lock atomics (loads + CAS) are counted inside pto2_fanout_lock
-        g_orch_fanin_atomic_count += fanin_count * 3;
-        if (early_finished > 0) {
-            g_orch_fanin_atomic_count += 1;  // fanin_refcount.fetch_add
-        }
+        g_orch_fanin_atomic_count += 0;  // No lock/atomic ops in submit hot path
 #endif
     }
 
@@ -803,10 +744,7 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
 #endif
 
     int32_t sm_last_task_alive = fc.last_task_alive.load(std::memory_order_acquire);
-    orch->tensor_map.sync_tensormap(ring_id, sm_last_task_alive);
-    if (prepared.sched != nullptr) {
-        orch->rings[ring_id].dep_pool.reclaim(*prepared.sched, ring_id, sm_last_task_alive);
-    }
+    orch->tensor_map.sync_tensormap(prepared.task_id, sm_last_task_alive);
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, prepared.task_id.raw);
 
     task.task_id = prepared.task_id;
@@ -864,17 +802,10 @@ void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
             LOG_INFO("=== [Orchestrator] ring %d: total_tasks=%d ===", r, total_tasks);
         }
         auto &fanin_pool = orch->rings[r].fanin_pool;
-        auto &pool = orch->rings[r].dep_pool;
         if (fanin_pool.top > 1) {
             LOG_INFO(
                 "=== [FaninPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===", r, fanin_pool.top,
                 fanin_pool.tail, fanin_pool.top - fanin_pool.tail, fanin_pool.high_water, fanin_pool.capacity
-            );
-        }
-        if (pool.top > 0) {
-            LOG_INFO(
-                "=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===", r, pool.top, pool.tail,
-                pool.top - pool.tail, pool.high_water, pool.capacity
             );
         }
     }
@@ -906,9 +837,6 @@ void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch) {
             );
             LOG_INFO(
                 "Ring %d fanin pool:   %d / %d", r, orch->rings[r].fanin_pool.used(), orch->rings[r].fanin_pool.capacity
-            );
-            LOG_INFO(
-                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity
             );
         }
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -666,7 +666,6 @@ struct PTO2DepListPool {
 struct PTO2RingSet {
     PTO2TaskAllocator task_allocator;
     PTO2FaninPool fanin_pool;
-    PTO2DepListPool dep_pool;
 };
 
 #endif  // PTO_RING_BUFFER_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -248,7 +248,7 @@ PTO2Runtime *pto2_runtime_create_custom(
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, dep_pool_capacity)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
@@ -284,7 +284,7 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, dep_pool_capacity)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt);
         return NULL;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -111,6 +111,9 @@
 // Ready queue
 #define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size
 
+// Wiring queue
+#define PTO2_WRIRING_QUEUE_SIZE 1024  // Per-shape queue size
+
 // Memory alignment
 #define PTO2_ALIGN_SIZE 64             // Cache line alignment
 #define PTO2_PACKED_OUTPUT_ALIGN 1024  // Each output in packed buffer aligned to 1024B; gap is padding

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -148,6 +148,9 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHandle *sm_handle,
         slot_states[i].ring_id = 0;
     }
 
+    wiring_batch_count = 0;
+    wiring_batch_index = 0;
+
     return true;
 }
 
@@ -157,7 +160,7 @@ void PTO2SchedulerState::RingSchedState::destroy() {
     slot_states = nullptr;
 }
 
-bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle) {
+bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle, int32_t dep_pool_capacity) {
     sched->sm_handle = sm_handle;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -188,12 +191,49 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
         }
     }
 
+    // Initialize per-ring wiring queues and dep pools (exclusively managed by scheduler thread 0)
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        if (!pto2_ready_queue_init(&sched->ring_sched_states[r].wiring_queue, PTO2_WRIRING_QUEUE_SIZE)) {
+            for (int j = 0; j < r; j++) {
+                pto2_ready_queue_destroy(&sched->ring_sched_states[j].wiring_queue);
+                free(sched->ring_sched_states[j].dep_pool.base);
+            }
+            for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+                pto2_ready_queue_destroy(&sched->ready_queues[i]);
+            }
+            for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
+                sched->ring_sched_states[rr].destroy();
+            }
+            return false;
+        }
+        PTO2DepListEntry *dep_entries =
+            reinterpret_cast<PTO2DepListEntry *>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
+        if (!dep_entries) {
+            pto2_ready_queue_destroy(&sched->ring_sched_states[r].wiring_queue);
+            for (int j = 0; j < r; j++) {
+                pto2_ready_queue_destroy(&sched->ring_sched_states[j].wiring_queue);
+                free(sched->ring_sched_states[j].dep_pool.base);
+            }
+            for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+                pto2_ready_queue_destroy(&sched->ready_queues[i]);
+            }
+            for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
+                sched->ring_sched_states[rr].destroy();
+            }
+            return false;
+        }
+        sched->ring_sched_states[r].dep_pool.init(dep_entries, dep_pool_capacity, &sm_handle->header->orch_error_code);
+    }
+
     return true;
 }
 
 void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].destroy();
+        free(sched->ring_sched_states[r].dep_pool.base);
+        sched->ring_sched_states[r].dep_pool.base = nullptr;
+        pto2_ready_queue_destroy(&sched->ring_sched_states[r].wiring_queue);
     }
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
@@ -211,6 +251,13 @@ void pto2_scheduler_print_stats(PTO2SchedulerState *sched) {
         if (sched->ring_sched_states[r].last_task_alive > 0) {
             LOG_INFO("Ring %d:", r);
             LOG_INFO("  last_task_alive: %d", sched->ring_sched_states[r].last_task_alive);
+            auto &dp = sched->ring_sched_states[r].dep_pool;
+            if (dp.top > 0) {
+                LOG_INFO(
+                    "  dep_pool: top=%d tail=%d used=%d high_water=%d capacity=%d", dp.top, dp.tail, dp.top - dp.tail,
+                    dp.high_water, dp.capacity
+                );
+            }
         }
     }
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -438,6 +438,19 @@ struct PTO2SchedulerState {
         // Try-lock used to advance this ring's last_task_alive pointer.
         std::atomic<int32_t> advance_lock;
 
+        // Dep pool for fanout wiring (exclusively managed by scheduler thread 0)
+        PTO2DepListPool dep_pool;
+
+        // Per-ring wiring queue: orchestrator pushes tasks, scheduler thread 0 pops and wires.
+        PTO2ReadyQueue wiring_queue;
+
+        // Local batch buffer for drain_wiring_queue (scheduler thread 0 only).
+        // Persists across calls so partially-consumed batches resume next call.
+        static constexpr int WIRING_BATCH_SIZE = 32;
+        PTO2TaskSlotState *wiring_batch[WIRING_BATCH_SIZE];
+        int wiring_batch_count = 0;
+        int wiring_batch_index = 0;
+
         bool init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id);
         void destroy();
 
@@ -476,9 +489,99 @@ struct PTO2SchedulerState {
     // =========================================================================
     // Inline hot-path methods
     // =========================================================================
+
+    /**
+     * Drain wiring queue: pop submitted tasks and wire their fanout edges.
+     * Called by scheduler thread 0 each loop iteration. Sets fanin_count,
+     * acquires fanout_lock per producer, allocates dep_pool entries, and
+     * pushes ready tasks to the appropriate ready queue.
+     *
+     * @return Number of tasks wired this call.
+     */
+    int drain_wiring_queue() {
+        int wired = 0;
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            wired += drain_ring_wiring_queue(r);
+        }
+        return wired;
+    }
+
+    /**
+     * Drain the wiring queue for a single ring. See drain_wiring_queue() for
+     * the peek/pop_batch FIFO protocol. Returns the number of tasks wired.
+     */
+    int drain_ring_wiring_queue(int ring_id) {
+        auto &rss = ring_sched_states[ring_id];
+        int wired = 0;
+
+        // Refill local batch buffer when exhausted.
+        if (rss.wiring_batch_index >= rss.wiring_batch_count) {
+            rss.wiring_batch_count = rss.wiring_queue.pop_batch(rss.wiring_batch, RingSchedState::WIRING_BATCH_SIZE);
+            rss.wiring_batch_index = 0;
+            if (rss.wiring_batch_count == 0) return 0;
+        }
+
+        // Process tasks from local buffer in strict FIFO order.
+        while (rss.wiring_batch_index < rss.wiring_batch_count) {
+            PTO2TaskSlotState *ws = rss.wiring_batch[rss.wiring_batch_index];
+            int32_t wfanin = ws->payload->fanin_actual_count;
+
+            if (wfanin > 0 && rss.dep_pool.available() < wfanin) {
+                rss.dep_pool.reclaim(*this, ring_id, rss.last_task_alive);
+                if (wfanin > 0 && rss.dep_pool.available() < wfanin) {
+                    break;  // not enough dep_pool space — keep remainder for next call
+                }
+            }
+
+            rss.wiring_batch_index++;
+            wire_task(ring_id, ws);
+            wired++;
+        }
+
+        return wired;
+    }
+
+    /**
+     * Wire fanout edges for a single task. Sets fanin_count, acquires each
+     * producer's fanout_lock, allocates dep_pool entries for live producers,
+     * pushes the task to the ready queue once its fanin refcount is satisfied.
+     */
+    void wire_task(int ring_id, PTO2TaskSlotState *ws) {
+        auto &rss = ring_sched_states[ring_id];
+        PTO2TaskPayload *wp = ws->payload;
+        int32_t wfanin = wp->fanin_actual_count;
+        ws->fanin_count = wfanin + 1;
+
+        if (wfanin != 0) {
+            int32_t early_finished = 0;
+            pto2_for_each_fanin_slot_state(*wp, [&](PTO2TaskSlotState *producer) {
+                pto2_fanout_lock(*producer);
+                int32_t pstate = producer->task_state.load(std::memory_order_acquire);
+                if (pstate >= PTO2_TASK_COMPLETED) {
+                    early_finished++;
+                } else {
+                    producer->fanout_head = rss.dep_pool.prepend(producer->fanout_head, ws);
+                }
+                pto2_fanout_unlock(*producer);
+            });
+
+            int32_t init_rc = early_finished + 1;
+            int32_t new_rc = ws->fanin_refcount.fetch_add(init_rc, std::memory_order_acq_rel) + init_rc;
+            if (new_rc >= ws->fanin_count) {
+                ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
+            }
+        } else {
+            ws->fanin_refcount.fetch_add(1, std::memory_order_acq_rel);
+            ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
+        }
+
+        ws->dep_pool_mark = rss.dep_pool.top;
+    }
+
     PTO2TaskSlotState &get_slot_state(int32_t ring_id, int32_t local_id) {
         return ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
     }
+
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t ring_id, int32_t slot) {
         return ring_sched_states[ring_id].get_slot_state_by_slot(slot);
     }
@@ -784,7 +887,9 @@ struct PTO2SchedulerState {
 // Scheduler API (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle);
+bool pto2_scheduler_init(
+    PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 void pto2_scheduler_destroy(PTO2SchedulerState *sched);
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -234,11 +234,15 @@ int32_t PTO2TensorMap::valid_count() {
     return count;
 }
 
-void PTO2TensorMap::sync_tensormap(uint8_t ring_id, int32_t sm_last_task_alive) {
+void PTO2TensorMap::sync_tensormap(PTO2TaskId task_id, int32_t sm_last_task_alive) {
+    auto ring_id = task_id.ring();
+    auto local_id = task_id.local();
     sync_validity(ring_id, sm_last_task_alive);
+
     // Only attempt cleanup when last_task_alive has actually advanced;
     // otherwise cleanup_retired would empty-loop and we'd spin forever.
-    if (sm_last_task_alive - last_cleanup[ring_id] >= PTO2_TENSORMAP_CLEANUP_INTERVAL) {
+    auto overlap = get_task_local_id_slot(ring_id, local_id) == get_task_local_id_slot(ring_id, last_cleanup[ring_id]);
+    if (sm_last_task_alive - last_cleanup[ring_id] >= PTO2_TENSORMAP_CLEANUP_INTERVAL || overlap) {
         cleanup_retired(ring_id, last_cleanup[ring_id], sm_last_task_alive);
         last_cleanup[ring_id] = sm_last_task_alive;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -221,6 +221,10 @@ struct PTO2TensorMap {
 
     PTO2OrchestratorState *orch{nullptr};
 
+    uint32_t get_task_local_id_slot(uint8_t ring_id, uint32_t task_local_id) const {
+        return task_local_id & (task_window_sizes[ring_id] - 1);
+    }
+
     // new_entry only allocates memory, does not assign attributes
     PTO2TensorMapEntry *new_entry() {
         if (free_num > 0) {
@@ -507,7 +511,7 @@ struct PTO2TensorMap {
      * Called periodically to refresh the lazy invalidation threshold.
      * Also triggers cleanup if threshold has advanced significantly.
      */
-    void sync_tensormap(uint8_t ring_id, int32_t sm_last_task_alive);
+    void sync_tensormap(PTO2TaskId task_id, int32_t sm_last_task_alive);
 };
 
 #if PTO2_TENSORMAP_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1484,11 +1484,13 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     uint64_t sched_scan_cycle = 0;
     uint64_t sched_complete_cycle = 0;
     uint64_t sched_dispatch_cycle = 0;
+    uint64_t sched_wiring_cycle = 0;
     uint64_t sched_idle_cycle = 0;
     uint64_t sched_loop_count = 0;
     uint32_t phase_complete_count = 0;
     uint32_t phase_dispatch_count = 0;
 #if PTO2_SCHED_PROFILING
+    uint32_t phase_wiring_count = 0;
     uint64_t complete_probe_count = 0;
     uint64_t complete_hit_count = 0;
     uint64_t notify_edges_total = 0;
@@ -1674,6 +1676,22 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             continue;
         }
 
+        // Phase 3: Drain wiring queue — wire fanout edges for newly submitted tasks.
+        // Only thread 0 does wiring to keep dep_pool single-threaded.
+        if (thread_idx == 0) {
+            int wired = rt->scheduler.drain_wiring_queue();
+            if (wired > 0) {
+                made_progress = true;
+#if PTO2_SCHED_PROFILING
+                phase_wiring_count += wired;
+#endif
+            }
+        }
+#if PTO2_PROFILING
+        CYCLE_COUNT_LAP(sched_wiring_cycle);
+#endif
+
+        // Phase 4: Dispatch
         const PTO2ResourceShape *dispatch_order = get_dispatch_order(thread_idx);
         bool entered_drain = false;
 
@@ -2020,7 +2038,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     );
 
     // Scheduler summary logging (always print when PTO2_PROFILING=1)
-    uint64_t sched_total = sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
+    uint64_t sched_total =
+        sched_wiring_cycle + sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
     if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
 
 #if PTO2_SCHED_PROFILING
@@ -2132,6 +2151,19 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_scan_cycle),
             sched_scan_cycle * 100.0 / sched_total
         );
+
+        // Level 1: wiring
+#if PTO2_SCHED_PROFILING
+        DEV_ALWAYS(
+            "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx, cycles_to_us(sched_wiring_cycle),
+            sched_wiring_cycle * 100.0 / sched_total, phase_wiring_count
+        );
+#else
+        DEV_ALWAYS(
+            "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_wiring_cycle),
+            sched_wiring_cycle * 100.0 / sched_total
+        );
+#endif
 
         // Level 1: idle
         DEV_ALWAYS(
@@ -2376,7 +2408,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #if PTO2_ORCH_PROFILING
             PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
             uint64_t total =
-                p.sync_cycle + p.alloc_cycle + p.params_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
+                p.sync_cycle + p.alloc_cycle + p.args_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
             DEV_ALWAYS(
                 "Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===", thread_idx,
@@ -2402,8 +2434,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             );
             DEV_ALWAYS(
                 "Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
-                cycles_to_us(p.params_cycle), p.params_cycle * 100.0 / total,
-                static_cast<uint64_t>(p.params_atomic_count)
+                cycles_to_us(p.args_cycle), p.args_cycle * 100.0 / total, static_cast<uint64_t>(p.args_atomic_count)
             );
             DEV_ALWAYS(
                 "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -10,7 +10,7 @@ The single-ring design uses one `last_task_alive` watermark shared by HeapRing, 
 
 Split HeapRing, TaskRing, and DepPool into arrays of `PTO2_MAX_RING_DEPTH` (4) independent instances. Each scope depth maps to its own ring, with an independent `last_task_alive` watermark.
 
-```
+```text
 Scope depth 0  ──►  rings[0] = { HeapRing, TaskRing, DepPool }
 Scope depth 1  ──►  rings[1] = { HeapRing, TaskRing, DepPool }
 Scope depth 2  ──►  rings[2] = { HeapRing, TaskRing, DepPool }
@@ -23,14 +23,14 @@ Inner-scope tasks can now be reclaimed independently without waiting for outer-s
 
 Task IDs are widened from 32-bit to 64-bit to carry the ring identity:
 
-```
+```text
 task_id.raw = (ring_id << 32) | local_id
 ```
 
 `PTO2TaskId` exposes direct accessors in `pto_runtime2_types.h`:
 
 | API | Purpose |
-|-----|---------|
+| --- | ------- |
 | `pto2_make_task_id(ring_id, local_id)` | Compose a 64-bit task ID (`PTO2TaskId`) |
 | `task_id.ring()` | Extract `ring_id` (bits 63-32) |
 | `task_id.local()` | Extract `local_id` (bits 31-0) |
@@ -39,7 +39,7 @@ task_id.raw = (ring_id << 32) | local_id
 Type changes:
 
 | Field | Before | After |
-|-------|--------|-------|
+| ----- | ------ | ----- |
 | `PTO2TaskDescriptor.task_id` | `int32_t` | `PTO2TaskId` |
 | `PTO2TensorMapEntry.producer_task_id` | `int32_t` | `PTO2TaskId` |
 | `PTO2TaskSlotState.ring_id` | N/A | `uint8_t` (new, denormalized for fast access) |
@@ -54,7 +54,7 @@ Bundles the three per-ring resources into a single aggregate (`pto_ring_buffer.h
 struct PTO2RingSet {
     PTO2HeapRing   heap_ring;
     PTO2TaskRing   task_ring;
-    PTO2DepListPool dep_pool;
+    PTO2FaninPool fanin_pool;
 };
 ```
 
@@ -66,9 +66,8 @@ PTO2HeapRing heap_ring;
 PTO2TaskRing task_ring;
 PTO2DepListPool dep_pool;
 
-// After: per-ring array
+// After: per-ring array (dep_pool moved to scheduler, see §4.5)
 PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
-int32_t dep_pool_last_reclaimed[PTO2_MAX_RING_DEPTH];
 ```
 
 Ring selection: `current_ring_id() = min(scope_stack_top, PTO2_MAX_RING_DEPTH - 1)`.
@@ -115,9 +114,11 @@ struct RingSchedState {
     int32_t task_window_size;
     int32_t task_window_mask;
     std::atomic<int32_t> advance_lock;
+    PTO2DepListPool dep_pool;  // fanout wiring dep pool (exclusively managed by scheduler thread 0)
 };
 
 RingSchedState ring_sched_states[PTO2_MAX_RING_DEPTH];
+PTO2ReadyQueue wiring_queue;  // deferred fanout wiring from orchestrator
 ```
 
 ### 4.6 PTO2TensorMap (modified)
@@ -140,7 +141,7 @@ bool entry_valid(const PTO2TensorMapEntry& e) {
 ### 4.7 Unchanged Structures
 
 | Structure | Reason |
-|-----------|--------|
+| --------- | ------ |
 | `PTO2DepListEntry` | Stores `PTO2TaskSlotState*` pointer — naturally crosses ring boundaries |
 | `PTO2TaskPayload` | `fanin_slot_states[]` are pointers — no ring coupling |
 | `PTO2ReadyQueue` | Global ready queues shared across all rings (tasks ready to dispatch regardless of origin ring) |
@@ -152,7 +153,7 @@ bool entry_valid(const PTO2TensorMapEntry& e) {
 
 Each ring's `last_task_alive` advances independently:
 
-```
+```text
 advance_ring_pointers(ring_id):
     la = rings[ring_id].fc.last_task_alive
     while task_state[la & mask] >= CONSUMED:
@@ -174,13 +175,16 @@ Dependency edges use `PTO2TaskSlotState*` pointers, which naturally span rings:
 
 ### 5.3 DepPool Reclamation
 
-```
-pto2_dep_pool_reclaim(ring_id):
+DepPool is exclusively managed by scheduler thread 0 (allocation during wiring, reclamation during watermark advancement):
+
+```text
+// Called by scheduler thread 0 during wiring_queue drain:
+dep_pool_reclaim(ring_id):
     la = rings[ring_id].fc.last_task_alive
     newest_consumed = la - 1
-    mark = task_payloads[ring_id][slot(newest_consumed)].dep_pool_mark
+    mark = slot_states[slot(newest_consumed)].dep_pool_mark
     if mark > 0:
-        rings[ring_id].dep_pool.advance_tail(mark)
+        ring_sched_states[ring_id].dep_pool.advance_tail(mark)
 ```
 
 Note: dep entries from ring N's pool may appear in ring M's fanout lists. Reclamation is safe because the entries are accessed during fanout traversal (completion time), which always happens before the consumer task — and therefore the dep entry — becomes eligible for reclamation.
@@ -189,7 +193,7 @@ Note: dep entries from ring N's pool may appear in ring M's fanout lists. Reclam
 
 The AICore dispatch protocol uses 32-bit registers. With multi-ring, `task_id` truncation to 32-bit loses the `ring_id`, causing collisions:
 
-```
+```text
 Ring 0, local_id=0  →  DATA_MAIN_BASE = 0 + 1 = 1
 Ring 1, local_id=0  →  DATA_MAIN_BASE = 0 + 1 = 1  (collision!)
 ```
@@ -203,7 +207,7 @@ AICore uses `last_reg_val` to detect new dispatches — identical values cause s
 ### 7.1 Compile-Time Defaults (per ring)
 
 | Constant | Default | Total (×4 rings) |
-|----------|---------|-------------------|
+| -------- | ------- | ---------------- |
 | `PTO2_TASK_WINDOW_SIZE` | 16384 | 65536 |
 | `PTO2_HEAP_SIZE` | 256 MB | 1 GB |
 | `PTO2_DEP_LIST_POOL_SIZE` | 16384 | 65536 |
@@ -212,7 +216,7 @@ AICore uses `last_reg_val` to detect new dispatches — identical values cause s
 
 Uniform (applies to all rings):
 
-```
+```bash
 PTO2_RING_TASK_WINDOW=1024
 PTO2_RING_HEAP=1048576
 PTO2_RING_DEP_POOL=1024

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -335,8 +335,8 @@ When `pto2_submit_task` processes parameters:
 | `kernel_id[3]` | Per-slot kernel IDs: `[AIC, AIV0, AIV1]`; `INVALID_KERNEL_ID` = inactive |
 | `active_mask` | Bitmask of active subtask slots: `bit0=AIC`, `bit1=AIV0`, `bit2=AIV1` |
 | `subtask_done_mask` | Atomic bitmask; each subtask sets its done bit on completion |
-| `fanin_count` | Number of producer dependencies |
-| `fanout_lock` | Per-task spinlock for concurrent fanout modification |
+| `fanin_count` | Number of producer dependencies (set by scheduler during wiring) |
+| `fanout_lock` | Per-task spinlock for concurrent fanout modification (used by scheduler wiring + completion) |
 | `fanout_head` | Head of fanout consumer list (pointer, protected by `fanout_lock`) |
 | `fanout_count` | 1 (scope ref) + number of consumers |
 | `packed_buffer_base` | Start of packed buffer in GM Heap |
@@ -380,42 +380,49 @@ The orchestrator runs on AICPU Thread 3 and builds the task graph by calling the
 
 Key members:
 
-- `rings[PTO2_MAX_RING_DEPTH]`: per-ring `PTO2RingSet` (HeapRing + TaskRing + DepPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
+- `rings[PTO2_MAX_RING_DEPTH]`: per-ring `PTO2RingSet` (HeapRing + TaskRing + FaninPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
 - `tensor_map`, `tensor_pool`: dependency tracking
 - `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
-- `scheduler`: pointer to scheduler state (for simulated mode or `init_task_on_submit`)
+- `scheduler`: pointer to scheduler state (for wiring queue and ready queue access)
 - `gm_heap_base`, `gm_heap_size`: GM heap for output buffers
 
-### 7.2 Task Submission Flow (`pto2_submit_task`)
+### 7.2 Task Submission Flow (`pto2_submit_mixed_task`)
 
 | Step | Operation |
 | ---- | --------- |
 | 0 | `pto2_orchestrator_sync_tensormap` — prune stale TensorMap entries |
 | 1 | `pto2_task_ring_alloc` — allocate task slot (may block on flow control) |
-| 2 | Initialize task descriptor, copy parameters |
-| 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers |
-| 4 | **Dependency**: `pto2_add_consumer_to_producer` for each producer found |
-| 5 | **Heap alloc**: `pto2_alloc_packed_buffer` for OUTPUT args (addr=0) |
-| 6 | **Insert**: register OUTPUT/INOUT args in TensorMap |
-| 7 | **Fanin**: finalize `fanin_count`; if `init_task_on_submit`, call scheduler's `init_task` |
-| 8 | **Publish**: `STORE_RELEASE(current_task_index)` makes task visible to scanners |
+| 2 | Initialize task descriptor + slot state, copy parameters |
+| 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers; collect producer pointers in `PTO2FaninBuilder` |
+| 4 | **Insert**: register OUTPUT/INOUT args in TensorMap |
+| 5 | **Record fanin metadata**: store producer pointers in `payload->fanin_inline_slot_states[]` (+ spill pool if >16); increment each producer's `fanout_count` (no lock needed — single writer) |
+| 6 | **Push to wiring queue**: scheduler thread 0 asynchronously wires fanout edges (lock + dep_pool + early_finished check + ready push) |
 
-### 7.3 Lock Protocol for Concurrent Dependency Setup
+> **Note**: Fanout wiring (Steps 4–7 in earlier versions) has been moved from the
+> orchestrator submit hot path to the scheduler's `wiring_queue`. This reduces the
+> orchestrator's shared L2 cache / memory bus pressure, as the orchestrator no longer
+> acquires `fanout_lock` or allocates from `dep_pool` during submission.
 
-The orchestrator and scheduler run concurrently. When adding a consumer to a producer's fanout list:
+### 7.3 Deferred Fanout Wiring (Scheduler Wiring Queue)
 
-1. **Orchestrator acquires** the producer's `fanout_lock` via `pto2_fanout_lock(task)` (CAS spin-lock)
-2. **Normal path**: prepend consumer to the producer's fanout list, increment `fanout_count`
-3. **Release** `fanout_lock`
+The orchestrator pushes each submitted task to `scheduler->wiring_queue`. Scheduler thread 0 drains this queue and, for each task:
+
+1. Sets `fanin_count = N + 1` (+1 redundance to prevent premature readiness)
+2. For each producer in `payload->fanin_slot_states[]`:
+   - **Acquires** the producer's `fanout_lock`
+   - Checks `task_state >= COMPLETED` (early-finished optimization)
+   - If not completed: prepends consumer to producer's `fanout_head` via `dep_pool.prepend`
+   - **Releases** `fanout_lock`
+3. Atomically releases the +1 redundance + early_finished count via `fanin_refcount.fetch_add`
+4. If all deps satisfied: pushes task to ready queue
 
 The scheduler's completion handler mirrors this:
 
-1. Mark `task_state[slot] = COMPLETED`
-2. **Acquire** `fanout_lock`, read `fanout_head`, **release** lock
-3. Traverse fanout list, incrementing each consumer's `fanin_refcount`
-4. Mark `task_state[slot] = CONSUMED` when `fanout_refcount` reaches `fanout_count`
+1. **Acquire** `fanout_lock`, mark `task_state = COMPLETED`, read `fanout_head`, **release** lock
+2. Traverse fanout list, incrementing each consumer's `fanin_refcount`
+3. Mark `task_state = CONSUMED` when `fanout_refcount` reaches `fanout_count`
 
-This lock protocol guarantees every consumer is accounted for exactly once.
+This protocol guarantees every consumer is accounted for exactly once.
 
 ### 7.4 Scope Mechanism (`PTO2_SCOPE`)
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -163,9 +163,9 @@ This project-defined flattened numbering is kept unchanged.
 ### 10.2 Runtime Behavior per Submit
 
 1. Validate submit arguments.
-2. Allocate mixed-task ID and initialize descriptor/payload once.
-3. Build fanin/fanout at mixed-task granularity.
-4. Enqueue by shape when ready.
+2. Allocate mixed-task ID and initialize descriptor/payload/slot_state once.
+3. Lookup producers via TensorMap; collect fanin metadata and increment producers' `fanout_count`.
+4. Push task to scheduler's wiring queue (scheduler thread 0 asynchronously wires fanout edges and determines readiness).
 5. Dispatch all active lanes atomically when resources allow.
 6. Aggregate completion and release downstream once.
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -301,17 +301,24 @@ static bool pto2_prepare_task(
         auto &rs = out->sched->ring_sched_states[ring_id];
         out->slot_state = &rs.get_slot_state_by_slot(out->alloc_result.slot);
         PTO2TaskSlotState &slot_state = *out->slot_state;
-        slot_state.fanin_count = 0;
         slot_state.fanout_head = nullptr;
         slot_state.fanout_lock.store(0, std::memory_order_relaxed);
         slot_state.fanout_count = 1;
-        slot_state.fanout_refcount.store(0, std::memory_order_release);
-        slot_state.fanin_refcount.store(0, std::memory_order_release);
+        slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
+        slot_state.fanin_refcount.store(0, std::memory_order_relaxed);
+        slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
+        slot_state.completed_subtasks.store(0, std::memory_order_relaxed);
+        slot_state.subtask_done_mask.store(0, std::memory_order_relaxed);
+        int16_t block_num = args.launch_spec.core_num();
+        slot_state.total_required_subtasks =
+            static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
+        slot_state.block_num = block_num;
+        slot_state.next_block_idx = 0;
         slot_state.payload = out->payload;
         slot_state.task = out->task;
         slot_state.active_mask = active_mask;
-        slot_state.subtask_done_mask.store(0, std::memory_order_relaxed);
         slot_state.ring_id = ring_id;
+        // fanin_count is set by scheduler during wiring
         scope_tasks_push(orch, &slot_state);
     } else {
         scope_tasks_push(orch, nullptr);
@@ -353,25 +360,10 @@ bool pto2_orchestrator_init(
         if (!fanin_entries) {
             for (int j = 0; j < r; j++) {
                 free(orch->rings[j].fanin_pool.base);
-                free(orch->rings[j].dep_pool.base);
             }
             return false;
         }
         orch->rings[r].fanin_pool.init(fanin_entries, dep_pool_capacity, &sm_handle->header->orch_error_code);
-
-        // Allocate and initialize dependency list pool (per-ring)
-        PTO2DepListEntry *dep_entries =
-            reinterpret_cast<PTO2DepListEntry *>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
-        if (!dep_entries) {
-            // Cleanup previously allocated rings
-            for (int j = 0; j < r; j++) {
-                free(orch->rings[j].fanin_pool.base);
-                free(orch->rings[j].dep_pool.base);
-            }
-            free(orch->rings[r].fanin_pool.base);
-            return false;
-        }
-        orch->rings[r].dep_pool.init(dep_entries, dep_pool_capacity, &sm_handle->header->orch_error_code);
     }
 
     // Initialize TensorMap with per-ring task window sizes
@@ -382,7 +374,6 @@ bool pto2_orchestrator_init(
     if (!orch->tensor_map.init_default(task_window_sizes)) {
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             free(orch->rings[r].fanin_pool.base);
-            free(orch->rings[r].dep_pool.base);
         }
         return false;
     }
@@ -398,7 +389,6 @@ bool pto2_orchestrator_init(
         free(orch->scope_begins);
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             free(orch->rings[r].fanin_pool.base);
-            free(orch->rings[r].dep_pool.base);
         }
         orch->tensor_map.destroy();
         return false;
@@ -417,8 +407,6 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState *orch) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         free(orch->rings[r].fanin_pool.base);
         orch->rings[r].fanin_pool.base = NULL;
-        free(orch->rings[r].dep_pool.base);
-        orch->rings[r].dep_pool.base = NULL;
     }
 
     free(orch->scope_tasks);
@@ -629,18 +617,23 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     if (sched) {
         auto &rs = sched->ring_sched_states[ring_id];
         PTO2TaskSlotState &slot_state = rs.get_slot_state_by_slot(slot);
-        slot_state.fanin_count = 0;
         slot_state.fanout_head = nullptr;
         slot_state.fanout_lock.store(0, std::memory_order_relaxed);
-        // Initial fanout_count = 1 (the owning scope holds one reference)
         slot_state.fanout_count = 1;
-        slot_state.fanout_refcount.store(0, std::memory_order_release);
-        slot_state.fanin_refcount.store(0, std::memory_order_release);
+        slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
+        slot_state.fanin_refcount.store(0, std::memory_order_relaxed);
+        slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
+        slot_state.completed_subtasks.store(0, std::memory_order_relaxed);
+        slot_state.subtask_done_mask.store(0, std::memory_order_relaxed);
+        slot_state.total_required_subtasks =
+            static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
+        slot_state.block_num = block_num;
+        slot_state.next_block_idx = 0;
         slot_state.payload = payload;
         slot_state.task = &task;
         slot_state.active_mask = active_mask;
-        slot_state.subtask_done_mask.store(0, std::memory_order_relaxed);
         slot_state.ring_id = ring_id;
+        // fanin_count is set by scheduler during wiring
         scope_tasks_push(orch, &slot_state);
     } else {
         scope_tasks_push(orch, nullptr);
@@ -664,11 +657,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     // Read current last_task_alive from shared memory for this ring
     int32_t sm_last_task_alive = fc.last_task_alive.load(std::memory_order_acquire);
 
-    orch->tensor_map.sync_tensormap(ring_id, sm_last_task_alive);
-
-    if (sched) {
-        orch->rings[ring_id].dep_pool.reclaim(*sched, ring_id, sm_last_task_alive);
-    }
+    orch->tensor_map.sync_tensormap(task_id, sm_last_task_alive);
 
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, task_id.raw);
 
@@ -749,16 +738,6 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     task.packed_buffer_base = alloc_result.packed_base;
     task.packed_buffer_end = alloc_result.packed_end;
 
-    // Prefetch producer slot_states and cur_slot_state (written at init but likely
-    // evicted by lookup/insert/heap). param_copy below provides hide time.
-    if (sched) {
-        auto &rs = sched->ring_sched_states[ring_id];
-        __builtin_prefetch(&rs.get_slot_state_by_slot(slot), 1, 0);
-        fanin_builder.for_each([](PTO2TaskSlotState *producer_slot_state) {
-            __builtin_prefetch(producer_slot_state, 1, 0);
-        });
-    }
-
     payload->init(args, result, alloc_result.packed_base, offsets, buffer_sizes);
 
     // Write owner_task_id into materialized OUTPUT tensors so creator-only dependency
@@ -774,69 +753,37 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     g_orch_args_atomic_count += 2;  // fanout_lock.store + fanout_count.store
 #endif
 
-    // === STEP 6: Finalize fanin list ===
-    // First build the fanin list
+    // === STEP 6: Record fanin metadata + push to wiring queue ===
+    // Deferred wiring: orchestrator only stores dependency metadata and increments
+    // fanout_count. The actual fanout_head wiring (lock + dep_pool + early_finished)
+    // is handled asynchronously by scheduler thread 0 via the wiring queue.
     if (sched) {
         auto &rs = sched->ring_sched_states[ring_id];
         PTO2TaskSlotState &cur_slot_state = rs.get_slot_state_by_slot(slot);
-        // Initialize scheduler state BEFORE adding to producer fanout lists,
-        // so concurrent on_mixed_task_complete can safely access task_state/fanout_refcount.
-        cur_slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
-        cur_slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
-        cur_slot_state.completed_subtasks.store(0, std::memory_order_relaxed);
-        cur_slot_state.total_required_subtasks =
-            static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
-        cur_slot_state.block_num = block_num;
-        cur_slot_state.next_block_idx = 0;
-
-        auto &dep_pool = orch->rings[ring_id].dep_pool;
         int32_t fanin_count = fanin_builder.count;
         int32_t inline_count = std::min(fanin_count, PTO2_FANIN_INLINE_CAP);
         int32_t spill_count = fanin_count - inline_count;
-        dep_pool.ensure_space(*sched, fc, ring_id, fanin_count + 1);
 
-        int32_t early_finished = 0;
-        cur_slot_state.fanin_count = fanin_count + 1;  // +1 redundance for not being ready too early
+        // Store fanin metadata in payload for scheduler to iterate
         payload->fanin_actual_count = fanin_count;
         payload->fanin_spill_start = (spill_count > 0) ? fanin_builder.spill_start : 0;
         payload->fanin_spill_pool = (spill_count > 0) ? fanin_builder.spill_pool : nullptr;
         for (int i = 0; i < inline_count; i++) {
             payload->fanin_inline_slot_states[i] = fanin_builder.inline_slots[i];
         }
-        pto2_for_each_fanin_slot_state(*payload, [&](PTO2TaskSlotState *producer_slot) {
-            PTO2TaskSlotState &producer_slot_state = *producer_slot;
-#if PTO2_ORCH_PROFILING
-            pto2_fanout_lock(producer_slot_state, g_orch_fanin_atomic_count, g_orch_fanin_wait_cycle);
-#else
-            pto2_fanout_lock(producer_slot_state);
-#endif
-            producer_slot_state.fanout_count += 1;
-            int32_t prod_state = producer_slot_state.task_state.load(std::memory_order_acquire);
-            if (prod_state >= PTO2_TASK_COMPLETED) {
-                early_finished++;
-            } else {
-                producer_slot_state.fanout_head = dep_pool.prepend(producer_slot_state.fanout_head, &cur_slot_state);
-            }
-            pto2_fanout_unlock(producer_slot_state);
+
+        // Increment fanout_count on each producer (no lock — only orch writes this field).
+        // Prevents premature CONSUMED: scope_end's release_producer checks fanout_refcount == fanout_count.
+        pto2_for_each_fanin_slot_state(*payload, [](PTO2TaskSlotState *producer) {
+            producer->fanout_count += 1;
         });
-        // Combined release: merge early_finished batch with the +1 init release
-        // into a single atomic fetch_add (saves one acq_rel cache-line bounce per task).
-        int32_t initial_refcount = early_finished + 1;  // +1 for the init release
-        int32_t new_rc =
-            cur_slot_state.fanin_refcount.fetch_add(initial_refcount, std::memory_order_acq_rel) + initial_refcount;
-        if (new_rc >= fanin_count + 1) {
-            PTO2ResourceShape shape = pto2_active_mask_to_shape(active_mask);
-            sched->ready_queues[static_cast<int32_t>(shape)].push(&cur_slot_state);
+
+        // Push to per-ring wiring queue — scheduler sets fanin_count, wires fanout, checks readiness
+        while (!sched->ring_sched_states[ring_id].wiring_queue.push(&cur_slot_state)) {
+            SPIN_WAIT_HINT();
         }
-        // Record dep pool watermark in local slot state (used by tail reclamation)
-        cur_slot_state.dep_pool_mark = orch->rings[ring_id].dep_pool.top;
 #if PTO2_ORCH_PROFILING
-        // Per producer: fetch_add(fanout_count) + load(task_state) + store(unlock) = 3 atomics
-        // Lock atomics (loads + CAS) are counted inside pto2_fanout_lock
-        g_orch_fanin_atomic_count += fanin_count * 3;
-        if (early_finished > 0) {
-            g_orch_fanin_atomic_count += 1;  // fanin_refcount.fetch_add
-        }
+        g_orch_fanin_atomic_count += 0;  // No lock/atomic ops in submit hot path
 #endif
     }
 
@@ -887,10 +834,7 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
 #endif
 
     int32_t sm_last_task_alive = fc.last_task_alive.load(std::memory_order_acquire);
-    orch->tensor_map.sync_tensormap(ring_id, sm_last_task_alive);
-    if (prepared.sched != nullptr) {
-        orch->rings[ring_id].dep_pool.reclaim(*prepared.sched, ring_id, sm_last_task_alive);
-    }
+    orch->tensor_map.sync_tensormap(prepared.task_id, sm_last_task_alive);
     CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, prepared.task_id.raw);
 
     task.task_id = prepared.task_id;
@@ -948,17 +892,10 @@ void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
             LOG_INFO("=== [Orchestrator] ring %d: total_tasks=%d ===", r, total_tasks);
         }
         auto &fanin_pool = orch->rings[r].fanin_pool;
-        auto &pool = orch->rings[r].dep_pool;
         if (fanin_pool.top > 1) {
             LOG_INFO(
                 "=== [FaninPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===", r, fanin_pool.top,
                 fanin_pool.tail, fanin_pool.top - fanin_pool.tail, fanin_pool.high_water, fanin_pool.capacity
-            );
-        }
-        if (pool.top > 0) {
-            LOG_INFO(
-                "=== [DepPool %d] top=%d tail=%d used=%d high_water=%d capacity=%d ===", r, pool.top, pool.tail,
-                pool.top - pool.tail, pool.high_water, pool.capacity
             );
         }
     }
@@ -990,9 +927,6 @@ void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch) {
             );
             LOG_INFO(
                 "Ring %d fanin pool:   %d / %d", r, orch->rings[r].fanin_pool.used(), orch->rings[r].fanin_pool.capacity
-            );
-            LOG_INFO(
-                "Ring %d dep pool:     %d / %d", r, orch->rings[r].dep_pool.used(), orch->rings[r].dep_pool.capacity
             );
         }
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -666,7 +666,6 @@ struct PTO2DepListPool {
 struct PTO2RingSet {
     PTO2TaskAllocator task_allocator;
     PTO2FaninPool fanin_pool;
-    PTO2DepListPool dep_pool;
 };
 
 #endif  // PTO_RING_BUFFER_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -248,7 +248,7 @@ PTO2Runtime *pto2_runtime_create_custom(
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, dep_pool_capacity)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt->gm_heap);
         pto2_sm_destroy(rt->sm_handle);
@@ -284,7 +284,7 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
+    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle, dep_pool_capacity)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt);
         return NULL;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -111,6 +111,9 @@
 // Ready queue
 #define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size
 
+// Wiring queue
+#define PTO2_WRIRING_QUEUE_SIZE 1024  // Per-shape queue size
+
 // Memory alignment
 #define PTO2_ALIGN_SIZE 64             // Cache line alignment
 #define PTO2_PACKED_OUTPUT_ALIGN 1024  // Each output in packed buffer aligned to 1024B; gap is padding

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -148,6 +148,9 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHandle *sm_handle,
         slot_states[i].ring_id = 0;
     }
 
+    wiring_batch_count = 0;
+    wiring_batch_index = 0;
+
     return true;
 }
 
@@ -157,7 +160,7 @@ void PTO2SchedulerState::RingSchedState::destroy() {
     slot_states = nullptr;
 }
 
-bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle) {
+bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle, int32_t dep_pool_capacity) {
     sched->sm_handle = sm_handle;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -188,12 +191,49 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
         }
     }
 
+    // Initialize per-ring wiring queues and dep pools (exclusively managed by scheduler thread 0)
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        if (!pto2_ready_queue_init(&sched->ring_sched_states[r].wiring_queue, PTO2_WRIRING_QUEUE_SIZE)) {
+            for (int j = 0; j < r; j++) {
+                pto2_ready_queue_destroy(&sched->ring_sched_states[j].wiring_queue);
+                free(sched->ring_sched_states[j].dep_pool.base);
+            }
+            for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+                pto2_ready_queue_destroy(&sched->ready_queues[i]);
+            }
+            for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
+                sched->ring_sched_states[rr].destroy();
+            }
+            return false;
+        }
+        PTO2DepListEntry *dep_entries =
+            reinterpret_cast<PTO2DepListEntry *>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
+        if (!dep_entries) {
+            pto2_ready_queue_destroy(&sched->ring_sched_states[r].wiring_queue);
+            for (int j = 0; j < r; j++) {
+                pto2_ready_queue_destroy(&sched->ring_sched_states[j].wiring_queue);
+                free(sched->ring_sched_states[j].dep_pool.base);
+            }
+            for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+                pto2_ready_queue_destroy(&sched->ready_queues[i]);
+            }
+            for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
+                sched->ring_sched_states[rr].destroy();
+            }
+            return false;
+        }
+        sched->ring_sched_states[r].dep_pool.init(dep_entries, dep_pool_capacity, &sm_handle->header->orch_error_code);
+    }
+
     return true;
 }
 
 void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].destroy();
+        free(sched->ring_sched_states[r].dep_pool.base);
+        sched->ring_sched_states[r].dep_pool.base = nullptr;
+        pto2_ready_queue_destroy(&sched->ring_sched_states[r].wiring_queue);
     }
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
@@ -211,6 +251,13 @@ void pto2_scheduler_print_stats(PTO2SchedulerState *sched) {
         if (sched->ring_sched_states[r].last_task_alive > 0) {
             LOG_INFO("Ring %d:", r);
             LOG_INFO("  last_task_alive: %d", sched->ring_sched_states[r].last_task_alive);
+            auto &dp = sched->ring_sched_states[r].dep_pool;
+            if (dp.top > 0) {
+                LOG_INFO(
+                    "  dep_pool: top=%d tail=%d used=%d high_water=%d capacity=%d", dp.top, dp.tail, dp.top - dp.tail,
+                    dp.high_water, dp.capacity
+                );
+            }
         }
     }
 #if PTO2_SCHED_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -438,12 +438,26 @@ struct PTO2SchedulerState {
         // Try-lock used to advance this ring's last_task_alive pointer.
         std::atomic<int32_t> advance_lock;
 
+        // Dep pool for fanout wiring (exclusively managed by scheduler thread 0)
+        PTO2DepListPool dep_pool;
+
+        // Per-ring wiring queue: orchestrator pushes tasks, scheduler thread 0 pops and wires.
+        PTO2ReadyQueue wiring_queue;
+
+        // Local batch buffer for drain_wiring_queue (scheduler thread 0 only).
+        // Persists across calls so partially-consumed batches resume next call.
+        static constexpr int WIRING_BATCH_SIZE = 16;
+        PTO2TaskSlotState *wiring_batch[WIRING_BATCH_SIZE];
+        int wiring_batch_count = 0;
+        int wiring_batch_index = 0;
+
         bool init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id);
         void destroy();
 
         PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
             return slot_states[local_id & task_window_mask];
         }
+
         PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
         void sync_to_sm(PTO2SharedMemoryRingHeader &ring) {
@@ -476,6 +490,94 @@ struct PTO2SchedulerState {
     // =========================================================================
     // Inline hot-path methods
     // =========================================================================
+
+    /**
+     * Drain wiring queue: pop submitted tasks and wire their fanout edges.
+     * Called by scheduler thread 0 each loop iteration. Sets fanin_count,
+     * acquires fanout_lock per producer, allocates dep_pool entries, and
+     * pushes ready tasks to the appropriate ready queue.
+     *
+     * @return Number of tasks wired this call.
+     */
+    int drain_wiring_queue() {
+        int wired = 0;
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            wired += drain_ring_wiring_queue(r);
+        }
+        return wired;
+    }
+
+    /**
+     * Drain the wiring queue for a single ring. See drain_wiring_queue() for
+     * the peek/pop_batch FIFO protocol. Returns the number of tasks wired.
+     */
+    int drain_ring_wiring_queue(int ring_id) {
+        auto &rss = ring_sched_states[ring_id];
+        int wired = 0;
+
+        // Refill local batch buffer when exhausted.
+        if (rss.wiring_batch_index >= rss.wiring_batch_count) {
+            rss.wiring_batch_count = rss.wiring_queue.pop_batch(rss.wiring_batch, RingSchedState::WIRING_BATCH_SIZE);
+            rss.wiring_batch_index = 0;
+            if (rss.wiring_batch_count == 0) return 0;
+        }
+
+        // Process tasks from local buffer in strict FIFO order.
+        while (rss.wiring_batch_index < rss.wiring_batch_count) {
+            PTO2TaskSlotState *ws = rss.wiring_batch[rss.wiring_batch_index];
+            int32_t wfanin = ws->payload->fanin_actual_count;
+
+            if (wfanin > 0 && rss.dep_pool.available() < wfanin) {
+                rss.dep_pool.reclaim(*this, ring_id, rss.last_task_alive);
+                if (wfanin > 0 && rss.dep_pool.available() < wfanin) {
+                    break;  // not enough dep_pool space — keep remainder for next call
+                }
+            }
+
+            rss.wiring_batch_index++;
+            wire_task(ring_id, ws);
+            wired++;
+        }
+        return wired;
+    }
+
+    /**
+     * Wire fanout edges for a single task. Sets fanin_count, acquires each
+     * producer's fanout_lock, allocates dep_pool entries for live producers,
+     * pushes the task to the ready queue once its fanin refcount is satisfied.
+     */
+    void wire_task(int ring_id, PTO2TaskSlotState *ws) {
+        auto &rss = ring_sched_states[ring_id];
+        PTO2TaskPayload *wp = ws->payload;
+        int32_t wfanin = wp->fanin_actual_count;
+        ws->fanin_count = wfanin + 1;
+
+        if (wfanin != 0) {
+            int32_t early_finished = 0;
+            pto2_for_each_fanin_slot_state(*wp, [&](PTO2TaskSlotState *producer) {
+                pto2_fanout_lock(*producer);
+                int32_t pstate = producer->task_state.load(std::memory_order_acquire);
+                if (pstate >= PTO2_TASK_COMPLETED) {
+                    early_finished++;
+                } else {
+                    producer->fanout_head = rss.dep_pool.prepend(producer->fanout_head, ws);
+                }
+                pto2_fanout_unlock(*producer);
+            });
+
+            int32_t init_rc = early_finished + 1;
+            int32_t new_rc = ws->fanin_refcount.fetch_add(init_rc, std::memory_order_acq_rel) + init_rc;
+            if (new_rc >= ws->fanin_count) {
+                ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
+            }
+        } else {
+            ws->fanin_refcount.fetch_add(1, std::memory_order_acq_rel);
+            ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
+        }
+
+        ws->dep_pool_mark = rss.dep_pool.top;
+    }
+
     PTO2TaskSlotState &get_slot_state(int32_t ring_id, int32_t local_id) {
         return ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
     }
@@ -784,7 +886,9 @@ struct PTO2SchedulerState {
 // Scheduler API (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle);
+bool pto2_scheduler_init(
+    PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+);
 void pto2_scheduler_destroy(PTO2SchedulerState *sched);
 
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.cpp
@@ -234,11 +234,15 @@ int32_t PTO2TensorMap::valid_count() {
     return count;
 }
 
-void PTO2TensorMap::sync_tensormap(uint8_t ring_id, int32_t sm_last_task_alive) {
+void PTO2TensorMap::sync_tensormap(PTO2TaskId task_id, int32_t sm_last_task_alive) {
+    auto ring_id = task_id.ring();
+    auto local_id = task_id.local();
     sync_validity(ring_id, sm_last_task_alive);
+
     // Only attempt cleanup when last_task_alive has actually advanced;
     // otherwise cleanup_retired would empty-loop and we'd spin forever.
-    if (sm_last_task_alive - last_cleanup[ring_id] >= PTO2_TENSORMAP_CLEANUP_INTERVAL) {
+    auto overlap = get_task_local_id_slot(ring_id, local_id) == get_task_local_id_slot(ring_id, last_cleanup[ring_id]);
+    if (sm_last_task_alive - last_cleanup[ring_id] >= PTO2_TENSORMAP_CLEANUP_INTERVAL || overlap) {
         cleanup_retired(ring_id, last_cleanup[ring_id], sm_last_task_alive);
         last_cleanup[ring_id] = sm_last_task_alive;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -221,6 +221,10 @@ struct PTO2TensorMap {
 
     PTO2OrchestratorState *orch{nullptr};
 
+    uint32_t get_task_local_id_slot(uint8_t ring_id, uint32_t task_local_id) const {
+        return task_local_id & (task_window_sizes[ring_id] - 1);
+    }
+
     // new_entry only allocates memory, does not assign attributes
     PTO2TensorMapEntry *new_entry() {
         if (free_num > 0) {
@@ -507,7 +511,7 @@ struct PTO2TensorMap {
      * Called periodically to refresh the lazy invalidation threshold.
      * Also triggers cleanup if threshold has advanced significantly.
      */
-    void sync_tensormap(uint8_t ring_id, int32_t sm_last_task_alive);
+    void sync_tensormap(PTO2TaskId task_id, int32_t sm_last_task_alive);
 };
 
 #if PTO2_TENSORMAP_PROFILING


### PR DESCRIPTION
Move fanout edge construction (fanout_lock acquisition, dep_pool allocation, early_finished check, and ready-queue push) from the orchestrator's submit hot path to a dedicated wiring queue drained by scheduler thread 0. This reduces cross-core L2 cache and memory bus contention between orchestrator and scheduler threads.

Key changes:
- Orchestrator submit (STEP 6) now only stores fanin metadata in payload and increments producers' fanout_count (no lock needed)
- New PTO2SchedulerState::drain_wiring_queue() method handles all fanout wiring asynchronously
- dep_pool ownership moved from PTO2RingSet to RingSchedState, exclusively managed by scheduler thread 0
- Slot state initialization consolidated into pto2_prepare_task()
- Scheduler profiling extended with wiring phase statistics
- Fix pre-existing MD040/MD060 markdown lint errors in touched docs

Measured on paged_attention_unroll (Case1, 100 rounds):
  entry_cost: 914 -> 739 us (-19%)
  sched_cost: 1143 -> 1148 us (no regression)


Example | Base (us) | HEAD (us) | Delta (us) | Change (%)
-- | -- | -- | -- | --
alternating_matmul_add | 916.0 | 785.9 | -130.1 | -14.20%
(orch) | 915.8 | 785.5 | -130.3 | -14.23%
benchmark_bgemm | 728.8 | 733.0 | +4.2 | +0.58%
(orch) | 697.2 | 689.7 | -7.5 | -1.08%
paged_attention_unroll (Case1) | 1146.3 | 1154.4 | +8.1 | +0.71%
(orch) | 934.4 | 733.1 | -201.3 | -21.54%
paged_attention_unroll (Case2) | 554.5 | 532.5 | -22.0 | -3.97%
(orch) | 412.3 | 306.9 | -105.4 | -25.56%
batch_paged_attention | 3165.6 | 2834.9 | -330.7 | -10.45%
(orch) | 2529.9 | 1877.1 | -652.8 | -25.80%

