### PR TITLE
Support: package simpler and ship runtime assets in wheel

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -8,18 +8,29 @@ See [docs/chip-level-arch.md](../../docs/chip-level-arch.md) for the full diagra
 - **Three runtimes** under `src/{arch}/runtime/`: `host_build_graph`, `aicpu_build_graph`, `tensormap_and_ringbuffer`
 - **Two platform backends** under `src/{arch}/platform/`: `onboard/` (hardware), `sim/` (simulation)
 
+## Python Package Layout
+
+| Package | Source | What's in wheel | Use for |
+| ------- | ------ | --------------- | ------- |
+| `simpler` | `python/simpler/` | `task_interface`, `worker`, `env_manager` only | Stable user API at runtime |
+| `simpler_setup` | `simpler_setup/` | All files + `_assets/{src,build/lib}` | Test framework, compilers, path resolution |
+| `_task_interface` | `python/bindings/` | nanobind `.so` at wheel root | Internal nanobind module |
+
+The 4 files `kernel_compiler.py`, `runtime_compiler.py`, `toolchain.py`, `elf_parser.py` exist in **both** `python/simpler/` and `simpler_setup/` during transition. The `simpler_setup/` copies are authoritative; the `python/simpler/` copies are excluded from wheel via `pyproject.toml::wheel.exclude`. New code must `import` from `simpler_setup.*`, not `simpler.*`, for these four.
+
 ## Build System Lookup
 
 | What | Where |
 | ---- | ----- |
 | Runtime selection | `kernel_config.py` → `RUNTIME_CONFIG.runtime` |
 | Per-runtime build config | `src/{arch}/runtime/{runtime}/build_config.py` |
-| Runtime build orchestration | `examples/scripts/runtime_builder.py` → `runtime_compiler.py` → cmake |
+| Runtime build orchestration | `simpler_setup/runtime_builder.py` → `simpler_setup/runtime_compiler.py` → cmake |
 | Pre-build all runtimes | `examples/scripts/build_runtimes.py` (invoked by `pip install .`) |
-| Platform/runtime discovery | `examples/scripts/platform_info.py` |
-| Kernel compilation | `python/kernel_compiler.py` (one `.cpp` per `func_id`) |
+| Platform/runtime discovery | `simpler_setup/platform_info.py` |
+| Kernel compilation | `simpler_setup/kernel_compiler.py` (one `.cpp` per `func_id`) |
 | Python bindings | `python/bindings/` (nanobind extension for ChipWorker, task types) |
-| Pre-built binary lookup | `build/lib/{arch}/{variant}/{runtime}/` |
+| Path resolution (wheel vs source tree) | `simpler_setup/environment.py::PROJECT_ROOT` |
+| Pre-built binary lookup | `build/lib/{arch}/{variant}/{runtime}/` (source tree) or `simpler_setup/_assets/build/lib/...` (wheel) |
 | Persistent cmake cache | `build/cache/{arch}/{variant}/{runtime}/` |
 
 ## Example / Test Layout

--- a/.claude/rules/venv-isolation.md
+++ b/.claude/rules/venv-isolation.md
@@ -27,8 +27,14 @@ Multiple AI agents may work on this repo concurrently (parallel sessions, worktr
 3. **Install the project**:
 
    ```bash
-   pip install .
+   # Production / CI install
+   pip install --no-build-isolation .
+
+   # Editable install for development (auto-rebuilds C++ on import)
+   pip install --no-build-isolation -e .
    ```
+
+   `--no-build-isolation` is required because scikit-build-core consumes the venv's already-installed `scikit-build-core`, `nanobind`, and `cmake` directly. Without the flag, pip spins up a temporary isolated build env that doesn't see them, slowing the install and risking version drift.
 
 4. **Run tests / examples** inside the activated venv.
 
@@ -42,7 +48,7 @@ When working in a git worktree (`.claude/worktrees/` or any other worktree path)
 # First time in a directory (or worktree)
 python3 -m venv --system-site-packages .venv
 source .venv/bin/activate
-pip install .
+pip install --no-build-isolation .            # or: -e . for editable
 
 # Subsequent runs — just activate
 source .venv/bin/activate
@@ -53,3 +59,4 @@ source .venv/bin/activate
 - Run `pip install .` without an activated local venv
 - Share a single venv across multiple worktrees
 - Use `--user` installs as a substitute for venv isolation
+- Drop `--no-build-isolation` — scikit-build-core needs the venv's `nanobind`/`cmake` directly

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,3 +36,11 @@ add_custom_target(build_runtimes ALL
         --cache-dir ${CMAKE_SOURCE_DIR}/build/cache
     COMMENT "Building runtime binaries (incremental)..."
 )
+
+if(SKBUILD_MODE)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/
+            DESTINATION simpler_setup/_assets/src)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/build/lib/
+            DESTINATION simpler_setup/_assets/build/lib
+            OPTIONAL)
+endif()

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -30,22 +30,34 @@ pto-runtime/
 │   │   ├── CMakeLists.txt
 │   │   ├── task_interface.cpp
 │   │   └── dist_worker_bind.h
-│   └── simpler/                       # Python package
+│   └── simpler/                       # Stable user-facing API (packaged in wheel)
 │       ├── worker.py                  # Unified Worker (L2 single-chip, L3 distributed)
 │       ├── task_interface.py          # Python re-exports of nanobind types + helpers
-│       ├── runtime_compiler.py        # Multi-platform runtime compiler
-│       ├── kernel_compiler.py         # Kernel compiler
-│       ├── elf_parser.py              # ELF binary parser
 │       ├── env_manager.py             # Environment variable management
-│       └── toolchain.py              # Toolchain configuration
+│       ├── kernel_compiler.py         # [transitional, NOT in wheel — use simpler_setup version]
+│       ├── runtime_compiler.py        # [transitional, NOT in wheel — use simpler_setup version]
+│       ├── elf_parser.py              # [transitional, NOT in wheel — use simpler_setup version]
+│       └── toolchain.py               # [transitional, NOT in wheel — use simpler_setup version]
+│
+├── simpler_setup/                     # Test framework + authoritative compilers (packaged in wheel)
+│   ├── scene_test.py                  # SceneTestCase + @scene_test decorator
+│   ├── runtime_builder.py             # RuntimeBuilder (pre-built lookup or compile)
+│   ├── runtime_compiler.py            # Authoritative copy of runtime cmake driver
+│   ├── kernel_compiler.py             # Authoritative copy of kernel compiler
+│   ├── toolchain.py                   # Authoritative copy
+│   ├── elf_parser.py                  # Authoritative copy
+│   ├── platform_info.py               # Platform/runtime discovery
+│   ├── environment.py                 # PROJECT_ROOT resolver (wheel vs source tree)
+│   ├── pto_isa.py                     # PTO_ISA_ROOT discovery
+│   └── _assets/                       # (wheel only) src/ + build/lib/ shipped with wheel
 │
 ├── examples/                          # Working examples
 │   ├── scripts/                       # Build and test framework
 │   │   ├── run_example.py             # Run a single example
 │   │   ├── code_runner.py             # Example execution engine
-│   │   ├── runtime_builder.py         # Runtime binary builder (pre-built lookup or compile)
+│   │   ├── runtime_builder.py         # [legacy shim — prefer simpler_setup.runtime_builder]
 │   │   ├── build_runtimes.py          # Pre-build all runtime variants
-│   │   └── platform_info.py           # Platform/runtime discovery utilities
+│   │   └── platform_info.py           # [legacy shim — prefer simpler_setup.platform_info]
 │   └── {arch}/                        # Architecture-specific examples
 │       ├── host_build_graph/
 │       ├── aicpu_build_graph/
@@ -80,11 +92,11 @@ The build has two layers: **runtime binaries** (platform-dependent, user-code-in
 
 ### Runtime binaries
 
-Runtime binaries (host `.so`, aicpu `.so`, aicore `.o`) are pre-built during `pip install .` and cached in `build/lib/{arch}/{variant}/{runtime}/`. The pipeline:
+Runtime binaries (host `.so`, aicpu `.so`, aicore `.o`) are pre-built during `pip install .` and cached in `build/lib/{arch}/{variant}/{runtime}/`. After wheel install they are shipped under `simpler_setup/_assets/build/lib/...`; `simpler_setup/environment.py::PROJECT_ROOT` resolves the right location automatically (see [Path resolution](#path-resolution)). The pipeline:
 
 1. `examples/scripts/build_runtimes.py` — detects available toolchains, iterates all (platform, runtime) combinations
-2. `examples/scripts/runtime_builder.py` — orchestrates per-runtime build (lookup pre-built or compile)
-3. `python/runtime_compiler.py` — invokes cmake for each target (host, aicpu, aicore)
+2. `simpler_setup/runtime_builder.py` — orchestrates per-runtime build (lookup pre-built or compile)
+3. `simpler_setup/runtime_compiler.py` — invokes cmake for each target (host, aicpu, aicore)
 
 Persistent cmake build directories under `build/cache/` enable incremental compilation — only changed files are recompiled.
 
@@ -95,8 +107,31 @@ Persistent cmake build directories under `build/cache/` enable incremental compi
 
 ### User code (per-example)
 
-1. `python/kernel_compiler.py` — compiles user-written kernel `.cpp` files (one per `func_id`)
+1. `simpler_setup/kernel_compiler.py` — compiles user-written kernel `.cpp` files (one per `func_id`)
 2. `python/bindings/` — nanobind extension providing ChipWorker, task types, and distributed types to Python
+
+### Path resolution
+
+`simpler_setup/environment.py::PROJECT_ROOT` returns one of two layouts depending on how the package was installed:
+
+| Install mode | `PROJECT_ROOT` | Where `src/` lives | Where `build/lib/` lives |
+| ------------ | -------------- | ------------------ | ------------------------ |
+| `pip install .` (wheel) | `<site-packages>/simpler_setup/_assets/` | `_assets/src/` | `_assets/build/lib/` |
+| `pip install -e .` (editable) | repo root | `<repo>/src/` | `<repo>/build/lib/` |
+| Source tree without install | repo root | `<repo>/src/` | `<repo>/build/lib/` |
+
+The resolver uses `importlib.resources.files("simpler_setup") / "_assets"`. If `_assets/src/` exists there, it picks that; otherwise it falls back to `Path(__file__).parent.parent` (repo root). All compilers (`runtime_compiler`, `kernel_compiler`, `runtime_builder`) consume `PROJECT_ROOT` and stay agnostic to install mode.
+
+### Python package layout
+
+| Package | Where on disk | What it ships in wheel |
+| ------- | ------------- | ---------------------- |
+| `simpler` | `python/simpler/` | Stable user API: `task_interface`, `worker`, `env_manager`, `__init__` |
+| `simpler` (excluded) | same dir | `kernel_compiler`, `runtime_compiler`, `toolchain`, `elf_parser` are **transitional** — present in source tree but excluded from wheel via `pyproject.toml::wheel.exclude` |
+| `simpler_setup` | `simpler_setup/` | Test framework + authoritative copies of the four transitional files |
+| `_task_interface` | built from `python/bindings/` | Top-level nanobind extension (.so) |
+
+**Migration direction:** existing `from simpler.{kernel_compiler,runtime_compiler,toolchain,elf_parser} import ...` should move to `from simpler_setup.{kernel_compiler,...} import ...`. Once all callers migrate, the four transitional files in `python/simpler/` can be deleted and `wheel.exclude` cleaned up.
 
 ## Cross-Platform Preprocessor Convention
 
@@ -133,19 +168,30 @@ Run with: `python examples/scripts/run_example.py -k <kernels_dir> -g <golden.py
 ### Initial setup
 
 ```bash
-pip install -e .
+pip install --no-build-isolation -e .
 ```
 
+`--no-build-isolation` is required: scikit-build-core needs the system `nanobind` and `cmake` (and any other build dep already in the venv); build isolation would hide them. The flag is also faster — no temporary build venv per install.
+
 This builds the nanobind `_task_interface` extension **and** pre-builds all runtime binaries for available toolchains into `build/lib/`. Sim platforms (a2a3sim, a5sim) are built when `gcc`/`g++` are available; onboard platforms (a2a3, a5) are built when `ccec` and the cross-compiler under `ASCEND_HOME_PATH` are available. Since a2a3 and a5 share the same compilation — differing only at runtime — both architectures are always built together when their toolchain is present.
+
+### Editable rebuild on import
+
+`pyproject.toml` enables `editable.rebuild = true`. Every fresh Python process that imports `simpler_setup` or `_task_interface` triggers `cmake --build` on the top-level CMake tree before the import returns. This auto-rebuilds the nanobind module when `python/bindings/` C++ changes — no manual `pip install -e .` needed. Also re-invokes `build_runtimes.py` (an `ALL` target), so the per-runtime cmake caches under `build/cache/` get checked too. Costs:
+
+- Nothing changed: a few hundred ms per inner cmake check (10-30+ inner cmakes total depending on installed toolchains)
+- Real C++ change: full incremental rebuild blocks the import until done
+
+If startup latency becomes painful, run `unset SKBUILD_EDITABLE_REBUILD` before pytest, or run `pip install --no-build-isolation -e .` once and revert. CI should never use editable installs.
 
 ### When to rebuild
 
 | What changed | Action |
 | ------------ | ------ |
-| First time / clean checkout | `pip install -e .` |
-| Runtime C++ source (`src/{arch}/runtime/`, `src/{arch}/platform/`) | Pass `--build` to `run_example.py` (incremental, ~1-2s) |
-| Nanobind bindings (`python/bindings/`) | Re-run `pip install -e .` |
-| Python-only code (`python/*.py`, `examples/scripts/*.py`) | No rebuild needed (editable install) |
+| First time / clean checkout | `pip install --no-build-isolation -e .` |
+| Runtime C++ source (`src/{arch}/runtime/`, `src/{arch}/platform/`) | Pass `--build` to `run_example.py` (incremental, ~1-2s); editable rebuild does **not** cover this (runtime cmake is decoupled from the top-level cmake target) |
+| Nanobind bindings (`python/bindings/`) | Auto-rebuilt on next import (`editable.rebuild = true`) |
+| Python-only code (`python/*.py`, `simpler_setup/*.py`, `examples/scripts/*.py`) | No rebuild needed (editable install) |
 | Examples / kernels (`examples/{arch}/`, `tests/st/`) | No rebuild needed, just re-run |
 
 ### The `--build` flag
@@ -165,22 +211,26 @@ This uses the persistent cmake cache in `build/cache/`, recompiling only what ch
 
 ```text
 build/
-  cache/{arch}/{variant}/{runtime}/   # cmake intermediate files (persistent)
+  cache/{arch}/{variant}/{runtime}/   # runtime cmake intermediate files (persistent)
     host/                             # cmake build dir for host target
     aicpu/                            # cmake build dir for aicpu target
     aicore/                           # cmake build dir for aicore target
-  lib/{arch}/{variant}/{runtime}/     # final binaries (stable lookup paths)
+  lib/{arch}/{variant}/{runtime}/     # runtime final binaries (stable lookup paths)
     libhost_runtime.so
     libaicpu_kernel.so
     aicore_kernel.o                   # or .so for sim
+  {wheel_tag}/                        # scikit-build-core's top-level cmake (e.g. cp39-cp39-linux-x86_64)
+                                      #   builds the _task_interface nanobind module
 ```
+
+All three subdirs are siblings under `build/` and ignored by `.gitignore`. `rm -rf build/` clears everything.
 
 ## Dynamic Kernel Compilation
 
 Kernels are compiled externally by `KernelCompiler` and uploaded to the device at runtime:
 
 ```python
-from simpler.kernel_compiler import KernelCompiler
+from simpler_setup.kernel_compiler import KernelCompiler
 
 compiler = KernelCompiler(platform="a2a3sim")
 kernel_binary = compiler.compile_incore("path/to/kernel.cpp", core_type="aiv")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,12 +79,153 @@ source /usr/local/Ascend/ascend-toolkit/latest/bin/setenv.bash
 export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
 ```
 
+## Install / Develop Workflows
+
+Three ways to get the project running, depending on your role. All three assume an activated project-local venv (see [`.claude/rules/venv-isolation.md`](../.claude/rules/venv-isolation.md)).
+
+### At a glance
+
+| Concern | `pip install .` | `pip install -e .` | `cmake + PYTHONPATH` |
+| ------- | --------------- | ------------------ | -------------------- |
+| **Who it's for** | Users / CI | Python + C++ developers | C++-only developers |
+| **`simpler_setup` resolves to** | site-packages | source tree (via `.pth`) | source tree (via `PYTHONPATH`) |
+| **`simpler` resolves to** | site-packages (4 files) | source tree `python/simpler/` (all 8 files) | source tree (all 8) |
+| **`_task_interface.*.so` lives at** | site-packages root | `build/{wheel_tag}/` (finder-dispatched) | `python/_task_interface.*.so` |
+| **`PROJECT_ROOT`** | `<site-packages>/simpler_setup/_assets/` | repo root | repo root |
+| **`src/` found under** | `_assets/src/` | `<repo>/src/` | `<repo>/src/` |
+| **`build/lib/` found under** | `_assets/build/lib/` | `<repo>/build/lib/` | `<repo>/build/lib/` |
+| **Edit `.py` → effect** | reinstall required | immediate | immediate |
+| **Edit nanobind `.cpp` → rebuild** | reinstall required | auto on next import (`editable.rebuild`) | manual `cmake --build build/` |
+| **Edit runtime `src/` → rebuild** | reinstall or manual | manual (`--build` flag or explicit script) | manual |
+| **`from simpler.kernel_compiler import`** | fails (excluded from wheel) | works (transitional source on disk) | works |
+| **`--build` path writable** | no (site-packages read-only) | yes | yes |
+
+### 1. `pip install .` — user / CI install
+
+```bash
+pip install --no-build-isolation .
+```
+
+`--no-build-isolation` is required: scikit-build-core consumes the venv's already-installed `scikit-build-core`, `nanobind`, `cmake` directly; isolation would hide them.
+
+**What lands in site-packages:**
+
+```text
+site-packages/
+├── _task_interface.cpython-*.so      # nanobind extension
+├── simpler/                          # stable 4 files only
+│   ├── __init__.py
+│   ├── env_manager.py
+│   ├── task_interface.py
+│   └── worker.py
+└── simpler_setup/
+    ├── *.py                          # test framework + authoritative compilers
+    └── _assets/
+        ├── src/                      # headers + orchestration sources
+        └── build/lib/                # pre-built runtime binaries
+```
+
+**Limitations:**
+
+- Python edits require `pip install .` again
+- `from simpler.{kernel_compiler,runtime_compiler,toolchain,elf_parser} import ...` does **not** work — use `simpler_setup.*` for those
+- `--build` (rebuild runtime from source) won't work (site-packages is read-only)
+
+Best for: `ci.sh` jobs and downstream consumers who only need to run examples.
+
+### 2. `pip install -e .` — editable developer install
+
+```bash
+pip install --no-build-isolation -e .
+```
+
+The build is invoked once during install; `pyproject.toml` sets `editable.rebuild = true`, so subsequent C++ changes are picked up automatically.
+
+**What happens at install time:**
+
+- `simpler_setup/` and `simpler/` get `.pth` redirects pointing at the source tree
+- `_task_interface.*.so` is built into `build/{wheel_tag}/` and dispatched by scikit-build-core's import finder
+- `build_runtimes.py` pre-builds runtime binaries into `<repo>/build/lib/`
+- `install()` rules also populate `<site-packages>/simpler_setup/_assets/`, but those are shadowed by the source-tree redirect
+
+**Rebuild behavior on import:**
+
+Every fresh Python process that imports `simpler_setup` or `_task_interface` triggers `cmake --build` + `cmake --install` against the top-level CMakeLists before the import returns. This covers:
+
+- nanobind module (`python/bindings/*.cpp`) — real incremental rebuild when source changed
+- `build_runtimes` ALL target — re-invokes `build_runtimes.py`, which fans out to per-runtime inner cmakes (each fast no-op when nothing changed)
+
+**Startup cost per fresh process:**
+
+- Nothing changed: ~6-15 seconds, depending on how many toolchains are installed (one inner cmake per runtime × platform combination, each a few hundred ms)
+- Real C++ change: full incremental rebuild blocks import until done
+
+**What's still manual:**
+
+- Runtime `src/{arch}/...` edits for `--build` code paths: pass `--build` to `run_example.py` (or re-run `build_runtimes.py`). `editable.rebuild` will also try, but the inner no-op walk is the same — running `--build` explicitly on the affected example is faster.
+- Transitional `from simpler.{kernel_compiler,...} import ...` still works in editable mode (source tree has the files); migrate to `simpler_setup.*` when convenient.
+
+Best for: daily development. Python edits are instant, C++ rebuilds without thinking about `pip install`.
+
+**Turning off rebuild temporarily** (e.g. for faster pytest iteration when nothing C++ changed):
+
+```bash
+# One-off: skip rebuild for this invocation
+SKBUILD_EDITABLE_REBUILD=0 pytest ...
+
+# Or edit pyproject.toml to set editable.rebuild = false, then re-install
+```
+
+### 3. `cmake + PYTHONPATH` — manual C++ workflow
+
+This path bypasses pip entirely. Useful if you want `compile_commands.json`, IDE integration, or are debugging a CMake-only concern.
+
+```bash
+# Dependencies (one-time, install into the venv)
+pip install --no-build-isolation nanobind cmake scikit-build-core torch pytest
+
+# Build
+cmake -B build -S .
+cmake --build build --parallel
+
+# Make Python find the project
+export PYTHONPATH="$(pwd):$(pwd)/python"
+
+# Now run anything
+python examples/scripts/run_example.py -k ... -g ... -p a2a3sim
+```
+
+**Why `PYTHONPATH="$(pwd):$(pwd)/python"`:**
+
+- `$(pwd)` makes `simpler_setup` importable (it lives at repo root)
+- `$(pwd)/python` makes `simpler.*` importable (lives under `python/simpler/`) and also finds `python/_task_interface.*.so`
+
+In this mode `SKBUILD_MODE=OFF`, so CMakeLists.txt takes the non-install branch: the nanobind module's `LIBRARY_OUTPUT_DIRECTORY` is set to `<repo>/python/`, and no `install()` runs. `_assets/` is **not** created — `PROJECT_ROOT` falls back to the repo root.
+
+**What's still needed from pip:**
+
+- `find_package(nanobind CONFIG REQUIRED)` in `python/bindings/CMakeLists.txt` requires `nanobind` to be discoverable via its Python-installed CMake config. Even without `pip install .`, you need `pip install nanobind` in the active venv.
+
+**Rebuild:**
+
+- C++ (nanobind or runtime): manual `cmake --build build/`
+- nanobind alone: `cmake --build build --target _task_interface`
+- Runtime alone: `cmake --build build --target build_runtimes` (or just `run_example.py --build`)
+
+**Limitations:**
+
+- `editable.rebuild` and everything else in `[tool.scikit-build]` are **not consulted** — this path doesn't go through scikit-build-core
+- You manage all dependencies manually
+- Good for CMake-centric debugging; not the recommended daily loop
+
+Best for: C++-only iteration, IDE integration, `tests/ut/cpp/` development.
+
 ## Build Process
 
 The **RuntimeCompiler** class handles compilation of all three components separately:
 
 ```python
-from simpler.runtime_compiler import RuntimeCompiler
+from simpler_setup.runtime_compiler import RuntimeCompiler
 
 # For real Ascend hardware (requires CANN toolkit)
 compiler = RuntimeCompiler(platform="a2a3")
@@ -141,7 +282,7 @@ TEST PASSED
 
 ```python
 from simpler.task_interface import ChipWorker
-from runtime_builder import RuntimeBuilder
+from simpler_setup.runtime_builder import RuntimeBuilder
 
 # Build or locate pre-built runtime binaries
 builder = RuntimeBuilder(platform="a2a3sim")

--- a/examples/scripts/run_example.py
+++ b/examples/scripts/run_example.py
@@ -43,9 +43,6 @@ from pathlib import Path
 # Get script and project directories
 script_dir = Path(__file__).parent.resolve()
 project_root = script_dir.parent.parent
-python_dir = project_root / "python"
-if python_dir.exists():
-    sys.path.insert(0, str(python_dir))
 golden_dir = project_root / "golden"
 if golden_dir.exists():
     sys.path.insert(0, str(golden_dir))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,5 +72,14 @@ pythonpath = ["python", "golden"]
 addopts = "--import-mode=importlib"
 
 [tool.scikit-build]
-wheel.packages = ["simpler_setup"]
+wheel.packages = ["simpler_setup", "python/simpler"]
+wheel.exclude = [
+    "simpler/elf_parser.py",
+    "simpler/kernel_compiler.py",
+    "simpler/runtime_compiler.py",
+    "simpler/toolchain.py",
+]
 cmake.build-type = "Release"
+build-dir = "build/{wheel_tag}"
+editable.rebuild = true
+editable.verbose = true

--- a/simpler_setup/environment.py
+++ b/simpler_setup/environment.py
@@ -6,24 +6,21 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Centralized path management for scene test setup."""
+"""Centralized path management.
 
-import sys
+PROJECT_ROOT auto-resolves between two layouts:
+  - wheel install: simpler_setup/_assets/{src,build/lib} populated by CMakeLists install()
+  - source tree / editable: repo root with src/ and build/lib/ in original positions
+"""
+
 from pathlib import Path
 
-# Single source of truth: project root derived from this file's location
-# tests/st/setup/environment.py → 4 parents up → project root
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
-# Key directories
-PYTHON_DIR = PROJECT_ROOT / "python"
-EXAMPLES_SCRIPTS_DIR = PROJECT_ROOT / "examples" / "scripts"
-BUILD_CACHE_DIR = PROJECT_ROOT / "build" / "cache"
-BUILD_LIB_DIR = PROJECT_ROOT / "build" / "lib"
+def _resolve_project_root() -> Path:
+    assets = Path(__file__).resolve().parent / "_assets"
+    if (assets / "src").is_dir():
+        return assets
+    return Path(__file__).resolve().parent.parent
 
 
-def ensure_python_path() -> None:
-    """Add python/ to sys.path for task_interface imports."""
-    p = str(PYTHON_DIR)
-    if p not in sys.path:
-        sys.path.insert(0, p)
+PROJECT_ROOT = _resolve_project_root()

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -27,8 +27,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, NamedTuple
 
-from .environment import ensure_python_path
-
 _compile_cache: dict[tuple[str, str, str], object] = {}
 
 
@@ -200,7 +198,6 @@ def _build_chip_task_args(test_args: TaskArgsBuilder, orch_signature: list):
         chip_args: ChipStorageTaskArgs (for worker.run)
         output_names: list of tensor names that are OUTPUT or INOUT
     """
-    ensure_python_path()
     from simpler.task_interface import (  # noqa: PLC0415
         ArgDirection,
         ChipStorageTaskArgs,
@@ -301,12 +298,11 @@ def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
     if cache_key in _compile_cache:
         return _compile_cache[cache_key]
 
+    from simpler.task_interface import ChipCallable, CoreCallable  # noqa: PLC0415
+
     from .elf_parser import extract_text_section  # noqa: PLC0415
     from .kernel_compiler import KernelCompiler  # noqa: PLC0415
     from .pto_isa import ensure_pto_isa_root  # noqa: PLC0415
-
-    ensure_python_path()
-    from simpler.task_interface import ChipCallable, CoreCallable  # noqa: PLC0415
 
     orch = spec["orchestration"]
     incores = spec["incores"]
@@ -419,7 +415,6 @@ class SceneTestCase:
 
     @classmethod
     def _create_worker(cls, platform, device_id=0, build=False):
-        ensure_python_path()
         from simpler.task_interface import ChipWorker  # noqa: PLC0415
 
         bins = cls._get_binaries(platform, build=build)
@@ -450,7 +445,6 @@ class SceneTestCase:
         raise ValueError(f"Unsupported level: {self._st_level}")
 
     def _build_config(self, config_dict, enable_profiling=False):
-        ensure_python_path()
         from simpler.task_interface import ChipCallConfig  # noqa: PLC0415
 
         config = ChipCallConfig()
@@ -537,7 +531,6 @@ class SceneTestCase:
     def _run_and_validate_l3(
         self, worker, compiled_callables, sub_ids, case, rounds=1, skip_golden=False, enable_profiling=False
     ):
-        ensure_python_path()
         from simpler.worker import Task  # noqa: PLC0415
 
         params = case.get("params", {})
@@ -706,7 +699,6 @@ def _create_standalone_worker(group, args):
     if level == 2:
         return first_cls._create_worker(args.platform, args.device, build=build), {}
 
-    ensure_python_path()
     from simpler.worker import Worker  # noqa: PLC0415
 
     max_devices = max((c.get("config", {}).get("device_count", 1) for cls in group for c in cls.CASES), default=1)


### PR DESCRIPTION
## Summary

Direct `python tests/.../test_xxx.py` runs were failing on `from simpler.task_interface import ...` because `python/` was only on sys.path under pytest. This PR makes `simpler` (and its dependencies) installable via wheel so any entry point can find it.

## Key changes

- `python/simpler` enters the wheel; the 4 files duplicated with `simpler_setup/` (`elf_parser`, `kernel_compiler`, `runtime_compiler`, `toolchain`) are excluded so the authoritative copies under `simpler_setup/` win in wheel mode while source-tree copies remain reachable for un-migrated callers
- `src/` (headers + orchestration sources) and `build/lib/` (pre-built runtime binaries) are installed under `simpler_setup/_assets/` so wheel users get everything kernel compilation needs without a source checkout
- `simpler_setup/environment.py::PROJECT_ROOT` auto-resolves: `_assets/` for wheel install, repo root for source tree / editable
- `editable.rebuild = true` so the nanobind module auto-rebuilds on import in editable mode (with `build-dir = "build/{wheel_tag}"` to satisfy the requirement)
- Cleanup: drop `ensure_python_path` helper + 6 callsites in `scene_test.py`, drop `python/` sys.path insert in `run_example.py`

## Documentation

Updated `docs/developer-guide.md`, `docs/getting-started.md`, `.claude/rules/architecture.md`, `.claude/rules/venv-isolation.md` to reflect the new packaging model, fix broken import examples (`simpler.kernel_compiler` → `simpler_setup.kernel_compiler`), and document the editable-install workflow.

## Test plan

- [x] `pip install --no-build-isolation -e .` succeeds; `simpler` and `simpler_setup` both importable
- [x] Wheel build: only stable 4 files of `simpler` ship; 4 transitional duplicates excluded; `_assets/{src,build/lib}` populated (296 src + 17 lib files)
- [x] Wheel install in fresh venv: `PROJECT_ROOT` resolves to `_assets/`; `simpler.task_interface` works; `simpler.kernel_compiler` correctly excluded
- [x] Editable install: `PROJECT_ROOT` resolves to repo root; `editable.rebuild` triggers cmake on import
- [x] `pytest tests/ut/` — 143 passed, 5 skipped
- [x] Originally-failing direct run `python tests/st/.../test_alternating_matmul_add.py` no longer hits ImportError (reaches argparse, fails only on missing `-p` as expected — needs hardware)
- [ ] Hardware ST tests (run by reviewer with NPU)