### PR TITLE
Support: add pytest --pto-session-timeout and --pto-isa-commit with CI retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,17 @@ jobs:
         run: python ci.py -p a2a3sim -c d96c8784 -t 600 --clone-protocol https
 
       - name: Run pytest scene tests (a2a3sim)
-        run: pytest examples tests/st --platform a2a3sim --device 0-15 -v
+        run: |
+          set +e
+          pytest examples tests/st --platform a2a3sim --device 0-15 -v --pto-session-timeout 600
+          rc=$?
+          if [ $rc -eq 124 ]; then
+            echo "pytest timed out; retrying with pinned PTO-ISA commit"
+            pytest examples tests/st --platform a2a3sim --device 0-15 -v \
+              --pto-session-timeout 600 --pto-isa-commit d96c8784 --clone-protocol https
+            rc=$?
+          fi
+          exit $rc
 
   st-sim-a5:
     runs-on: ${{ matrix.os }}
@@ -276,7 +286,17 @@ jobs:
         run: python ci.py -p a5sim -c d96c8784 -t 600 --clone-protocol https
 
       - name: Run pytest scene tests (a5sim)
-        run: pytest examples tests/st --platform a5sim --device 0-15 -v
+        run: |
+          set +e
+          pytest examples tests/st --platform a5sim --device 0-15 -v --pto-session-timeout 600
+          rc=$?
+          if [ $rc -eq 124 ]; then
+            echo "pytest timed out; retrying with pinned PTO-ISA commit"
+            pytest examples tests/st --platform a5sim --device 0-15 -v \
+              --pto-session-timeout 600 --pto-isa-commit d96c8784 --clone-protocol https
+            rc=$?
+          fi
+          exit $rc
 
   # ---------- Python unit tests (a2a3 hardware) ----------
   ut-py-a2a3:
@@ -322,8 +342,18 @@ jobs:
 
       - name: Run pytest scene tests (a2a3)
         run: |
+          set +e
           source .venv/bin/activate
-          source ${ASCEND_HOME_PATH}/bin/setenv.bash && python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v
+          source ${ASCEND_HOME_PATH}/bin/setenv.bash
+          python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v --pto-session-timeout 600
+          rc=$?
+          if [ $rc -eq 124 ]; then
+            echo "pytest timed out; retrying with pinned PTO-ISA commit"
+            python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v \
+              --pto-session-timeout 600 --pto-isa-commit d96c8784 --clone-protocol https
+            rc=$?
+          fi
+          exit $rc
 
 
   # ---------- Detect A5 changes (runs on GitHub server, not A5 machine) ----------
@@ -403,4 +433,5 @@ jobs:
         run: |
           source ${ASCEND_HOME_PATH}/bin/setenv.bash
           DEVICE_LIST=$(python -c "s,e='${DEVICE_RANGE}'.split('-'); print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v"
+          PYTEST="python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "set +e; $PYTEST --pto-session-timeout 1200; rc=\$?; if [ \$rc -eq 124 ]; then echo 'pytest timed out; retrying with pinned PTO-ISA commit'; $PYTEST --pto-session-timeout 1200 --pto-isa-commit d96c8784 --clone-protocol https; rc=\$?; fi; exit \$rc"

--- a/conftest.py
+++ b/conftest.py
@@ -17,10 +17,16 @@ subprocess per runtime so each gets a clean CANN context. See docs/testing.md.
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
 
 import pytest
+
+# Exit code used when the session watchdog fires. Matches the GNU `timeout`
+# convention so shell wrappers (e.g. CI) can distinguish timeout from other
+# failures.
+TIMEOUT_EXIT_CODE = 124
 
 
 def _parse_device_range(s: str) -> list[int]:
@@ -82,6 +88,46 @@ def pytest_addoption(parser):
     )
     parser.addoption("--dump-tensor", action="store_true", default=False, help="Dump per-task tensor I/O at runtime")
     parser.addoption("--build", action="store_true", default=False, help="Compile runtime from source")
+    parser.addoption(
+        "--pto-isa-commit",
+        action="store",
+        default=None,
+        help="Pin pto-isa clone to this commit before running tests",
+    )
+    parser.addoption(
+        "--clone-protocol",
+        action="store",
+        default="ssh",
+        choices=["ssh", "https"],
+        help="Protocol for cloning pto-isa when --pto-isa-commit is set",
+    )
+    # Distinct from pytest-timeout's per-test --timeout (which `.[test]` pulls
+    # in on the a2a3 hardware runner); this is session-level.
+    parser.addoption(
+        "--pto-session-timeout",
+        action="store",
+        type=int,
+        default=0,
+        help=(f"Abort whole pytest session after N seconds (0 = disabled; exit code {TIMEOUT_EXIT_CODE} on timeout)"),
+    )
+
+
+def _install_session_timeout(timeout_s: int) -> None:
+    def _handler(signum, frame):
+        print(
+            f"\n{'=' * 40}\n"
+            f"[pytest] TIMEOUT: session exceeded {timeout_s}s "
+            f"({timeout_s // 60}min) limit, aborting\n"
+            f"{'=' * 40}",
+            flush=True,
+        )
+        os._exit(TIMEOUT_EXIT_CODE)
+
+    # signal.alarm / SIGALRM are Unix-only; skip silently on platforms without
+    # them so --pto-session-timeout is a no-op rather than a crash (e.g. Windows).
+    if hasattr(signal, "alarm") and hasattr(signal, "SIGALRM"):
+        signal.signal(signal.SIGALRM, _handler)
+        signal.alarm(timeout_s)
 
 
 def pytest_configure(config):
@@ -98,6 +144,22 @@ def pytest_configure(config):
     log_level = config.getoption("--log-level", default=None)
     if log_level:
         os.environ["PTO_LOG_LEVEL"] = log_level
+
+    commit = config.getoption("--pto-isa-commit")
+    if commit:
+        from simpler_setup.code_runner import _ensure_pto_isa_root  # noqa: PLC0415
+
+        root = _ensure_pto_isa_root(
+            verbose=True,
+            commit=commit,
+            clone_protocol=config.getoption("--clone-protocol"),
+        )
+        if root:
+            os.environ["PTO_ISA_ROOT"] = root
+
+    timeout = config.getoption("--pto-session-timeout")
+    if timeout and timeout > 0:
+        _install_session_timeout(timeout)
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -186,6 +248,9 @@ def pytest_runtestloop(session):
         print(f"\n{'=' * 60}\n{header}\n{'=' * 60}\n", flush=True)
 
         result = subprocess.run(cmd, check=False, cwd=session.config.invocation_params.dir)
+        if result.returncode == TIMEOUT_EXIT_CODE:
+            print(f"\n*** Runtime {rt}: TIMED OUT ***\n", flush=True)
+            os._exit(TIMEOUT_EXIT_CODE)
         if result.returncode != 0:
             failed = True
             print(f"\n*** Runtime {rt}: FAILED ***\n", flush=True)


### PR DESCRIPTION
## Summary

- Register `--pto-session-timeout` (SIGALRM watchdog, exits 124; Unix-guarded), `--pto-isa-commit`, and `--clone-protocol` in the root `conftest.py`, mirroring the flags already exposed by `ci.py`. Project-prefixed to avoid clashing with `pytest-timeout`'s `--timeout` and `--session-timeout` that the a2a3 hardware runner has pre-installed.
- When `--pto-isa-commit` is set, reuse `simpler_setup.code_runner._ensure_pto_isa_root` so the `pto-isa` clone is checked out to that commit and `PTO_ISA_ROOT` is exported before scene tests compile kernels.
- Propagate exit `124` through the runtime-isolation subprocess loop in `pytest_runtestloop` so the top-level pytest exit distinguishes timeout from other failures.
- Update the four pytest scene-test CI steps (`a2a3sim`, `a5sim`, `a2a3`, `a5`) in `.github/workflows/ci.yml`: each runs with `--pto-session-timeout`, and on exit `124` retries the same invocation with `--pto-isa-commit d96c8784 --clone-protocol https`, matching the pin-on-failure behaviour `ci.py` already uses for its own phase.

## Why

`ci.py` already has `-c/--pto-isa-commit` and `-t/--timeout`, and the sim/hw pytest phase that runs after it was the only leg without a timeout watchdog or pto-isa pin-retry. A transient pto-isa breakage on `main` could hang or fail the pytest phase with no automatic recovery; now it falls back to the known-good pinned commit the same way `ci.py` does.

## Test plan

- [x] `pytest --help` shows the three new options
- [x] `pytest <slow_test> --pto-session-timeout 2` exits `124` on a 5s sleep
- [x] `ruff check`, `ruff format`, `pyright` pass (via pre-commit)
- [x] `check-yaml` validates `.github/workflows/ci.yml`
- [x] Sim CI legs pass (`st-sim-a2a3` × ubuntu/macos, `st-sim-a5` × ubuntu/macos, `ut-py`, `ut-cpp`, `packaging-matrix`, `pre-commit`)
- [x] `st-onboard-a5` passes (task-submit `--run` single-line form works)
- [ ] `ut-py-a2a3`, `st-onboard-a2a3` pass after the rename to `--pto-session-timeout` (was colliding with `pytest-timeout`'s own `--session-timeout`)