### PR TITLE
Fix: split conda-injected flags from CC/CXX before passing to CMake

### DIFF
--- a/simpler_setup/toolchain.py
+++ b/simpler_setup/toolchain.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 from enum import IntEnum
 
@@ -35,6 +36,42 @@ def _is_gcc(cxx_path: str) -> bool:
         return "clang" not in out
     except (OSError, subprocess.SubprocessError):
         return False
+
+
+def _parse_compiler_env(var_name: str, default: str) -> tuple[str, list[str]]:
+    """Split a CC/CXX env var into (compiler_path, extra_flags).
+
+    Conda activate scripts set CC/CXX to a multi-token string such as
+    ``gcc -pthread -B <env>/compiler_compat``. CMake rejects that as
+    ``CMAKE_C_COMPILER`` because it expects a single executable path, so we
+    separate the leading token from the injected flags.
+    """
+    raw = os.environ.get(var_name, "")
+    tokens = shlex.split(raw) if raw else []
+    if not tokens:
+        return default, []
+    return tokens[0], tokens[1:]
+
+
+def _host_compiler_cmake_args(default_cc: str, default_cxx: str) -> list[str]:
+    """CMake ``-D`` args for a host GCC/G++ toolchain.
+
+    Reads CC/CXX from the environment and splits off any conda-injected flags
+    (e.g. ``-pthread -B <env>/compiler_compat``) into CMAKE_{C,CXX}_FLAGS. The
+    flags are re-joined with ``shlex.join`` so tokens containing spaces survive
+    CMake's shell-style re-parse of the flag string.
+    """
+    cc, cc_flags = _parse_compiler_env("CC", default_cc)
+    cxx, cxx_flags = _parse_compiler_env("CXX", default_cxx)
+    args = [
+        f"-DCMAKE_C_COMPILER={cc}",
+        f"-DCMAKE_CXX_COMPILER={cxx}",
+    ]
+    if cc_flags:
+        args.append(f"-DCMAKE_C_FLAGS={shlex.join(cc_flags)}")
+    if cxx_flags:
+        args.append(f"-DCMAKE_CXX_FLAGS={shlex.join(cxx_flags)}")
+    return args
 
 
 class Toolchain:
@@ -153,13 +190,8 @@ class Gxx15Toolchain(Toolchain):
         return flags
 
     def get_cmake_args(self) -> list[str]:
-        # Respect CC/CXX environment variables (e.g., CXX=g++-15 on macOS CI)
-        cc = os.environ.get("CC", "gcc")
-        cxx = os.environ.get("CXX", "g++")
-        return [
-            f"-DCMAKE_C_COMPILER={cc}",
-            f"-DCMAKE_CXX_COMPILER={cxx}",
-        ]
+        # Default to gcc-15/g++-15 to match self.cxx_path used for direct compilation.
+        return _host_compiler_cmake_args("gcc-15", self.cxx_path)
 
 
 class GxxToolchain(Toolchain):
@@ -179,13 +211,7 @@ class GxxToolchain(Toolchain):
         return flags
 
     def get_cmake_args(self) -> list[str]:
-        # Respect CC/CXX environment variables (e.g., CXX=g++-15 on macOS CI)
-        cc = os.environ.get("CC", "gcc")
-        cxx = os.environ.get("CXX", "g++")
-        args = [
-            f"-DCMAKE_C_COMPILER={cc}",
-            f"-DCMAKE_CXX_COMPILER={cxx}",
-        ]
+        args = _host_compiler_cmake_args("gcc", self.cxx_path)
         if self.ascend_home_path:
             args.append(f"-DASCEND_HOME_PATH={self.ascend_home_path}")
         return args

--- a/tests/ut/py/test_toolchain.py
+++ b/tests/ut/py/test_toolchain.py
@@ -1,0 +1,125 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Tests for host toolchain CMake argument generation."""
+
+import pytest
+
+
+class TestParseCompilerEnv:
+    """Conda activate scripts inject flags into CC/CXX (e.g.,
+    ``gcc -pthread -B <env>/compiler_compat``). Verify we split them cleanly."""
+
+    def test_unset_returns_default(self, monkeypatch):
+        from simpler_setup.toolchain import _parse_compiler_env  # noqa: PLC0415
+
+        monkeypatch.delenv("CC", raising=False)
+        assert _parse_compiler_env("CC", "gcc") == ("gcc", [])
+
+    def test_empty_returns_default(self, monkeypatch):
+        from simpler_setup.toolchain import _parse_compiler_env  # noqa: PLC0415
+
+        monkeypatch.setenv("CC", "")
+        assert _parse_compiler_env("CC", "gcc") == ("gcc", [])
+
+    def test_bare_name(self, monkeypatch):
+        from simpler_setup.toolchain import _parse_compiler_env  # noqa: PLC0415
+
+        monkeypatch.setenv("CC", "gcc-12")
+        assert _parse_compiler_env("CC", "gcc") == ("gcc-12", [])
+
+    def test_conda_style_injection(self, monkeypatch):
+        from simpler_setup.toolchain import _parse_compiler_env  # noqa: PLC0415
+
+        monkeypatch.setenv("CC", "gcc -pthread -B /data/envs/lyf/compiler_compat")
+        path, flags = _parse_compiler_env("CC", "gcc")
+        assert path == "gcc"
+        assert flags == ["-pthread", "-B", "/data/envs/lyf/compiler_compat"]
+
+    def test_quoted_path_with_spaces(self, monkeypatch):
+        from simpler_setup.toolchain import _parse_compiler_env  # noqa: PLC0415
+
+        monkeypatch.setenv("CC", "'/opt/my compilers/gcc' -O2")
+        path, flags = _parse_compiler_env("CC", "gcc")
+        assert path == "/opt/my compilers/gcc"
+        assert flags == ["-O2"]
+
+
+class TestGxxToolchainCmakeArgs:
+    """Verify the host g++ toolchain emits CMake args that work under conda."""
+
+    @pytest.fixture
+    def toolchain(self, monkeypatch):
+        # Avoid probing a real compiler; _is_gcc is only used for compile flags.
+        monkeypatch.setattr("simpler_setup.toolchain._is_gcc", lambda _p: True)
+        from simpler_setup.toolchain import GxxToolchain  # noqa: PLC0415
+
+        return GxxToolchain()
+
+    def test_plain_env(self, toolchain, monkeypatch):
+        monkeypatch.delenv("CC", raising=False)
+        monkeypatch.delenv("CXX", raising=False)
+        args = toolchain.get_cmake_args()
+        assert "-DCMAKE_C_COMPILER=gcc" in args
+        assert "-DCMAKE_CXX_COMPILER=g++" in args
+        # No flags injected → no CMAKE_C_FLAGS arg.
+        assert not any(a.startswith("-DCMAKE_C_FLAGS=") for a in args)
+        assert not any(a.startswith("-DCMAKE_CXX_FLAGS=") for a in args)
+
+    def test_conda_env_splits_flags(self, toolchain, monkeypatch):
+        monkeypatch.setenv("CC", "gcc -pthread -B /data/envs/lyf/compiler_compat")
+        monkeypatch.setenv("CXX", "g++ -pthread -B /data/envs/lyf/compiler_compat")
+        args = toolchain.get_cmake_args()
+        assert "-DCMAKE_C_COMPILER=gcc" in args
+        assert "-DCMAKE_CXX_COMPILER=g++" in args
+        assert "-DCMAKE_C_FLAGS=-pthread -B /data/envs/lyf/compiler_compat" in args
+        assert "-DCMAKE_CXX_FLAGS=-pthread -B /data/envs/lyf/compiler_compat" in args
+
+
+class TestGxx15ToolchainCmakeArgs:
+    """Same split behavior for the simulation-kernel toolchain."""
+
+    @pytest.fixture
+    def toolchain(self):
+        from simpler_setup.toolchain import Gxx15Toolchain  # noqa: PLC0415
+
+        return Gxx15Toolchain()
+
+    def test_plain_env_defaults_to_version_15(self, toolchain, monkeypatch):
+        # Defaults must match self.cxx_path so CMake uses the same compiler
+        # that KernelCompiler uses for direct invocation.
+        monkeypatch.delenv("CC", raising=False)
+        monkeypatch.delenv("CXX", raising=False)
+        args = toolchain.get_cmake_args()
+        assert "-DCMAKE_C_COMPILER=gcc-15" in args
+        assert "-DCMAKE_CXX_COMPILER=g++-15" in args
+
+    def test_conda_env_splits_flags(self, toolchain, monkeypatch):
+        monkeypatch.setenv("CC", "gcc -pthread -B /data/envs/lyf/compiler_compat")
+        monkeypatch.delenv("CXX", raising=False)
+        args = toolchain.get_cmake_args()
+        assert "-DCMAKE_C_COMPILER=gcc" in args
+        # CXX falls back to self.cxx_path = g++-15
+        assert "-DCMAKE_CXX_COMPILER=g++-15" in args
+        assert "-DCMAKE_C_FLAGS=-pthread -B /data/envs/lyf/compiler_compat" in args
+        assert not any(a.startswith("-DCMAKE_CXX_FLAGS=") for a in args)
+
+
+class TestShlexJoinSafety:
+    """Flags containing spaces must survive CMake's shell-style re-parse of CMAKE_C_FLAGS."""
+
+    def test_path_with_spaces_is_quoted(self, monkeypatch):
+        from simpler_setup.toolchain import GxxToolchain  # noqa: PLC0415
+
+        monkeypatch.setattr("simpler_setup.toolchain._is_gcc", lambda _p: True)
+        monkeypatch.setenv("CC", "gcc -B '/opt/my compilers/compat'")
+        monkeypatch.delenv("CXX", raising=False)
+        args = GxxToolchain().get_cmake_args()
+        flags_arg = next(a for a in args if a.startswith("-DCMAKE_C_FLAGS="))
+        # shlex.join must re-quote the path so CMake re-parses it as one token.
+        assert "'/opt/my compilers/compat'" in flags_arg


### PR DESCRIPTION
## Summary

Fixes #474

Conda activate scripts set `CC`/`CXX` to a multi-token string such as
`gcc -pthread -B <env>/compiler_compat`. The host toolchains in
`simpler_setup/toolchain.py` passed these verbatim via
`-DCMAKE_C_COMPILER=`, but CMake requires `CMAKE_C_COMPILER` to be a
single executable path, so `pip install` failed with:

```
The CMAKE_C_COMPILER:
    gcc -pthread -B /data/.../compiler_compat
is not a full path and was not found in the PATH.
```

## Changes

- Add `_parse_compiler_env()` helper that uses `shlex.split` to split
  the leading compiler binary from any injected flags.
- `Gxx15Toolchain` and `GxxToolchain` now forward the compiler path via
  `CMAKE_{C,CXX}_COMPILER` and the remaining tokens via
  `CMAKE_{C,CXX}_FLAGS`, preserving conda's `-B compiler_compat` so the
  bundled `ld` is still picked up at link time.
- New `tests/ut/py/test_toolchain.py` covering bare names, conda-style
  injection, quoted paths with spaces, and unset env vars.

## Testing

- [x] New `test_toolchain.py` — 8 cases pass locally
- [x] Existing `test_runtime_builder.py` — 20 pass / 5 skipped (hardware)
- [ ] Full CI