### PR TITLE
Fix: use WIP staging slots in PerfBuffer to prevent profiling data loss

### DIFF
--- a/src/a2a3/platform/include/aicore/performance_collector_aicore.h
+++ b/src/a2a3/platform/include/aicore/performance_collector_aicore.h
@@ -34,8 +34,8 @@
 /**
  * Record task execution performance data
  *
- * Writes performance metrics to the provided buffer. Buffer management
- * and status tracking are handled by AICPU.
+ * Writes timing metrics to the WIP staging slot (wip[task_id & 1]).
+ * Buffer management and final commit are handled by AICPU.
  *
  * AICore writes PerfRecord.task_id as the register dispatch token (low 32 bits, zero-extended).
  * For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), AICPU overwrites
@@ -48,18 +48,14 @@
  */
 __aicore__ __attribute__((always_inline)) static inline void
 perf_aicore_record_task(__gm__ PerfBuffer *perf_buf, uint32_t task_id, uint64_t start_time, uint64_t end_time) {
-    // Read current buffer count (AICPU owns the count, AICore reads only)
-    dcci(&perf_buf->count, SINGLE_CACHE_LINE);
-    uint32_t idx = perf_buf->count;
+    // Write to WIP staging slot — parity alternates with dual-slot dispatch
+    __gm__ PerfRecord *record = &perf_buf->wip[task_id & 1u];
 
-    __gm__ PerfRecord *record = &perf_buf->records[idx];
-
-    // Write record data (func_id, core_type, and count filled by AICPU at completion)
     record->start_time = start_time;
     record->end_time = end_time;
     record->task_id = static_cast<uint64_t>(task_id);
 
-    // Flush cache to make data visible
+    // Flush cache to make data visible to AICPU
     dcci(record, SINGLE_CACHE_LINE, CACHELINE_OUT);
     dsb((mem_dsb_t)0);
 }

--- a/src/a2a3/platform/include/common/perf_profiling.h
+++ b/src/a2a3/platform/include/common/perf_profiling.h
@@ -98,7 +98,7 @@ struct PerfRecord {
 static_assert(sizeof(PerfRecord) % 64 == 0, "PerfRecord must be 64-byte aligned for optimal cache performance");
 
 // =============================================================================
-// PerfBuffer - Fixed-Size Record Buffer
+// PerfBuffer - Fixed-Size Record Buffer with WIP Staging Slots
 // =============================================================================
 
 /**
@@ -106,10 +106,14 @@ static_assert(sizeof(PerfRecord) % 64 == 0, "PerfRecord must be 64-byte aligned 
  *
  * Capacity: PLATFORM_PROF_BUFFER_SIZE (defined in platform_config.h)
  * Allocated dynamically by Host, pushed into per-core free_queue.
+ *
+ * WIP protocol: AICore writes timing to wip[reg_task_id & 1], AICPU copies
+ * it into records[count] at completion. Dual-slot parity ensures no overlap.
  */
 struct PerfBuffer {
-    PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Record array
-    volatile uint32_t count;                        // Current record count
+    PerfRecord wip[2];                              // AICore WIP staging slots (index = reg_task_id & 1)
+    PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Committed records (AICPU writes)
+    volatile uint32_t count;                        // Current committed record count
 } __attribute__((aligned(64)));
 
 // =============================================================================

--- a/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -23,6 +23,7 @@
 #include <cinttypes>
 #include <cstring>
 
+#include "aicpu/platform_regs.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
@@ -133,9 +134,19 @@ int perf_aicpu_complete_record(
     uint32_t count = perf_buf->count;
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
 
-    PerfRecord *record = &perf_buf->records[count];
-    if (static_cast<uint32_t>(record->task_id) != expected_reg_task_id) return -1;
+    // Read from WIP staging slot (AICore writes here, parity = reg_task_id & 1)
+    PerfRecord *wip = &perf_buf->wip[expected_reg_task_id & 1u];
+    // One PoC cache line: matches AICore perf_aicore_record_task() dcci(..., SINGLE_CACHE_LINE, ...)
+    // and aicpu/cache_ops.cpp step size; wip timing fields live in the first line.
+    cache_invalidate_range(wip, 64);
+    if (static_cast<uint32_t>(wip->task_id) != expected_reg_task_id) return -1;
 
+    // Copy AICore timing to committed record slot
+    PerfRecord *record = &perf_buf->records[count];
+    record->start_time = wip->start_time;
+    record->end_time = wip->end_time;
+
+    // Fill AICPU-owned fields
     record->task_id = task_id;
     record->func_id = func_id;
     record->core_type = core_type;

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -623,8 +623,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 int completed_task_id = pending_task_ids_[core_id];
                 int prev_running_id = running_task_ids_[core_id];
 
-                // Profiling: when prev_running_id exists, its AICore record was
-                // written first (at records[count]), so complete it BEFORE the
+                // Profiling: when prev_running_id exists, its AICore timing was
+                // written to wip[id & 1] first, so complete it BEFORE the
                 // pending task's record to maintain buffer ordering.
                 if (profiling_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();

--- a/src/a5/platform/include/aicore/performance_collector_aicore.h
+++ b/src/a5/platform/include/aicore/performance_collector_aicore.h
@@ -34,8 +34,8 @@
 /**
  * Record task execution performance data
  *
- * Writes performance metrics to the provided buffer. Buffer management
- * and status tracking are handled by AICPU.
+ * Writes timing metrics to the WIP staging slot (wip[task_id & 1]).
+ * Buffer management and final commit are handled by AICPU.
  *
  * AICore writes PerfRecord.task_id as the register dispatch token (low 32 bits, zero-extended).
  * For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), AICPU overwrites
@@ -48,18 +48,14 @@
  */
 __aicore__ __attribute__((always_inline)) static inline void
 perf_aicore_record_task(__gm__ PerfBuffer *perf_buf, uint32_t task_id, uint64_t start_time, uint64_t end_time) {
-    // Read current buffer count (AICPU owns the count, AICore reads only)
-    dcci(&perf_buf->count, SINGLE_CACHE_LINE);
-    uint32_t idx = perf_buf->count;
+    // Write to WIP staging slot — parity alternates with dual-slot dispatch
+    __gm__ PerfRecord *record = &perf_buf->wip[task_id & 1u];
 
-    __gm__ PerfRecord *record = &perf_buf->records[idx];
-
-    // Write record data (func_id, core_type, and count filled by AICPU at completion)
     record->start_time = start_time;
     record->end_time = end_time;
     record->task_id = static_cast<uint64_t>(task_id);
 
-    // Flush cache to make data visible
+    // Flush cache to make data visible to AICPU
     dcci(record, SINGLE_CACHE_LINE, CACHELINE_OUT);
     dsb((mem_dsb_t)0);
 }

--- a/src/a5/platform/include/common/perf_profiling.h
+++ b/src/a5/platform/include/common/perf_profiling.h
@@ -76,21 +76,26 @@ struct PerfRecord {
 static_assert(sizeof(PerfRecord) % 64 == 0, "PerfRecord must be 64-byte aligned for optimal cache performance");
 
 // =============================================================================
-// PerfBuffer - Record Buffer with Count-First Layout
+// PerfBuffer - Record Buffer with Count-First Layout and WIP Staging Slots
 // =============================================================================
 
 /**
  * Performance record buffer (count-first + flexible array)
  *
- * Layout: 64B header (count + padding) followed by records[].
- * Actual allocation: 64 + capacity * sizeof(PerfRecord).
+ * Layout: 64B header (count + padding), then wip[2] staging slots,
+ * then records[].
+ * Actual allocation: sizeof(PerfBuffer) + capacity * sizeof(PerfRecord).
  *
- * Count-first enables two-step collection: Host copies 64B to read count,
- * then copies only count * sizeof(PerfRecord) of actual data.
+ * Count-first enables two-step collection: Host copies sizeof(PerfBuffer) to
+ * read count, then copies only count * sizeof(PerfRecord) of actual data.
+ *
+ * WIP protocol: AICore writes timing to wip[reg_task_id & 1], AICPU copies
+ * it into records[count] at completion. Dual-slot parity ensures no overlap.
  */
 struct PerfBuffer {
-    volatile uint32_t count;  // Current record count (at offset 0 for cache-line read)
+    volatile uint32_t count;  // Current committed record count (at offset 0 for cache-line read)
     uint32_t pad[15];         // Pad to 64B cache line boundary
+    PerfRecord wip[2];        // AICore WIP staging slots (index = reg_task_id & 1)
     PerfRecord records[];     // Flexible array member (not counted in sizeof)
 } __attribute__((aligned(64)));
 

--- a/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -24,6 +24,7 @@
 #include <cinttypes>
 #include <cstring>
 
+#include "aicpu/platform_regs.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
@@ -83,9 +84,19 @@ int perf_aicpu_complete_record(
     // silently drops the record, caller ignores the failure.
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
 
-    PerfRecord *record = &perf_buf->records[count];
-    if (static_cast<uint32_t>(record->task_id) != expected_reg_task_id) return -1;
+    // Read from WIP staging slot (AICore writes here, parity = reg_task_id & 1)
+    PerfRecord *wip = &perf_buf->wip[expected_reg_task_id & 1u];
+    // One PoC cache line: matches AICore perf_aicore_record_task() dcci(..., SINGLE_CACHE_LINE, ...)
+    // and aicpu/cache_ops.cpp step size; wip timing fields live in the first line.
+    cache_invalidate_range(wip, 64);
+    if (static_cast<uint32_t>(wip->task_id) != expected_reg_task_id) return -1;
 
+    // Copy AICore timing to committed record slot
+    PerfRecord *record = &perf_buf->records[count];
+    record->start_time = wip->start_time;
+    record->end_time = wip->end_time;
+
+    // Fill AICPU-owned fields
     record->task_id = task_id;
     record->func_id = func_id;
     record->core_type = core_type;

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -616,8 +616,8 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 int completed_task_id = pending_task_ids_[core_id];
                 int prev_running_id = running_task_ids_[core_id];
 
-                // Profiling: when prev_running_id exists, its AICore record was
-                // written first (at records[count]), so complete it BEFORE the
+                // Profiling: when prev_running_id exists, its AICore timing was
+                // written to wip[id & 1] first, so complete it BEFORE the
                 // pending task's record to maintain buffer ordering.
                 if (profiling_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();


### PR DESCRIPTION
When dual-slot dispatch is active, two tasks can be in-flight on the same core simultaneously. The old path had AICore read perf_buf->count via dcci then write directly to records[count] — if a second task dispatched before AICPU committed the first, both tasks wrote to the same slot, silently overwriting timing data. This caused sporadic missing entries in the profiling swimlane diagram.

The fix is at the platform perf layer (PerfBuffer + perf_aicore_record_task
+ perf_aicpu_complete_record), so all runtimes that compile against this path pick up the new protocol. For single-in-flight runtimes the behavior is equivalent but avoids the old records[count] indexing.

- Add wip[2] staging slots to PerfBuffer; AICore writes timing to wip[task_id & 1] instead of records[count], removing the dcci read and the shared-index race
- AICPU reads from the matching wip slot at completion, validates task_id, copies timing into records[count], then fills remaining fields and increments count