### PR TITLE
Fix: report PTO2 fatal through runtime return

### DIFF
--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 
+#include <atomic>
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -366,12 +367,17 @@ int DeviceRunner::run(
     LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
     std::vector<std::thread> aicpu_threads;
     aicpu_threads.reserve(over_launch);
+    std::atomic<int> aicpu_rc{0};
     for (int i = 0; i < over_launch; i++) {
-        aicpu_threads.push_back(create_thread([this, &runtime, launch_aicpu_num, over_launch]() {
+        aicpu_threads.push_back(create_thread([this, &runtime, launch_aicpu_num, over_launch, &aicpu_rc]() {
             if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
                 return;
             }
-            aicpu_execute_func_(&runtime);
+            int rc = aicpu_execute_func_(&runtime);
+            if (rc != 0) {
+                int expected = 0;
+                aicpu_rc.compare_exchange_strong(expected, rc, std::memory_order_acq_rel);
+            }
         }));
     }
 
@@ -414,6 +420,12 @@ int DeviceRunner::run(
     }
 
     LOG_INFO("All threads completed");
+
+    int runtime_rc = aicpu_rc.load(std::memory_order_acquire);
+    if (runtime_rc != 0) {
+        LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
+        return runtime_rc;
+    }
 
     // Stop memory management, drain remaining buffers, collect phase data, export
     if (runtime.enable_profiling) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -89,6 +89,22 @@ constexpr int32_t STALL_DUMP_CORE_MAX = 8;
 constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
 constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
 
+static int32_t read_pto2_runtime_status(Runtime *runtime) {
+    if (runtime == nullptr) {
+        return 0;
+    }
+
+    void *sm = runtime->get_pto2_gm_sm_ptr();
+    if (sm == nullptr) {
+        return 0;
+    }
+
+    auto *header = static_cast<PTO2SharedMemoryHeader *>(sm);
+    int32_t orch_error_code = header->orch_error_code.load(std::memory_order_acquire);
+    int32_t sched_error_code = header->sched_error_code.load(std::memory_order_acquire);
+    return pto2_runtime_status_from_error_codes(orch_error_code, sched_error_code);
+}
+
 static PTO2Runtime *rt{nullptr};
 
 // Per-core dispatch payload storage: dual-buffer to allow pipelining.
@@ -2876,10 +2892,17 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
         return rc;
     }
 
+    int32_t runtime_rc = read_pto2_runtime_status(runtime);
+
     // Last thread cleans up
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
         DEV_INFO("aicpu_execute: Last thread finished, cleaning up");
         g_aicpu_executor.deinit(runtime);
+    }
+
+    if (runtime_rc != 0) {
+        DEV_ERROR("aicpu_execute: PTO2 runtime failed with rc=%d", runtime_rc);
+        return runtime_rc;
     }
 
     DEV_INFO("%s", "aicpu_execute: Kernel execution completed successfully");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -780,7 +780,7 @@ struct AicpuExecutor {
         }
         // Per-dispatch local context: read block_idx/block_num directly from slot_state.
         dispatch_payload.local_context.block_idx = slot_state.next_block_idx;
-        dispatch_payload.local_context.block_num = slot_state.block_num;
+        dispatch_payload.local_context.block_num = slot_state.logical_block_num;
         // Store context pointers at fixed suffix positions in args[]
         // (GlobalContext content is already set by init_global_context, but the
         //  pointer must be written each dispatch since args[] is rebuilt entirely)
@@ -1770,8 +1770,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                     if (pto2_requires_sync_start(slot_state->active_mask)) {
                         int32_t available = (shape == PTO2ResourceShape::AIV) ? tracker.count_idle_aiv_cores() :
                                                                                 valid_cluster_states.count();
-                        if (available < slot_state->block_num) {
-                            if (!enter_drain_mode(slot_state, slot_state->block_num)) {
+                        if (available < slot_state->logical_block_num) {
+                            if (!enter_drain_mode(slot_state, slot_state->logical_block_num)) {
                                 // CAS lost: drain already active for another task; re-push and wait.
                                 rt->scheduler.ready_queues[static_cast<int32_t>(shape)].push(slot_state);
                             }
@@ -1799,18 +1799,20 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                         slot_state->next_block_idx++;
                         // For AIV, refresh cluster states so the do-while can pick up the
                         // other AIV core in the same cluster on the next iteration.
-                        if (shape == PTO2ResourceShape::AIV && slot_state->next_block_idx < slot_state->block_num) {
+                        if (shape == PTO2ResourceShape::AIV &&
+                            slot_state->next_block_idx < slot_state->logical_block_num) {
                             valid_cluster_states = tracker.get_idle_cluster_offset_states(shape);
                         }
                         DEV_DEBUG(
                             "Thread %d: Dispatched %s task %" PRId64 " block %d/%d to cluster_offset %d", thread_idx,
                             shape_name(shape), static_cast<int64_t>(slot_state->task->task_id.raw),
-                            slot_state->next_block_idx - 1, slot_state->block_num, current_valid_cluster_offset
+                            slot_state->next_block_idx - 1, slot_state->logical_block_num, current_valid_cluster_offset
                         );
-                    } while (slot_state->next_block_idx < slot_state->block_num && valid_cluster_states.has_value());
+                    } while (slot_state->next_block_idx < slot_state->logical_block_num &&
+                             valid_cluster_states.has_value());
 
                     // Re-enqueue only if blocks remain after exhausting local clusters
-                    if (slot_state->next_block_idx < slot_state->block_num) {
+                    if (slot_state->next_block_idx < slot_state->logical_block_num) {
                         rt->scheduler.ready_queues[static_cast<int32_t>(shape)].push(slot_state);
                     }
                     made_progress = true;
@@ -1865,7 +1867,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 #endif
                         );
                         slot_state->next_block_idx++;
-                        if (slot_state->next_block_idx < slot_state->block_num) {
+                        if (slot_state->next_block_idx < slot_state->logical_block_num) {
                             rt->scheduler.ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC)].push(slot_state);
                         }
                         made_progress = true;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * PTO2 Runtime Status Helpers
+ *
+ * Shared error-code contract used inside the tensormap_and_ringbuffer runtime.
+ */
+
+#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_
+#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_
+
+#include <stdint.h>
+
+// Orchestrator errors (1-99): detected in orchestrator thread
+#define PTO2_ERROR_NONE 0  // Explicitly means "no error"; it is not an "unknown/unspecified" error code.
+#define PTO2_ERROR_SCOPE_DEADLOCK 1
+#define PTO2_ERROR_HEAP_RING_DEADLOCK 2
+#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK 3
+#define PTO2_ERROR_DEP_POOL_OVERFLOW 4
+#define PTO2_ERROR_INVALID_ARGS 5         // Arg construction error (invalid args)
+#define PTO2_ERROR_DEPENDENCY_OVERFLOW 6  // Too many unique fanin dependencies for one task
+#define PTO2_ERROR_REQUIRE_SYNC_START_INVALID 7
+#define PTO2_ERROR_TENSOR_WAIT_TIMEOUT 8
+#define PTO2_ERROR_EXPLICIT_ORCH_FATAL 9
+
+// Scheduler errors (100+): detected in scheduler threads
+#define PTO2_ERROR_SCHEDULER_TIMEOUT 100
+
+static inline int32_t pto2_runtime_status_from_error_codes(int32_t orch_error_code, int32_t sched_error_code) {
+    if (orch_error_code != PTO2_ERROR_NONE) {
+        return orch_error_code < 0 ? orch_error_code : -orch_error_code;
+    }
+    if (sched_error_code != PTO2_ERROR_NONE) {
+        return sched_error_code < 0 ? sched_error_code : -sched_error_code;
+    }
+    return 0;
+}
+
+#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -35,6 +35,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "../common/pto_runtime_status.h"
 #include "../runtime/pto_shared_memory.h"
 #include "../runtime/runtime.h"
 #include "callable.h"
@@ -67,6 +68,27 @@ static uint64_t parse_env_uint64(const char *name, uint64_t min_val, bool requir
         return 0;
     }
     return static_cast<uint64_t>(val);
+}
+
+static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader *host_header) {
+    if (runtime == nullptr || host_header == nullptr) {
+        return 0;
+    }
+
+    void *pto2_sm = runtime->get_pto2_gm_sm_ptr();
+    if (pto2_sm == nullptr) {
+        return 0;
+    }
+
+    int hdr_rc = runtime->host_api.copy_from_device(host_header, pto2_sm, sizeof(PTO2SharedMemoryHeader));
+    if (hdr_rc != 0) {
+        LOG_WARN("Failed to copy PTO2 header from device");
+        return 0;
+    }
+
+    int32_t orch_error_code = host_header->orch_error_code.load(std::memory_order_relaxed);
+    int32_t sched_error_code = host_header->sched_error_code.load(std::memory_order_relaxed);
+    return pto2_runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
 /**
@@ -299,58 +321,67 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     LOG_INFO("Tensor pairs to process: %d", tensor_pair_count);
 
     // PTO2 (device orchestration): graph output may be in packed buffer
-    void *pto2_sm = runtime->get_pto2_gm_sm_ptr();
     uint64_t graph_out_ptr = 0;
     uint64_t graph_out_size = 0;
+    bool skip_tensor_copy_back = false;
+    int32_t runtime_status = 0;
+    PTO2SharedMemoryHeader host_header;
+    memset(&host_header, 0, sizeof(host_header));
 
-    if (pto2_sm != nullptr) {
-        // Copy header from device to host to read graph_output_ptr/size
-        PTO2SharedMemoryHeader host_header;
-        int hdr_rc = runtime->host_api.copy_from_device(&host_header, pto2_sm, sizeof(PTO2SharedMemoryHeader));
-        if (hdr_rc == 0) {
-            graph_out_ptr = host_header.graph_output_ptr;
-            graph_out_size = host_header.graph_output_size;
-            if (graph_out_ptr != 0) {
-                LOG_INFO("Graph output buffer: ptr=0x%" PRIx64 ", size=%" PRIu64, graph_out_ptr, graph_out_size);
-            }
-        } else {
-            LOG_WARN("Failed to copy PTO2 header from device");
+    runtime_status = pto2_read_runtime_status(runtime, &host_header);
+    if (runtime_status != 0) {
+        int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
+        int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);
+        LOG_ERROR(
+            "PTO2 runtime failed: orch_error_code=%d sched_error_code=%d runtime_status=%d", orch_error_code,
+            sched_error_code, runtime_status
+        );
+        skip_tensor_copy_back = true;
+    } else {
+        graph_out_ptr = host_header.graph_output_ptr;
+        graph_out_size = host_header.graph_output_size;
+        if (graph_out_ptr != 0) {
+            LOG_INFO("Graph output buffer: ptr=0x%" PRIx64 ", size=%" PRIu64, graph_out_ptr, graph_out_size);
         }
     }
 
-    bool first_output_tensor = true;
-    for (int i = 0; i < tensor_pair_count; i++) {
-        const TensorPair &pair = tensor_pairs[i];
+    if (skip_tensor_copy_back) {
+        LOG_WARN("Skipping tensor copy-back because PTO2 runtime reported fatal status");
+    } else {
+        bool first_output_tensor = true;
+        for (int i = 0; i < tensor_pair_count; i++) {
+            const TensorPair &pair = tensor_pairs[i];
 
-        // Skip if device pointer is null
-        if (pair.dev_ptr == nullptr) {
-            LOG_WARN("Tensor %d has null device pointer, skipping", i);
-            continue;
-        }
+            // Skip if device pointer is null
+            if (pair.dev_ptr == nullptr) {
+                LOG_WARN("Tensor %d has null device pointer, skipping", i);
+                continue;
+            }
 
-        // If host pointer is null, this is a device-only allocation (no copy-back)
-        if (pair.host_ptr == nullptr) {
-            LOG_INFO("Tensor %d: device-only allocation (no copy-back)", i);
-            continue;
-        }
+            // If host pointer is null, this is a device-only allocation (no copy-back)
+            if (pair.host_ptr == nullptr) {
+                LOG_INFO("Tensor %d: device-only allocation (no copy-back)", i);
+                continue;
+            }
 
-        void *src_ptr = pair.dev_ptr;
-        size_t copy_size = pair.size;
+            void *src_ptr = pair.dev_ptr;
+            size_t copy_size = pair.size;
 
-        // Use graph_output_ptr for the first output tensor if available
-        if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
-            src_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(graph_out_ptr));
-            copy_size = static_cast<size_t>(graph_out_size);
-            LOG_INFO("Using packed output buffer for tensor %d", i);
-            first_output_tensor = false;
-        }
+            // Use graph_output_ptr for the first output tensor if available
+            if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
+                src_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(graph_out_ptr));
+                copy_size = static_cast<size_t>(graph_out_size);
+                LOG_INFO("Using packed output buffer for tensor %d", i);
+                first_output_tensor = false;
+            }
 
-        int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, src_ptr, copy_size);
-        if (copy_rc != 0) {
-            LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
-            rc = copy_rc;
-        } else {
-            LOG_INFO("Tensor %d: %zu bytes copied to host", i, pair.size);
+            int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, src_ptr, copy_size);
+            if (copy_rc != 0) {
+                LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
+                rc = copy_rc;
+            } else {
+                LOG_INFO("Tensor %d: %zu bytes copied to host", i, pair.size);
+            }
         }
     }
 
@@ -379,6 +410,10 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     runtime->clear_tensor_pairs();
 
     LOG_INFO("=== Finalize Complete ===");
+
+    if (rc == 0 && runtime_status != 0) {
+        rc = runtime_status;
+    }
 
     return rc;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -34,10 +34,11 @@
 #include <type_traits>
 
 // Type headers needed by orchestration
-#include "pto_submit_types.h"  // MixedKernels, INVALID_KERNEL_ID, subtask slots  // NOLINT(build/include_subdir)
-#include "pto_types.h"         // Arg, TaskOutputTensors, TensorArgType  // NOLINT(build/include_subdir)
-#include "task_args.h"         // ChipStorageTaskArgs, ContinuousTensor  // NOLINT(build/include_subdir)
-#include "tensor.h"            // Tensor, TensorCreateInfo  // NOLINT(build/include_subdir)
+#include "pto_runtime2_types.h"  // PTO2_ERROR_*  // NOLINT(build/include_subdir)
+#include "pto_submit_types.h"    // MixedKernels, INVALID_KERNEL_ID, subtask slots  // NOLINT(build/include_subdir)
+#include "pto_types.h"           // Arg, TaskOutputTensors, TensorArgType  // NOLINT(build/include_subdir)
+#include "task_args.h"           // ChipStorageTaskArgs, ContinuousTensor  // NOLINT(build/include_subdir)
+#include "tensor.h"              // Tensor, TensorCreateInfo  // NOLINT(build/include_subdir)
 
 // =============================================================================
 // Tensor Factory Helpers
@@ -119,6 +120,7 @@ typedef struct PTO2RuntimeOps {
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);
     bool (*is_fatal)(PTO2Runtime *rt);
+    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -155,15 +157,28 @@ static inline PTO2Runtime *pto2_current_runtime() { return pto2_framework_curren
 
 static inline TaskOutputTensors alloc_tensors(const Arg &args) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     return rt->ops->alloc_tensors(rt, args);
 }
 
 static inline TaskOutputTensors alloc_tensors(const TensorCreateInfo create_infos[], uint32_t count) {
+    PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     Arg args;
     for (uint32_t i = 0; i < count; i++) {
         args.add_output(create_infos[i]);
     }
-    always_assert(!args.has_error && "alloc_tensors failed to construct output-only Arg");
+    if (args.has_error) {
+        rt->ops->report_fatal(
+            rt, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "%s",
+            args.error_msg ? args.error_msg : "alloc_tensors failed to construct output-only Arg"
+        );
+        return TaskOutputTensors{};
+    }
     return alloc_tensors(args);
 }
 
@@ -174,14 +189,27 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
         (std::is_same_v<std::decay_t<CIs>, TensorCreateInfo> && ...),
         "alloc_tensors only accepts TensorCreateInfo arguments"
     );
+    PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     Arg args;
     (args.add_output(cis), ...);
-    always_assert(!args.has_error && "alloc_tensors failed to construct output-only Arg");
+    if (args.has_error) {
+        rt->ops->report_fatal(
+            rt, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "%s",
+            args.error_msg ? args.error_msg : "alloc_tensors failed to construct output-only Arg"
+        );
+        return TaskOutputTensors{};
+    }
     return alloc_tensors(args);
 }
 
 static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     return rt->ops->submit_task(rt, mixed_kernels, args);
 }
 
@@ -190,6 +218,9 @@ static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_ke
  */
 static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
@@ -200,6 +231,9 @@ static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const
  */
 static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
@@ -207,11 +241,17 @@ static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const
 
 static inline void pto2_rt_scope_begin() {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return;
+    }
     rt->ops->scope_begin(rt);
 }
 
 static inline void pto2_rt_scope_end() {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return;
+    }
     rt->ops->scope_end(rt);
 }
 
@@ -224,6 +264,12 @@ static inline bool pto2_rt_is_fatal() {
     PTO2Runtime *rt = pto2_current_runtime();
     return rt->ops->is_fatal(rt);
 }
+
+#define pto2_rt_report_fatal(code, fmt, ...)                                               \
+    do {                                                                                   \
+        PTO2Runtime *_pto2_rt = pto2_current_runtime();                                    \
+        _pto2_rt->ops->report_fatal(_pto2_rt, (code), __FUNCTION__, (fmt), ##__VA_ARGS__); \
+    } while (0)
 
 // =============================================================================
 // Logging Macros for Orchestration (call through ops table)
@@ -255,6 +301,9 @@ static inline bool pto2_rt_is_fatal() {
 template <typename T = uint64_t>
 static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return from_u64<T>(0);
+    }
     return from_u64<T>(rt->ops->get_tensor_data(rt, tensor, ndims, indices));
 }
 
@@ -288,6 +337,9 @@ static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint
 template <typename T = uint64_t>
 static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return;
+    }
     rt->ops->set_tensor_data(rt, tensor, ndims, indices, to_u64(value));
 }
 
@@ -302,9 +354,15 @@ class PTO2ScopeGuard {
 public:  // NOLINT(whitespace/indent)
     PTO2ScopeGuard() :
         rt_(pto2_current_runtime()) {
-        rt_->ops->scope_begin(rt_);
+        if (!rt_->ops->is_fatal(rt_)) {
+            rt_->ops->scope_begin(rt_);
+        }
     }
-    ~PTO2ScopeGuard() { rt_->ops->scope_end(rt_); }
+    ~PTO2ScopeGuard() {
+        if (!rt_->ops->is_fatal(rt_)) {
+            rt_->ops->scope_end(rt_);
+        }
+    }
 
 private:  // NOLINT(whitespace/indent)
     PTO2Runtime *rt_;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -22,6 +22,7 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -123,6 +124,51 @@ static void *pto2_aligned_zalloc(size_t size, size_t alignment) {
     return ptr;
 }
 
+static int32_t pto2_orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_code) {
+    always_assert(orch != nullptr);
+    orch->fatal = true;
+    if (error_code == PTO2_ERROR_NONE || orch->sm_handle == nullptr || orch->sm_handle->header == nullptr) {
+        return PTO2_ERROR_NONE;
+    }
+
+    int32_t expected = PTO2_ERROR_NONE;
+    std::atomic<int32_t> &orch_error_code = orch->sm_handle->header->orch_error_code;
+    if (orch_error_code.compare_exchange_strong(expected, error_code, std::memory_order_acq_rel)) {
+        return error_code;
+    }
+    return expected;
+}
+
+static void pto2_orch_report_fatal_v(
+    PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, va_list args
+) {
+    int32_t latched_code = pto2_orch_mark_fatal(orch, error_code);
+
+    if (fmt == nullptr || fmt[0] == '\0') {
+        if (latched_code != PTO2_ERROR_NONE && latched_code != error_code) {
+            unified_log_error(func, "FATAL(code=%d, latched=%d)", error_code, latched_code);
+        } else {
+            unified_log_error(func, "FATAL(code=%d)", error_code);
+        }
+        return;
+    }
+
+    char message[1024];
+    vsnprintf(message, sizeof(message), fmt, args);
+    if (latched_code != PTO2_ERROR_NONE && latched_code != error_code) {
+        unified_log_error(func, "FATAL(code=%d, latched=%d): %s", error_code, latched_code, message);
+        return;
+    }
+    unified_log_error(func, "FATAL(code=%d): %s", error_code, message);
+}
+
+void pto2_orch_report_fatal(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    pto2_orch_report_fatal_v(orch, error_code, func, fmt, args);
+    va_end(args);
+}
+
 struct PTO2FaninBuilder {
     PTO2TaskSlotState *inline_slots[PTO2_FANIN_INLINE_CAP];
     int32_t count{0};
@@ -174,8 +220,7 @@ static bool pto2_append_fanin_or_fail(
         LOG_ERROR("  tensor_arg_type:    %d", static_cast<int>(ptype));
         LOG_ERROR("  reason:             %s", reason);
         LOG_ERROR("========================================");
-        orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_DEPENDENCY_OVERFLOW, std::memory_order_release);
-        orch->fatal = true;
+        pto2_orch_mark_fatal(orch, PTO2_ERROR_DEPENDENCY_OVERFLOW);
         return false;
     }
 
@@ -184,7 +229,7 @@ static bool pto2_append_fanin_or_fail(
     int32_t spill_idx = fanin_pool.top;
     PTO2FaninSpillEntry *entry = fanin_pool.alloc();
     if (entry == nullptr) {
-        orch->fatal = true;
+        pto2_orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
         return false;
     }
     if (fanin_builder->count == PTO2_FANIN_INLINE_CAP) {
@@ -256,8 +301,7 @@ pto2_check_scope_can_accept_task(PTO2OrchestratorState *orch, PTO2TaskAllocator 
     LOG_ERROR("     Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2>");
     LOG_ERROR("  3. Split work across multiple scopes");
     LOG_ERROR("========================================");
-    orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_SCOPE_DEADLOCK, std::memory_order_release);
-    orch->fatal = true;
+    pto2_orch_mark_fatal(orch, PTO2_ERROR_SCOPE_DEADLOCK);
     return false;
 }
 
@@ -287,7 +331,7 @@ static bool pto2_prepare_task(
     out->sched = orch->scheduler;
     out->alloc_result = allocator.alloc(total_output_size);
     if (out->alloc_result.failed()) {
-        orch->fatal = true;
+        pto2_orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
 
@@ -481,7 +525,8 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
 
     TaskOutputTensors result;
 
-    // Fast path after fatal error — all subsequent submits are no-ops
+    // Orchestration API should short-circuit after fatal, but keep this entry
+    // robust as a no-op in case a caller reaches it directly.
     if (orch->fatal) {
         return result;
     }
@@ -495,8 +540,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         LOG_ERROR("  tensor_count: %d, scalar_count: %d", args.tensor_count(), args.scalar_count());
         LOG_ERROR("This is a bug in the orchestration code.");
         LOG_ERROR("========================================");
-        orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_INVALID_ARGS, std::memory_order_release);
-        orch->fatal = true;
+        pto2_orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
         return result;
     }
 
@@ -530,9 +574,11 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         PTO2ResourceShape shape = pto2_active_mask_to_shape(active_mask);
         int32_t limit = (shape == PTO2ResourceShape::AIV) ? orch->total_aiv_count : orch->total_cluster_count;
         if (limit > 0 && block_num > limit) {
-            LOG_ERROR("FATAL: require_sync_start block_num=%d > limit=%d (deadlock guaranteed)", block_num, limit);
-            orch->fatal = true;
-            return TaskOutputTensors{};
+            pto2_orch_report_fatal(
+                orch, PTO2_ERROR_REQUIRE_SYNC_START_INVALID, __FUNCTION__,
+                "require_sync_start block_num=%d > limit=%d (deadlock guaranteed)", block_num, limit
+            );
+            return result;
         }
         active_mask |= PTO2_SUBTASK_FLAG_SYNC_START;
     }
@@ -710,18 +756,42 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
 }
 
 TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &args) {
-    always_assert(!orch->fatal && "alloc_tensor cannot be called after the runtime becomes fatal");
-    always_assert(args.tensor_count() > 0 && "alloc_tensors requires at least one TensorCreateInfo");
-    always_assert(args.scalar_count() == 0 && "alloc_tensors only accepts output TensorCreateInfo args");
-    for (int32_t i = 0; i < args.tensor_count(); i++) {
-        always_assert(
-            args.tag(i) == TensorArgType::OUTPUT && "alloc_tensors only accepts output TensorCreateInfo args"
+    // Orchestration API should short-circuit after fatal, but keep this entry
+    // robust as a no-op in case a caller reaches it directly.
+    if (orch->fatal) {
+        return TaskOutputTensors{};
+    }
+
+    if (args.tensor_count() <= 0) {
+        pto2_orch_report_fatal(
+            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors requires at least one TensorCreateInfo"
         );
+        return TaskOutputTensors{};
+    }
+    if (args.scalar_count() != 0) {
+        pto2_orch_report_fatal(
+            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args"
+        );
+        return TaskOutputTensors{};
+    }
+    for (int32_t i = 0; i < args.tensor_count(); i++) {
+        if (args.tag(i) != TensorArgType::OUTPUT) {
+            pto2_orch_report_fatal(
+                orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args"
+            );
+            return TaskOutputTensors{};
+        }
     }
 
     CYCLE_COUNT_START();
 
-    always_assert(!args.has_error && "alloc_tensors failed to construct output-only Arg");
+    if (args.has_error) {
+        pto2_orch_report_fatal(
+            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "%s",
+            args.error_msg ? args.error_msg : "alloc_tensors failed to construct output-only Arg"
+        );
+        return TaskOutputTensors{};
+    }
 
     PTO2OutputLayout layout = pto2_calculate_output_layout(args);
     PTO2PreparedTask prepared;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -356,7 +356,7 @@ static bool pto2_prepare_task(
         int16_t block_num = args.launch_spec.block_num();
         slot_state.total_required_subtasks =
             static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
-        slot_state.block_num = block_num;
+        slot_state.logical_block_num = block_num;
         slot_state.next_block_idx = 0;
         slot_state.payload = out->payload;
         slot_state.task = out->task;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -141,6 +141,12 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState *orch);
 void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler);
 
 // =============================================================================
+// Fatal Reporting
+// =============================================================================
+
+void pto2_orch_report_fatal(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, ...);
+
+// =============================================================================
 // Scope Management
 // =============================================================================
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -19,6 +19,7 @@
 
 #include "pto_runtime2.h"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -52,6 +53,19 @@ void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrator); }
 void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrator); }
 
 static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
+
+void pto2_rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    if (fmt == nullptr || fmt[0] == '\0') {
+        pto2_orch_report_fatal(&rt->orchestrator, error_code, func, nullptr);
+    } else {
+        char message[1024];
+        vsnprintf(message, sizeof(message), fmt, args);
+        pto2_orch_report_fatal(&rt->orchestrator, error_code, func, "%s", message);
+    }
+    va_end(args);
+}
 
 // Wait for all producers of this tensor to be safe for data access.
 // Checks owner metadata (lifecycle anchor) and OverlapMap (modifier writers).
@@ -105,9 +119,9 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                orch.fatal = true;
-                unified_log_error(
-                    caller, "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
+                pto2_orch_report_fatal(
+                    &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
+                    "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
                     (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES,  // NOLINT(runtime/int)
                     ring_id, local_id
                 );
@@ -121,9 +135,9 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
             while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
                 SPIN_WAIT_HINT();
                 if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                    orch.fatal = true;
-                    unified_log_error(
-                        caller, "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
+                    pto2_orch_report_fatal(
+                        &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
+                        "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
                         (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES,  // NOLINT(runtime/int)
                         ring_id, local_id
                     );
@@ -185,6 +199,7 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .scope_end = pto2_rt_scope_end,
     .orchestration_done = pto2_rt_orchestration_done,
     .is_fatal = is_fatal_impl,
+    .report_fatal = pto2_rt_report_fatal,
     .log_error = unified_log_error,
     .log_warn = unified_log_warn,
     .log_info = unified_log_info,

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -71,6 +71,7 @@ struct PTO2RuntimeOps {
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);
     bool (*is_fatal)(PTO2Runtime *rt);
+    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -192,6 +193,11 @@ void pto2_rt_scope_end(PTO2Runtime *rt);
  * Signals that no more tasks will be submitted.
  */
 void pto2_rt_orchestration_done(PTO2Runtime *rt);
+
+/**
+ * Enter fatal state explicitly from orchestration.
+ */
+void pto2_rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -445,8 +445,8 @@ struct alignas(64) PTO2TaskSlotState {
 
     // SPMD multi-block (occupies the 8 tail bytes previously implicit padding)
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
-    int16_t total_required_subtasks{0};          // = block_num * popcount(active_mask)
-    int16_t block_num{1};                        // Total logical blocks (set by orchestrator)
+    int16_t total_required_subtasks{0};          // = logical_block_num * popcount(active_mask)
+    int16_t logical_block_num{1};                // Total logical blocks (set by orchestrator)
     int16_t next_block_idx{0};                   // Next block to dispatch (scheduler state)
 };
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -31,6 +31,7 @@
 
 #include <atomic>
 
+#include "pto_runtime_status.h"
 #include "pto2_dispatch_payload.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
@@ -67,22 +68,6 @@
 #if PTO2_TENSORMAP_PROFILING && !PTO2_ORCH_PROFILING
 #error "PTO2_TENSORMAP_PROFILING requires PTO2_ORCH_PROFILING=1"
 #endif
-
-// =============================================================================
-// AICPU Error Codes (written to shared memory for Host-side diagnosis)
-// =============================================================================
-
-// Orchestrator errors (1-99): detected in orchestrator thread
-#define PTO2_ERROR_NONE 0
-#define PTO2_ERROR_SCOPE_DEADLOCK 1
-#define PTO2_ERROR_HEAP_RING_DEADLOCK 2
-#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK 3
-#define PTO2_ERROR_DEP_POOL_OVERFLOW 4
-#define PTO2_ERROR_INVALID_ARGS 5         // Arg construction error (invalid args)
-#define PTO2_ERROR_DEPENDENCY_OVERFLOW 6  // Too many unique fanin dependencies for one task
-
-// Scheduler errors (100+): detected in scheduler threads
-#define PTO2_ERROR_SCHEDULER_TIMEOUT 100
 
 // =============================================================================
 // Configuration Constants

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -89,6 +89,22 @@ constexpr int32_t STALL_DUMP_CORE_MAX = 8;
 constexpr int32_t PROGRESS_VERBOSE_THRESHOLD = 10;  // log every completion for the first N tasks
 constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions after threshold
 
+static int32_t read_pto2_runtime_status(Runtime *runtime) {
+    if (runtime == nullptr) {
+        return 0;
+    }
+
+    void *sm = runtime->get_pto2_gm_sm_ptr();
+    if (sm == nullptr) {
+        return 0;
+    }
+
+    auto *header = static_cast<PTO2SharedMemoryHeader *>(sm);
+    int32_t orch_error_code = header->orch_error_code.load(std::memory_order_acquire);
+    int32_t sched_error_code = header->sched_error_code.load(std::memory_order_acquire);
+    return pto2_runtime_status_from_error_codes(orch_error_code, sched_error_code);
+}
+
 static PTO2Runtime *rt{nullptr};
 
 // Per-core dispatch payload storage: dual-buffer to allow pipelining.
@@ -2847,10 +2863,17 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
         return rc;
     }
 
+    int32_t runtime_rc = read_pto2_runtime_status(runtime);
+
     // Last thread cleans up
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
         DEV_INFO("aicpu_execute: Last thread finished, cleaning up");
         g_aicpu_executor.deinit(runtime);
+    }
+
+    if (runtime_rc != 0) {
+        DEV_ERROR("aicpu_execute: PTO2 runtime failed with rc=%d", runtime_rc);
+        return runtime_rc;
     }
 
     DEV_INFO("%s", "aicpu_execute: Kernel execution completed successfully");

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -779,7 +779,7 @@ struct AicpuExecutor {
         }
         // Per-dispatch local context: read block_idx/block_num directly from slot_state.
         dispatch_payload.local_context.s_block_idx = slot_state.next_block_idx;
-        dispatch_payload.local_context.s_block_num = slot_state.block_num;
+        dispatch_payload.local_context.s_block_num = slot_state.logical_block_num;
         // Store context pointers at fixed suffix positions in args[]
         // (GlobalContext content is already set by init_global_context, but the
         //  pointer must be written each dispatch since args[] is rebuilt entirely)
@@ -1751,8 +1751,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                     if (pto2_requires_sync_start(slot_state->active_mask)) {
                         int32_t available = (shape == PTO2ResourceShape::AIV) ? tracker.count_idle_aiv_cores() :
                                                                                 valid_cluster_states.count();
-                        if (available < slot_state->block_num) {
-                            if (!enter_drain_mode(slot_state, slot_state->block_num)) {
+                        if (available < slot_state->logical_block_num) {
+                            if (!enter_drain_mode(slot_state, slot_state->logical_block_num)) {
                                 // CAS lost: drain already active for another task; re-push and wait.
                                 rt->scheduler.ready_queues[static_cast<int32_t>(shape)].push(slot_state);
                             }
@@ -1780,18 +1780,20 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                         slot_state->next_block_idx++;
                         // For AIV, refresh cluster states so the do-while can pick up the
                         // other AIV core in the same cluster on the next iteration.
-                        if (shape == PTO2ResourceShape::AIV && slot_state->next_block_idx < slot_state->block_num) {
+                        if (shape == PTO2ResourceShape::AIV &&
+                            slot_state->next_block_idx < slot_state->logical_block_num) {
                             valid_cluster_states = tracker.get_idle_cluster_offset_states(shape);
                         }
                         DEV_DEBUG(
                             "Thread %d: Dispatched %s task %" PRId64 " block %d/%d to cluster_offset %d", thread_idx,
                             shape_name(shape), static_cast<int64_t>(slot_state->task->task_id.raw),
-                            slot_state->next_block_idx - 1, slot_state->block_num, current_valid_cluster_offset
+                            slot_state->next_block_idx - 1, slot_state->logical_block_num, current_valid_cluster_offset
                         );
-                    } while (slot_state->next_block_idx < slot_state->block_num && valid_cluster_states.has_value());
+                    } while (slot_state->next_block_idx < slot_state->logical_block_num &&
+                             valid_cluster_states.has_value());
 
                     // Re-enqueue only if blocks remain after exhausting local clusters
-                    if (slot_state->next_block_idx < slot_state->block_num) {
+                    if (slot_state->next_block_idx < slot_state->logical_block_num) {
                         rt->scheduler.ready_queues[static_cast<int32_t>(shape)].push(slot_state);
                     }
                     made_progress = true;
@@ -1846,7 +1848,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 #endif
                         );
                         slot_state->next_block_idx++;
-                        if (slot_state->next_block_idx < slot_state->block_num) {
+                        if (slot_state->next_block_idx < slot_state->logical_block_num) {
                             rt->scheduler.ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC)].push(slot_state);
                         }
                         made_progress = true;

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * PTO2 Runtime Status Helpers
+ *
+ * Shared error-code contract used inside the tensormap_and_ringbuffer runtime.
+ */
+
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_
+
+#include <stdint.h>
+
+// Orchestrator errors (1-99): detected in orchestrator thread
+#define PTO2_ERROR_NONE 0  // Explicitly means "no error"; it is not an "unknown/unspecified" error code.
+#define PTO2_ERROR_SCOPE_DEADLOCK 1
+#define PTO2_ERROR_HEAP_RING_DEADLOCK 2
+#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK 3
+#define PTO2_ERROR_DEP_POOL_OVERFLOW 4
+#define PTO2_ERROR_INVALID_ARGS 5         // Arg construction error (invalid args)
+#define PTO2_ERROR_DEPENDENCY_OVERFLOW 6  // Too many unique fanin dependencies for one task
+#define PTO2_ERROR_REQUIRE_SYNC_START_INVALID 7
+#define PTO2_ERROR_TENSOR_WAIT_TIMEOUT 8
+#define PTO2_ERROR_EXPLICIT_ORCH_FATAL 9
+
+// Scheduler errors (100+): detected in scheduler threads
+#define PTO2_ERROR_SCHEDULER_TIMEOUT 100
+
+static inline int32_t pto2_runtime_status_from_error_codes(int32_t orch_error_code, int32_t sched_error_code) {
+    if (orch_error_code != PTO2_ERROR_NONE) {
+        return orch_error_code < 0 ? orch_error_code : -orch_error_code;
+    }
+    if (sched_error_code != PTO2_ERROR_NONE) {
+        return sched_error_code < 0 ? sched_error_code : -sched_error_code;
+    }
+    return 0;
+}
+
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -35,6 +35,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "../common/pto_runtime_status.h"
 #include "../runtime/pto_shared_memory.h"
 #include "../runtime/runtime.h"
 #include "callable.h"
@@ -67,6 +68,27 @@ static uint64_t parse_env_uint64(const char *name, uint64_t min_val, bool requir
         return 0;
     }
     return static_cast<uint64_t>(val);
+}
+
+static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader *host_header) {
+    if (runtime == nullptr || host_header == nullptr) {
+        return 0;
+    }
+
+    void *pto2_sm = runtime->get_pto2_gm_sm_ptr();
+    if (pto2_sm == nullptr) {
+        return 0;
+    }
+
+    int hdr_rc = runtime->host_api.copy_from_device(host_header, pto2_sm, sizeof(PTO2SharedMemoryHeader));
+    if (hdr_rc != 0) {
+        LOG_WARN("Failed to copy PTO2 header from device");
+        return 0;
+    }
+
+    int32_t orch_error_code = host_header->orch_error_code.load(std::memory_order_relaxed);
+    int32_t sched_error_code = host_header->sched_error_code.load(std::memory_order_relaxed);
+    return pto2_runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
 /**
@@ -299,58 +321,67 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     LOG_INFO("Tensor pairs to process: %d", tensor_pair_count);
 
     // PTO2 (device orchestration): graph output may be in packed buffer
-    void *pto2_sm = runtime->get_pto2_gm_sm_ptr();
     uint64_t graph_out_ptr = 0;
     uint64_t graph_out_size = 0;
+    bool skip_tensor_copy_back = false;
+    int32_t runtime_status = 0;
+    PTO2SharedMemoryHeader host_header;
+    memset(&host_header, 0, sizeof(host_header));
 
-    if (pto2_sm != nullptr) {
-        // Copy header from device to host to read graph_output_ptr/size
-        PTO2SharedMemoryHeader host_header;
-        int hdr_rc = runtime->host_api.copy_from_device(&host_header, pto2_sm, sizeof(PTO2SharedMemoryHeader));
-        if (hdr_rc == 0) {
-            graph_out_ptr = host_header.graph_output_ptr;
-            graph_out_size = host_header.graph_output_size;
-            if (graph_out_ptr != 0) {
-                LOG_INFO("Graph output buffer: ptr=0x%" PRIx64 ", size=%" PRIu64, graph_out_ptr, graph_out_size);
-            }
-        } else {
-            LOG_WARN("Failed to copy PTO2 header from device");
+    runtime_status = pto2_read_runtime_status(runtime, &host_header);
+    if (runtime_status != 0) {
+        int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
+        int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);
+        LOG_ERROR(
+            "PTO2 runtime failed: orch_error_code=%d sched_error_code=%d runtime_status=%d", orch_error_code,
+            sched_error_code, runtime_status
+        );
+        skip_tensor_copy_back = true;
+    } else {
+        graph_out_ptr = host_header.graph_output_ptr;
+        graph_out_size = host_header.graph_output_size;
+        if (graph_out_ptr != 0) {
+            LOG_INFO("Graph output buffer: ptr=0x%" PRIx64 ", size=%" PRIu64, graph_out_ptr, graph_out_size);
         }
     }
 
-    bool first_output_tensor = true;
-    for (int i = 0; i < tensor_pair_count; i++) {
-        const TensorPair &pair = tensor_pairs[i];
+    if (skip_tensor_copy_back) {
+        LOG_WARN("Skipping tensor copy-back because PTO2 runtime reported fatal status");
+    } else {
+        bool first_output_tensor = true;
+        for (int i = 0; i < tensor_pair_count; i++) {
+            const TensorPair &pair = tensor_pairs[i];
 
-        // Skip if device pointer is null
-        if (pair.dev_ptr == nullptr) {
-            LOG_WARN("Tensor %d has null device pointer, skipping", i);
-            continue;
-        }
+            // Skip if device pointer is null
+            if (pair.dev_ptr == nullptr) {
+                LOG_WARN("Tensor %d has null device pointer, skipping", i);
+                continue;
+            }
 
-        // If host pointer is null, this is a device-only allocation (no copy-back)
-        if (pair.host_ptr == nullptr) {
-            LOG_INFO("Tensor %d: device-only allocation (no copy-back)", i);
-            continue;
-        }
+            // If host pointer is null, this is a device-only allocation (no copy-back)
+            if (pair.host_ptr == nullptr) {
+                LOG_INFO("Tensor %d: device-only allocation (no copy-back)", i);
+                continue;
+            }
 
-        void *src_ptr = pair.dev_ptr;
-        size_t copy_size = pair.size;
+            void *src_ptr = pair.dev_ptr;
+            size_t copy_size = pair.size;
 
-        // Use graph_output_ptr for the first output tensor if available
-        if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
-            src_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(graph_out_ptr));
-            copy_size = static_cast<size_t>(graph_out_size);
-            LOG_INFO("Using packed output buffer for tensor %d", i);
-            first_output_tensor = false;
-        }
+            // Use graph_output_ptr for the first output tensor if available
+            if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
+                src_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(graph_out_ptr));
+                copy_size = static_cast<size_t>(graph_out_size);
+                LOG_INFO("Using packed output buffer for tensor %d", i);
+                first_output_tensor = false;
+            }
 
-        int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, src_ptr, copy_size);
-        if (copy_rc != 0) {
-            LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
-            rc = copy_rc;
-        } else {
-            LOG_INFO("Tensor %d: %zu bytes copied to host", i, pair.size);
+            int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, src_ptr, copy_size);
+            if (copy_rc != 0) {
+                LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
+                rc = copy_rc;
+            } else {
+                LOG_INFO("Tensor %d: %zu bytes copied to host", i, pair.size);
+            }
         }
     }
 
@@ -379,6 +410,10 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     runtime->clear_tensor_pairs();
 
     LOG_INFO("=== Finalize Complete ===");
+
+    if (rc == 0 && runtime_status != 0) {
+        rc = runtime_status;
+    }
 
     return rc;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -34,10 +34,11 @@
 #include <type_traits>
 
 // Type headers needed by orchestration
-#include "pto_submit_types.h"  // MixedKernels, INVALID_KERNEL_ID, subtask slots  // NOLINT(build/include_subdir)
-#include "pto_types.h"         // Arg, TaskOutputTensors, TensorArgType  // NOLINT(build/include_subdir)
-#include "task_args.h"         // ChipStorageTaskArgs, ContinuousTensor  // NOLINT(build/include_subdir)
-#include "tensor.h"            // Tensor, TensorCreateInfo  // NOLINT(build/include_subdir)
+#include "pto_runtime2_types.h"  // PTO2_ERROR_*  // NOLINT(build/include_subdir)
+#include "pto_submit_types.h"    // MixedKernels, INVALID_KERNEL_ID, subtask slots  // NOLINT(build/include_subdir)
+#include "pto_types.h"           // Arg, TaskOutputTensors, TensorArgType  // NOLINT(build/include_subdir)
+#include "task_args.h"           // ChipStorageTaskArgs, ContinuousTensor  // NOLINT(build/include_subdir)
+#include "tensor.h"              // Tensor, TensorCreateInfo  // NOLINT(build/include_subdir)
 
 // =============================================================================
 // Tensor Factory Helpers
@@ -119,6 +120,7 @@ typedef struct PTO2RuntimeOps {
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);
     bool (*is_fatal)(PTO2Runtime *rt);
+    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -155,15 +157,28 @@ static inline PTO2Runtime *pto2_current_runtime() { return pto2_framework_curren
 
 static inline TaskOutputTensors alloc_tensors(const Arg &args) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     return rt->ops->alloc_tensors(rt, args);
 }
 
 static inline TaskOutputTensors alloc_tensors(const TensorCreateInfo create_infos[], uint32_t count) {
+    PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     Arg args;
     for (uint32_t i = 0; i < count; i++) {
         args.add_output(create_infos[i]);
     }
-    always_assert(!args.has_error && "alloc_tensors failed to construct output-only Arg");
+    if (args.has_error) {
+        rt->ops->report_fatal(
+            rt, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "%s",
+            args.error_msg ? args.error_msg : "alloc_tensors failed to construct output-only Arg"
+        );
+        return TaskOutputTensors{};
+    }
     return alloc_tensors(args);
 }
 
@@ -174,14 +189,27 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
         (std::is_same_v<std::decay_t<CIs>, TensorCreateInfo> && ...),
         "alloc_tensors only accepts TensorCreateInfo arguments"
     );
+    PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     Arg args;
     (args.add_output(cis), ...);
-    always_assert(!args.has_error && "alloc_tensors failed to construct output-only Arg");
+    if (args.has_error) {
+        rt->ops->report_fatal(
+            rt, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "%s",
+            args.error_msg ? args.error_msg : "alloc_tensors failed to construct output-only Arg"
+        );
+        return TaskOutputTensors{};
+    }
     return alloc_tensors(args);
 }
 
 static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     return rt->ops->submit_task(rt, mixed_kernels, args);
 }
 
@@ -190,6 +218,9 @@ static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_ke
  */
 static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
@@ -200,6 +231,9 @@ static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const
  */
 static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
@@ -207,11 +241,17 @@ static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const
 
 static inline void pto2_rt_scope_begin() {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return;
+    }
     rt->ops->scope_begin(rt);
 }
 
 static inline void pto2_rt_scope_end() {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return;
+    }
     rt->ops->scope_end(rt);
 }
 
@@ -224,6 +264,12 @@ static inline bool pto2_rt_is_fatal() {
     PTO2Runtime *rt = pto2_current_runtime();
     return rt->ops->is_fatal(rt);
 }
+
+#define pto2_rt_report_fatal(code, fmt, ...)                                               \
+    do {                                                                                   \
+        PTO2Runtime *_pto2_rt = pto2_current_runtime();                                    \
+        _pto2_rt->ops->report_fatal(_pto2_rt, (code), __FUNCTION__, (fmt), ##__VA_ARGS__); \
+    } while (0)
 
 // =============================================================================
 // Logging Macros for Orchestration (call through ops table)
@@ -255,6 +301,9 @@ static inline bool pto2_rt_is_fatal() {
 template <typename T = uint64_t>
 static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return from_u64<T>(0);
+    }
     return from_u64<T>(rt->ops->get_tensor_data(rt, tensor, ndims, indices));
 }
 
@@ -288,6 +337,9 @@ static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint
 template <typename T = uint64_t>
 static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {
     PTO2Runtime *rt = pto2_current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return;
+    }
     rt->ops->set_tensor_data(rt, tensor, ndims, indices, to_u64(value));
 }
 
@@ -302,9 +354,15 @@ class PTO2ScopeGuard {
 public:  // NOLINT(whitespace/indent)
     PTO2ScopeGuard() :
         rt_(pto2_current_runtime()) {
-        rt_->ops->scope_begin(rt_);
+        if (!rt_->ops->is_fatal(rt_)) {
+            rt_->ops->scope_begin(rt_);
+        }
     }
-    ~PTO2ScopeGuard() { rt_->ops->scope_end(rt_); }
+    ~PTO2ScopeGuard() {
+        if (!rt_->ops->is_fatal(rt_)) {
+            rt_->ops->scope_end(rt_);
+        }
+    }
 
 private:  // NOLINT(whitespace/indent)
     PTO2Runtime *rt_;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -22,6 +22,7 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -123,6 +124,51 @@ static void *pto2_aligned_zalloc(size_t size, size_t alignment) {
     return ptr;
 }
 
+static int32_t pto2_orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_code) {
+    always_assert(orch != nullptr);
+    orch->fatal = true;
+    if (error_code == PTO2_ERROR_NONE || orch->sm_handle == nullptr || orch->sm_handle->header == nullptr) {
+        return PTO2_ERROR_NONE;
+    }
+
+    int32_t expected = PTO2_ERROR_NONE;
+    std::atomic<int32_t> &orch_error_code = orch->sm_handle->header->orch_error_code;
+    if (orch_error_code.compare_exchange_strong(expected, error_code, std::memory_order_acq_rel)) {
+        return error_code;
+    }
+    return expected;
+}
+
+static void pto2_orch_report_fatal_v(
+    PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, va_list args
+) {
+    int32_t latched_code = pto2_orch_mark_fatal(orch, error_code);
+
+    if (fmt == nullptr || fmt[0] == '\0') {
+        if (latched_code != PTO2_ERROR_NONE && latched_code != error_code) {
+            unified_log_error(func, "FATAL(code=%d, latched=%d)", error_code, latched_code);
+        } else {
+            unified_log_error(func, "FATAL(code=%d)", error_code);
+        }
+        return;
+    }
+
+    char message[1024];
+    vsnprintf(message, sizeof(message), fmt, args);
+    if (latched_code != PTO2_ERROR_NONE && latched_code != error_code) {
+        unified_log_error(func, "FATAL(code=%d, latched=%d): %s", error_code, latched_code, message);
+        return;
+    }
+    unified_log_error(func, "FATAL(code=%d): %s", error_code, message);
+}
+
+void pto2_orch_report_fatal(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    pto2_orch_report_fatal_v(orch, error_code, func, fmt, args);
+    va_end(args);
+}
+
 struct PTO2FaninBuilder {
     PTO2TaskSlotState *inline_slots[PTO2_FANIN_INLINE_CAP];
     int32_t count{0};
@@ -174,8 +220,7 @@ static bool pto2_append_fanin_or_fail(
         LOG_ERROR("  tensor_arg_type:    %d", static_cast<int>(ptype));
         LOG_ERROR("  reason:             %s", reason);
         LOG_ERROR("========================================");
-        orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_DEPENDENCY_OVERFLOW, std::memory_order_release);
-        orch->fatal = true;
+        pto2_orch_mark_fatal(orch, PTO2_ERROR_DEPENDENCY_OVERFLOW);
         return false;
     }
 
@@ -184,7 +229,7 @@ static bool pto2_append_fanin_or_fail(
     int32_t spill_idx = fanin_pool.top;
     PTO2FaninSpillEntry *entry = fanin_pool.alloc();
     if (entry == nullptr) {
-        orch->fatal = true;
+        pto2_orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
         return false;
     }
     if (fanin_builder->count == PTO2_FANIN_INLINE_CAP) {
@@ -256,8 +301,7 @@ pto2_check_scope_can_accept_task(PTO2OrchestratorState *orch, PTO2TaskAllocator 
     LOG_ERROR("     Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2>");
     LOG_ERROR("  3. Split work across multiple scopes");
     LOG_ERROR("========================================");
-    orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_SCOPE_DEADLOCK, std::memory_order_release);
-    orch->fatal = true;
+    pto2_orch_mark_fatal(orch, PTO2_ERROR_SCOPE_DEADLOCK);
     return false;
 }
 
@@ -287,7 +331,7 @@ static bool pto2_prepare_task(
     out->sched = orch->scheduler;
     out->alloc_result = allocator.alloc(total_output_size);
     if (out->alloc_result.failed()) {
-        orch->fatal = true;
+        pto2_orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
 
@@ -495,8 +539,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         LOG_ERROR("  tensor_count: %d, scalar_count: %d", args.tensor_count(), args.scalar_count());
         LOG_ERROR("This is a bug in the orchestration code.");
         LOG_ERROR("========================================");
-        orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_INVALID_ARGS, std::memory_order_release);
-        orch->fatal = true;
+        pto2_orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
         return result;
     }
 
@@ -536,9 +579,11 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         PTO2ResourceShape shape = pto2_active_mask_to_shape(active_mask);
         int32_t limit = (shape == PTO2ResourceShape::AIV) ? orch->total_aiv_count : orch->total_cluster_count;
         if (limit > 0 && block_num > limit) {
-            LOG_ERROR("FATAL: require_sync_start block_num=%d > limit=%d (deadlock guaranteed)", block_num, limit);
-            orch->fatal = true;
-            return TaskOutputTensors{};
+            pto2_orch_report_fatal(
+                orch, PTO2_ERROR_REQUIRE_SYNC_START_INVALID, __FUNCTION__,
+                "require_sync_start block_num=%d > limit=%d (deadlock guaranteed)", block_num, limit
+            );
+            return result;
         }
         active_mask |= PTO2_SUBTASK_FLAG_SYNC_START;
     }
@@ -800,18 +845,40 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
 }
 
 TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &args) {
-    always_assert(!orch->fatal && "alloc_tensor cannot be called after the runtime becomes fatal");
-    always_assert(args.tensor_count() > 0 && "alloc_tensors requires at least one TensorCreateInfo");
-    always_assert(args.scalar_count() == 0 && "alloc_tensors only accepts output TensorCreateInfo args");
-    for (int32_t i = 0; i < args.tensor_count(); i++) {
-        always_assert(
-            args.tag(i) == TensorArgType::OUTPUT && "alloc_tensors only accepts output TensorCreateInfo args"
+    if (orch->fatal) {
+        return TaskOutputTensors{};
+    }
+
+    if (args.tensor_count() <= 0) {
+        pto2_orch_report_fatal(
+            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors requires at least one TensorCreateInfo"
         );
+        return TaskOutputTensors{};
+    }
+    if (args.scalar_count() != 0) {
+        pto2_orch_report_fatal(
+            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args"
+        );
+        return TaskOutputTensors{};
+    }
+    for (int32_t i = 0; i < args.tensor_count(); i++) {
+        if (args.tag(i) != TensorArgType::OUTPUT) {
+            pto2_orch_report_fatal(
+                orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args"
+            );
+            return TaskOutputTensors{};
+        }
     }
 
     CYCLE_COUNT_START();
 
-    always_assert(!args.has_error && "alloc_tensors failed to construct output-only Arg");
+    if (args.has_error) {
+        pto2_orch_report_fatal(
+            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "%s",
+            args.error_msg ? args.error_msg : "alloc_tensors failed to construct output-only Arg"
+        );
+        return TaskOutputTensors{};
+    }
 
     PTO2OutputLayout layout = pto2_calculate_output_layout(args);
     PTO2PreparedTask prepared;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -356,7 +356,7 @@ static bool pto2_prepare_task(
         int16_t block_num = args.launch_spec.core_num();
         slot_state.total_required_subtasks =
             static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
-        slot_state.block_num = block_num;
+        slot_state.logical_block_num = block_num;
         slot_state.next_block_idx = 0;
         slot_state.payload = out->payload;
         slot_state.task = out->task;
@@ -672,7 +672,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         slot_state.subtask_done_mask.store(0, std::memory_order_relaxed);
         slot_state.total_required_subtasks =
             static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
-        slot_state.block_num = block_num;
+        slot_state.logical_block_num = block_num;
         slot_state.next_block_idx = 0;
         slot_state.payload = payload;
         slot_state.task = &task;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -141,6 +141,12 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState *orch);
 void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler);
 
 // =============================================================================
+// Fatal Reporting
+// =============================================================================
+
+void pto2_orch_report_fatal(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, ...);
+
+// =============================================================================
 // Scope Management
 // =============================================================================
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -19,6 +19,7 @@
 
 #include "pto_runtime2.h"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -52,6 +53,19 @@ void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrator); }
 void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrator); }
 
 static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
+
+void pto2_rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    if (fmt == nullptr || fmt[0] == '\0') {
+        pto2_orch_report_fatal(&rt->orchestrator, error_code, func, nullptr);
+    } else {
+        char message[1024];
+        vsnprintf(message, sizeof(message), fmt, args);
+        pto2_orch_report_fatal(&rt->orchestrator, error_code, func, "%s", message);
+    }
+    va_end(args);
+}
 
 // Wait for all producers of this tensor to be safe for data access.
 // Checks owner metadata (lifecycle anchor) and OverlapMap (modifier writers).
@@ -105,9 +119,9 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                orch.fatal = true;
-                unified_log_error(
-                    caller, "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
+                pto2_orch_report_fatal(
+                    &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
+                    "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
                     (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES,  // NOLINT(runtime/int)
                     ring_id, local_id
                 );
@@ -121,9 +135,9 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
             while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
                 SPIN_WAIT_HINT();
                 if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                    orch.fatal = true;
-                    unified_log_error(
-                        caller, "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
+                    pto2_orch_report_fatal(
+                        &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
+                        "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
                         (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES,  // NOLINT(runtime/int)
                         ring_id, local_id
                     );
@@ -185,6 +199,7 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .scope_end = pto2_rt_scope_end,
     .orchestration_done = pto2_rt_orchestration_done,
     .is_fatal = is_fatal_impl,
+    .report_fatal = pto2_rt_report_fatal,
     .log_error = unified_log_error,
     .log_warn = unified_log_warn,
     .log_info = unified_log_info,

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -71,6 +71,7 @@ struct PTO2RuntimeOps {
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);
     bool (*is_fatal)(PTO2Runtime *rt);
+    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -192,6 +193,11 @@ void pto2_rt_scope_end(PTO2Runtime *rt);
  * Signals that no more tasks will be submitted.
  */
 void pto2_rt_orchestration_done(PTO2Runtime *rt);
+
+/**
+ * Enter fatal state explicitly from orchestration.
+ */
+void pto2_rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -441,8 +441,8 @@ struct alignas(64) PTO2TaskSlotState {
 
     // SPMD multi-block (occupies the 8 tail bytes previously implicit padding)
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
-    int16_t total_required_subtasks{0};          // = block_num * popcount(active_mask)
-    int16_t block_num{1};                        // Total logical blocks (set by orchestrator)
+    int16_t total_required_subtasks{0};          // = logical_block_num * popcount(active_mask)
+    int16_t logical_block_num{1};                // Total logical blocks (set by orchestrator)
     int16_t next_block_idx{0};                   // Next block to dispatch (scheduler state)
 };
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -31,6 +31,7 @@
 
 #include <atomic>
 
+#include "pto_runtime_status.h"
 #include "pto2_dispatch_payload.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
@@ -67,22 +68,6 @@
 #if PTO2_TENSORMAP_PROFILING && !PTO2_ORCH_PROFILING
 #error "PTO2_TENSORMAP_PROFILING requires PTO2_ORCH_PROFILING=1"
 #endif
-
-// =============================================================================
-// AICPU Error Codes (written to shared memory for Host-side diagnosis)
-// =============================================================================
-
-// Orchestrator errors (1-99): detected in orchestrator thread
-#define PTO2_ERROR_NONE 0
-#define PTO2_ERROR_SCOPE_DEADLOCK 1
-#define PTO2_ERROR_HEAP_RING_DEADLOCK 2
-#define PTO2_ERROR_FLOW_CONTROL_DEADLOCK 3
-#define PTO2_ERROR_DEP_POOL_OVERFLOW 4
-#define PTO2_ERROR_INVALID_ARGS 5         // Arg construction error (invalid args)
-#define PTO2_ERROR_DEPENDENCY_OVERFLOW 6  // Too many unique fanin dependencies for one task
-
-// Scheduler errors (100+): detected in scheduler threads
-#define PTO2_ERROR_SCHEDULER_TIMEOUT 100
 
 // =============================================================================
 // Configuration Constants

--- a/tests/st/a2a3/tensormap_and_ringbuffer/explicit_fatal/kernels/orchestration/explicit_fatal_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/explicit_fatal/kernels/orchestration/explicit_fatal_orch.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 0,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+
+    uint32_t shape[1] = {1};
+    TensorCreateInfo ci(shape, 1, DataType::FLOAT32);
+    (void)alloc_tensors(ci);
+
+    pto2_rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "st injected fatal");
+
+    // Exercise API short-circuit after fatal. These calls must become no-ops
+    // instead of falling through into runtime-side asserts or extra reporting.
+    Arg alloc_args;
+    (void)alloc_tensors(alloc_args);
+
+    Tensor dummy = make_tensor_external(reinterpret_cast<void *>(0x1), shape, 1);
+    uint32_t indices[1] = {0};
+    (void)get_tensor_data<uint64_t>(dummy, 0, indices);
+    set_tensor_data<uint64_t>(dummy, 0, indices, 1U);
+
+    pto2_rt_scope_begin();
+    pto2_rt_scope_end();
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_explicit_fatal.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_explicit_fatal.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Negative ST for explicit orchestration fatal reporting."""
+
+import pytest
+from _task_interface import ChipStorageTaskArgs
+
+from simpler_setup import SceneTestCase, scene_test
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class _ExplicitFatal(SceneTestCase):
+    __test__ = False
+    CALLABLE = {
+        "orchestration": {
+            "source": "explicit_fatal/kernels/orchestration/explicit_fatal_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [],
+        },
+        "incores": [],
+    }
+
+
+@pytest.mark.platforms(["a2a3sim"])
+@pytest.mark.device_count(1)
+def test_explicit_fatal_reports(st_platform, st_device_ids, monkeypatch):
+    monkeypatch.setenv("PTO_LOG_LEVEL", "error")
+
+    callable_obj = _ExplicitFatal.compile_chip_callable(st_platform)
+    worker = _ExplicitFatal._create_worker(st_platform, st_device_ids[0])
+
+    try:
+        with pytest.raises(RuntimeError, match=r"run_runtime failed with code -9"):
+            worker.run(callable_obj, ChipStorageTaskArgs(), block_dim=24, aicpu_thread_num=4)
+    finally:
+        worker.finalize()

--- a/tests/st/a5/tensormap_and_ringbuffer/explicit_fatal/kernels/orchestration/explicit_fatal_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/explicit_fatal/kernels/orchestration/explicit_fatal_orch.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 0,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+
+    uint32_t shape[1] = {1};
+    TensorCreateInfo ci(shape, 1, DataType::FLOAT32);
+    (void)alloc_tensors(ci);
+
+    pto2_rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "st injected fatal");
+
+    // Exercise API short-circuit after fatal. These calls must become no-ops
+    // instead of falling through into runtime-side asserts or extra reporting.
+    Arg alloc_args;
+    (void)alloc_tensors(alloc_args);
+
+    Tensor dummy = make_tensor_external(reinterpret_cast<void *>(0x1), shape, 1);
+    uint32_t indices[1] = {0};
+    (void)get_tensor_data<uint64_t>(dummy, 0, indices);
+    set_tensor_data<uint64_t>(dummy, 0, indices, 1U);
+
+    pto2_rt_scope_begin();
+    pto2_rt_scope_end();
+}
+
+}  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/test_explicit_fatal.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/test_explicit_fatal.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Negative ST for explicit orchestration fatal reporting."""
+
+import pytest
+from _task_interface import ChipStorageTaskArgs
+
+from simpler_setup import SceneTestCase, scene_test
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class _ExplicitFatal(SceneTestCase):
+    __test__ = False
+    CALLABLE = {
+        "orchestration": {
+            "source": "explicit_fatal/kernels/orchestration/explicit_fatal_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [],
+        },
+        "incores": [],
+    }
+
+
+@pytest.mark.platforms(["a5sim"])
+@pytest.mark.device_count(1)
+def test_explicit_fatal_reports(st_platform, st_device_ids, monkeypatch):
+    monkeypatch.setenv("PTO_LOG_LEVEL", "error")
+
+    callable_obj = _ExplicitFatal.compile_chip_callable(st_platform)
+    worker = _ExplicitFatal._create_worker(st_platform, st_device_ids[0])
+
+    try:
+        with pytest.raises(RuntimeError, match=r"run_runtime failed with code -9"):
+            worker.run(callable_obj, ChipStorageTaskArgs(), block_dim=24, aicpu_thread_num=4)
+    finally:
+        worker.finalize()

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -68,6 +68,44 @@ function(add_dist_test name src)
     add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
+function(add_a2a3_pto2_test name src)
+    add_executable(${name} ${src})
+    target_include_directories(${name} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/orchestration
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/runtime
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/common
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+    )
+    target_compile_options(${name} PRIVATE -D_GLIBCXX_USE_CXX11_ABI=0)
+    target_link_libraries(${name} PRIVATE
+        ${GTEST_MAIN_LIB}
+        ${GTEST_LIB}
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+endfunction()
+
+function(add_a5_pto2_test name src)
+    add_executable(${name} ${src})
+    target_include_directories(${name} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/orchestration
+        ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/runtime
+        ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/common
+        ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+    )
+    target_compile_options(${name} PRIVATE -D_GLIBCXX_USE_CXX11_ABI=0)
+    target_link_libraries(${name} PRIVATE
+        ${GTEST_MAIN_LIB}
+        ${GTEST_LIB}
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+endfunction()
+
 enable_testing()
 
 add_dist_test(test_dist_tensormap  test_dist_tensormap.cpp)
@@ -75,3 +113,5 @@ add_dist_test(test_dist_ring       test_dist_ring.cpp)
 add_dist_test(test_dist_scope      test_dist_scope.cpp)
 add_dist_test(test_dist_orchestrator test_dist_orchestrator.cpp)
 add_dist_test(test_dist_scheduler  test_dist_scheduler.cpp)
+add_a2a3_pto2_test(test_a2a3_pto2_fatal test_a2a3_pto2_fatal.cpp)
+add_a5_pto2_test(test_a5_pto2_fatal test_a5_pto2_fatal.cpp)

--- a/tests/ut/cpp/test_a2a3_pto2_fatal.cpp
+++ b/tests/ut/cpp/test_a2a3_pto2_fatal.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+
+#include "pto_orchestration_api.h"
+[[noreturn]] void assert_impl(const char *, const char *, int) { throw "assert_impl"; }
+
+namespace {
+
+PTO2Runtime *g_bound_runtime = nullptr;
+
+extern "C" PTO2Runtime *pto2_framework_current_runtime(void) { return g_bound_runtime; }
+extern "C" void pto2_framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; }
+
+struct FakeRuntime {
+    const PTO2RuntimeOps *ops;
+    bool fatal = false;
+    int submit_calls = 0;
+    int alloc_calls = 0;
+    int scope_begin_calls = 0;
+    int scope_end_calls = 0;
+    int get_calls = 0;
+    int set_calls = 0;
+    int report_fatal_calls = 0;
+    int32_t last_fatal_code = PTO2_ERROR_NONE;
+    std::string last_fatal_func;
+    std::string last_fatal_message;
+};
+
+FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
+
+TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const Arg &) {
+    as_fake(rt)->submit_calls++;
+    return TaskOutputTensors{};
+}
+
+void fake_scope_begin(PTO2Runtime *rt) { as_fake(rt)->scope_begin_calls++; }
+void fake_scope_end(PTO2Runtime *rt) { as_fake(rt)->scope_end_calls++; }
+void fake_orchestration_done(PTO2Runtime *) {}
+bool fake_is_fatal(PTO2Runtime *rt) { return as_fake(rt)->fatal; }
+
+void fake_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+    FakeRuntime *fake = as_fake(rt);
+    fake->report_fatal_calls++;
+    fake->fatal = true;
+    fake->last_fatal_code = error_code;
+    fake->last_fatal_func = func ? func : "";
+
+    char buffer[256] = {};
+    if (fmt != nullptr) {
+        va_list args;
+        va_start(args, fmt);
+        vsnprintf(buffer, sizeof(buffer), fmt, args);
+        va_end(args);
+    }
+    fake->last_fatal_message = buffer;
+}
+
+void fake_log(const char *, const char *, ...) {}
+
+uint64_t fake_get_tensor_data(PTO2Runtime *rt, const Tensor &, uint32_t, const uint32_t[]) {
+    as_fake(rt)->get_calls++;
+    return 0x1234ULL;
+}
+
+void fake_set_tensor_data(PTO2Runtime *rt, const Tensor &, uint32_t, const uint32_t[], uint64_t) {
+    as_fake(rt)->set_calls++;
+}
+
+TaskOutputTensors fake_alloc_tensors(PTO2Runtime *rt, const Arg &) {
+    as_fake(rt)->alloc_calls++;
+    return TaskOutputTensors{};
+}
+
+const PTO2RuntimeOps kFakeOps = {
+    fake_submit,
+    fake_scope_begin,
+    fake_scope_end,
+    fake_orchestration_done,
+    fake_is_fatal,
+    fake_report_fatal,
+    fake_log,
+    fake_log,
+    fake_log,
+    fake_log,
+    fake_log,
+    fake_get_tensor_data,
+    fake_set_tensor_data,
+    fake_alloc_tensors,
+};
+
+class RuntimeBindingGuard {
+public:
+    explicit RuntimeBindingGuard(PTO2Runtime *rt) { pto2_framework_bind_runtime(rt); }
+    ~RuntimeBindingGuard() { pto2_framework_bind_runtime(nullptr); }
+};
+
+TensorCreateInfo make_ci() {
+    static const uint32_t kShape[1] = {1};
+    return TensorCreateInfo(kShape, 1, DataType::FLOAT32);
+}
+
+}  // namespace
+
+TEST(A2A3PTO2Fatal, ApiShortCircuitsAfterFatal) {
+    FakeRuntime runtime{};
+    runtime.ops = &kFakeOps;
+    runtime.fatal = true;
+    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+
+    MixedKernels mixed{};
+    Arg args;
+    uint32_t indices[1] = {0};
+    uint32_t shape[1] = {1};
+    Tensor tensor = make_tensor_external(reinterpret_cast<void *>(0x1), shape, 1);
+
+    EXPECT_TRUE(pto2_rt_submit_task(mixed, args).empty());
+    EXPECT_TRUE(alloc_tensors(args).empty());
+    EXPECT_EQ(get_tensor_data<uint64_t>(tensor, 0, indices), 0U);
+    set_tensor_data<uint64_t>(tensor, 0, indices, 1U);
+    pto2_rt_scope_begin();
+    pto2_rt_scope_end();
+    {
+        PTO2ScopeGuard guard;
+        (void)guard;
+    }
+
+    EXPECT_EQ(runtime.submit_calls, 0);
+    EXPECT_EQ(runtime.alloc_calls, 0);
+    EXPECT_EQ(runtime.get_calls, 0);
+    EXPECT_EQ(runtime.set_calls, 0);
+    EXPECT_EQ(runtime.scope_begin_calls, 0);
+    EXPECT_EQ(runtime.scope_end_calls, 0);
+    EXPECT_EQ(runtime.report_fatal_calls, 0);
+}
+
+TEST(A2A3PTO2Fatal, ExplicitFatalRoutesThroughOps) {
+    FakeRuntime runtime{};
+    runtime.ops = &kFakeOps;
+    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+
+    pto2_rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "boom %d", 7);
+
+    EXPECT_TRUE(runtime.fatal);
+    EXPECT_EQ(runtime.report_fatal_calls, 1);
+    EXPECT_EQ(runtime.last_fatal_code, PTO2_ERROR_EXPLICIT_ORCH_FATAL);
+    EXPECT_EQ(runtime.last_fatal_message, "boom 7");
+    EXPECT_FALSE(runtime.last_fatal_func.empty());
+
+    MixedKernels mixed{};
+    Arg args;
+    EXPECT_TRUE(pto2_rt_submit_task(mixed, args).empty());
+    EXPECT_EQ(runtime.submit_calls, 0);
+}
+
+TEST(A2A3PTO2Fatal, AllocTensorConvenienceReportsInvalidArgsInsteadOfAsserting) {
+    FakeRuntime runtime{};
+    runtime.ops = &kFakeOps;
+    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+
+    std::array<TensorCreateInfo, MAX_TENSOR_ARGS + 1> create_infos{};
+    for (TensorCreateInfo &ci : create_infos) {
+        ci = make_ci();
+    }
+
+    auto alloc_from_array = static_cast<TaskOutputTensors (*)(const TensorCreateInfo[], uint32_t)>(&alloc_tensors);
+    EXPECT_TRUE(alloc_from_array(create_infos.data(), static_cast<uint32_t>(create_infos.size())).empty());
+    EXPECT_EQ(runtime.report_fatal_calls, 1);
+    EXPECT_EQ(runtime.last_fatal_code, PTO2_ERROR_INVALID_ARGS);
+    EXPECT_EQ(runtime.alloc_calls, 0);
+}

--- a/tests/ut/cpp/test_a5_pto2_fatal.cpp
+++ b/tests/ut/cpp/test_a5_pto2_fatal.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+
+#include "pto_orchestration_api.h"
+[[noreturn]] void assert_impl(const char *, const char *, int) { throw "assert_impl"; }
+
+namespace {
+
+PTO2Runtime *g_bound_runtime = nullptr;
+
+extern "C" PTO2Runtime *pto2_framework_current_runtime(void) { return g_bound_runtime; }
+extern "C" void pto2_framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; }
+
+struct FakeRuntime {
+    const PTO2RuntimeOps *ops;
+    bool fatal = false;
+    int submit_calls = 0;
+    int alloc_calls = 0;
+    int scope_begin_calls = 0;
+    int scope_end_calls = 0;
+    int get_calls = 0;
+    int set_calls = 0;
+    int report_fatal_calls = 0;
+    int32_t last_fatal_code = PTO2_ERROR_NONE;
+    std::string last_fatal_func;
+    std::string last_fatal_message;
+};
+
+FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
+
+TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const Arg &) {
+    as_fake(rt)->submit_calls++;
+    return TaskOutputTensors{};
+}
+
+void fake_scope_begin(PTO2Runtime *rt) { as_fake(rt)->scope_begin_calls++; }
+void fake_scope_end(PTO2Runtime *rt) { as_fake(rt)->scope_end_calls++; }
+void fake_orchestration_done(PTO2Runtime *) {}
+bool fake_is_fatal(PTO2Runtime *rt) { return as_fake(rt)->fatal; }
+
+void fake_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+    FakeRuntime *fake = as_fake(rt);
+    fake->report_fatal_calls++;
+    fake->fatal = true;
+    fake->last_fatal_code = error_code;
+    fake->last_fatal_func = func ? func : "";
+
+    char buffer[256] = {};
+    if (fmt != nullptr) {
+        va_list args;
+        va_start(args, fmt);
+        vsnprintf(buffer, sizeof(buffer), fmt, args);
+        va_end(args);
+    }
+    fake->last_fatal_message = buffer;
+}
+
+void fake_log(const char *, const char *, ...) {}
+
+uint64_t fake_get_tensor_data(PTO2Runtime *rt, const Tensor &, uint32_t, const uint32_t[]) {
+    as_fake(rt)->get_calls++;
+    return 0x1234ULL;
+}
+
+void fake_set_tensor_data(PTO2Runtime *rt, const Tensor &, uint32_t, const uint32_t[], uint64_t) {
+    as_fake(rt)->set_calls++;
+}
+
+TaskOutputTensors fake_alloc_tensors(PTO2Runtime *rt, const Arg &) {
+    as_fake(rt)->alloc_calls++;
+    return TaskOutputTensors{};
+}
+
+const PTO2RuntimeOps kFakeOps = {
+    fake_submit,
+    fake_scope_begin,
+    fake_scope_end,
+    fake_orchestration_done,
+    fake_is_fatal,
+    fake_report_fatal,
+    fake_log,
+    fake_log,
+    fake_log,
+    fake_log,
+    fake_log,
+    fake_get_tensor_data,
+    fake_set_tensor_data,
+    fake_alloc_tensors,
+};
+
+class RuntimeBindingGuard {
+public:
+    explicit RuntimeBindingGuard(PTO2Runtime *rt) { pto2_framework_bind_runtime(rt); }
+    ~RuntimeBindingGuard() { pto2_framework_bind_runtime(nullptr); }
+};
+
+TensorCreateInfo make_ci() {
+    static const uint32_t kShape[1] = {1};
+    return TensorCreateInfo(kShape, 1, DataType::FLOAT32);
+}
+
+}  // namespace
+
+TEST(A5PTO2Fatal, ApiShortCircuitsAfterFatal) {
+    FakeRuntime runtime{};
+    runtime.ops = &kFakeOps;
+    runtime.fatal = true;
+    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+
+    MixedKernels mixed{};
+    Arg args;
+    uint32_t indices[1] = {0};
+    uint32_t shape[1] = {1};
+    Tensor tensor = make_tensor_external(reinterpret_cast<void *>(0x1), shape, 1);
+
+    EXPECT_TRUE(pto2_rt_submit_task(mixed, args).empty());
+    EXPECT_TRUE(alloc_tensors(args).empty());
+    EXPECT_EQ(get_tensor_data<uint64_t>(tensor, 0, indices), 0U);
+    set_tensor_data<uint64_t>(tensor, 0, indices, 1U);
+    pto2_rt_scope_begin();
+    pto2_rt_scope_end();
+    {
+        PTO2ScopeGuard guard;
+        (void)guard;
+    }
+
+    EXPECT_EQ(runtime.submit_calls, 0);
+    EXPECT_EQ(runtime.alloc_calls, 0);
+    EXPECT_EQ(runtime.get_calls, 0);
+    EXPECT_EQ(runtime.set_calls, 0);
+    EXPECT_EQ(runtime.scope_begin_calls, 0);
+    EXPECT_EQ(runtime.scope_end_calls, 0);
+    EXPECT_EQ(runtime.report_fatal_calls, 0);
+}
+
+TEST(A5PTO2Fatal, ExplicitFatalRoutesThroughOps) {
+    FakeRuntime runtime{};
+    runtime.ops = &kFakeOps;
+    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+
+    pto2_rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "boom %d", 7);
+
+    EXPECT_TRUE(runtime.fatal);
+    EXPECT_EQ(runtime.report_fatal_calls, 1);
+    EXPECT_EQ(runtime.last_fatal_code, PTO2_ERROR_EXPLICIT_ORCH_FATAL);
+    EXPECT_EQ(runtime.last_fatal_message, "boom 7");
+    EXPECT_FALSE(runtime.last_fatal_func.empty());
+
+    MixedKernels mixed{};
+    Arg args;
+    EXPECT_TRUE(pto2_rt_submit_task(mixed, args).empty());
+    EXPECT_EQ(runtime.submit_calls, 0);
+}
+
+TEST(A5PTO2Fatal, AllocTensorConvenienceReportsInvalidArgsInsteadOfAsserting) {
+    FakeRuntime runtime{};
+    runtime.ops = &kFakeOps;
+    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+
+    std::array<TensorCreateInfo, MAX_TENSOR_ARGS + 1> create_infos{};
+    for (TensorCreateInfo &ci : create_infos) {
+        ci = make_ci();
+    }
+
+    auto alloc_from_array = static_cast<TaskOutputTensors (*)(const TensorCreateInfo[], uint32_t)>(&alloc_tensors);
+    EXPECT_TRUE(alloc_from_array(create_infos.data(), static_cast<uint32_t>(create_infos.size())).empty());
+    EXPECT_EQ(runtime.report_fatal_calls, 1);
+    EXPECT_EQ(runtime.last_fatal_code, PTO2_ERROR_INVALID_ARGS);
+    EXPECT_EQ(runtime.alloc_calls, 0);
+}


### PR DESCRIPTION
- route controlled PTO2 fatal status through aicpu_execute so platform runners no longer read tensormap_and_ringbuffer shared memory
- keep the PTO2 status helpers in runtime-local common code and preserve host-side finalize handling in runtime_maker
- add UT coverage for fatal short-circuit/reporting paths and keep the explicit fatal ST on a2a3sim only

**This PR would not catch the possible orchestration segfaults or so, especially the faults caused by the returning value of short-circuited `get_tensor_data()`.**

Fixes issue https://github.com/hw-native-sys/simpler/issues/505