### PR TITLE
Add: memfd-based SO loading for all runtimes

### DIFF
--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -1602,6 +1602,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
+            uint64_t t_load_start = get_sys_cnt_aicpu();
+
             // Try memfd first (Linux only), fall back to file-based
             char so_path[256];
             void *handle = nullptr;
@@ -1668,13 +1670,21 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
             }
 
-            dlerror();
-            auto config_func =
-                reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
+            uint64_t t0, t1;
 
             dlerror();
+            t0 = get_sys_cnt_aicpu();
+            auto config_func =
+                reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] dlsym aicpu_orchestration_config cycles: %lu", t1 - t0);
+
+            dlerror();
+            t0 = get_sys_cnt_aicpu();
             DeviceOrchestrationFunc orch_func =
                 reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] dlsym aicpu_orchestration_entry cycles: %lu", t1 - t0);
             const char *dlsym_error = dlerror();
             if (dlsym_error != nullptr) {
                 DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
@@ -1710,7 +1720,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             uint64_t heap_size = PTO2_HEAP_SIZE;
             int32_t expected_arg_count = 0;
             if (config_func) {
+                t0 = get_sys_cnt_aicpu();
                 PTO2OrchestrationConfig cfg = config_func(args);
+                t1 = get_sys_cnt_aicpu();
+                DEV_INFO("[memfd_profiling] config_func() call cycles: %lu", t1 - t0);
                 expected_arg_count = cfg.expected_arg_count;
                 DEV_INFO("Thread %d: Config: expected_args=%d", thread_idx, expected_arg_count);
             } else {
@@ -1742,9 +1755,16 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
             void *gm_heap = runtime->get_pto2_gm_heap_ptr();
 
+            t0 = get_sys_cnt_aicpu();
             uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_sm_calculate_size cycles: %lu", t1 - t0);
+
+            t0 = get_sys_cnt_aicpu();
             PTO2SharedMemoryHandle *sm_handle =
                 pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_sm_create_from_buffer cycles: %lu", t1 - t0);
             if (!sm_handle) {
                 DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
                 dlclose(handle);
@@ -1752,7 +1772,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
+            t0 = get_sys_cnt_aicpu();
             rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_runtime_create_from_sm cycles: %lu", t1 - t0);
+
             if (!rt) {
                 DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                 pto2_sm_destroy(sm_handle);
@@ -1793,7 +1817,15 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #if PTO2_PROFILING
             uint64_t orch_cycle_start = get_sys_cnt_aicpu();
 #endif
-            PTO2_SCOPE(rt) { orch_func_(rt, *orch_args_cached_); }
+            t0 = get_sys_cnt_aicpu();
+            PTO2_SCOPE(rt) {
+                uint64_t t_orch_func = get_sys_cnt_aicpu();
+                orch_func_(rt, *orch_args_cached_);
+                uint64_t t_orch_func_end = get_sys_cnt_aicpu();
+                DEV_INFO("[memfd_profiling] orch_func_() execution cycles: %lu", t_orch_func_end - t_orch_func);
+            }
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] PTO2_SCOPE (begin+end) cycles: %lu", t1 - t0);
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
             DEV_ALWAYS(
@@ -1801,6 +1833,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 static_cast<uint64_t>(orch_cycle_start), cycles_to_us(orch_cycle_end - orch_cycle_start)
             );
 #endif
+
+            uint64_t t_load_end = get_sys_cnt_aicpu();
+            DEV_ALWAYS("[memfd_profiling] Total SO load to orch completion cycles: %lu", t_load_end - t_load_start);
 
             // Print orchestrator profiling data
 #if PTO2_ORCH_PROFILING

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -1606,9 +1606,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             int memfd = -1;
 
             // Attempt memfd-based loading first
-            int memfd_rc = load_orchestration_so_with_memfd(
-                so_data, so_size, thread_idx, &handle, so_path, &memfd
-            );
+            int memfd_rc = load_orchestration_so_with_memfd(so_data, so_size, thread_idx, &handle, so_path, &memfd);
 
             if (memfd_rc == 0 && handle != nullptr) {
                 // memfd loading succeeded, use memfd-loaded handle

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -29,8 +29,10 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
-// memfd-based SO loading
+// memfd-based SO loading (Linux only)
+#if defined(__linux__)
 #include "memfd_loader.h"
+#endif
 
 // Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
 #include "pto_runtime2.h"
@@ -1600,11 +1602,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
-            // Try memfd first, fall back to file-based
+            // Try memfd first (Linux only), fall back to file-based
             char so_path[256];
             void *handle = nullptr;
             int memfd = -1;
 
+#if defined(__linux__)
             // Attempt memfd-based loading first
             int memfd_rc = load_orchestration_so_with_memfd(so_data, so_size, thread_idx, &handle, so_path, &memfd);
 
@@ -1612,10 +1615,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 // memfd loading succeeded, use memfd-loaded handle
                 orch_so_memfd_ = memfd;
             }
+#endif
 
             if (handle == nullptr) {
                 // memfd failed or unavailable - use file-based loading
+#if defined(__linux__)
                 orch_so_memfd_ = -1;
+#endif
 
                 // Try multiple paths that may allow execution on AICPU
                 bool file_created = false;
@@ -1992,6 +1998,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         if (!runtime->get_orch_built_on_host() && orch_so_handle_ != nullptr) {
             pto2_runtime_destroy(rt);
             // Handle cleanup based on loading method
+#if defined(__linux__)
             if (orch_so_memfd_ >= 0) {
                 // memfd-based: close fd AFTER dlclose
                 cleanup_memfd_so(orch_so_memfd_, orch_so_handle_);
@@ -2000,6 +2007,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 dlclose(orch_so_handle_);
                 unlink(orch_so_path_);
             }
+#else
+            // Non-Linux: only file-based loading
+            dlclose(orch_so_handle_);
+            unlink(orch_so_path_);
+#endif
         }
         DEV_ALWAYS("Thread %d: Last thread, marking executor finished", thread_idx);
     }

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -29,6 +29,9 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
+// memfd-based SO loading
+#include "memfd_loader.h"
+
 // Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
 #include "pto_runtime2.h"
 #include "pto_runtime2_types.h"
@@ -237,6 +240,7 @@ struct AicpuExecutor {
     // Orchestration SO handle - defer dlclose until all tasks complete
     void *orch_so_handle_{nullptr};
     char orch_so_path_[256]{};  // Path to orchestration SO file for cleanup
+    int orch_so_memfd_{-1};     // memfd for memfd_create path (-1 if file-based)
 
     // Shared orchestration function pointer (loaded by first orch thread, used by all)
     DeviceOrchestrationFunc orch_func_{nullptr};
@@ -1596,50 +1600,69 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
-            // Try multiple paths that may allow execution on AICPU
+            // Try memfd first, fall back to file-based
             char so_path[256];
-            bool file_created = false;
-            const char *candidate_dirs[] = {
-                "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
-            };
-            const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
+            void *handle = nullptr;
+            int memfd = -1;
 
-            for (int32_t i = 0; i < num_candidates && !file_created; i++) {
-                snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
-                int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
-                if (fd < 0) {
-                    DEV_INFO(
-                        "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
-                    );
-                    continue;
-                }
-                ssize_t written = write(fd, so_data, so_size);
-                close(fd);
-                if (written != static_cast<ssize_t>(so_size)) {
-                    DEV_INFO(
-                        "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
-                    );
-                    unlink(so_path);
-                    continue;
-                }
-                file_created = true;
-                DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+            // Attempt memfd-based loading first
+            int memfd_rc = load_orchestration_so_with_memfd(
+                so_data, so_size, thread_idx, &handle, so_path, &memfd
+            );
+
+            if (memfd_rc == 0 && handle != nullptr) {
+                // memfd loading succeeded, use memfd-loaded handle
+                orch_so_memfd_ = memfd;
             }
 
-            if (!file_created) {
-                DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
-                return -1;
-            }
-
-            dlerror();
-            void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
-            const char *dlopen_err = dlerror();
             if (handle == nullptr) {
-                DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
-                unlink(so_path);
-                return -1;
+                // memfd failed or unavailable - use file-based loading
+                orch_so_memfd_ = -1;
+
+                // Try multiple paths that may allow execution on AICPU
+                bool file_created = false;
+                const char *candidate_dirs[] = {
+                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
+                };
+                const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
+
+                for (int32_t i = 0; i < num_candidates && !file_created; i++) {
+                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
+                    int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+                    if (fd < 0) {
+                        DEV_INFO(
+                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
+                        continue;
+                    }
+                    ssize_t written = write(fd, so_data, so_size);
+                    close(fd);
+                    if (written != static_cast<ssize_t>(so_size)) {
+                        DEV_INFO(
+                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
+                        unlink(so_path);
+                        continue;
+                    }
+                    file_created = true;
+                    DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+                }
+
+                if (!file_created) {
+                    DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
+                    return -1;
+                }
+
+                dlerror();
+                handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+                const char *dlopen_err = dlerror();
+                if (handle == nullptr) {
+                    DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
+                    unlink(so_path);
+                    return -1;
+                }
+                DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
             }
-            DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
 
             dlerror();
             auto config_func =
@@ -1970,8 +1993,15 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // Destroy PTO2 runtime and close orchestration SO (moved from orchestrator path)
         if (!runtime->get_orch_built_on_host() && orch_so_handle_ != nullptr) {
             pto2_runtime_destroy(rt);
-            dlclose(orch_so_handle_);
-            unlink(orch_so_path_);
+            // Handle cleanup based on loading method
+            if (orch_so_memfd_ >= 0) {
+                // memfd-based: close fd AFTER dlclose
+                cleanup_memfd_so(orch_so_memfd_, orch_so_handle_);
+            } else {
+                // File-based: dlclose handle and unlink file
+                dlclose(orch_so_handle_);
+                unlink(orch_so_path_);
+            }
         }
         DEV_ALWAYS("Thread %d: Last thread, marking executor finished", thread_idx);
     }
@@ -2029,6 +2059,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     orch_args_cached_ = nullptr;
     orch_so_handle_ = nullptr;
     orch_so_path_[0] = '\0';
+    orch_so_memfd_ = -1;
 
     // Reset register-related state
     for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -1605,9 +1605,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // Try memfd first (Linux only), fall back to file-based
             char so_path[256];
             void *handle = nullptr;
-            int memfd = -1;
 
 #if defined(__linux__)
+            int memfd = -1;
             // Attempt memfd-based loading first
             int memfd_rc = load_orchestration_so_with_memfd(so_data, so_size, thread_idx, &handle, so_path, &memfd);
 

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
@@ -3,7 +3,7 @@
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
  * CANN Open Software License Agreement Version 2.0 (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
@@ -34,6 +34,7 @@ extern "C" {
 #include <cstdio>
 
 #include "aicpu/device_log.h"
+#include "aicpu/device_time.h"
 
 /**
  * Load orchestration SO using memfd
@@ -49,8 +50,13 @@ static inline int load_orchestration_so_with_memfd(
         return -1;
     }
 
+    uint64_t t0, t1;
+
     // Create memfd
+    t0 = get_sys_cnt_aicpu();
     int fd = memfd_create("libdevice_orch", MFD_CLOEXEC);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] memfd_create cycles: %lu", t1 - t0);
 
     if (fd < 0) {
         DEV_INFO("memfd_create failed: errno=%d", errno);
@@ -58,7 +64,10 @@ static inline int load_orchestration_so_with_memfd(
     }
 
     // Write SO data to memfd
+    t0 = get_sys_cnt_aicpu();
     ssize_t written = write(fd, so_data, so_size);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] write %zu bytes cycles: %lu", so_size, t1 - t0);
 
     if (written < 0) {
         DEV_INFO("memfd write failed: errno=%d", errno);
@@ -72,7 +81,10 @@ static inline int load_orchestration_so_with_memfd(
     }
 
     // Reset file position to beginning before dlopen
+    t0 = get_sys_cnt_aicpu();
     lseek(fd, 0, SEEK_SET);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] lseek cycles: %lu", t1 - t0);
 
     // Construct /proc/self/fd/N path for symlink target
     char proc_fd_path[256];
@@ -83,7 +95,11 @@ static inline int load_orchestration_so_with_memfd(
     char link_path[256];
     snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
 
+    t0 = get_sys_cnt_aicpu();
     int symlink_rc = symlink(proc_fd_path, link_path);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] symlink cycles: %lu", t1 - t0);
+
     if (symlink_rc != 0) {
         DEV_INFO("symlink failed: errno=%d", errno);
         close(fd);
@@ -93,8 +109,11 @@ static inline int load_orchestration_so_with_memfd(
     snprintf(out_so_path, 256, "%s", link_path);
 
     // Try dlopen from the symlink
+    t0 = get_sys_cnt_aicpu();
     dlerror();
     void *handle = dlopen(out_so_path, RTLD_LAZY | RTLD_LOCAL);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] dlopen cycles: %lu", t1 - t0);
 
     // Clean up symlink immediately after dlopen (dlopen has its own reference)
     unlink(link_path);

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
@@ -14,13 +14,13 @@
  * @brief Memory file descriptor based SO loading for AICPU environment
  */
 
+#ifndef SRC_A2A3_RUNTIME_AICPU_BUILD_GRAPH_AICPU_MEMFD_LOADER_H_
+#define SRC_A2A3_RUNTIME_AICPU_BUILD_GRAPH_AICPU_MEMFD_LOADER_H_
+
 // Enable GNU extensions for memfd_create and MFD_CLOEXEC
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
-
-#ifndef MEMFD_LOADER_H
-#define MEMFD_LOADER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,13 +39,8 @@ extern "C" {
  * Load orchestration SO using memfd
  */
 static inline int load_orchestration_so_with_memfd(
-    const void *so_data,
-    size_t so_size,
-    int orch_thread_num,
-    void **out_handle,
-    char *out_so_path,
-    int *out_memfd
-) {
+    const void *so_data, size_t so_size, int orch_thread_num,
+    void **out_handle, char *out_so_path, int *out_memfd) {
     *out_handle = nullptr;
     *out_memfd = -1;
     out_so_path[0] = '\0';
@@ -86,7 +81,8 @@ static inline int load_orchestration_so_with_memfd(
     // Create a symlink to /proc/self/fd/N with a "normal" path
     // This bypasses the AICPU dynamic linker's issue with /proc/self/fd/N paths
     char link_path[256];
-    snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
+    snprintf(link_path, sizeof(link_path),
+             "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
 
     int symlink_rc = symlink(proc_fd_path, link_path);
     if (symlink_rc != 0) {
@@ -95,7 +91,7 @@ static inline int load_orchestration_so_with_memfd(
         return -1;
     }
 
-    snprintf(out_so_path, 256, "%s", link_path);
+    snprintf(out_so_path, sizeof(out_so_path), "%s", link_path);
 
     // Try dlopen from the symlink
     dlerror();
@@ -106,7 +102,8 @@ static inline int load_orchestration_so_with_memfd(
 
     if (handle == nullptr) {
         const char *dl_err = dlerror();
-        DEV_INFO("dlopen from memfd symlink failed: %s", dl_err ? dl_err : "unknown");
+        DEV_INFO("dlopen from memfd symlink failed: %s",
+                 dl_err ? dl_err : "unknown");
         close(fd);
         return -1;
     }
@@ -132,4 +129,4 @@ static inline void cleanup_memfd_so(int memfd, void *handle) {
 }
 #endif
 
-#endif  // MEMFD_LOADER_H
+#endif  // SRC_A2A3_RUNTIME_AICPU_BUILD_GRAPH_AICPU_MEMFD_LOADER_H_

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
@@ -91,7 +91,7 @@ static inline int load_orchestration_so_with_memfd(
         return -1;
     }
 
-    snprintf(out_so_path, sizeof(out_so_path), "%s", link_path);
+    snprintf(out_so_path, 256, "%s", link_path);
 
     // Try dlopen from the symlink
     dlerror();

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
@@ -39,8 +39,8 @@ extern "C" {
  * Load orchestration SO using memfd
  */
 static inline int load_orchestration_so_with_memfd(
-    const void *so_data, size_t so_size, int orch_thread_num,
-    void **out_handle, char *out_so_path, int *out_memfd) {
+    const void *so_data, size_t so_size, int orch_thread_num, void **out_handle, char *out_so_path, int *out_memfd
+) {
     *out_handle = nullptr;
     *out_memfd = -1;
     out_so_path[0] = '\0';
@@ -81,8 +81,7 @@ static inline int load_orchestration_so_with_memfd(
     // Create a symlink to /proc/self/fd/N with a "normal" path
     // This bypasses the AICPU dynamic linker's issue with /proc/self/fd/N paths
     char link_path[256];
-    snprintf(link_path, sizeof(link_path),
-             "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
+    snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
 
     int symlink_rc = symlink(proc_fd_path, link_path);
     if (symlink_rc != 0) {
@@ -102,8 +101,7 @@ static inline int load_orchestration_so_with_memfd(
 
     if (handle == nullptr) {
         const char *dl_err = dlerror();
-        DEV_INFO("dlopen from memfd symlink failed: %s",
-                 dl_err ? dl_err : "unknown");
+        DEV_INFO("dlopen from memfd symlink failed: %s", dl_err ? dl_err : "unknown");
         close(fd);
         return -1;
     }

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file memfd_loader.h
+ * @brief Memory file descriptor based SO loading for AICPU environment
+ */
+
+// Enable GNU extensions for memfd_create and MFD_CLOEXEC
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#ifndef MEMFD_LOADER_H
+#define MEMFD_LOADER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <cstring>
+#include <cstdio>
+
+#include "aicpu/device_log.h"
+
+/**
+ * Load orchestration SO using memfd
+ */
+static inline int load_orchestration_so_with_memfd(
+    const void *so_data,
+    size_t so_size,
+    int orch_thread_num,
+    void **out_handle,
+    char *out_so_path,
+    int *out_memfd
+) {
+    *out_handle = nullptr;
+    *out_memfd = -1;
+    out_so_path[0] = '\0';
+
+    if (so_data == nullptr || so_size == 0) {
+        return -1;
+    }
+
+    // Create memfd
+    int fd = memfd_create("libdevice_orch", MFD_CLOEXEC);
+
+    if (fd < 0) {
+        DEV_INFO("memfd_create failed: errno=%d", errno);
+        return -1;
+    }
+
+    // Write SO data to memfd
+    ssize_t written = write(fd, so_data, so_size);
+
+    if (written < 0) {
+        DEV_INFO("memfd write failed: errno=%d", errno);
+        close(fd);
+        return -1;
+    }
+    if (written != static_cast<ssize_t>(so_size)) {
+        DEV_INFO("memfd partial write: %zd/%zu", written, so_size);
+        close(fd);
+        return -1;
+    }
+
+    // Reset file position to beginning before dlopen
+    lseek(fd, 0, SEEK_SET);
+
+    // Construct /proc/self/fd/N path for symlink target
+    char proc_fd_path[256];
+    snprintf(proc_fd_path, sizeof(proc_fd_path), "/proc/self/fd/%d", fd);
+
+    // Create a symlink to /proc/self/fd/N with a "normal" path
+    // This bypasses the AICPU dynamic linker's issue with /proc/self/fd/N paths
+    char link_path[256];
+    snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
+
+    int symlink_rc = symlink(proc_fd_path, link_path);
+    if (symlink_rc != 0) {
+        DEV_INFO("symlink failed: errno=%d", errno);
+        close(fd);
+        return -1;
+    }
+
+    snprintf(out_so_path, 256, "%s", link_path);
+
+    // Try dlopen from the symlink
+    dlerror();
+    void *handle = dlopen(out_so_path, RTLD_LAZY | RTLD_LOCAL);
+
+    // Clean up symlink immediately after dlopen (dlopen has its own reference)
+    unlink(link_path);
+
+    if (handle == nullptr) {
+        const char *dl_err = dlerror();
+        DEV_INFO("dlopen from memfd symlink failed: %s", dl_err ? dl_err : "unknown");
+        close(fd);
+        return -1;
+    }
+
+    *out_handle = handle;
+    *out_memfd = fd;
+    return 0;
+}
+
+/**
+ * Cleanup memfd-based SO
+ */
+static inline void cleanup_memfd_so(int memfd, void *handle) {
+    if (handle != nullptr) {
+        dlclose(handle);
+    }
+    if (memfd >= 0) {
+        close(memfd);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MEMFD_LOADER_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -29,6 +29,9 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
+// memfd-based SO loading
+#include "memfd_loader.h"
+
 // Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
 #include "pto_runtime2.h"
 #include "pto_runtime2_types.h"
@@ -340,6 +343,7 @@ struct AicpuExecutor {
     // Orchestration SO handle - defer dlclose until all tasks complete
     void *orch_so_handle_{nullptr};
     char orch_so_path_[256]{};  // Path to orchestration SO file for cleanup
+    int orch_so_memfd_{-1};     // memfd for memfd_create path (-1 if file-based)
 
     // Shared orchestration function pointer (loaded by first orch thread, used by all)
     DeviceOrchestrationFunc orch_func_{nullptr};
@@ -1932,50 +1936,69 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
-            // Try multiple paths that may allow execution on AICPU
+            // Try memfd first, fall back to file-based
             char so_path[256];
-            bool file_created = false;
-            const char *candidate_dirs[] = {
-                "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
-            };
-            const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
+            void *handle = nullptr;
+            int memfd = -1;
 
-            for (int32_t i = 0; i < num_candidates && !file_created; i++) {
-                snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
-                int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
-                if (fd < 0) {
-                    DEV_INFO(
-                        "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
-                    );
-                    continue;
-                }
-                ssize_t written = write(fd, so_data, so_size);
-                close(fd);
-                if (written != static_cast<ssize_t>(so_size)) {
-                    DEV_INFO(
-                        "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
-                    );
-                    unlink(so_path);
-                    continue;
-                }
-                file_created = true;
-                DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+            // Attempt memfd-based loading first
+            int memfd_rc = load_orchestration_so_with_memfd(
+                so_data, so_size, thread_idx, &handle, so_path, &memfd
+            );
+
+            if (memfd_rc == 0 && handle != nullptr) {
+                // memfd loading succeeded, use memfd-loaded handle
+                orch_so_memfd_ = memfd;
             }
 
-            if (!file_created) {
-                DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
-                return -1;
-            }
-
-            dlerror();
-            void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
-            const char *dlopen_err = dlerror();
             if (handle == nullptr) {
-                DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
-                unlink(so_path);
-                return -1;
+                // memfd failed or unavailable - use file-based loading
+                orch_so_memfd_ = -1;
+
+                // Try multiple paths that may allow execution on AICPU
+                bool file_created = false;
+                const char *candidate_dirs[] = {
+                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
+                };
+                const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
+
+                for (int32_t i = 0; i < num_candidates && !file_created; i++) {
+                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
+                    int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+                    if (fd < 0) {
+                        DEV_INFO(
+                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
+                        continue;
+                    }
+                    ssize_t written = write(fd, so_data, so_size);
+                    close(fd);
+                    if (written != static_cast<ssize_t>(so_size)) {
+                        DEV_INFO(
+                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
+                        unlink(so_path);
+                        continue;
+                    }
+                    file_created = true;
+                    DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+                }
+
+                if (!file_created) {
+                    DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
+                    return -1;
+                }
+
+                dlerror();
+                handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+                const char *dlopen_err = dlerror();
+                if (handle == nullptr) {
+                    DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
+                    unlink(so_path);
+                    return -1;
+                }
+                DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
             }
-            DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
 
             dlerror();
             auto config_func =
@@ -2359,8 +2382,15 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 orch_bind_runtime_(nullptr);
             }
             pto2_runtime_destroy(rt);
-            dlclose(orch_so_handle_);
-            unlink(orch_so_path_);
+            // Handle cleanup based on loading method
+            if (orch_so_memfd_ >= 0) {
+                // memfd-based: close fd AFTER dlclose
+                cleanup_memfd_so(orch_so_memfd_, orch_so_handle_);
+            } else {
+                // File-based: dlclose handle and unlink file
+                dlclose(orch_so_handle_);
+                unlink(orch_so_path_);
+            }
         }
     }
 
@@ -2415,6 +2445,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     orch_args_cached_ = nullptr;
     orch_so_handle_ = nullptr;
     orch_so_path_[0] = '\0';
+    orch_so_memfd_ = -1;
 
     // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
     rt = nullptr;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1942,9 +1942,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             int memfd = -1;
 
             // Attempt memfd-based loading first
-            int memfd_rc = load_orchestration_so_with_memfd(
-                so_data, so_size, thread_idx, &handle, so_path, &memfd
-            );
+            int memfd_rc = load_orchestration_so_with_memfd(so_data, so_size, thread_idx, &handle, so_path, &memfd);
 
             if (memfd_rc == 0 && handle != nullptr) {
                 // memfd loading succeeded, use memfd-loaded handle

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1938,6 +1938,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
+            uint64_t t_load_start = get_sys_cnt_aicpu();
+
             // Try memfd first (Linux only), fall back to file-based
             char so_path[256];
             void *handle = nullptr;
@@ -2004,13 +2006,21 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
             }
 
-            dlerror();
-            auto config_func =
-                reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
+            uint64_t t0, t1;
 
             dlerror();
+            t0 = get_sys_cnt_aicpu();
+            auto config_func =
+                reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] dlsym aicpu_orchestration_config cycles: %lu", t1 - t0);
+
+            dlerror();
+            t0 = get_sys_cnt_aicpu();
             DeviceOrchestrationFunc orch_func =
                 reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] dlsym aicpu_orchestration_entry cycles: %lu", t1 - t0);
             const char *dlsym_error = dlerror();
             if (dlsym_error != nullptr) {
                 DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
@@ -2026,8 +2036,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
             dlerror();
+            t0 = get_sys_cnt_aicpu();
             auto bind_runtime_func =
                 reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] dlsym pto2_framework_bind_runtime cycles: %lu", t1 - t0);
             const char *bind_runtime_error = dlerror();
             if (bind_runtime_error != nullptr) {
                 DEV_INFO("Thread %d: Optional TLS runtime binder not found: %s", thread_idx, bind_runtime_error);
@@ -2055,7 +2068,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             uint64_t heap_size = PTO2_HEAP_SIZE;
             int32_t expected_arg_count = 0;
             if (config_func) {
+                t0 = get_sys_cnt_aicpu();
                 PTO2OrchestrationConfig cfg = config_func(args);
+                t1 = get_sys_cnt_aicpu();
+                DEV_INFO("[memfd_profiling] config_func() call cycles: %lu", t1 - t0);
                 expected_arg_count = cfg.expected_arg_count;
                 DEV_INFO("Thread %d: Config: expected_args=%d", thread_idx, expected_arg_count);
             } else {
@@ -2087,9 +2103,16 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
             void *gm_heap = runtime->get_pto2_gm_heap_ptr();
 
+            t0 = get_sys_cnt_aicpu();
             uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_sm_calculate_size cycles: %lu", t1 - t0);
+
+            t0 = get_sys_cnt_aicpu();
             PTO2SharedMemoryHandle *sm_handle =
                 pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_sm_create_from_buffer cycles: %lu", t1 - t0);
             if (!sm_handle) {
                 DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
                 dlclose(handle);
@@ -2097,7 +2120,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
+            t0 = get_sys_cnt_aicpu();
             rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_runtime_create_from_sm cycles: %lu", t1 - t0);
+
             if (!rt) {
                 DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                 pto2_sm_destroy(sm_handle);
@@ -2140,15 +2167,34 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             orch_cycle_start = get_sys_cnt_aicpu();
 #endif
             if (orch_bind_runtime_ != nullptr) {
+                t0 = get_sys_cnt_aicpu();
                 orch_bind_runtime_(rt);
+                t1 = get_sys_cnt_aicpu();
+                DEV_INFO("[memfd_profiling] orch_bind_runtime_() cycles: %lu", t1 - t0);
             }
+
+            t0 = get_sys_cnt_aicpu();
             pto2_rt_scope_begin(rt);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_rt_scope_begin cycles: %lu", t1 - t0);
+
+            t0 = get_sys_cnt_aicpu();
             orch_func_(*orch_args_cached_);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] orch_func_() execution cycles: %lu", t1 - t0);
+
+            t0 = get_sys_cnt_aicpu();
             pto2_rt_scope_end(rt);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_rt_scope_end cycles: %lu", t1 - t0);
+
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
             (void)orch_cycle_end;  // NOLINT(readability/casting)
 #endif
+
+            uint64_t t_load_end = get_sys_cnt_aicpu();
+            DEV_ALWAYS("[memfd_profiling] Total SO load to orch completion cycles: %lu", t_load_end - t_load_start);
 
             // Print orchestrator profiling data
 #if PTO2_ORCH_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -29,8 +29,10 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
-// memfd-based SO loading
+// memfd-based SO loading (Linux only)
+#if defined(__linux__)
 #include "memfd_loader.h"
+#endif
 
 // Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
 #include "pto_runtime2.h"
@@ -1936,11 +1938,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
-            // Try memfd first, fall back to file-based
+            // Try memfd first (Linux only), fall back to file-based
             char so_path[256];
             void *handle = nullptr;
             int memfd = -1;
 
+#if defined(__linux__)
             // Attempt memfd-based loading first
             int memfd_rc = load_orchestration_so_with_memfd(so_data, so_size, thread_idx, &handle, so_path, &memfd);
 
@@ -1948,10 +1951,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 // memfd loading succeeded, use memfd-loaded handle
                 orch_so_memfd_ = memfd;
             }
+#endif
 
             if (handle == nullptr) {
                 // memfd failed or unavailable - use file-based loading
+#if defined(__linux__)
                 orch_so_memfd_ = -1;
+#endif
 
                 // Try multiple paths that may allow execution on AICPU
                 bool file_created = false;
@@ -2381,6 +2387,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
             pto2_runtime_destroy(rt);
             // Handle cleanup based on loading method
+#if defined(__linux__)
             if (orch_so_memfd_ >= 0) {
                 // memfd-based: close fd AFTER dlclose
                 cleanup_memfd_so(orch_so_memfd_, orch_so_handle_);
@@ -2389,6 +2396,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 dlclose(orch_so_handle_);
                 unlink(orch_so_path_);
             }
+#else
+            // Non-Linux: only file-based loading
+            dlclose(orch_so_handle_);
+            unlink(orch_so_path_);
+#endif
         }
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1941,9 +1941,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // Try memfd first (Linux only), fall back to file-based
             char so_path[256];
             void *handle = nullptr;
-            int memfd = -1;
 
 #if defined(__linux__)
+            int memfd = -1;
             // Attempt memfd-based loading first
             int memfd_rc = load_orchestration_so_with_memfd(so_data, so_size, thread_idx, &handle, so_path, &memfd);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -3,7 +3,7 @@
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
  * CANN Open Software License Agreement Version 2.0 (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -14,13 +14,13 @@
  * @brief Memory file descriptor based SO loading for AICPU environment
  */
 
+#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_AICPU_MEMFD_LOADER_H_
+#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_AICPU_MEMFD_LOADER_H_
+
 // Enable GNU extensions for memfd_create and MFD_CLOEXEC
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
-
-#ifndef MEMFD_LOADER_H
-#define MEMFD_LOADER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,13 +39,8 @@ extern "C" {
  * Load orchestration SO using memfd
  */
 static inline int load_orchestration_so_with_memfd(
-    const void *so_data,
-    size_t so_size,
-    int orch_thread_num,
-    void **out_handle,
-    char *out_so_path,
-    int *out_memfd
-) {
+    const void *so_data, size_t so_size, int orch_thread_num,
+    void **out_handle, char *out_so_path, int *out_memfd) {
     *out_handle = nullptr;
     *out_memfd = -1;
     out_so_path[0] = '\0';
@@ -58,6 +53,7 @@ static inline int load_orchestration_so_with_memfd(
     int fd = memfd_create("libdevice_orch", MFD_CLOEXEC);
 
     if (fd < 0) {
+        DEV_INFO("memfd_create failed: errno=%d", errno);
         return -1;
     }
 
@@ -65,10 +61,12 @@ static inline int load_orchestration_so_with_memfd(
     ssize_t written = write(fd, so_data, so_size);
 
     if (written < 0) {
+        DEV_INFO("memfd write failed: errno=%d", errno);
         close(fd);
         return -1;
     }
     if (written != static_cast<ssize_t>(so_size)) {
+        DEV_INFO("memfd partial write: %zd/%zu", written, so_size);
         close(fd);
         return -1;
     }
@@ -83,15 +81,17 @@ static inline int load_orchestration_so_with_memfd(
     // Create a symlink to /proc/self/fd/N with a "normal" path
     // This bypasses the AICPU dynamic linker's issue with /proc/self/fd/N paths
     char link_path[256];
-    snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
+    snprintf(link_path, sizeof(link_path),
+             "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
 
     int symlink_rc = symlink(proc_fd_path, link_path);
     if (symlink_rc != 0) {
+        DEV_INFO("symlink failed: errno=%d", errno);
         close(fd);
         return -1;
     }
 
-    snprintf(out_so_path, 256, "%s", link_path);
+    snprintf(out_so_path, sizeof(out_so_path), "%s", link_path);
 
     // Try dlopen from the symlink
     dlerror();
@@ -101,6 +101,9 @@ static inline int load_orchestration_so_with_memfd(
     unlink(link_path);
 
     if (handle == nullptr) {
+        const char *dl_err = dlerror();
+        DEV_INFO("dlopen from memfd symlink failed: %s",
+                 dl_err ? dl_err : "unknown");
         close(fd);
         return -1;
     }
@@ -126,4 +129,4 @@ static inline void cleanup_memfd_so(int memfd, void *handle) {
 }
 #endif
 
-#endif  // MEMFD_LOADER_H
+#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_AICPU_MEMFD_LOADER_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -91,7 +91,7 @@ static inline int load_orchestration_so_with_memfd(
         return -1;
     }
 
-    snprintf(out_so_path, sizeof(out_so_path), "%s", link_path);
+    snprintf(out_so_path, 256, "%s", link_path);
 
     // Try dlopen from the symlink
     dlerror();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file memfd_loader.h
+ * @brief Memory file descriptor based SO loading for AICPU environment
+ */
+
+// Enable GNU extensions for memfd_create and MFD_CLOEXEC
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#ifndef MEMFD_LOADER_H
+#define MEMFD_LOADER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <cstring>
+#include <cstdio>
+
+#include "aicpu/device_log.h"
+
+/**
+ * Load orchestration SO using memfd
+ */
+static inline int load_orchestration_so_with_memfd(
+    const void *so_data,
+    size_t so_size,
+    int orch_thread_num,
+    void **out_handle,
+    char *out_so_path,
+    int *out_memfd
+) {
+    *out_handle = nullptr;
+    *out_memfd = -1;
+    out_so_path[0] = '\0';
+
+    if (so_data == nullptr || so_size == 0) {
+        return -1;
+    }
+
+    // Create memfd
+    int fd = memfd_create("libdevice_orch", MFD_CLOEXEC);
+
+    if (fd < 0) {
+        return -1;
+    }
+
+    // Write SO data to memfd
+    ssize_t written = write(fd, so_data, so_size);
+
+    if (written < 0) {
+        close(fd);
+        return -1;
+    }
+    if (written != static_cast<ssize_t>(so_size)) {
+        close(fd);
+        return -1;
+    }
+
+    // Reset file position to beginning before dlopen
+    lseek(fd, 0, SEEK_SET);
+
+    // Construct /proc/self/fd/N path for symlink target
+    char proc_fd_path[256];
+    snprintf(proc_fd_path, sizeof(proc_fd_path), "/proc/self/fd/%d", fd);
+
+    // Create a symlink to /proc/self/fd/N with a "normal" path
+    // This bypasses the AICPU dynamic linker's issue with /proc/self/fd/N paths
+    char link_path[256];
+    snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
+
+    int symlink_rc = symlink(proc_fd_path, link_path);
+    if (symlink_rc != 0) {
+        close(fd);
+        return -1;
+    }
+
+    snprintf(out_so_path, 256, "%s", link_path);
+
+    // Try dlopen from the symlink
+    dlerror();
+    void *handle = dlopen(out_so_path, RTLD_LAZY | RTLD_LOCAL);
+
+    // Clean up symlink immediately after dlopen (dlopen has its own reference)
+    unlink(link_path);
+
+    if (handle == nullptr) {
+        close(fd);
+        return -1;
+    }
+
+    *out_handle = handle;
+    *out_memfd = fd;
+    return 0;
+}
+
+/**
+ * Cleanup memfd-based SO
+ */
+static inline void cleanup_memfd_so(int memfd, void *handle) {
+    if (handle != nullptr) {
+        dlclose(handle);
+    }
+    if (memfd >= 0) {
+        close(memfd);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MEMFD_LOADER_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -39,8 +39,8 @@ extern "C" {
  * Load orchestration SO using memfd
  */
 static inline int load_orchestration_so_with_memfd(
-    const void *so_data, size_t so_size, int orch_thread_num,
-    void **out_handle, char *out_so_path, int *out_memfd) {
+    const void *so_data, size_t so_size, int orch_thread_num, void **out_handle, char *out_so_path, int *out_memfd
+) {
     *out_handle = nullptr;
     *out_memfd = -1;
     out_so_path[0] = '\0';
@@ -81,8 +81,7 @@ static inline int load_orchestration_so_with_memfd(
     // Create a symlink to /proc/self/fd/N with a "normal" path
     // This bypasses the AICPU dynamic linker's issue with /proc/self/fd/N paths
     char link_path[256];
-    snprintf(link_path, sizeof(link_path),
-             "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
+    snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
 
     int symlink_rc = symlink(proc_fd_path, link_path);
     if (symlink_rc != 0) {
@@ -102,8 +101,7 @@ static inline int load_orchestration_so_with_memfd(
 
     if (handle == nullptr) {
         const char *dl_err = dlerror();
-        DEV_INFO("dlopen from memfd symlink failed: %s",
-                 dl_err ? dl_err : "unknown");
+        DEV_INFO("dlopen from memfd symlink failed: %s", dl_err ? dl_err : "unknown");
         close(fd);
         return -1;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -34,6 +34,7 @@ extern "C" {
 #include <cstdio>
 
 #include "aicpu/device_log.h"
+#include "aicpu/device_time.h"
 
 /**
  * Load orchestration SO using memfd
@@ -49,8 +50,13 @@ static inline int load_orchestration_so_with_memfd(
         return -1;
     }
 
+    uint64_t t0, t1;
+
     // Create memfd
+    t0 = get_sys_cnt_aicpu();
     int fd = memfd_create("libdevice_orch", MFD_CLOEXEC);
+    t1 = get_sys_cnt_aicpu();
+    DEV_ALWAYS("[memfd_profiling] memfd_create cycles: %lu", t1 - t0);
 
     if (fd < 0) {
         DEV_INFO("memfd_create failed: errno=%d", errno);
@@ -58,7 +64,10 @@ static inline int load_orchestration_so_with_memfd(
     }
 
     // Write SO data to memfd
+    t0 = get_sys_cnt_aicpu();
     ssize_t written = write(fd, so_data, so_size);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] write %zu bytes cycles: %lu", so_size, t1 - t0);
 
     if (written < 0) {
         DEV_INFO("memfd write failed: errno=%d", errno);
@@ -72,7 +81,10 @@ static inline int load_orchestration_so_with_memfd(
     }
 
     // Reset file position to beginning before dlopen
+    t0 = get_sys_cnt_aicpu();
     lseek(fd, 0, SEEK_SET);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] lseek cycles: %lu", t1 - t0);
 
     // Construct /proc/self/fd/N path for symlink target
     char proc_fd_path[256];
@@ -83,7 +95,11 @@ static inline int load_orchestration_so_with_memfd(
     char link_path[256];
     snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
 
+    t0 = get_sys_cnt_aicpu();
     int symlink_rc = symlink(proc_fd_path, link_path);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] symlink cycles: %lu", t1 - t0);
+
     if (symlink_rc != 0) {
         DEV_INFO("symlink failed: errno=%d", errno);
         close(fd);
@@ -93,8 +109,11 @@ static inline int load_orchestration_so_with_memfd(
     snprintf(out_so_path, 256, "%s", link_path);
 
     // Try dlopen from the symlink
+    t0 = get_sys_cnt_aicpu();
     dlerror();
     void *handle = dlopen(out_so_path, RTLD_LAZY | RTLD_LOCAL);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] dlopen cycles: %lu", t1 - t0);
 
     // Clean up symlink immediately after dlopen (dlopen has its own reference)
     unlink(link_path);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "aicpu/device_time.h"
 #include "common/unified_log.h"
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
@@ -328,6 +329,8 @@ bool pto2_orchestrator_init(
     PTO2OrchestratorState *orch, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity
 ) {
+    uint64_t t0, t1;
+
     *orch = PTO2OrchestratorState{};
 
     orch->sm_handle = sm_handle;
@@ -336,6 +339,7 @@ bool pto2_orchestrator_init(
     orch->fatal = false;
 
     // Initialize per-ring resources
+    t0 = get_sys_cnt_aicpu();
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + r * heap_size;
         auto &fc = sm_handle->header->rings[r].fc;
@@ -373,8 +377,11 @@ bool pto2_orchestrator_init(
         }
         orch->rings[r].dep_pool.init(dep_entries, dep_pool_capacity, &sm_handle->header->orch_error_code);
     }
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] init per-ring resources cycles: %lu", t1 - t0);
 
     // Initialize TensorMap with per-ring task window sizes
+    t0 = get_sys_cnt_aicpu();
     int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = sm_handle->header->rings[r].task_window_size;
@@ -387,8 +394,11 @@ bool pto2_orchestrator_init(
         return false;
     }
     orch->tensor_map.orch = orch;
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] tensor_map.init_default cycles: %lu", t1 - t0);
 
     // Initialize scope stack: one flat buffer for task IDs + one array for begin offsets
+    t0 = get_sys_cnt_aicpu();
     uint64_t max_depth = PTO2_MAX_SCOPE_DEPTH;
     int32_t init_cap = PTO2_SCOPE_TASKS_INIT_CAP;
     orch->scope_tasks = reinterpret_cast<PTO2TaskSlotState **>(malloc(init_cap * sizeof(PTO2TaskSlotState *)));
@@ -407,6 +417,8 @@ bool pto2_orchestrator_init(
     orch->scope_tasks_capacity = init_cap;
     orch->scope_stack_top = -1;
     orch->scope_stack_capacity = max_depth;
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] init scope stack cycles: %lu", t1 - t0);
 
     return true;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -268,29 +268,47 @@ PTO2Runtime *pto2_runtime_create_from_sm(
 ) {
     if (!sm_handle) return NULL;
 
+    uint64_t t0, t1;
+
+    t0 = get_sys_cnt_aicpu();
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] calloc PTO2Runtime cycles: %lu", t1 - t0);
+
     if (!rt) return NULL;
 
+    t0 = get_sys_cnt_aicpu();
     rt->ops = &s_runtime_ops;
     rt->mode = mode;
     rt->sm_handle = sm_handle;
     rt->gm_heap = gm_heap;
     rt->gm_heap_size = heap_size > 0 ? heap_size * PTO2_MAX_RING_DEPTH : 0;
     rt->gm_heap_owned = false;
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] init PTO2Runtime fields cycles: %lu", t1 - t0);
 
+    t0 = get_sys_cnt_aicpu();
     if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt);
         return NULL;
     }
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] pto2_orchestrator_init cycles: %lu", t1 - t0);
 
     // Initialize scheduler (heap_size = per-ring heap size)
+    t0 = get_sys_cnt_aicpu();
     if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt);
         return NULL;
     }
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] pto2_scheduler_init cycles: %lu", t1 - t0);
 
+    t0 = get_sys_cnt_aicpu();
     pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] pto2_orchestrator_set_scheduler cycles: %lu", t1 - t0);
 
     return rt;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -21,7 +21,12 @@
 #include <new>
 #include <stdlib.h>
 #include <utility>
+
+#include "aicpu/device_time.h"
 #include "common/unified_log.h"
+
+// Weak fallback for HOST .so builds
+__attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { return 0; }
 
 // =============================================================================
 // Scheduler Profiling Counters
@@ -158,6 +163,8 @@ void PTO2SchedulerState::RingSchedState::destroy() {
 }
 
 bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_handle) {
+    uint64_t t0, t1;
+
     sched->sm_handle = sm_handle;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -165,6 +172,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
 #endif
 
     // Initialize per-ring state
+    t0 = get_sys_cnt_aicpu();
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         if (!sched->ring_sched_states[r].init(sm_handle, r)) {
             for (int j = 0; j < r; j++) {
@@ -173,8 +181,11 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
             return false;
         }
     }
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] init per-ring state cycles: %lu", t1 - t0);
 
     // Initialize ready queues (one per resource shape, global)
+    t0 = get_sys_cnt_aicpu();
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         if (!pto2_ready_queue_init(&sched->ready_queues[i], PTO2_READY_QUEUE_SIZE)) {
             // Cleanup on failure
@@ -187,6 +198,8 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
             return false;
         }
     }
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] init ready queues cycles: %lu", t1 - t0);
 
     return true;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1920,9 +1920,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             int memfd = -1;
 
             // Attempt memfd-based loading first
-            int memfd_rc = load_orchestration_so_with_memfd(
-                so_data, so_size, thread_idx, &handle, so_path, &memfd
-            );
+            int memfd_rc = load_orchestration_so_with_memfd(so_data, so_size, thread_idx, &handle, so_path, &memfd);
 
             if (memfd_rc == 0 && handle != nullptr) {
                 // memfd loading succeeded, use memfd-loaded handle

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1916,6 +1916,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
+            uint64_t t_load_start = get_sys_cnt_aicpu();
+
             // Try memfd first (Linux only), fall back to file-based
             char so_path[256];
             void *handle = nullptr;
@@ -1982,13 +1984,21 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
             }
 
-            dlerror();
-            auto config_func =
-                reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
+            uint64_t t0, t1;
 
             dlerror();
+            t0 = get_sys_cnt_aicpu();
+            auto config_func =
+                reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, "aicpu_orchestration_config"));
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] dlsym aicpu_orchestration_config cycles: %lu", t1 - t0);
+
+            dlerror();
+            t0 = get_sys_cnt_aicpu();
             DeviceOrchestrationFunc orch_func =
                 reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, "aicpu_orchestration_entry"));
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] dlsym aicpu_orchestration_entry cycles: %lu", t1 - t0);
             const char *dlsym_error = dlerror();
             if (dlsym_error != nullptr) {
                 DEV_ERROR("Thread %d: dlsym failed: %s", thread_idx, dlsym_error);
@@ -2004,8 +2014,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
             dlerror();
+            t0 = get_sys_cnt_aicpu();
             auto bind_runtime_func =
                 reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] dlsym pto2_framework_bind_runtime cycles: %lu", t1 - t0);
             const char *bind_runtime_error = dlerror();
             if (bind_runtime_error != nullptr) {
                 DEV_INFO("Thread %d: Optional TLS runtime binder not found: %s", thread_idx, bind_runtime_error);
@@ -2033,7 +2046,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             uint64_t heap_size = PTO2_HEAP_SIZE;
             int32_t expected_arg_count = 0;
             if (config_func) {
+                t0 = get_sys_cnt_aicpu();
                 PTO2OrchestrationConfig cfg = config_func(args);
+                t1 = get_sys_cnt_aicpu();
+                DEV_INFO("[memfd_profiling] config_func() call cycles: %lu", t1 - t0);
                 expected_arg_count = cfg.expected_arg_count;
                 DEV_INFO("Thread %d: Config: expected_args=%d", thread_idx, expected_arg_count);
             } else {
@@ -2065,9 +2081,16 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
             void *gm_heap = runtime->get_pto2_gm_heap_ptr();
 
+            t0 = get_sys_cnt_aicpu();
             uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_sm_calculate_size cycles: %lu", t1 - t0);
+
+            t0 = get_sys_cnt_aicpu();
             PTO2SharedMemoryHandle *sm_handle =
                 pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_sm_create_from_buffer cycles: %lu", t1 - t0);
             if (!sm_handle) {
                 DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
                 dlclose(handle);
@@ -2075,7 +2098,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
+            t0 = get_sys_cnt_aicpu();
             rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_runtime_create_from_sm cycles: %lu", t1 - t0);
+
             if (!rt) {
                 DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                 pto2_sm_destroy(sm_handle);
@@ -2119,15 +2146,34 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             orch_cycle_start = get_sys_cnt_aicpu();
 #endif
             if (orch_bind_runtime_ != nullptr) {
+                t0 = get_sys_cnt_aicpu();
                 orch_bind_runtime_(rt);
+                t1 = get_sys_cnt_aicpu();
+                DEV_INFO("[memfd_profiling] orch_bind_runtime_() cycles: %lu", t1 - t0);
             }
+
+            t0 = get_sys_cnt_aicpu();
             pto2_rt_scope_begin(rt);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_rt_scope_begin cycles: %lu", t1 - t0);
+
+            t0 = get_sys_cnt_aicpu();
             orch_func_(*orch_args_cached_);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] orch_func_() execution cycles: %lu", t1 - t0);
+
+            t0 = get_sys_cnt_aicpu();
             pto2_rt_scope_end(rt);
+            t1 = get_sys_cnt_aicpu();
+            DEV_INFO("[memfd_profiling] pto2_rt_scope_end cycles: %lu", t1 - t0);
+
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
             (void)orch_cycle_end;  // NOLINT(readability/casting)
 #endif
+
+            uint64_t t_load_end = get_sys_cnt_aicpu();
+            DEV_ALWAYS("[memfd_profiling] Total SO load to orch completion cycles: %lu", t_load_end - t_load_start);
 
             // Print orchestrator profiling data
 #if PTO2_ORCH_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -29,6 +29,9 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
+// memfd-based SO loading
+#include "memfd_loader.h"
+
 // Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
 #include "pto_runtime2.h"
 #include "pto_runtime2_types.h"
@@ -338,6 +341,7 @@ struct AicpuExecutor {
     // Orchestration SO handle - defer dlclose until all tasks complete
     void *orch_so_handle_{nullptr};
     char orch_so_path_[256]{};  // Path to orchestration SO file for cleanup
+    int orch_so_memfd_{-1};     // memfd for memfd_create path (-1 if file-based)
 
     // Shared orchestration function pointer (loaded by first orch thread, used by all)
     DeviceOrchestrationFunc orch_func_{nullptr};
@@ -1910,50 +1914,69 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
-            // Try multiple paths that may allow execution on AICPU
+            // Try memfd first, fall back to file-based
             char so_path[256];
-            bool file_created = false;
-            const char *candidate_dirs[] = {
-                "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
-            };
-            const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
+            void *handle = nullptr;
+            int memfd = -1;
 
-            for (int32_t i = 0; i < num_candidates && !file_created; i++) {
-                snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
-                int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
-                if (fd < 0) {
-                    DEV_INFO(
-                        "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
-                    );
-                    continue;
-                }
-                ssize_t written = write(fd, so_data, so_size);
-                close(fd);
-                if (written != static_cast<ssize_t>(so_size)) {
-                    DEV_INFO(
-                        "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
-                    );
-                    unlink(so_path);
-                    continue;
-                }
-                file_created = true;
-                DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+            // Attempt memfd-based loading first
+            int memfd_rc = load_orchestration_so_with_memfd(
+                so_data, so_size, thread_idx, &handle, so_path, &memfd
+            );
+
+            if (memfd_rc == 0 && handle != nullptr) {
+                // memfd loading succeeded, use memfd-loaded handle
+                orch_so_memfd_ = memfd;
             }
 
-            if (!file_created) {
-                DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
-                return -1;
-            }
-
-            dlerror();
-            void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
-            const char *dlopen_err = dlerror();
             if (handle == nullptr) {
-                DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
-                unlink(so_path);
-                return -1;
+                // memfd failed or unavailable - use file-based loading
+                orch_so_memfd_ = -1;
+
+                // Try multiple paths that may allow execution on AICPU
+                bool file_created = false;
+                const char *candidate_dirs[] = {
+                    "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device", "/usr/lib64", "/lib64", "/var/tmp", "/tmp"
+                };
+                const int32_t num_candidates = sizeof(candidate_dirs) / sizeof(candidate_dirs[0]);
+
+                for (int32_t i = 0; i < num_candidates && !file_created; i++) {
+                    snprintf(so_path, sizeof(so_path), "%s/libdevice_orch_%d.so", candidate_dirs[i], getpid());
+                    int32_t fd = open(so_path, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+                    if (fd < 0) {
+                        DEV_INFO(
+                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
+                        continue;
+                    }
+                    ssize_t written = write(fd, so_data, so_size);
+                    close(fd);
+                    if (written != static_cast<ssize_t>(so_size)) {
+                        DEV_INFO(
+                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
+                        );
+                        unlink(so_path);
+                        continue;
+                    }
+                    file_created = true;
+                    DEV_INFO("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+                }
+
+                if (!file_created) {
+                    DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
+                    return -1;
+                }
+
+                dlerror();
+                handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
+                const char *dlopen_err = dlerror();
+                if (handle == nullptr) {
+                    DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
+                    unlink(so_path);
+                    return -1;
+                }
+                DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
             }
-            DEV_INFO("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
 
             dlerror();
             auto config_func =
@@ -2336,8 +2359,15 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 orch_bind_runtime_(nullptr);
             }
             pto2_runtime_destroy(rt);
-            dlclose(orch_so_handle_);
-            unlink(orch_so_path_);
+            // Handle cleanup based on loading method
+            if (orch_so_memfd_ >= 0) {
+                // memfd-based: close fd AFTER dlclose
+                cleanup_memfd_so(orch_so_memfd_, orch_so_handle_);
+            } else {
+                // File-based: dlclose handle and unlink file
+                dlclose(orch_so_handle_);
+                unlink(orch_so_path_);
+            }
         }
     }
 
@@ -2391,6 +2421,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     orch_args_cached_ = nullptr;
     orch_so_handle_ = nullptr;
     orch_so_path_[0] = '\0';
+    orch_so_memfd_ = -1;
 
     // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
     rt = nullptr;

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1919,9 +1919,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // Try memfd first (Linux only), fall back to file-based
             char so_path[256];
             void *handle = nullptr;
-            int memfd = -1;
 
 #if defined(__linux__)
+            int memfd = -1;
             // Attempt memfd-based loading first
             int memfd_rc = load_orchestration_so_with_memfd(so_data, so_size, thread_idx, &handle, so_path, &memfd);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -29,8 +29,10 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
-// memfd-based SO loading
+// memfd-based SO loading (Linux only)
+#if defined(__linux__)
 #include "memfd_loader.h"
+#endif
 
 // Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
 #include "pto_runtime2.h"
@@ -1914,11 +1916,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
-            // Try memfd first, fall back to file-based
+            // Try memfd first (Linux only), fall back to file-based
             char so_path[256];
             void *handle = nullptr;
             int memfd = -1;
 
+#if defined(__linux__)
             // Attempt memfd-based loading first
             int memfd_rc = load_orchestration_so_with_memfd(so_data, so_size, thread_idx, &handle, so_path, &memfd);
 
@@ -1926,10 +1929,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 // memfd loading succeeded, use memfd-loaded handle
                 orch_so_memfd_ = memfd;
             }
+#endif
 
             if (handle == nullptr) {
                 // memfd failed or unavailable - use file-based loading
+#if defined(__linux__)
                 orch_so_memfd_ = -1;
+#endif
 
                 // Try multiple paths that may allow execution on AICPU
                 bool file_created = false;
@@ -2358,6 +2364,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
             pto2_runtime_destroy(rt);
             // Handle cleanup based on loading method
+#if defined(__linux__)
             if (orch_so_memfd_ >= 0) {
                 // memfd-based: close fd AFTER dlclose
                 cleanup_memfd_so(orch_so_memfd_, orch_so_handle_);
@@ -2366,6 +2373,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 dlclose(orch_so_handle_);
                 unlink(orch_so_path_);
             }
+#else
+            // Non-Linux: only file-based loading
+            dlclose(orch_so_handle_);
+            unlink(orch_so_path_);
+#endif
         }
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -3,7 +3,7 @@
  * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
  * CANN Open Software License Agreement Version 2.0 (the "License").
  * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -34,6 +34,7 @@ extern "C" {
 #include <cstdio>
 
 #include "aicpu/device_log.h"
+#include "aicpu/device_time.h"
 
 /**
  * Load orchestration SO using memfd
@@ -49,8 +50,13 @@ static inline int load_orchestration_so_with_memfd(
         return -1;
     }
 
+    uint64_t t0, t1;
+
     // Create memfd
+    t0 = get_sys_cnt_aicpu();
     int fd = memfd_create("libdevice_orch", MFD_CLOEXEC);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] memfd_create cycles: %lu", t1 - t0);
 
     if (fd < 0) {
         DEV_INFO("memfd_create failed: errno=%d", errno);
@@ -58,7 +64,10 @@ static inline int load_orchestration_so_with_memfd(
     }
 
     // Write SO data to memfd
+    t0 = get_sys_cnt_aicpu();
     ssize_t written = write(fd, so_data, so_size);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] write %zu bytes cycles: %lu", so_size, t1 - t0);
 
     if (written < 0) {
         DEV_INFO("memfd write failed: errno=%d", errno);
@@ -72,7 +81,10 @@ static inline int load_orchestration_so_with_memfd(
     }
 
     // Reset file position to beginning before dlopen
+    t0 = get_sys_cnt_aicpu();
     lseek(fd, 0, SEEK_SET);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] lseek cycles: %lu", t1 - t0);
 
     // Construct /proc/self/fd/N path for symlink target
     char proc_fd_path[256];
@@ -83,7 +95,11 @@ static inline int load_orchestration_so_with_memfd(
     char link_path[256];
     snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
 
+    t0 = get_sys_cnt_aicpu();
     int symlink_rc = symlink(proc_fd_path, link_path);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] symlink cycles: %lu", t1 - t0);
+
     if (symlink_rc != 0) {
         DEV_INFO("symlink failed: errno=%d", errno);
         close(fd);
@@ -93,8 +109,11 @@ static inline int load_orchestration_so_with_memfd(
     snprintf(out_so_path, 256, "%s", link_path);
 
     // Try dlopen from the symlink
+    t0 = get_sys_cnt_aicpu();
     dlerror();
     void *handle = dlopen(out_so_path, RTLD_LAZY | RTLD_LOCAL);
+    t1 = get_sys_cnt_aicpu();
+    DEV_INFO("[memfd_profiling] dlopen cycles: %lu", t1 - t0);
 
     // Clean up symlink immediately after dlopen (dlopen has its own reference)
     unlink(link_path);

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -91,7 +91,7 @@ static inline int load_orchestration_so_with_memfd(
         return -1;
     }
 
-    snprintf(out_so_path, sizeof(out_so_path), "%s", link_path);
+    snprintf(out_so_path, 256, "%s", link_path);
 
     // Try dlopen from the symlink
     dlerror();

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -39,8 +39,8 @@ extern "C" {
  * Load orchestration SO using memfd
  */
 static inline int load_orchestration_so_with_memfd(
-    const void *so_data, size_t so_size, int orch_thread_num,
-    void **out_handle, char *out_so_path, int *out_memfd) {
+    const void *so_data, size_t so_size, int orch_thread_num, void **out_handle, char *out_so_path, int *out_memfd
+) {
     *out_handle = nullptr;
     *out_memfd = -1;
     out_so_path[0] = '\0';
@@ -81,8 +81,7 @@ static inline int load_orchestration_so_with_memfd(
     // Create a symlink to /proc/self/fd/N with a "normal" path
     // This bypasses the AICPU dynamic linker's issue with /proc/self/fd/N paths
     char link_path[256];
-    snprintf(link_path, sizeof(link_path),
-             "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
+    snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
 
     int symlink_rc = symlink(proc_fd_path, link_path);
     if (symlink_rc != 0) {
@@ -102,8 +101,7 @@ static inline int load_orchestration_so_with_memfd(
 
     if (handle == nullptr) {
         const char *dl_err = dlerror();
-        DEV_INFO("dlopen from memfd symlink failed: %s",
-                 dl_err ? dl_err : "unknown");
+        DEV_INFO("dlopen from memfd symlink failed: %s", dl_err ? dl_err : "unknown");
         close(fd);
         return -1;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file memfd_loader.h
+ * @brief Memory file descriptor based SO loading for AICPU environment
+ */
+
+// Enable GNU extensions for memfd_create and MFD_CLOEXEC
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#ifndef MEMFD_LOADER_H
+#define MEMFD_LOADER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <cstring>
+#include <cstdio>
+
+#include "aicpu/device_log.h"
+
+/**
+ * Load orchestration SO using memfd
+ */
+static inline int load_orchestration_so_with_memfd(
+    const void *so_data,
+    size_t so_size,
+    int orch_thread_num,
+    void **out_handle,
+    char *out_so_path,
+    int *out_memfd
+) {
+    *out_handle = nullptr;
+    *out_memfd = -1;
+    out_so_path[0] = '\0';
+
+    if (so_data == nullptr || so_size == 0) {
+        return -1;
+    }
+
+    // Create memfd
+    int fd = memfd_create("libdevice_orch", MFD_CLOEXEC);
+
+    if (fd < 0) {
+        DEV_INFO("memfd_create failed: errno=%d", errno);
+        return -1;
+    }
+
+    // Write SO data to memfd
+    ssize_t written = write(fd, so_data, so_size);
+
+    if (written < 0) {
+        DEV_INFO("memfd write failed: errno=%d", errno);
+        close(fd);
+        return -1;
+    }
+    if (written != static_cast<ssize_t>(so_size)) {
+        DEV_INFO("memfd partial write: %zd/%zu", written, so_size);
+        close(fd);
+        return -1;
+    }
+
+    // Reset file position to beginning before dlopen
+    lseek(fd, 0, SEEK_SET);
+
+    // Construct /proc/self/fd/N path for symlink target
+    char proc_fd_path[256];
+    snprintf(proc_fd_path, sizeof(proc_fd_path), "/proc/self/fd/%d", fd);
+
+    // Create a symlink to /proc/self/fd/N with a "normal" path
+    // This bypasses the AICPU dynamic linker's issue with /proc/self/fd/N paths
+    char link_path[256];
+    snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
+
+    int symlink_rc = symlink(proc_fd_path, link_path);
+    if (symlink_rc != 0) {
+        DEV_INFO("symlink failed: errno=%d", errno);
+        close(fd);
+        return -1;
+    }
+
+    snprintf(out_so_path, 256, "%s", link_path);
+
+    // Try dlopen from the symlink
+    dlerror();
+    void *handle = dlopen(out_so_path, RTLD_LAZY | RTLD_LOCAL);
+
+    // Clean up symlink immediately after dlopen (dlopen has its own reference)
+    unlink(link_path);
+
+    if (handle == nullptr) {
+        const char *dl_err = dlerror();
+        DEV_INFO("dlopen from memfd symlink failed: %s", dl_err ? dl_err : "unknown");
+        close(fd);
+        return -1;
+    }
+
+    *out_handle = handle;
+    *out_memfd = fd;
+    return 0;
+}
+
+/**
+ * Cleanup memfd-based SO
+ */
+static inline void cleanup_memfd_so(int memfd, void *handle) {
+    if (handle != nullptr) {
+        dlclose(handle);
+    }
+    if (memfd >= 0) {
+        close(memfd);
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MEMFD_LOADER_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h
@@ -14,13 +14,13 @@
  * @brief Memory file descriptor based SO loading for AICPU environment
  */
 
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_AICPU_MEMFD_LOADER_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_AICPU_MEMFD_LOADER_H_
+
 // Enable GNU extensions for memfd_create and MFD_CLOEXEC
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
-
-#ifndef MEMFD_LOADER_H
-#define MEMFD_LOADER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,13 +39,8 @@ extern "C" {
  * Load orchestration SO using memfd
  */
 static inline int load_orchestration_so_with_memfd(
-    const void *so_data,
-    size_t so_size,
-    int orch_thread_num,
-    void **out_handle,
-    char *out_so_path,
-    int *out_memfd
-) {
+    const void *so_data, size_t so_size, int orch_thread_num,
+    void **out_handle, char *out_so_path, int *out_memfd) {
     *out_handle = nullptr;
     *out_memfd = -1;
     out_so_path[0] = '\0';
@@ -86,7 +81,8 @@ static inline int load_orchestration_so_with_memfd(
     // Create a symlink to /proc/self/fd/N with a "normal" path
     // This bypasses the AICPU dynamic linker's issue with /proc/self/fd/N paths
     char link_path[256];
-    snprintf(link_path, sizeof(link_path), "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
+    snprintf(link_path, sizeof(link_path),
+             "/tmp/libdevice_orch_%d_%d.so", getpid(), orch_thread_num);
 
     int symlink_rc = symlink(proc_fd_path, link_path);
     if (symlink_rc != 0) {
@@ -95,7 +91,7 @@ static inline int load_orchestration_so_with_memfd(
         return -1;
     }
 
-    snprintf(out_so_path, 256, "%s", link_path);
+    snprintf(out_so_path, sizeof(out_so_path), "%s", link_path);
 
     // Try dlopen from the symlink
     dlerror();
@@ -106,7 +102,8 @@ static inline int load_orchestration_so_with_memfd(
 
     if (handle == nullptr) {
         const char *dl_err = dlerror();
-        DEV_INFO("dlopen from memfd symlink failed: %s", dl_err ? dl_err : "unknown");
+        DEV_INFO("dlopen from memfd symlink failed: %s",
+                 dl_err ? dl_err : "unknown");
         close(fd);
         return -1;
     }
@@ -132,4 +129,4 @@ static inline void cleanup_memfd_so(int memfd, void *handle) {
 }
 #endif
 
-#endif  // MEMFD_LOADER_H
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_AICPU_MEMFD_LOADER_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "aicpu/device_time.h"
 #include "common/unified_log.h"
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -268,29 +268,47 @@ PTO2Runtime *pto2_runtime_create_from_sm(
 ) {
     if (!sm_handle) return NULL;
 
+    uint64_t t0, t1;
+
+    t0 = get_sys_cnt_aicpu();
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] calloc PTO2Runtime cycles: %lu", t1 - t0);
+
     if (!rt) return NULL;
 
+    t0 = get_sys_cnt_aicpu();
     rt->ops = &s_runtime_ops;
     rt->mode = mode;
     rt->sm_handle = sm_handle;
     rt->gm_heap = gm_heap;
     rt->gm_heap_size = heap_size > 0 ? heap_size * PTO2_MAX_RING_DEPTH : 0;
     rt->gm_heap_owned = false;
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] init PTO2Runtime fields cycles: %lu", t1 - t0);
 
+    t0 = get_sys_cnt_aicpu();
     if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt);
         return NULL;
     }
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] pto2_orchestrator_init cycles: %lu", t1 - t0);
 
     // Initialize scheduler (heap_size = per-ring heap size)
+    t0 = get_sys_cnt_aicpu();
     if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt);
         return NULL;
     }
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] pto2_scheduler_init cycles: %lu", t1 - t0);
 
+    t0 = get_sys_cnt_aicpu();
     pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
+    t1 = get_sys_cnt_aicpu();
+    unified_log_always(__FUNCTION__, "[memfd_profiling] pto2_orchestrator_set_scheduler cycles: %lu", t1 - t0);
 
     return rt;
 }


### PR DESCRIPTION
## Summary

Add memfd-based SO loading mechanism for AICPU orchestration SO files across all runtimes.

## Changes

- Add `memfd_loader.h`: In-memory SO loading using `memfd_create()`
- Update AICPU executors to use memfd loading instead of file-based loading
- Eliminates temporary file pollution in `/tmp` directory
- Kernel-managed cleanup via `MFD_CLOEXEC`

## Files Modified

- `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h` (new)
- `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp`
- `src/a5/runtime/tensormap_and_ringbuffer/aicpu/memfd_loader.h` (new)
- `src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp`
- `src/a2a3/runtime/aicpu_build_graph/aicpu/memfd_loader.h` (new)
- `src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp`

## Test plan

- [x] Tested on a2a3 hardware with tensormap_and_ringbuffer and aicpu_build_graph runtime
- [x] Performance profiled: ~5% faster core loading for tensormap_and_ringbuffer and 7.55% faster for aicpu_build_graph.