### PR TITLE
Refactor: drop WorkerPayload; IWorker::run takes TaskArgsView

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -147,9 +147,9 @@ def pytest_configure(config):
 
     commit = config.getoption("--pto-isa-commit")
     if commit:
-        from simpler_setup.code_runner import _ensure_pto_isa_root  # noqa: PLC0415
+        from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: PLC0415
 
-        root = _ensure_pto_isa_root(
+        root = ensure_pto_isa_root(
             verbose=True,
             commit=commit,
             clone_protocol=config.getoption("--clone-protocol"),

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,13 +67,22 @@ get if I pip install `main` today", this page.
 
 ### Dispatch internals
 
-- `Scheduler` dispatches via a single ready queue into `WorkerManager`
-  pools (next-level + sub). Slot stores `chip_storage_list` (one
-  `ChipStorageTaskArgs` per group worker) that dispatch passes through
-  a `WorkerPayload` handed to `IWorker::run`.
+- `IWorker::run(uint64_t callable, TaskArgsView args, ChipCallConfig cfg)`
+  is the dispatch surface — no `WorkerPayload` carrier. Each
+  `WorkerThread` reads `callable` / `task_args` / `config` from
+  `ring->slot_state(task_slot)` at dispatch time and builds a
+  `TaskArgsView` on demand (`slot.args_view(i)` for THREAD;
+  `write_blob` / `read_blob` for PROCESS). `ChipWorker::run` assembles
+  the L2 ABI `ChipStorageTaskArgs` POD from the view right before
+  `pto2_run_runtime` — the slot itself stores only the tagged
+  `TaskArgs` (single) or `task_args_list` (group).
+- `Scheduler` dispatches slot ids via a single ready queue into
+  `WorkerManager` pools (next-level + sub); for group slots it pushes
+  a `WorkerDispatch { slot, group_index }` per member onto N idle
+  threads.
 - `DistChipProcess` / `DistSubWorker` are separate classes today;
   unified `WorkerThread` with `THREAD | PROCESS` modes is not yet
-  implemented.
+  implemented (lands in PR-D).
 - `DistRing` owns the task-id counter, the heap slab, **and** the
   per-slot state (`std::deque<std::unique_ptr<DistTaskSlotState>>`).
   Slot ids are monotonic within a run (no fixed window, no modulo
@@ -89,15 +98,14 @@ get if I pip install `main` today", this page.
 
 ## In flight / not yet landed
 
-### PR-C: drop `WorkerPayload`, new `IWorker::run` signature
+### PR-Scope: user-facing nested scope + Strict-1 per-scope rings
 
-- `IWorker::run(callable, TaskArgsView, config)` — no `WorkerPayload`
-  wrapper; mailbox encodes a length-prefixed blob of `callable +
-  config + args` at dispatch.
-- Slot drops `chip_storage_list` and stores the `TaskArgs` itself.
-  Child assembles `ChipStorageTaskArgs` from the view at the L2 ABI
-  edge only.
-- Strict-1 (per-scope rings, 4 depth) lands here.
+- Expose `Orchestrator.scope_begin` / `scope_end` to the user's orch fn
+  (allow nesting up to `DIST_MAX_SCOPE_DEPTH = 64`).
+- Refactor `DistRing` into `DIST_MAX_RING_DEPTH = 4` independent
+  HeapRing instances; `alloc_for_scope(depth)` picks one. Per-ring
+  `last_alive` so deeply nested scopes never contend on a single
+  reclamation pointer.
 
 ### PR-D: WorkerThread unification + per-shape ready queues
 
@@ -137,7 +145,10 @@ get if I pip install `main` today", this page.
   call paths (`release_ref` and `try_consume`).
 - **scene_test has two helper functions** —
   `_build_chip_task_args` returns `ChipStorageTaskArgs` (POD, for the
-  current L2 path: `ChipWorker.run(callable, POD, config)`) and
-  `_build_l3_task_args` returns a tagged `TaskArgs` (for
-  `orch.submit_next_level`). PR-C will collapse these into one helper
-  when `ChipWorker::run` takes a `TaskArgsView`.
+  L2 `ChipWorker.run(callable, POD, config)` overload still used by
+  inline callers) and `_build_l3_task_args` returns a tagged
+  `TaskArgs` (for `orch.submit_next_level`). The
+  `ChipWorker::run(uint64_t, TaskArgsView, ChipCallConfig)` IWorker
+  entry now accepts a view, so these helpers can collapse into one —
+  the POD overload is retained as an internal convenience for the
+  Python-bound `_ChipWorker.run_raw` path.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,10 +1,9 @@
 # Scheduler — DAG Dispatch Internals
 
-> **Status**: target design. Current code dispatches via
-> `IWorker::run(const WorkerPayload&)` rather than `run(callable, view,
-> config)`; per-worker-type ready queue split (Strict-4) is not yet
-> implemented. See [roadmap.md](roadmap.md) for the full
-> landed-vs-planned breakdown.
+> **Status**: target design. `IWorker::run(uint64_t callable, TaskArgsView,
+> ChipCallConfig)` is the live dispatch signature; per-worker-type ready
+> queue split (Strict-4) is not yet implemented (lands in PR-D). See
+> [roadmap.md](roadmap.md) for the full landed-vs-planned breakdown.
 
 The Scheduler is the **DAG executor**. A dedicated C++ thread that consumes
 submitted slots, wires fanout edges, dispatches ready tasks to worker threads,

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -340,11 +340,19 @@ The mailbox layout, fork ordering, and child loop are in
 
 | Region | Lives in | Used by | Lifetime |
 | ------ | -------- | ------- | -------- |
-| `slots_[N]` (TaskSlotState array) | parent heap | Orchestrator, Scheduler, WorkerThread parent side | ring-managed |
-| `slots_[i].task_args` (vector-backed) | parent heap | same | until slot released |
+| `DistRing` slot-state pool (`std::deque<unique_ptr<TaskSlotState>>`) | parent heap | Orchestrator, Scheduler, WorkerThread parent side | monotonic task-id; reset at `Worker.run` drain |
+| `slot.task_args` (single) or `task_args_list[N]` (group, vector-backed) | parent heap | same | until slot reaches CONSUMED |
 | per-WT mailbox (PROCESS only) | shm MAP_SHARED | parent WorkerThread writes, child reads | lifetime of WorkerThread |
-| tensor data bytes | torch shm (`share_memory_()` or equiv) | kernel reads/writes | user-managed |
+| HeapRing (user OUTPUT auto-alloc + `orch.alloc`) | shm MAP_SHARED | output to user code; inherited by forked children | FIFO reclaimed via `last_alive` |
+| tensor data bytes (user-provided) | torch shm (`share_memory_()` or equiv) | kernel reads/writes | user-managed |
 | `Callable` target (ChipCallable / OrchFn / Python fn) | parent heap | child via fork COW | pre-fork registered |
+
+Slot state lives inside `DistRing` as `std::deque<std::unique_ptr<…>>` so
+`push_back` never invalidates pointers to live slots (see PR-I in
+[roadmap.md](roadmap.md)). `ring.slot_state(id)` hands out a stable
+pointer for every live slot; `drain()` calls `ring.reset_to_empty()` to
+drop all slot state at the end of each `Worker.run`, bounding per-run
+memory.
 
 **Child never reads the slot.** Child only sees:
 

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -2,8 +2,9 @@
 
 > **Status**: describes the **target** design. Current code still has
 > separate `DistChipProcess` / `DistSubWorker` classes (target: merged
-> into `WorkerThread` in PR-D) and passes `const WorkerPayload&` to
-> `IWorker::run` (target: replaced in PR-C). See
+> into `WorkerThread` in PR-D). `IWorker::run(uint64_t callable,
+> TaskArgsView args, const ChipCallConfig &config)` is the live
+> signature; no `WorkerPayload` dispatch carrier exists. See
 > [roadmap.md](roadmap.md) for the full landed-vs-planned breakdown.
 
 `WorkerManager` and `WorkerThread` together implement the **execution layer**
@@ -77,26 +78,31 @@ use different modes independently (e.g., L4 THREAD containing L3 PROCESS).
 One WorkerThread per IWorker instance.
 
 ```cpp
+struct WorkerDispatch {
+    TaskSlot task_slot;
+    int32_t  group_index = 0;    // 0 for non-group; 0..N-1 for group members
+};
+
 class WorkerThread {
 public:
     enum class Mode { THREAD, PROCESS };
 
     WorkerThread(Mode mode,
                  IWorker *worker,
-                 TaskSlotState *parent_slots,
+                 DistRing *ring,
                  size_t mailbox_size = 0);
 
     void start(OnCompleteFn on_done);
     void stop();
-    void dispatch(TaskSlot slot_id);
+    void dispatch(WorkerDispatch d);       // slot id + group sub-index
     bool is_idle() const;
 
 private:
     Mode mode_;
     IWorker *worker_;
-    TaskSlotState *parent_slots_;          // reference to parent's slot pool
+    DistRing *ring_;                       // reads slot state via ring->slot_state(id)
     std::thread parent_thread_;
-    LockFreeQueue<TaskSlot> queue_;
+    LockFreeQueue<WorkerDispatch> queue_;
 
     // PROCESS mode only
     void *mailbox_ = nullptr;              // shm
@@ -104,8 +110,8 @@ private:
     size_t mailbox_size_ = 0;
 
     void loop();
-    void dispatch_thread(TaskSlot slot_id);
-    void dispatch_process(TaskSlot slot_id);
+    void dispatch_thread(WorkerDispatch d);
+    void dispatch_process(WorkerDispatch d);
     [[noreturn]] void child_loop();
     void fork_child();
 };
@@ -115,6 +121,15 @@ The WorkerThread's `std::thread` always exists regardless of mode — it pumps
 the internal queue and either runs the worker in-process or drives the shm
 handshake to a forked child.
 
+`WorkerDispatch` carries only `{slot_id, group_index}`; the thread reads
+`slot.callable` / `slot.task_args` / `slot.config` on each dispatch via
+`ring->slot_state(slot_id)`. For a group slot with `group_size() == N`,
+the Scheduler pushes N `WorkerDispatch` entries (one per member) onto N
+idle threads; each thread's `group_index` selects which
+`task_args_list[i]` view to hand to the worker. There is no
+`WorkerPayload` — the per-dispatch carrier is just the slot id plus the
+group sub-index.
+
 ---
 
 ## 3. THREAD mode
@@ -122,16 +137,24 @@ handshake to a forked child.
 The simple case: same process, no shm, no serialization.
 
 ```cpp
-void WorkerThread::dispatch_thread(TaskSlot slot_id) {
-    TaskSlotState &s = parent_slots_[slot_id];
-    worker_->run(s.callable, s.task_args.view(), s.config);
-    on_complete_(slot_id);
+void WorkerThread::dispatch_thread(WorkerDispatch d) {
+    TaskSlotState &s = *ring_->slot_state(d.task_slot);
+    uint64_t callable = (s.worker_type == WorkerType::SUB)
+        ? static_cast<uint64_t>(s.callable_id)      // registry id for sub path
+        : s.callable;                                // ChipCallable buffer ptr
+    TaskArgsView view = s.args_view(d.group_index); // 0 for single tasks
+    worker_->run(callable, view, s.config);
+    on_complete_(d.task_slot);
 }
 ```
 
-- `TaskArgs::view()` returns a zero-copy `TaskArgsView` pointing into the
-  slot's `std::vector` backing (parent heap)
-- `IWorker::run` dispatches polymorphically based on the actual worker type
+- `slot.args_view(i)` returns a zero-copy `TaskArgsView` over
+  `task_args` (single) or `task_args_list[i]` (group member). The backing
+  `std::vector` lives on the parent heap until the slot reaches CONSUMED.
+- `callable` unifies the two registry shapes: `uint64 = ChipCallable*`
+  for next-level, `uint64 = callable_id` for sub. The receiving
+  `IWorker` casts back appropriately.
+- `IWorker::run` dispatches polymorphically based on the actual worker type.
 
 **When is THREAD mode safe?**
 
@@ -195,14 +218,21 @@ child inherits locks held by threads that don't exist post-fork.
 ### 4.3 Parent-side dispatch
 
 ```cpp
-void WorkerThread::dispatch_process(TaskSlot slot_id) {
-    TaskSlotState &s = parent_slots_[slot_id];
-    uint8_t *d = (uint8_t*)mailbox_ + HEADER_SIZE;
+void WorkerThread::dispatch_process(WorkerDispatch d) {
+    TaskSlotState &s = *ring_->slot_state(d.task_slot);
+    uint8_t *m = (uint8_t*)mailbox_ + HEADER_SIZE;
 
-    // Write task data
-    *reinterpret_cast<Callable*>(d)               = s.callable;
-    *reinterpret_cast<CallConfig*>(d + 8)         = s.config;
-    write_blob(d + 8 + sizeof(CallConfig), s.task_args);
+    // Write task data: callable (8 B) + config (~16 B) + length-prefixed
+    // TaskArgs blob. The blob is derived from the slot's stored TaskArgs
+    // via write_blob() — tags are stripped, only [T][S][tensors][scalars]
+    // crosses the fork boundary.
+    uint64_t callable = (s.worker_type == WorkerType::SUB)
+        ? static_cast<uint64_t>(s.callable_id)
+        : s.callable;
+    *reinterpret_cast<uint64_t*>(m)            = callable;
+    *reinterpret_cast<CallConfig*>(m + 8)      = s.config;
+    const TaskArgs &args = s.is_group() ? s.task_args_list[d.group_index] : s.task_args;
+    write_blob(m + 8 + sizeof(CallConfig), args);
 
     // Signal child
     write_state(mailbox_, MailboxState::TASK_READY);
@@ -213,7 +243,7 @@ void WorkerThread::dispatch_process(TaskSlot slot_id) {
 
     int err = read_error(mailbox_);
     write_state(mailbox_, MailboxState::IDLE);
-    on_complete_(slot_id, err);
+    on_complete_(d.task_slot, err);
 }
 ```
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -579,7 +579,24 @@ NB_MODULE(_task_interface, m) {
                 self.run(reinterpret_cast<const void *>(callable), reinterpret_cast<const void *>(args), config);
             },
             nb::arg("callable"), nb::arg("args"), nb::arg("block_dim") = 1, nb::arg("aicpu_thread_num") = 3,
-            nb::arg("enable_profiling") = false, "Run with raw pointer arguments (used from forked chip process)."
+            nb::arg("enable_profiling") = false, "Run with a raw ChipStorageTaskArgs POD pointer."
+        )
+        .def(
+            "run_from_blob",
+            [](ChipWorker &self, uint64_t callable, uint64_t blob_ptr, int block_dim, int aicpu_thread_num,
+               bool enable_profiling) {
+                ChipCallConfig config;
+                config.block_dim = block_dim;
+                config.aicpu_thread_num = aicpu_thread_num;
+                config.enable_profiling = enable_profiling;
+                TaskArgsView view = read_blob(reinterpret_cast<const uint8_t *>(blob_ptr));
+                self.run(callable, view, config);
+            },
+            nb::arg("callable"), nb::arg("blob_ptr"), nb::arg("block_dim") = 1, nb::arg("aicpu_thread_num") = 3,
+            nb::arg("enable_profiling") = false,
+            "Decode a length-prefixed TaskArgs blob ([T][S][tensors][scalars]) at "
+            "blob_ptr and dispatch to the runtime. Used from forked chip processes "
+            "reading the WorkerThread mailbox."
         )
         .def_prop_ro("device_id", &ChipWorker::device_id)
         .def_prop_ro("initialized", &ChipWorker::initialized)

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -58,7 +58,7 @@ from .task_interface import (
 class Task:
     """Execution unit for Worker.run() at any level.
 
-    For L2: set callable/args directly on a WorkerPayload and pass to run().
+    For L2: call ``Worker.run(chip_callable, chip_args, config)`` directly.
     For L3+: provide an orch function ``fn(orchestrator, args)`` that builds
     the DAG via ``orchestrator.submit_*``.
     """
@@ -83,15 +83,6 @@ def _mailbox_addr(shm: SharedMemory) -> int:
     buf = shm.buf
     assert buf is not None
     return ctypes.addressof(ctypes.c_char.from_buffer(buf))
-
-
-def _args_size(csa_cls) -> int:
-    """Return sizeof(ChipStorageTaskArgs). Uses C++ binding if available, else heap probe."""
-    if hasattr(csa_cls, "sizeof"):
-        return csa_cls.sizeof()
-    objs = [csa_cls() for _ in range(5)]
-    ptrs = [o.__ptr__() for o in objs]
-    return min(abs(ptrs[i + 1] - ptrs[i]) for i in range(len(ptrs) - 1))
 
 
 def _sub_worker_loop(buf, registry: dict) -> None:
@@ -132,9 +123,17 @@ def _chip_process_loop(
     aicpu_path: str,
     aicore_path: str,
     sim_context_lib_path: str = "",
-    args_size: int = 1712,
 ) -> None:
-    """Runs in forked child process. Loads host_runtime.so in own address space."""
+    """Runs in forked child process. Loads host_runtime.so in own address space.
+
+    The parent writes a length-prefixed TaskArgs blob ([T][S][tensors][scalars])
+    into the mailbox at OFF_ARGS. The child reads the blob directly from the
+    mailbox via ChipWorker.run_from_blob — safe because the parent is blocked
+    on TASK_DONE for the duration of the call, so the mailbox bytes are
+    stable, and run_from_blob's view_to_chip_storage already memcpys the
+    tensor / scalar data into the ChipStorageTaskArgs POD it hands to
+    pto2_run_runtime. No per-task heap buffer needed.
+    """
     import traceback as _tb  # noqa: PLC0415
 
     try:
@@ -147,6 +146,8 @@ def _chip_process_loop(
         return
 
     mailbox_addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
+    # The blob pointer is a constant offset into the mailbox — compute once.
+    args_ptr = mailbox_addr + _CHIP_OFF_ARGS
     sys.stderr.write(f"[chip_process pid={os.getpid()} dev={device_id}] ready\n")
     sys.stderr.flush()
 
@@ -157,16 +158,10 @@ def _chip_process_loop(
             block_dim = struct.unpack_from("i", buf, _CHIP_OFF_BLOCK_DIM)[0]
             aicpu_tn = struct.unpack_from("i", buf, _CHIP_OFF_AICPU_THREAD_NUM)[0]
             profiling = struct.unpack_from("i", buf, _CHIP_OFF_ENABLE_PROFILING)[0]
-            args_ptr = mailbox_addr + _CHIP_OFF_ARGS
-
-            # Copy args from shm to heap — run_runtime requires heap-backed args
-            args_buf = ctypes.create_string_buffer(args_size)
-            ctypes.memmove(args_buf, args_ptr, args_size)
-            heap_args_ptr = ctypes.addressof(args_buf)
 
             error = 0
             try:
-                cw.run_raw(callable_ptr, heap_args_ptr, block_dim, aicpu_tn, bool(profiling))
+                cw.run_from_blob(callable_ptr, args_ptr, block_dim, aicpu_tn, bool(profiling))
             except Exception:  # noqa: BLE001
                 error = 1
             struct.pack_into("i", buf, _CHIP_OFF_ERROR, error)
@@ -274,14 +269,14 @@ class Worker:
         if device_ids:
             from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
 
-            from .task_interface import ChipStorageTaskArgs as _CSA  # noqa: PLC0415
-
             platform = self._config["platform"]
             runtime = self._config["runtime"]
             builder = RuntimeBuilder(platform)
             binaries = builder.get_binaries(runtime, build=self._config.get("build", False))
 
-            self._l3_args_size = _args_size(_CSA)
+            # args_capacity: how many bytes the parent can write at mailbox
+            # OFF_ARGS. Matches DIST_CHIP_ARGS_CAPACITY on the C++ side.
+            self._l3_args_capacity = DIST_CHIP_MAILBOX_SIZE - _CHIP_OFF_ARGS
             self._l3_host_lib_path = str(binaries.host_path)
             self._l3_aicpu_path = str(binaries.aicpu_path)
             self._l3_aicore_path = str(binaries.aicore_path)
@@ -342,7 +337,6 @@ class Worker:
                         self._l3_aicpu_path,
                         self._l3_aicore_path,
                         self._l3_sim_ctx_path,
-                        self._l3_args_size,
                     )
                     os._exit(0)
                 else:
@@ -356,7 +350,7 @@ class Worker:
 
         if device_ids:
             for shm in self._chip_shms:
-                cp = DistChipProcess(_mailbox_addr(shm), self._l3_args_size)
+                cp = DistChipProcess(_mailbox_addr(shm), self._l3_args_capacity)
                 self._dist_chip_procs.append(cp)
                 dw.add_next_level_worker(cp)
 

--- a/src/common/distributed/dist_chip_process.cpp
+++ b/src/common/distributed/dist_chip_process.cpp
@@ -13,12 +13,12 @@
 
 #include <stdexcept>
 
-DistChipProcess::DistChipProcess(void *mailbox_ptr, size_t args_size) :
+DistChipProcess::DistChipProcess(void *mailbox_ptr, size_t args_capacity) :
     mailbox_(mailbox_ptr),
-    args_size_(args_size) {
+    args_capacity_(args_capacity) {
     if (!mailbox_ptr) throw std::invalid_argument("DistChipProcess: null mailbox_ptr");
-    if (args_size > DIST_CHIP_ARGS_CAPACITY) {
-        throw std::invalid_argument("DistChipProcess: args_size exceeds mailbox capacity");
+    if (args_capacity > DIST_CHIP_ARGS_CAPACITY) {
+        throw std::invalid_argument("DistChipProcess: args_capacity exceeds mailbox capacity");
     }
 }
 
@@ -49,28 +49,46 @@ void DistChipProcess::write_state(ChipMailboxState s) {
 #endif
 }
 
-void DistChipProcess::run(const WorkerPayload &payload) {
-    // Write callable pointer
-    uint64_t callable_val = reinterpret_cast<uint64_t>(payload.callable);
-    std::memcpy(base() + OFF_CALLABLE, &callable_val, sizeof(uint64_t));
+void DistChipProcess::run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) {
+    // Write callable pointer (child dereferences this via fork-COW).
+    std::memcpy(base() + OFF_CALLABLE, &callable, sizeof(uint64_t));
 
-    // Write config fields
-    int32_t block_dim = payload.block_dim;
-    int32_t aicpu_tn = payload.aicpu_thread_num;
-    int32_t profiling = payload.enable_profiling ? 1 : 0;
+    // Write config fields.
+    int32_t block_dim = config.block_dim;
+    int32_t aicpu_tn = config.aicpu_thread_num;
+    int32_t profiling = config.enable_profiling ? 1 : 0;
     std::memcpy(base() + OFF_BLOCK_DIM, &block_dim, sizeof(int32_t));
     std::memcpy(base() + OFF_AICPU_THREAD_NUM, &aicpu_tn, sizeof(int32_t));
     std::memcpy(base() + OFF_ENABLE_PROFILING, &profiling, sizeof(int32_t));
 
-    // Copy args into mailbox (child reads from mailbox address)
-    if (payload.args != nullptr && args_size_ > 0) {
-        std::memcpy(base() + OFF_ARGS, payload.args, args_size_);
+    // Write length-prefixed TaskArgs blob: [T][S][tensors][scalars]. The
+    // child reads it with read_blob() and assembles a ChipStorageTaskArgs
+    // POD on its own heap before invoking pto2_run_runtime.
+    size_t blob_bytes = TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(args.tensor_count) * sizeof(ContinuousTensor) +
+                        static_cast<size_t>(args.scalar_count) * sizeof(uint64_t);
+    if (blob_bytes > args_capacity_) {
+        throw std::runtime_error("DistChipProcess::run: args blob exceeds mailbox capacity");
+    }
+    uint8_t *d = reinterpret_cast<uint8_t *>(base() + OFF_ARGS);
+    std::memcpy(d + 0, &args.tensor_count, sizeof(int32_t));
+    std::memcpy(d + 4, &args.scalar_count, sizeof(int32_t));
+    if (args.tensor_count > 0) {
+        std::memcpy(
+            d + TASK_ARGS_BLOB_HEADER_SIZE, args.tensors,
+            static_cast<size_t>(args.tensor_count) * sizeof(ContinuousTensor)
+        );
+    }
+    if (args.scalar_count > 0) {
+        std::memcpy(
+            d + TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(args.tensor_count) * sizeof(ContinuousTensor),
+            args.scalars, static_cast<size_t>(args.scalar_count) * sizeof(uint64_t)
+        );
     }
 
-    // Signal child process
+    // Signal child process.
     write_state(ChipMailboxState::TASK_READY);
 
-    // Spin-poll until child signals TASK_DONE
+    // Spin-poll until child signals TASK_DONE.
     while (read_state() != ChipMailboxState::TASK_DONE) {
         std::this_thread::sleep_for(std::chrono::microseconds(50));
     }

--- a/src/common/distributed/dist_chip_process.h
+++ b/src/common/distributed/dist_chip_process.h
@@ -17,8 +17,8 @@
  * The fork and ChipWorker init are managed from Python (Worker.__init__).
  *
  * run() flow (executes in WorkerThread's own thread, not the Scheduler thread):
- *   1. Write callable_ptr, config fields to mailbox
- *   2. memcpy ChipStorageTaskArgs into mailbox at ARGS_OFFSET
+ *   1. Write callable, config fields to mailbox
+ *   2. write_blob(TaskArgs) at OFF_ARGS — length-prefixed [T][S][tensors][scalars]
  *   3. write_state(TASK_READY)  — release store
  *   4. Spin-poll until read_state() == TASK_DONE  — blocking in WorkerThread
  *   5. write_state(IDLE)        — reset for next task
@@ -27,11 +27,13 @@
  * Mailbox layout (DIST_CHIP_MAILBOX_SIZE bytes):
  *   offset  0  int32   state              IDLE=0, TASK_READY=1, TASK_DONE=2, SHUTDOWN=3
  *   offset  4  int32   error_code         0=ok
- *   offset  8  uint64  callable_ptr       ChipCallable buffer address (COW)
+ *   offset  8  uint64  callable           ChipCallable buffer address (COW)
  *   offset 16  int32   block_dim
  *   offset 20  int32   aicpu_thread_num
  *   offset 24  int32   enable_profiling
- *   offset 64  [bytes] ChipStorageTaskArgs (memcpy'd, read in-place by child)
+ *   offset 64  [bytes] length-prefixed TaskArgs blob; child decodes via
+ *                      read_blob and assembles the ChipStorageTaskArgs POD
+ *                      locally before calling pto2_run_runtime.
  */
 
 #pragma once
@@ -42,6 +44,7 @@
 #include <cstring>
 #include <thread>
 
+#include "../task_interface/task_args.h"
 #include "dist_types.h"
 
 static constexpr size_t DIST_CHIP_MAILBOX_SIZE = 4096;
@@ -56,16 +59,20 @@ enum class ChipMailboxState : int32_t {
 
 class DistChipProcess : public IWorker {
 public:
-    explicit DistChipProcess(void *mailbox_ptr, size_t args_size);
+    // `mailbox_ptr` must point to DIST_CHIP_MAILBOX_SIZE bytes of shared
+    // memory. `args_capacity` is the maximum length-prefixed blob the
+    // parent may write at OFF_ARGS (bounded by DIST_CHIP_ARGS_CAPACITY).
+    DistChipProcess(void *mailbox_ptr, size_t args_capacity);
 
-    // IWorker: write payload to mailbox → spin-poll TASK_DONE → reset IDLE.
-    void run(const WorkerPayload &payload) override;
+    // IWorker: encode (callable, args, config) into the mailbox → signal
+    // TASK_READY → spin-poll TASK_DONE → reset IDLE.
+    void run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) override;
 
     void shutdown();
 
 private:
     void *mailbox_;
-    size_t args_size_;
+    size_t args_capacity_;
 
     static constexpr ptrdiff_t OFF_STATE = 0;
     static constexpr ptrdiff_t OFF_ERROR = 4;

--- a/src/common/distributed/dist_orchestrator.cpp
+++ b/src/common/distributed/dist_orchestrator.cpp
@@ -152,19 +152,28 @@ DistSubmitResult DistOrchestrator::submit_impl(
     s.reset();
 
     s.worker_type = worker_type;
-    s.callable_ptr = callable_ptr;
+    s.callable = callable_ptr;
     s.callable_id = callable_id;
     s.config = config;
 
-    // --- Step 2: Per-worker chip storage (one ChipStorageTaskArgs per group member) ---
-    s.chip_storage_list.reserve(args_list.size());
-    for (const TaskArgs &a : args_list) {
-        s.chip_storage_list.push_back(view_to_chip_storage(make_view(a)));
-    }
-
-    // --- Step 3 + 4: Walk tags → tensormap.lookup (deps) + tensormap.insert (outputs) ---
+    // --- Step 2: Walk tags → tensormap.lookup (deps) + tensormap.insert
+    // (outputs). Must happen before we move args_list into the slot because
+    // infer_deps reads tensor data pointers and tags from it.
     std::vector<DistTaskSlot> producers;
     infer_deps(slot, args_list, producers, s.output_keys);
+
+    // --- Step 3: Store TaskArgs directly (no chip-storage pre-build) ---
+    // Dispatch builds a TaskArgsView on demand via `slot.args_view(i)`
+    // (THREAD mode) or write_blob → read_blob (PROCESS mode). The L2 ABI
+    // ChipStorageTaskArgs conversion now runs inside ChipWorker::run
+    // rather than at submit time.
+    if (args_list.size() == 1) {
+        s.is_group_ = false;
+        s.task_args = std::move(args_list.front());
+    } else {
+        s.is_group_ = true;
+        s.task_args_list = std::move(args_list);
+    }
 
     // --- Step 5: Finalize fanin — lock each producer's fanout_mu, attach ---
     //

--- a/src/common/distributed/dist_scheduler.cpp
+++ b/src/common/distributed/dist_scheduler.cpp
@@ -14,6 +14,7 @@
 #include <stdexcept>
 
 #include "dist_ring.h"
+#include "dist_types.h"
 #include "dist_worker_manager.h"
 
 // =============================================================================
@@ -186,16 +187,10 @@ void DistScheduler::dispatch_ready() {
 
         s.state.store(TaskState::RUNNING, std::memory_order_release);
         for (int i = 0; i < N; i++) {
-            WorkerPayload p;
-            p.task_slot = slot;
-            p.worker_type = s.worker_type;
-            p.callable = reinterpret_cast<const void *>(s.callable_ptr);
-            p.args = &s.chip_storage_list[i];
-            p.block_dim = s.config.block_dim;
-            p.aicpu_thread_num = s.config.aicpu_thread_num;
-            p.enable_profiling = s.config.enable_profiling;
-            p.callable_id = s.callable_id;
-            workers[i]->dispatch(p);
+            WorkerDispatch d;
+            d.task_slot = slot;
+            d.group_index = i;
+            workers[i]->dispatch(d);
         }
     }
 }

--- a/src/common/distributed/dist_sub_worker.cpp
+++ b/src/common/distributed/dist_sub_worker.cpp
@@ -60,8 +60,10 @@ void DistSubWorker::write_state(SubMailboxState s) {
 // IWorker::run() — blocks in the WorkerThread's own thread
 // =============================================================================
 
-void DistSubWorker::run(const WorkerPayload &payload) {
-    *callable_id_ptr() = payload.callable_id;
+void DistSubWorker::run(uint64_t callable, TaskArgsView /*args*/, const ChipCallConfig & /*config*/) {
+    // `callable` encodes the registered callable id as uint64. Write the
+    // low 32 bits — matches the Python-side mailbox layout.
+    *callable_id_ptr() = static_cast<int32_t>(callable);
     write_state(SubMailboxState::TASK_READY);
 
     // Self-poll until child signals TASK_DONE.

--- a/src/common/distributed/dist_sub_worker.h
+++ b/src/common/distributed/dist_sub_worker.h
@@ -54,9 +54,12 @@ public:
     // (allocated from Python before fork).
     explicit DistSubWorker(void *mailbox_ptr);
 
-    // IWorker: write mailbox → spin-poll TASK_DONE → reset IDLE.
+    // IWorker: write mailbox → spin-poll TASK_DONE → reset IDLE. `callable`
+    // carries the registered callable id (uint64; low 32 bits = int32 cid).
+    // `args` is currently ignored — the child's py registry receives no
+    // args yet; PR-E threads the TaskArgsView into the Python call.
     // Blocks in the caller's thread (WorkerThread), not the Scheduler thread.
-    void run(const WorkerPayload &payload) override;
+    void run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) override;
 
     // Signal the child process to exit (SHUTDOWN state).
     void shutdown();

--- a/src/common/distributed/dist_types.cpp
+++ b/src/common/distributed/dist_types.cpp
@@ -28,10 +28,12 @@ void DistTaskSlotState::reset() {
     output_keys.clear();
     fanin_producers.clear();
     worker_type = WorkerType::NEXT_LEVEL;
-    callable_ptr = 0;
+    callable = 0;
     callable_id = -1;
     config = ChipCallConfig{};
-    chip_storage_list.clear();
+    task_args.clear();
+    task_args_list.clear();
+    is_group_ = false;
     sub_complete_count.store(0, std::memory_order_relaxed);
 }
 

--- a/src/common/distributed/dist_types.h
+++ b/src/common/distributed/dist_types.h
@@ -15,12 +15,17 @@
  * Every level in the hierarchy (L3 HostWorker, L4, L5, …) runs the same
  * scheduling engine.  This header defines:
  *   - WorkerType / TaskState enumerations
- *   - WorkerPayload: internal dispatch carrier (Orchestrator → WorkerThread →
- *                    IWorker::run); not part of the user-facing surface
- *   - DistTaskSlotState: per-task scheduling bookkeeping
+ *   - DistTaskSlotState: per-task scheduling bookkeeping (stores TaskArgs
+ *                        directly — no separate dispatch carrier struct)
  *   - DistReadyQueue: Orch→Scheduler notification channel
  *   - IWorker: abstract interface implemented by ChipWorker, SubWorker,
  *              and DistWorker itself (recursive composition)
+ *
+ * IWorker::run takes (callable, TaskArgsView, ChipCallConfig) directly.
+ * THREAD-mode dispatch builds the view via `slot.args_view(i)` from the
+ * slot's stored TaskArgs; PROCESS-mode dispatch encodes the TaskArgs into
+ * the per-WorkerThread shm mailbox via write_blob() and the child rebuilds
+ * the view with read_blob().
  */
 
 #pragma once
@@ -72,32 +77,13 @@ enum class TaskState : int32_t {
 };
 
 // =============================================================================
-// WorkerPayload — internal dispatch carrier (Scheduler → WorkerThread → IWorker)
-// =============================================================================
-//
-// Not part of the user-facing surface. Constructed by the Scheduler at
-// dispatch time from the slot's stored TaskArgs + callable + config, then
-// handed to IWorker::run. ChipWorker / DistChipProcess / DistSubWorker each
-// read the fields they need.
-
-struct WorkerPayload {
-    DistTaskSlot task_slot = DIST_INVALID_SLOT;
-    WorkerType worker_type = WorkerType::NEXT_LEVEL;
-
-    // --- ChipWorker / DistChipProcess fields ---
-    const void *callable = nullptr;  // ChipCallable buffer ptr
-    const void *args = nullptr;      // ChipStorageTaskArgs* (in slot storage)
-    int32_t block_dim = 1;
-    int32_t aicpu_thread_num = 3;
-    bool enable_profiling = false;
-
-    // --- SubWorker fields ---
-    int32_t callable_id = -1;
-};
-
-// =============================================================================
 // DistTaskSlotState — per-task scheduling bookkeeping
 // =============================================================================
+//
+// Stores the submitted TaskArgs directly. Dispatch builds a TaskArgsView on
+// demand via `args_view(i)` (THREAD mode) or write_blob → read_blob
+// (PROCESS mode). There is no separate dispatch carrier struct; the old
+// WorkerPayload was removed in PR-C.
 
 struct DistTaskSlotState {
     std::atomic<TaskState> state{TaskState::FREE};
@@ -123,14 +109,18 @@ struct DistTaskSlotState {
 
     // --- Task data (stored on parent heap, lives until slot CONSUMED) ---
     WorkerType worker_type{WorkerType::NEXT_LEVEL};
-    uint64_t callable_ptr{0};  // NEXT_LEVEL: ChipCallable buffer ptr
-    int32_t callable_id{-1};   // SUB: registered callable id
-    ChipCallConfig config{};   // NEXT_LEVEL config (block_dim, aicpu_thread_num, enable_profiling)
+    uint64_t callable{0};     // NEXT_LEVEL: ChipCallable buffer ptr; SUB: unused
+    int32_t callable_id{-1};  // SUB: registered callable id
+    ChipCallConfig config{};  // NEXT_LEVEL config (block_dim, aicpu_thread_num, enable_profiling)
 
-    // Per-worker chip-storage args (size()==1 for normal tasks, ==N for groups).
-    // Pre-built at submit time (assembled from each TaskArgs via view_to_chip_storage)
-    // so scheduler dispatch can pass &chip_storage_list[i] in the WorkerPayload.
-    std::vector<ChipStorageTaskArgs> chip_storage_list;
+    // Unified task-args storage: `task_args` is the single-task builder;
+    // when `is_group_` is true, `task_args_list` carries one TaskArgs per
+    // worker (N-SPMD group, L3-flavoured — each member has its own distinct
+    // tensors/scalars, unlike L2's SPMD single-payload). `task_args` stays
+    // empty for groups.
+    TaskArgs task_args;
+    std::vector<TaskArgs> task_args_list;
+    bool is_group_{false};
 
     // Runtime-owned OUTPUT slabs live in the Worker's HeapRing and are
     // reclaimed implicitly by DistRing::release(slot) — no per-slot
@@ -139,8 +129,14 @@ struct DistTaskSlotState {
     // --- Group bookkeeping ---
     std::atomic<int32_t> sub_complete_count{0};
 
-    bool is_group() const { return chip_storage_list.size() > 1; }
-    int32_t group_size() const { return static_cast<int32_t>(chip_storage_list.size()); }
+    bool is_group() const { return is_group_; }
+    int32_t group_size() const { return is_group_ ? static_cast<int32_t>(task_args_list.size()) : 1; }
+
+    // Zero-copy view over the i-th worker's args (THREAD-mode dispatch).
+    // `i` must be 0 for non-group slots; 0..group_size()-1 for groups.
+    TaskArgsView args_view(int32_t i) const {
+        return is_group_ ? make_view(task_args_list[static_cast<size_t>(i)]) : make_view(task_args);
+    }
 
     DistTaskSlotState() = default;
     DistTaskSlotState(const DistTaskSlotState &) = delete;
@@ -181,7 +177,19 @@ class IWorker {
 public:
     virtual ~IWorker() = default;
 
-    // Execute one task synchronously.  Called in the worker's own thread.
-    // Blocks until the task is complete (mirroring ChipWorker::run()).
-    virtual void run(const WorkerPayload &payload) = 0;
+    // Execute one task synchronously. Called in the worker's own thread,
+    // blocking until the task is complete.
+    //
+    // Each implementation interprets `callable` per its semantics:
+    //   - ChipWorker: uint64 holding a ChipCallable buffer ptr; builds a
+    //     ChipStorageTaskArgs POD from `args` and calls pto2_run_runtime.
+    //   - DistChipProcess / DistSubWorker: dispatch proxies — forward
+    //     callable / config / args through the shm mailbox to the forked
+    //     child, which invokes the actual IWorker in its own address space.
+    //   - DistWorker (L4+): `callable` decodes to an orch-fn handle;
+    //     placeholder until PR-F.
+    //
+    // slot_id is not a parameter — completion routing is owned by
+    // WorkerThread / Scheduler at a higher layer.
+    virtual void run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) = 0;
 };

--- a/src/common/distributed/dist_worker.cpp
+++ b/src/common/distributed/dist_worker.cpp
@@ -132,7 +132,7 @@ void DistWorker::init() {
 
     // Start WorkerManager first — creates WorkerThreads.
     // The on_complete callback routes through the Scheduler's worker_done().
-    manager_.start([this](DistTaskSlot slot) {
+    manager_.start(&allocator_, [this](DistTaskSlot slot) {
         scheduler_.worker_done(slot);
     });
 
@@ -160,7 +160,8 @@ void DistWorker::close() {
 // IWorker::run() — DistWorker as sub-worker of a higher level (placeholder)
 // =============================================================================
 
-void DistWorker::run(const WorkerPayload & /*payload*/) {
-    // Full L4+ support: payload would carry a HostTask* to execute.
-    // Placeholder for plan step F.
+void DistWorker::run(uint64_t /*callable*/, TaskArgsView /*args*/, const ChipCallConfig & /*config*/) {
+    // Full L4+ support: `callable` decodes to an orch-fn handle; Worker::run
+    // opens a fresh scope, invokes the orch fn on its own Orchestrator,
+    // drains, and closes the scope. Placeholder for plan step F.
 }

--- a/src/common/distributed/dist_worker.h
+++ b/src/common/distributed/dist_worker.h
@@ -81,7 +81,7 @@ public:
 
     // IWorker — used when this DistWorker is itself a sub-worker of L4+.
     // Placeholder for recursive composition; filled in by plan step F.
-    void run(const WorkerPayload &payload) override;
+    void run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) override;
 
 private:
     int32_t level_;

--- a/src/common/distributed/dist_worker_manager.cpp
+++ b/src/common/distributed/dist_worker_manager.cpp
@@ -11,22 +11,27 @@
 
 #include "dist_worker_manager.h"
 
+#include <stdexcept>
+
+#include "dist_ring.h"
+
 // =============================================================================
 // WorkerThread
 // =============================================================================
 
-void WorkerThread::start(IWorker *worker, const std::function<void(DistTaskSlot)> &on_complete) {
+void WorkerThread::start(IWorker *worker, DistRing *ring, const std::function<void(DistTaskSlot)> &on_complete) {
     worker_ = worker;
+    ring_ = ring;
     on_complete_ = on_complete;
     shutdown_ = false;
     idle_.store(true, std::memory_order_relaxed);
     thread_ = std::thread(&WorkerThread::loop, this);
 }
 
-void WorkerThread::dispatch(const WorkerPayload &payload) {
+void WorkerThread::dispatch(WorkerDispatch d) {
     idle_.store(false, std::memory_order_release);
     std::lock_guard<std::mutex> lk(mu_);
-    queue_.push(payload);
+    queue_.push(d);
     cv_.notify_one();
 }
 
@@ -41,20 +46,28 @@ void WorkerThread::stop() {
 
 void WorkerThread::loop() {
     while (true) {
-        WorkerPayload payload;
+        WorkerDispatch d;
         {
             std::unique_lock<std::mutex> lk(mu_);
             cv_.wait(lk, [this] {
                 return !queue_.empty() || shutdown_;
             });
             if (queue_.empty()) break;  // shutdown
-            payload = queue_.front();
+            d = queue_.front();
             queue_.pop();
         }
 
-        worker_->run(payload);  // blocking in this thread
+        // Resolve callable / args / config from the slot. For NEXT_LEVEL
+        // tasks `callable` is the ChipCallable buffer pointer; for SUB
+        // tasks it encodes the registry id in the low 32 bits. The view
+        // is a zero-copy handle over the slot's vector-backed TaskArgs.
+        DistTaskSlotState &s = *ring_->slot_state(d.task_slot);
+        uint64_t callable = (s.worker_type == WorkerType::SUB) ? static_cast<uint64_t>(s.callable_id) : s.callable;
+        TaskArgsView view = s.args_view(d.group_index);
+
+        worker_->run(callable, view, s.config);  // blocking in this thread
         idle_.store(true, std::memory_order_release);
-        on_complete_(payload.task_slot);  // notify Scheduler
+        on_complete_(d.task_slot);  // notify Scheduler
     }
 }
 
@@ -66,12 +79,13 @@ void DistWorkerManager::add_next_level(IWorker *worker) { next_level_workers_.pu
 
 void DistWorkerManager::add_sub(IWorker *worker) { sub_workers_.push_back(worker); }
 
-void DistWorkerManager::start(const OnCompleteFn &on_complete) {
+void DistWorkerManager::start(DistRing *ring, const OnCompleteFn &on_complete) {
+    if (ring == nullptr) throw std::invalid_argument("DistWorkerManager::start: null ring");
     auto make_threads = [&](const std::vector<IWorker *> &workers,
                             std::vector<std::unique_ptr<WorkerThread>> &threads) {
         for (IWorker *w : workers) {
             auto wt = std::make_unique<WorkerThread>();
-            wt->start(w, on_complete);
+            wt->start(w, ring, on_complete);
             threads.push_back(std::move(wt));
         }
     };

--- a/src/common/distributed/dist_worker_manager.h
+++ b/src/common/distributed/dist_worker_manager.h
@@ -15,6 +15,11 @@
  * Owns WorkerThread instances (one per registered IWorker).
  * Provides idle-worker selection and dispatch to the Scheduler.
  * The Scheduler drives the DAG; the Manager drives the workers.
+ *
+ * Each WorkerThread carries a `WorkerDispatch` queue (slot id + group
+ * sub-index); on dispatch the thread reads `callable` / `task_args` /
+ * `config` from the ring's slot pool and builds a `TaskArgsView` on
+ * demand. The old `WorkerPayload` dispatch carrier is gone (PR-C).
  */
 
 #pragma once
@@ -30,6 +35,21 @@
 
 #include "dist_types.h"
 
+class DistRing;  // forward decl — owns the slot state pool
+
+// =============================================================================
+// WorkerDispatch — per-dispatch handle handed to a WorkerThread.
+// =============================================================================
+//
+// `task_slot` is the slot id; `group_index` is 0 for single tasks and
+// 0..group_size-1 for group members. The thread resolves callable / args /
+// config by reading `ring->slot_state(task_slot)`.
+
+struct WorkerDispatch {
+    DistTaskSlot task_slot{DIST_INVALID_SLOT};
+    int32_t group_index{0};
+};
+
 // =============================================================================
 // WorkerThread — gives one IWorker its own execution thread
 // =============================================================================
@@ -41,12 +61,14 @@ public:
     WorkerThread(const WorkerThread &) = delete;
     WorkerThread &operator=(const WorkerThread &) = delete;
 
-    // Start the worker thread.
+    // Start the worker thread. `ring` is a borrowed pointer to the engine's
+    // slot-state pool — the thread reads callable/args/config from
+    // `ring->slot_state(task_slot)` on each dispatch.
     // on_complete(slot) is called (in the WorkerThread) after each run().
-    void start(IWorker *worker, const std::function<void(DistTaskSlot)> &on_complete);
+    void start(IWorker *worker, DistRing *ring, const std::function<void(DistTaskSlot)> &on_complete);
 
-    // Enqueue a task for the worker.  Non-blocking.
-    void dispatch(const WorkerPayload &payload);
+    // Enqueue a dispatch for the worker. Non-blocking.
+    void dispatch(WorkerDispatch d);
 
     // True if the worker has no active task.
     bool idle() const { return idle_.load(std::memory_order_acquire); }
@@ -55,10 +77,11 @@ public:
 
 private:
     IWorker *worker_{nullptr};
+    DistRing *ring_{nullptr};
     std::function<void(DistTaskSlot)> on_complete_;
 
     std::thread thread_;
-    std::queue<WorkerPayload> queue_;
+    std::queue<WorkerDispatch> queue_;
     std::mutex mu_;
     std::condition_variable cv_;
     bool shutdown_{false};
@@ -78,9 +101,10 @@ public:
     void add_next_level(IWorker *worker);
     void add_sub(IWorker *worker);
 
-    /// Start all WorkerThreads. on_complete is called (from the WorkerThread)
-    /// after each task finishes — the Scheduler hooks into this.
-    void start(const OnCompleteFn &on_complete);
+    /// Start all WorkerThreads. `ring` is the engine's slot-state pool;
+    /// WorkerThreads read slot state from it at dispatch time.
+    /// on_complete is called (from the WorkerThread) after each task finishes.
+    void start(DistRing *ring, const OnCompleteFn &on_complete);
 
     /// Stop and join all WorkerThreads.
     void stop();

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -187,12 +187,13 @@ void ChipWorker::finalize() {
     finalized_ = true;
 }
 
-void ChipWorker::run(const WorkerPayload &payload) {
-    ChipCallConfig config;
-    config.block_dim = payload.block_dim;
-    config.aicpu_thread_num = payload.aicpu_thread_num;
-    config.enable_profiling = payload.enable_profiling;
-    run(payload.callable, payload.args, config);
+void ChipWorker::run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) {
+    // L2 ABI edge: assemble the fixed-size ChipStorageTaskArgs POD from the
+    // view and hand it to the runtime. This conversion used to happen at
+    // submit time (stored on the slot); it now runs lazily in the worker so
+    // the slot can carry a single TaskArgs irrespective of the destination.
+    ChipStorageTaskArgs chip_storage = view_to_chip_storage(args);
+    run(reinterpret_cast<const void *>(callable), &chip_storage, config);
 }
 
 void ChipWorker::run(const void *callable, const void *args, const ChipCallConfig &config) {

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "../task_interface/chip_call_config.h"
+#include "../task_interface/task_args.h"
 #include "dist_types.h"
 
 class ChipWorker : public IWorker {
@@ -46,10 +47,13 @@ public:
     /// Terminal — the object cannot be reused after this.
     void finalize();
 
-    // IWorker: extract callable/args/config from payload and execute synchronously.
-    void run(const WorkerPayload &payload) override;
+    // IWorker: build a ChipStorageTaskArgs POD from `args` and execute the
+    // runtime synchronously. `callable` is a ChipCallable buffer pointer
+    // cast to uint64.
+    void run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) override;
 
-    // Direct invocation (used by Python wrapper and internal tests).
+    // Direct invocation (used by Python wrapper and internal tests) — bypasses
+    // the TaskArgsView path and takes a ready-made ChipStorageTaskArgs POD.
     void run(const void *callable, const void *args, const ChipCallConfig &config);
 
     int device_id() const { return device_id_; }

--- a/tests/ut/cpp/test_dist_orchestrator.cpp
+++ b/tests/ut/cpp/test_dist_orchestrator.cpp
@@ -150,7 +150,7 @@ TEST_F(OrchestratorFixture, NoDepTagSkipsDependencyTracking) {
     EXPECT_EQ(S(b.task_slot).fanin_count, 0);
 }
 
-TEST_F(OrchestratorFixture, GroupTaskHasAllChipStorageEntries) {
+TEST_F(OrchestratorFixture, GroupTaskStoresArgsListPerMember) {
     TaskArgs a0 = single_tensor_args(0xA0, TensorArgType::OUTPUT);
     TaskArgs a1 = single_tensor_args(0xA1, TensorArgType::OUTPUT);
     auto res = orch.submit_next_level_group(0xDEAD, {a0, a1}, cfg);
@@ -158,16 +158,30 @@ TEST_F(OrchestratorFixture, GroupTaskHasAllChipStorageEntries) {
     EXPECT_NE(res.task_slot, DIST_INVALID_SLOT);
     EXPECT_TRUE(S(res.task_slot).is_group());
     EXPECT_EQ(S(res.task_slot).group_size(), 2);
-    EXPECT_EQ(S(res.task_slot).chip_storage_list.size(), 2u);
+    EXPECT_EQ(S(res.task_slot).task_args_list.size(), 2u);
+
+    // args_view(i) yields each member's distinct tensor list.
+    EXPECT_EQ(S(res.task_slot).args_view(0).tensors[0].data, 0xA0u);
+    EXPECT_EQ(S(res.task_slot).args_view(1).tensors[0].data, 0xA1u);
 
     // Both keys registered as producers for the group slot.
     EXPECT_EQ(tm.lookup(0xA0), res.task_slot);
     EXPECT_EQ(tm.lookup(0xA1), res.task_slot);
 }
 
+TEST_F(OrchestratorFixture, SingleTaskStoresTaskArgsDirectly) {
+    TaskArgs a0 = single_tensor_args(0xC0, TensorArgType::OUTPUT);
+    auto res = orch.submit_next_level(0xDEAD, a0, cfg);
+    ASSERT_NE(res.task_slot, DIST_INVALID_SLOT);
+    EXPECT_FALSE(S(res.task_slot).is_group());
+    EXPECT_EQ(S(res.task_slot).group_size(), 1);
+    EXPECT_EQ(S(res.task_slot).task_args.tensor_count(), 1);
+    EXPECT_EQ(S(res.task_slot).args_view(0).tensors[0].data, 0xC0u);
+}
+
 TEST_F(OrchestratorFixture, OutputAutoAllocsFromHeapRing) {
     // An OUTPUT tensor submitted with `data == 0` is auto-allocated from
-    // the HeapRing: the slot's chip_storage tensor ends up with a non-zero
+    // the HeapRing: the slot's task_args tensor ends up with a non-zero
     // data pointer that falls inside the allocator's mmap'd region, and
     // the TensorMap routes that pointer to the slot.
     TaskArgs args;
@@ -181,8 +195,7 @@ TEST_F(OrchestratorFixture, OutputAutoAllocsFromHeapRing) {
     auto res = orch.submit_next_level(0xDEAD, args, cfg);
     ASSERT_NE(res.task_slot, DIST_INVALID_SLOT);
 
-    const auto &chip = S(res.task_slot).chip_storage_list.front();
-    uint64_t data = chip.tensor(0).data;
+    uint64_t data = S(res.task_slot).task_args.tensor(0).data;
     ASSERT_NE(data, 0u);
     uintptr_t base = reinterpret_cast<uintptr_t>(allocator.heap_base());
     EXPECT_GE(data, base);

--- a/tests/ut/cpp/test_dist_scheduler.cpp
+++ b/tests/ut/cpp/test_dist_scheduler.cpp
@@ -11,8 +11,10 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <iterator>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -33,9 +35,9 @@
 
 struct MockWorker : public IWorker {
     struct Record {
-        DistTaskSlot slot;
-        WorkerType type;
-        const void *args;
+        uint64_t callable;
+        uint64_t tensor_key;              // tensors[0].data (unique per submit in tests)
+        const ContinuousTensor *tensors;  // backing pointer (distinct per group member)
     };
 
     std::vector<Record> dispatched;
@@ -46,10 +48,11 @@ struct MockWorker : public IWorker {
     std::atomic<bool> should_complete{false};
     std::atomic<bool> is_running{false};
 
-    void run(const WorkerPayload &p) override {
+    void run(uint64_t callable, TaskArgsView args, const ChipCallConfig & /*cfg*/) override {
         {
             std::lock_guard<std::mutex> lk(dispatched_mu);
-            dispatched.push_back({p.task_slot, p.worker_type, p.args});
+            uint64_t key = (args.tensor_count > 0) ? args.tensors[0].data : 0;
+            dispatched.push_back({callable, key, args.tensors});
         }
         is_running.store(true, std::memory_order_release);
 
@@ -120,7 +123,7 @@ struct SchedulerFixture : public ::testing::Test {
         orch.init(&tm, &allocator, &scope, &rq);
 
         manager.add_next_level(&mock_worker);
-        manager.start([this](DistTaskSlot slot) {
+        manager.start(&allocator, [this](DistTaskSlot slot) {
             sched.worker_done(slot);
         });
 
@@ -167,7 +170,8 @@ TEST_F(SchedulerFixture, IndependentTaskDispatchedAndConsumed) {
 
     mock_worker.wait_running();
     ASSERT_GE(mock_worker.dispatched_count(), 1);
-    EXPECT_EQ(mock_worker.dispatched[0].slot, slot);
+    EXPECT_EQ(mock_worker.dispatched[0].tensor_key, 0xCAFEu);
+    EXPECT_EQ(mock_worker.dispatched[0].callable, 0xDEADu);
 
     mock_worker.complete();
     wait_consumed(slot);
@@ -175,14 +179,14 @@ TEST_F(SchedulerFixture, IndependentTaskDispatchedAndConsumed) {
 
 TEST_F(SchedulerFixture, DependentTaskDispatchedAfterProducerCompletes) {
     auto args_a = single_tensor_args(0xBEEF, TensorArgType::OUTPUT);
-    auto a = orch.submit_next_level(0xDEAD, args_a, cfg);
+    auto a = orch.submit_next_level(0xAA, args_a, cfg);
 
     auto args_b = single_tensor_args(0xBEEF, TensorArgType::INPUT);
-    auto b = orch.submit_next_level(0xDEAD, args_b, cfg);
+    auto b = orch.submit_next_level(0xBB, args_b, cfg);
     EXPECT_EQ(S(b.task_slot).state.load(), TaskState::PENDING);
 
     mock_worker.wait_running();
-    EXPECT_EQ(mock_worker.dispatched[0].slot, a.task_slot);
+    EXPECT_EQ(mock_worker.dispatched[0].callable, 0xAAu);
     mock_worker.complete();  // A done
 
     auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(300);
@@ -190,10 +194,11 @@ TEST_F(SchedulerFixture, DependentTaskDispatchedAfterProducerCompletes) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     ASSERT_GE(mock_worker.dispatched_count(), 2);
-    EXPECT_EQ(mock_worker.dispatched[1].slot, b.task_slot);
+    EXPECT_EQ(mock_worker.dispatched[1].callable, 0xBBu);
 
     mock_worker.complete();  // B done
     wait_consumed(b.task_slot);
+    (void)a;
 }
 
 // ===========================================================================
@@ -223,7 +228,7 @@ struct GroupSchedulerFixture : public ::testing::Test {
 
         manager.add_next_level(&worker_a);
         manager.add_next_level(&worker_b);
-        manager.start([this](DistTaskSlot slot) {
+        manager.start(&allocator, [this](DistTaskSlot slot) {
             sched.worker_done(slot);
         });
 
@@ -271,13 +276,14 @@ TEST_F(GroupSchedulerFixture, GroupDispatchesToNWorkers) {
 
     EXPECT_EQ(worker_a.dispatched_count(), 1);
     EXPECT_EQ(worker_b.dispatched_count(), 1);
-    EXPECT_EQ(worker_a.dispatched[0].slot, slot);
-    EXPECT_EQ(worker_b.dispatched[0].slot, slot);
 
-    // Each worker got a different chip-storage pointer (slot.chip_storage_list[i])
-    EXPECT_NE(worker_a.dispatched[0].args, nullptr);
-    EXPECT_NE(worker_b.dispatched[0].args, nullptr);
-    EXPECT_NE(worker_a.dispatched[0].args, worker_b.dispatched[0].args);
+    // Each worker got a different TaskArgs from the slot's task_args_list.
+    uint64_t keys[2] = {worker_a.dispatched[0].tensor_key, worker_b.dispatched[0].tensor_key};
+    std::sort(std::begin(keys), std::end(keys));
+    EXPECT_EQ(keys[0], 0xA0u);
+    EXPECT_EQ(keys[1], 0xA1u);
+    EXPECT_NE(worker_a.dispatched[0].tensors, worker_b.dispatched[0].tensors);
+    (void)slot;
 
     worker_a.complete();
     worker_b.complete();


### PR DESCRIPTION
## Summary

- `IWorker::run(uint64_t callable, TaskArgsView args, ChipCallConfig)` replaces the `WorkerPayload` dispatch carrier. Each worker interprets `callable` per its semantics (ChipCallable ptr / registry id / orch-fn handle).
- `DistTaskSlotState` drops `chip_storage_list` in favour of `TaskArgs` (single) / `task_args_list` (N-SPMD group) + `is_group_` flag. `slot.args_view(i)` is a zero-copy `TaskArgsView`. `callable_ptr` renames to `callable`.
- `view_to_chip_storage` moves from submit into `ChipWorker::run` — the L2 ABI POD is assembled lazily at the worker.
- PROCESS-mode mailbox writes a length-prefixed blob via `write_blob`; the Python child decodes it through a new `_ChipWorker.run_from_blob` binding that rebuilds the `ChipStorageTaskArgs` POD on the child heap.
- `WorkerThread` queue now carries `WorkerDispatch { slot, group_index }`; the thread resolves slot state via `ring->slot_state(id)`. Scheduler pushes N dispatches per group member.
- Strict-1 per-scope rings were split out into a separate PR-Scope (plan revision 2026-04-15) that also exposes user-facing `scope_begin` / `scope_end`. PR-C intentionally does not touch ring partitioning.

## Docs

`docs/roadmap.md`, `docs/scheduler.md`, `docs/worker-manager.md`, `docs/task-flow.md`, and the PR-C entry in the plan are updated to match the new dispatch surface, slot shape, and PR-Scope split.

## Test plan

- [x] Python unit tests pass: `pytest tests/ut/py/test_dist_worker/` (18/18)
- [x] C++ unit tests pass: `ctest` in `build/ut_cpp` (7/7 — ring, scope, tensormap, orchestrator, scheduler, pto2_fatal × 2)
- [x] `pip install --no-build-isolation -e .` builds cleanly
- [x] `grep -r WorkerPayload src/ python/` returns only historical doc references (all source clean)
- [x] `grep -r chip_storage_list src/ python/` returns 0 matches
- [ ] Hardware / sim scene tests (not run locally — need device)