### PR TITLE
Fix: harden ring heap boundary checks and add allocator diagnostics

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -280,16 +280,30 @@ private:
                 result = static_cast<char *>(heap_base_) + top;
                 heap_top_ = top + alloc_size;
             } else if (tail > alloc_size) {
+                LOG_DEBUG(
+                    "try_bump_heap wrap-around alloc: top=%" PRIu64 ", tail=%" PRIu64 ", alloc=%" PRIu64, top, tail,
+                    alloc_size
+                );
                 result = heap_base_;
                 heap_top_ = alloc_size;
             } else {
+                LOG_DEBUG(
+                    "try_bump_heap failed (top>=tail): top=%" PRIu64 ", tail=%" PRIu64 ", alloc=%" PRIu64
+                    ", heap_size=%" PRIu64,
+                    top, tail, alloc_size, heap_size_
+                );
                 return nullptr;
             }
         } else {
-            if (tail - top >= alloc_size) {
+            if (tail - top > alloc_size) {
                 result = static_cast<char *>(heap_base_) + top;
                 heap_top_ = top + alloc_size;
             } else {
+                LOG_DEBUG(
+                    "try_bump_heap failed (top<tail): top=%" PRIu64 ", tail=%" PRIu64 ", alloc=%" PRIu64
+                    ", free_gap=%" PRIu64,
+                    top, tail, alloc_size, tail - top
+                );
                 return nullptr;
             }
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -280,16 +280,30 @@ private:
                 result = static_cast<char *>(heap_base_) + top;
                 heap_top_ = top + alloc_size;
             } else if (tail > alloc_size) {
+                LOG_DEBUG(
+                    "try_bump_heap wrap-around alloc: top=%" PRIu64 ", tail=%" PRIu64 ", alloc=%" PRIu64, top, tail,
+                    alloc_size
+                );
                 result = heap_base_;
                 heap_top_ = alloc_size;
             } else {
+                LOG_DEBUG(
+                    "try_bump_heap failed (top>=tail): top=%" PRIu64 ", tail=%" PRIu64 ", alloc=%" PRIu64
+                    ", heap_size=%" PRIu64,
+                    top, tail, alloc_size, heap_size_
+                );
                 return nullptr;
             }
         } else {
-            if (tail - top >= alloc_size) {
+            if (tail - top > alloc_size) {
                 result = static_cast<char *>(heap_base_) + top;
                 heap_top_ = top + alloc_size;
             } else {
+                LOG_DEBUG(
+                    "try_bump_heap failed (top<tail): top=%" PRIu64 ", tail=%" PRIu64 ", alloc=%" PRIu64
+                    ", free_gap=%" PRIu64,
+                    top, tail, alloc_size, tail - top
+                );
                 return nullptr;
             }
         }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/kernel_config.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/kernel_config.py
@@ -74,7 +74,3 @@ RUNTIME_CONFIG = {
     "aicpu_thread_num": 4,
     "block_dim": 24,
 }
-
-RUNTIME_ENV = {
-    "PTO2_RING_HEAP": "1073741824",
-}


### PR DESCRIPTION
Disallow full-gap allocation when `tail - top == alloc_size` to preserve unambiguous top/tail semantics, and add targeted allocator logs for wrap-around and allocation-failure paths to simplify field debugging.