### PR TITLE
Refactor: split runtime design docs by component focus

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Quick Reference
 
-See [docs/architecture.md](../../docs/architecture.md) for the full diagram, API layers, execution flow, and handshake protocol.
+See [docs/chip-level-arch.md](../../docs/chip-level-arch.md) for the full diagram, API layers, execution flow, and handshake protocol. See [docs/distributed_level_runtime.md](../../docs/distributed_level_runtime.md) for the L0–L6 level model and component composition, and [docs/task-flow.md](../../docs/task-flow.md) for end-to-end data flow through the hierarchical runtime.
 
 ## Key Concepts
 

--- a/README.md
+++ b/README.md
@@ -68,16 +68,22 @@ export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
 
 | Document | Description |
 | -------- | ----------- |
-| [Architecture](docs/architecture.md) | Three-program model, API layers, execution flow, handshake protocol |
+| [Chip-Level Architecture](docs/chip-level-arch.md) | L2 single-chip: three-program model (host/AICPU/AICore), API layers, handshake protocol |
+| [Distributed Level Runtime](docs/distributed_level_runtime.md) | L0–L6 level model, component composition (Orchestrator / Scheduler / Worker) |
+| [Task Flow](docs/task-flow.md) | End-to-end data flow: Callable / TaskArgs / CallConfig handles, IWorker interface |
+| [Orchestrator](docs/orchestrator.md) | DAG submission internals: submit flow, TensorMap, Scope, Ring, task state machine |
+| [Scheduler](docs/scheduler.md) | DAG dispatch internals: wiring/ready/completion queues, dispatch loop |
+| [Worker Manager](docs/worker-manager.md) | Worker pool, WorkerThread, THREAD/PROCESS modes, fork + mailbox mechanics |
 | [Getting Started](docs/getting-started.md) | Setup, prerequisites, build process, configuration |
 | [Developer Guide](docs/developer-guide.md) | Directory structure, role ownership, conventions |
 | [Testing Guide](docs/testing.md) | CI pipeline, test types, writing new tests |
-| **Per-arch (a2a3):** | |
-| [Runtimes](src/a2a3/docs/runtimes.md) | Runtime comparison and links to per-runtime docs |
-| [Platform](src/a2a3/docs/platform.md) | onboard vs sim, hardware requirements |
-| **Per-arch (a5):** | |
-| [Runtimes](src/a5/docs/runtimes.md) | Runtime comparison and links to per-runtime docs |
-| [Platform](src/a5/docs/platform.md) | onboard vs sim, hardware requirements |
+
+### Per-arch docs
+
+| Document | a2a3 arch | a5 arch |
+| -------- | --------- | ------- |
+| Runtimes | [a2a3/docs/runtimes.md](src/a2a3/docs/runtimes.md) | [a5/docs/runtimes.md](src/a5/docs/runtimes.md) |
+| Platform | [a2a3/docs/platform.md](src/a2a3/docs/platform.md) | [a5/docs/platform.md](src/a5/docs/platform.md) |
 
 ## License
 

--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -1,4 +1,11 @@
-# Architecture
+# Chip-Level Architecture (L2)
+
+This document describes the **single-chip (L2) architecture** — how a host
+program, AICPU kernel, and AICore kernel cooperate on one Ascend NPU chip. For
+the multi-chip hierarchy (L3+: Orchestrator / Scheduler / Worker composition)
+see [distributed_level_runtime.md](distributed_level_runtime.md). For how task
+data (Callable / TaskArgs / CallConfig) flows through all levels, see
+[task-flow.md](task-flow.md).
 
 ## Three-Program Model
 
@@ -135,7 +142,7 @@ worker.finalize()
 ### Python Type Naming Convention
 
 Layer 3 Python types use a **level-prefixed naming convention** that mirrors the
-level model (see [Distributed Level Runtime](distributed_level_runtime.md)):
+level model (see [distributed_level_runtime.md](distributed_level_runtime.md)):
 
 | Concept | L2 (Chip) type | L3+ (Distributed) type | Unified factory |
 | ------- | -------------- | ---------------------- | --------------- |

--- a/docs/distributed_level_runtime.md
+++ b/docs/distributed_level_runtime.md
@@ -1,8 +1,28 @@
-# Distributed Level Runtime
+# Distributed Level Runtime — Level Model and Component Composition
+
+This document covers:
+
+- The **L0–L6 level model** (what each level represents)
+- The **three engine components** (Orchestrator / Scheduler / Worker) and
+  their division of responsibility
+- How components compose recursively from L3 upward
+
+For details of each component's internals, see:
+
+- [orchestrator.md](orchestrator.md) — submit flow, TensorMap, Scope, Ring, task state machine
+- [scheduler.md](scheduler.md) — dispatch loop, queues, completion handling
+- [worker-manager.md](worker-manager.md) — WorkerThread pool, THREAD/PROCESS modes, fork + mailbox
+- [task-flow.md](task-flow.md) — Callable / TaskArgs / CallConfig data flow, IWorker interface
+
+For the L2 chip-level details (host `.so`, AICPU, AICore), see
+[chip-level-arch.md](chip-level-arch.md).
+
+---
 
 ## 1. Level Model
 
-The runtime uses a 7-level hierarchy that mirrors the physical topology of Ascend NPU clusters:
+The runtime uses a 7-level hierarchy mirroring the physical topology of Ascend
+NPU clusters:
 
 ```text
 L6  CLOS2 / Cluster    ── full cluster (N6 super-nodes)
@@ -16,351 +36,240 @@ L0  CORE  / AIV, AIC   ── individual compute core (hardware-managed)
 
 **L2 is the boundary** between two worlds:
 
-- **L0–L2** (on-device): AICPU scheduler, AICore/AIV workers, device Global Memory. Managed by the simpler runtime. Communication via shared GM with atomics and barriers (Tier 1).
-- **L3–L6** (host/cluster): each level is a separate process. Communication via IPC — Unix sockets, TCP, or RDMA (Tier 3). L3↔L2 uses host-device DMA (Tier 2).
-
-Every level from L3 upward is designed to run the **same scheduling engine** (`DistWorker`). Currently **only L2 and L3 are implemented**. L4–L6 are the intended future extension — the `DistWorker` class implements `IWorker` so it can be nested, but `DistWorker::run()` is a placeholder today.
+- **L0–L2** (on-device): AICPU scheduler, AICore/AIV workers, device Global
+  Memory. Managed by the chip-level runtime (see
+  [chip-level-arch.md](chip-level-arch.md)). Communication via shared GM with
+  atomics and barriers.
+- **L3–L6** (host/cluster): each level runs the same scheduling engine
+  composed of Orchestrator + Scheduler + Worker pool. Communication via IPC
+  (fork + shm at L3 today; RDMA / sockets at L4+).
 
 | Level | Workers it contains | Status |
 | ----- | ------------------- | ------ |
-| L3 (Host) | ChipWorker ×N + DistSubWorker ×M | Implemented |
-| L4 (Pod) | DistWorker(3) ×N (each is an L3 node) | Planned |
-| L5 (SuperNode) | DistWorker(4) ×N | Planned |
-| L6 (Cluster) | DistWorker(5) ×N | Planned |
+| L3 (Host) | `ChipWorker` ×N + `SubWorker` ×M | Implemented |
+| L4 (Pod) | `Worker(level=3)` ×N | Planned |
+| L5 (SuperNode) | `Worker(level=4)` ×N | Planned |
+| L6 (Cluster) | `Worker(level=5)` ×N | Planned |
 
-A `DistWorker` at any level implements `IWorker`, so a higher level can treat it as just another worker — recursive composition. The scheduling engine, DAG tracking, and scope management are designed to be identical at every level. Today only L3 uses this engine; L4+ will reuse it when inter-node IPC is added.
+`Worker` is a single C++ class that handles every level from L3 upward — the
+`level` parameter is a diagnostic label; behavior does not branch on it. The
+same Orchestrator/Scheduler/Worker code runs unchanged.
 
-## 2. One Level: Orchestrator / Scheduler / Worker
+---
 
-Within each level, three roles cooperate:
+## 2. Three Components — Roles
 
-```text
-                    Orch thread                    Scheduler thread             Worker threads
-                    ───────────                    ────────────────             ──────────────
-User code ──►  DistOrchestrator                   DistScheduler
-               │                                   │
-               │ submit(callable, args, config)     │
-               │   1. alloc ring slot               │
-               │   2. TensorMap: lookup deps        │
-               │   3. record fanin metadata         │
-               │   4. push wiring_queue ───────────►│
-               │                                    │ Phase 0: drain wiring_queue
-               │                                    │   wire fanout edges (lock + dep_pool)
-               │                                    │   if ready → push ready_queue
-               │                                    │ pop ready_queue
-               │                                    │ pick idle WorkerThread
-               │                                    │ dispatch(payload) ──────► IWorker::run()
-               │                                    │                           (blocking)
-               │                                    │◄── worker_done(slot) ────  return
-               │                                    │ on_task_complete:
-               │                                    │   fanout release
-               │                                    │   wake downstream tasks
-               │                                    │   try_consume → ring release
-               │                                    │
-               │ drain() ◄── notify when all done ──│
-```
+Every level L3+ runs three cooperating components. Each has its own dedicated
+thread in the parent process.
 
-**Orchestrator** (main thread, single-threaded):
+### Orchestrator (Orch thread)
 
-- Owns TensorMap, Scope, Ring alloc side — no locks needed
-- Builds the dependency metadata: for each submit, looks up input tensors to find producers, records fanin pointers in payload, increments producers' `fanout_count`
-- Pushes tasks to scheduler's wiring queue for asynchronous fanout edge construction
+The **DAG builder**. Exposed to the user's orchestration function as the
+first argument of `submit_*`. Runs single-threaded on the user's thread.
 
-**Scheduler** (dedicated C++ thread):
+Owns:
 
-- **Wiring**: drains wiring queue, wires fanout edges (acquires `fanout_lock`, allocates dep_pool entries), determines task readiness
-- Pops ready tasks from ready queue, finds idle WorkerThreads, dispatches
-- Receives completion callbacks from WorkerThreads
-- Releases fanout refs, wakes downstream consumers, retires consumed slots
+- `Ring` — fixed-size slot pool, allocates with back-pressure
+- `TensorMap` — `tensor_base_ptr → producer_slot` lookup, drives automatic dep inference
+- `Scope` — lifetime management for intermediate tensors
 
-**WorkerThread** (one per IWorker, dedicated thread):
+One `submit_next_level(callable, task_args, config)` call:
 
-- Wraps one `IWorker` (ChipWorker, DistSubWorker, or nested DistWorker)
-- Calls `worker->run(payload)` synchronously — blocks until done
-- Notifies Scheduler via `worker_done(slot)`
+1. allocates a slot
+2. moves task data into the slot
+3. walks `TaskArgs` tags (INPUT/OUTPUT/INOUT/OUTPUT_EXISTING/NO_DEP) to
+   lookup/insert TensorMap entries
+4. records fanin metadata on producer slots
+5. pushes the new slot onto the scheduler's wiring queue
 
-## 3. How It Works: Scope, TensorMap, RingBuffer
+See [orchestrator.md](orchestrator.md) for the 7-step submit flow and state machine.
 
-### TensorMap — automatic dependency inference
+### Scheduler (Scheduler thread)
 
-TensorMap maps `tensor_base_ptr → producer_task_slot`. When a task is submitted:
+The **DAG executor**. A dedicated C++ thread that drains three queues:
 
-```text
-submit(inputs=[ptr_A, ptr_B], outputs=[ptr_C]):
+- **wiring queue** — slots just submitted; wire fanout edges, compute readiness
+- **ready queue** — slots with all fanin satisfied; pick an idle WorkerThread and dispatch
+- **completion queue** — slots whose worker finished; release fanout, wake downstream consumers, retire slot
 
-  TensorMap.lookup(ptr_A) → slot 3 (producer)  → fanin edge: 3 → current
-  TensorMap.lookup(ptr_B) → not found           → no dependency
-  TensorMap.insert(ptr_C, current_slot)          → future consumers will depend on us
-```
+The Scheduler never inspects task data — it just moves slot ids between queues
+and consults TaskSlotState metadata.
 
-The user never explicitly declares "task X depends on task Y". Dependencies are inferred from which tasks produce/consume the same tensor addresses.
+See [scheduler.md](scheduler.md) for the dispatch loop and coordination.
 
-### RingBuffer — slot allocation with back-pressure
+### Worker / WorkerManager / WorkerThread
 
-The ring manages a fixed window of task slots (`DIST_TASK_WINDOW_SIZE = 128`). The Orchestrator calls `alloc()` to claim the next slot. If all slots are occupied by in-flight tasks, `alloc()` blocks until a slot is freed — this is **back-pressure**, preventing the Orchestrator from running too far ahead of the Scheduler.
+The **execution layer**. `WorkerManager` holds two pools of `WorkerThread`s
+(next-level pool and sub pool). Each `WorkerThread`:
+
+- owns one `IWorker` (`ChipWorker`, `SubWorker`, or nested `Worker`)
+- has its own `std::thread`
+- runs in one of two modes:
+  - `THREAD`: calls `worker->run(callable, view, config)` directly in-process
+  - `PROCESS`: forks a child at init; each dispatch writes task data to a shm
+    mailbox, the child decodes and runs
+
+See [worker-manager.md](worker-manager.md) for thread/process mechanics, fork
+ordering, and mailbox layout. See [task-flow.md](task-flow.md) for what flows
+through `IWorker::run`.
+
+---
+
+## 3. Component Coordination
 
 ```text
-alloc() ──► [slot 0][slot 1]...[slot 127] ──► release()
-  ↑ blocks if full                              ↑ called when task CONSUMED
+                   Orch thread                    Scheduler thread             Worker threads
+                   ───────────                    ────────────────             ──────────────
+  User code ──► Orchestrator                      Scheduler
+                 │                                 │
+                 │ submit(callable, args, config)  │
+                 │   1. ring.alloc()               │
+                 │   2. TensorMap lookup/insert    │
+                 │   3. record fanin              │
+                 │   4. push wiring_queue ───────►│
+                 │                                 │ Phase 0: drain wiring_queue
+                 │                                 │   wire fanout edges
+                 │                                 │   if ready → ready_queue
+                 │                                 │ pop ready_queue
+                 │                                 │ pick idle WorkerThread
+                 │                                 │ wt.dispatch(slot_id) ──────► WorkerThread
+                 │                                 │                              worker->run(callable, view, config)
+                 │                                 │                              (blocking, THREAD or PROCESS mode)
+                 │                                 │◄── completion_queue ────── on_complete_(slot_id)
+                 │                                 │ on_task_complete:
+                 │                                 │   fanout release
+                 │                                 │   wake downstream
+                 │                                 │   try_consume → ring release
+                 │ drain() ◄── notify when all done │
 ```
 
-### Scope — intermediate tensor lifetime
+Communication channels:
 
-Scopes group tasks whose intermediate outputs should be released together. Each task submitted inside a scope carries one extra "scope reference" in its fanout count. When `scope_end()` is called, that reference is released for every task in the scope, allowing completed tasks with no downstream consumers to reach CONSUMED and free their ring slot.
+| Path | Mechanism | Payload |
+| ---- | --------- | ------- |
+| Orch → Scheduler | wiring_queue (mutex + CV) | slot id |
+| Scheduler → WorkerThread | WorkerThread internal queue | slot id |
+| WorkerThread → Scheduler | completion_queue (mutex + CV) | slot id |
+| WorkerThread ↔ child (PROCESS mode) | shm mailbox (state + error + task data) | encoded blob |
+| Python ↔ C++ | nanobind bindings | TaskArgs / CallConfig / callable handle |
+| Tensor data | `torch.share_memory_()` or host malloc | zero-copy shared address |
+
+---
+
+## 4. Recursive Composition
+
+A `Worker` is itself an `IWorker`, so a higher-level `Worker` can register it
+as a next-level child:
 
 ```python
-with hw.scope():
-    r1 = hw.submit(...)   # r1 gets scope ref (fanout_total += 1)
-    r2 = hw.submit(...)   # r2 gets scope ref
-# scope_end: release scope ref on r1 and r2
-# if r1/r2 have no downstream consumers, they transition to CONSUMED
+w3 = Worker(level=3, child_mode=WorkerManager.Mode.PROCESS)
+w3.add_worker(NEXT_LEVEL, chip_worker_0)
+w3.add_worker(SUB,        sub_worker_0)
+w3.init()
+
+w4 = Worker(level=4, child_mode=WorkerManager.Mode.THREAD)
+w4.add_worker(NEXT_LEVEL, w3)         # w3 is an IWorker
+w4.init()
+
+w4.run(Task(orch=my_l4_orch, task_args=..., config=...))
 ```
 
-Without scopes, tasks with no downstream consumers would never be consumed (no one releases their fanout ref), eventually exhausting the ring.
+When L4's `WorkerThread` dispatches to L3, L3's `Worker::run` opens its own
+scope, executes the L4-supplied orch function with L3's own `Orchestrator`,
+and drains. Each level's orch fn receives its own Orchestrator — recursion is
+symmetric.
 
-### Task State Machine
+**Mode per level is independent**: L3 might use PROCESS (sim isolation), L4
+THREAD (L3 workers are thread-safe composites). Each `Worker` chooses its
+children's mode at construction.
 
-```text
-FREE ──► PENDING ──► READY ──► RUNNING ──► COMPLETED ──► CONSUMED
-           │           │          │            │              │
-         has fanin   fanin=0   Scheduler    worker(s)     all fanout
-         deps        satisfied  dispatches   done          refs released
-                                                          → ring slot freed
-```
+See [task-flow.md](task-flow.md) §9 for the full recursive data-flow
+walk-through.
 
-For group tasks, RUNNING → COMPLETED requires ALL N workers to finish (`sub_complete_count == group_size`).
+---
 
-## 4. Python/C++ Division and Process/Thread Model
+## 5. Python/C++ Division
 
-### Division of Responsibility
+| Concern | Python layer | C++ layer |
+| ------- | ------------ | --------- |
+| Process lifecycle | fork() timing, `SharedMemory` alloc/unlink, waitpid | — |
+| Callable registration | maintains `py_registry[cid]` for sub callables | — |
+| Orchestration DAG | user's orch fn, `submit_*` calls | `Orchestrator::submit_*` engine |
+| Scheduling | — | `Scheduler` thread, queues, `WorkerThread` pool |
+| Dispatch | — | `WorkerManager::dispatch`, THREAD/PROCESS mode |
+| Runtime execution | — | `ChipWorker` via dlsym'd runtime `.so` |
 
-```text
-Python layer                              C++ layer
-──────────────                            ──────────────
-Worker                                    DistWorker
-  - fork() SubWorker processes              - DistOrchestrator (DAG, TensorMap)
-  - register callables (before fork)        - DistScheduler (thread, dispatch)
-  - manage SharedMemory lifecycle           - DistRing (slot allocation)
-  - provide submit() / scope() API         - WorkerThread (per-worker thread)
-  - call drain() to wait                    - DistSubWorker (mailbox I/O)
-                                            - ChipWorker (device runtime)
-```
+Python handles **when** things happen (fork ordering, lifecycle). C++ handles
+**how fast** (threading, atomics, zero-copy dispatch).
 
-Python handles **process lifecycle** (fork, waitpid, SharedMemory alloc/unlink). C++ handles **scheduling and execution** (threads, atomics, condition variables).
+---
 
-### Process Model
+## 6. Process Model
 
 ```text
 ┌─────────────────────────────────────────────────────┐
-│  Main process                                        │
+│  Parent (main) process                              │
 │                                                      │
 │  Python main thread (Orch)                           │
 │    │                                                 │
 │    ├── C++ Scheduler thread                          │
 │    ├── C++ WorkerThread[0] → ChipWorker[0]           │
 │    ├── C++ WorkerThread[1] → ChipWorker[1]           │
-│    ├── C++ WorkerThread[2] → DistSubWorker[0]        │
-│    └── C++ WorkerThread[3] → DistSubWorker[1]        │
+│    ├── C++ WorkerThread[2] → SubWorker[0]            │
+│    └── C++ WorkerThread[3] → SubWorker[1]            │
 │                                                      │
-└──────────────────────────┬───────────────────────────┘
-                           │ fork() (before C++ threads start)
+└──────────────────────────┬──────────────────────────┘
+                           │ fork() (PROCESS mode only, before C++ threads start)
             ┌──────────────┼──────────────┐
             ▼                             ▼
    ┌────────────────┐            ┌────────────────┐
    │ Child process 0 │            │ Child process 1 │
-   │ Python loop:    │            │ Python loop:    │
-   │  poll mailbox   │            │  poll mailbox   │
-   │  run callable   │            │  run callable   │
+   │ poll mailbox    │            │ poll mailbox    │
+   │ run callable    │            │ run callable    │
    └────────────────┘            └────────────────┘
 ```
 
-**Fork ordering**: Python forks child processes FIRST, then creates C++ threads (`DistWorker.init()`). This avoids POSIX fork-in-multithreaded-process issues.
+**Fork ordering invariant**: Python forks child processes FIRST (before C++
+`Scheduler` / `WorkerThread` threads are started). This avoids
+fork-in-multithreaded-process hazards.
 
-### Data Exchange
+THREAD mode workers skip the fork entirely — they run in the parent process's
+`WorkerThread::std::thread`.
 
-| Path | Mechanism | Data |
-| ---- | --------- | ---- |
-| Orch → Scheduler | `DistReadyQueue` (mutex + CV) | task slot index |
-| Scheduler → WorkerThread | `WorkerThread.queue_` (mutex + CV) | `WorkerPayload` copy |
-| WorkerThread → Scheduler | `completion_queue_` (mutex + CV) | task slot index |
-| WorkerThread ↔ Child process | SharedMemory mailbox (256 bytes, acquire/release) | callable_id, state, error_code |
-| Python ↔ ChipWorker | `WorkerPayload.callable` / `.args` (raw pointers) | ChipCallable buffer, TaskArgs |
-| All tensors | `torch.share_memory_()` or host malloc | zero-copy shared address space |
+---
 
-## 5. Unified Interface — Designed for All Levels
+## 7. Runtime Isolation (Onboard Hardware)
 
-The API is designed so that orchestration functions can be reused across levels without modification — only the physical workers change. Currently L2 and L3 are implemented; L4+ will use the same `submit()` / `scope()` / `drain()` interface.
+A single device can only run **one runtime** per CANN process context. CANN's
+AICPU framework (`libaicpu_extend_kernels.so`) caches the user AICPU `.so` on
+first load and skips reloading on subsequent launches. If a different
+runtime's AICPU `.so` is launched on the same device, the cached (stale)
+function pointers are used, causing hangs.
 
-### Core Operations
+**Do not reuse a device across different runtimes within a single process.**
+Use separate processes (one per runtime), or partition devices so each
+runtime gets exclusive devices. See
+[testing.md](testing.md#runtime-isolation-constraint-onboard) for the pytest
+device allocation algorithm.
 
-```python
-# At any level:
-worker.submit(worker_type, payload, inputs=[...], outputs=[...])  # submit a task
-worker.submit(..., args_list=[a0, a1, a2, a3])                    # submit a group task
-with worker.scope():                                               # scope lifetime
-    worker.submit(...)
-worker.run(Task(orch=my_orch))                                    # run and drain
-```
+---
 
-### L2 Usage — Single Chip
+## 8. Source layout
 
-```python
-w = Worker(level=2, device_id=0, platform="a2a3sim", runtime="tensormap_and_ringbuffer")
-w.init()
-w.run(chip_callable, chip_args, block_dim=24)
-w.close()
-```
+| Path | Role |
+| ---- | ---- |
+| `src/common/distributed/orchestrator.{h,cpp}` | `Orchestrator`: submit, TensorMap, Scope |
+| `src/common/distributed/scheduler.{h,cpp}` | `Scheduler`: dispatch loop + queues |
+| `src/common/distributed/worker_manager.{h,cpp}` | `WorkerManager`: WorkerThread pool |
+| `src/common/distributed/worker_thread.{h,cpp}` | `WorkerThread`: THREAD/PROCESS dispatch |
+| `src/common/distributed/worker.{h,cpp}` | `Worker` (L3+): composes the above |
+| `src/common/distributed/ring.{h,cpp}` | slot allocator |
+| `src/common/distributed/tensormap.{h,cpp}` | base_ptr → producer slot |
+| `src/common/distributed/scope.{h,cpp}` | scope lifetime management |
+| `src/common/worker/chip_worker.{h,cpp}` | L2 `ChipWorker` (IWorker leaf) |
+| `src/common/worker/sub_worker.{h,cpp}` | `SubWorker` (IWorker leaf for Python callables) |
+| `python/bindings/` | nanobind exposure of C++ engine to Python |
+| `python/simpler/worker.py` | Python `Worker` factory + lifecycle wrapper |
 
-### L3 Usage — Multiple Chips + SubWorkers
-
-```python
-w = Worker(level=3, device_ids=[0, 1], num_sub_workers=2,
-           platform="a2a3sim", runtime="tensormap_and_ringbuffer")
-cid = w.register(my_python_fn)     # register before init (inherited by fork)
-w.init()
-
-def my_orch(w, args):
-    # Build callable and task args (same types as L2)
-    chip_callable = ChipCallable.build(signature, func_name, orch_bin, children)
-    task_args = ChipStorageTaskArgs()
-    task_args.add_tensor(make_tensor_arg(input_tensor))
-    task_args.add_tensor(make_tensor_arg(output_tensor))
-
-    with w.scope():
-        # ChipWorker task: runs kernel on NPU
-        payload = WorkerPayload()
-        payload.callable = chip_callable.buffer_ptr()
-        payload.args = task_args.__ptr__()
-        payload.block_dim = 24
-        r = w.submit(WorkerType.NEXT_LEVEL, payload, outputs=[64])
-
-        # SubWorker task: runs Python callable, depends on chip output
-        sub_p = WorkerPayload()
-        sub_p.callable_id = cid
-        w.submit(WorkerType.SUB, sub_p, inputs=[r.outputs[0].ptr])
-
-w.run(Task(orch=my_orch))
-w.close()
-```
-
-### L3 Group Task — N Chips as One Logical Worker
-
-```python
-def my_orch(w, args):
-    # Each chip gets its own args with rank-specific data
-    args_list = []
-    for rank in range(4):
-        a = ChipStorageTaskArgs()
-        a.add_tensor(make_tensor_arg(input))
-        a.add_tensor(make_tensor_arg(output))
-        a.add_scalar(rank)
-        a.add_scalar(4)
-        args_list.append(a.__ptr__())
-
-    # 1 DAG node, 4 chips execute in parallel
-    w.submit(WorkerType.NEXT_LEVEL, payload, args_list=args_list, outputs=[out_size])
-```
-
-### Why It's Uniform
-
-The internal C++ interface is `IWorker::run(payload)` — one method, implemented by every worker type:
-
-| Implementation | What `run()` does |
-| -------------- | ----------------- |
-| `ChipWorker` | Calls NPU runtime → device executes kernel |
-| `DistSubWorker` | Writes shared-memory mailbox → forked child executes Python callable |
-| `DistChipProcess` | Writes shared-memory mailbox → forked child runs ChipWorker (process-isolated) |
-| `DistWorker` | Placeholder for L4+ — will run sub-engine (Orchestrator + Scheduler + workers) |
-
-The `IWorker` interface enables recursive composition: an L4 `DistWorker` would contain L3 `DistWorker` instances as workers, dispatching to them via `run()`. This is the intended design for L4+, not yet implemented.
-
-## 6. Callable Hierarchy
-
-Callable types form a hierarchy that mirrors the level model. Each level has its own callable type with different storage and transport characteristics:
-
-```text
-CoreCallable   ── C++ struct, binary kernel code, resolved by platform loader
-     │              Lives on device. Used by AICPU dispatch (resolved_addr_).
-     │
-ChipCallable   ── C++ struct, orchestration binary + nested CoreCallable children
-     │              Serialized binary layout — host builds it, copies to AICPU.
-     │              Template: Callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 32>
-     │
-HostCallable   ── Python object, never leaves host process
-                   Contains: ChipCallable(s) + Python orch fn + Python sub fns
-                   C++ side stores only callable_id (int) in WorkerPayload.
-```
-
-### CoreCallable and ChipCallable (C++ binary layout)
-
-These two types use a C++ `Callable<>` template with fixed-size arrays and flexible array member (FAM) storage. They are **serialization formats** — the host builds them into a `vector<uint8_t>` buffer via `make_callable()`, then the buffer is copied to device memory or passed by pointer.
-
-```cpp
-// src/common/task_interface/callable.h
-using CoreCallable = Callable<void, CORE_MAX_TENSOR_ARGS, 0>;       // leaf: kernel binary
-using ChipCallable = Callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 32>; // parent: orch + children
-```
-
-**CoreCallable** carries one kernel binary and a `resolved_addr_` field. The platform loader (`device_runner.cpp`) resolves the binary to a device address and writes `resolved_addr_`. AICPU dispatch reads `resolved_addr()` to jump to the kernel entry point.
-
-**ChipCallable** carries the orchestration binary, a `func_name` for AICPU entry, and up to 32 child CoreCallables indexed by `func_id`. The Python binding (`ChipCallable.build()`) constructs the serialized buffer; the C runtime treats it as an opaque `const void*` pointer in `WorkerPayload.callable`.
-
-### HostCallable (Python-only, L3+)
-
-HostCallable is a **Python-side composition** — it never crosses the host↔device boundary and has no C++ struct representation. It combines:
-
-- **ChipCallable(s)**: pre-compiled binary callables for ChipWorker tasks
-- **Python orch function**: the DAG orchestration logic (calls `w.submit()`)
-- **Python sub functions**: host-side callables for SubWorker tasks
-
-At L3, the Python orch function runs in the main thread and submits tasks to the C++ scheduling engine. ChipWorker tasks carry `WorkerPayload.callable` (ChipCallable buffer pointer). SubWorker tasks carry `WorkerPayload.callable_id` (int index into a Python registry). The C++ Scheduler does not inspect either — it dispatches the payload to the appropriate WorkerThread.
-
-At L4+, a HostCallable submitted to a higher-level engine would also use `callable_id` in WorkerPayload. The C++ Scheduler treats it as opaque — the receiving DistWorker looks up the ID in its Python registry to retrieve the full HostCallable object.
-
-### Design Rationale
-
-Only CoreCallable and ChipCallable require C++ binary layout because they cross the host↔device boundary (DMA copy to AICPU). HostCallable stays in host memory and is better represented as a Python object — it contains Python functions which cannot be serialized into a C struct.
-
-## Architecture Diagram
-
-```text
-Python Application
-  │
-  └─► Worker                              ← Python wrapper (lifecycle, fork management)
-       │
-       └── DistWorker(level=3)               ← C++ scheduling engine
-            │
-            ├── DistOrchestrator             ← submit(), TensorMap, Scope
-            ├── DistScheduler                ← ready_queue → WorkerThread dispatch
-            ├── DistRing                     ← slot allocator with back-pressure
-            ├── DistTensorMap                ← base_ptr → producer slot mapping
-            ├── DistScope                    ← scope lifetime management
-            │
-            ├── ChipWorker ×N               ← IWorker: NPU device execution
-            │    └── DeviceRunner (thread_local)
-            │
-            └── DistSubWorker ×M            ← IWorker: fork/shm Python callable
-                 └── forked child process    ← mailbox state machine
-```
-
-## Runtime Isolation (Onboard Hardware)
-
-A single device can only run **one runtime** per CANN process context. CANN's AICPU framework (`libaicpu_extend_kernels.so`) caches the user AICPU .so on first load and skips reloading on subsequent launches. If a different runtime's AICPU .so is launched on the same device, the cached (stale) function pointers are used, causing hangs.
-
-This means: **do not reuse a device across different runtimes within a single process.** Either use separate processes (one per runtime), or partition devices so each runtime gets exclusive devices. See [testing.md](testing.md#runtime-isolation-constraint-onboard) for details and the pytest device allocation algorithm.
-
-## Files
-
-| File | Purpose |
-| ---- | ------- |
-| `src/common/distributed/dist_types.h/.cpp` | WorkerPayload, DistTaskSlotState, IWorker, DistReadyQueue |
-| `src/common/distributed/dist_orchestrator.h/.cpp` | submit / submit_group, TensorMap wiring, scope |
-| `src/common/distributed/dist_scheduler.h/.cpp` | Scheduler thread, WorkerThread, group dispatch/completion |
-| `src/common/distributed/dist_worker.h/.cpp` | Top-level engine: composes all components |
-| `src/common/distributed/dist_ring.h/.cpp` | Circular slot allocator with back-pressure |
-| `src/common/distributed/dist_tensormap.h/.cpp` | base_ptr → producer slot mapping |
-| `src/common/distributed/dist_scope.h/.cpp` | Scope depth tracking and ref management |
-| `src/common/distributed/dist_sub_worker.h/.cpp` | fork/shm IWorker with mailbox protocol |
-| `src/common/worker/chip_worker.h/.cpp` | L2 device execution, thread_local DeviceRunner |
-| `python/worker.py` | Unified Worker (L2 + L3): Python wrapper, fork management, scope context manager |
-| `python/bindings/dist_worker_bind.h` | nanobind bindings for distributed types |
+> Current source still uses `Dist*` names in several places; rename is tracked
+> as a separate cleanup.

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -1,0 +1,420 @@
+# Orchestrator — DAG Submission Internals
+
+The Orchestrator is the **DAG builder**. It runs single-threaded on the user's
+thread (inside `Worker::run` between `scope_begin` and `drain`) and owns the
+three data structures that turn a sequence of `submit_*` calls into a scheduled
+DAG: `Ring`, `TensorMap`, and `Scope`.
+
+For the high-level role of the Orchestrator among the three engine components,
+see [distributed_level_runtime.md](distributed_level_runtime.md). For what
+flows through `submit`, see [task-flow.md](task-flow.md).
+
+---
+
+## 1. Public API
+
+The user's orch fn receives an `Orchestrator*` as its first argument:
+
+```cpp
+class Orchestrator {
+public:
+    SubmitResult submit_next_level(Callable cb, TaskArgs args, const CallConfig &config);
+    SubmitResult submit_next_level_group(Callable cb,
+                                          std::vector<TaskArgs> args_list,
+                                          const CallConfig &config);
+    SubmitResult submit_sub(Callable cb, TaskArgs args, const CallConfig &config);
+
+private:
+    friend class Worker;
+    void scope_begin();
+    void scope_end();
+    void drain();
+    // ... components: Ring, TensorMap, Scope, slot pool
+};
+
+struct SubmitResult { TaskSlot slot_id; };
+```
+
+`scope_begin` / `scope_end` / `drain` are not user-visible — they are invoked
+by `Worker::run` around the orch fn. See
+[task-flow.md](task-flow.md) §5 for the Worker::run wrapper.
+
+---
+
+## 2. `submit_next_level` — the 7-step flow
+
+This is the entry point for every task in the DAG. All submit variants share
+the same skeleton; `submit_next_level_group` and `submit_sub` differ only in
+how the slot is set up.
+
+```cpp
+SubmitResult Orchestrator::submit_next_level(Callable cb,
+                                              TaskArgs args,
+                                              const CallConfig &config) {
+    // 1. Alloc slot (blocks on back-pressure if ring full)
+    TaskSlot sid = ring_.alloc();
+    TaskSlotState &s = slots_[sid];
+    s.reset();
+
+    // 2. Move task data into slot (parent heap, no encoding)
+    s.worker_type = WorkerType::NEXT_LEVEL;
+    s.callable    = cb;
+    s.task_args   = std::move(args);
+    s.config      = config;
+
+    // 3. Walk task_args tags, derive dependencies
+    //    (dedup producers: same producer may appear on multiple input tensors)
+    std::vector<TaskSlot> producers;
+    std::unordered_set<TaskSlot> producers_seen;
+    for (int i = 0; i < s.task_args.tensor_count(); i++) {
+        TensorArgType tag = s.task_args.tag(i);
+        uint64_t ptr      = s.task_args.tensor(i).data;
+
+        if (tag == INPUT || tag == INOUT) {
+            if (TaskSlot prod = tensormap_.lookup(ptr); prod != INVALID)
+                if (producers_seen.insert(prod).second)
+                    producers.push_back(prod);
+        }
+        if (tag == OUTPUT || tag == INOUT || tag == OUTPUT_EXISTING) {
+            tensormap_.insert(ptr, sid);
+        }
+        // NO_DEP: skip both
+    }
+
+    // 4. Record fanin on self
+    s.fanin_count    = static_cast<int32_t>(producers.size());
+    s.fanin_released = 0;
+
+    // 5. Register with scope (holds slot open until scope_end releases ref)
+    scope_.register_task(sid);          // increments s.fanout_total by 1
+
+    // 6. Push fanout edges onto scheduler's wiring queue
+    //    (Scheduler wires producer→consumer asynchronously; avoids blocking
+    //    the Orch thread on fanout_mu)
+    scheduler_.enqueue_wiring(sid, std::move(producers));
+
+    // 7. Return handle
+    return {sid};
+}
+```
+
+### Step details
+
+**Step 1 — `ring_.alloc()`**: See [§5 Ring](#5-ring). Blocks the Orch thread
+if all slots are in-flight; this is the system's back-pressure mechanism.
+
+**Step 2 — store task data**: `TaskArgs` is moved (not copied). `config` is a
+small POD copied by value. `callable` is a `uint64_t` opaque handle (see
+[task-flow.md](task-flow.md) §2).
+
+**Step 3 — tag walk**: The only place tags are consumed. After this step tags
+are never inspected again; they are not carried into the slot's stored
+`task_args` value during dispatch (see [task-flow.md](task-flow.md) §3).
+
+| Tag | `tensormap.lookup` | `tensormap.insert` |
+| --- | ------------------ | ------------------ |
+| `INPUT` | ✓ | — |
+| `OUTPUT` | — | ✓ |
+| `INOUT` | ✓ | ✓ |
+| `OUTPUT_EXISTING` | — | ✓ |
+| `NO_DEP` | — | — |
+
+`OUTPUT_EXISTING` differs from `OUTPUT` in runtime semantics (user-provided
+buffer vs. runtime-allocated) but dependency tracking is identical: both
+register this task as the new producer of `tensor.data`.
+
+**Step 4 — fanin count**: The number of live producers. Decremented by
+`fanin_released++` each time a producer completes; when `fanin_released ==
+fanin_count`, the slot is ready.
+
+**Step 5 — scope ref**: Each slot starts with one "scope reference" in its
+fanout_total. Without this, a task with no downstream consumer would never be
+reclaimable. See [§6 Scope](#6-scope).
+
+**Step 6 — wiring queue**: Fanout edges (producer knows its consumers) are
+wired **asynchronously** by the Scheduler thread. This decouples submit from
+`fanout_mu` contention. See [scheduler.md](scheduler.md) §2 for the wiring
+phase.
+
+---
+
+## 3. `submit_next_level_group` — N workers, 1 DAG node
+
+A group task is a single DAG node that executes in parallel on N workers.
+Each worker gets its own `TaskArgs`; the node only reaches COMPLETED when all
+N finish.
+
+```cpp
+SubmitResult Orchestrator::submit_next_level_group(Callable cb,
+                                                    std::vector<TaskArgs> args_list,
+                                                    const CallConfig &config) {
+    TaskSlot sid = ring_.alloc();
+    TaskSlotState &s = slots_[sid];
+    s.reset();
+    s.worker_type     = WorkerType::NEXT_LEVEL;
+    s.callable        = cb;
+    s.config          = config;
+    s.group_size      = args_list.size();
+    s.sub_complete_count = 0;
+    s.task_args_list  = std::move(args_list);
+
+    // Tag walk unions all entries in args_list (any input in any member → fanin)
+    // Dedup both producers and outputs across all args_list entries.
+    std::vector<TaskSlot> producers;
+    std::unordered_set<TaskSlot> producers_seen;
+    std::unordered_set<uint64_t> outputs_seen;
+    for (auto &a : s.task_args_list) {
+        for (int i = 0; i < a.tensor_count(); i++) {
+            TensorArgType tag = a.tag(i);
+            uint64_t ptr      = a.tensor(i).data;
+            if (tag == INPUT || tag == INOUT)
+                if (auto prod = tensormap_.lookup(ptr); prod != INVALID)
+                    if (producers_seen.insert(prod).second)
+                        producers.push_back(prod);
+            if (tag == OUTPUT || tag == INOUT || tag == OUTPUT_EXISTING)
+                if (outputs_seen.insert(ptr).second)
+                    tensormap_.insert(ptr, sid);
+        }
+    }
+
+    s.fanin_count    = static_cast<int32_t>(producers.size());
+    s.fanin_released = 0;
+    scope_.register_task(sid);
+    scheduler_.enqueue_wiring(sid, std::move(producers));
+    return {sid};
+}
+```
+
+At dispatch time the Scheduler reserves `group_size` idle WorkerThreads, and
+each WorkerThread runs `worker->run` with its own `task_args_list[i]`.
+Completion is gated on `sub_complete_count.fetch_add(1) + 1 == group_size`.
+
+---
+
+## 4. `submit_sub` — Python callable leaf
+
+Sub tasks have no C++ callable — they look up a Python function by id:
+
+```cpp
+SubmitResult Orchestrator::submit_sub(Callable cb, TaskArgs args, const CallConfig &config) {
+    TaskSlot sid = ring_.alloc();
+    TaskSlotState &s = slots_[sid];
+    s.reset();
+    s.worker_type = WorkerType::SUB;
+    s.callable    = cb;                 // interpreted as callable_id
+    s.task_args   = std::move(args);
+    s.config      = config;
+
+    std::vector<TaskSlot> producers;
+    std::unordered_set<TaskSlot> producers_seen;
+    for (int i = 0; i < s.task_args.tensor_count(); i++) {
+        TensorArgType tag = s.task_args.tag(i);
+        uint64_t ptr      = s.task_args.tensor(i).data;
+        if (tag == INPUT || tag == INOUT)
+            if (auto prod = tensormap_.lookup(ptr); prod != INVALID)
+                if (producers_seen.insert(prod).second)
+                    producers.push_back(prod);
+        if (tag == OUTPUT || tag == INOUT || tag == OUTPUT_EXISTING)
+            tensormap_.insert(ptr, sid);
+    }
+
+    s.fanin_count = static_cast<int32_t>(producers.size());
+    scope_.register_task(sid);
+    scheduler_.enqueue_wiring(sid, std::move(producers));
+    return {sid};
+}
+```
+
+---
+
+## 5. Ring
+
+The `Ring` is a fixed-size slot pool with back-pressure.
+
+```cpp
+class Ring {
+public:
+    explicit Ring(int32_t window_size);   // typical: 128
+
+    TaskSlot alloc();                      // blocks if full
+    void     release(TaskSlot sid);        // called by Scheduler on CONSUMED
+
+private:
+    TaskSlotState *slots_;
+    int32_t size_;
+    std::atomic<uint32_t> head_;           // orch-only, next to alloc
+    std::atomic<uint32_t> tail_;           // scheduler-only, next to release
+    std::mutex mu_;
+    std::condition_variable cv_;
+};
+```
+
+**Back-pressure rationale**: if the Orch thread submits tasks faster than the
+Scheduler + Workers can drain them, slots pile up. A fixed window forces the
+Orch thread to pause, preventing unbounded memory growth and keeping DAG
+depth reasonable.
+
+**Ownership by role**:
+
+| Field | Writer | Reader |
+| ----- | ------ | ------ |
+| `head_` | Orch (`alloc`) | Orch only |
+| `tail_` | Scheduler (`release`) | Scheduler only |
+| `slots_[i]` | Orch at submit, Scheduler on completion | both per-phase |
+
+Orch and Scheduler coordinate via per-slot atomics (`state`, `fanin_released`)
+and per-slot mutexes (`fanout_mu`), not via ring-level atomics beyond the
+head/tail positions.
+
+---
+
+## 6. Scope
+
+Scope solves: **"how do we release a task's ring slot if it has no downstream
+consumer?"**
+
+Every slot has a `fanout_total` counter: the number of outstanding references
+(downstream consumers + any scope refs). A slot transitions to `CONSUMED`
+(ring slot freed) only when `fanout_total == fanout_released`.
+
+Without scope, a leaf task (no consumers, `fanout_total = 0`) would reach
+COMPLETED but never transition further — but then all its outputs have been
+observed at the earliest moment, so it's actually fine in this degenerate
+case. The problem appears when user code does this:
+
+```python
+def my_orch(orch, args, cfg):
+    r = orch.submit_next_level(...)    # produces tensor X
+    # no one consumes X within this DAG
+    # without scope: slot stays, ring fills up eventually
+```
+
+Scope adds a deferred reference that releases at `scope_end`:
+
+```cpp
+class Scope {
+public:
+    void scope_begin();
+    void scope_end(const std::function<void(TaskSlot)> &release_ref);
+    void register_task(TaskSlot sid);       // called by Orchestrator.submit_*
+private:
+    std::vector<std::vector<TaskSlot>> depth_;   // stack of scope levels
+};
+```
+
+Flow:
+
+1. `scope_begin` pushes an empty vector onto the depth stack
+2. Each `submit_*` calls `scope.register_task(sid)`, appending to the top
+   vector and bumping `slots_[sid].fanout_total` by 1
+3. `scope_end` pops the top vector; for each `sid`, releases the scope ref
+   (`release_ref(sid)` decrements `fanout_total` bookkeeping and may
+   transition the slot to CONSUMED)
+
+Nested scopes are supported (the stack structure). For now only `Worker::run`
+opens a single top-level scope; nested scopes would be a future extension for
+explicit user scoping.
+
+---
+
+## 7. TensorMap
+
+The TensorMap maps `tensor_base_ptr → current_producer_slot`. It drives
+automatic dependency inference.
+
+```cpp
+class TensorMap {
+public:
+    TaskSlot lookup(uint64_t base_ptr) const;         // returns INVALID if absent
+    void     insert(uint64_t base_ptr, TaskSlot sid); // overwrites; previous
+                                                      // producer remains wire-referenced
+    void     erase(uint64_t base_ptr);                // called when producer
+                                                      // reaches CONSUMED
+private:
+    std::unordered_map<uint64_t, TaskSlot> map_;
+};
+```
+
+### Semantics
+
+- **RAW (read-after-write)**: consumer's `INPUT` sees producer's `OUTPUT`
+  entry → fanin edge recorded.
+- **WAW (write-after-write)**: a new `OUTPUT` on the same address replaces
+  the entry. The previous producer remains live (still has wire references
+  from any prior consumers); new consumers depend only on the latest.
+- **WAR (write-after-read)** is not tracked directly. Read tasks don't
+  register in TensorMap; write tasks only look up current producer. If a
+  consumer reads `X` (recording fanin on producer P1) and then a later task
+  writes `X` (new producer P2 in TensorMap), there's no P1 → P2 edge. This is
+  correct: the reader only needs P1 to have completed, the new writer only
+  needs its own prior producer. Simultaneous read and write races are a user
+  bug, not a scheduler concern.
+
+### Thread safety
+
+TensorMap is written only by the Orch thread (in `submit_*`) and modified by
+the Scheduler thread via `erase` (on CONSUMED). Since `submit_*` and `erase`
+for different entries are non-overlapping in practice, a single mutex guards
+the map in the current implementation. If contention becomes a concern, a
+concurrent hash map can replace it.
+
+---
+
+## 8. Task State Machine
+
+Each `TaskSlotState.state` progresses through:
+
+```text
+FREE ──► PENDING ──► READY ──► RUNNING ──► COMPLETED ──► CONSUMED ──► FREE
+ ↑         │           │          │            │             │
+ │       submit       fanin=0   Scheduler    worker        all refs
+ │       has fanin    (submit   dispatches   done          released
+ │                    or fanout  to WT                     (scope +
+ │                    release)                              fanout)
+ │                                                          │
+ └──────────────────── ring.release(sid) ◄─────────────────┘
+```
+
+- **FREE**: slot in the ring pool, not allocated
+- **PENDING**: allocated, `fanin_count > 0`, waiting on producers
+- **READY**: pushed to ready_queue (will be dispatched)
+- **RUNNING**: Scheduler has dispatched to a WorkerThread; for group tasks,
+  `sub_complete_count < group_size`
+- **COMPLETED**: worker(s) done; may still be referenced by fanout / scope
+- **CONSUMED**: all references released; Scheduler calls `ring.release(sid)`
+  and the slot returns to FREE
+
+State transitions are driven by atomic CAS operations:
+
+- Orch: FREE → PENDING/READY at submit time
+- Scheduler: READY → RUNNING → COMPLETED → CONSUMED during dispatch/completion
+
+---
+
+## 9. Invariants
+
+1. **Orch is single-threaded**: only one thread ever calls `submit_*` or holds
+   the `Orchestrator`. No locking is needed on TensorMap, Scope, or Ring-head
+   for self-writes.
+2. **Tags are consumed at submit**: `task_args.tag(i)` is read only inside
+   `submit_*`. Phases after submit (slot storage, dispatch, execution) do not
+   see tags.
+3. **Slot is parent-heap**: all `TaskSlotState` state is in the parent
+   process's heap. Child processes (PROCESS mode workers) never read slot
+   state; they receive task data via the mailbox (see
+   [worker-manager.md](worker-manager.md) §4).
+4. **Ring.alloc is the only blocking point in Orch**: `submit_*` never
+   blocks except on ring pressure.
+5. **Scope.register_task is idempotent per slot per scope level**: each
+   submitted slot gets exactly one scope ref at its current scope depth.
+
+---
+
+## 10. Related
+
+- [distributed_level_runtime.md](distributed_level_runtime.md) — how
+  Orchestrator fits alongside Scheduler and Worker
+- [scheduler.md](scheduler.md) — what happens to slots after they're pushed
+  onto the wiring queue
+- [task-flow.md](task-flow.md) — the data (Callable / TaskArgs / CallConfig)
+  being moved by `submit_*`

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,0 +1,320 @@
+# Scheduler — DAG Dispatch Internals
+
+The Scheduler is the **DAG executor**. A dedicated C++ thread that consumes
+submitted slots, wires fanout edges, dispatches ready tasks to worker threads,
+and handles completion callbacks. It is the bridge between the Orchestrator
+(producer of DAG nodes) and the WorkerManager (consumer of ready nodes).
+
+For the high-level role of the Scheduler among the three engine components,
+see [distributed_level_runtime.md](distributed_level_runtime.md). For the DAG
+construction side (what feeds the Scheduler), see
+[orchestrator.md](orchestrator.md). For dispatch mechanics (how
+`WorkerThread::dispatch` actually runs a task), see
+[worker-manager.md](worker-manager.md).
+
+---
+
+## 1. Role
+
+The Scheduler's job:
+
+- Drain the **wiring queue** (Phase 0): wire fanout edges for newly
+  submitted slots; if all producers are already done, promote to the ready queue.
+- Drain the **ready queue** (Phase 1): for each ready slot, pick an idle
+  `WorkerThread` from the appropriate pool and hand off.
+- Drain the **completion queue** (Phase 2): for each completed slot, release
+  its fanout references, wake downstream consumers, and (if all refs
+  released) retire the ring slot.
+
+One Scheduler per `Worker` instance, one thread per Scheduler. The Scheduler
+**does not inspect task data** — it moves slot ids between queues and
+consults scheduling metadata (`fanin_count`, `fanout_consumers`, `state`).
+
+---
+
+## 2. The three queues
+
+```cpp
+class Scheduler {
+    // Producer: Orchestrator.submit_*. Consumer: Scheduler's own loop, Phase 0.
+    LockFreeQueue<WiringEntry> wiring_queue_;       // {slot, producers}
+
+    // Producer: Scheduler Phase 0 (newly-ready) + Phase 2 (fanout-released).
+    // Consumer: Scheduler's own loop, Phase 1.
+    LockFreeQueue<TaskSlot> ready_queue_;
+
+    // Producer: WorkerThread (on worker->run() return).
+    // Consumer: Scheduler's own loop, Phase 2.
+    LockFreeQueue<TaskSlot> completion_queue_;
+};
+```
+
+### Wiring queue
+
+Introduced so that `Orchestrator::submit_*` does not need to acquire
+`fanout_mu` on every producer slot at submit time (see
+[orchestrator.md](orchestrator.md) §2 step 6).
+
+Each entry:
+
+```cpp
+struct WiringEntry {
+    TaskSlot consumer;
+    std::vector<TaskSlot> producers;    // producers this consumer depends on
+};
+```
+
+### Ready queue
+
+Slots whose `fanin_count == fanin_released` are ready to dispatch. The queue
+holds just the slot id; dispatch reads task data from `slots_[sid]`.
+
+### Completion queue
+
+Slots whose worker returned. The Scheduler runs completion handling
+(fanout release, downstream wake, try_consume) in its own thread so that
+WorkerThreads can immediately return to their next task.
+
+---
+
+## 3. Scheduler loop (pseudocode)
+
+```cpp
+void Scheduler::run() {
+    while (running_) {
+        // Phase 0: wiring
+        WiringEntry w;
+        while (wiring_queue_.try_pop(w)) {
+            wire_fanout(w);   // see §4
+        }
+
+        // Phase 1: dispatch
+        TaskSlot sid;
+        while (ready_queue_.try_pop(sid)) {
+            dispatch_ready(sid);   // see §5
+        }
+
+        // Phase 2: completion
+        while (completion_queue_.try_pop(sid)) {
+            on_task_complete(sid);   // see §6
+        }
+
+        // If all three queues empty, block on a condition variable until
+        // any producer signals work.
+        wait_for_work();
+    }
+}
+```
+
+Phase order matters:
+
+- Wiring before dispatch: a task may become ready during wiring (all its
+  producers already completed); wiring promotes it to ready_queue in the
+  same Scheduler iteration.
+- Dispatch before completion: dispatch the backlog first to keep workers
+  busy; completion handling is not time-critical (fanout release just
+  queues more work for the next iteration).
+
+---
+
+## 4. Phase 0 — wiring
+
+```cpp
+void Scheduler::wire_fanout(const WiringEntry &w) {
+    TaskSlot csid = w.consumer;
+    TaskSlotState &c = slots_[csid];
+    int32_t actual_live = 0;
+
+    for (TaskSlot psid : w.producers) {
+        TaskSlotState &p = slots_[psid];
+        std::lock_guard lk(p.fanout_mu);
+        // If producer has already reached COMPLETED/CONSUMED, its fanout is
+        // already finalized — consumer sees it as "done", no edge to add.
+        if (p.state.load() >= TaskState::COMPLETED) continue;
+        p.fanout_consumers.push_back(csid);
+        p.fanout_total++;
+        actual_live++;
+    }
+
+    // Update consumer's fanin to the actual live count (producers already
+    // finished don't count).
+    c.fanin_count = actual_live;
+    if (actual_live == 0) ready_queue_.push(csid);
+}
+```
+
+**Race with completion**: a producer may finish between submit and wiring.
+The `lock_guard(p.fanout_mu)` + `p.state.load()` check ensures we either:
+
+- wire an edge and the producer's future completion will fire `fanin_released++`
+  for this consumer, or
+- see "already completed" and skip, correctly counting this producer as not
+  contributing to fanin.
+
+---
+
+## 5. Phase 1 — dispatch
+
+```cpp
+void Scheduler::dispatch_ready(TaskSlot sid) {
+    TaskSlotState &s = slots_[sid];
+    s.state.store(TaskState::READY);
+
+    if (s.group_size == 0) {
+        // Single-worker task
+        WorkerThread *wt = manager_->pick_idle(s.worker_type);
+        wt->dispatch(sid);
+    } else {
+        // Group task — reserve N idle workers
+        auto wts = manager_->pick_n_idle(s.worker_type, s.group_size);
+        s.state.store(TaskState::RUNNING);
+        for (size_t i = 0; i < wts.size(); i++) {
+            wts[i]->dispatch(sid, /*group_index=*/static_cast<int32_t>(i));
+        }
+    }
+}
+```
+
+Dispatch hands off the slot id to a `WorkerThread`. The WorkerThread reads
+`slots_[sid].{callable, task_args, config}` on its own thread and executes —
+see [worker-manager.md](worker-manager.md) §3 for THREAD mode and §4 for
+PROCESS mode.
+
+**Pick-idle back-pressure**: if no idle worker exists in the pool,
+`pick_idle` blocks. The Scheduler thread is then stalled, which is fine —
+ready tasks pile up in the queue until a worker frees up. The ring's
+back-pressure at the Orch side already caps the number of in-flight tasks.
+
+---
+
+## 6. Phase 2 — completion
+
+Called by `WorkerThread::on_complete_(sid)` which pushes to
+`completion_queue_`. The Scheduler then:
+
+```cpp
+void Scheduler::on_task_complete(TaskSlot sid) {
+    TaskSlotState &s = slots_[sid];
+
+    // Group tasks require all sub-workers to finish
+    if (s.group_size > 0) {
+        if (s.sub_complete_count.fetch_add(1) + 1 < s.group_size) return;
+    }
+
+    s.state.store(TaskState::COMPLETED);
+
+    // Release fanout refs on downstream consumers
+    std::vector<TaskSlot> consumers;
+    {
+        std::lock_guard lk(s.fanout_mu);
+        consumers = s.fanout_consumers;    // snapshot (mutex protects vector)
+    }
+    for (TaskSlot csid : consumers) {
+        TaskSlotState &c = slots_[csid];
+        if (++c.fanin_released == c.fanin_count) {
+            ready_queue_.push(csid);       // consumer now ready
+        }
+    }
+
+    // Also: this task itself may now be CONSUMED
+    try_consume(sid);
+}
+```
+
+### `try_consume`
+
+```cpp
+void Scheduler::try_consume(TaskSlot sid) {
+    TaskSlotState &s = slots_[sid];
+    if (s.state.load() != TaskState::COMPLETED) return;
+    if (s.fanout_released.load() != s.fanout_total) return;
+
+    s.state.store(TaskState::CONSUMED);
+
+    // Erase tensormap entries this task produced
+    for (int i = 0; i < s.task_args.tensor_count(); i++) {
+        // only erase entries still pointing at this slot
+        uint64_t ptr = s.task_args.tensor(i).data;
+        if (orchestrator_->tensormap_lookup(ptr) == sid)
+            orchestrator_->tensormap_erase(ptr);
+    }
+
+    // Return slot to ring pool
+    ring_->release(sid);
+    s.state.store(TaskState::FREE);
+}
+```
+
+Scope release (when `scope_end` runs) calls back into the Scheduler to bump
+`fanout_released` by 1 on each scope-registered slot, triggering
+`try_consume`. This is how leaf tasks get reclaimed.
+
+---
+
+## 7. Start / Stop
+
+```cpp
+void Scheduler::start(Config cfg) {
+    manager_ = cfg.manager;
+    orchestrator_ = cfg.orchestrator;
+    running_.store(true);
+    thread_ = std::thread([this] { run(); });
+}
+
+void Scheduler::stop() {
+    running_.store(false);
+    wake();
+    thread_.join();
+}
+```
+
+`Worker::init` calls `start` after all children are registered and
+`WorkerManager::start` has spawned the WorkerThread pool.
+
+---
+
+## 8. Completion channel from WorkerThread
+
+```cpp
+// In WorkerThread, after worker->run() returns:
+void WorkerThread::loop() {
+    for (;;) {
+        TaskSlot sid = queue_.pop();
+        // ... run worker (see worker-manager.md for THREAD/PROCESS) ...
+        scheduler_->completion_queue_.push(sid);   // notify Scheduler
+    }
+}
+```
+
+The completion path is one-way and asynchronous: the WorkerThread returns to
+its own queue immediately, and the Scheduler handles completion in its own
+loop. This keeps worker dispatch latency bounded by dispatch cost alone, not
+by completion-handling cost.
+
+---
+
+## 9. Invariants
+
+1. **Scheduler is single-threaded**: all three phase handlers run in the
+   Scheduler's own thread. Atomics/mutexes on slot state are only needed for
+   Orch/WorkerThread ↔ Scheduler coordination.
+2. **Slot transitions are monotonic**: `FREE → PENDING → READY → RUNNING →
+   COMPLETED → CONSUMED` never reverses within one allocation.
+3. **Dispatch consumes one ready entry**: every `ready_queue.push` is
+   matched by exactly one `pick_idle + dispatch`. Group tasks push once,
+   dispatch N times via `pick_n_idle`.
+4. **Completion is per-worker for groups**: `on_task_complete` is called
+   `group_size` times; only the last one triggers the actual transition.
+5. **`try_consume` is idempotent on CONSUMED**: a repeated call after
+   CONSUMED is a no-op.
+
+---
+
+## 10. Related
+
+- [distributed_level_runtime.md](distributed_level_runtime.md) — high-level
+  three-component picture
+- [orchestrator.md](orchestrator.md) — the producer feeding the wiring queue
+- [worker-manager.md](worker-manager.md) — where dispatched slots go
+- [task-flow.md](task-flow.md) — the data (Callable / TaskArgs / CallConfig)
+  that the Scheduler moves around, opaquely, by slot id

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -1,0 +1,527 @@
+# Task Flow — Callable / TaskArgs / CallConfig Pass-Through
+
+This document specifies **what data flows through the hierarchical runtime and
+what shapes it takes at each stage**. It covers:
+
+- The three handles carried through every level: `Callable`, `TaskArgs`, `CallConfig`
+- The `IWorker` interface and its three implementations
+- The L2 ABI edge where internal formats are converted to `ChipStorageTaskArgs`
+- Recursive composition for L4+
+- A single end-to-end walkthrough
+
+For the components that move this data (how it's stored, dispatched,
+scheduled), see:
+
+- [orchestrator.md](orchestrator.md) — submit flow, Ring, TensorMap, Scope
+- [scheduler.md](scheduler.md) — dispatch loop, queues, completion handling
+- [worker-manager.md](worker-manager.md) — WorkerThread, THREAD/PROCESS
+  modes, mailbox mechanics
+- [distributed_level_runtime.md](distributed_level_runtime.md) — level model
+  and how components compose
+
+---
+
+## 1. The three handles
+
+Every task flowing through any level carries exactly three pieces of data:
+
+| Handle | Type | What it is |
+| ------ | ---- | ---------- |
+| `Callable` | `uint64_t` (opaque) | What the target worker should execute — interpretation depends on the receiving `IWorker` subclass |
+| `TaskArgs` | user builder class | Tensors + scalars + per-tensor tags (IN/OUT/INOUT/etc.) |
+| `CallConfig` | small POD | Execution knobs (block_dim, aicpu_thread_num, enable_profiling, …) |
+
+Everything else in the engine is either plumbing (slots, ring, tensormap,
+scheduler) or per-kernel state (stored in `Callable`).
+
+---
+
+## 2. `Callable` — one type, three meanings
+
+```cpp
+using Callable = uint64_t;
+```
+
+Opaque 64-bit handle. What it actually is depends on the destination worker:
+
+| Context | `Callable` encodes | Who casts it | How |
+| ------- | ------------------ | ------------ | --- |
+| `w3.submit_next_level(cb, …)` dispatched to `ChipWorker` (L2) | `ChipCallable*` — C++ object with compiled kernels | `ChipWorker::run` | `reinterpret_cast<ChipCallable*>(callable)` |
+| `w4.submit_next_level(cb, …)` dispatched to `Worker(level=3)` (L3 as L4 child) | `OrchFn` — Python orchestration function pointer | `Worker::run` | `reinterpret_cast<OrchFn>(callable)` |
+| `w3.submit_sub(cb, …)` dispatched to `SubWorker` | `uint64_t` callable_id indexing `py_registry_` | `SubWorker::run` | direct use as integer |
+
+Where `OrchFn` is:
+
+```cpp
+using OrchFn = void (*)(Orchestrator*, TaskArgsView, const CallConfig&);
+```
+
+The `submit_*` API uses `Callable` (uint64) uniformly — no `void*` / `int32_t`
+split, no three-way cast.
+
+### Lifetime — pre-fork registration
+
+Every concrete `Callable` object (ChipCallable, Python orch fn, sub callable)
+**must be registered before any child process is forked**. After fork, the
+child inherits these through COW and the uint64 handle dereferences validly
+in the child.
+
+---
+
+## 3. `TaskArgs` — one class, four representations
+
+One user-facing class. Its contents appear in four different physical
+representations across a task's lifetime — these are **phases**, not
+hierarchy levels.
+
+```cpp
+class TaskArgs {
+    std::vector<ContinuousTensor> tensors_;
+    std::vector<TensorArgType>    tags_;     // per-tensor: INPUT/OUTPUT/INOUT/OUTPUT_EXISTING/NO_DEP
+    std::vector<uint64_t>         scalars_;
+public:
+    void add_tensor(const ContinuousTensor&, TensorArgType tag = TensorArgType::INPUT);
+    void add_scalar(uint64_t);
+    TaskArgsView view() const;
+    int32_t tensor_count() const;
+    int32_t scalar_count() const;
+    TensorArgType tag(int32_t i) const;    // only Orchestrator reads tags
+};
+```
+
+`TensorArgType` has five values (matches existing `tensor_arg.h:53-59`):
+`INPUT`, `OUTPUT`, `INOUT`, `OUTPUT_EXISTING`, `NO_DEP`.
+
+### Representation at each phase
+
+| Phase | Form | Backing memory | Who writes | Who reads |
+| ----- | ---- | -------------- | ---------- | --------- |
+| **① User submit** | `TaskArgs` object (builder) | Python/C++ parent heap | user orch fn | Orchestrator |
+| **② Slot storage** | `TaskArgs` object (inside `slot.task_args`) | parent heap | Orchestrator.submit moves it here | WorkerThread at dispatch |
+| **③ Dispatch wire (PROCESS only)** | length-prefixed blob | shm mailbox (MAP_SHARED) | parent WorkerThread encodes | forked child decodes |
+| **④ L2 ABI edge** | `ChipStorageTaskArgs` POD (1672 B) | child stack | `ChipWorker::run` assembles | `pto2_run_runtime` consumes |
+
+### Tags stripped at submit
+
+Tags are consumed by `Orchestrator::submit_*` to derive TensorMap dependencies
+and then discarded. Phases ②, ③, ④ do not carry tags — scheduler, worker
+thread, child, and runtime.so all ignore per-tensor direction.
+
+### Blob byte layout (phase ③)
+
+```text
+offset 0:            int32  tensor_count = T
+offset 4:            int32  scalar_count = S
+offset 8:            ContinuousTensor tensors[T]    // 40 B each
+offset 8 + 40T:      uint64_t scalars[S]            // 8 B each
+total used:          8 + 40T + 8S
+```
+
+No tags, no pickle, no schema versioning — pure memcpy.
+
+### TaskArgsView — the interface type
+
+Both THREAD mode (from `TaskArgs::view()`) and PROCESS mode (from `read_blob`)
+yield the same view type:
+
+```cpp
+struct TaskArgsView {
+    int32_t tensor_count;
+    int32_t scalar_count;
+    const ContinuousTensor *tensors;   // T items
+    const uint64_t         *scalars;   // S items
+};
+```
+
+24 bytes, POD, passable by value. Where the pointed-to arrays live depends on
+mode:
+
+- **THREAD**: `tensors` points into the `std::vector<ContinuousTensor>` heap
+  backing inside `slot.task_args`
+- **PROCESS**: `tensors` points into the shm mailbox blob region
+
+View does **not** own memory. Valid for the duration of a single `IWorker::run`
+call.
+
+### Conversion diagram
+
+```text
+① TaskArgs (user)                    — parent heap (vectors)
+     │
+     │ Orchestrator::submit_next_level (tags consumed)
+     ▼
+② slot.task_args: TaskArgs           — parent heap, stored in slot
+
+     ┌── THREAD mode ─────────────────────────────────────┐
+     │  view = slot.task_args.view()                       │
+     │    (pointers into slot's vector backing)            │
+     └─────────────────────────────────────────────────────┘
+                     OR
+     ┌── PROCESS mode ────────────────────────────────────┐
+     │  write_blob(mailbox, slot.task_args)                │
+     │    (memcpy into shm mailbox)                        │
+     │  child reads mailbox:                               │
+     │  view = read_blob(mailbox_bytes)                    │
+     │    (pointers into shm mailbox)                      │
+     └─────────────────────────────────────────────────────┘
+
+     │ (both paths yield TaskArgsView)
+     ▼
+    IWorker::run(callable, view, config)
+
+     │ (ChipWorker only, at L2 ABI)
+     ▼
+④ ChipStorageTaskArgs POD — child stack
+     │ memcpy view.tensors, view.scalars into struct
+     ▼
+    pto2_run_runtime(callable, &chip_storage, &config)
+```
+
+---
+
+## 4. `CallConfig` — small POD, always by value
+
+```cpp
+struct CallConfig {
+    int32_t block_dim = 1;
+    int32_t aicpu_thread_num = 3;
+    bool    enable_profiling = false;
+    // future fields here — same POD used at all levels
+};
+```
+
+Propagated by value throughout:
+
+1. User builds `CallConfig` and passes into `submit_next_level`
+2. Orchestrator stores it inline in `slot.config` (POD copy)
+3. Dispatch: THREAD passes `const slot.config &`; PROCESS memcpy into mailbox
+4. Child reads `CallConfig` from mailbox by value
+5. `IWorker::run` receives `const CallConfig&`; passed on to `pto2_run_runtime`
+   at the L2 edge
+
+Same type at every level. `ChipCallConfig` is an alias for `CallConfig` at the
+L2 runtime ABI (they must have identical layout).
+
+---
+
+## 5. `IWorker` — the unified execution interface
+
+```cpp
+class IWorker {
+public:
+    virtual ~IWorker() = default;
+    virtual void run(Callable callable,
+                     TaskArgsView args,
+                     const CallConfig &config) = 0;
+};
+```
+
+Three implementations:
+
+### `ChipWorker` (L2 leaf)
+
+Wraps a dlsym'd `runtime.so`. `run()` assembles `ChipStorageTaskArgs` from the
+view and calls `pto2_run_runtime`:
+
+```cpp
+void ChipWorker::run(Callable cb, TaskArgsView view, const CallConfig &config) override {
+    ChipStorageTaskArgs chip_storage;
+    chip_storage.tensor_count_ = view.tensor_count;
+    chip_storage.scalar_count_ = view.scalar_count;
+    memcpy(chip_storage.tensors_, view.tensors, view.tensor_count * sizeof(ContinuousTensor));
+    memcpy(chip_storage.scalars_, view.scalars, view.scalar_count * sizeof(uint64_t));
+    pto2_run_runtime(reinterpret_cast<ChipCallable*>(cb), &chip_storage, &config);
+}
+```
+
+~1.6 KB memcpy per task; negligible.
+
+### `SubWorker` (Python callable leaf)
+
+```cpp
+void SubWorker::run(Callable cb, TaskArgsView view, const CallConfig &config) override {
+    uint64_t cid = cb;                     // no cast
+    py_registry_[cid](view);               // invoke Python callable with view
+}
+```
+
+Child inherits the Python registry through fork COW; the registry lookup works
+with no IPC.
+
+### `Worker` (L3+ composite)
+
+Runs one DAG per `run` invocation. The `Callable` is the user's orch fn:
+
+```cpp
+void Worker::run(Callable cb, TaskArgsView args, const CallConfig &config) override {
+    orchestrator_.scope_begin();
+    reinterpret_cast<OrchFn>(cb)(&orchestrator_, args, config);   // user orch fn
+    orchestrator_.drain();
+    orchestrator_.scope_end();
+}
+```
+
+User convenience overload:
+
+```cpp
+void Worker::run(const Task &task) {
+    run(reinterpret_cast<Callable>(task.orch), task.task_args.view(), task.config);
+}
+```
+
+---
+
+## 6. Data flow through a submit
+
+The user's orch fn receives an `Orchestrator*` (not a `Worker*`) and calls
+`submit_next_level` / `submit_sub`:
+
+```cpp
+class Orchestrator {
+public:
+    SubmitResult submit_next_level(Callable cb, TaskArgs args, const CallConfig &config);
+    SubmitResult submit_next_level_group(Callable cb, std::vector<TaskArgs> args_list, const CallConfig &config);
+    SubmitResult submit_sub(Callable cb, TaskArgs args, const CallConfig &config);
+};
+
+struct SubmitResult { TaskSlot slot_id; };
+```
+
+Only `slot_id` is returned — downstream consumers reference tensors by their
+own pointers (already registered in TensorMap by the OUTPUT/INOUT tag).
+
+Where the data goes after submit:
+
+1. `Callable` — copied into `slot.callable` (parent heap, one `uint64_t`)
+2. `TaskArgs` — moved into `slot.task_args` (parent heap, vector-backed).
+   Tags are consumed during the same submit call for dep inference and
+   **never carried further**.
+3. `CallConfig` — copied into `slot.config` (parent heap, POD)
+
+For the full submit mechanics (ring alloc, TensorMap lookup/insert, scope ref,
+fanout wiring), see [orchestrator.md](orchestrator.md).
+
+## 7. Data flow through dispatch
+
+After the scheduler picks an idle `WorkerThread` and calls `wt->dispatch(sid)`,
+the WorkerThread reads task data from the slot and hands it to
+`IWorker::run`:
+
+### THREAD mode — zero-copy
+
+`TaskArgs::view()` returns pointers into the slot's vector backing. No encode,
+no memcpy beyond `CallConfig` value-passing.
+
+```cpp
+worker_->run(slot.callable, slot.task_args.view(), slot.config);
+```
+
+### PROCESS mode — encode once to mailbox
+
+Parent-side WorkerThread encodes callable + config + TaskArgs blob into a
+shm mailbox; child reads the blob back as a view:
+
+```text
+slot.callable   ─┐
+slot.config     ─┼─► memcpy into shm mailbox ─► child reads view ─► worker_->run(cb, view, config)
+slot.task_args  ─┘    (write_blob)                (read_blob)
+```
+
+The mailbox layout, fork ordering, and child loop are in
+[worker-manager.md](worker-manager.md) §4.
+
+### Memory partitioning
+
+| Region | Lives in | Used by | Lifetime |
+| ------ | -------- | ------- | -------- |
+| `slots_[N]` (TaskSlotState array) | parent heap | Orchestrator, Scheduler, WorkerThread parent side | ring-managed |
+| `slots_[i].task_args` (vector-backed) | parent heap | same | until slot released |
+| per-WT mailbox (PROCESS only) | shm MAP_SHARED | parent WorkerThread writes, child reads | lifetime of WorkerThread |
+| tensor data bytes | torch shm (`share_memory_()` or equiv) | kernel reads/writes | user-managed |
+| `Callable` target (ChipCallable / OrchFn / Python fn) | parent heap | child via fork COW | pre-fork registered |
+
+**Child never reads the slot.** Child only sees:
+
+1. its mailbox (shm)
+2. parent's pre-fork heap via COW (read-only in practice)
+3. MAP_SHARED tensor data buffers
+
+## 8. Data flow on completion
+
+When `IWorker::run` returns, the WorkerThread signals completion:
+
+- **THREAD mode**: direct call to `on_complete_(slot_id)`, which pushes to
+  `Scheduler::completion_queue_`
+- **PROCESS mode**: child writes `TASK_DONE` to mailbox; parent WorkerThread
+  sees it, calls `on_complete_(slot_id)`
+
+At this point:
+
+- Tensor output data is already written to shm (kernel wrote via
+  `ContinuousTensor.data` pointer → shm page visible to parent)
+- Control returns to the Scheduler, which releases fanout refs and wakes
+  downstream consumers
+
+For the completion-side mechanics (fanout release, `try_consume`, ring
+release), see [scheduler.md](scheduler.md) §6.
+
+---
+
+## 9. Recursive composition (L4+)
+
+`Worker` implements `IWorker`, so a higher-level `Worker` can use it as a
+next-level child:
+
+```python
+w3 = Worker(level=3, child_mode=WorkerManager.Mode.PROCESS)
+w3.add_worker(NEXT_LEVEL, chip_worker_0)
+w3.add_worker(NEXT_LEVEL, chip_worker_1)
+w3.add_worker(SUB, sub_worker_0)
+
+w4 = Worker(level=4, child_mode=WorkerManager.Mode.THREAD)
+w4.add_worker(NEXT_LEVEL, w3)                 # L3 Worker is IWorker
+```
+
+At L4 the `Callable` passed to `submit_next_level` is an **L3 orch fn**, not a
+`ChipCallable`:
+
+```python
+def my_l3_orch(orch3, args, cfg):
+    orch3.submit_next_level(chip_callable_handle, args, cfg)
+
+def my_l4_orch(orch4, args, cfg):
+    orch4.submit_next_level(my_l3_orch_handle, args, cfg)
+
+w4.run(Task(orch=my_l4_orch, task_args=..., config=...))
+```
+
+L4's WorkerThread dispatches to `w3` via `IWorker::run`. `Worker::run`
+interprets the `Callable` as an `OrchFn`:
+
+```cpp
+void Worker::run(Callable cb, TaskArgsView args, const CallConfig &cfg) override {
+    orchestrator_.scope_begin();
+    reinterpret_cast<OrchFn>(cb)(&orchestrator_, args, cfg);
+    orchestrator_.drain();
+    orchestrator_.scope_end();
+}
+```
+
+Each level's orch fn receives **its own** `Orchestrator` — the recursion is
+symmetric. `Worker` code does not branch on `level_`; the level is only a
+label (for diagnostics).
+
+---
+
+## 10. Worked example — one L3 chip task
+
+User code:
+
+```python
+a = torch.randn(N).share_memory_()
+b = torch.randn(N).share_memory_()
+c = torch.zeros(N).share_memory_()
+
+args = TaskArgs()
+args.add_tensor(make_ct(a), IN)
+args.add_tensor(make_ct(b), IN)
+args.add_tensor(make_ct(c), OUT)
+
+def my_orch(orch, view, cfg):
+    chip_args = TaskArgs()
+    for i in range(view.tensor_count):
+        chip_args.add_tensor(view.tensors[i], IN if i < 2 else OUT)
+    orch.submit_next_level(chip_kernel_handle, chip_args, cfg)
+
+w3 = Worker(level=3, child_mode=PROCESS)
+w3.add_worker(NEXT_LEVEL, chip_worker_0)
+w3.init()    # fork chip_0 here
+
+w3.run(Task(orch=my_orch, task_args=args, config=CallConfig(block_dim=3)))
+```
+
+Step-by-step (PROCESS mode, one chip worker):
+
+| Step | Where | What happens |
+| ---- | ----- | ------------ |
+| 1 | parent Python | user builds `args: TaskArgs`, calls `w3.run(Task)` |
+| 2 | `Worker::run` | `scope_begin` → call `my_orch(&orch_, args.view(), cfg)` |
+| 3 | `Orchestrator::submit_next_level` | `slot = ring.alloc()`; move `chip_args` into `slot.task_args`; walk tags → `tensormap.lookup(a.data)`, `tensormap.lookup(b.data)`, `tensormap.insert(c.data, slot)`; push ready |
+| 4 | Scheduler thread | pop `slot`; `wt = manager.pick_idle(NEXT_LEVEL)` (WT_chip_0); `wt->dispatch(slot)` |
+| 5 | WT_chip_0 parent side | encode mailbox: write `callable` = chip_kernel handle, `config`, `write_blob` of task_args; set `TASK_READY`; spin-poll |
+| 6 | chip_0 child process | wake on `TASK_READY`; `read_blob` → `view`; call `ChipWorker::run(cb, view, cfg)` |
+| 7 | `ChipWorker::run` | assemble `ChipStorageTaskArgs` POD (memcpy view); call `pto2_run_runtime(cb, &chip_storage, &cfg)` |
+| 8 | runtime.so | translate host ptrs → device ptrs; dispatch AICPU / AICore; write output into `c`'s shm |
+| 9 | chip_0 child | `run` returns; write `TASK_DONE` |
+| 10 | WT_chip_0 parent | see `TASK_DONE`; call `on_complete_(slot)` |
+| 11 | Scheduler | mark slot COMPLETED; fanout release (none in this DAG); scope_end will release scope ref |
+| 12 | `Worker::run` returns | user's `w3.run(Task)` returns; `c` contains result in shm, visible to user |
+
+---
+
+## 11. Design notes
+
+### Why `Callable = uint64_t`, not `void*`
+
+All three callable meanings (ChipCallable pointer, OrchFn pointer, sub
+callable_id) fit in 64 bits. Using `void*` forced `int32_t callable_id` to go
+through `reinterpret_cast<intptr_t>` then `static_cast<int32_t>` — three layers
+of cast. `uint64_t` lets each receiver do a single cast appropriate to its
+semantics.
+
+### Why tags live only on user-side `TaskArgs`
+
+Tags (IN/OUT/INOUT/…) are used by `Orchestrator::submit_*` to derive TensorMap
+dependencies and nothing else. Scheduler, WorkerThread, child, runtime.so, and
+kernels do not inspect them. Keeping tags only in Layer ① simplifies the blob
+and makes the "tags are Orchestrator input" rule explicit. Matches existing
+runtime: `ChipStorageTaskArgs` (`task_args.h:157`) is already declared with
+`void` as the TensorTag parameter.
+
+### Why no `WorkerPayload` wrapper
+
+`IWorker::run` takes `(Callable, TaskArgsView, const CallConfig&)` directly.
+Wrapping them in a struct added no value and made mailbox serialization
+indirect. Task identity (slot_id) is held by the WorkerThread for the
+completion callback, not passed into the IWorker.
+
+### Why slots on heap, mailbox on shm
+
+Slots carry scheduler-only state (atomics, mutex, `std::vector` of fanout
+consumers) that is parent-private. Putting them in shm would force cross-
+process atomics and shm-safe containers. The only data that needs to cross
+the fork boundary is per-task: callable, config, args — and that fits in a
+~2 KB mailbox with a one-time memcpy per dispatch (matches the pattern
+already used by `DistChipProcess` today).
+
+### Why TaskArgs in slot (not encoded blob in slot)
+
+`TaskArgs` is vector-backed. Storing an `uint8_t args_blob[N]` inline in the
+slot would cap task size per level and waste memory per slot. Since the slot
+is parent-heap, there is no fork-boundary constraint on what it holds — just
+store the `TaskArgs` object and encode only at dispatch (PROCESS only), or
+hand over `task_args.view()` (THREAD).
+
+### Why `TaskArgsView` is just pointers + counts
+
+View is constructed at both ends of dispatch (from `TaskArgs::view()` and
+from `read_blob()`). Making it POD (24 B) lets it pass by value through
+`IWorker::run`. The underlying `ContinuousTensor[]` lives either in the
+vector's heap backing or inline in the mailbox blob — view doesn't care.
+
+---
+
+## Related
+
+- [distributed_level_runtime.md](distributed_level_runtime.md) — L0–L6 level
+  model, three-component composition
+- [orchestrator.md](orchestrator.md) — how `submit_*` actually builds the DAG
+- [scheduler.md](scheduler.md) — how dispatched slots get worker threads
+- [worker-manager.md](worker-manager.md) — `WorkerThread`, THREAD/PROCESS
+  modes, mailbox layout, fork ordering
+- [chip-level-arch.md](chip-level-arch.md) — L2 single-chip: three-program
+  model (host / AICPU / AICore)
+- [`../src/common/task_interface/task_args.h`](../src/common/task_interface/task_args.h)
+  — `TaskArgs` template and `ChipStorageTaskArgs` alias
+- [`../src/common/task_interface/tensor_arg.h`](../src/common/task_interface/tensor_arg.h)
+  — `ContinuousTensor` POD and `TensorArgType` enum

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -1,0 +1,348 @@
+# Worker Manager — Pool, Threading, and Dispatch Modes
+
+`WorkerManager` and `WorkerThread` together implement the **execution layer**
+of a `Worker` engine. `WorkerManager` owns two pools of `WorkerThread`s (one
+for next-level workers, one for sub workers); each `WorkerThread` owns an
+`IWorker` and a `std::thread`, and dispatches to it in either THREAD or
+PROCESS mode.
+
+For the high-level role of this layer among the three engine components, see
+[distributed_level_runtime.md](distributed_level_runtime.md). For what the
+`IWorker` implementations actually do with task data, see
+[task-flow.md](task-flow.md). For where dispatched tasks come from, see
+[scheduler.md](scheduler.md).
+
+---
+
+## 1. `WorkerManager`
+
+```cpp
+class WorkerManager {
+public:
+    enum class Mode { THREAD, PROCESS };
+
+    explicit WorkerManager(Mode mode);
+
+    // Registration (before init)
+    void add_next_level(IWorker *worker);
+    void add_sub       (IWorker *worker);
+
+    // Lifecycle
+    void start(OnCompleteFn on_complete);   // starts all WorkerThreads
+    void stop();
+
+    // Scheduler API
+    WorkerThread *pick_idle(WorkerType type);
+    std::vector<WorkerThread *> pick_n_idle(WorkerType type, int n);
+    void dispatch(WorkerThread *wt, TaskSlot slot_id);
+
+private:
+    Mode mode_;
+    std::vector<std::unique_ptr<WorkerThread>> next_level_;
+    std::vector<std::unique_ptr<WorkerThread>> sub_;
+};
+```
+
+### Responsibilities
+
+- **Pool ownership**: two `std::vector` pools, sized at init from `add_*`
+  calls
+- **Idle selection**: `pick_idle(type)` finds a WorkerThread whose queue is
+  empty; blocks if none available
+- **Mode propagation**: every `WorkerThread` constructed under this manager
+  inherits `mode_` (picked per `Worker` at construction)
+
+### Mode choice
+
+| Deployment | Recommended mode |
+| ---------- | ---------------- |
+| Onboard real hardware | `THREAD` — driver is thread-safe per device, no fork overhead |
+| Simulation (sim runtime) | `PROCESS` — sim backend has shared state that needs isolation |
+| `ci.py` parallel tests | `PROCESS` — test independence; per-test dlopen state |
+| L4+ when L3 children are thread-safe composites | `THREAD` |
+
+Mode is a per-`Worker` decision. Different levels in a nested hierarchy can
+use different modes independently (e.g., L4 THREAD containing L3 PROCESS).
+
+---
+
+## 2. `WorkerThread`
+
+One WorkerThread per IWorker instance.
+
+```cpp
+class WorkerThread {
+public:
+    enum class Mode { THREAD, PROCESS };
+
+    WorkerThread(Mode mode,
+                 IWorker *worker,
+                 TaskSlotState *parent_slots,
+                 size_t mailbox_size = 0);
+
+    void start(OnCompleteFn on_done);
+    void stop();
+    void dispatch(TaskSlot slot_id);
+    bool is_idle() const;
+
+private:
+    Mode mode_;
+    IWorker *worker_;
+    TaskSlotState *parent_slots_;          // reference to parent's slot pool
+    std::thread parent_thread_;
+    LockFreeQueue<TaskSlot> queue_;
+
+    // PROCESS mode only
+    void *mailbox_ = nullptr;              // shm
+    pid_t child_pid_ = -1;
+    size_t mailbox_size_ = 0;
+
+    void loop();
+    void dispatch_thread(TaskSlot slot_id);
+    void dispatch_process(TaskSlot slot_id);
+    [[noreturn]] void child_loop();
+    void fork_child();
+};
+```
+
+The WorkerThread's `std::thread` always exists regardless of mode — it pumps
+the internal queue and either runs the worker in-process or drives the shm
+handshake to a forked child.
+
+---
+
+## 3. THREAD mode
+
+The simple case: same process, no shm, no serialization.
+
+```cpp
+void WorkerThread::dispatch_thread(TaskSlot slot_id) {
+    TaskSlotState &s = parent_slots_[slot_id];
+    worker_->run(s.callable, s.task_args.view(), s.config);
+    on_complete_(slot_id);
+}
+```
+
+- `TaskArgs::view()` returns a zero-copy `TaskArgsView` pointing into the
+  slot's `std::vector` backing (parent heap)
+- `IWorker::run` dispatches polymorphically based on the actual worker type
+
+**When is THREAD mode safe?**
+
+- The IWorker implementation must be thread-safe relative to other concurrent
+  calls and other system state
+- `ChipWorker` (dlsym'd runtime.so) is safe when the runtime `.so` and its
+  device driver support concurrent use
+- `SubWorker` in THREAD mode is constrained by Python's GIL (all SubWorkers
+  in the pool effectively serialize), but this is often fine for light
+  Python callables
+
+---
+
+## 4. PROCESS mode
+
+Each WorkerThread forks a child at init. Each dispatch encodes task data into
+a shm mailbox, signals the child, and polls for completion.
+
+### 4.1 Fork at init
+
+`fork_child()` is called once by `WorkerThread::start()` **before any C++
+worker thread spawns**:
+
+```cpp
+void WorkerThread::fork_child() {
+    // Alloc mailbox in MAP_SHARED shm
+    mailbox_ = mmap(nullptr, mailbox_size_,
+                    PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    // Initialize mailbox state to IDLE
+    write_state(mailbox_, MailboxState::IDLE);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        // Child
+        child_loop();   // never returns
+    } else {
+        child_pid_ = pid;
+    }
+}
+```
+
+### 4.2 Fork ordering invariant
+
+**Fork must happen before any `std::thread` is created in the parent.** The
+Python `Worker` ensures this by:
+
+1. `Worker.register(fn)` registers Python callables (pre-fork)
+2. C++ `WorkerManager::add_*` registers IWorker pointers
+3. `Worker::init`:
+   - First: `WorkerManager::start()` — this calls each WorkerThread's
+     `start`, which **forks the child, then spawns the parent's
+     std::thread** for that WT
+   - Then: `Scheduler::start()` spawns the scheduler thread
+4. Fork ordering: at the moment `fork()` is called, the parent has only the
+   Python main thread and zero C++ worker threads. Safe.
+
+This avoids the classical "fork in multithreaded process" hazard where a
+child inherits locks held by threads that don't exist post-fork.
+
+### 4.3 Parent-side dispatch
+
+```cpp
+void WorkerThread::dispatch_process(TaskSlot slot_id) {
+    TaskSlotState &s = parent_slots_[slot_id];
+    uint8_t *d = (uint8_t*)mailbox_ + HEADER_SIZE;
+
+    // Write task data
+    *reinterpret_cast<Callable*>(d)               = s.callable;
+    *reinterpret_cast<CallConfig*>(d + 8)         = s.config;
+    write_blob(d + 8 + sizeof(CallConfig), s.task_args);
+
+    // Signal child
+    write_state(mailbox_, MailboxState::TASK_READY);
+
+    // Poll for completion
+    while (read_state(mailbox_) != MailboxState::TASK_DONE)
+        std::this_thread::sleep_for(std::chrono::microseconds(50));
+
+    int err = read_error(mailbox_);
+    write_state(mailbox_, MailboxState::IDLE);
+    on_complete_(slot_id, err);
+}
+```
+
+Parent-side cost per dispatch:
+
+- One memcpy of `Callable` (8 B) + `CallConfig` (~16 B) + blob (≤~1.7 KB for
+  L3)
+- One signal (`write_state`)
+- Poll loop with `sleep_for(50us)` (not busy-wait)
+
+Total ~nanoseconds overhead; the wait is dominated by actual kernel execution.
+
+### 4.4 Child loop
+
+```cpp
+void WorkerThread::child_loop() {
+    for (;;) {
+        while (read_state(mailbox_) != MailboxState::TASK_READY)
+            pause_short();
+
+        if (read_state(mailbox_) == MailboxState::SHUTDOWN) exit(0);
+
+        uint8_t *d = (uint8_t*)mailbox_ + HEADER_SIZE;
+        Callable     cb     = *reinterpret_cast<Callable*>(d);
+        CallConfig   config = *reinterpret_cast<CallConfig*>(d + 8);
+        TaskArgsView view   = read_blob(d + 8 + sizeof(CallConfig));
+
+        int err = 0;
+        try {
+            worker_->run(cb, view, config);
+        } catch (...) {
+            err = 1;
+        }
+        write_error(mailbox_, err);
+        write_state(mailbox_, MailboxState::TASK_DONE);
+    }
+}
+```
+
+Child's `worker_` is polymorphic (ChipWorker / SubWorker / nested Worker).
+The child inherits the parent's full address space at fork time, so:
+
+- ChipCallable objects (pre-fork allocated) are COW-visible at the same VA
+- `py_registry` (for SubWorker) is COW-visible
+- Tensor data in `torch.share_memory_()` regions is fully shared (MAP_SHARED)
+
+### 4.5 Mailbox layout
+
+```text
+offset 0:                              int32  state    (IDLE / TASK_READY / TASK_DONE / SHUTDOWN)
+offset 4:                              int32  error
+offset 8:                              uint64 callable
+offset 16:                             CallConfig config
+offset 16 + sizeof(CallConfig):        bytes  blob:  [int32 T][int32 S][ContinuousTensor × T][uint64_t × S]
+```
+
+Sized at WorkerThread construction:
+
+```cpp
+mailbox_size_ = HEADER_SIZE                    // 8 B (state + error)
+              + sizeof(Callable)                // 8 B
+              + sizeof(CallConfig)              // ~16 B
+              + MAX_BLOB_SIZE;                  // per-level, e.g. 1672 B for L3
+```
+
+Per-worker total: ~2 KB. Typical pool: 4-8 workers → ~8-16 KB shm total.
+
+### 4.6 Shutdown
+
+```cpp
+void WorkerThread::stop() {
+    if (mode_ == Mode::PROCESS) {
+        write_state(mailbox_, MailboxState::SHUTDOWN);
+        waitpid(child_pid_, nullptr, 0);
+        munmap(mailbox_, mailbox_size_);
+    }
+    // Signal parent thread to exit its loop
+    queue_.push_sentinel();
+    parent_thread_.join();
+}
+```
+
+---
+
+## 5. Adding a new IWorker type
+
+To add a new worker kind (e.g., a RemoteWorker over RPC):
+
+1. Implement `IWorker::run(Callable, TaskArgsView, const CallConfig&)` on the
+   new class
+2. Register via `manager.add_next_level(ptr)` or `manager.add_sub(ptr)`
+3. If the new worker needs to run in PROCESS mode, ensure any resources it
+   needs (shm regions, sockets) are established before fork
+
+The dispatch path (THREAD vs PROCESS) is chosen by `WorkerManager::mode_`,
+not by the IWorker type — so the same IWorker implementation works in both
+modes. This is why `ChipWorker`, `SubWorker`, and `Worker` all share one
+interface: the dispatch layer is orthogonal to the worker semantics.
+
+---
+
+## 6. Why this layering
+
+Three decisions that led here:
+
+### 6.1 Why not fork per task?
+
+Forking per submit eliminates the mailbox and serialization, but costs
+~1-10 ms per fork (COW page-table setup for a large parent image). For
+thousands of tasks per DAG, the overhead dominates. Pre-forked pool amortizes
+fork across many dispatches.
+
+### 6.2 Why slot pool on parent heap, not shm?
+
+The scheduling state (TaskSlotState.fanin_count, fanout_consumers,
+fanout_mu) is parent-only — Scheduler and Orchestrator read/write it, but
+children never do. Putting the slot in shm would force cross-process atomics
+and shm-safe containers for no benefit. See
+[task-flow.md](task-flow.md) §11 for full rationale.
+
+### 6.3 Why one WorkerThread per IWorker?
+
+Alternative: N workers share one dispatch queue. Rejected because:
+
+- `WorkerThread` queue is the natural unit of backpressure — if worker `i` is
+  slow, its queue fills up and scheduler falls back to another
+- Simpler mental model: one IWorker = one thread that drives it
+- Zero contention on queue access (only one producer, one consumer per queue)
+
+---
+
+## 7. Related
+
+- [distributed_level_runtime.md](distributed_level_runtime.md) — where this
+  layer fits in the three-component engine
+- [task-flow.md](task-flow.md) — what `IWorker::run` receives
+- [scheduler.md](scheduler.md) — the producer of `WorkerThread::dispatch`
+  calls

--- a/src/common/task_interface/callable.h
+++ b/src/common/task_interface/callable.h
@@ -25,8 +25,9 @@
  * The returned vector<uint8_t> owns the memory; reinterpret_cast to access.
  *
  * Higher-level callables (L3 HostCallable) are Python-only objects that
- * reference ChipCallable(s) by pointer. They use callable_id in WorkerPayload
- * and never cross the host-device boundary. See distributed_level_runtime.md.
+ * reference ChipCallable(s) by pointer. At L3+ submit, callables are passed as
+ * an opaque uint64 Callable handle (see docs/task-flow.md); they never cross
+ * the host-device boundary.
  *
  * Type aliases:
  *   CoreCallable = Callable<void, CORE_MAX_TENSOR_ARGS, 0>       — leaf kernel binary


### PR DESCRIPTION
## Summary

Break the monolithic `distributed_level_runtime.md` and rename `architecture.md` so each design doc has one audience and one scope.

- **Rename** `architecture.md` → `chip-level-arch.md` (L2 single-chip scope)
- **Slim** `distributed_level_runtime.md` to level model + component overview; move internal details to per-component docs
- **New** `orchestrator.md` — submit flow, Ring, TensorMap, Scope, task state machine
- **New** `scheduler.md` — wiring/ready/completion queues, dispatch loop
- **New** `worker-manager.md` — WorkerManager + WorkerThread, THREAD/PROCESS modes, fork + mailbox mechanics
- **New** `task-flow.md` — Callable / TaskArgs / CallConfig handles, IWorker interface, L2 ABI edge, end-to-end walkthrough
- Update `README.md`, `.claude/rules/architecture.md`, `callable.h` doc comment to the new filenames

## Reader path

| Goal | Read |
| --- | --- |
| Understand single-chip (L2) | `chip-level-arch.md` |
| Understand level hierarchy + components | `distributed_level_runtime.md` |
| Trace a task end-to-end | `task-flow.md` |
| Modify DAG submission logic | `orchestrator.md` |
| Modify scheduling strategy | `scheduler.md` |
| Add a new worker type / fork mechanics | `worker-manager.md` |

## Test plan

- [x] `markdownlint-cli2` passes on all changed/new docs
- [x] All cross-references resolve (verified with `grep -rn`)
- [x] No stale references to `architecture.md` or `task-data-flow.md` remain
- [ ] Review prose for readability

Docs-only change; no code or test changes.