### PR TITLE
Fix: align docs and code comments with recent API refactors

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -18,7 +18,7 @@ See [docs/architecture.md](../../docs/architecture.md) for the full diagram, API
 | Pre-build all runtimes | `examples/scripts/build_runtimes.py` (invoked by `pip install .`) |
 | Platform/runtime discovery | `examples/scripts/platform_info.py` |
 | Kernel compilation | `python/kernel_compiler.py` (one `.cpp` per `func_id`) |
-| Python bindings | `python/bindings.py` (ctypes wrappers for host `.so`) |
+| Python bindings | `python/bindings/` (nanobind extension for ChipWorker, task types) |
 | Pre-built binary lookup | `build/lib/{arch}/{variant}/{runtime}/` |
 | Persistent cmake cache | `build/cache/{arch}/{variant}/{runtime}/` |
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@ PTO ISA headers are automatically cloned on first run. See [Getting Started](doc
 ## Platforms
 
 | Platform | Description | Requirements |
-|----------|-------------|--------------|
-| `a2a3` | Real Ascend hardware | CANN toolkit (ccec, aarch64 cross-compiler) |
-| `a2a3sim` | Thread-based host simulation | gcc/g++ only (no Ascend SDK needed) |
+| -------- | ----------- | ------------ |
+| `a2a3` | Real Ascend A2/A3 hardware | CANN toolkit (ccec, aarch64 cross-compiler) |
+| `a2a3sim` | Thread-based A2/A3 simulation | gcc/g++ only (no Ascend SDK needed) |
+| `a5` | Real Ascend A5 hardware | CANN toolkit (ccec, aarch64 cross-compiler) |
+| `a5sim` | Thread-based A5 simulation | gcc/g++ only (no Ascend SDK needed) |
 
 ## Runtime Variants
 
 Three runtimes under `src/{arch}/runtime/`, each with a different graph-building strategy:
 
 | Runtime | Graph built on | Use case |
-|---------|---------------|----------|
+| ------- | -------------- | -------- |
 | `host_build_graph` | Host CPU | Development, debugging |
 | `aicpu_build_graph` | AICPU (device) | Reduced host-device transfer |
 | `tensormap_and_ringbuffer` | AICPU (device) | Production workloads |
@@ -50,7 +52,7 @@ See runtime docs per arch: [a2a3](src/a2a3/docs/runtimes.md), [a5](src/a5/docs/r
 pytest tests -m "not requires_hardware" -v
 
 # C++ unit tests
-cmake -B tests/cpp/build -S tests/cpp && cmake --build tests/cpp/build && ctest --test-dir tests/cpp/build --output-on-failure
+cmake -B tests/ut/cpp/build -S tests/ut/cpp && cmake --build tests/ut/cpp/build && ctest --test-dir tests/ut/cpp/build --output-on-failure
 ```
 
 See [Testing Guide](docs/testing.md) for details.
@@ -65,7 +67,7 @@ export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
 ## Documentation
 
 | Document | Description |
-|----------|-------------|
+| -------- | ----------- |
 | [Architecture](docs/architecture.md) | Three-program model, API layers, execution flow, handshake protocol |
 | [Getting Started](docs/getting-started.md) | Setup, prerequisites, build process, configuration |
 | [Developer Guide](docs/developer-guide.md) | Directory structure, role ownership, conventions |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,16 +4,16 @@
 
 The PTO Runtime consists of **three separate programs** that communicate through well-defined APIs:
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                    Python Application                        │
-│              (examples/scripts/run_example.py)                   │
+│              (examples/scripts/run_example.py)               │
 └─────────────────────────┬───────────────────────────────────┘
                           │
          ┌────────────────┼────────────────┐
          │                │                │
-    Python Bindings   (ctypes)      Device I/O
-    bindings.py
+    nanobind          ChipWorker       RuntimeBuilder
+    (task_interface)  (dlopen host.so)  (compile binaries)
          │                │                │
          ▼                ▼                ▼
 ┌──────────────────┐  ┌──────────────────┐
@@ -41,13 +41,16 @@ The PTO Runtime consists of **three separate programs** that communicate through
 ## Components
 
 ### 1. Host Runtime (`src/{arch}/platform/*/host/`)
+
 **C++ library** - Device orchestration and management
-- `DeviceRunner`: Singleton managing device operations
+
+- `DeviceRunner`: Handle-based device context manager (one per `ChipWorker`)
 - `MemoryAllocator`: Device tensor memory management
-- `pto_runtime_c_api.h`: Pure C API for Python bindings
+- `pto_runtime_c_api.h`: Pure C API for `ChipWorker` bindings (`src/common/worker/pto_runtime_c_api.h`)
 - Compiled to shared library (.so) at runtime
 
 **Key Responsibilities:**
+
 - Allocate/free device memory
 - Host <-> Device data transfer
 - AICPU kernel launching and configuration
@@ -55,12 +58,15 @@ The PTO Runtime consists of **three separate programs** that communicate through
 - Runtime execution workflow coordination
 
 ### 2. AICPU Kernel (`src/{arch}/platform/*/aicpu/`)
+
 **Device program** - Task scheduler running on AICPU processor
+
 - `kernel.cpp`: Kernel entry points and handshake protocol
 - Runtime-specific executor in `src/{arch}/runtime/*/aicpu/`
 - Compiled to device binary at build time
 
 **Key Responsibilities:**
+
 - Initialize handshake protocol with AICore cores
 - Identify initially ready tasks (fanin=0)
 - Dispatch ready tasks to idle AICore cores
@@ -68,12 +74,15 @@ The PTO Runtime consists of **three separate programs** that communicate through
 - Continue until all tasks complete
 
 ### 3. AICore Kernel (`src/{arch}/platform/*/aicore/`)
+
 **Device program** - Computation kernels executing on AICore processors
+
 - `kernel.cpp`: Task execution kernels (add, mul, etc.)
 - Runtime-specific executor in `src/{arch}/runtime/*/aicore/`
 - Compiled to object file (.o) at build time
 
 **Key Responsibilities:**
+
 - Wait for task assignment via handshake buffer
 - Read task arguments and kernel address
 - Execute kernel using PTO ISA
@@ -83,88 +92,83 @@ The PTO Runtime consists of **three separate programs** that communicate through
 ## API Layers
 
 ### Layer 1: C++ API (`src/{arch}/platform/*/host/device_runner.h`)
+
 ```cpp
-DeviceRunner& runner = DeviceRunner::Get();
-runner.Init(device_id, num_cores, aicpu_bin, aicore_bin, pto_isa_root);
-runner.AllocateTensor(bytes);
-runner.CopyToDevice(device_ptr, host_ptr, bytes);
-runner.Run(runtime);
-runner.Finalize();
+DeviceRunner runner;
+void *ptr = runner.allocate_tensor(bytes);
+runner.copy_to_device(dev_ptr, host_ptr, bytes);
+runner.run(runtime, block_dim, device_id, aicpu_binary, aicore_binary, launch_aicpu_num);
+runner.finalize();
 ```
 
-### Layer 2: C API (`src/{arch}/platform/include/host/pto_runtime_c_api.h`)
+### Layer 2: C API (`src/common/worker/pto_runtime_c_api.h`)
+
 ```c
-int DeviceRunner_Init(device_id, num_cores, aicpu_binary, aicpu_size,
-                      aicore_binary, aicore_size, pto_isa_root);
-int DeviceRunner_Run(runtime_handle, launch_aicpu_num);
-int InitRuntime(runtime_handle);
-int FinalizeRuntime(runtime_handle);
-int DeviceRunner_Finalize();
+DeviceContextHandle ctx = create_device_context();
+set_device(ctx, device_id);
+size_t size = get_runtime_size();
+run_runtime(ctx, runtime, callable, args, block_dim,
+            aicpu_thread_num, device_id,
+            aicpu_binary, aicpu_size, aicore_binary, aicore_size,
+            enable_profiling);
+finalize_device(ctx);
+destroy_device_context(ctx);
 ```
 
-### Layer 3: Python API (`python/bindings.py`)
+### Layer 3: Python API (`python/bindings/task_interface.cpp` via nanobind)
+
 ```python
-Runtime = bind_host_binary(host_binary)
-runtime = Runtime()
-runtime.initialize()
-launch_runtime(runtime, aicpu_thread_num=1, block_dim=1,
-               device_id=device_id, aicpu_binary=aicpu_bytes,
-               aicore_binary=aicore_bytes)
-runtime.finalize()
+from simpler.task_interface import ChipWorker, ChipCallable, ChipStorageTaskArgs, CallConfig
+
+worker = ChipWorker()
+worker.init(host_lib_path, aicpu_path, aicore_path, sim_context_lib_path="")
+worker.set_device(device_id)
+
+config = CallConfig()
+config.block_dim = 24
+config.aicpu_thread_num = 3
+worker.run(callable, args, config)
+worker.finalize()
 ```
 
 ## Execution Flow
 
 ### 1. Python Setup Phase
-```
+
+```text
 Python run_example.py
   │
-  ├─→ RuntimeCompiler.compile("host", ...) → host_binary (.so)
-  ├─→ RuntimeCompiler.compile("aicpu", ...) → aicpu_binary (.so)
-  ├─→ RuntimeCompiler.compile("aicore", ...) → aicore_binary (.o)
+  ├─→ RuntimeBuilder(platform).get_binaries(runtime_name) → host.so, aicpu.so, aicore.o
+  ├─→ KernelCompiler(platform).compile_incore(source, core_type) → kernel .o/.so
+  ├─→ KernelCompiler(platform).compile_orchestration(runtime, source) → orch .so
   │
-  └─→ bind_host_binary(host_binary)
-       └─→ RuntimeLibraryLoader(host_binary)
-            └─→ CDLL(host_binary) ← Loads .so into memory
+  └─→ ChipWorker()
+       └─→ init(host_path, aicpu_path, aicore_path)
+            └─→ dlopen(host.so) → resolve C API symbols via dlsym
 ```
 
 ### 2. Initialization Phase
-```
-runner.init(device_id, num_cores, aicpu_binary, aicore_binary, pto_isa_root)
+
+```text
+worker.set_device(device_id)
   │
-  ├─→ DeviceRunner_Init (C API)
-  │    ├─→ Initialize CANN device
-  │    ├─→ Allocate device streams
-  │    ├─→ Load AICPU binary to device
-  │    ├─→ Register AICore kernel binary
-  │    └─→ Create handshake buffers (one per core)
-  │
-  └─→ DeviceRunner singleton ready
+  └─→ create_device_context() → DeviceContextHandle
+       └─→ set_device(ctx, device_id)
+            ├─→ Initialize device (CANN on hardware, no-op on sim)
+            └─→ Allocate device streams
 ```
 
-### 3. Runtime Building Phase
-```
-runtime.initialize()
-  │
-  └─→ InitRuntime (C API)
-       └─→ InitRuntimeImpl (C++)
-            ├─→ Compile kernels at runtime (CompileAndLoadKernel)
-            │    ├─→ KernelCompiler calls ccec
-            │    ├─→ Load .o to device GM memory
-            │    └─→ Update kernel function address table
-            │
-            ├─→ Allocate device tensors via MemoryAllocator
-            ├─→ Copy input data to device
-            ├─→ Build task runtime with dependencies
-            └─→ Return Runtime pointer
-```
+### 3. Execution Phase
 
-### 4. Execution Phase
-```
-launch_runtime(runtime, aicpu_thread_num=1, block_dim=1, device_id=device_id,
-               aicpu_binary=aicpu_bytes, aicore_binary=aicore_bytes)
+```text
+worker.run(callable, args, CallConfig(block_dim, aicpu_thread_num))
   │
-  └─→ launch_runtime (C API)
+  └─→ run_runtime(ctx, runtime, callable, args, ...)
+       │
+       ├─→ Upload kernel binaries (upload_kernel_binary per func_id)
+       ├─→ Allocate device tensors via MemoryAllocator
+       ├─→ Copy input data to device
+       ├─→ Build task graph with dependencies
        │
        ├─→ Copy Runtime to device memory
        │
@@ -183,20 +187,20 @@ launch_runtime(runtime, aicpu_thread_num=1, block_dim=1, device_id=device_id,
        │         ├─→ Execute kernel
        │         └─→ Signal completion, repeat
        │
-       └─→ rtStreamSynchronize (wait for completion)
+       ├─→ rtStreamSynchronize (wait for completion)
+       │
+       ├─→ Copy results from device to host
+       └─→ Clean up device tensors and runtime
 ```
 
-### 5. Validation Phase
-```
-runtime.finalize()
+### 4. Finalization Phase
+
+```text
+worker.finalize()
   │
-  └─→ FinalizeRuntime (C API)
-       └─→ FinalizeRuntimeImpl (C++)
-            ├─→ Copy results from device to host
-            ├─→ Verify correctness (compare with expected values)
-            ├─→ Free all device tensors
-            ├─→ Delete runtime
-            └─→ Return success/failure
+  └─→ finalize_device(ctx)
+       ├─→ Release device resources
+       └─→ destroy_device_context(ctx)
 ```
 
 ## Handshake Protocol
@@ -214,6 +218,7 @@ struct Handshake {
 ```
 
 **Flow:**
+
 1. AICPU finds a ready task
 2. AICPU writes task pointer to handshake buffer and sets `aicpu_ready`
 3. AICore polls buffer, sees task, reads from device memory

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -26,11 +26,18 @@ pto-runtime/
 │           └── tensormap_and_ringbuffer/  # Advanced production runtime
 │
 ├── python/                            # Language bindings
-│   ├── bindings.py                    # ctypes wrapper (C -> Python)
-│   ├── runtime_compiler.py            # Multi-platform runtime compiler
-│   ├── kernel_compiler.py             # Kernel compiler
-│   ├── elf_parser.py                  # ELF binary parser
-│   └── toolchain.py                   # Toolchain configuration
+│   ├── bindings/                      # nanobind extension module (_task_interface)
+│   │   ├── CMakeLists.txt
+│   │   ├── task_interface.cpp
+│   │   └── dist_worker_bind.h
+│   └── simpler/                       # Python package
+│       ├── worker.py                  # Unified Worker (L2 single-chip, L3 distributed)
+│       ├── task_interface.py          # Python re-exports of nanobind types + helpers
+│       ├── runtime_compiler.py        # Multi-platform runtime compiler
+│       ├── kernel_compiler.py         # Kernel compiler
+│       ├── elf_parser.py              # ELF binary parser
+│       ├── env_manager.py             # Environment variable management
+│       └── toolchain.py              # Toolchain configuration
 │
 ├── examples/                          # Working examples
 │   ├── scripts/                       # Build and test framework
@@ -45,9 +52,10 @@ pto-runtime/
 │       └── tensormap_and_ringbuffer/
 │
 ├── tests/                             # Test suite
-│   ├── ut/                           # Python unit tests
-│   ├── st/                           # Device scene tests (hardware-only)
-│   └── cpp/                          # C++ unit tests (GoogleTest)
+│   ├── ut/                           # Unit tests
+│   │   ├── py/                       # Python unit tests (pytest)
+│   │   └── cpp/                      # C++ unit tests (GoogleTest)
+│   └── st/                           # Device scene tests (hardware-only)
 │
 └── docs/                              # Documentation
 ```
@@ -88,7 +96,7 @@ Persistent cmake build directories under `build/cache/` enable incremental compi
 ### User code (per-example)
 
 1. `python/kernel_compiler.py` — compiles user-written kernel `.cpp` files (one per `func_id`)
-2. `python/bindings.py` — provides ctypes wrappers for calling the host `.so` from Python
+2. `python/bindings/` — nanobind extension providing ChipWorker, task types, and distributed types to Python
 
 ## Cross-Platform Preprocessor Convention
 
@@ -169,18 +177,20 @@ build/
 
 ## Dynamic Kernel Compilation
 
-Compile and load kernels at runtime without rebuilding:
+Kernels are compiled externally by `KernelCompiler` and uploaded to the device at runtime:
 
-```cpp
-// In host code
-runner.CompileAndLoadKernel(func_id, "path/to/kernel.cpp", core_type);
+```python
+from simpler.kernel_compiler import KernelCompiler
+
+compiler = KernelCompiler(platform="a2a3sim")
+kernel_binary = compiler.compile_incore("path/to/kernel.cpp", core_type="aiv")
 ```
 
-This compiles the kernel source using `ccec`, loads the binary to device memory, and registers it for task dispatch.
+The compiled binary is then uploaded via `DeviceRunner::upload_kernel_binary(func_id, bin_data, bin_size)`, which loads it into device memory and returns the function address for task dispatch.
 
 ## Features
 
 - **Three programs compile independently** with clear API boundaries
-- **Full Python API** with ctypes and NumPy integration
+- **Full Python API** via nanobind with torch integration
 - **Modular design** enables parallel component development
 - **Runtime linking** via binary loading

--- a/docs/distributed_level_runtime.md
+++ b/docs/distributed_level_runtime.md
@@ -133,7 +133,7 @@ For group tasks, RUNNING → COMPLETED requires ALL N workers to finish (`sub_co
 ```text
 Python layer                              C++ layer
 ──────────────                            ──────────────
-Worker / HostWorker                       DistWorker
+Worker                                    DistWorker
   - fork() SubWorker processes              - DistOrchestrator (DAG, TensorMap)
   - register callables (before fork)        - DistScheduler (thread, dispatch)
   - manage SharedMemory lifecycle           - DistRing (slot allocation)
@@ -275,7 +275,7 @@ The `IWorker` interface enables recursive composition: an L4 `DistWorker` would 
 ```text
 Python Application
   │
-  └─► Worker / HostWorker                    ← Python wrapper (lifecycle, fork management)
+  └─► Worker                              ← Python wrapper (lifecycle, fork management)
        │
        └── DistWorker(level=3)               ← C++ scheduling engine
             │
@@ -305,6 +305,5 @@ Python Application
 | `src/common/distributed/dist_scope.h/.cpp` | Scope depth tracking and ref management |
 | `src/common/distributed/dist_sub_worker.h/.cpp` | fork/shm IWorker with mailbox protocol |
 | `src/common/worker/chip_worker.h/.cpp` | L2 device execution, thread_local DeviceRunner |
-| `python/host_worker/host_worker.py` | L3 Python wrapper, fork management, scope context manager |
-| `python/worker.py` | Unified Worker factory (L2 + L3) |
+| `python/worker.py` | Unified Worker (L2 + L3): Python wrapper, fork management, scope context manager |
 | `python/bindings/dist_worker_bind.h` | nanobind bindings for distributed types |

--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -32,7 +32,7 @@ Python process (ChipWorker)
   |
   dlopen(host_runtime.so, RTLD_GLOBAL)        ← host SO
     |
-    +-- DeviceRunner (singleton)
+    +-- DeviceRunner (handle-based, one per ChipWorker)
     |     |
     |     +-- rtMemcpy(aicpu_binary → device HBM)    ← NOT dlopen, binary blob upload
     |     +-- rtRegisterAllKernel(aicore_binary)      ← CANN kernel registration
@@ -162,7 +162,9 @@ uses `pthread_key_t` (POSIX TLS) for per-thread state in framework SOs.
 | -------- | ------- | -- | ------- |
 | `g_reg_base_key` | `pthread_key_t` | AICore SO | Per-core simulated register base address |
 | `g_core_id_key` | `pthread_key_t` | AICore SO | Per-core physical core ID |
-| `g_cpu_sim_context_key` | `pthread_key_t` | Host SO | Per-thread execution context (block_idx, subblock_id, etc.) |
+| `g_device_id_key` | `pthread_key_t` | Sim Context SO (`libcpu_sim_context.so`) | Per-thread device binding (device_id) |
+| `g_subblock_id_key` | `pthread_key_t` | Sim Context SO (`libcpu_sim_context.so`) | Per-thread subblock identity (for TPUSH/TPOP) |
+| `g_cluster_id_key` | `pthread_key_t` | Sim Context SO (`libcpu_sim_context.so`) | Per-thread cluster identity (for TPUSH/TPOP) |
 | `s_orch_thread_idx` | `__thread int` | AICPU SO | Profiling thread index (profiling off by default) |
 | `execution_context` | `thread_local` | Kernel SO (PTO ISA) | Per-thread execution context (fallback, cached values only) |
 | `NPUMemoryModel::instance` | `thread_local` | Kernel SO (PTO ISA) | Per-core memory model simulation |
@@ -201,7 +203,7 @@ When the AICPU SO is dlclosed and re-dlopen'd between tasks, the static is
 reconstructed. But when the AICPU SO is **reused** (same runtime, consecutive
 tasks), `deinit()` must reset all fields. Previously missing resets:
 
-- `cores_total_num_`, `thread_num_`, `orch_thread_num_`, `sched_thread_num_`
+- `cores_total_num_`, `thread_num_`, `sched_thread_num_`
 - `trackers_` / `core_trackers_`, `core_assignments_`, `core_count_per_thread_`
 - `orch_func_`, `orch_args_cached_`, `orch_so_handle_`, `orch_so_path_`
 
@@ -213,7 +215,7 @@ Applies to all 5 runtime executors: a2a3 (abg, hbg, tmr), a5 (hbg, tmr).
 
 | SO | Caching | Lifecycle |
 | -- | ------- | --------- |
-| Host runtime | `ChipWorker::lib_handle_` | Per-task: dlopen in `init()`, dlclose in `reset()` |
+| Host runtime | `ChipWorker::lib_handle_` | Per-init: dlopen in `init()`, dlclose in `finalize()` |
 | AICPU | `DeviceRunner::aicpu_so_handle_` | Per-run: loaded in `ensure_binaries_loaded()`, closed in `unload_executor_binaries()` at end of `run()` |
 | AICore | `DeviceRunner::aicore_so_handle_` | Same as AICPU |
 | Kernel | `DeviceRunner::func_id_to_addr_` (map by func_id) | Per-task: uploaded in `init_runtime_impl()`, removed in `validate_runtime_impl()` |
@@ -231,8 +233,8 @@ Applies to all 5 runtime executors: a2a3 (abg, hbg, tmr), a5 (hbg, tmr).
 
 ### Key difference
 
-Onboard caches more aggressively — the DeviceRunner singleton persists
-across tasks and the AICPU binary stays in device memory. Simulation
+Onboard caches more aggressively — the DeviceRunner persists
+across tasks within a runtime group, and the AICPU binary stays in device memory. Simulation
 re-loads AICPU/AICore SOs every `run()` call because the SO's internal
 static state (`g_aicpu_executor`) must be fresh for each task when
 different tasks have different configurations.
@@ -242,13 +244,17 @@ different tasks have different configurations.
 ### Simulation (in-process, per-task init/reset)
 
 ```text
-ChipWorker.init(host_path, aicpu_bytes, aicore_bytes)
+ChipWorker.init(host_path, aicpu_path, aicore_path)
   dlopen(host_runtime.so, RTLD_GLOBAL)
-  dlsym: set_device, get_runtime_size, run_runtime, finalize_device
-  set_device(device_id)
+  dlsym: create_device_context, destroy_device_context, set_device,
+         get_runtime_size, run_runtime, finalize_device
+
+ChipWorker.set_device(device_id)
+  create_device_context() → DeviceContextHandle
+  set_device(ctx, device_id)
 
 ChipWorker.run(callable, args, config)
-  run_runtime(buf, callable, args, ...)
+  run_runtime(ctx, buf, callable, args, ...)
     new (buf) Runtime()
     init_runtime_impl(r, callable, args)     build graph, upload kernels
     DeviceRunner::run(r, ...)
@@ -260,8 +266,12 @@ ChipWorker.run(callable, args, config)
     validate_runtime_impl(r)                 copy results, remove kernels
     r->~Runtime()
 
-ChipWorker.reset()
-  finalize_device()
+ChipWorker.reset_device()
+  finalize_device(ctx)
+  destroy_device_context(ctx)
+
+ChipWorker.finalize()
+  reset_device() (if needed)
   dlclose(host_runtime.so)                   -fno-gnu-unique ensures real unload
 ```
 
@@ -270,13 +280,15 @@ ChipWorker.reset()
 ```text
 device_worker_main(device_id)
   for each runtime_group:
-    ChipWorker.init(host_path, aicpu_bytes, aicore_bytes)
+    ChipWorker.init(host_path, aicpu_path, aicore_path)
       dlopen(host_runtime.so, RTLD_GLOBAL)
-      set_device(device_id)                  rtSetDevice()
+    ChipWorker.set_device(device_id)
+      create_device_context()
+      set_device(ctx, device_id)               rtSetDevice()
 
     for each task in group:
       ChipWorker.run(callable, args, config)
-        run_runtime(buf, callable, args, ...)
+        run_runtime(ctx, buf, callable, args, ...)
           new (buf) Runtime()
           init_runtime_impl()                rtMalloc, rtMemcpy to device
           DeviceRunner::run()
@@ -286,7 +298,10 @@ device_worker_main(device_id)
             launch_aicore_kernel()           rtRegisterAllKernel + rtKernelLaunch
           validate_runtime_impl()            rtMemcpy results back to host
 
-    ChipWorker.reset()
-      finalize_device()                      rtDeviceReset()
+    ChipWorker.reset_device()
+      finalize_device(ctx)                     rtDeviceReset()
+      destroy_device_context(ctx)
+
+    ChipWorker.finalize()
       dlclose(host_runtime.so)
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -155,7 +155,9 @@ worker.init(host_path=str(binaries.host_path),
 worker.set_device(device_id=0)
 
 # Execute callable on device
-worker.run(chip_callable, orch_args, CallConfig(block_dim=24))
+config = CallConfig()
+config.block_dim = 24
+worker.run(chip_callable, orch_args, config)
 
 # Cleanup
 worker.reset_device()
@@ -176,14 +178,20 @@ In `src/{arch}/runtime/host_build_graph/runtime/runtime.h`:
 
 ### Runtime Configuration
 
+Runtime behavior is configured via `kernel_config.py` in each example:
+
 ```python
-runner.init(
-    device_id=0,              # Device ID (0-15)
-    num_cores=3,              # Number of cores for handshake
-    aicpu_binary=...,         # AICPU .so binary
-    aicore_binary=...,        # AICore .o binary
-    pto_isa_root="/path/to/pto-isa"  # PTO-ISA headers location
-)
+RUNTIME_CONFIG = {
+    "runtime": "host_build_graph",    # Runtime to use
+    "aicpu_thread_num": 3,            # Number of AICPU scheduler threads
+    "block_dim": 3,                   # Number of AICore blocks (1 block = 1 AIC + 2 AIV)
+}
+```
+
+Device selection is done via CLI flag:
+
+```bash
+python examples/scripts/run_example.py -k <kernels> -g <golden.py> -p a2a3 --device 0
 ```
 
 ## Notes

--- a/src/a2a3/docs/runtimes.md
+++ b/src/a2a3/docs/runtimes.md
@@ -57,10 +57,10 @@ See [tensormap_and_ringbuffer/docs/](../runtime/tensormap_and_ringbuffer/docs/):
 
 ## Shared Components
 
-Runtime-specific shared files are in `src/a2a3/runtime/common/`:
+Ring buffer and submit type definitions are duplicated per-runtime (not in a shared `common/` directory):
 
-- `pto_ring_buffer.h/cpp` — Ring buffer data structures (HeapRing, TaskRing, DepListPool)
-- `pto_submit_types.h` — Subtask types, MixedKernels, ResourceShape
+- `{runtime}/runtime/pto_ring_buffer.cpp` — Ring buffer data structures (HeapRing, TaskRing, DepListPool)
+- `{runtime}/runtime/pto_runtime2_types.h` — Task descriptor types, resource shapes
 
 Cross-architecture shared files are in `src/common/task_interface/`:
 

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -12,10 +12,12 @@
  * Device Runner - Thread-Based Simulation
  *
  * This module simulates the Ascend AICPU/AICore execution model using threads.
- * It provides the SAME interface as the real a2a3 DeviceRunner, ensuring
- * API compatibility with Python bindings and examples.
+ * It provides a compatible interface with the onboard DeviceRunner for the
+ * core operations (allocate, copy, run, finalize, upload/remove kernel).
+ * The onboard version exposes additional low-level methods (launch_aicpu_kernel,
+ * launch_aicore_kernel, ensure_device_set) for custom workflows.
  *
- * Key differences from real a2a3:
+ * Key differences from onboard:
  * - Uses host memory instead of device memory
  * - Uses std::thread instead of CANN kernel launches
  * - Kernel .text binaries are loaded into executable memory (mmap)
@@ -64,7 +66,7 @@ struct MappedKernel {
 /**
  * Device runner for simulated kernel execution
  *
- * This class provides the SAME interface as the real a2a3 DeviceRunner,
+ * This class provides a compatible interface with the onboard DeviceRunner,
  * but implements execution using host threads instead of actual device
  * kernel launches.
  *

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -273,7 +273,7 @@ int validate_runtime_impl(Runtime *runtime) {
         }
     }
 
-    // Note: PrintHandshakeResults is now called in DeviceRunner's destructor
+    // Note: print_handshake_results() is called in DeviceRunner::run()
 
     // Cleanup device tensors
     LOG_INFO("=== Cleaning Up ===");

--- a/src/a5/docs/runtimes.md
+++ b/src/a5/docs/runtimes.md
@@ -5,7 +5,7 @@ Two runtime implementations live under `src/a5/runtime/`, each providing a diffe
 ## Comparison
 
 | Feature | host_build_graph | tensormap_and_ringbuffer |
-|---------|-----------------|--------------------------|
+| ------- | ---------------- | ------------------------ |
 | Graph built on | Host CPU | AICPU (device) |
 | Task storage | Fixed `Task[]` array | Ring buffer (`PTO2TaskDescriptor[]`) |
 | Dependencies | Explicit edges | Auto-derived via TensorMap |
@@ -18,8 +18,10 @@ See [host_build_graph/docs/RUNTIME_LOGIC.md](../runtime/host_build_graph/docs/RU
 ## tensormap_and_ringbuffer (PTO2)
 
 See [tensormap_and_ringbuffer/docs/](../runtime/tensormap_and_ringbuffer/docs/):
+
 - [RUNTIME_LOGIC.md](../runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md) — Full system design
 - [MULTI_RING.md](../runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md) — Multi-ring buffer architecture
 - [SUBMIT_BY_CLUSTER.md](../runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md) — Cluster submission design
+- [SCALAR_DATA_ACCESS.md](../runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md) — Scalar data access patterns
 - [profiling_levels.md](../runtime/tensormap_and_ringbuffer/docs/profiling_levels.md) — Profiling levels
 - [device_log_profiling.md](../runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md) — Device log profiling guide

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -273,7 +273,7 @@ int validate_runtime_impl(Runtime *runtime) {
         }
     }
 
-    // Note: PrintHandshakeResults is now called in DeviceRunner's destructor
+    // Note: print_handshake_results() is called in DeviceRunner::run()
 
     // Cleanup device tensors
     LOG_INFO("=== Cleaning Up ===");


### PR DESCRIPTION
## Summary

Recent refactors (DeviceRunner singleton→handle-based C API, ChipWorker path-based init, hub tasks removal, cpu_sim_context extraction) left documentation and code comments stale. This commit brings all affected files into consistency.

**Docs (9 files):**
- `docs/architecture.md` — rewrite API layers (C++/C/Python), execution flow, diagram to match handle-based DeviceRunner and nanobind ChipWorker API
- `docs/dynamic-linking.md` — fix ChipWorker.init() signature (paths not bytes), DeviceRunner singleton→handle, TLS table (g_cpu_sim_context_key→g_exec_ctx_key+g_device_id_key), lifecycle pseudocode
- `docs/getting-started.md` — replace stale `runner.init()` with kernel_config.py-based runtime configuration
- `docs/distributed_level_runtime.md` — remove nonexistent `python/host_worker/` path and `HostWorker` class references
- `docs/developer-guide.md` — `python/bindings.py`→`python/bindings/` directory, add missing modules (worker.py, task_interface.py, env_manager.py), fix `CompileAndLoadKernel`→`upload_kernel_binary`, ctypes→nanobind
- `README.md` — add a5/a5sim to platforms table, fix C++ test command path, fix table delimiter formatting
- `.claude/rules/architecture.md` — fix `python/bindings.py`→`python/bindings/`
- `src/a2a3/docs/runtimes.md` — fix nonexistent `src/a2a3/runtime/common/` directory reference
- `src/a5/docs/runtimes.md` — add missing SCALAR_DATA_ACCESS.md link, fix table delimiter

**Code comments (3 files):**
- `src/a2a3/platform/sim/host/device_runner.h` — correct "provides the SAME interface" → "provides a compatible interface" (sim lacks launch_aicpu/aicore_kernel, ensure_device_set)
- `src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp` — fix "PrintHandshakeResults called in destructor" → "called in run()"
- `src/a5/runtime/host_build_graph/host/runtime_maker.cpp` — same as above

## Testing

- [ ] Documentation-only and comment-only changes — no behavior change
- [ ] Markdownlint passes on all modified .md files