### PR TITLE
Fix: detect stale _task_interface.so from cross-repo pip install

### DIFF
--- a/python/bindings/CMakeLists.txt
+++ b/python/bindings/CMakeLists.txt
@@ -43,6 +43,10 @@ target_include_directories(_task_interface PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+target_compile_definitions(_task_interface PRIVATE
+    SIMPLER_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
+
 target_link_libraries(_task_interface PRIVATE ${CMAKE_DL_LIBS} pthread)
 
 if(SKBUILD_MODE)

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -623,4 +623,10 @@ NB_MODULE(_task_interface, m) {
         .def_prop_ro("device_set", &ChipWorker::device_set);
 
     bind_dist_worker(m);
+
+#ifdef SIMPLER_SOURCE_DIR
+    m.attr("_source_dir") = SIMPLER_SOURCE_DIR;
+#else
+    m.attr("_source_dir") = "";
+#endif
 }

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -16,7 +16,28 @@ Usage:
     from task_interface import DataType, ContinuousTensor, ChipStorageTaskArgs, make_tensor_arg
 """
 
-from _task_interface import (  # pyright: ignore[reportMissingImports]
+import pathlib as _pathlib
+
+import _task_interface  # pyright: ignore[reportMissingImports]
+
+# Detect stale .so loaded from a different source tree (cross-repo pollution).
+# Only runs when this file lives in a source tree (not in site-packages).
+# Compares repo directory names (not full paths) to tolerate CI runners that
+# check out the same repo under different workspace prefixes.
+_this_dir = _pathlib.Path(__file__).resolve()
+_candidate_root = _this_dir.parents[2]  # python/simpler/task_interface.py → repo root
+if (_candidate_root / "pyproject.toml").is_file():
+    _loaded_root = getattr(_task_interface, "_source_dir", "")
+    if _loaded_root and _pathlib.Path(_loaded_root).name != _candidate_root.name:
+        raise ImportError(
+            f"Stale _task_interface binary detected.\n"
+            f"  Loaded .so was built from: {_loaded_root}\n"
+            f"  Current source tree:       {_candidate_root}\n"
+            f"  Fix: activate your project venv and run 'pip install .'"
+        )
+del _pathlib, _this_dir, _candidate_root
+
+from _task_interface import (  # pyright: ignore[reportMissingImports]  # noqa: E402
     CONTINUOUS_TENSOR_MAX_DIMS,
     DIST_CHIP_MAILBOX_SIZE,
     DIST_SUB_MAILBOX_SIZE,


### PR DESCRIPTION
## Summary
- Embed `CMAKE_SOURCE_DIR` as `_task_interface._source_dir` at build time
- On import, `task_interface.py` validates the loaded `.so` matches the current source tree
- Guard only runs when file is in a source tree (detected by `pyproject.toml` presence), safely skipped for wheel/site-packages installs
- Compares repo directory names (not full paths) to tolerate CI runners that check out the same repo under different workspace prefixes
- Raises a descriptive `ImportError` with both paths and a rebuild command if mismatched

## Testing
- [x] 101 unit tests pass (`test_task_interface.py` + `test_chip_worker.py`)
- [x] Guard triggers correctly when `_source_dir` repo name doesn't match current tree
- [x] Guard is silently skipped when running from site-packages (no `pyproject.toml`)
- [x] Same repo under different CI runner paths does NOT trigger the guard

Fixes #531