### PR TITLE
Refactor: back orch.alloc with merged slot+heap DistRing + fork hygiene

### DIFF
--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -119,7 +119,7 @@ SubmitResult Orchestrator::submit_next_level(Callable cb,
 
 ### Step details
 
-**Step 1 — `ring_.alloc()`**: See [§5 Ring](#5-ring). Blocks the Orch thread
+**Step 1 — `ring_.alloc()`**: See [§5 Ring](#5-ring-unified-slot--heap-allocator). Blocks the Orch thread
 if all slots are in-flight; this is the system's back-pressure mechanism.
 
 **Step 2 — store task data**: `TaskArgs` is moved (not copied). `config` is a
@@ -246,44 +246,76 @@ SubmitResult Orchestrator::submit_sub(Callable cb, TaskArgs args, const CallConf
 
 ---
 
-## 5. Ring
+## 5. Ring (unified slot + heap allocator)
 
-The `Ring` is a fixed-size slot pool with back-pressure.
+`DistRing` is a single allocator that hands out both a task slot and an
+aligned heap slab in one atomic call — matching L2's `PTO2TaskAllocator`
+(Strict-2). The slot window and the heap region share one mutex, one
+`last_alive` pointer, and one back-pressure signal; there is no "got a slot
+but no heap" rollback path.
 
 ```cpp
-class Ring {
+struct DistAllocResult {
+    TaskSlot slot;
+    void    *heap_ptr;          // nullptr when alloc(0)
+    uint64_t heap_end_offset;   // recorded per-slot for FIFO reclamation
+};
+
+class DistRing {
 public:
-    explicit Ring(int32_t window_size);   // typical: 128
+    void  init(int32_t window_size,
+               uint64_t heap_bytes,      // default 1 GiB, Worker-configurable
+               uint32_t timeout_ms);     // default 10 s
 
-    TaskSlot alloc();                      // blocks if full
-    void     release(TaskSlot sid);        // called by Scheduler on CONSUMED
+    DistAllocResult alloc(uint64_t bytes = 0);   // blocks, throws on timeout
+    void            release(TaskSlot sid);       // FIFO-advances last_alive
+    void            shutdown();
 
-private:
-    TaskSlotState *slots_;
-    int32_t size_;
-    std::atomic<uint32_t> head_;           // orch-only, next to alloc
-    std::atomic<uint32_t> tail_;           // scheduler-only, next to release
-    std::mutex mu_;
-    std::condition_variable cv_;
+    void    *heap_base()  const;
+    uint64_t heap_size()  const;
 };
 ```
 
 **Back-pressure rationale**: if the Orch thread submits tasks faster than the
-Scheduler + Workers can drain them, slots pile up. A fixed window forces the
-Orch thread to pause, preventing unbounded memory growth and keeping DAG
-depth reasonable.
+Scheduler + Workers can drain, either the slot window or the heap fills up
+first. `alloc()` spin-waits on the shared cv; if `timeout_ms` elapses with no
+progress, it throws `std::runtime_error`. That surfaces as a Python exception
+so users can enlarge `heap_ring_size` on the `Worker` instead of deadlocking.
+
+**Alignment**: every heap allocation is rounded up to `DIST_HEAP_ALIGN = 1024 B`
+(matches L2's `PTO2_PACKED_OUTPUT_ALIGN`, Strict-3).
+
+**Heap mapping**: the heap region is a single `mmap(MAP_SHARED | MAP_ANONYMOUS)`
+taken in the `DistWorker` ctor — *before* any fork — so forked child workers
+inherit the same virtual address range.
+
+**FIFO reclamation**: each `alloc()` records the slot's `heap_end_offset`.
+`release(slot)` flags that slot consumed and advances `last_alive_` as long
+as the next-oldest slot is also released, walking the `heap_tail_` forward
+accordingly. Heap space is reclaimed implicitly; no per-slot `munmap` runs.
 
 **Ownership by role**:
 
 | Field | Writer | Reader |
 | ----- | ------ | ------ |
-| `head_` | Orch (`alloc`) | Orch only |
-| `tail_` | Scheduler (`release`) | Scheduler only |
-| `slots_[i]` | Orch at submit, Scheduler on completion | both per-phase |
+| `next_task_id_`, `heap_top_` | Orch (`alloc`, under `mu_`) | Allocator only |
+| `last_alive_`, `heap_tail_`, `released_[]` | `release` (scheduler or Orch thread) | Allocator only |
+| `slot_heap_end_[]` | Orch at alloc | `release` during FIFO advance |
 
-Orch and Scheduler coordinate via per-slot atomics (`state`, `fanin_released`)
-and per-slot mutexes (`fanout_mu`), not via ring-level atomics beyond the
-head/tail positions.
+All shared state is guarded by a single mutex. The Orch thread is the only
+writer of `next_task_id_` / `heap_top_`, so the mutex serves primarily to
+coordinate with `release` and to protect the back-pressure condition
+variable.
+
+**Slot window is transitional.** The fixed-size
+`DIST_TASK_WINDOW_SIZE = 128` slot pool is legacy from matching L2's
+shmem-backed `PTO2TaskAllocator`. L3+ has no reason to bound slot count:
+slot state lives in the parent process's heap, is only read by Orch and
+Scheduler (never crossed into child workers), and the real back-pressure
+at L3 is the heap. A follow-up PR (PR-I in the plan) replaces the slot
+ring with a dynamic `std::deque<std::unique_ptr<TaskSlotState>>`; slot
+ids become monotonic task ids and only the heap throws on overflow.
+`DistRing` keeps its heap role and `last_alive_` reclamation clock.
 
 ---
 
@@ -428,45 +460,45 @@ when both fire concurrently at threshold.
 
 ## 8b. `alloc(shape, dtype)` — runtime-owned intermediate buffers
 
-Mirrors L2's "task slot owns its output buffer" model: `alloc` creates a
-synthetic task slot in `COMPLETED` state that owns an mmap'd buffer. The
-buffer is freed when the slot reaches `CONSUMED` — i.e. after all downstream
-consumers have completed and the scope ref has been released.
+`alloc` creates a synthetic task slot in `COMPLETED` state that owns a
+1024-byte-aligned slab of the Worker's HeapRing. The slab is reclaimed
+implicitly once the slot reaches `CONSUMED` and `last_alive` sweeps over it
+— no per-slot `munmap` runs.
 
 ```cpp
 ContinuousTensor Orchestrator::alloc(const std::vector<uint32_t> &shape, DataType dtype) {
-    // 1. mmap(MAP_SHARED|MAP_ANONYMOUS) a page-aligned region — visible to
-    //    forked child workers at the same virtual address.
-    void *buf = mmap(...);
-    // 2. Claim a task slot.
-    TaskSlot sid = ring_.alloc();
-    TaskSlotState &s = slots_[sid];
-    // 3. Record buffer for on_consumed munmap.
-    s.alloc_bufs.push_back(buf);
-    s.alloc_sizes.push_back(mmap_bytes);
-    // 4. Register as this slot's output so downstream `INPUT`-tagged tensors
-    //    with the same data ptr look up this slot as producer.
-    tensormap_.insert(reinterpret_cast<uint64_t>(buf), sid);
-    s.output_keys.push_back(reinterpret_cast<uint64_t>(buf));
-    // 5. No fanin — alloc has no work to wait on.
+    // 1. Atomic {slot, heap_ptr} from the merged DistRing. Blocks on
+    //    back-pressure; throws on timeout.
+    uint64_t aligned = align_up(nbytes(shape, dtype), DIST_HEAP_ALIGN);
+    DistAllocResult ar = allocator_.alloc(aligned);
+    TaskSlotState &s   = slots_[ar.slot];
+    s.reset();
+    // 2. Register as this slot's output so downstream tensors with the same
+    //    data pointer look up this slot as producer.
+    uint64_t key = reinterpret_cast<uint64_t>(ar.heap_ptr);
+    tensormap_.insert(key, ar.slot);
+    s.output_keys.push_back(key);
+    // 3. No fanin — alloc has no work to wait on.
     s.fanin_count = 0;
-    // 6. Initial fanout = scope_ref. Consumers that wire on this slot in
+    // 4. Initial fanout = scope_ref. Consumers that wire on this slot in
     //    infer_deps bump fanout_total; this slot's CONSUMED transition waits
     //    for all of them + scope_end.
     s.fanout_total = (scope_.depth() > 0) ? 1 : 0;
-    if (s.fanout_total > 0) scope_.register_task(sid);
-    // 7. Sim self-consume so the fanout-release threshold math aligns with
+    if (s.fanout_total > 0) scope_.register_task(ar.slot);
+    // 5. Sim self-consume so the fanout-release threshold math aligns with
     //    normal slots (see §8 Fanout-release threshold).
     s.fanout_released = 1;
-    // 8. Straight to COMPLETED — no dispatch needed.
+    // 6. Straight to COMPLETED — no dispatch needed.
     s.state = TaskState::COMPLETED;
     active_tasks_++;
-    return ContinuousTensor{buf, shape, dtype};
+    return ContinuousTensor{key, shape, dtype};
 }
 ```
 
-On `on_consumed`, in addition to the usual `tensormap.erase_task_outputs` and
-`ring.release(sid)`, the slot's `alloc_bufs` are `munmap`'d.
+`on_consumed` runs the usual `tensormap.erase_task_outputs` and then calls
+`allocator_.release(sid)`. FIFO reclamation inside the allocator returns the
+slab to the heap's free region as `last_alive` advances; callers see no
+per-slab free syscall.
 
 ### Consumer interaction
 
@@ -483,16 +515,78 @@ s.fanin_producers.push_back(prod);
 if (ps_state != TaskState::COMPLETED) live_fanins++;   // wait only if not yet done
 ```
 
-### Status — placeholder vs target (PR-H)
+### Tag semantics for write-after-write
 
-The current implementation uses **per-alloc `mmap`** (one syscall per
-`alloc()` invocation). This is a placeholder. The target design (PR-H,
-"HeapRing") pre-allocates a single MAP_SHARED region at `Worker::init()`
-before any fork, bump-allocates from it, and reclaims via FIFO
-`last_alive` tracking — mirroring L2's `PTO2TaskAllocator`. Under the
-target design, `OUTPUT`-tagged tensors will be auto-allocated by the
-Orchestrator (no explicit `alloc` call), and `OUTPUT_EXISTING` will
-preserve the current "user-provided buffer" path.
+`infer_deps` mirrors L2 (`pto_orchestrator.cpp` Step B): only `INPUT`
+and `INOUT` do a tensormap lookup. `OUTPUT` and `OUTPUT_EXISTING`
+are pure inserts — the latter is the way users signal "skip the
+lookup even though I'm writing a pre-existing buffer".
+
+| Tag | TensorMap lookup | TensorMap insert | Dep wired on prior owner |
+| --- | ---------------- | ---------------- | ------------------------ |
+| `INPUT` | ✓ | — | RaW |
+| `INOUT` | ✓ | ✓ | RaW + WaW |
+| `OUTPUT` | — | ✓ | **none** — pure overwrite |
+| `OUTPUT_EXISTING` | — | ✓ | **none** — pure overwrite, skips lookup |
+| `NO_DEP` | — | — | — |
+
+A task that writes into a buffer handed out by `orch.alloc()` and
+needs the alloc-slot to stay live while it writes must tag the
+tensor `INOUT`. `INOUT` is the only tag that pulls the creator in
+as a fanin producer, pinning the alloc-slot against reclamation.
+Tagging the same buffer `OUTPUT` / `OUTPUT_EXISTING` is a pure
+overwrite and leaves no lifetime link: if the caller needs the
+buffer to outlive the creator they must maintain that lifetime
+themselves.
+
+### `OUTPUT` auto-allocation
+
+If an `OUTPUT`-tagged tensor arrives at `submit_*` with `data == 0`, the
+Orchestrator reserves a slab from the HeapRing as part of the same
+`DistRing::alloc` call that claims the slot. All OUTPUT slabs for a
+single submit share one `alloc(total_bytes)` call — the returned base
+pointer is carved into per-tensor slabs, each 1024-byte aligned.
+OUTPUT tensors whose `data` is already set are left alone (legacy
+"user-provided buffer" path, and the entry point for
+`orch.alloc()`-then-submit). `OUTPUT_EXISTING` is never auto-allocated.
+
+### `heap_ring_size` and back-pressure
+
+The HeapRing size is a `DistWorker` ctor parameter, surfaced on the Python
+`Worker` as `heap_ring_size=` (default 1 GiB). The heap is `mmap`'d in the
+C++ ctor — before Python forks the ChipProcess / SubWorker children — so
+children inherit the same `MAP_SHARED | MAP_ANONYMOUS` region at the same
+virtual address.
+
+When the heap or the slot window is full, `allocator.alloc()` spin-waits on
+the shared cv. If the `timeout_ms` elapses with no progress, it throws
+`std::runtime_error` (typical wrappers: `"HeapRing exhausted, increase
+heap_ring_size on Worker"` or `"task window full"`). That bubbles out of
+`Worker.run` as a Python exception so users can recover or grow the ring
+instead of stalling forever. Default timeout: 10 s.
+
+## 8c. Fork hygiene
+
+`DistWorker`'s ctor runs a one-shot `fork_hygiene_once()` step before it
+`mmap`s the heap. Two pieces:
+
+1. **Thread-pool env defaults** — `setenv` with `overwrite=0`:
+   - `OMP_NUM_THREADS=1`
+   - `OPENBLAS_NUM_THREADS=1`
+   - `MKL_NUM_THREADS=1`
+   - `BLIS_NUM_THREADS=1`
+   - `KMP_DUPLICATE_LIB_OK=TRUE` (macOS only, tolerates duplicate libomp
+     loads across Python / PyTorch / NumPy)
+
+   These keep transitively-linked thread pools from spinning up worker
+   threads we would then inherit across `fork()`. User-supplied values win.
+
+2. **`pthread_atfork`** handler registered once per process. The handler is
+   currently a landing pad; the Allocator's mutex is the only Worker-owned
+   lock that matters today, and it is not held across any fork point. The
+   handler documents the acquisition order we'll use as more locks are added
+   in subsequent PRs (callable registry → worker manager → worker thread →
+   scheduler → allocator → tensormap, coarse-to-fine).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,10 +41,29 @@ get if I pip install `main` today", this page.
   `Orchestrator._scope_begin` / `_scope_end` / `_drain` are invoked by
   the Python `Worker.run` facade only.
 - **`orch.alloc(shape, dtype)`** — runtime-owned intermediate buffer
-  backed by `mmap(MAP_SHARED | MAP_ANONYMOUS)`. Lifetime follows a
-  synthetic task slot so the buffer is freed once all downstream
-  consumers have completed (see
+  carved out of the Worker's HeapRing (a single
+  `mmap(MAP_SHARED | MAP_ANONYMOUS)` region taken in the `DistWorker`
+  ctor, before fork, inherited by child workers at the same virtual
+  address). Lifetime follows a synthetic task slot; the slab is
+  reclaimed implicitly by the allocator once all downstream consumers
+  have completed and `last_alive` sweeps over it (see
   [orchestrator.md](orchestrator.md) §8b).
+- **`OUTPUT` auto-allocation** — `OUTPUT`-tagged tensors submitted with
+  `data == 0` are auto-allocated from the same HeapRing as part of the
+  allocator call that claims the slot (1024-byte aligned). `OUTPUT`
+  tensors with a pre-set `data` pointer are passed through untouched —
+  pure overwrite with no WaW dep on the prior owner. Matching L2
+  semantics, only `INPUT` and `INOUT` do a tensormap lookup in
+  `infer_deps`; user code that writes into an `orch.alloc()` buffer
+  must tag it `INOUT` so the alloc-slot stays live as a WaW producer
+  (see [orchestrator.md](orchestrator.md) §8b "Tag semantics for
+  write-after-write"). `OUTPUT_EXISTING` is never auto-allocated.
+- **`heap_ring_size` knob** — `Worker(level=3, heap_ring_size=...)`
+  selects the HeapRing size (default 1 GiB). The underlying
+  `DistWorker(level, heap_ring_size)` ctor also installs fork hygiene
+  (setenv of `OMP/BLIS/OPENBLAS/MKL_NUM_THREADS=1`, plus
+  `KMP_DUPLICATE_LIB_OK=TRUE` on macOS, and a `pthread_atfork` landing
+  pad).
 
 ### Dispatch internals
 
@@ -55,23 +74,15 @@ get if I pip install `main` today", this page.
 - `DistChipProcess` / `DistSubWorker` are separate classes today;
   unified `WorkerThread` with `THREAD | PROCESS` modes is not yet
   implemented.
+- Slot-ring and heap-ring share one `DistRing` (merged, matches
+  L2-consistency audit Strict-2). One mutex guards both; FIFO
+  reclamation via `last_alive` advances both resources at once. There
+  is no partial-failure rollback path between slot and heap
+  acquisition.
 
 ---
 
 ## In flight / not yet landed
-
-### PR-H: HeapRing + `OUTPUT` auto-alloc
-
-- Replace the current per-call `mmap` in `orch.alloc` with a single
-  pre-allocated `MAP_SHARED` region at `Worker.init()` (default 1 GB),
-  bump-allocated with FIFO reclamation (mirrors L2's
-  `PTO2TaskAllocator`).
-- `OUTPUT` tag will auto-allocate from the ring;
-  `OUTPUT_EXISTING` keeps the "user-provided buffer" path.
-- Merge slot ring + heap ring into one allocator
-  (matches L2-consistency audit Strict-2).
-- Fork-safety hygiene at `Worker.init()` (`setenv
-  OMP_NUM_THREADS=1` / `pthread_atfork` on runtime-owned locks).
 
 ### PR-C: drop `WorkerPayload`, new `IWorker::run` signature
 

--- a/python/bindings/dist_worker_bind.h
+++ b/python/bindings/dist_worker_bind.h
@@ -27,6 +27,7 @@
 #include <stdexcept>
 
 #include "chip_worker.h"
+#include "dist_ring.h"
 #include "dist_chip_process.h"
 #include "dist_orchestrator.h"
 #include "dist_sub_worker.h"
@@ -145,9 +146,18 @@ inline void bind_dist_worker(nb::module_ &m) {
         );
 
     // --- DistWorker ---
+    //
+    // `heap_ring_size` is the MAP_SHARED|MAP_ANONYMOUS region the Orchestrator
+    // hands out for auto-allocated OUTPUT slabs and `orch.alloc()` buffers.
+    // The mapping is taken in the ctor, before the Python caller forks any
+    // child workers, so children see the same bytes at the same virtual
+    // address.
     nb::class_<DistWorker>(m, "DistWorker")
         .def(
-            nb::init<int32_t>(), nb::arg("level"), "Create a DistWorker for the given hierarchy level (3=L3, 4=L4, …)."
+            nb::init<int32_t, uint64_t>(), nb::arg("level"), nb::arg("heap_ring_size") = DIST_DEFAULT_HEAP_RING_SIZE,
+            "Create a DistWorker for the given hierarchy level (3=L3, 4=L4, …). "
+            "`heap_ring_size` selects the MAP_SHARED heap mmap'd in the ctor "
+            "(default 1 GiB)."
         )
 
         .def(
@@ -189,4 +199,6 @@ inline void bind_dist_worker(nb::module_ &m) {
             "get_orchestrator", &DistWorker::get_orchestrator, nb::rv_policy::reference_internal,
             "Return the Orchestrator handle (lifetime tied to this DistWorker)."
         );
+
+    m.attr("DIST_DEFAULT_HEAP_RING_SIZE") = static_cast<uint64_t>(DIST_DEFAULT_HEAP_RING_SIZE);
 }

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -261,6 +261,7 @@ class Worker:
     def _init_level3(self) -> None:
         device_ids = self._config.get("device_ids", [])
         n_sub = self._config.get("num_sub_workers", 0)
+        heap_ring_size = self._config.get("heap_ring_size", None)
 
         # 1. Allocate sub-worker mailboxes
         for _ in range(n_sub):
@@ -294,6 +295,15 @@ class Worker:
                 assert shm.buf is not None
                 struct.pack_into("i", shm.buf, _CHIP_OFF_STATE, _IDLE)
                 self._chip_shms.append(shm)
+
+        # 3. Construct the DistWorker *before* fork so the HeapRing mmap
+        #    (taken in the C++ ctor) is inherited by every child process at
+        #    the same virtual address. No C++ thread is spawned here; the
+        #    scheduler + WorkerThreads start in init(), after forks.
+        if heap_ring_size is None:
+            self._dist_worker = DistWorker(3)
+        else:
+            self._dist_worker = DistWorker(3, int(heap_ring_size))
 
         self._l3_started = False
 
@@ -338,9 +348,11 @@ class Worker:
                 else:
                     self._chip_pids.append(pid)
 
-        # Create DistWorker and wire chip processes + sub workers
-        dw = DistWorker(3)
-        self._dist_worker = dw
+        # DistWorker was constructed in _init_level3 (pre-fork) so children
+        # inherit the HeapRing MAP_SHARED mmap. Wire chip processes + sub
+        # workers now that their mailboxes exist.
+        dw = self._dist_worker
+        assert dw is not None
 
         if device_ids:
             for shm in self._chip_shms:

--- a/src/common/distributed/dist_orchestrator.cpp
+++ b/src/common/distributed/dist_orchestrator.cpp
@@ -11,18 +11,16 @@
 
 #include "dist_orchestrator.h"
 
-#include <sys/mman.h>
-
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
 
 void DistOrchestrator::init(
-    DistTensorMap *tensormap, DistRing *ring, DistScope *scope, DistReadyQueue *ready_queue, DistTaskSlotState *slots,
-    int32_t num_slots
+    DistTensorMap *tensormap, DistRing *allocator, DistScope *scope, DistReadyQueue *ready_queue,
+    DistTaskSlotState *slots, int32_t num_slots
 ) {
     tensormap_ = tensormap;
-    ring_ = ring;
+    allocator_ = allocator;
     scope_ = scope;
     ready_queue_ = ready_queue;
     slots_ = slots;
@@ -30,42 +28,42 @@ void DistOrchestrator::init(
     active_tasks_.store(0, std::memory_order_relaxed);
 }
 
+// ---------------------------------------------------------------------------
+// alloc(shape, dtype) — user-facing intermediate buffer from the HeapRing
+// ---------------------------------------------------------------------------
+
+uint64_t DistOrchestrator::output_alloc_bytes(const ContinuousTensor &t) {
+    return dist_align_up(t.nbytes(), DIST_HEAP_ALIGN);
+}
+
 ContinuousTensor DistOrchestrator::alloc(const std::vector<uint32_t> &shape, DataType dtype) {
     if (shape.size() > CONTINUOUS_TENSOR_MAX_DIMS) {
         throw std::invalid_argument("DistOrchestrator::alloc: shape exceeds CONTINUOUS_TENSOR_MAX_DIMS");
     }
 
-    // --- Compute size and mmap a MAP_SHARED|MAP_ANONYMOUS region ---
-    // Page-align so munmap on this exact size is valid.
-    size_t numel = 1;
+    uint64_t numel = 1;
     for (uint32_t d : shape)
-        numel *= static_cast<size_t>(d);
-    size_t bytes = numel * get_element_size(dtype);
-    static constexpr size_t PAGE = 4096;
-    size_t mmap_bytes = (bytes + PAGE - 1) & ~(PAGE - 1);
-    if (mmap_bytes == 0) mmap_bytes = PAGE;
+        numel *= static_cast<uint64_t>(d);
+    uint64_t bytes = numel * get_element_size(dtype);
+    uint64_t aligned = dist_align_up(bytes, DIST_HEAP_ALIGN);
 
-    void *buf = mmap(nullptr, mmap_bytes, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-    if (buf == MAP_FAILED) {
-        throw std::runtime_error("DistOrchestrator::alloc: mmap failed");
+    // 0-byte request (e.g. shape with a zero dim) flows straight through the
+    // allocator as a slot-only claim — matches reserve_outputs_and_slot.
+    // Skip tensormap registration when the returned heap_ptr is nullptr,
+    // since 0 is the sentinel for "no tensor" in infer_deps.
+    DistAllocResult ar = allocator_->alloc(aligned);
+    if (ar.slot == DIST_INVALID_SLOT) {
+        throw std::runtime_error("DistOrchestrator::alloc: allocator shutdown");
     }
 
-    // --- Synthetic task slot to own the buffer's lifecycle ---
-    DistTaskSlot slot = ring_->alloc();
-    if (slot == DIST_INVALID_SLOT) {
-        munmap(buf, mmap_bytes);
-        throw std::runtime_error("DistOrchestrator::alloc: ring shutdown");
-    }
-    DistTaskSlotState &s = slot_state(slot);
+    DistTaskSlotState &s = slot_state(ar.slot);
     s.reset();
-    s.alloc_bufs.push_back(buf);
-    s.alloc_sizes.push_back(mmap_bytes);
 
-    // Register the buffer as this slot's output in the TensorMap so any
-    // downstream task tagging it as INPUT/INOUT lookups this slot as producer.
-    uint64_t key = reinterpret_cast<uint64_t>(buf);
-    tensormap_->insert(key, slot);
-    s.output_keys.push_back(key);
+    uint64_t key = reinterpret_cast<uint64_t>(ar.heap_ptr);
+    if (key != 0) {
+        tensormap_->insert(key, ar.slot);
+        s.output_keys.push_back(key);
+    }
 
     // No fanin — alloc has no work to wait on.
     s.fanin_count = 0;
@@ -83,12 +81,8 @@ ContinuousTensor DistOrchestrator::alloc(const std::vector<uint32_t> &shape, Dat
     // bump, the fanout-release threshold (`>= total + 1`) would be one
     // short and the slot would never reach CONSUMED.
     s.fanout_released.store(1, std::memory_order_relaxed);
-    if (scope_ref > 0) scope_->register_task(slot);
+    if (scope_ref > 0) scope_->register_task(ar.slot);
 
-    // Mark COMPLETED — alloc has no work, so it's "done" immediately.
-    // Downstream consumers in infer_deps see this state and skip live_fanin
-    // wiring (consumer is immediately ready) but still wire fanout (so this
-    // slot waits for them before being consumed and freeing its buffer).
     s.state.store(TaskState::COMPLETED, std::memory_order_release);
 
     active_tasks_.fetch_add(1, std::memory_order_relaxed);
@@ -131,7 +125,7 @@ DistSubmitResult DistOrchestrator::submit_sub_group(int32_t callable_id, const s
 
 DistSubmitResult DistOrchestrator::submit_impl(
     WorkerType worker_type, uint64_t callable_ptr, int32_t callable_id, const ChipCallConfig &config,
-    const std::vector<TaskArgs> &args_list
+    std::vector<TaskArgs> args_list
 ) {
     if (args_list.empty()) throw std::invalid_argument("DistOrchestrator: args_list must not be empty");
 
@@ -140,9 +134,16 @@ DistSubmitResult DistOrchestrator::submit_impl(
     // group_size N.
     active_tasks_.fetch_add(1, std::memory_order_relaxed);
 
-    // --- Step 1: Alloc slot (blocks if ring full) ---
-    DistTaskSlot slot = ring_->alloc();
-    if (slot == DIST_INVALID_SLOT) throw std::runtime_error("DistOrchestrator: ring shutdown");
+    // --- Step 1: Atomically claim slot + auto-alloc any OUTPUT tensors that
+    // arrived with a null data pointer. Both resources come from the same
+    // merged allocator (Strict-2) so there is no partial-failure rollback
+    // path.
+    DistAllocResult ar = reserve_outputs_and_slot(args_list);
+    if (ar.slot == DIST_INVALID_SLOT) {
+        active_tasks_.fetch_sub(1, std::memory_order_relaxed);
+        throw std::runtime_error("DistOrchestrator: allocator shutdown");
+    }
+    DistTaskSlot slot = ar.slot;
 
     DistTaskSlotState &s = slot_state(slot);
     s.reset();
@@ -211,6 +212,46 @@ DistSubmitResult DistOrchestrator::submit_impl(
 }
 
 // =============================================================================
+// reserve_outputs_and_slot — atomic slot + heap carve-up for this submit
+// =============================================================================
+//
+// Walks every OUTPUT-tagged tensor that arrived with `data == 0` and reserves
+// aligned slabs out of a single contiguous HeapRing allocation. OUTPUT tensors
+// with a user-supplied data pointer are left untouched (that's the
+// OUTPUT_EXISTING-equivalent back-compat path for callers that pre-fill
+// OUTPUT.data themselves). The single allocator call owns both the slot and
+// the heap range, so there is no partial-failure rollback.
+
+DistAllocResult DistOrchestrator::reserve_outputs_and_slot(std::vector<TaskArgs> &args_list) {
+    uint64_t total_bytes = 0;
+    for (const TaskArgs &a : args_list) {
+        for (int32_t i = 0; i < a.tensor_count(); ++i) {
+            if (a.tag(i) != TensorArgType::OUTPUT) continue;
+            if (a.tensor(i).data != 0) continue;  // user supplied a pointer — leave alone
+            total_bytes += output_alloc_bytes(a.tensor(i));
+        }
+    }
+
+    DistAllocResult ar = allocator_->alloc(total_bytes);
+    if (ar.slot == DIST_INVALID_SLOT) return ar;
+
+    // Hand slabs out in the same order we counted them.
+    uint64_t off = 0;
+    char *base = static_cast<char *>(ar.heap_ptr);
+    for (TaskArgs &a : args_list) {
+        for (int32_t i = 0; i < a.tensor_count(); ++i) {
+            if (a.tag(i) != TensorArgType::OUTPUT) continue;
+            ContinuousTensor &t = a.tensor(i);
+            if (t.data != 0) continue;
+            uint64_t slab = output_alloc_bytes(t);
+            t.data = reinterpret_cast<uint64_t>(base + off);
+            off += slab;
+        }
+    }
+    return ar;
+}
+
+// =============================================================================
 // infer_deps — tag-driven dependency inference
 // =============================================================================
 
@@ -219,14 +260,28 @@ void DistOrchestrator::infer_deps(
     std::vector<uint64_t> &output_keys
 ) {
     auto add_unique_producer = [&](DistTaskSlot p) {
+        // Group submits walk many TaskArgs under one slot: if two entries in
+        // the same group tag the same buffer (e.g. both OUTPUT 0xCAFE), the
+        // second-pass lookup would return the slot that the first pass just
+        // inserted — a self-loop. Skip it.
+        if (p == slot) return;
         for (DistTaskSlot existing : producers) {
             if (existing == p) return;
         }
         producers.push_back(p);
     };
 
-    // Inputs (and INOUT) → lookup producer; outputs (and INOUT, OUTPUT_EXISTING)
-    // → insert as producer of `slot`. NO_DEP tags are skipped.
+    // Tag-driven dependency inference — mirrors L2
+    // (src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+    //  steps B and 4):
+    //   INPUT            → lookup only (RaW)
+    //   INOUT            → lookup + insert (RaW + WaW)
+    //   OUTPUT_EXISTING  → insert only (user-provided buffer; any WaW dep on
+    //                      the creator must be expressed via INOUT instead)
+    //   OUTPUT           → insert only (pure overwrite; if auto-alloc is
+    //                      needed, the data ptr is assigned in
+    //                      reserve_outputs_and_slot before this step)
+    //   NO_DEP           → skip
     for (const TaskArgs &a : args_list) {
         for (int32_t i = 0; i < a.tensor_count(); ++i) {
             uint64_t key = a.tensor(i).data;
@@ -287,9 +342,8 @@ void DistOrchestrator::release_ref(DistTaskSlot slot) {
     // 1 (self try_consume from on_task_complete, or the alloc-time sim) +
     // N (per consumer's deferred try_consume) + 1 (this scope_end release)
     // = N + 2 = total + 1 where total = scope_ref + N.
-    // Using `>= total + 1` keeps scope_end from prematurely consuming when
-    // a consumer is still running — important once on_consumed actually
-    // frees runtime-owned buffers (orch.alloc).
+    // Using `>= total + 1` keeps scope_end from prematurely consuming while
+    // a consumer (or a HeapRing peer) is still live.
     if (released >= total + 1 && s.state.load(std::memory_order_acquire) == TaskState::COMPLETED) {
         on_consumed(slot);
     }
@@ -311,14 +365,9 @@ bool DistOrchestrator::on_consumed(DistTaskSlot slot) {
 
     tensormap_->erase_task_outputs(s.output_keys);
 
-    // Free any runtime-owned intermediate buffers (orch.alloc).
-    for (size_t i = 0; i < s.alloc_bufs.size(); ++i) {
-        munmap(s.alloc_bufs[i], s.alloc_sizes[i]);
-    }
-    s.alloc_bufs.clear();
-    s.alloc_sizes.clear();
-
-    ring_->release(slot);
+    // HeapRing-owned OUTPUT slabs are reclaimed implicitly when the allocator
+    // advances last_alive past this slot — no per-slot munmap needed.
+    allocator_->release(slot);
 
     // Decrement active-task counter so drain() observes completion. Gated
     // on the CAS win so both consume paths — release_ref (Orch thread,

--- a/src/common/distributed/dist_orchestrator.h
+++ b/src/common/distributed/dist_orchestrator.h
@@ -17,10 +17,12 @@
  *   - submit_next_level_group(callable, vector<TaskArgs>, ChipCallConfig)
  *   - submit_sub(callable_id, TaskArgs)
  *   - submit_sub_group(callable_id, vector<TaskArgs>)
+ *   - alloc(shape, dtype) — runtime-owned intermediate buffer
  *
  * Each TaskArgs carries per-tensor TensorArgType tags. The Orchestrator
- * walks those tags to drive dependency inference (INPUT/INOUT → tensormap
- * lookup; OUTPUT/INOUT/OUTPUT_EXISTING → tensormap insert; NO_DEP → skip).
+ * walks those tags to drive dependency inference and — for OUTPUT tags with
+ * a null data pointer — automatically assigns a slab from the HeapRing
+ * (see docs/orchestrator.md §8b).
  *
  * Internal:
  *   - scope_begin / scope_end / drain — invoked only by Worker::run
@@ -49,7 +51,7 @@
 // ---------------------------------------------------------------------------
 //
 // Downstream consumers reference outputs by their own tensor pointers (the
-// tensors live in shm/heap allocated by the user), and tensormap.lookup
+// tensors live in the HeapRing allocated by the Worker), and tensormap.lookup
 // finds the producer slot from the data pointer. No outputs[] field needed.
 
 struct DistSubmitResult {
@@ -63,25 +65,23 @@ struct DistSubmitResult {
 class DistOrchestrator {
 public:
     void init(
-        DistTensorMap *tensormap, DistRing *ring, DistScope *scope, DistReadyQueue *ready_queue,
+        DistTensorMap *tensormap, DistRing *allocator, DistScope *scope, DistReadyQueue *ready_queue,
         DistTaskSlotState *slots, int32_t num_slots
     );
 
-    // Allocate an intermediate buffer (mmap MAP_SHARED|MAP_ANONYMOUS so child
-    // workers see it after fork). Returns a ContinuousTensor with .data
-    // pointing at the buffer.
+    // Allocate an intermediate buffer from the Worker's HeapRing (MAP_SHARED,
+    // visible to forked child workers). Returns a ContinuousTensor whose
+    // `.data` points into the ring.
     //
-    // Lifetime: aligned with the slot lifecycle. alloc creates a synthetic
-    // task slot in COMPLETED state that owns the buffer. Downstream tasks
-    // that tag the buffer as INPUT/INOUT/OUTPUT_EXISTING wire a fanout edge
-    // on this slot via TensorMap; the buffer is munmap'd in on_consumed
-    // once all consumers have released their fanout refs and scope_end has
-    // released the scope ref.
+    // Lifetime: aligned with a synthetic task slot. The buffer is reclaimed
+    // (FIFO, via last_alive) once every downstream consumer tagging the
+    // pointer has reached CONSUMED and scope_end has released the scope ref.
     ContinuousTensor alloc(const std::vector<uint32_t> &shape, DataType dtype);
 
     // Submit a NEXT_LEVEL task. `callable` is the chip callable buffer pointer
     // (uint64_t handle from Python — typically ChipCallable.buffer_ptr()).
-    // Tags inside `args` drive dependency inference.
+    // Tags inside `args` drive dependency inference; OUTPUT tensors with null
+    // data are auto-allocated from the HeapRing.
     DistSubmitResult submit_next_level(uint64_t callable, const TaskArgs &args, const ChipCallConfig &config);
 
     // Submit a group of NEXT_LEVEL tasks: N args -> N workers, 1 DAG node.
@@ -103,7 +103,8 @@ public:
     void drain();
 
     // Called by Scheduler (via DistWorker) when a task becomes CONSUMED:
-    // erases TensorMap entries, frees alloc'd buffers, releases the ring slot.
+    // erases TensorMap entries, releases the allocator slot (and implicitly
+    // the slot's heap slab via last_alive).
     // Returns true iff this call performed the COMPLETED -> CONSUMED transition.
     // Idempotent: concurrent callers (release_ref vs try_consume) race on a
     // CAS — only the winner returns true and runs cleanup; losers return false.
@@ -111,7 +112,7 @@ public:
 
 private:
     DistTensorMap *tensormap_ = nullptr;
-    DistRing *ring_ = nullptr;
+    DistRing *allocator_ = nullptr;
     DistScope *scope_ = nullptr;
     DistReadyQueue *ready_queue_ = nullptr;
     DistTaskSlotState *slots_ = nullptr;
@@ -124,13 +125,22 @@ private:
 
     DistTaskSlotState &slot_state(DistTaskSlot s) { return slots_[s]; }
 
-    // Shared submit machinery — installs slot, walks tags for deps, dispatches
-    // ready transitions. `callable_ptr` and `callable_id` are mutually
-    // exclusive depending on `worker_type`.
+    // Shared submit machinery. Takes `args_list` by value so the Orchestrator
+    // can patch `tensor.data` on OUTPUT tensors flagged for auto-allocation.
     DistSubmitResult submit_impl(
         WorkerType worker_type, uint64_t callable_ptr, int32_t callable_id, const ChipCallConfig &config,
-        const std::vector<TaskArgs> &args_list
+        std::vector<TaskArgs> args_list
     );
+
+    // Size, in aligned bytes, an OUTPUT tensor should occupy in the HeapRing.
+    static uint64_t output_alloc_bytes(const ContinuousTensor &t);
+
+    // Rewrite any OUTPUT tensors with a null data pointer to point into a
+    // freshly-allocated HeapRing slab. Returns the total aligned byte span
+    // consumed, and populates `slot` / `heap_ptr` / `heap_end_offset` via the
+    // output params (reused for book-keeping on the slot state). Throws on
+    // back-pressure timeout.
+    DistAllocResult reserve_outputs_and_slot(std::vector<TaskArgs> &args_list);
 
     // Walk the tags of each TaskArgs in `args_list`, accumulating producer
     // slots (for INPUT/INOUT tags) and registering outputs in the tensormap

--- a/src/common/distributed/dist_ring.cpp
+++ b/src/common/distributed/dist_ring.cpp
@@ -11,40 +11,133 @@
 
 #include "dist_ring.h"
 
+#include <sys/mman.h>
+
+#include <chrono>
+#include <cstring>
 #include <stdexcept>
 
-void DistRing::init(int32_t window_size) {
-    if (window_size <= 0 || (window_size & (window_size - 1)) != 0)
+DistRing::~DistRing() {
+    if (heap_mapped_ && heap_base_) {
+        munmap(heap_base_, heap_size_);
+        heap_base_ = nullptr;
+        heap_mapped_ = false;
+    }
+}
+
+void DistRing::init(int32_t window_size, uint64_t heap_bytes, uint32_t timeout_ms) {
+    if (window_size <= 0 || (window_size & (window_size - 1)) != 0) {
         throw std::invalid_argument("DistRing window_size must be a positive power of 2");
+    }
+    if (heap_mapped_) {
+        throw std::logic_error("DistRing::init called twice");
+    }
+
     window_size_ = window_size;
     window_mask_ = window_size - 1;
+    timeout_ms_ = timeout_ms == 0 ? DIST_ALLOC_TIMEOUT_MS : timeout_ms;
+
     next_task_id_ = 0;
-    released_count_.store(0, std::memory_order_relaxed);
+    last_alive_ = 0;
+    heap_top_ = 0;
+    heap_tail_ = 0;
     shutdown_ = false;
+
+    released_.assign(static_cast<size_t>(window_size_), 0);
+    slot_heap_end_.assign(static_cast<size_t>(window_size_), 0);
+
+    if (heap_bytes > 0) {
+        heap_size_ = heap_bytes;
+        heap_base_ = mmap(nullptr, heap_size_, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        if (heap_base_ == MAP_FAILED) {
+            heap_base_ = nullptr;
+            heap_size_ = 0;
+            throw std::runtime_error("DistRing: heap mmap failed");
+        }
+        heap_mapped_ = true;
+    } else {
+        heap_base_ = nullptr;
+        heap_size_ = 0;
+    }
 }
 
-DistTaskSlot DistRing::alloc() {
+// ---------------------------------------------------------------------------
+// alloc — atomic {slot, heap_ptr} under a single mutex
+// ---------------------------------------------------------------------------
+
+DistAllocResult DistRing::alloc(uint64_t bytes) {
+    if (bytes > 0 && heap_size_ == 0) {
+        throw std::runtime_error("DistRing: heap disabled (heap_bytes=0) but alloc(bytes>0) requested");
+    }
+    uint64_t aligned = bytes > 0 ? dist_align_up(bytes, DIST_HEAP_ALIGN) : 0;
+    if (aligned > heap_size_) {
+        throw std::runtime_error("DistRing: requested allocation exceeds heap size");
+    }
+
     std::unique_lock<std::mutex> lk(mu_);
-    cv_.wait(lk, [this] {
-        if (shutdown_) return true;
-        // Active = allocated - released.  Allow alloc when active < window_size.
-        return (next_task_id_ - released_count_.load(std::memory_order_acquire)) < window_size_;
-    });
-    if (shutdown_) return DIST_INVALID_SLOT;
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms_);
+
+    void *heap_ptr = nullptr;
+    uint64_t heap_end = heap_top_;
+    while (true) {
+        if (shutdown_) return DistAllocResult{DIST_INVALID_SLOT, nullptr, 0};
+
+        if (has_window_space_locked()) {
+            if (aligned == 0) {
+                heap_ptr = nullptr;
+                heap_end = heap_top_;
+                break;
+            }
+            if (try_bump_heap_locked(aligned, heap_ptr, heap_end)) {
+                break;
+            }
+        }
+
+        // Wait for a release to advance last_alive_ (and heap_tail_) or for
+        // shutdown. Treat the timeout as a deadlock signal so Python callers
+        // can enlarge the heap instead of stalling forever.
+        if (cv_.wait_until(lk, deadline) == std::cv_status::timeout) {
+            if (shutdown_) return DistAllocResult{DIST_INVALID_SLOT, nullptr, 0};
+            int32_t active = next_task_id_ - last_alive_;
+            throw std::runtime_error(
+                aligned > heap_size_ / 2 ?
+                    "DistRing: heap exhausted (timed out waiting). Increase heap_ring_size on Worker." :
+                    (active >= window_size_ ? "DistRing: task window full (timed out waiting). "
+                                              "Either the DAG is too wide or the scheduler has stalled." :
+                                              "DistRing: timed out waiting for reclamation.")
+            );
+        }
+    }
+
     int32_t task_id = next_task_id_++;
-    return task_id & window_mask_;
+    DistTaskSlot slot = task_id & window_mask_;
+    released_[static_cast<size_t>(slot)] = 0;
+    slot_heap_end_[static_cast<size_t>(slot)] = heap_end;
+    return DistAllocResult{slot, heap_ptr, heap_end};
 }
 
-void DistRing::release(DistTaskSlot /*slot*/) {
-    // Simply count released slots.  Out-of-order release is safe: alloc() only
-    // checks total active count, not which specific slots are free.
-    released_count_.fetch_add(1, std::memory_order_release);
+// ---------------------------------------------------------------------------
+// release — mark consumed and FIFO-advance last_alive_
+// ---------------------------------------------------------------------------
+
+void DistRing::release(DistTaskSlot slot) {
+    {
+        std::lock_guard<std::mutex> lk(mu_);
+        if (slot < 0 || slot >= window_size_) return;
+        released_[static_cast<size_t>(slot)] = 1;
+        advance_last_alive_locked();
+    }
     cv_.notify_all();
 }
 
+// ---------------------------------------------------------------------------
+// Queries & shutdown
+// ---------------------------------------------------------------------------
+
 int32_t DistRing::active_count() const {
     std::lock_guard<std::mutex> lk(mu_);
-    return next_task_id_ - released_count_.load(std::memory_order_acquire);
+    return next_task_id_ - last_alive_;
 }
 
 void DistRing::shutdown() {
@@ -53,4 +146,61 @@ void DistRing::shutdown() {
         shutdown_ = true;
     }
     cv_.notify_all();
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (all called under mu_)
+// ---------------------------------------------------------------------------
+
+bool DistRing::has_window_space_locked() const { return (next_task_id_ - last_alive_) < window_size_; }
+
+bool DistRing::try_bump_heap_locked(uint64_t aligned, void *&out_ptr, uint64_t &out_end) {
+    uint64_t top = heap_top_;
+    uint64_t tail = heap_tail_;
+
+    // Case 1: heap fully live forward (top >= tail). Space either after top
+    // to the end of the region, or (after wrap) from 0 to tail-1.
+    if (top >= tail) {
+        uint64_t at_end = heap_size_ - top;
+        if (at_end >= aligned) {
+            out_ptr = static_cast<char *>(heap_base_) + top;
+            heap_top_ = top + aligned;
+            out_end = heap_top_;
+            return true;
+        }
+        // Wrap only when there is real space at the start. Must be strictly >,
+        // not ==: leaving a single byte gap prevents top==tail being ambiguous
+        // between "full" and "empty".
+        if (tail > aligned) {
+            out_ptr = heap_base_;
+            heap_top_ = aligned;
+            out_end = heap_top_;
+            return true;
+        }
+        return false;
+    }
+
+    // Case 2: wrapped (top < tail). Allocate in the gap only.
+    if (tail - top > aligned) {
+        out_ptr = static_cast<char *>(heap_base_) + top;
+        heap_top_ = top + aligned;
+        out_end = heap_top_;
+        return true;
+    }
+    return false;
+}
+
+void DistRing::advance_last_alive_locked() {
+    // Advance last_alive_ while the next-oldest task is already released.
+    // Reset the released bit as we cross it so the slot can be reused without
+    // leaking a stale "consumed" flag into the next generation.
+    while (last_alive_ < next_task_id_) {
+        DistTaskSlot la_slot = last_alive_ & window_mask_;
+        if (released_[static_cast<size_t>(la_slot)] == 0) break;
+
+        uint64_t end = slot_heap_end_[static_cast<size_t>(la_slot)];
+        released_[static_cast<size_t>(la_slot)] = 0;
+        last_alive_++;
+        heap_tail_ = end;
+    }
 }

--- a/src/common/distributed/dist_ring.h
+++ b/src/common/distributed/dist_ring.h
@@ -10,15 +10,24 @@
  */
 
 /**
- * DistRing — task slot allocator with back-pressure.
+ * DistRing — unified task-slot + heap-buffer allocator (Strict-2).
  *
- * Maintains a circular window of slots.  The Orchestrator calls alloc() to
- * claim the next slot.  The Scheduler calls release() when a task reaches
- * CONSUMED.
+ * Single allocator guarding both resources under one mutex, mirroring L2's
+ * `PTO2TaskAllocator`. The orchestrator calls `alloc(bytes)` to claim a slot
+ * plus a contiguous heap slab in one atomic step; there is no partial-failure
+ * rollback. `release(slot)` advances a FIFO `last_alive` pointer, which
+ * implicitly reclaims heap space belonging to the trailing range of slots.
  *
- * Back-pressure: alloc() blocks when all slots are occupied.
- * Out-of-order release: tracked via released_count_ (total released so far).
- * alloc() checks (next_task_id_ - released_count_) < window_size_.
+ * Heap memory is a single `mmap(MAP_SHARED | MAP_ANONYMOUS)` region taken
+ * at construction time, before any fork, so forked child workers see the
+ * same bytes at the same virtual address.
+ *
+ * Output-buffer alignment is 1024 B (matches L2's `PTO2_PACKED_OUTPUT_ALIGN`).
+ *
+ * Back-pressure: `alloc()` spin-waits with cv when either the slot window or
+ * the heap is exhausted. If no progress is made for `timeout_ms` the call
+ * throws `std::runtime_error` so Python users can catch it and grow the heap
+ * instead of deadlocking.
  */
 
 #pragma once
@@ -27,33 +36,94 @@
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <vector>
 
 #include "dist_types.h"
 
+// User-facing output alignment (Strict-3; matches L2 PTO2_PACKED_OUTPUT_ALIGN).
+static constexpr uint64_t DIST_HEAP_ALIGN = 1024;
+
+// Default heap ring size for L3+ Worker: 1 GiB, overridable per-Worker.
+static constexpr uint64_t DIST_DEFAULT_HEAP_RING_SIZE = 1ULL << 30;
+
+// Default back-pressure timeout (ms). Surfaces as std::runtime_error when the
+// allocator makes no progress for this long — acts as a deadlock detector.
+static constexpr uint32_t DIST_ALLOC_TIMEOUT_MS = 10000;
+
+// Align an unsigned value up to the next multiple of `align` (must be power of 2).
+inline uint64_t dist_align_up(uint64_t v, uint64_t align) { return (v + align - 1) & ~(align - 1); }
+
+struct DistAllocResult {
+    DistTaskSlot slot{DIST_INVALID_SLOT};
+    void *heap_ptr{nullptr};
+    uint64_t heap_end_offset{0};  // absolute byte offset in the heap region
+};
+
 class DistRing {
 public:
-    void init(int32_t window_size = DIST_TASK_WINDOW_SIZE);
+    DistRing() = default;
+    ~DistRing();
 
-    // Allocate next slot.  Blocks until space is available.
-    // Returns the slot index (task_id % window_size).
-    DistTaskSlot alloc();
+    DistRing(const DistRing &) = delete;
+    DistRing &operator=(const DistRing &) = delete;
 
-    // Release slot.  Called by Scheduler when task reaches CONSUMED.
-    // Safe for out-of-order release.
+    // Initialise. `heap_bytes == 0` disables the heap — `alloc(0)` still
+    // hands out slots, but any `alloc(bytes>0)` throws. `timeout_ms == 0`
+    // selects the default. Must be called before any fork if the heap is
+    // to be inherited by children.
+    void init(
+        int32_t window_size = DIST_TASK_WINDOW_SIZE, uint64_t heap_bytes = DIST_DEFAULT_HEAP_RING_SIZE,
+        uint32_t timeout_ms = DIST_ALLOC_TIMEOUT_MS
+    );
+
+    // Allocate a slot (and, if `bytes > 0`, a heap slab). Blocks with
+    // back-pressure; throws `std::runtime_error` on timeout. Returns the
+    // sentinel `{DIST_INVALID_SLOT, nullptr, 0}` on `shutdown()`.
+    //
+    // `bytes` is rounded up to `DIST_HEAP_ALIGN`. Passing `0` skips the heap
+    // bump entirely (slot-only allocation).
+    DistAllocResult alloc(uint64_t bytes = 0);
+
+    // Release a slot. Marks the slot consumed; advances `last_alive_` (and
+    // `heap_tail_`) as far as the FIFO ordering allows.
     void release(DistTaskSlot slot);
 
     int32_t window_size() const { return window_size_; }
     int32_t active_count() const;
+    void *heap_base() const { return heap_base_; }
+    uint64_t heap_size() const { return heap_size_; }
 
     void shutdown();
 
 private:
     int32_t window_size_{DIST_TASK_WINDOW_SIZE};
     int32_t window_mask_{DIST_TASK_WINDOW_SIZE - 1};
-    int32_t next_task_id_{0};                 // orch-only, no atomic needed
-    std::atomic<int32_t> released_count_{0};  // total slots released (any order)
+    uint32_t timeout_ms_{DIST_ALLOC_TIMEOUT_MS};
+
+    // Orch-owned counter (single-writer from alloc(), so no atomic needed —
+    // it's still read under mu_).
+    int32_t next_task_id_{0};
+
+    // FIFO consumption frontier. `[last_alive_, next_task_id_)` are live.
+    int32_t last_alive_{0};
+
+    // Per-slot bookkeeping (sized to window_size_ after init).
+    std::vector<uint8_t> released_;        // 0 = live, 1 = consumed
+    std::vector<uint64_t> slot_heap_end_;  // byte-offset high-water of each slot's allocation
+
+    // Heap region.
+    void *heap_base_{nullptr};
+    uint64_t heap_size_{0};
+    uint64_t heap_top_{0};   // next free byte (bump head, can wrap)
+    uint64_t heap_tail_{0};  // oldest live byte (derived from last_alive_)
 
     mutable std::mutex mu_;
     std::condition_variable cv_;
     bool shutdown_{false};
+    bool heap_mapped_{false};
+
+    // Helpers — all called under mu_.
+    bool has_window_space_locked() const;
+    bool try_bump_heap_locked(uint64_t aligned_bytes, void *&out_ptr, uint64_t &out_end);
+    void advance_last_alive_locked();
 };

--- a/src/common/distributed/dist_types.cpp
+++ b/src/common/distributed/dist_types.cpp
@@ -32,12 +32,6 @@ void DistTaskSlotState::reset() {
     callable_id = -1;
     config = ChipCallConfig{};
     chip_storage_list.clear();
-    // alloc_bufs / alloc_sizes are owned mmaps freed in on_consumed.
-    // reset() runs at submit time on a freshly-released slot — these vectors
-    // should already be empty here. Guard with assertions in debug builds if
-    // we want to catch leaks.
-    alloc_bufs.clear();
-    alloc_sizes.clear();
     sub_complete_count.store(0, std::memory_order_relaxed);
 }
 

--- a/src/common/distributed/dist_types.h
+++ b/src/common/distributed/dist_types.h
@@ -133,11 +133,9 @@ struct DistTaskSlotState {
     // so scheduler dispatch can pass &chip_storage_list[i] in the WorkerPayload.
     std::vector<ChipStorageTaskArgs> chip_storage_list;
 
-    // Runtime-owned intermediate buffers (DistOrchestrator::alloc). Each entry
-    // is a MAP_SHARED|MAP_ANONYMOUS mmap that must be munmap'd when this slot
-    // reaches CONSUMED. Empty for non-alloc slots.
-    std::vector<void *> alloc_bufs;
-    std::vector<size_t> alloc_sizes;
+    // Runtime-owned OUTPUT slabs live in the Worker's HeapRing and are
+    // reclaimed implicitly by DistRing::release(slot) — no per-slot
+    // munmap is needed. See docs/orchestrator.md §8b.
 
     // --- Group bookkeeping ---
     std::atomic<int32_t> sub_complete_count{0};

--- a/src/common/distributed/dist_worker.cpp
+++ b/src/common/distributed/dist_worker.cpp
@@ -11,11 +11,110 @@
 
 #include "dist_worker.h"
 
+#include <pthread.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
 #include <stdexcept>
 
-DistWorker::DistWorker(int32_t level) :
+// ---------------------------------------------------------------------------
+// Fork hygiene
+// ---------------------------------------------------------------------------
+//
+// Thread-pool libraries linked transitively into the Python process (OpenMP,
+// OpenBLAS, MKL, BLIS, KMP) spin up worker threads the first time they are
+// touched, and those threads do not survive `fork()` cleanly. Pin every
+// library we know about to a single thread before Worker.init() spawns its
+// own pool, and let KMP tolerate duplicate libomp loads on macOS where
+// multiple shared libraries link against their own copy.
+//
+// pthread_atfork installs handlers once per process that take the locks we
+// own in a fixed order on the parent side and release them in reverse on
+// both parent and child. The order is coarse-to-fine so nested locking in
+// normal paths cannot deadlock the atfork handler. The set of locks is
+// intentionally narrow: only those we own. Foreign locks (malloc, GIL) are
+// out of scope and handled by the other libraries' own atfork plumbing.
+//
+// The handler list is process-global (pthread_atfork cannot be unregistered)
+// and idempotent — installing it more than once is harmless because the
+// actual state it touches is per-Worker. For PR-H we keep the handler empty
+// until we have a second Worker-owned lock worth guarding (Allocator::mu_
+// is the only one so far, and its lifetime is tied to a DistWorker that
+// always fork-then-init). Registering an empty handler is still valuable as
+// a diagnostic hook for fork misuse and as a landing pad for locks added
+// in PR-C / PR-D (per-scope rings, per-worker-type queues, callable registry).
+
+namespace {
+
+std::once_flag g_fork_hygiene_once;
+
+void apply_env_defaults_once() {
+    // setenv with overwrite=0 leaves user-supplied values intact.
+    setenv("OMP_NUM_THREADS", "1", 0);
+    setenv("OPENBLAS_NUM_THREADS", "1", 0);
+    setenv("MKL_NUM_THREADS", "1", 0);
+    setenv("BLIS_NUM_THREADS", "1", 0);
+#if defined(__APPLE__)
+    setenv("KMP_DUPLICATE_LIB_OK", "TRUE", 0);
+#endif
+}
+
+void atfork_prepare() {
+    // Reserved for locks we own. Acquisition order (coarse-to-fine):
+    //   1. callable_registry.mu_   (owned by Python Worker today; future
+    //      PR-E will move this to C++)
+    //   2. worker_manager.pool_mu_ (PR-D)
+    //   3. worker_thread.queue_mu_ (PR-D, per thread)
+    //   4. scheduler.completion_mu_
+    //   5. allocator.mu_
+    //   6. tensormap.mu_
+    // Locks are taken in this order and released in reverse on prepare/parent
+    // handlers so the handlers never themselves deadlock. Today none of our
+    // locks are held across potential fork points, so the handler is empty;
+    // keep the landing pad so subsequent PRs can add locks without revisiting
+    // the atfork bookkeeping.
+}
+
+void atfork_parent() {}
+
+void atfork_child() {}
+
+void install_atfork_once() {
+    // Registered once per process; the handlers close over file-scope statics
+    // so multiple DistWorker instances share a single registration.
+    static std::once_flag s_atfork;
+    std::call_once(s_atfork, []() {
+        pthread_atfork(atfork_prepare, atfork_parent, atfork_child);
+    });
+}
+
+void fork_hygiene_once() {
+    std::call_once(g_fork_hygiene_once, []() {
+        apply_env_defaults_once();
+        install_atfork_once();
+    });
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// DistWorker
+// ---------------------------------------------------------------------------
+
+DistWorker::DistWorker(int32_t level, uint64_t heap_ring_size) :
     level_(level) {
     slots_ = std::make_unique<DistTaskSlotState[]>(DIST_TASK_WINDOW_SIZE);
+
+    // Fork hygiene runs before the HeapRing mmap so the env-var defaults
+    // apply to any thread-pool library that observes them at library init.
+    fork_hygiene_once();
+
+    // mmap the HeapRing region here, in the ctor, so Python callers can
+    // construct the DistWorker before fork()-ing children. The children
+    // inherit the MAP_SHARED region at the same virtual address.
+    allocator_.init(DIST_TASK_WINDOW_SIZE, heap_ring_size, DIST_ALLOC_TIMEOUT_MS);
 }
 
 DistWorker::~DistWorker() {
@@ -31,8 +130,7 @@ void DistWorker::add_worker(WorkerType type, IWorker *worker) {
 void DistWorker::init() {
     if (initialized_) throw std::runtime_error("DistWorker: already initialized");
 
-    ring_.init(DIST_TASK_WINDOW_SIZE);
-    orchestrator_.init(&tensormap_, &ring_, &scope_, &ready_queue_, slots_.get(), DIST_TASK_WINDOW_SIZE);
+    orchestrator_.init(&tensormap_, &allocator_, &scope_, &ready_queue_, slots_.get(), DIST_TASK_WINDOW_SIZE);
 
     // Start WorkerManager first — creates WorkerThreads.
     // The on_complete callback routes through the Scheduler's worker_done().
@@ -57,7 +155,7 @@ void DistWorker::close() {
     if (!initialized_) return;
     scheduler_.stop();
     manager_.stop();
-    ring_.shutdown();
+    allocator_.shutdown();
     initialized_ = false;
 }
 

--- a/src/common/distributed/dist_worker.h
+++ b/src/common/distributed/dist_worker.h
@@ -14,7 +14,7 @@
  *
  * DistWorker is the implementation of one level in the hierarchy (L3, L4, …).
  * From the level above it looks like an IWorker; internally it contains the
- * full scheduling engine (TensorMap, Ring, Scope, Orchestrator, Scheduler)
+ * full scheduling engine (TensorMap, Allocator, Scope, Orchestrator, Scheduler)
  * and a set of sub-IWorkers it dispatches to.
  *
  * Public surface:
@@ -27,6 +27,11 @@
  *
  * Worker holds no submit / scope / drain / active-task bookkeeping — those
  * concepts belong to Orchestrator.
+ *
+ * Construction is separated from `init()` so Python callers can mmap the
+ * HeapRing in the parent process *before* forking children (children see the
+ * MAP_SHARED region at the same virtual address). Start the scheduler and
+ * WorkerThreads with `init()` only after forks have happened.
  */
 
 #pragma once
@@ -34,8 +39,8 @@
 #include <cstdint>
 #include <memory>
 
-#include "dist_orchestrator.h"
 #include "dist_ring.h"
+#include "dist_orchestrator.h"
 #include "dist_scheduler.h"
 #include "dist_scope.h"
 #include "dist_tensormap.h"
@@ -44,7 +49,16 @@
 
 class DistWorker : public IWorker {
 public:
-    explicit DistWorker(int32_t level);
+    // Construct a Worker for hierarchy `level`. `heap_ring_size` is the
+    // MAP_SHARED|MAP_ANONYMOUS region handed out by the Orchestrator for
+    // auto-allocated OUTPUT tensors and `orch.alloc()` buffers.
+    //
+    // The heap is mmap'd here (before any fork) so forked child workers
+    // inherit the same mapping. Thread-hostile hygiene (setenv of
+    // OMP/MKL/BLIS/OPENBLAS thread-count knobs and the pthread_atfork
+    // installation) also runs in the ctor, still in the parent, before
+    // child forks.
+    explicit DistWorker(int32_t level, uint64_t heap_ring_size = DIST_DEFAULT_HEAP_RING_SIZE);
     ~DistWorker() override;
 
     DistWorker(const DistWorker &) = delete;
@@ -53,7 +67,9 @@ public:
     // Register sub-workers before calling init().
     void add_worker(WorkerType type, IWorker *worker);
 
-    // Initialise the engine and start the Scheduler thread.
+    // Start the scheduler thread. Must be called AFTER the parent has forked
+    // any child workers — init() spins up threads in the parent that would
+    // otherwise be accidentally inherited across fork.
     void init();
 
     // Shut down the Scheduler thread and release resources.
@@ -74,7 +90,7 @@ private:
     // --- Scheduling engine components ---
     std::unique_ptr<DistTaskSlotState[]> slots_;
     DistTensorMap tensormap_;
-    DistRing ring_;
+    DistRing allocator_;
     DistScope scope_;
     DistReadyQueue ready_queue_;
     DistOrchestrator orchestrator_;

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -110,7 +110,7 @@ endfunction()
 enable_testing()
 
 add_dist_test(test_dist_tensormap  test_dist_tensormap.cpp)
-add_dist_test(test_dist_ring       test_dist_ring.cpp)
+add_dist_test(test_dist_ring  test_dist_ring.cpp)
 add_dist_test(test_dist_scope      test_dist_scope.cpp)
 add_dist_test(test_dist_orchestrator test_dist_orchestrator.cpp)
 add_dist_test(test_dist_scheduler  test_dist_scheduler.cpp)

--- a/tests/ut/cpp/test_dist_orchestrator.cpp
+++ b/tests/ut/cpp/test_dist_orchestrator.cpp
@@ -14,8 +14,8 @@
 #include <atomic>
 
 #include "chip_call_config.h"
-#include "dist_orchestrator.h"
 #include "dist_ring.h"
+#include "dist_orchestrator.h"
 #include "dist_scope.h"
 #include "dist_tensormap.h"
 #include "dist_types.h"
@@ -30,7 +30,7 @@ struct OrchestratorFixture : public ::testing::Test {
 
     std::unique_ptr<DistTaskSlotState[]> slots;
     DistTensorMap tm;
-    DistRing ring;
+    DistRing allocator;
     DistScope scope;
     DistReadyQueue rq;
     DistOrchestrator orch;
@@ -38,11 +38,11 @@ struct OrchestratorFixture : public ::testing::Test {
 
     void SetUp() override {
         slots = std::make_unique<DistTaskSlotState[]>(N);
-        ring.init(N);
-        orch.init(&tm, &ring, &scope, &rq, slots.get(), N);
+        allocator.init(N, /*heap_bytes=*/1ULL << 20);
+        orch.init(&tm, &allocator, &scope, &rq, slots.get(), N);
     }
 
-    void TearDown() override { ring.shutdown(); }
+    void TearDown() override { allocator.shutdown(); }
 
     // Helper: build a TaskArgs whose only tensor has the given (data, tag).
     static TaskArgs single_tensor_args(uint64_t data_ptr, TensorArgType tag) {
@@ -164,4 +164,95 @@ TEST_F(OrchestratorFixture, GroupTaskHasAllChipStorageEntries) {
     // Both keys registered as producers for the group slot.
     EXPECT_EQ(tm.lookup(0xA0), res.task_slot);
     EXPECT_EQ(tm.lookup(0xA1), res.task_slot);
+}
+
+TEST_F(OrchestratorFixture, OutputAutoAllocsFromHeapRing) {
+    // An OUTPUT tensor submitted with `data == 0` is auto-allocated from
+    // the HeapRing: the slot's chip_storage tensor ends up with a non-zero
+    // data pointer that falls inside the allocator's mmap'd region, and
+    // the TensorMap routes that pointer to the slot.
+    TaskArgs args;
+    ContinuousTensor t{};
+    t.data = 0;
+    t.ndims = 1;
+    t.shapes[0] = 1024;  // 1024 * 1 byte = 1024, one aligned slab
+    t.dtype = DataType::UINT8;
+    args.add_tensor(t, TensorArgType::OUTPUT);
+
+    auto res = orch.submit_next_level(0xDEAD, args, cfg);
+    ASSERT_NE(res.task_slot, DIST_INVALID_SLOT);
+
+    const auto &chip = slots[res.task_slot].chip_storage_list.front();
+    uint64_t data = chip.tensor(0).data;
+    ASSERT_NE(data, 0u);
+    uintptr_t base = reinterpret_cast<uintptr_t>(allocator.heap_base());
+    EXPECT_GE(data, base);
+    EXPECT_LT(data, base + allocator.heap_size());
+    EXPECT_EQ(data % DIST_HEAP_ALIGN, 0u);
+
+    EXPECT_EQ(tm.lookup(data), res.task_slot);
+}
+
+TEST_F(OrchestratorFixture, InoutWiresCreatorAsFanin) {
+    // INOUT is the only tag that pulls in the prior writer as a fanin
+    // producer — matching L2's pto_orchestrator.cpp Step B where only
+    // INPUT / INOUT do tensor_map.lookup. Users who want a WaW dep on
+    // the alloc-slot (so its HeapRing slab stays live while they write)
+    // must tag the buffer INOUT.
+    auto creator_args = single_tensor_args(0xFEED, TensorArgType::OUTPUT);
+    auto creator = orch.submit_next_level(0xDEAD, creator_args, cfg);
+    DistTaskSlot drain;
+    rq.try_pop(drain);
+    // Mark the creator COMPLETED so the new submit mimics the alloc-slot
+    // path (COMPLETED producer with non-zero fanout).
+    slots[creator.task_slot].state.store(TaskState::COMPLETED, std::memory_order_relaxed);
+
+    auto writer_args = single_tensor_args(0xFEED, TensorArgType::INOUT);
+    auto writer = orch.submit_next_level(0xDEAD, writer_args, cfg);
+    DistTaskSlot writer_slot;
+    rq.try_pop(writer_slot);
+
+    // TensorMap now points at the new writer.
+    EXPECT_EQ(tm.lookup(0xFEED), writer.task_slot);
+    // Writer has the creator recorded as a fanin producer (via INOUT
+    // lookup) but no *live* fanin since the creator is already COMPLETED.
+    EXPECT_EQ(slots[writer.task_slot].fanin_count, 0);
+    ASSERT_EQ(slots[writer.task_slot].fanin_producers.size(), 1u);
+    EXPECT_EQ(slots[writer.task_slot].fanin_producers[0], creator.task_slot);
+    // Creator's fanout_total bumped so it waits for writer before CONSUMED.
+    {
+        std::lock_guard<std::mutex> lk(slots[creator.task_slot].fanout_mu);
+        EXPECT_EQ(slots[creator.task_slot].fanout_total, 1);
+        ASSERT_EQ(slots[creator.task_slot].fanout_consumers.size(), 1u);
+        EXPECT_EQ(slots[creator.task_slot].fanout_consumers[0], writer.task_slot);
+    }
+}
+
+TEST_F(OrchestratorFixture, OutputAndOutputExistingAreInsertOnly) {
+    // Contrast with INOUT: plain OUTPUT and OUTPUT_EXISTING are pure
+    // overwrites — insert into TensorMap, no lookup, so no fanin wire
+    // on the prior writer. Matches L2 semantics for both tags. Users
+    // who need creator lifetime must tag the buffer INOUT.
+    struct Case {
+        uint64_t key;
+        TensorArgType tag;
+    };
+    for (Case c : {Case{0xABCD, TensorArgType::OUTPUT}, Case{0xBEEF, TensorArgType::OUTPUT_EXISTING}}) {
+        auto prior_args = single_tensor_args(c.key, TensorArgType::OUTPUT);
+        auto prior = orch.submit_next_level(0xDEAD, prior_args, cfg);
+        DistTaskSlot drain;
+        rq.try_pop(drain);
+        slots[prior.task_slot].state.store(TaskState::COMPLETED, std::memory_order_relaxed);
+
+        auto writer_args = single_tensor_args(c.key, c.tag);
+        auto writer = orch.submit_next_level(0xDEAD, writer_args, cfg);
+
+        EXPECT_EQ(tm.lookup(c.key), writer.task_slot);
+        EXPECT_EQ(slots[writer.task_slot].fanin_count, 0);
+        EXPECT_TRUE(slots[writer.task_slot].fanin_producers.empty()) << "tag=" << static_cast<int>(c.tag);
+        {
+            std::lock_guard<std::mutex> lk(slots[prior.task_slot].fanout_mu);
+            EXPECT_EQ(slots[prior.task_slot].fanout_total, 0) << "tag=" << static_cast<int>(c.tag);
+        }
+    }
 }

--- a/tests/ut/cpp/test_dist_ring.cpp
+++ b/tests/ut/cpp/test_dist_ring.cpp
@@ -11,67 +11,159 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <chrono>
 #include <thread>
+#include <vector>
 
 #include "dist_ring.h"
 
+namespace {
+
+// Most tests only need a small heap to exercise wrap/back-pressure quickly.
+constexpr uint64_t kSmallHeap = 8ULL * DIST_HEAP_ALIGN;  // 8 KiB
+constexpr uint32_t kQuickTimeoutMs = 500;
+
+}  // namespace
+
 TEST(DistRing, InvalidWindowSizeThrows) {
-    DistRing r;
-    EXPECT_THROW(r.init(0), std::invalid_argument);
-    EXPECT_THROW(r.init(3), std::invalid_argument);  // not power-of-2
-    EXPECT_THROW(r.init(-1), std::invalid_argument);
+    DistRing a;
+    EXPECT_THROW(a.init(0, kSmallHeap, kQuickTimeoutMs), std::invalid_argument);
+    EXPECT_THROW(a.init(3, kSmallHeap, kQuickTimeoutMs), std::invalid_argument);
+    EXPECT_THROW(a.init(-1, kSmallHeap, kQuickTimeoutMs), std::invalid_argument);
 }
 
-TEST(DistRing, AllocReturnsValidSlots) {
-    DistRing r;
-    r.init(8);
+TEST(DistRing, SlotOnlyBumpsDistinctSlots) {
+    DistRing a;
+    a.init(8, /*heap_bytes=*/0, kQuickTimeoutMs);
     std::vector<DistTaskSlot> slots;
     for (int i = 0; i < 8; ++i) {
-        DistTaskSlot s = r.alloc();
-        EXPECT_GE(s, 0);
-        EXPECT_LT(s, 8);
-        slots.push_back(s);
+        auto r = a.alloc();
+        ASSERT_GE(r.slot, 0);
+        ASSERT_LT(r.slot, 8);
+        EXPECT_EQ(r.heap_ptr, nullptr);
+        slots.push_back(r.slot);
     }
-    // All 8 slots should be distinct
     std::sort(slots.begin(), slots.end());
     for (int i = 0; i < 8; ++i)
         EXPECT_EQ(slots[i], i);
 }
 
-TEST(DistRing, BackPressureAndRelease) {
-    DistRing r;
-    r.init(4);
+TEST(DistRing, HeapSlabsAreAlignedAndDistinct) {
+    DistRing a;
+    a.init(8, kSmallHeap, kQuickTimeoutMs);
 
-    // Fill the ring
-    std::vector<DistTaskSlot> held;
+    auto r1 = a.alloc(100);  // rounds to 1024
+    auto r2 = a.alloc(100);
+    ASSERT_NE(r1.heap_ptr, nullptr);
+    ASSERT_NE(r2.heap_ptr, nullptr);
+    uintptr_t p1 = reinterpret_cast<uintptr_t>(r1.heap_ptr);
+    uintptr_t p2 = reinterpret_cast<uintptr_t>(r2.heap_ptr);
+    EXPECT_EQ(p1 % DIST_HEAP_ALIGN, 0u);
+    EXPECT_EQ(p2 % DIST_HEAP_ALIGN, 0u);
+    EXPECT_EQ(p2 - p1, DIST_HEAP_ALIGN);
+}
+
+TEST(DistRing, AllocBytesGreaterThanHeapThrows) {
+    DistRing a;
+    a.init(8, kSmallHeap, kQuickTimeoutMs);
+    EXPECT_THROW(a.alloc(kSmallHeap + 1), std::runtime_error);
+}
+
+TEST(DistRing, AllocBytesWithHeapDisabledThrows) {
+    DistRing a;
+    a.init(8, /*heap_bytes=*/0, kQuickTimeoutMs);
+    EXPECT_THROW(a.alloc(32), std::runtime_error);
+}
+
+TEST(DistRing, HeapReclamationIsFifo) {
+    DistRing a;
+    // heap exactly 4 slabs, slot window large so only heap drives back-pressure.
+    a.init(32, 4 * DIST_HEAP_ALIGN, kQuickTimeoutMs);
+
+    auto r0 = a.alloc(100);
+    auto r1 = a.alloc(100);
+    auto r2 = a.alloc(100);
+    auto r3 = a.alloc(100);  // heap exactly full
+
+    // Releasing r2 first does not free heap space (r0/r1 still FIFO-alive).
+    a.release(r2.slot);
+    EXPECT_THROW(a.alloc(100), std::runtime_error);
+
+    // Releasing r0, r1 advances last_alive; r2 then releases for free and a
+    // fresh alloc succeeds. (r3 remains live, capping the forward tail.)
+    a.release(r0.slot);
+    a.release(r1.slot);
+    auto r4 = a.alloc(100);
+    ASSERT_NE(r4.heap_ptr, nullptr);
+    a.release(r3.slot);
+    a.release(r4.slot);
+}
+
+TEST(DistRing, HeapWrapsAroundWhenTailLeadsTop) {
+    DistRing a;
+    a.init(32, 4 * DIST_HEAP_ALIGN, kQuickTimeoutMs);
+
+    auto r0 = a.alloc(DIST_HEAP_ALIGN);
+    auto r1 = a.alloc(DIST_HEAP_ALIGN);
+    auto r2 = a.alloc(DIST_HEAP_ALIGN);
+    auto r3 = a.alloc(DIST_HEAP_ALIGN);  // heap full
+
+    // Free the front of the heap so the next alloc must wrap to offset 0.
+    a.release(r0.slot);
+    a.release(r1.slot);
+
+    auto wrapped = a.alloc(DIST_HEAP_ALIGN);
+    ASSERT_NE(wrapped.heap_ptr, nullptr);
+    // Wrapped allocation lives at the base of the region.
+    EXPECT_EQ(wrapped.heap_ptr, a.heap_base());
+
+    a.release(r2.slot);
+    a.release(r3.slot);
+    a.release(wrapped.slot);
+}
+
+TEST(DistRing, BackPressureThenReleaseUnblocks) {
+    DistRing a;
+    a.init(4, kSmallHeap, /*timeout_ms=*/5000);
+
+    std::vector<DistAllocResult> held;
     for (int i = 0; i < 4; ++i)
-        held.push_back(r.alloc());
-    EXPECT_EQ(r.active_count(), 4);
+        held.push_back(a.alloc());
+    EXPECT_EQ(a.active_count(), 4);
 
-    // Release one slot from another thread, then alloc should succeed
     std::thread releaser([&] {
         std::this_thread::sleep_for(std::chrono::milliseconds(20));
-        r.release(held[0]);
+        a.release(held[0].slot);
     });
 
-    DistTaskSlot s = r.alloc();  // blocks until releaser runs
-    EXPECT_NE(s, DIST_INVALID_SLOT);
+    auto r = a.alloc();  // blocks until releaser runs
+    EXPECT_NE(r.slot, DIST_INVALID_SLOT);
     releaser.join();
 
-    r.shutdown();
+    a.shutdown();
+}
+
+TEST(DistRing, TimeoutThrowsRuntimeError) {
+    DistRing a;
+    a.init(2, kSmallHeap, /*timeout_ms=*/50);
+    (void)a.alloc();
+    (void)a.alloc();  // slot window full, nobody releases
+    EXPECT_THROW(a.alloc(), std::runtime_error);
 }
 
 TEST(DistRing, ShutdownUnblocksAlloc) {
-    DistRing r;
-    r.init(2);
-    r.alloc();
-    r.alloc();  // ring full
+    DistRing a;
+    a.init(2, kSmallHeap, /*timeout_ms=*/5000);
+    (void)a.alloc();
+    (void)a.alloc();  // ring full
 
     std::thread t([&] {
-        DistTaskSlot s = r.alloc();  // should unblock when shutdown
-        EXPECT_EQ(s, DIST_INVALID_SLOT);
+        auto r = a.alloc();  // should unblock on shutdown, not timeout
+        EXPECT_EQ(r.slot, DIST_INVALID_SLOT);
+        EXPECT_EQ(r.heap_ptr, nullptr);
     });
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    r.shutdown();
+    a.shutdown();
     t.join();
 }

--- a/tests/ut/cpp/test_dist_scheduler.cpp
+++ b/tests/ut/cpp/test_dist_scheduler.cpp
@@ -104,7 +104,7 @@ struct SchedulerFixture : public ::testing::Test {
 
     std::unique_ptr<DistTaskSlotState[]> slots;
     DistTensorMap tm;
-    DistRing ring;
+    DistRing allocator;
     DistScope scope;
     DistReadyQueue rq;
     DistOrchestrator orch;
@@ -118,8 +118,8 @@ struct SchedulerFixture : public ::testing::Test {
 
     void SetUp() override {
         slots = std::make_unique<DistTaskSlotState[]>(N);
-        ring.init(N);
-        orch.init(&tm, &ring, &scope, &rq, slots.get(), N);
+        allocator.init(N, /*heap_bytes=*/1ULL << 20);
+        orch.init(&tm, &allocator, &scope, &rq, slots.get(), N);
 
         manager.add_next_level(&mock_worker);
         manager.start([this](DistTaskSlot slot) {
@@ -142,7 +142,7 @@ struct SchedulerFixture : public ::testing::Test {
     void TearDown() override {
         sched.stop();
         manager.stop();
-        ring.shutdown();
+        allocator.shutdown();
     }
 
     void wait_consumed(DistTaskSlot slot, int timeout_ms = 500) {
@@ -208,7 +208,7 @@ struct GroupSchedulerFixture : public ::testing::Test {
 
     std::unique_ptr<DistTaskSlotState[]> slots;
     DistTensorMap tm;
-    DistRing ring;
+    DistRing allocator;
     DistScope scope;
     DistReadyQueue rq;
     DistOrchestrator orch;
@@ -223,8 +223,8 @@ struct GroupSchedulerFixture : public ::testing::Test {
 
     void SetUp() override {
         slots = std::make_unique<DistTaskSlotState[]>(N);
-        ring.init(N);
-        orch.init(&tm, &ring, &scope, &rq, slots.get(), N);
+        allocator.init(N, /*heap_bytes=*/1ULL << 20);
+        orch.init(&tm, &allocator, &scope, &rq, slots.get(), N);
 
         manager.add_next_level(&worker_a);
         manager.add_next_level(&worker_b);
@@ -248,7 +248,7 @@ struct GroupSchedulerFixture : public ::testing::Test {
     void TearDown() override {
         sched.stop();
         manager.stop();
-        ring.shutdown();
+        allocator.shutdown();
     }
 
     void wait_consumed(DistTaskSlot slot, int timeout_ms = 1000) {

--- a/tests/ut/py/test_dist_worker/test_host_worker.py
+++ b/tests/ut/py/test_dist_worker/test_host_worker.py
@@ -227,7 +227,7 @@ class TestOrchAlloc:
         assert shape0 == 64
 
     def test_alloc_dep_wires_via_tensormap(self):
-        """OUTPUT producer -> alloc'd ptr -> INPUT consumer wires the dep."""
+        """INOUT producer -> alloc'd ptr -> INPUT consumer wires the dep."""
         marker_shm, marker_buf = _make_shared_counter()
 
         try:
@@ -239,11 +239,14 @@ class TestOrchAlloc:
             def orch(o, _args):
                 inter = o.alloc((128,), DataType.FLOAT32)
 
-                # Producer tags inter as OUTPUT — alloc slot is the initial
-                # producer (synthetic), then tensormap.insert reassigns it
-                # to the producer slot.
+                # Producer writes into the alloc'd slab and must depend on
+                # the alloc-slot (the creator) so the slab is not reclaimed
+                # while the producer is still writing. That lifetime link
+                # goes through INOUT — matching L2, only INPUT and INOUT
+                # do TensorMap.lookup. Plain OUTPUT / OUTPUT_EXISTING are
+                # pure inserts and would leave no dep on the alloc slot.
                 p_args = TaskArgs()
-                p_args.add_tensor(inter, TensorArgType.OUTPUT)
+                p_args.add_tensor(inter, TensorArgType.INOUT)
                 o.submit_sub(producer_cid, p_args)
 
                 # Consumer tags inter as INPUT — tensormap.lookup finds the


### PR DESCRIPTION
## Summary

Replaces the per-call `mmap` placeholder in `DistOrchestrator::alloc` (landed in #543) with a pre-allocated `MAP_SHARED | MAP_ANONYMOUS` heap region taken in `DistWorker`'s ctor, and merges the slot ring with the heap region into a single `DistRing` — mirroring L2's `PTO2TaskAllocator` (Strict-2).

- **Merged slot+heap `DistRing`**: one mutex guards `next_task_id_`, `last_alive_`, `heap_top_`, `heap_tail_`; `alloc(bytes)` atomically returns `{slot, heap_ptr, heap_end_offset}`; `release(slot)` advances a FIFO `last_alive_` pointer that in turn drives `heap_tail_` forward. No partial-failure rollback path.
- **Pre-fork heap mmap**: heap comes from one `mmap(MAP_SHARED | MAP_ANONYMOUS)` in the `DistWorker` ctor. Python `Worker` now constructs `DistWorker` in `_init_level3` (before forking chip/sub workers) and only wires the mailboxes in `_start_level3`, so forked children inherit the region at the same virtual address.
- **1024 B alignment** (`DIST_HEAP_ALIGN`, matches `PTO2_PACKED_OUTPUT_ALIGN`, Strict-3) on every heap slab.
- **`OUTPUT` auto-allocation**: `OUTPUT` with `data == 0` is auto-allocated from the HeapRing inside `submit_impl` (all OUTPUTs for one submit share a single allocator call). `data != 0` `OUTPUT` and `OUTPUT_EXISTING` remain pure inserts — only `INPUT` / `INOUT` do a tensormap lookup in `infer_deps` (matches L2 `pto_orchestrator.cpp` step B). WaW dependencies (e.g. writing into an `orch.alloc()` buffer) are expressed with `INOUT`.
- **`Worker(level=3, heap_ring_size=…)`** ctor knob, default 1 GiB, surfaced through the nanobind binding.
- **Fork hygiene** in the `DistWorker` ctor: `setenv` (`overwrite=0`) of `OMP_NUM_THREADS` / `OPENBLAS_NUM_THREADS` / `MKL_NUM_THREADS` / `BLIS_NUM_THREADS` to `1`, plus `KMP_DUPLICATE_LIB_OK=TRUE` on macOS, and a single `pthread_atfork` handler registered once per process (landing pad; acquisition order documented inline for follow-up PRs).
- **Back-pressure timeout**: `DistRing::alloc` spin-waits on a cv and throws `std::runtime_error` after `DIST_ALLOC_TIMEOUT_MS` (default 10 s). An exhausted heap or full slot window now surfaces as a Python exception instead of silently deadlocking.
- **`DistTaskSlotState::alloc_bufs` / `alloc_sizes` removed** — heap reclamation is implicit via `last_alive_`, no per-slot `munmap` runs any more.

### Open questions resolved (from the plan)
- **Q5** (atfork lock order): single `pthread_atfork` handler, coarse-to-fine acquisition order, documented.
- **Q6** (heap back-pressure deadlock): bounded spin + `std::runtime_error` on timeout; no grow (post-fork `mremap` of a `MAP_SHARED` region would diverge from children).
- **Q7** (merge vs split allocators): merged, single `mu_` + single `last_alive_` for both resources.

### Known L2/L3 deviations (tracked for follow-ups)
- `DIST_TASK_WINDOW_SIZE = 128` is still a legacy fixed ring. Slot state lives on the parent heap and is never crossed into children; the real back-pressure at L3 is the heap. A follow-up (PR-I in the plan) replaces the slot ring with a dynamic `std::deque<std::unique_ptr<TaskSlotState>>` and drops `window_size` from the public API. Flagged in `docs/orchestrator.md` §5 and added as an allowed exception in the plan's L2 Consistency Audit.

## Docs

- `docs/orchestrator.md` §5 rewritten as the unified allocator, §8b rewritten for HeapRing + tag-semantics table (tags that do vs. don't wire WaW), new §8c for fork hygiene.
- `docs/roadmap.md` moves the PR-H items to **Landed** (heap ring, OUTPUT auto-alloc, `heap_ring_size` knob, fork hygiene) and drops the in-flight entry.

## Test plan
- [x] cpput: new `test_dist_ring` (FIFO reclamation, heap wrap-around, back-pressure timeout, shutdown, 1024 B alignment) and new orchestrator tests (`OutputAutoAllocsFromHeapRing`, `InoutWiresCreatorAsFanin`, `OutputAndOutputExistingAreInsertOnly`). **7/7 targets pass** locally (`cmake --build /tmp/dist_ut_build && ctest`).
- [x] pyut: `tests/ut/py/test_dist_worker` + `tests/ut/py/test_task_interface.py` — **100 passed, 3 deselected** (torch-only tests; torch not installed on dev box). `test_alloc_dep_wires_via_tensormap` migrated to `INOUT` so the alloc-slot is pinned as a WaW producer — plain `OUTPUT` would be a pure overwrite and UAF under the real heap ring.
- [ ] Linux CI for full coverage (macOS dev box doesn't exercise glibc feature gates; pushing for CI).