### PR TITLE
Cleanup: dead PATH export, wider cache key, runtime-test filter, docs dedup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: build/cache
-          key: cmake-sim-${{ runner.os }}-${{ hashFiles('src/**/CMakeLists.txt', 'src/**/build_config.py', 'simpler_setup/runtime_compiler.py') }}
+          key: cmake-sim-${{ runner.os }}-${{ hashFiles('src/**/CMakeLists.txt', 'src/**/build_config.py', 'simpler_setup/runtime_compiler.py', 'simpler_setup/kernel_compiler.py', 'simpler_setup/toolchain.py') }}
           restore-keys: |
             cmake-sim-${{ runner.os }}-
 
@@ -297,7 +297,6 @@ jobs:
       - name: Run hardware unit tests (a2a3)
         run: |
           source .venv/bin/activate
-          export PATH="$HOME/.local/bin:$PATH"
           source ${ASCEND_HOME_PATH}/bin/setenv.bash && python -m pytest tests -m requires_hardware --platform a2a3 -v
 
   # ---------- Scene tests (a2a3 hardware) ----------
@@ -319,13 +318,11 @@ jobs:
       - name: Run on-device examples (a2a3)
         run: |
           source .venv/bin/activate
-          export PATH="$HOME/.local/bin:$PATH"
           source ${ASCEND_HOME_PATH}/bin/setenv.bash && python ci.py -p a2a3 -d ${DEVICE_RANGE} -c d96c8784 -t 600 --clone-protocol https
 
       - name: Run pytest scene tests (a2a3)
         run: |
           source .venv/bin/activate
-          export PATH="$HOME/.local/bin:$PATH"
           source ${ASCEND_HOME_PATH}/bin/setenv.bash && python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v
 
 
@@ -398,12 +395,10 @@ jobs:
 
       - name: Run on-device examples (a5)
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           source ${ASCEND_HOME_PATH}/bin/setenv.bash
           DEVICE_LIST=$(python -c "s,e='${DEVICE_RANGE}'.split('-'); print(','.join(str(i) for i in range(int(s),int(e)+1)))")
           task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python ci.py -p a5 -d ${DEVICE_RANGE} -c d96c8784 -t 1200 --clone-protocol https"
 
       - name: Run pytest scene tests (a5)
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
           source ${ASCEND_HOME_PATH}/bin/setenv.bash && python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v

--- a/conftest.py
+++ b/conftest.py
@@ -77,6 +77,11 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "platforms(list): supported platforms for standalone ST functions")
     config.addinivalue_line("markers", "requires_hardware: test needs Ascend toolchain and real device")
     config.addinivalue_line("markers", "device_count(n): number of NPU devices needed")
+    config.addinivalue_line(
+        "markers",
+        "runtime(name): runtime this standalone test targets; used by runtime-isolation subprocess "
+        "filtering so non-@scene_test tests only run under their matching runtime",
+    )
 
     log_level = config.getoption("--log-level", default=None)
     if log_level:
@@ -115,6 +120,14 @@ def pytest_collection_modifyitems(session, config, items):
                 item.add_marker(pytest.mark.skip(reason="--platform required"))
             elif platform not in platforms_marker.args[0]:
                 item.add_marker(pytest.mark.skip(reason=f"Not supported on {platform}"))
+
+        # runtime-isolation filter for non-@scene_test tests: if the item declares
+        # `@pytest.mark.runtime("X")` and a --runtime filter is active, skip when
+        # they don't match. Prevents test_explicit_fatal_reports and friends from
+        # running under every runtime's subprocess.
+        runtime_marker = item.get_closest_marker("runtime")
+        if runtime_marker and runtime_marker.args and runtime_filter and runtime_marker.args[0] != runtime_filter:
+            item.add_marker(pytest.mark.skip(reason=f"Runtime {runtime_marker.args[0]} != {runtime_filter}"))
 
 
 # ---------------------------------------------------------------------------

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,146 +79,24 @@ source /usr/local/Ascend/ascend-toolkit/latest/bin/setenv.bash
 export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
 ```
 
-## Install / Develop Workflows
+## Install
 
-Three ways to get the project running, depending on your role. All three assume an activated project-local venv (see [`.claude/rules/venv-isolation.md`](../.claude/rules/venv-isolation.md)).
+All workflows assume an activated project-local venv (see [`.claude/rules/venv-isolation.md`](../.claude/rules/venv-isolation.md) for why `--no-build-isolation` is required).
 
-### At a glance
-
-| Concern | `pip install .` | `pip install -e .` | `cmake + PYTHONPATH` |
-| ------- | --------------- | ------------------ | -------------------- |
-| **Who it's for** | Users / CI | Python + C++ developers | C++-only developers |
-| **`simpler_setup` resolves to** | site-packages | source tree (via `.pth`) | source tree (via `PYTHONPATH`) |
-| **`simpler` resolves to** | site-packages (4 files) | source tree `python/simpler/` (all 8 files) | source tree (all 8) |
-| **`_task_interface.*.so` lives at** | site-packages root | `build/{wheel_tag}/` (finder-dispatched) | `python/_task_interface.*.so` |
-| **`PROJECT_ROOT`** | `<site-packages>/simpler_setup/_assets/` | repo root | repo root |
-| **`src/` found under** | `_assets/src/` | `<repo>/src/` | `<repo>/src/` |
-| **`build/lib/` found under** | `_assets/build/lib/` | `<repo>/build/lib/` | `<repo>/build/lib/` |
-| **Edit `.py` → effect** | reinstall required | immediate | immediate |
-| **Edit nanobind `.cpp` → rebuild** | reinstall required | auto on next import (`editable.rebuild`) | manual `cmake --build build/` |
-| **Edit runtime `src/` → rebuild** | reinstall or manual | manual (`--build` flag or explicit script) | manual |
-| **`from simpler.kernel_compiler import`** | fails (excluded from wheel) | works (transitional copy — use `simpler_setup` instead) | works (transitional copy — use `simpler_setup` instead) |
-| **`--build` path writable** | no (site-packages read-only) | yes | yes |
-
-### 1. `pip install .` — user / CI install
+**Recommended daily-dev setup:**
 
 ```bash
-pip install --no-build-isolation .
-```
-
-`--no-build-isolation` is required: scikit-build-core consumes the venv's already-installed `scikit-build-core`, `nanobind`, `cmake` directly; isolation would hide them.
-
-**What lands in site-packages:**
-
-```text
-site-packages/
-├── _task_interface.cpython-*.so      # nanobind extension
-├── simpler/                          # stable 4 files only
-│   ├── __init__.py
-│   ├── env_manager.py
-│   ├── task_interface.py
-│   └── worker.py
-└── simpler_setup/
-    ├── *.py                          # test framework + authoritative compilers
-    └── _assets/
-        ├── src/                      # headers + orchestration sources
-        └── build/lib/                # pre-built runtime binaries
-```
-
-**Limitations:**
-
-- Python edits require `pip install .` again
-- `from simpler.{kernel_compiler,runtime_compiler,toolchain,elf_parser} import ...` does **not** work — use `simpler_setup.*` for those
-- `--build` (rebuild runtime from source) won't work (site-packages is read-only)
-
-Best for: `ci.sh` jobs and downstream consumers who only need to run examples.
-
-### 2. `pip install -e .` — editable developer install
-
-```bash
+python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
+pip install --no-build-isolation scikit-build-core nanobind cmake pytest numpy ml_dtypes torch
 pip install --no-build-isolation -e .
 ```
 
-The build is invoked once during install; `pyproject.toml` sets `editable.rebuild = true`, so subsequent C++ changes are picked up automatically.
+Editing Python is instant (editable install). Editing C++ requires re-running `pip install --no-build-isolation -e .` (scikit-build-core's auto-rebuild is disabled because it interacts badly with pip's ephemeral build env — see `docs/python-packaging.md`).
 
-**What happens at install time:**
+**Other supported paths:** `pip install .` (non-editable), `pip install --no-build-isolation .`, `pip install -e .`, and `cmake + PYTHONPATH` (no pip). Full comparison of all 5 paths — what lands where, which entry points work under each, trade-offs — lives in [`docs/python-packaging.md`](python-packaging.md).
 
-- `simpler_setup/` and `simpler/` get `.pth` redirects pointing at the source tree
-- `_task_interface.*.so` is built into `build/{wheel_tag}/` and dispatched by scikit-build-core's import finder
-- `build_runtimes.py` pre-builds runtime binaries into `<repo>/build/lib/`
-- `install()` rules also populate `<site-packages>/simpler_setup/_assets/`, but those are shadowed by the source-tree redirect
-
-**Rebuild behavior on import:**
-
-Every fresh Python process that imports `simpler_setup` or `_task_interface` triggers `cmake --build` + `cmake --install` against the top-level CMakeLists before the import returns. This covers:
-
-- nanobind module (`python/bindings/*.cpp`) — real incremental rebuild when source changed
-- `build_runtimes` ALL target — re-invokes `build_runtimes.py`, which fans out to per-runtime inner cmakes (each fast no-op when nothing changed)
-
-**Startup cost per fresh process:**
-
-- Nothing changed: ~6-15 seconds, depending on how many toolchains are installed (one inner cmake per runtime × platform combination, each a few hundred ms)
-- Real C++ change: full incremental rebuild blocks import until done
-
-**What's still manual:**
-
-- Runtime `src/{arch}/...` edits for `--build` code paths: pass `--build` to `run_example.py` (or re-run `build_runtimes.py`). `editable.rebuild` will also try, but the inner no-op walk is the same — running `--build` explicitly on the affected example is faster.
-- Transitional `from simpler.{kernel_compiler,...} import ...` still works in editable mode (source tree has the files); migrate to `simpler_setup.*` when convenient.
-
-Best for: daily development. Python edits are instant, C++ rebuilds without thinking about `pip install`.
-
-**Turning off rebuild temporarily** (e.g. for faster pytest iteration when nothing C++ changed):
-
-```bash
-# One-off: skip rebuild for this invocation
-SKBUILD_EDITABLE_REBUILD=0 pytest ...
-
-# Or edit pyproject.toml to set editable.rebuild = false, then re-install
-```
-
-### 3. `cmake + PYTHONPATH` — manual C++ workflow
-
-This path bypasses pip entirely. Useful if you want `compile_commands.json`, IDE integration, or are debugging a CMake-only concern.
-
-```bash
-# Dependencies (one-time, install into the venv)
-pip install --no-build-isolation nanobind cmake scikit-build-core torch pytest
-
-# Build
-cmake -B build -S .
-cmake --build build --parallel
-
-# Make Python find the project
-export PYTHONPATH="$(pwd):$(pwd)/python"
-
-# Now run anything
-python examples/scripts/run_example.py -k ... -g ... -p a2a3sim
-```
-
-**Why `PYTHONPATH="$(pwd):$(pwd)/python"`:**
-
-- `$(pwd)` makes `simpler_setup` importable (it lives at repo root)
-- `$(pwd)/python` makes `simpler.*` importable (lives under `python/simpler/`) and also finds `python/_task_interface.*.so`
-
-In this mode `SKBUILD_MODE=OFF`, so CMakeLists.txt takes the non-install branch: the nanobind module's `LIBRARY_OUTPUT_DIRECTORY` is set to `<repo>/python/`, and no `install()` runs. `_assets/` is **not** created — `PROJECT_ROOT` falls back to the repo root.
-
-**What's still needed from pip:**
-
-- `find_package(nanobind CONFIG REQUIRED)` in `python/bindings/CMakeLists.txt` requires `nanobind` to be discoverable via its Python-installed CMake config. Even without `pip install .`, you need `pip install nanobind` in the active venv.
-
-**Rebuild:**
-
-- C++ (nanobind or runtime): manual `cmake --build build/`
-- nanobind alone: `cmake --build build --target _task_interface`
-- Runtime alone: `cmake --build build --target build_runtimes` (or just `run_example.py --build`)
-
-**Limitations:**
-
-- `editable.rebuild` and everything else in `[tool.scikit-build]` are **not consulted** — this path doesn't go through scikit-build-core
-- You manage all dependencies manually
-- Good for CMake-centric debugging; not the recommended daily loop
-
-Best for: C++-only iteration, IDE integration, `tests/ut/cpp/` development.
+**Verifying an install:** the single source of truth is `tools/verify_packaging.sh`, which exercises all 5 install paths × 4 entry points from a fully clean state. CI runs the same script on macOS + Ubuntu (see the `packaging-matrix` job in `.github/workflows/ci.yml`).
 
 ## Build Process
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_explicit_fatal.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_explicit_fatal.py
@@ -30,6 +30,7 @@ class _ExplicitFatal(SceneTestCase):
 
 @pytest.mark.platforms(["a2a3sim"])
 @pytest.mark.device_count(1)
+@pytest.mark.runtime("tensormap_and_ringbuffer")
 def test_explicit_fatal_reports(st_platform, st_device_ids, monkeypatch):
     monkeypatch.setenv("PTO_LOG_LEVEL", "error")
 

--- a/tests/st/a5/tensormap_and_ringbuffer/test_explicit_fatal.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/test_explicit_fatal.py
@@ -30,6 +30,7 @@ class _ExplicitFatal(SceneTestCase):
 
 @pytest.mark.platforms(["a5sim"])
 @pytest.mark.device_count(1)
+@pytest.mark.runtime("tensormap_and_ringbuffer")
 def test_explicit_fatal_reports(st_platform, st_device_ids, monkeypatch):
     monkeypatch.setenv("PTO_LOG_LEVEL", "error")
 


### PR DESCRIPTION
## Summary

Four small, independent cleanups piled into one PR.

### (1) Drop dead \`export PATH=\"\$HOME/.local/bin:\$PATH\"\` from self-hosted jobs
\`ls ~/.local/bin/\` on the a2a3 runner shows only node tools (corepack/node/npm/npx) — nothing the test steps use. pytest lives at \`/usr/local/bin/pytest\`. Removed from \`ut-py-a2a3\`, both \`st-onboard-a2a3\` steps, and \`st-onboard-a5\`'s pytest step. Kept on \`st-onboard-a5\`'s \`task-submit\` step with an inline comment (a5 runner not audited, task-submit may be pip-user-installed there).

### (2) Widen pre-commit cmake cache hash
Was hashing only \`simpler_setup/runtime_compiler.py\`. Also add \`kernel_compiler.py\` and \`toolchain.py\` — edits to those now properly invalidate the cache.

### (4) \`@pytest.mark.runtime(\"<name>\")\` — filter non-@scene_test tests to matching runtime
Added a custom marker and corresponding skip logic in \`conftest.py::pytest_collection_modifyitems\`. Applied to the two \`test_explicit_fatal_reports\` functions. Previously these ran 3 times per CI run (once per runtime-isolation subprocess), spraying rc=-9 across the logs. Now run exactly once (tensormap_and_ringbuffer only) and skip under mismatched runtimes.

### (7) Collapse duplicated install docs
\`docs/getting-started.md\`'s 140-line "Install / Develop Workflows" section duplicated \`docs/python-packaging.md\` AND had stale claims (\`editable.rebuild = true\`, transitional \`from simpler.kernel_compiler\` working, \`SKBUILD_EDITABLE_REBUILD=0\` — all no longer true after #552). Replaced with a short pointer to \`python-packaging.md\`. Single source of truth for install behaviour.

## Test plan

- [x] \`pytest tests/ut/py\` — 116 passed, 5 skipped
- [x] \`bash tools/verify_packaging.sh\` — all 5 install modes × 4 entry points green on macOS
- [x] Runtime marker filter: \`pytest tests/st -k explicit_fatal --platform a2a3sim --runtime tensormap_and_ringbuffer -v\` → PASSED (a2a3) + SKIPPED (a5, platform mismatch). Under \`--runtime host_build_graph\` → both SKIPPED (runtime mismatch).
- [ ] Full CI (\`packaging-matrix\`, \`ut-py\`, \`ut-cpp\`, \`st-sim-*\`) green
- [ ] Self-hosted \`ut-py-a2a3\` + \`st-onboard-a2a3\` green (confirms dead PATH removal didn't break anything)