### PR TITLE
Fix: rename BLK local var to avoid CANN 8.5.1 macro collision

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -297,8 +297,8 @@ struct alignas(64) Tensor {
         always_assert(reinterpret_cast<char *>(buffer.addr) != nullptr);
         uint64_t elem_size = get_element_size(dtype);
         char *dst = reinterpret_cast<char *>(buffer.addr);
-        constexpr uint64_t BLK = 64;
-        uint64_t blk = (buffer.size < BLK) ? buffer.size : BLK;
+        constexpr uint64_t blk_size = 64;
+        uint64_t blk = (buffer.size < blk_size) ? buffer.size : blk_size;
         for (uint64_t b = 0; b < blk; b += elem_size) {
             memcpy(dst + b, &initial_value, elem_size);
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -297,8 +297,8 @@ struct alignas(64) Tensor {
         always_assert(reinterpret_cast<char *>(buffer.addr) != nullptr);
         uint64_t elem_size = get_element_size(dtype);
         char *dst = reinterpret_cast<char *>(buffer.addr);
-        constexpr uint64_t BLK = 64;
-        uint64_t blk = (buffer.size < BLK) ? buffer.size : BLK;
+        constexpr uint64_t blk_size = 64;
+        uint64_t blk = (buffer.size < blk_size) ? buffer.size : blk_size;
         for (uint64_t b = 0; b < blk; b += elem_size) {
             memcpy(dst + b, &initial_value, elem_size);
         }


### PR DESCRIPTION
## Summary

- Rename `constexpr uint64_t BLK = 64` to `blk_size` in `fill_initial_value()` for both `a2a3` and `a5` tensor.h
- CANN 8.5.1 defines `#define BLK BLK_Type()` in `__clang_cce_vector_intrinsics.h:555`, causing the device compiler to expand the local variable declaration into invalid code

## Testing

- [ ] Simulation tests pass
- [ ] Hardware tests pass (if applicable)

Fixes #517