### PR TITLE
Refactor: extract Orchestrator as L3 DAG builder handle

### DIFF
--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -1,0 +1,149 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Orchestrator — DAG builder exposed to the user's orch function during Worker.run().
+
+An Orchestrator instance is Worker's private member. Users receive it as the
+first argument of their orch function::
+
+    def my_orch(orch, args):
+        r = orch.submit_next_level(chip_callable, chip_args_ptr, config, outputs=[64])
+        orch.submit_sub(cid, inputs=[r.outputs[0].ptr])
+
+    w.run(Task(orch=my_orch, args=my_args))
+
+Scope/drain lifecycle is managed by ``Worker.run()``; users never call those
+directly.
+"""
+
+from typing import Any, Optional
+
+from .task_interface import (
+    DistInputSpec,
+    DistOutputSpec,
+    DistWorker,
+    WorkerPayload,
+    WorkerType,
+)
+
+
+def _resolve_callable_ptr(callable_: Any) -> int:
+    """Accept either a ChipCallable (has buffer_ptr()) or a raw int pointer."""
+    if hasattr(callable_, "buffer_ptr"):
+        return callable_.buffer_ptr()
+    return int(callable_)
+
+
+class Orchestrator:
+    """DAG builder. Valid only inside the orch function passed to Worker.run()."""
+
+    def __init__(self, dist_worker: DistWorker) -> None:
+        self._dw = dist_worker
+
+    # ------------------------------------------------------------------
+    # User-facing submit API
+    # ------------------------------------------------------------------
+
+    def submit_next_level(
+        self,
+        callable_: Any,
+        args: int = 0,
+        config: Optional[Any] = None,
+        *,
+        inputs: Optional[list[int]] = None,
+        outputs: Optional[list[int]] = None,
+    ):
+        """Submit a next-level (chip) task.
+
+        Args:
+            callable_: ChipCallable or raw callable pointer (int).
+            args: Pointer to ChipStorageTaskArgs (int).
+            config: ChipCallConfig-like (reads block_dim, aicpu_thread_num,
+                enable_profiling). If None, defaults apply.
+            inputs: List of input pointers for dependency inference.
+            outputs: List of output byte sizes to allocate.
+        """
+        p = self._build_next_level_payload(callable_, args, config)
+        in_specs = [DistInputSpec(x) for x in (inputs or [])]
+        out_specs = [DistOutputSpec(s) for s in (outputs or [])]
+        return self._dw.submit(WorkerType.NEXT_LEVEL, p, in_specs, out_specs)
+
+    def submit_next_level_group(
+        self,
+        callable_: Any,
+        args_list: list[int],
+        config: Optional[Any] = None,
+        *,
+        inputs: Optional[list[int]] = None,
+        outputs: Optional[list[int]] = None,
+    ):
+        """Submit a group of next-level tasks (N args → N workers, 1 DAG node)."""
+        p = self._build_next_level_payload(callable_, 0, config)
+        in_specs = [DistInputSpec(x) for x in (inputs or [])]
+        out_specs = [DistOutputSpec(s) for s in (outputs or [])]
+        return self._dw.submit_group(WorkerType.NEXT_LEVEL, p, args_list, in_specs, out_specs)
+
+    def submit_sub(
+        self,
+        callable_id: int,
+        *,
+        inputs: Optional[list[int]] = None,
+        outputs: Optional[list[int]] = None,
+    ):
+        """Submit a SUB task by registered callable id."""
+        p = WorkerPayload()
+        p.worker_type = WorkerType.SUB
+        p.callable_id = callable_id
+        in_specs = [DistInputSpec(x) for x in (inputs or [])]
+        out_specs = [DistOutputSpec(s) for s in (outputs or [])]
+        return self._dw.submit(WorkerType.SUB, p, in_specs, out_specs)
+
+    def submit_sub_group(
+        self,
+        callable_id: int,
+        args_list: list[int],
+        *,
+        inputs: Optional[list[int]] = None,
+        outputs: Optional[list[int]] = None,
+    ):
+        """Submit a group of SUB tasks (N args → N workers, 1 DAG node)."""
+        p = WorkerPayload()
+        p.worker_type = WorkerType.SUB
+        p.callable_id = callable_id
+        in_specs = [DistInputSpec(x) for x in (inputs or [])]
+        out_specs = [DistOutputSpec(s) for s in (outputs or [])]
+        return self._dw.submit_group(WorkerType.SUB, p, args_list, in_specs, out_specs)
+
+    # ------------------------------------------------------------------
+    # Internal (called by Worker.run)
+    # ------------------------------------------------------------------
+
+    def _scope_begin(self) -> None:
+        self._dw.scope_begin()
+
+    def _scope_end(self) -> None:
+        self._dw.scope_end()
+
+    def _drain(self) -> None:
+        self._dw.drain()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_next_level_payload(callable_: Any, args: int, config: Optional[Any]) -> WorkerPayload:
+        p = WorkerPayload()
+        p.worker_type = WorkerType.NEXT_LEVEL
+        p.callable = _resolve_callable_ptr(callable_)
+        p.args = int(args)
+        if config is not None:
+            p.block_dim = int(config.block_dim)
+            p.aicpu_thread_num = int(config.aicpu_thread_num)
+            p.enable_profiling = bool(getattr(config, "enable_profiling", False))
+        return p

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -22,9 +22,9 @@ Usage::
     cid = w.register(lambda: postprocess())
     w.init()
 
-    def my_orch(w, args):
-        r = w.submit(WorkerType.NEXT_LEVEL, chip_payload, inputs=[...], outputs=[64])
-        w.submit(WorkerType.SUB, sub_payload(cid), inputs=[r.outputs[0].ptr])
+    def my_orch(orch, args):
+        r = orch.submit_next_level(chip_callable, chip_args_ptr, config, outputs=[64])
+        orch.submit_sub(cid, inputs=[r.outputs[0].ptr])
 
     w.run(Task(orch=my_orch, args=my_args))
     w.close()
@@ -44,17 +44,15 @@ _SCRIPTS = str(Path(__file__).parent.parent.parent / "examples" / "scripts")
 if _SCRIPTS not in sys.path:
     sys.path.insert(0, _SCRIPTS)
 
+from .orchestrator import Orchestrator  # noqa: E402
 from .task_interface import (  # noqa: E402
     DIST_CHIP_MAILBOX_SIZE,
     DIST_SUB_MAILBOX_SIZE,
     ChipWorker,
     DistChipProcess,
-    DistInputSpec,
-    DistOutputSpec,
     DistSubWorker,
     DistWorker,
     WorkerPayload,
-    WorkerType,
     _ChipWorker,
 )
 
@@ -68,7 +66,8 @@ class Task:
     """Execution unit for Worker.run() at any level.
 
     For L2: set callable/args directly on a WorkerPayload and pass to run().
-    For L3+: provide an orch function that calls worker.submit().
+    For L3+: provide an orch function ``fn(orchestrator, args)`` that builds
+    the DAG via ``orchestrator.submit_*``.
     """
 
     orch: Callable
@@ -189,20 +188,6 @@ def _chip_process_loop(
 # ---------------------------------------------------------------------------
 
 
-class _ScopeGuard:
-    """RAII scope guard for DistWorker.scope_begin/scope_end."""
-
-    def __init__(self, dw: DistWorker) -> None:
-        self._dw = dw
-
-    def __enter__(self):
-        self._dw.scope_begin()
-        return self
-
-    def __exit__(self, *_):
-        self._dw.scope_end()
-
-
 class Worker:
     """Unified worker for all hierarchy levels.
 
@@ -222,6 +207,7 @@ class Worker:
 
         # Level-3 internals
         self._dist_worker: Optional[DistWorker] = None
+        self._orch: Optional[Orchestrator] = None
         self._dist_chip_procs: list[DistChipProcess] = []
         self._chip_shms: list[SharedMemory] = []
         self._chip_pids: list[int] = []
@@ -377,6 +363,8 @@ class Worker:
         # Start Scheduler + WorkerThreads (C++ threads start here, after fork)
         dw.init()
 
+        self._orch = Orchestrator(dw)
+
     # ------------------------------------------------------------------
     # run — uniform entry point
     # ------------------------------------------------------------------
@@ -398,10 +386,16 @@ class Worker:
                 self._chip_worker.run(task_or_payload, args, **kwargs)
         else:
             self._start_level3()
-            assert self._dist_worker is not None
+            assert self._orch is not None
             task = task_or_payload
-            task.orch(self, task.args)
-            self._dist_worker.drain()
+            self._orch._scope_begin()
+            try:
+                task.orch(self._orch, task.args)
+            finally:
+                # Always release scope refs and drain so ring slots aren't
+                # stranded when the orch fn raises mid-DAG.
+                self._orch._scope_end()
+                self._orch._drain()
 
     def _run_l2_from_payload(self, payload: WorkerPayload) -> None:
         """Unpack a WorkerPayload and forward to ChipWorker (L2 only)."""
@@ -419,31 +413,6 @@ class Worker:
         )
 
     # ------------------------------------------------------------------
-    # Orchestration API (called from inside orch functions at L3+)
-    # ------------------------------------------------------------------
-
-    def submit(
-        self,
-        worker_type: WorkerType,
-        payload: WorkerPayload,
-        inputs: Optional[list[int]] = None,
-        outputs: Optional[list[int]] = None,
-        args_list: Optional[list[int]] = None,
-    ):
-        """Submit a task. If args_list has >1 entries, submits a group task."""
-        assert self._dist_worker is not None
-        in_specs = [DistInputSpec(p) for p in (inputs or [])]
-        out_specs = [DistOutputSpec(s) for s in (outputs or [])]
-        if args_list and len(args_list) > 1:
-            return self._dist_worker.submit_group(worker_type, payload, args_list, in_specs, out_specs)
-        return self._dist_worker.submit(worker_type, payload, in_specs, out_specs)
-
-    def scope(self):
-        """Context manager for scope lifetime. Usage: ``with w.scope(): ...``"""
-        assert self._dist_worker is not None
-        return _ScopeGuard(self._dist_worker)
-
-    # ------------------------------------------------------------------
     # close
     # ------------------------------------------------------------------
 
@@ -458,6 +427,7 @@ class Worker:
             if self._dist_worker:
                 self._dist_worker.close()
                 self._dist_worker = None
+                self._orch = None
 
             # Shutdown SubWorker processes
             for sw in self._dist_sub_workers:

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -573,9 +573,9 @@ class SceneTestCase:
 
             config = self._build_config(config_dict, enable_profiling=(enable_profiling and round_idx == 0))
 
-            # Wrap in Task — orch signature: (w, callables, task_args, config)
-            def task_orch(w, _unused, _ns=ns, _test_args=test_args, _config=config):
-                orch_fn(w, _ns, _test_args, _config)
+            # Wrap in Task — user orch signature: (orch, callables, task_args, config)
+            def task_orch(orch, _unused, _ns=ns, _test_args=test_args, _config=config):
+                orch_fn(orch, _ns, _test_args, _config)
 
             with _temporary_env(self._resolve_env()):
                 worker.run(Task(orch=task_orch))

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py
@@ -16,7 +16,6 @@ SubWorker reads result produced by ChipWorker.
 
 import torch
 from simpler.task_interface import ArgDirection as D
-from simpler.task_interface import WorkerPayload, WorkerType
 
 from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 from simpler_setup.scene_test import _build_chip_task_args
@@ -28,23 +27,18 @@ def verify():
     """SubCallable — dependency target, runs after ChipTask completes."""
 
 
-def run_dag(w, callables, task_args, config):
+def run_dag(orch, callables, task_args, config):
     """L3 orchestration: ChipTask → SubTask dependency."""
     chip_args, _ = _build_chip_task_args(task_args, callables.vector_kernel_sig)
     callables.keep(chip_args)  # prevent GC before drain
 
-    chip_p = WorkerPayload()
-    chip_p.worker_type = WorkerType.NEXT_LEVEL
-    chip_p.callable = callables.vector_kernel.buffer_ptr()
-    chip_p.args = chip_args.__ptr__()
-    chip_p.block_dim = config.block_dim
-    chip_p.aicpu_thread_num = config.aicpu_thread_num
-    chip_result = w.submit(WorkerType.NEXT_LEVEL, chip_p, inputs=[], outputs=[task_args.f.numel() * 4])
-
-    sub_p = WorkerPayload()
-    sub_p.worker_type = WorkerType.SUB
-    sub_p.callable_id = callables.verify
-    w.submit(WorkerType.SUB, sub_p, inputs=[chip_result.outputs[0].ptr])
+    chip_result = orch.submit_next_level(
+        callables.vector_kernel,
+        chip_args.__ptr__(),
+        config,
+        outputs=[task_args.f.numel() * 4],
+    )
+    orch.submit_sub(callables.verify, inputs=[chip_result.outputs[0].ptr])
 
 
 @scene_test(level=3, runtime="tensormap_and_ringbuffer")

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py
@@ -17,7 +17,7 @@ group completion aggregation, downstream dependency waits for group.
 
 import torch
 from simpler.task_interface import ArgDirection as D
-from simpler.task_interface import ChipStorageTaskArgs, WorkerPayload, WorkerType, make_tensor_arg
+from simpler.task_interface import ChipStorageTaskArgs, make_tensor_arg
 
 from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 
@@ -28,7 +28,7 @@ def verify():
     """SubCallable — runs after group completes."""
 
 
-def run_dag(w, callables, task_args, config):
+def run_dag(orch, callables, task_args, config):
     """L3 orchestration: group of 2 chips → SubTask dependency."""
     # Build per-chip ChipStorageTaskArgs from shared-memory tensors
     args0 = ChipStorageTaskArgs()
@@ -41,17 +41,13 @@ def run_dag(w, callables, task_args, config):
 
     callables.keep(args0, args1)  # prevent GC before drain
 
-    chip_p = WorkerPayload()
-    chip_p.worker_type = WorkerType.NEXT_LEVEL
-    chip_p.callable = callables.vector_kernel.buffer_ptr()
-    chip_p.block_dim = config.block_dim
-    chip_p.aicpu_thread_num = config.aicpu_thread_num
-    group_result = w.submit(WorkerType.NEXT_LEVEL, chip_p, args_list=[args0.__ptr__(), args1.__ptr__()], outputs=[4])
-
-    sub_p = WorkerPayload()
-    sub_p.worker_type = WorkerType.SUB
-    sub_p.callable_id = callables.verify
-    w.submit(WorkerType.SUB, sub_p, inputs=[group_result.outputs[0].ptr])
+    group_result = orch.submit_next_level_group(
+        callables.vector_kernel,
+        args_list=[args0.__ptr__(), args1.__ptr__()],
+        config=config,
+        outputs=[4],
+    )
+    orch.submit_sub(callables.verify, inputs=[group_result.outputs[0].ptr])
 
 
 @scene_test(level=3, runtime="tensormap_and_ringbuffer")

--- a/tests/ut/py/test_dist_worker/test_group_task.py
+++ b/tests/ut/py/test_dist_worker/test_group_task.py
@@ -26,7 +26,6 @@ import struct
 from multiprocessing import Value
 from multiprocessing.shared_memory import SharedMemory
 
-from simpler.task_interface import WorkerPayload, WorkerType
 from simpler.worker import Task, Worker
 
 # ---------------------------------------------------------------------------
@@ -65,19 +64,16 @@ class TestGroupBasic:
         cid = hw.register(inc)
         hw.init()
 
-        def orch(hw, _args):
-            p = WorkerPayload()
-            p.worker_type = WorkerType.SUB
-            p.callable_id = cid
-            hw.submit(WorkerType.SUB, p, args_list=[0, 0])
+        def orch(o, _args):
+            o.submit_sub_group(cid, args_list=[0, 0])
 
         hw.run(Task(orch=orch))
         hw.close()
 
         assert counter.value == 2, f"Expected 2, got {counter.value}"
 
-    def test_single_args_is_normal_task(self):
-        """submit with 1 args behaves like normal submit."""
+    def test_single_args_group_runs_once(self):
+        """submit_sub_group with 1 arg still runs exactly once."""
         counter = Value("i", 0)
 
         hw = Worker(level=3, num_sub_workers=1)
@@ -89,11 +85,8 @@ class TestGroupBasic:
         cid = hw.register(inc)
         hw.init()
 
-        def orch(hw, _args):
-            p = WorkerPayload()
-            p.worker_type = WorkerType.SUB
-            p.callable_id = cid
-            hw.submit(WorkerType.SUB, p, args_list=[0])
+        def orch(o, _args):
+            o.submit_sub_group(cid, args_list=[0])
 
         hw.run(Task(orch=orch))
         hw.close()
@@ -123,17 +116,10 @@ class TestGroupDependency:
             dep_cid = hw.register(lambda: struct.pack_into("i", db, 0, 1))
             hw.init()
 
-            def orch(hw, _args):
-                p = WorkerPayload()
-                p.worker_type = WorkerType.SUB
-                p.callable_id = group_cid
-                group_result = hw.submit(WorkerType.SUB, p, args_list=[0, 0], outputs=[64])
+            def orch(o, _args):
+                group_result = o.submit_sub_group(group_cid, args_list=[0, 0], outputs=[64])
                 out_ptr = group_result.outputs[0].ptr
-
-                dp = WorkerPayload()
-                dp.worker_type = WorkerType.SUB
-                dp.callable_id = dep_cid
-                hw.submit(WorkerType.SUB, dp, inputs=[out_ptr])
+                o.submit_sub(dep_cid, inputs=[out_ptr])
 
             hw.run(Task(orch=orch))
             hw.close()

--- a/tests/ut/py/test_dist_worker/test_host_worker.py
+++ b/tests/ut/py/test_dist_worker/test_host_worker.py
@@ -17,7 +17,6 @@ import time as _time
 from multiprocessing.shared_memory import SharedMemory
 
 import pytest
-from simpler.task_interface import WorkerPayload, WorkerType
 from simpler.worker import Task, Worker
 
 # ---------------------------------------------------------------------------
@@ -86,11 +85,8 @@ class TestSingleSubTask:
             cid = hw.register(lambda: _increment_counter(counter_buf))
             hw.init()
 
-            def orch(hw, _args):
-                p = WorkerPayload()
-                p.worker_type = WorkerType.SUB
-                p.callable_id = cid
-                hw.submit(WorkerType.SUB, p)
+            def orch(o, _args):
+                o.submit_sub(cid)
 
             hw.run(Task(orch=orch))
             hw.close()
@@ -108,12 +104,9 @@ class TestSingleSubTask:
             cid = hw.register(lambda: _increment_counter(counter_buf))
             hw.init()
 
-            def orch(hw, _args):
+            def orch(o, _args):
                 for _ in range(3):
-                    p = WorkerPayload()
-                    p.worker_type = WorkerType.SUB
-                    p.callable_id = cid
-                    hw.submit(WorkerType.SUB, p)
+                    o.submit_sub(cid)
 
             hw.run(Task(orch=orch))
             hw.close()
@@ -155,12 +148,9 @@ class TestParallelSubWorkers:
             cids.append(hw.register(make_fn(buf)))
         hw.init()
 
-        def orch(hw, _args):
+        def orch(o, _args):
             for i in range(n):
-                p = WorkerPayload()
-                p.worker_type = WorkerType.SUB
-                p.callable_id = cids[i]
-                hw.submit(WorkerType.SUB, p)
+                o.submit_sub(cids[i])
 
         start = _time.monotonic()
         hw.run(Task(orch=orch))
@@ -187,17 +177,6 @@ class TestOutputAllocation:
     def test_output_buffer_allocated(self):
         hw = Worker(level=3, num_sub_workers=0)
         hw.init()
-
-        def orch(hw, _args):
-            p = WorkerPayload()
-            # no workers — submit with empty workers list isn't useful here;
-            # instead verify that submit() allocates output buffers correctly
-            # by using a SUB worker that immediately signals done
-            p.worker_type = WorkerType.NEXT_LEVEL  # no NEXT_LEVEL workers — task stays RUNNING
-            # For output allocation test, just verify DistSubmitResult has outputs
-            # We re-init with sub workers for a real execution test
-            pass
-
         hw.close()
 
         # Re-test with actual SUB worker + output allocation
@@ -210,11 +189,8 @@ class TestOutputAllocation:
 
             captured = []
 
-            def orch2(hw, _args):
-                p = WorkerPayload()
-                p.worker_type = WorkerType.SUB
-                p.callable_id = cid
-                result = hw.submit(WorkerType.SUB, p, outputs=[64, 128])
+            def orch2(o, _args):
+                result = o.submit_sub(cid, outputs=[64, 128])
                 captured.append(result)
 
             hw2.run(Task(orch=orch2))
@@ -236,12 +212,12 @@ class TestOutputAllocation:
 
 
 # ---------------------------------------------------------------------------
-# Test: scope management
+# Test: scope management (owned by Worker.run; user doesn't see scope_begin/end)
 # ---------------------------------------------------------------------------
 
 
 class TestScope:
-    def test_scope_begin_end(self):
+    def test_scope_managed_by_run(self):
         counter_shm, counter_buf = _make_shared_counter()
 
         try:
@@ -249,12 +225,8 @@ class TestScope:
             cid = hw.register(lambda: _increment_counter(counter_buf))
             hw.init()
 
-            def orch(hw, _args):
-                with hw.scope():
-                    p = WorkerPayload()
-                    p.worker_type = WorkerType.SUB
-                    p.callable_id = cid
-                    hw.submit(WorkerType.SUB, p)
+            def orch(o, _args):
+                o.submit_sub(cid)
 
             hw.run(Task(orch=orch))
             hw.close()

--- a/tests/ut/py/test_dist_worker/test_multi_worker.py
+++ b/tests/ut/py/test_dist_worker/test_multi_worker.py
@@ -20,7 +20,6 @@ import threading
 import time
 from multiprocessing.shared_memory import SharedMemory
 
-from simpler.task_interface import WorkerPayload, WorkerType
 from simpler.worker import Task, Worker
 
 # ---------------------------------------------------------------------------
@@ -76,11 +75,8 @@ class TestTwoWorkersParallel:
             for hw, cid in workers:
 
                 def make_orch(c):
-                    def orch(hw, _args):
-                        p = WorkerPayload()
-                        p.worker_type = WorkerType.SUB
-                        p.callable_id = c
-                        hw.submit(WorkerType.SUB, p)
+                    def orch(o, _args):
+                        o.submit_sub(c)
 
                     return orch
 
@@ -126,11 +122,8 @@ class TestTwoWorkersParallel:
             start = time.monotonic()
 
             def run(hw, cid):
-                def orch(hw, _args):
-                    p = WorkerPayload()
-                    p.worker_type = WorkerType.SUB
-                    p.callable_id = cid
-                    hw.submit(WorkerType.SUB, p)
+                def orch(o, _args):
+                    o.submit_sub(cid)
 
                 hw.run(Task(orch=orch))
 
@@ -178,12 +171,9 @@ class TestManyTasksNoLeak:
             cid = hw.register(lambda: _inc(buf))
             hw.init()
 
-            def orch(hw, _args):
+            def orch(o, _args):
                 for _ in range(n_tasks):
-                    p = WorkerPayload()
-                    p.worker_type = WorkerType.SUB
-                    p.callable_id = cid
-                    hw.submit(WorkerType.SUB, p)
+                    o.submit_sub(cid)
 
             hw.run(Task(orch=orch))
             hw.close()
@@ -207,12 +197,9 @@ class TestManyTasksNoLeak:
                 cids.append(hw.register(lambda b=buf: _inc(b)))
             hw.init()
 
-            def orch(hw, _args):
+            def orch(o, _args):
                 for i in range(n_tasks):
-                    p = WorkerPayload()
-                    p.worker_type = WorkerType.SUB
-                    p.callable_id = cids[i]
-                    hw.submit(WorkerType.SUB, p)
+                    o.submit_sub(cids[i])
 
             hw.run(Task(orch=orch))
             hw.close()


### PR DESCRIPTION
## Summary

- Split the L3 orchestration surface from `Worker` into a dedicated `Orchestrator` class whose lifetime is scoped to a single `run()` call.
- User orch fn signature changes from `fn(worker, args)` to `fn(orch, args)`; all DAG building goes through `orch.submit_next_level` / `submit_next_level_group` / `submit_sub` / `submit_sub_group`.
- `scope_begin` / `scope_end` / `drain` become private details of `Worker.run()` (order: `scope_begin → orch_fn → scope_end → drain`).
- Remove `Worker.submit`, `Worker.scope`, and `_ScopeGuard` from the public API; `Worker` keeps `register` / `init` / `close` / `run(Task)`.

This is the **A1** step of the hierarchical runtime refactor plan. C++ `DistWorker.submit` / `scope_*` remain internal for now; a later **A2** step will take them private or re-expose them via nanobind on `Orchestrator` directly.

## Changes

- Add `python/simpler/orchestrator.py`
- Refactor `python/simpler/worker.py`
- Migrate Python UT tests: `tests/ut/py/test_dist_worker/{test_host_worker,test_multi_worker,test_group_task}.py`
- Migrate ST tests: `tests/st/a2a3/tensormap_and_ringbuffer/{test_l3_dependency,test_l3_group}.py`
- Update `simpler_setup/scene_test.py` wrapper to pass the Orchestrator
- Refresh `docs/distributed_level_runtime.md`

## Test plan

- [x] `pytest tests/ut/py/test_dist_worker` — 17/17 passed on macOS
- [x] `pytest tests/ut/py` — 135/138 passed (3 failures are pre-existing torch-env issues, unrelated to this PR)
- [x] `ruff check` — clean
- [ ] Linux CI — ST tests blocked locally by macOS libomp + external `pto-isa` clone; relying on CI to verify `tests/st/a2a3/tensormap_and_ringbuffer/test_l3_{dependency,group}.py`