### PR TITLE
Refactor: drop slot ring, make DistTaskSlotState storage dynamic

### DIFF
--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -119,7 +119,7 @@ SubmitResult Orchestrator::submit_next_level(Callable cb,
 
 ### Step details
 
-**Step 1 — `ring_.alloc()`**: See [§5 Ring](#5-ring-unified-slot--heap-allocator). Blocks the Orch thread
+**Step 1 — `ring_.alloc()`**: See [§5 Ring](#5-ring-slot--heap-allocator). Blocks the Orch thread
 if all slots are in-flight; this is the system's back-pressure mechanism.
 
 **Step 2 — store task data**: `TaskArgs` is moved (not copied). `config` is a
@@ -246,13 +246,27 @@ SubmitResult Orchestrator::submit_sub(Callable cb, TaskArgs args, const CallConf
 
 ---
 
-## 5. Ring (unified slot + heap allocator)
+## 5. Ring (slot + heap allocator)
 
-`DistRing` is a single allocator that hands out both a task slot and an
-aligned heap slab in one atomic call — matching L2's `PTO2TaskAllocator`
-(Strict-2). The slot window and the heap region share one mutex, one
-`last_alive` pointer, and one back-pressure signal; there is no "got a slot
-but no heap" rollback path.
+`DistRing` owns three correlated per-task resources:
+
+1. A **monotonic task id** — allocated by the Orchestrator, incremented
+   on every `alloc()`. There is no fixed window and no modulo wrap at
+   L3: slot state lives in parent-process heap (never crossed into
+   child workers), so the ring index L2 uses to address shmem
+   descriptors buys us nothing here (see plan Allowed Exception #6).
+   A monotonic `int32_t` gives ~2 billion ids per `reset_to_empty()`
+   interval, reset back to 0 at the end of every `Worker.run()`.
+2. A **shared-memory heap slab** — bump-allocated under the same mutex,
+   FIFO-reclaimed via `last_alive_`. This still mirrors L2 (Strict-2):
+   the heap must be `mmap(MAP_SHARED)` and forked into child workers,
+   so it has to be pre-sized. `heap_ring_size` on the Worker ctor
+   controls the total bytes (default 1 GiB).
+3. The **per-task slot state** (`DistTaskSlotState`) — stored in a
+   `std::deque<std::unique_ptr<...>>`. `std::deque::push_back` never
+   invalidates pointers to existing elements, so the pointer returned
+   by `slot_state(id)` stays valid until `reset_to_empty()` drops the
+   whole deque.
 
 ```cpp
 struct DistAllocResult {
@@ -263,24 +277,24 @@ struct DistAllocResult {
 
 class DistRing {
 public:
-    void  init(int32_t window_size,
-               uint64_t heap_bytes,      // default 1 GiB, Worker-configurable
-               uint32_t timeout_ms);     // default 10 s
+    void  init(uint64_t heap_bytes,       // default 1 GiB, Worker-configurable
+               uint32_t timeout_ms);      // default 10 s
 
-    DistAllocResult alloc(uint64_t bytes = 0);   // blocks, throws on timeout
-    void            release(TaskSlot sid);       // FIFO-advances last_alive
-    void            shutdown();
+    DistAllocResult      alloc(uint64_t bytes = 0);  // blocks on heap full, throws on timeout
+    void                 release(TaskSlot sid);      // FIFO-advances last_alive
+    DistTaskSlotState   *slot_state(TaskSlot sid);   // pointer-stable until reset_to_empty
+    void                 reset_to_empty();           // drop per-task state at drain boundary
+    void                 shutdown();
 
     void    *heap_base()  const;
     uint64_t heap_size()  const;
 };
 ```
 
-**Back-pressure rationale**: if the Orch thread submits tasks faster than the
-Scheduler + Workers can drain, either the slot window or the heap fills up
-first. `alloc()` spin-waits on the shared cv; if `timeout_ms` elapses with no
-progress, it throws `std::runtime_error`. That surfaces as a Python exception
-so users can enlarge `heap_ring_size` on the `Worker` instead of deadlocking.
+**Back-pressure rationale**: only the heap can be full at L3. `alloc()`
+spin-waits on a cv; if `timeout_ms` elapses with no progress, it throws
+`std::runtime_error`. That surfaces as a Python exception so users can
+enlarge `heap_ring_size` on the `Worker` instead of deadlocking.
 
 **Alignment**: every heap allocation is rounded up to `DIST_HEAP_ALIGN = 1024 B`
 (matches L2's `PTO2_PACKED_OUTPUT_ALIGN`, Strict-3).
@@ -294,28 +308,26 @@ inherit the same virtual address range.
 as the next-oldest slot is also released, walking the `heap_tail_` forward
 accordingly. Heap space is reclaimed implicitly; no per-slot `munmap` runs.
 
+**End-of-run reset**: `DistOrchestrator::drain()` waits for `active_tasks_`
+to hit 0, then calls `ring.reset_to_empty()` which clears the deque of
+slot states, zeroes the heap cursors, and resets `next_task_id_` to 0.
+Memory per `Worker.run()` is bounded by that run's peak alive task count;
+nothing accumulates across runs.
+
 **Ownership by role**:
 
 | Field | Writer | Reader |
 | ----- | ------ | ------ |
 | `next_task_id_`, `heap_top_` | Orch (`alloc`, under `mu_`) | Allocator only |
 | `last_alive_`, `heap_tail_`, `released_[]` | `release` (scheduler or Orch thread) | Allocator only |
-| `slot_heap_end_[]` | Orch at alloc | `release` during FIFO advance |
+| `slot_heap_end_[]`, `slot_states_[]` | Orch at alloc | `release` / `slot_state()` readers |
 
 All shared state is guarded by a single mutex. The Orch thread is the only
 writer of `next_task_id_` / `heap_top_`, so the mutex serves primarily to
 coordinate with `release` and to protect the back-pressure condition
-variable.
-
-**Slot window is transitional.** The fixed-size
-`DIST_TASK_WINDOW_SIZE = 128` slot pool is legacy from matching L2's
-shmem-backed `PTO2TaskAllocator`. L3+ has no reason to bound slot count:
-slot state lives in the parent process's heap, is only read by Orch and
-Scheduler (never crossed into child workers), and the real back-pressure
-at L3 is the heap. A follow-up PR (PR-I in the plan) replaces the slot
-ring with a dynamic `std::deque<std::unique_ptr<TaskSlotState>>`; slot
-ids become monotonic task ids and only the heap throws on overflow.
-`DistRing` keeps its heap role and `last_alive_` reclamation clock.
+variable. `slot_state()` takes the mutex briefly to read the deque cell, but
+the returned pointer is safe to dereference without the mutex because
+`std::deque::push_back` doesn't invalidate existing elements.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,11 +74,16 @@ get if I pip install `main` today", this page.
 - `DistChipProcess` / `DistSubWorker` are separate classes today;
   unified `WorkerThread` with `THREAD | PROCESS` modes is not yet
   implemented.
-- Slot-ring and heap-ring share one `DistRing` (merged, matches
-  L2-consistency audit Strict-2). One mutex guards both; FIFO
-  reclamation via `last_alive` advances both resources at once. There
-  is no partial-failure rollback path between slot and heap
-  acquisition.
+- `DistRing` owns the task-id counter, the heap slab, **and** the
+  per-slot state (`std::deque<std::unique_ptr<DistTaskSlotState>>`).
+  Slot ids are monotonic within a run (no fixed window, no modulo
+  wrap); `std::deque::push_back` keeps existing pointers valid across
+  concurrent allocs, so `ring.slot_state(id)` hands out a stable
+  pointer for every live slot. Heap bytes are the only back-pressure
+  source: `alloc()` throws `std::runtime_error` on timeout if the heap
+  is full. At end of `Worker.run()`, `drain()` calls
+  `ring.reset_to_empty()` to drop all slot state and zero counters,
+  so per-run memory stays bounded (see plan Allowed Exception #6).
 
 ---
 

--- a/src/common/distributed/dist_orchestrator.cpp
+++ b/src/common/distributed/dist_orchestrator.cpp
@@ -16,16 +16,19 @@
 #include <stdexcept>
 
 void DistOrchestrator::init(
-    DistTensorMap *tensormap, DistRing *allocator, DistScope *scope, DistReadyQueue *ready_queue,
-    DistTaskSlotState *slots, int32_t num_slots
+    DistTensorMap *tensormap, DistRing *allocator, DistScope *scope, DistReadyQueue *ready_queue
 ) {
     tensormap_ = tensormap;
     allocator_ = allocator;
     scope_ = scope;
     ready_queue_ = ready_queue;
-    slots_ = slots;
-    num_slots_ = num_slots;
     active_tasks_.store(0, std::memory_order_relaxed);
+}
+
+DistTaskSlotState &DistOrchestrator::slot_state(DistTaskSlot s) {
+    DistTaskSlotState *p = allocator_->slot_state(s);
+    if (!p) throw std::runtime_error("DistOrchestrator::slot_state: invalid slot id");
+    return *p;
 }
 
 // ---------------------------------------------------------------------------
@@ -383,8 +386,14 @@ bool DistOrchestrator::on_consumed(DistTaskSlot slot) {
 }
 
 void DistOrchestrator::drain() {
-    std::unique_lock<std::mutex> lk(drain_mu_);
-    drain_cv_.wait(lk, [this] {
-        return active_tasks_.load(std::memory_order_acquire) == 0;
-    });
+    {
+        std::unique_lock<std::mutex> lk(drain_mu_);
+        drain_cv_.wait(lk, [this] {
+            return active_tasks_.load(std::memory_order_acquire) == 0;
+        });
+    }
+    // Every slot is CONSUMED (active_tasks_ == 0 ⇒ allocator last_alive_ ==
+    // next_task_id_). Drop all per-slot state so the next Worker.run()
+    // starts from task_id = 0 with no accumulated memory.
+    allocator_->reset_to_empty();
 }

--- a/src/common/distributed/dist_orchestrator.h
+++ b/src/common/distributed/dist_orchestrator.h
@@ -64,10 +64,7 @@ struct DistSubmitResult {
 
 class DistOrchestrator {
 public:
-    void init(
-        DistTensorMap *tensormap, DistRing *allocator, DistScope *scope, DistReadyQueue *ready_queue,
-        DistTaskSlotState *slots, int32_t num_slots
-    );
+    void init(DistTensorMap *tensormap, DistRing *allocator, DistScope *scope, DistReadyQueue *ready_queue);
 
     // Allocate an intermediate buffer from the Worker's HeapRing (MAP_SHARED,
     // visible to forked child workers). Returns a ContinuousTensor whose
@@ -115,15 +112,16 @@ private:
     DistRing *allocator_ = nullptr;
     DistScope *scope_ = nullptr;
     DistReadyQueue *ready_queue_ = nullptr;
-    DistTaskSlotState *slots_ = nullptr;
-    int32_t num_slots_ = 0;
 
     // --- Drain support (owned here, not on Worker) ---
     std::atomic<int32_t> active_tasks_{0};
     std::mutex drain_mu_;
     std::condition_variable drain_cv_;
 
-    DistTaskSlotState &slot_state(DistTaskSlot s) { return slots_[s]; }
+    // Slot state lives in the DistRing; the pointer stays stable for the
+    // slot's lifetime. Throws if the id is out of range — callers that
+    // hold a recently-allocated slot id should always get a valid pointer.
+    DistTaskSlotState &slot_state(DistTaskSlot s);
 
     // Shared submit machinery. Takes `args_list` by value so the Orchestrator
     // can patch `tensor.data` on OUTPUT tensors flagged for auto-allocation.

--- a/src/common/distributed/dist_ring.cpp
+++ b/src/common/distributed/dist_ring.cpp
@@ -14,7 +14,6 @@
 #include <sys/mman.h>
 
 #include <chrono>
-#include <cstring>
 #include <stdexcept>
 
 DistRing::~DistRing() {
@@ -25,16 +24,11 @@ DistRing::~DistRing() {
     }
 }
 
-void DistRing::init(int32_t window_size, uint64_t heap_bytes, uint32_t timeout_ms) {
-    if (window_size <= 0 || (window_size & (window_size - 1)) != 0) {
-        throw std::invalid_argument("DistRing window_size must be a positive power of 2");
-    }
+void DistRing::init(uint64_t heap_bytes, uint32_t timeout_ms) {
     if (heap_mapped_) {
         throw std::logic_error("DistRing::init called twice");
     }
 
-    window_size_ = window_size;
-    window_mask_ = window_size - 1;
     timeout_ms_ = timeout_ms == 0 ? DIST_ALLOC_TIMEOUT_MS : timeout_ms;
 
     next_task_id_ = 0;
@@ -43,8 +37,9 @@ void DistRing::init(int32_t window_size, uint64_t heap_bytes, uint32_t timeout_m
     heap_tail_ = 0;
     shutdown_ = false;
 
-    released_.assign(static_cast<size_t>(window_size_), 0);
-    slot_heap_end_.assign(static_cast<size_t>(window_size_), 0);
+    released_.clear();
+    slot_heap_end_.clear();
+    slot_states_.clear();
 
     if (heap_bytes > 0) {
         heap_size_ = heap_bytes;
@@ -62,7 +57,7 @@ void DistRing::init(int32_t window_size, uint64_t heap_bytes, uint32_t timeout_m
 }
 
 // ---------------------------------------------------------------------------
-// alloc — atomic {slot, heap_ptr} under a single mutex
+// alloc — slot + heap under a single mutex
 // ---------------------------------------------------------------------------
 
 DistAllocResult DistRing::alloc(uint64_t bytes) {
@@ -83,38 +78,31 @@ DistAllocResult DistRing::alloc(uint64_t bytes) {
     while (true) {
         if (shutdown_) return DistAllocResult{DIST_INVALID_SLOT, nullptr, 0};
 
-        if (has_window_space_locked()) {
-            if (aligned == 0) {
-                heap_ptr = nullptr;
-                heap_end = heap_top_;
-                break;
-            }
-            if (try_bump_heap_locked(aligned, heap_ptr, heap_end)) {
-                break;
-            }
+        if (aligned == 0) {
+            heap_ptr = nullptr;
+            heap_end = heap_top_;
+            break;
+        }
+        if (try_bump_heap_locked(aligned, heap_ptr, heap_end)) {
+            break;
         }
 
-        // Wait for a release to advance last_alive_ (and heap_tail_) or for
-        // shutdown. Treat the timeout as a deadlock signal so Python callers
-        // can enlarge the heap instead of stalling forever.
+        // Heap full. Wait for a release to advance last_alive_ / heap_tail_,
+        // or for shutdown. Timing out surfaces as a Python exception so the
+        // user can enlarge `heap_ring_size` instead of deadlocking.
         if (cv_.wait_until(lk, deadline) == std::cv_status::timeout) {
             if (shutdown_) return DistAllocResult{DIST_INVALID_SLOT, nullptr, 0};
-            int32_t active = next_task_id_ - last_alive_;
             throw std::runtime_error(
-                aligned > heap_size_ / 2 ?
-                    "DistRing: heap exhausted (timed out waiting). Increase heap_ring_size on Worker." :
-                    (active >= window_size_ ? "DistRing: task window full (timed out waiting). "
-                                              "Either the DAG is too wide or the scheduler has stalled." :
-                                              "DistRing: timed out waiting for reclamation.")
+                "DistRing: heap exhausted (timed out waiting). Increase heap_ring_size on Worker."
             );
         }
     }
 
     int32_t task_id = next_task_id_++;
-    DistTaskSlot slot = task_id & window_mask_;
-    released_[static_cast<size_t>(slot)] = 0;
-    slot_heap_end_[static_cast<size_t>(slot)] = heap_end;
-    return DistAllocResult{slot, heap_ptr, heap_end};
+    released_.push_back(0);
+    slot_heap_end_.push_back(heap_end);
+    slot_states_.emplace_back(std::make_unique<DistTaskSlotState>());
+    return DistAllocResult{task_id, heap_ptr, heap_end};
 }
 
 // ---------------------------------------------------------------------------
@@ -124,11 +112,43 @@ DistAllocResult DistRing::alloc(uint64_t bytes) {
 void DistRing::release(DistTaskSlot slot) {
     {
         std::lock_guard<std::mutex> lk(mu_);
-        if (slot < 0 || slot >= window_size_) return;
+        if (slot < 0 || slot >= next_task_id_) return;
+        if (released_[static_cast<size_t>(slot)] != 0) return;  // idempotent
         released_[static_cast<size_t>(slot)] = 1;
         advance_last_alive_locked();
     }
     cv_.notify_all();
+}
+
+// ---------------------------------------------------------------------------
+// slot_state accessor — pointer-stable until reset_to_empty()
+// ---------------------------------------------------------------------------
+
+DistTaskSlotState *DistRing::slot_state(DistTaskSlot slot) {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (slot < 0 || slot >= static_cast<int32_t>(slot_states_.size())) return nullptr;
+    return slot_states_[static_cast<size_t>(slot)].get();
+}
+
+// ---------------------------------------------------------------------------
+// reset_to_empty — drop all per-task state, return counters to zero
+// ---------------------------------------------------------------------------
+
+void DistRing::reset_to_empty() {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (last_alive_ != next_task_id_) {
+        throw std::logic_error(
+            "DistRing::reset_to_empty: tasks still live "
+            "(last_alive_ != next_task_id_). Did drain() complete?"
+        );
+    }
+    next_task_id_ = 0;
+    last_alive_ = 0;
+    heap_top_ = 0;
+    heap_tail_ = 0;
+    released_.clear();
+    slot_heap_end_.clear();
+    slot_states_.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +158,11 @@ void DistRing::release(DistTaskSlot slot) {
 int32_t DistRing::active_count() const {
     std::lock_guard<std::mutex> lk(mu_);
     return next_task_id_ - last_alive_;
+}
+
+int32_t DistRing::next_task_id() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return next_task_id_;
 }
 
 void DistRing::shutdown() {
@@ -151,8 +176,6 @@ void DistRing::shutdown() {
 // ---------------------------------------------------------------------------
 // Internal helpers (all called under mu_)
 // ---------------------------------------------------------------------------
-
-bool DistRing::has_window_space_locked() const { return (next_task_id_ - last_alive_) < window_size_; }
 
 bool DistRing::try_bump_heap_locked(uint64_t aligned, void *&out_ptr, uint64_t &out_end) {
     uint64_t top = heap_top_;
@@ -192,15 +215,12 @@ bool DistRing::try_bump_heap_locked(uint64_t aligned, void *&out_ptr, uint64_t &
 
 void DistRing::advance_last_alive_locked() {
     // Advance last_alive_ while the next-oldest task is already released.
-    // Reset the released bit as we cross it so the slot can be reused without
-    // leaking a stale "consumed" flag into the next generation.
-    while (last_alive_ < next_task_id_) {
-        DistTaskSlot la_slot = last_alive_ & window_mask_;
-        if (released_[static_cast<size_t>(la_slot)] == 0) break;
-
-        uint64_t end = slot_heap_end_[static_cast<size_t>(la_slot)];
-        released_[static_cast<size_t>(la_slot)] = 0;
+    // Slot state and heap_end entries stay in their vectors — memory is
+    // only reclaimed by reset_to_empty() at drain time — so we don't have
+    // to worry about invalidating pointers that other threads may still
+    // hold to in-flight slots.
+    while (last_alive_ < next_task_id_ && released_[static_cast<size_t>(last_alive_)] == 1) {
+        heap_tail_ = slot_heap_end_[static_cast<size_t>(last_alive_)];
         last_alive_++;
-        heap_tail_ = end;
     }
 }

--- a/src/common/distributed/dist_ring.h
+++ b/src/common/distributed/dist_ring.h
@@ -10,31 +10,48 @@
  */
 
 /**
- * DistRing — unified task-slot + heap-buffer allocator (Strict-2).
+ * DistRing — unified slot + heap allocator for L3+ distributed workers.
  *
- * Single allocator guarding both resources under one mutex, mirroring L2's
- * `PTO2TaskAllocator`. The orchestrator calls `alloc(bytes)` to claim a slot
- * plus a contiguous heap slab in one atomic step; there is no partial-failure
- * rollback. `release(slot)` advances a FIFO `last_alive` pointer, which
- * implicitly reclaims heap space belonging to the trailing range of slots.
+ * A single structure owns three correlated, per-task resources:
  *
- * Heap memory is a single `mmap(MAP_SHARED | MAP_ANONYMOUS)` region taken
- * at construction time, before any fork, so forked child workers see the
- * same bytes at the same virtual address.
+ *   1. A monotonic task id (`next_task_id_`), allocated by the Orchestrator.
+ *      Unlike L2's `PTO2TaskAllocator` the id is NOT masked into a fixed-size
+ *      window — slot state lives in parent-process heap (never crossed into
+ *      child workers), so a ring index buys us nothing at L3 (see the plan's
+ *      L2 Consistency Audit, allowed exception #6).
+ *   2. A shared-memory heap slab (bump-allocated under one mutex, FIFO
+ *      reclaimed via `last_alive_`). This part still mirrors L2 (Strict-2):
+ *      the heap must be `mmap(MAP_SHARED)` and forked into child workers,
+ *      which forces a pre-sized region.
+ *   3. The per-task scheduling state (`DistTaskSlotState`). Stored in a
+ *      `std::deque<std::unique_ptr<...>>` so push_back never invalidates
+ *      pointers, and destruction happens only at `reset_to_empty()` /
+ *      process teardown, giving callers stable references to a slot until
+ *      it is consumed.
  *
- * Output-buffer alignment is 1024 B (matches L2's `PTO2_PACKED_OUTPUT_ALIGN`).
+ * Back-pressure: only the heap can be full. `alloc(bytes)` spin-waits on a
+ * cv; if no progress is made for `timeout_ms` it throws `std::runtime_error`
+ * so Python callers see an exception rather than a silent deadlock.
  *
- * Back-pressure: `alloc()` spin-waits with cv when either the slot window or
- * the heap is exhausted. If no progress is made for `timeout_ms` the call
- * throws `std::runtime_error` so Python users can catch it and grow the heap
- * instead of deadlocking.
+ * Lifecycle:
+ *
+ *   Worker.run() → orch submits N tasks → each submit calls
+ *   `ring.alloc()` (task id allocated, slot state constructed) → scheduler
+ *   dispatches → workers run → on_consumed calls `ring.release(id)` which
+ *   marks the slot consumed and advances `last_alive_` FIFO-wise → drain
+ *   waits until `active_count() == 0` → `ring.reset_to_empty()` resets
+ *   counters and drops all slot states so the next run starts fresh.
+ *
+ *   Memory footprint per Worker.run() is bounded by the peak alive task
+ *   count; no state accumulates across runs.
  */
 
 #pragma once
 
-#include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include <deque>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -71,45 +88,59 @@ public:
     // hands out slots, but any `alloc(bytes>0)` throws. `timeout_ms == 0`
     // selects the default. Must be called before any fork if the heap is
     // to be inherited by children.
-    void init(
-        int32_t window_size = DIST_TASK_WINDOW_SIZE, uint64_t heap_bytes = DIST_DEFAULT_HEAP_RING_SIZE,
-        uint32_t timeout_ms = DIST_ALLOC_TIMEOUT_MS
-    );
+    void init(uint64_t heap_bytes = DIST_DEFAULT_HEAP_RING_SIZE, uint32_t timeout_ms = DIST_ALLOC_TIMEOUT_MS);
 
-    // Allocate a slot (and, if `bytes > 0`, a heap slab). Blocks with
-    // back-pressure; throws `std::runtime_error` on timeout. Returns the
-    // sentinel `{DIST_INVALID_SLOT, nullptr, 0}` on `shutdown()`.
+    // Allocate a slot (and, if `bytes > 0`, a heap slab). Blocks on the
+    // heap cv; throws `std::runtime_error` on timeout. Returns the sentinel
+    // `{DIST_INVALID_SLOT, nullptr, 0}` on `shutdown()`.
     //
     // `bytes` is rounded up to `DIST_HEAP_ALIGN`. Passing `0` skips the heap
     // bump entirely (slot-only allocation).
     DistAllocResult alloc(uint64_t bytes = 0);
 
     // Release a slot. Marks the slot consumed; advances `last_alive_` (and
-    // `heap_tail_`) as far as the FIFO ordering allows.
+    // `heap_tail_`) as far as the FIFO ordering allows. Safe to call from
+    // any thread; safe under concurrent `alloc()`.
     void release(DistTaskSlot slot);
 
-    int32_t window_size() const { return window_size_; }
+    // Pointer to the slot's state. Stable for the slot's lifetime (i.e.
+    // until `reset_to_empty()` drops it). Returns nullptr for invalid ids.
+    //
+    // Thread safety: the pointer refers to heap-allocated storage held by a
+    // `std::deque<std::unique_ptr<...>>`. `std::deque::push_back` never
+    // invalidates pointers to existing elements, so once a slot id has been
+    // handed out by `alloc()`, `slot_state(id)` stays valid across concurrent
+    // allocs. The caller is responsible for not using the pointer across a
+    // matching `reset_to_empty()` call.
+    DistTaskSlotState *slot_state(DistTaskSlot slot);
+
+    // Clear all per-task state and return to `next_task_id_ = last_alive_ = 0`.
+    // Requires that no slots are currently live (`active_count() == 0`) —
+    // typically called by `DistOrchestrator::drain()` right after the active
+    // count hits zero.
+    void reset_to_empty();
+
     int32_t active_count() const;
+    int32_t next_task_id() const;
     void *heap_base() const { return heap_base_; }
     uint64_t heap_size() const { return heap_size_; }
 
     void shutdown();
 
 private:
-    int32_t window_size_{DIST_TASK_WINDOW_SIZE};
-    int32_t window_mask_{DIST_TASK_WINDOW_SIZE - 1};
     uint32_t timeout_ms_{DIST_ALLOC_TIMEOUT_MS};
 
-    // Orch-owned counter (single-writer from alloc(), so no atomic needed —
-    // it's still read under mu_).
+    // Monotonic within a run. Reset to 0 by `reset_to_empty()`.
     int32_t next_task_id_{0};
 
     // FIFO consumption frontier. `[last_alive_, next_task_id_)` are live.
     int32_t last_alive_{0};
 
-    // Per-slot bookkeeping (sized to window_size_ after init).
+    // Per-slot bookkeeping, indexed directly by task id (0..next_task_id_).
+    // All three grow together under `mu_`; no erase while the run is live.
     std::vector<uint8_t> released_;        // 0 = live, 1 = consumed
     std::vector<uint64_t> slot_heap_end_;  // byte-offset high-water of each slot's allocation
+    std::deque<std::unique_ptr<DistTaskSlotState>> slot_states_;
 
     // Heap region.
     void *heap_base_{nullptr};
@@ -123,7 +154,6 @@ private:
     bool heap_mapped_{false};
 
     // Helpers — all called under mu_.
-    bool has_window_space_locked() const;
     bool try_bump_heap_locked(uint64_t aligned_bytes, void *&out_ptr, uint64_t &out_end);
     void advance_last_alive_locked();
 };

--- a/src/common/distributed/dist_scheduler.cpp
+++ b/src/common/distributed/dist_scheduler.cpp
@@ -13,6 +13,7 @@
 
 #include <stdexcept>
 
+#include "dist_ring.h"
 #include "dist_worker_manager.h"
 
 // =============================================================================
@@ -24,7 +25,7 @@
 // =============================================================================
 
 void DistScheduler::start(const Config &cfg) {
-    if (cfg.slots == nullptr || cfg.ready_queue == nullptr || cfg.manager == nullptr)
+    if (cfg.ring == nullptr || cfg.ready_queue == nullptr || cfg.manager == nullptr)
         throw std::invalid_argument("DistScheduler::start: null config fields");
     cfg_ = cfg;
 
@@ -48,7 +49,7 @@ void DistScheduler::stop() {
 // =============================================================================
 
 void DistScheduler::worker_done(DistTaskSlot slot) {
-    DistTaskSlotState &s = cfg_.slots[slot];
+    DistTaskSlotState &s = *cfg_.ring->slot_state(slot);
 
     // Group aggregation: only push to completion queue when ALL workers done
     if (s.is_group()) {
@@ -118,7 +119,7 @@ void DistScheduler::run() {
 // =============================================================================
 
 void DistScheduler::on_task_complete(DistTaskSlot slot) {
-    DistTaskSlotState &s = cfg_.slots[slot];
+    DistTaskSlotState &s = *cfg_.ring->slot_state(slot);
     s.state.store(TaskState::COMPLETED, std::memory_order_release);
 
     // Release fanin on downstream consumers
@@ -128,7 +129,7 @@ void DistScheduler::on_task_complete(DistTaskSlot slot) {
         consumers = s.fanout_consumers;
     }
     for (DistTaskSlot consumer : consumers) {
-        DistTaskSlotState &cs = cfg_.slots[consumer];
+        DistTaskSlotState &cs = *cfg_.ring->slot_state(consumer);
         int32_t released = cs.fanin_released.fetch_add(1, std::memory_order_acq_rel) + 1;
         if (released >= cs.fanin_count) {
             TaskState expected = TaskState::PENDING;
@@ -153,7 +154,7 @@ void DistScheduler::on_task_complete(DistTaskSlot slot) {
 }
 
 void DistScheduler::try_consume(DistTaskSlot slot) {
-    DistTaskSlotState &s = cfg_.slots[slot];
+    DistTaskSlotState &s = *cfg_.ring->slot_state(slot);
     int32_t released = s.fanout_released.fetch_add(1, std::memory_order_acq_rel) + 1;
     int32_t total;
     {
@@ -174,7 +175,7 @@ void DistScheduler::try_consume(DistTaskSlot slot) {
 void DistScheduler::dispatch_ready() {
     DistTaskSlot slot;
     while (cfg_.ready_queue->try_pop(slot)) {
-        DistTaskSlotState &s = cfg_.slots[slot];
+        DistTaskSlotState &s = *cfg_.ring->slot_state(slot);
         int N = s.group_size();  // 1 for normal tasks
 
         auto workers = cfg_.manager->pick_n_idle(s.worker_type, N);

--- a/src/common/distributed/dist_scheduler.h
+++ b/src/common/distributed/dist_scheduler.h
@@ -43,6 +43,7 @@
 #include "dist_types.h"
 
 class DistWorkerManager;  // forward decl
+class DistRing;           // forward decl
 
 // =============================================================================
 // DistScheduler — DAG engine (no worker pool ownership)
@@ -51,8 +52,7 @@ class DistWorkerManager;  // forward decl
 class DistScheduler {
 public:
     struct Config {
-        DistTaskSlotState *slots;
-        int32_t num_slots;
+        DistRing *ring;  // owns slot state storage; Scheduler reads via ring->slot_state(id)
         DistReadyQueue *ready_queue;
         DistWorkerManager *manager;  // not owned — Scheduler calls manager for dispatch
         // Called when a task reaches CONSUMED (TensorMap cleanup + ring release).

--- a/src/common/distributed/dist_types.h
+++ b/src/common/distributed/dist_types.h
@@ -40,7 +40,6 @@
 // Constants
 // =============================================================================
 
-static constexpr int32_t DIST_TASK_WINDOW_SIZE = 128;  // slots per engine instance
 static constexpr int32_t DIST_MAX_SCOPE_DEPTH = 64;
 static constexpr int32_t DIST_INVALID_SLOT = -1;
 

--- a/src/common/distributed/dist_worker.cpp
+++ b/src/common/distributed/dist_worker.cpp
@@ -105,8 +105,6 @@ void fork_hygiene_once() {
 
 DistWorker::DistWorker(int32_t level, uint64_t heap_ring_size) :
     level_(level) {
-    slots_ = std::make_unique<DistTaskSlotState[]>(DIST_TASK_WINDOW_SIZE);
-
     // Fork hygiene runs before the HeapRing mmap so the env-var defaults
     // apply to any thread-pool library that observes them at library init.
     fork_hygiene_once();
@@ -114,7 +112,7 @@ DistWorker::DistWorker(int32_t level, uint64_t heap_ring_size) :
     // mmap the HeapRing region here, in the ctor, so Python callers can
     // construct the DistWorker before fork()-ing children. The children
     // inherit the MAP_SHARED region at the same virtual address.
-    allocator_.init(DIST_TASK_WINDOW_SIZE, heap_ring_size, DIST_ALLOC_TIMEOUT_MS);
+    allocator_.init(heap_ring_size, DIST_ALLOC_TIMEOUT_MS);
 }
 
 DistWorker::~DistWorker() {
@@ -130,7 +128,7 @@ void DistWorker::add_worker(WorkerType type, IWorker *worker) {
 void DistWorker::init() {
     if (initialized_) throw std::runtime_error("DistWorker: already initialized");
 
-    orchestrator_.init(&tensormap_, &allocator_, &scope_, &ready_queue_, slots_.get(), DIST_TASK_WINDOW_SIZE);
+    orchestrator_.init(&tensormap_, &allocator_, &scope_, &ready_queue_);
 
     // Start WorkerManager first — creates WorkerThreads.
     // The on_complete callback routes through the Scheduler's worker_done().
@@ -139,8 +137,7 @@ void DistWorker::init() {
     });
 
     DistScheduler::Config cfg;
-    cfg.slots = slots_.get();
-    cfg.num_slots = DIST_TASK_WINDOW_SIZE;
+    cfg.ring = &allocator_;
     cfg.ready_queue = &ready_queue_;
     cfg.manager = &manager_;
     cfg.on_consumed_cb = [this](DistTaskSlot slot) {

--- a/src/common/distributed/dist_worker.h
+++ b/src/common/distributed/dist_worker.h
@@ -88,7 +88,9 @@ private:
     bool initialized_{false};
 
     // --- Scheduling engine components ---
-    std::unique_ptr<DistTaskSlotState[]> slots_;
+    // Per-task slot state lives inside `allocator_` (DistRing) — Orchestrator
+    // and Scheduler access it via `allocator_.slot_state(id)`. No separate
+    // fixed-size slots array at L3 (see plan Allowed Exception #6).
     DistTensorMap tensormap_;
     DistRing allocator_;
     DistScope scope_;

--- a/tests/ut/cpp/test_dist_orchestrator.cpp
+++ b/tests/ut/cpp/test_dist_orchestrator.cpp
@@ -26,9 +26,6 @@
 // ---------------------------------------------------------------------------
 
 struct OrchestratorFixture : public ::testing::Test {
-    static constexpr int32_t N = DIST_TASK_WINDOW_SIZE;
-
-    std::unique_ptr<DistTaskSlotState[]> slots;
     DistTensorMap tm;
     DistRing allocator;
     DistScope scope;
@@ -37,12 +34,14 @@ struct OrchestratorFixture : public ::testing::Test {
     ChipCallConfig cfg;
 
     void SetUp() override {
-        slots = std::make_unique<DistTaskSlotState[]>(N);
-        allocator.init(N, /*heap_bytes=*/1ULL << 20);
-        orch.init(&tm, &allocator, &scope, &rq, slots.get(), N);
+        allocator.init(/*heap_bytes=*/1ULL << 20);
+        orch.init(&tm, &allocator, &scope, &rq);
     }
 
     void TearDown() override { allocator.shutdown(); }
+
+    // Per-slot accessor — slot state lives inside the DistRing now.
+    DistTaskSlotState &S(DistTaskSlot id) { return *allocator.slot_state(id); }
 
     // Helper: build a TaskArgs whose only tensor has the given (data, tag).
     static TaskArgs single_tensor_args(uint64_t data_ptr, TensorArgType tag) {
@@ -69,7 +68,7 @@ TEST_F(OrchestratorFixture, IndependentTaskIsImmediatelyReady) {
     DistTaskSlot slot;
     EXPECT_TRUE(rq.try_pop(slot));
     EXPECT_EQ(slot, res.task_slot);
-    EXPECT_EQ(slots[slot].state.load(), TaskState::READY);
+    EXPECT_EQ(S(slot).state.load(), TaskState::READY);
 }
 
 TEST_F(OrchestratorFixture, DependentTaskIsPending) {
@@ -82,8 +81,8 @@ TEST_F(OrchestratorFixture, DependentTaskIsPending) {
     // Task B reads INPUT at the same key — depends on A
     auto args_b = single_tensor_args(0xBEEF, TensorArgType::INPUT);
     auto b = orch.submit_next_level(0xDEAD, args_b, cfg);
-    EXPECT_EQ(slots[b.task_slot].state.load(), TaskState::PENDING);
-    EXPECT_EQ(slots[b.task_slot].fanin_count, 1);
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::PENDING);
+    EXPECT_EQ(S(b.task_slot).fanin_count, 1);
 
     DistTaskSlot extra;
     EXPECT_FALSE(rq.try_pop(extra));  // B should NOT be in ready queue
@@ -106,11 +105,11 @@ TEST_F(OrchestratorFixture, OnConsumedCleansUpTensorMap) {
 
     EXPECT_EQ(tm.lookup(0x42), slot);
 
-    slots[slot].state.store(TaskState::COMPLETED, std::memory_order_relaxed);
+    S(slot).state.store(TaskState::COMPLETED, std::memory_order_relaxed);
     orch.on_consumed(slot);
 
     EXPECT_EQ(tm.lookup(0x42), DIST_INVALID_SLOT);
-    EXPECT_EQ(slots[slot].state.load(), TaskState::CONSUMED);
+    EXPECT_EQ(S(slot).state.load(), TaskState::CONSUMED);
 }
 
 TEST_F(OrchestratorFixture, ScopeRegistersAndReleasesRef) {
@@ -121,8 +120,8 @@ TEST_F(OrchestratorFixture, ScopeRegistersAndReleasesRef) {
     rq.try_pop(slot);
 
     {
-        std::lock_guard<std::mutex> lk(slots[slot].fanout_mu);
-        EXPECT_EQ(slots[slot].fanout_total, 1);
+        std::lock_guard<std::mutex> lk(S(slot).fanout_mu);
+        EXPECT_EQ(S(slot).fanout_total, 1);
     }
 
     // Simulate the completion path that would run if this test drove the
@@ -130,11 +129,11 @@ TEST_F(OrchestratorFixture, ScopeRegistersAndReleasesRef) {
     // on_task_complete would normally fire (bumps fanout_released by 1).
     // Without this simulated self-release, the `>= total + 1` threshold in
     // release_ref / try_consume cannot be met from scope_end alone.
-    slots[slot].state.store(TaskState::COMPLETED, std::memory_order_relaxed);
-    slots[slot].fanout_released.fetch_add(1, std::memory_order_relaxed);
+    S(slot).state.store(TaskState::COMPLETED, std::memory_order_relaxed);
+    S(slot).fanout_released.fetch_add(1, std::memory_order_relaxed);
     orch.scope_end();
 
-    EXPECT_EQ(slots[slot].state.load(), TaskState::CONSUMED);
+    EXPECT_EQ(S(slot).state.load(), TaskState::CONSUMED);
 }
 
 TEST_F(OrchestratorFixture, NoDepTagSkipsDependencyTracking) {
@@ -147,8 +146,8 @@ TEST_F(OrchestratorFixture, NoDepTagSkipsDependencyTracking) {
     // Second task references same key but tagged NO_DEP — should be independent
     auto args_b = single_tensor_args(0xAAAA, TensorArgType::NO_DEP);
     auto b = orch.submit_next_level(0xDEAD, args_b, cfg);
-    EXPECT_EQ(slots[b.task_slot].state.load(), TaskState::READY);
-    EXPECT_EQ(slots[b.task_slot].fanin_count, 0);
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::READY);
+    EXPECT_EQ(S(b.task_slot).fanin_count, 0);
 }
 
 TEST_F(OrchestratorFixture, GroupTaskHasAllChipStorageEntries) {
@@ -157,9 +156,9 @@ TEST_F(OrchestratorFixture, GroupTaskHasAllChipStorageEntries) {
     auto res = orch.submit_next_level_group(0xDEAD, {a0, a1}, cfg);
 
     EXPECT_NE(res.task_slot, DIST_INVALID_SLOT);
-    EXPECT_TRUE(slots[res.task_slot].is_group());
-    EXPECT_EQ(slots[res.task_slot].group_size(), 2);
-    EXPECT_EQ(slots[res.task_slot].chip_storage_list.size(), 2u);
+    EXPECT_TRUE(S(res.task_slot).is_group());
+    EXPECT_EQ(S(res.task_slot).group_size(), 2);
+    EXPECT_EQ(S(res.task_slot).chip_storage_list.size(), 2u);
 
     // Both keys registered as producers for the group slot.
     EXPECT_EQ(tm.lookup(0xA0), res.task_slot);
@@ -182,7 +181,7 @@ TEST_F(OrchestratorFixture, OutputAutoAllocsFromHeapRing) {
     auto res = orch.submit_next_level(0xDEAD, args, cfg);
     ASSERT_NE(res.task_slot, DIST_INVALID_SLOT);
 
-    const auto &chip = slots[res.task_slot].chip_storage_list.front();
+    const auto &chip = S(res.task_slot).chip_storage_list.front();
     uint64_t data = chip.tensor(0).data;
     ASSERT_NE(data, 0u);
     uintptr_t base = reinterpret_cast<uintptr_t>(allocator.heap_base());
@@ -205,7 +204,7 @@ TEST_F(OrchestratorFixture, InoutWiresCreatorAsFanin) {
     rq.try_pop(drain);
     // Mark the creator COMPLETED so the new submit mimics the alloc-slot
     // path (COMPLETED producer with non-zero fanout).
-    slots[creator.task_slot].state.store(TaskState::COMPLETED, std::memory_order_relaxed);
+    S(creator.task_slot).state.store(TaskState::COMPLETED, std::memory_order_relaxed);
 
     auto writer_args = single_tensor_args(0xFEED, TensorArgType::INOUT);
     auto writer = orch.submit_next_level(0xDEAD, writer_args, cfg);
@@ -216,15 +215,15 @@ TEST_F(OrchestratorFixture, InoutWiresCreatorAsFanin) {
     EXPECT_EQ(tm.lookup(0xFEED), writer.task_slot);
     // Writer has the creator recorded as a fanin producer (via INOUT
     // lookup) but no *live* fanin since the creator is already COMPLETED.
-    EXPECT_EQ(slots[writer.task_slot].fanin_count, 0);
-    ASSERT_EQ(slots[writer.task_slot].fanin_producers.size(), 1u);
-    EXPECT_EQ(slots[writer.task_slot].fanin_producers[0], creator.task_slot);
+    EXPECT_EQ(S(writer.task_slot).fanin_count, 0);
+    ASSERT_EQ(S(writer.task_slot).fanin_producers.size(), 1u);
+    EXPECT_EQ(S(writer.task_slot).fanin_producers[0], creator.task_slot);
     // Creator's fanout_total bumped so it waits for writer before CONSUMED.
     {
-        std::lock_guard<std::mutex> lk(slots[creator.task_slot].fanout_mu);
-        EXPECT_EQ(slots[creator.task_slot].fanout_total, 1);
-        ASSERT_EQ(slots[creator.task_slot].fanout_consumers.size(), 1u);
-        EXPECT_EQ(slots[creator.task_slot].fanout_consumers[0], writer.task_slot);
+        std::lock_guard<std::mutex> lk(S(creator.task_slot).fanout_mu);
+        EXPECT_EQ(S(creator.task_slot).fanout_total, 1);
+        ASSERT_EQ(S(creator.task_slot).fanout_consumers.size(), 1u);
+        EXPECT_EQ(S(creator.task_slot).fanout_consumers[0], writer.task_slot);
     }
 }
 
@@ -242,17 +241,17 @@ TEST_F(OrchestratorFixture, OutputAndOutputExistingAreInsertOnly) {
         auto prior = orch.submit_next_level(0xDEAD, prior_args, cfg);
         DistTaskSlot drain;
         rq.try_pop(drain);
-        slots[prior.task_slot].state.store(TaskState::COMPLETED, std::memory_order_relaxed);
+        S(prior.task_slot).state.store(TaskState::COMPLETED, std::memory_order_relaxed);
 
         auto writer_args = single_tensor_args(c.key, c.tag);
         auto writer = orch.submit_next_level(0xDEAD, writer_args, cfg);
 
         EXPECT_EQ(tm.lookup(c.key), writer.task_slot);
-        EXPECT_EQ(slots[writer.task_slot].fanin_count, 0);
-        EXPECT_TRUE(slots[writer.task_slot].fanin_producers.empty()) << "tag=" << static_cast<int>(c.tag);
+        EXPECT_EQ(S(writer.task_slot).fanin_count, 0);
+        EXPECT_TRUE(S(writer.task_slot).fanin_producers.empty()) << "tag=" << static_cast<int>(c.tag);
         {
-            std::lock_guard<std::mutex> lk(slots[prior.task_slot].fanout_mu);
-            EXPECT_EQ(slots[prior.task_slot].fanout_total, 0) << "tag=" << static_cast<int>(c.tag);
+            std::lock_guard<std::mutex> lk(S(prior.task_slot).fanout_mu);
+            EXPECT_EQ(S(prior.task_slot).fanout_total, 0) << "tag=" << static_cast<int>(c.tag);
         }
     }
 }

--- a/tests/ut/cpp/test_dist_ring.cpp
+++ b/tests/ut/cpp/test_dist_ring.cpp
@@ -11,7 +11,6 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <chrono>
 #include <thread>
 #include <vector>
@@ -26,32 +25,31 @@ constexpr uint32_t kQuickTimeoutMs = 500;
 
 }  // namespace
 
-TEST(DistRing, InvalidWindowSizeThrows) {
+TEST(DistRing, SlotOnlyIdsAreMonotonic) {
     DistRing a;
-    EXPECT_THROW(a.init(0, kSmallHeap, kQuickTimeoutMs), std::invalid_argument);
-    EXPECT_THROW(a.init(3, kSmallHeap, kQuickTimeoutMs), std::invalid_argument);
-    EXPECT_THROW(a.init(-1, kSmallHeap, kQuickTimeoutMs), std::invalid_argument);
-}
-
-TEST(DistRing, SlotOnlyBumpsDistinctSlots) {
-    DistRing a;
-    a.init(8, /*heap_bytes=*/0, kQuickTimeoutMs);
-    std::vector<DistTaskSlot> slots;
+    a.init(/*heap_bytes=*/0, kQuickTimeoutMs);
     for (int i = 0; i < 8; ++i) {
         auto r = a.alloc();
-        ASSERT_GE(r.slot, 0);
-        ASSERT_LT(r.slot, 8);
+        ASSERT_EQ(r.slot, i);
         EXPECT_EQ(r.heap_ptr, nullptr);
-        slots.push_back(r.slot);
     }
-    std::sort(slots.begin(), slots.end());
-    for (int i = 0; i < 8; ++i)
-        EXPECT_EQ(slots[i], i);
+}
+
+TEST(DistRing, SlotAllocGrowsPastLegacyWindow) {
+    // The old fixed window was 128 slots; confirm we can allocate well past
+    // that without hitting a "task window full" error.
+    DistRing a;
+    a.init(/*heap_bytes=*/0, kQuickTimeoutMs);
+    for (int i = 0; i < 2048; ++i) {
+        auto r = a.alloc();
+        ASSERT_EQ(r.slot, i);
+    }
+    EXPECT_EQ(a.active_count(), 2048);
 }
 
 TEST(DistRing, HeapSlabsAreAlignedAndDistinct) {
     DistRing a;
-    a.init(8, kSmallHeap, kQuickTimeoutMs);
+    a.init(kSmallHeap, kQuickTimeoutMs);
 
     auto r1 = a.alloc(100);  // rounds to 1024
     auto r2 = a.alloc(100);
@@ -66,20 +64,19 @@ TEST(DistRing, HeapSlabsAreAlignedAndDistinct) {
 
 TEST(DistRing, AllocBytesGreaterThanHeapThrows) {
     DistRing a;
-    a.init(8, kSmallHeap, kQuickTimeoutMs);
+    a.init(kSmallHeap, kQuickTimeoutMs);
     EXPECT_THROW(a.alloc(kSmallHeap + 1), std::runtime_error);
 }
 
 TEST(DistRing, AllocBytesWithHeapDisabledThrows) {
     DistRing a;
-    a.init(8, /*heap_bytes=*/0, kQuickTimeoutMs);
+    a.init(/*heap_bytes=*/0, kQuickTimeoutMs);
     EXPECT_THROW(a.alloc(32), std::runtime_error);
 }
 
 TEST(DistRing, HeapReclamationIsFifo) {
     DistRing a;
-    // heap exactly 4 slabs, slot window large so only heap drives back-pressure.
-    a.init(32, 4 * DIST_HEAP_ALIGN, kQuickTimeoutMs);
+    a.init(4 * DIST_HEAP_ALIGN, kQuickTimeoutMs);
 
     auto r0 = a.alloc(100);
     auto r1 = a.alloc(100);
@@ -102,7 +99,7 @@ TEST(DistRing, HeapReclamationIsFifo) {
 
 TEST(DistRing, HeapWrapsAroundWhenTailLeadsTop) {
     DistRing a;
-    a.init(32, 4 * DIST_HEAP_ALIGN, kQuickTimeoutMs);
+    a.init(4 * DIST_HEAP_ALIGN, kQuickTimeoutMs);
 
     auto r0 = a.alloc(DIST_HEAP_ALIGN);
     auto r1 = a.alloc(DIST_HEAP_ALIGN);
@@ -123,43 +120,87 @@ TEST(DistRing, HeapWrapsAroundWhenTailLeadsTop) {
     a.release(wrapped.slot);
 }
 
+TEST(DistRing, SlotStateIsPointerStable) {
+    DistRing a;
+    a.init(/*heap_bytes=*/0, kQuickTimeoutMs);
+
+    auto r0 = a.alloc();
+    DistTaskSlotState *p0 = a.slot_state(r0.slot);
+    ASSERT_NE(p0, nullptr);
+
+    // Push many more slots through — the deque may grow/chain, but the
+    // pointer we grabbed for slot 0 has to stay valid.
+    for (int i = 0; i < 1000; ++i) {
+        (void)a.alloc();
+    }
+    EXPECT_EQ(a.slot_state(r0.slot), p0);
+}
+
+TEST(DistRing, ResetToEmptyRequiresAllReleased) {
+    DistRing a;
+    a.init(/*heap_bytes=*/0, kQuickTimeoutMs);
+    (void)a.alloc();
+    EXPECT_THROW(a.reset_to_empty(), std::logic_error);
+}
+
+TEST(DistRing, ResetToEmptyResetsCounters) {
+    DistRing a;
+    a.init(kSmallHeap, kQuickTimeoutMs);
+    auto r0 = a.alloc(100);
+    auto r1 = a.alloc(100);
+    a.release(r0.slot);
+    a.release(r1.slot);
+    EXPECT_EQ(a.active_count(), 0);
+    EXPECT_EQ(a.next_task_id(), 2);
+    a.reset_to_empty();
+    EXPECT_EQ(a.next_task_id(), 0);
+
+    auto r2 = a.alloc(100);
+    EXPECT_EQ(r2.slot, 0);
+    a.release(r2.slot);
+}
+
 TEST(DistRing, BackPressureThenReleaseUnblocks) {
     DistRing a;
-    a.init(4, kSmallHeap, /*timeout_ms=*/5000);
+    a.init(2 * DIST_HEAP_ALIGN, /*timeout_ms=*/5000);
 
-    std::vector<DistAllocResult> held;
-    for (int i = 0; i < 4; ++i)
-        held.push_back(a.alloc());
-    EXPECT_EQ(a.active_count(), 4);
+    auto r0 = a.alloc(DIST_HEAP_ALIGN);
+    auto r1 = a.alloc(DIST_HEAP_ALIGN);  // heap full
+    EXPECT_EQ(a.active_count(), 2);
 
+    // Release both so the wrap has room. try_bump_heap_locked keeps a
+    // one-slab guard (`tail > aligned`, strictly) between full and empty,
+    // so releasing only one slab can still leave the waiter stuck.
     std::thread releaser([&] {
         std::this_thread::sleep_for(std::chrono::milliseconds(20));
-        a.release(held[0].slot);
+        a.release(r0.slot);
+        a.release(r1.slot);
     });
 
-    auto r = a.alloc();  // blocks until releaser runs
+    auto r = a.alloc(DIST_HEAP_ALIGN);  // blocks until releaser runs
     EXPECT_NE(r.slot, DIST_INVALID_SLOT);
     releaser.join();
+    a.release(r.slot);
 
     a.shutdown();
 }
 
 TEST(DistRing, TimeoutThrowsRuntimeError) {
     DistRing a;
-    a.init(2, kSmallHeap, /*timeout_ms=*/50);
-    (void)a.alloc();
-    (void)a.alloc();  // slot window full, nobody releases
-    EXPECT_THROW(a.alloc(), std::runtime_error);
+    a.init(2 * DIST_HEAP_ALIGN, /*timeout_ms=*/50);
+    (void)a.alloc(DIST_HEAP_ALIGN);
+    (void)a.alloc(DIST_HEAP_ALIGN);  // heap full, nobody releases
+    EXPECT_THROW(a.alloc(DIST_HEAP_ALIGN), std::runtime_error);
 }
 
 TEST(DistRing, ShutdownUnblocksAlloc) {
     DistRing a;
-    a.init(2, kSmallHeap, /*timeout_ms=*/5000);
-    (void)a.alloc();
-    (void)a.alloc();  // ring full
+    a.init(2 * DIST_HEAP_ALIGN, /*timeout_ms=*/5000);
+    (void)a.alloc(DIST_HEAP_ALIGN);
+    (void)a.alloc(DIST_HEAP_ALIGN);  // heap full
 
     std::thread t([&] {
-        auto r = a.alloc();  // should unblock on shutdown, not timeout
+        auto r = a.alloc(DIST_HEAP_ALIGN);  // should unblock on shutdown, not timeout
         EXPECT_EQ(r.slot, DIST_INVALID_SLOT);
         EXPECT_EQ(r.heap_ptr, nullptr);
     });

--- a/tests/ut/cpp/test_dist_scheduler.cpp
+++ b/tests/ut/cpp/test_dist_scheduler.cpp
@@ -100,9 +100,6 @@ static TaskArgs single_tensor_args(uint64_t data_ptr, TensorArgType tag) {
 // ---------------------------------------------------------------------------
 
 struct SchedulerFixture : public ::testing::Test {
-    static constexpr int32_t N = DIST_TASK_WINDOW_SIZE;
-
-    std::unique_ptr<DistTaskSlotState[]> slots;
     DistTensorMap tm;
     DistRing allocator;
     DistScope scope;
@@ -116,10 +113,11 @@ struct SchedulerFixture : public ::testing::Test {
     std::vector<DistTaskSlot> consumed_slots;
     std::mutex consumed_mu;
 
+    DistTaskSlotState &S(DistTaskSlot id) { return *allocator.slot_state(id); }
+
     void SetUp() override {
-        slots = std::make_unique<DistTaskSlotState[]>(N);
-        allocator.init(N, /*heap_bytes=*/1ULL << 20);
-        orch.init(&tm, &allocator, &scope, &rq, slots.get(), N);
+        allocator.init(/*heap_bytes=*/1ULL << 20);
+        orch.init(&tm, &allocator, &scope, &rq);
 
         manager.add_next_level(&mock_worker);
         manager.start([this](DistTaskSlot slot) {
@@ -127,8 +125,7 @@ struct SchedulerFixture : public ::testing::Test {
         });
 
         DistScheduler::Config c;
-        c.slots = slots.get();
-        c.num_slots = N;
+        c.ring = &allocator;
         c.ready_queue = &rq;
         c.manager = &manager;
         c.on_consumed_cb = [this](DistTaskSlot s) {
@@ -182,7 +179,7 @@ TEST_F(SchedulerFixture, DependentTaskDispatchedAfterProducerCompletes) {
 
     auto args_b = single_tensor_args(0xBEEF, TensorArgType::INPUT);
     auto b = orch.submit_next_level(0xDEAD, args_b, cfg);
-    EXPECT_EQ(slots[b.task_slot].state.load(), TaskState::PENDING);
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::PENDING);
 
     mock_worker.wait_running();
     EXPECT_EQ(mock_worker.dispatched[0].slot, a.task_slot);
@@ -204,9 +201,6 @@ TEST_F(SchedulerFixture, DependentTaskDispatchedAfterProducerCompletes) {
 // ===========================================================================
 
 struct GroupSchedulerFixture : public ::testing::Test {
-    static constexpr int32_t N = DIST_TASK_WINDOW_SIZE;
-
-    std::unique_ptr<DistTaskSlotState[]> slots;
     DistTensorMap tm;
     DistRing allocator;
     DistScope scope;
@@ -221,10 +215,11 @@ struct GroupSchedulerFixture : public ::testing::Test {
     std::vector<DistTaskSlot> consumed_slots;
     std::mutex consumed_mu;
 
+    DistTaskSlotState &S(DistTaskSlot id) { return *allocator.slot_state(id); }
+
     void SetUp() override {
-        slots = std::make_unique<DistTaskSlotState[]>(N);
-        allocator.init(N, /*heap_bytes=*/1ULL << 20);
-        orch.init(&tm, &allocator, &scope, &rq, slots.get(), N);
+        allocator.init(/*heap_bytes=*/1ULL << 20);
+        orch.init(&tm, &allocator, &scope, &rq);
 
         manager.add_next_level(&worker_a);
         manager.add_next_level(&worker_b);
@@ -233,8 +228,7 @@ struct GroupSchedulerFixture : public ::testing::Test {
         });
 
         DistScheduler::Config c;
-        c.slots = slots.get();
-        c.num_slots = N;
+        c.ring = &allocator;
         c.ready_queue = &rq;
         c.manager = &manager;
         c.on_consumed_cb = [this](DistTaskSlot s) {
@@ -301,7 +295,7 @@ TEST_F(GroupSchedulerFixture, GroupCompletesOnlyWhenAllDone) {
 
     worker_a.complete();
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    EXPECT_EQ(slots[slot].state.load(), TaskState::RUNNING);
+    EXPECT_EQ(S(slot).state.load(), TaskState::RUNNING);
 
     worker_b.complete();
     wait_consumed(slot);
@@ -316,7 +310,7 @@ TEST_F(GroupSchedulerFixture, GroupDependencyChain) {
 
     auto args_b = single_tensor_args(0xCAFE, TensorArgType::INPUT);
     auto b = orch.submit_next_level(0xDEAD, args_b, cfg);
-    EXPECT_EQ(slots[b.task_slot].state.load(), TaskState::PENDING);
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::PENDING);
 
     worker_a.wait_running();
     worker_b.wait_running();


### PR DESCRIPTION
## Summary

Internal cleanup PR, follow-up to #560. Replaces the fixed-size slot pool (`DIST_TASK_WINDOW_SIZE = 128` + `DistTaskSlotState[]` inside `DistWorker`) with dynamic storage owned by `DistRing`. Slot state lives entirely in the parent process's heap at L3 — Orchestrator and Scheduler read it directly; child workers only receive payloads through a mailbox, never the slot state — so the shmem-backed ring index L2 uses is unnecessary at this level.

Only the heap still needs a pre-sized region (`MAP_SHARED | MAP_ANONYMOUS` inherited across fork). Heap back-pressure behaviour is unchanged.

**No user-visible change**: `heap_ring_size=…` still works, `OUTPUT` auto-alloc / `INOUT` WaW semantics unchanged, back-pressure timeout still throws `std::runtime_error`.

## What changed

- **`DistRing`** owns three correlated per-task resources now:
  - a monotonic `int32_t` task id (no window, no modulo wrap),
  - the shared-memory heap slab (unchanged from #560),
  - the per-slot state as `std::deque<std::unique_ptr<DistTaskSlotState>>`. `std::deque::push_back` never invalidates existing pointers, so `ring.slot_state(id)` hands out a pointer that stays valid for the slot's lifetime without keeping the mutex held past the lookup.
- **`init(heap_bytes, timeout_ms)`** drops the `window_size` parameter; the slot ring is gone entirely.
- **`reset_to_empty()`**: new method called by `DistOrchestrator::drain()` right after `active_tasks_` hits 0. Drops all slot states and zeroes task-id / heap cursors so each `Worker.run()` starts from `task_id = 0` with bounded memory (per-run peak, not cumulative).
- **`DistOrchestrator::init`** drops `slots` / `num_slots`. `slot_state(id)` delegates to `ring.slot_state(id)` with a nullptr-check.
- **`DistScheduler::Config`** drops `slots` / `num_slots`, takes `DistRing *ring` instead. Every `cfg_.slots[id]` access becomes `*cfg_.ring->slot_state(id)`.
- **`DistWorker`** drops the `std::unique_ptr<DistTaskSlotState[]> slots_` member; slot state lives inside the allocator now. `DistWorker::init()` is a straight pass-through.
- **`DIST_TASK_WINDOW_SIZE`** constant removed from `dist_types.h`.

## Tests

- `test_dist_ring` rewritten:
  - drops window-size test cases
  - adds `SlotAllocGrowsPastLegacyWindow` — 2048 allocs past the old 128 cap, verifies no "window full" error
  - adds `SlotStateIsPointerStable` — grabs a ptr to slot 0, allocs 1000 more slots, verifies ptr identity
  - adds `ResetToEmptyRequiresAllReleased` + `ResetToEmptyResetsCounters`
  - `BackPressureThenReleaseUnblocks` / `TimeoutThrowsRuntimeError` / `ShutdownUnblocksAlloc` now exercise heap back-pressure directly (the only source of back-pressure remaining)
- `test_dist_orchestrator` / `test_dist_scheduler` fixtures drop the `std::unique_ptr<DistTaskSlotState[]> slots` member and access slot state via a short `S(id)` fixture helper that wraps `ring.slot_state(id)`.

## Test plan
- [x] cpput: 7/7 targets pass locally (`cmake --build /tmp/dist_ut_build && ctest`)
- [x] pyut: 100 passed, 3 deselected (torch-only; dev box has no torch). `test_alloc_dep_wires_via_tensormap` and friends unchanged — same `INOUT`-driven WaW path.
- [ ] Linux CI

## Plan reference

Follow-up of #560 (PR-H). Tracked as **PR-I** in the hierarchical-runtime plan under "Follow-up PR chain" / Allowed Exception #6 in the L2 Consistency Audit.