### PR TITLE
Support: auto-run swimlane converter per case in scene_test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -59,8 +59,19 @@ def pytest_addoption(parser):
     """Register CLI options."""
     parser.addoption("--platform", action="store", default=None, help="Target platform (e.g., a2a3sim, a2a3)")
     parser.addoption("--device", action="store", default="0", help="Device ID or range (e.g., 0, 4-7)")
-    parser.addoption("--case", action="store", default=None, help="Run specific case name only")
-    parser.addoption("--all-cases", action="store_true", default=False, help="Include manual cases")
+    parser.addoption(
+        "--case",
+        action="append",
+        default=None,
+        help="Case selector; repeatable. Forms: 'Foo' (any class), 'ClassA::Foo', 'ClassA::' (whole class).",
+    )
+    parser.addoption(
+        "--manual",
+        action="store",
+        choices=["exclude", "include", "only"],
+        default="exclude",
+        help="Manual case handling: exclude (default), include, only",
+    )
     parser.addoption("--runtime", action="store", default=None, help="Only run tests for this runtime")
     parser.addoption("--rounds", type=int, default=1, help="Run each case N times (default: 1)")
     parser.addoption(
@@ -232,11 +243,12 @@ def st_worker(request, st_platform, device_pool):
     if level == 2:
         ids = device_pool.allocate(1)
         if not ids:
-            pytest.fail("no devices available")
+            pytest.fail(f"no devices available in --device pool (requested 1, pool has {len(device_pool._available)})")
 
         from simpler.worker import Worker  # noqa: PLC0415
 
         w = Worker(level=2, device_id=ids[0], platform=st_platform, runtime=runtime, build=build)
+        w._st_device_id = ids[0]  # expose primary device to test_run for profiling snapshots
         w.init()
         yield w
         w.close()
@@ -247,7 +259,9 @@ def st_worker(request, st_platform, device_pool):
         max_subs = max((c.get("config", {}).get("num_sub_workers", 0) for c in cls.CASES), default=0)
         ids = device_pool.allocate(max_devices)
         if not ids:
-            pytest.fail(f"need {max_devices} devices")
+            pytest.fail(
+                f"need {max_devices} devices but --device pool has {len(device_pool._available)}; widen --device range"
+            )
 
         from simpler.worker import Worker  # noqa: PLC0415
 
@@ -259,6 +273,7 @@ def st_worker(request, st_platform, device_pool):
             runtime=runtime,
             build=build,
         )
+        w._st_device_id = ids[0]  # expose primary device to test_run for profiling snapshots
 
         # Register SubCallable entries from cls.CALLABLE
         sub_ids = {}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -447,7 +447,20 @@ def compute_golden(self, args, params):
 | Batch (pytest) | `python examples/scripts/ci.py` | `pytest examples tests/st --platform a2a3sim` |
 | Multi-round | Not supported | `python test_*.py -p a2a3sim -n 3` |
 | Benchmark | Manual | `python test_*.py -p a2a3 -d 0 -n 100 --skip-golden --case CaseName` |
-| Profiling | `--enable-profiling` flag on run_example.py | `python test_*.py -p a2a3 -d 0 --enable-profiling` |
+| Profiling | `--enable-profiling` flag on run_example.py | `python test_*.py -p a2a3 -d 0 --enable-profiling` (auto-runs `tools/swimlane_converter.py` per case at end) |
+
+##### `--case` selector and `--manual`
+
+`--case` is repeatable and accepts compound forms (useful when a test file declares multiple `SceneTestCase` classes):
+
+| Form | Meaning |
+| ---- | ------- |
+| `--case Foo` | case named `Foo` in any class |
+| `--case ClassA::Foo` | `Foo` in `ClassA` only |
+| `--case ClassA::` | all cases in `ClassA` |
+| `--case A::x --case B::y` | multiple selectors (repeatable) |
+
+`--manual exclude` (default) skips `manual: True` cases; `--manual include` runs them alongside normal cases; `--manual only` runs only manual cases. These compose orthogonally with `--case`: explicit selectors still respect the manual filter — to run a manual case by name, pass `--manual include`.
 
 #### After Migration
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -20,6 +20,8 @@ A scene test class declares three things:
   generate_args / compute_golden: data + golden comparison
 """
 
+from __future__ import annotations
+
 import inspect
 import os
 import sys
@@ -111,7 +113,7 @@ class TaskArgsBuilder:
         except KeyError:
             raise AttributeError(f"TaskArgsBuilder has no argument '{name}'") from None
 
-    def clone(self) -> "TaskArgsBuilder":
+    def clone(self) -> TaskArgsBuilder:
         """Deep clone: all tensors are cloned, scalars copied."""
         import torch  # noqa: PLC0415
 
@@ -333,6 +335,205 @@ def _resolve_chip_entry_paths(entry, cls_dir):
                 k["source"] = str(cls_dir / k["source"])
             resolved.append(k)
         entry["incores"] = resolved
+
+
+def _parse_case_selector(value: str) -> tuple[str | None, str | None]:
+    """Parse one ``--case`` value into ``(class_name, case_name)``.
+
+    ``Foo`` -> ``(None, "Foo")`` (any class)
+    ``ClassA::Foo`` -> ``("ClassA", "Foo")``
+    ``ClassA::`` -> ``("ClassA", None)`` (all cases in ClassA)
+    ``::Foo`` -> ``(None, "Foo")``
+    """
+    if "::" in value:
+        cls_part, case_part = value.split("::", 1)
+        return (cls_part or None, case_part or None)
+    return (None, value)
+
+
+def _match_selectors(cls_name: str, case_name: str, selectors: list[tuple]) -> bool:
+    """True if ``(cls_name, case_name)`` matches any selector (empty list means no selector filter)."""
+    if not selectors:
+        return True
+    for sel_cls, sel_case in selectors:
+        if (sel_cls is None or sel_cls == cls_name) and (sel_case is None or sel_case == case_name):
+            return True
+    return False
+
+
+def _select_cases(test_classes, platform: str, selectors: list[tuple], manual_mode: str):
+    """Resolve (class, case) pairs to run. Validates selectors strictly.
+
+    Filters: platform match -> selector match -> manual_mode (exclude/include/only).
+    Raises ``ValueError`` on unknown selector class/case or empty selection.
+    """
+    class_index = {c.__name__: c for c in test_classes}
+    for sel_cls, _ in selectors:
+        if sel_cls is not None and sel_cls not in class_index:
+            available = ", ".join(sorted(class_index)) or "(none)"
+            raise ValueError(f"--case: unknown class '{sel_cls}'. Available: {available}")
+    for sel_cls, sel_case in selectors:
+        if sel_case is None:
+            continue
+        scoped = [class_index[sel_cls]] if sel_cls else test_classes
+        if not any(case["name"] == sel_case for c in scoped for case in c.CASES):
+            scope = sel_cls or "any class"
+            raise ValueError(f"--case: case '{sel_case}' not found in {scope}")
+
+    selected: list[tuple] = []
+    for cls in test_classes:
+        for case in cls.CASES:
+            if platform not in case["platforms"]:
+                continue
+            if not _match_selectors(cls.__name__, case["name"], selectors):
+                continue
+            is_manual = bool(case.get("manual"))
+            if manual_mode == "exclude" and is_manual:
+                continue
+            if manual_mode == "only" and not is_manual:
+                continue
+            selected.append((cls, case))
+
+    if not selected:
+        if selectors:
+            sel_str = ", ".join(f"{c or '*'}::{n or '*'}" for c, n in selectors)
+            hint = " (matches are manual; pass --manual include or only)" if manual_mode == "exclude" else ""
+            raise ValueError(f"--case: no cases matched [{sel_str}] for platform={platform}{hint}")
+        raise ValueError(f"No cases matched platform={platform} (manual={manual_mode})")
+    return selected
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _outputs_dir() -> Path:
+    return _project_root() / "outputs"
+
+
+def _snapshot_perf_files() -> set[Path]:
+    d = _outputs_dir()
+    return set(d.glob("perf_swimlane_*.json")) if d.exists() else set()
+
+
+def _wait_new_perf_file(before: set[Path], timeout: float = 2.0) -> Path | None:
+    """Wait briefly for a new ``perf_swimlane_*.json`` to appear in outputs/."""
+    import time  # noqa: PLC0415
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        new = _snapshot_perf_files() - before
+        if new:
+            return max(new, key=lambda p: p.stat().st_mtime)
+        time.sleep(0.1)
+    return None
+
+
+def _get_device_log_dir(device_id) -> Path:
+    """Return CANN device log directory (matches device_log_resolver)."""
+    ascend_work_path = os.environ.get("ASCEND_WORK_PATH")
+    if ascend_work_path:
+        root = Path(ascend_work_path).expanduser() / "log" / "debug"
+        if root.exists():
+            return root / f"device-{device_id}"
+    return Path.home() / "ascend" / "log" / "debug" / f"device-{device_id}"
+
+
+def _snapshot_device_logs(device_id) -> set[Path]:
+    log_dir = _get_device_log_dir(device_id)
+    return set(log_dir.glob("*.log")) if log_dir.exists() else set()
+
+
+def _wait_new_device_log(device_id, before: set[Path], timeout: float = 15.0) -> Path | None:
+    """Wait for a new CANN device log; returns the newest new file or None."""
+    import time  # noqa: PLC0415
+
+    log_dir = _get_device_log_dir(device_id)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if log_dir.exists():
+            new = set(log_dir.glob("*.log")) - before
+            if new:
+                return max(new, key=lambda p: p.stat().st_mtime)
+        time.sleep(0.5)
+    return None
+
+
+def _run_swimlane_converter(
+    input_path: Path | None = None,
+    device_id=None,
+    device_log: Path | None = None,
+) -> None:
+    """Invoke ``tools/swimlane_converter.py``.
+
+    When ``input_path`` is given, the converter derives its output filename from
+    the input's timestamp (see ``tools/swimlane_converter.py::_resolve_output_path``).
+    Without it, the converter auto-selects the latest ``perf_swimlane_*.json``.
+    """
+    import logging  # noqa: PLC0415
+    import subprocess  # noqa: PLC0415
+
+    logger = logging.getLogger(__name__)
+    script = _project_root() / "tools" / "swimlane_converter.py"
+    if not script.exists():
+        logger.warning(f"Swimlane converter script not found: {script}")
+        return
+    cmd = [sys.executable, str(script)]
+    if input_path is not None:
+        cmd.append(str(input_path))
+    if device_log is not None:
+        cmd += ["--device-log", str(device_log)]
+    elif device_id is not None:
+        cmd += ["-d", str(device_id)]
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        if result.stdout:
+            logger.info(result.stdout)
+        logger.info("Swimlane JSON generation completed")
+    except subprocess.CalledProcessError as e:
+        logger.warning(f"Failed to generate swimlane JSON: {e}")
+        if e.stdout:
+            logger.debug(f"stdout: {e.stdout}")
+        if e.stderr:
+            logger.debug(f"stderr: {e.stderr}")
+
+
+def _sanitize_for_filename(s: str) -> str:
+    return "".join(c if c.isalnum() or c in "._-" else "_" for c in s)
+
+
+def _convert_case_swimlane(
+    case_label: str,
+    device_id,
+    before_perf: set[Path],
+    before_device: set[Path] | None,
+) -> None:
+    """Post-case: rename the new perf file to include ``case_label`` (guarding against
+    the runtime's second-precision filename collisions), then invoke the converter.
+
+    The ``perf_swimlane_`` prefix is preserved so the converter's stem-based output
+    naming still strips it and produces ``merged_swimlane_<ts>_<case_label>.json``.
+    """
+    import logging  # noqa: PLC0415
+
+    logger = logging.getLogger(__name__)
+    perf_file = _wait_new_perf_file(before_perf)
+    if perf_file is None:
+        logger.warning(f"[{case_label}] No new perf_swimlane_*.json produced; skipping conversion")
+        return
+    safe_label = _sanitize_for_filename(case_label)
+    suffix = perf_file.stem[len("perf_swimlane_") :] if perf_file.stem.startswith("perf_swimlane_") else perf_file.stem
+    renamed = perf_file.with_name(f"perf_swimlane_{suffix}_{safe_label}.json")
+    if renamed.exists():
+        logger.warning(f"[{case_label}] target {renamed.name} already exists; overwriting")
+        renamed.unlink()
+    perf_file.rename(renamed)
+    device_log = None
+    if before_device is not None:
+        device_log = _wait_new_device_log(device_id, before_device)
+        if device_log is None:
+            logger.warning(f"[{case_label}] no new device log found; scheduler deep-dive may use stale log")
+    _run_swimlane_converter(input_path=renamed, device_id=device_id, device_log=device_log)
 
 
 def _compare_outputs(test_args, golden_args, output_names, rtol, atol):
@@ -666,39 +867,60 @@ class SceneTestCase:
 
     def test_run(self, st_platform, st_worker, request):
         """Auto test method — runs matching cases for the current platform."""
-        case_filter = request.config.getoption("--case", default=None)
-        all_cases = request.config.getoption("--all-cases", default=False)
+        raw_selectors = request.config.getoption("--case", default=None) or []
+        selectors = [_parse_case_selector(v) for v in raw_selectors]
+        manual_mode = request.config.getoption("--manual", default="exclude")
         rounds = request.config.getoption("--rounds", default=1)
         skip_golden = request.config.getoption("--skip-golden", default=False)
         enable_profiling = request.config.getoption("--enable-profiling", default=False)
         enable_dump_tensor = request.config.getoption("--dump-tensor", default=False)
 
+        cls_name = type(self).__name__
         callable_obj = self.build_callable(st_platform)
         sub_ids = getattr(type(self), "_st_sub_ids", {})
+
+        # Primary device id: prefer the one actually allocated by st_worker
+        # (each test class can hold a different slot from DevicePool); fall back
+        # to the first id in --device if the fixture didn't stash it.
+        primary_device_id = getattr(st_worker, "_st_device_id", None)
+        if primary_device_id is None:
+            raw_device = request.config.getoption("--device", default="0")
+            primary_device_id = raw_device.split("-", 1)[0] if "-" in raw_device else raw_device
+        is_hardware = not st_platform.endswith("sim")
+
         ran_any = False
         for case in self.CASES:
             if st_platform not in case["platforms"]:
                 continue
-            if case_filter and case["name"] != case_filter:
+            if not _match_selectors(cls_name, case["name"], selectors):
                 continue
-            if case.get("manual") and not case_filter and not all_cases:
+            is_manual = bool(case.get("manual"))
+            if manual_mode == "exclude" and is_manual:
                 continue
-            self._run_and_validate(
-                st_worker,
-                callable_obj,
-                case,
-                sub_ids=sub_ids,
-                rounds=rounds,
-                skip_golden=skip_golden,
-                enable_profiling=enable_profiling,
-                enable_dump_tensor=enable_dump_tensor,
-            )
+            if manual_mode == "only" and not is_manual:
+                continue
+            before_perf = _snapshot_perf_files() if enable_profiling else set()
+            before_device = _snapshot_device_logs(primary_device_id) if enable_profiling and is_hardware else None
+            try:
+                self._run_and_validate(
+                    st_worker,
+                    callable_obj,
+                    case,
+                    sub_ids=sub_ids,
+                    rounds=rounds,
+                    skip_golden=skip_golden,
+                    enable_profiling=enable_profiling,
+                    enable_dump_tensor=enable_dump_tensor,
+                )
+            finally:
+                if enable_profiling:
+                    _convert_case_swimlane(f"{cls_name}_{case['name']}", primary_device_id, before_perf, before_device)
             ran_any = True
 
         if not ran_any:
             import pytest  # noqa: PLC0415
 
-            pytest.skip(f"No cases matched platform={st_platform}")
+            pytest.skip(f"No cases matched {cls_name} (platform={st_platform}, manual={manual_mode})")
 
     # ------------------------------------------------------------------
     # Standalone entry point
@@ -712,8 +934,18 @@ class SceneTestCase:
         parser = argparse.ArgumentParser()
         parser.add_argument("-p", "--platform", required=True)
         parser.add_argument("-d", "--device", type=int, default=0)
-        parser.add_argument("--case", help="Run specific case name")
-        parser.add_argument("--all-cases", action="store_true", help="Include manual cases")
+        parser.add_argument(
+            "--case",
+            action="append",
+            default=None,
+            help="Case selector; repeatable. Forms: 'Foo' (any class), 'ClassA::Foo', 'ClassA::'",
+        )
+        parser.add_argument(
+            "--manual",
+            choices=["exclude", "include", "only"],
+            default="exclude",
+            help="Manual case handling: exclude (default), include, only",
+        )
         parser.add_argument("-n", "--rounds", type=int, default=1, help="Run each case N times (default: 1)")
         parser.add_argument("--skip-golden", action="store_true", help="Skip golden comparison (benchmark mode)")
         parser.add_argument("--enable-profiling", action="store_true", help="Enable profiling (first round only)")
@@ -735,9 +967,28 @@ class SceneTestCase:
             if isinstance(v, type) and issubclass(v, SceneTestCase) and v is not SceneTestCase and hasattr(v, "CASES")
         ]
 
+        selectors = [_parse_case_selector(v) for v in (args.case or [])]
+        try:
+            selected = _select_cases(test_classes, args.platform, selectors, args.manual)
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(2)
+
+        selected_by_cls: dict[type, list[dict]] = {}
+        for cls, case in selected:
+            selected_by_cls.setdefault(cls, []).append(case)
+
         by_runtime: dict[str, list[type]] = {}
-        for cls in test_classes:
+        for cls in selected_by_cls:
             by_runtime.setdefault(cls._st_runtime, []).append(cls)
+
+        is_hardware = not args.platform.endswith("sim")
+        if args.enable_profiling and is_hardware and "-d" not in sys.argv and "--device" not in sys.argv:
+            print(
+                f"WARNING: --enable-profiling on hardware platform '{args.platform}' without explicit "
+                "-d/--device; defaulting to device 0 may point scheduler deep-dive at the wrong log.",
+                file=sys.stderr,
+            )
 
         ok = True
         for runtime, group in by_runtime.items():
@@ -748,15 +999,13 @@ class SceneTestCase:
                     inst = cls()
                     callable_obj = inst.build_callable(args.platform)
                     sub_ids = per_class_sub_ids.get(cls, {})
-                    for case in inst.CASES:
-                        if args.platform not in case["platforms"]:
-                            continue
-                        if args.case and case["name"] != args.case:
-                            continue
-                        if case.get("manual") and not args.case and not args.all_cases:
-                            continue
+                    for case in selected_by_cls[cls]:
                         label = f"{cls.__name__}::{case['name']}"
                         print(f"  {label} ... ", end="", flush=True)
+                        before_perf = _snapshot_perf_files() if args.enable_profiling else set()
+                        before_device = (
+                            _snapshot_device_logs(args.device) if args.enable_profiling and is_hardware else None
+                        )
                         try:
                             inst._run_and_validate(
                                 worker,
@@ -772,11 +1021,20 @@ class SceneTestCase:
                         except Exception as e:
                             print(f"FAILED: {e}")
                             ok = False
+                        finally:
+                            if args.enable_profiling:
+                                _convert_case_swimlane(
+                                    f"{cls.__name__}_{case['name']}",
+                                    args.device,
+                                    before_perf,
+                                    before_device,
+                                )
             finally:
                 if group[0]._st_level == 2:
                     worker.finalize()
                 else:
                     worker.close()
+
         sys.exit(0 if ok else 1)
 
 


### PR DESCRIPTION
## Summary

Wire `tools/swimlane_converter.py` into both pytest and standalone scene test paths so `--enable-profiling` runs always produce a usable merged swimlane without a manual follow-up step. Also revamps the scene test CLI: `--all-cases` -> `--manual {exclude,include,only}`, and `--case` now accepts compound `ClassA::Foo` selectors.

## Per-case conversion flow

For each case that runs with profiling enabled:

1. Snapshot `outputs/perf_swimlane_*.json` and CANN device log dir
2. Run the case
3. Wait briefly (<=2s) for the new perf file
4. **Rename** the perf file to embed `Class_Case` in its name — the runtime writes `perf_swimlane_<second-timestamp>.json`, so two cases completing within the same second would otherwise clobber each other
5. Wait (<=15s, hardware only) for the new CANN device log
6. Invoke the converter with `--device-log` when available; the output name is derived from the renamed input stem by the converter's existing `_resolve_output_path` logic

## CLI changes

### `--manual` replaces `--all-cases`

The old flag was misnamed; its actual semantics were already "include manual cases":

```
--manual exclude   # default, skip manual cases
--manual include   # run manual cases alongside normal ones
--manual only      # run only manual cases (new capability)
```

### `--case` is now repeatable and supports compound forms

```
--case Foo              # any class has a case named Foo
--case ClassA::Foo      # qualified: only ClassA::Foo
--case ClassA::         # all cases in ClassA
--case A::x --case B::y # repeatable
```

`--case` and `--manual` compose orthogonally. A fully-qualified selector that resolves only to manual cases while `--manual=exclude` raises with a hint to pass `--manual include`.

Standalone `run_module` strictly validates selectors (unknown class/case or empty selection → error). pytest path silently skips non-matches to match `-k` ergonomics.

## Other changes

- `st_worker` fixture stashes allocated device ids on the Worker so `test_run` can discover the primary device for log snapshots — fixes a bug where multi-class tests sharing a `DevicePool` range all snapshotted the first `--device` only
- `run_module` warns when `--enable-profiling` is combined with a hardware platform but no explicit `-d/--device`
- `docs/testing.md` documents the new selector and manual model

## Test plan

- [x] Helper unit checks (`_parse_case_selector`, `_match_selectors`, `_select_cases`) — edge cases: compound forms, manual override, unknown class/case errors
- [x] `python -m py_compile` on touched files
- [x] Pre-commit hooks (ruff, pyright, markdownlint) pass
- [ ] Live run: `pytest examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py --platform a2a3sim --enable-profiling --case '::'` verifies per-case swimlane generation
- [ ] Live run on hardware: `python test_*.py -p a2a3 -d 0 --enable-profiling` verifies device-log pairing and rename path