### PR TITLE
Fix: guard idle-dispatch do-while against empty cluster mask

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1827,6 +1827,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                     }
 
                     // Dispatch as many blocks as possible for this task using available clusters.
+                    // Guard: a preceding task in this batch may have drained all clusters;
+                    // re-enqueue the rest of the batch instead of popping an empty mask.
+                    if (!valid_cluster_states.has_value()) {
+                        rt->scheduler.ready_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi);
+                        break;
+                    }
                     // For block_num=1 the inner body executes exactly once (no overhead).
                     do {
                         auto current_valid_cluster_offset = valid_cluster_states.pop_first();

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1810,6 +1810,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                     }
 
                     // Dispatch as many blocks as possible for this task using available clusters.
+                    // Guard: a preceding task in this batch may have drained all clusters;
+                    // re-enqueue the rest of the batch instead of popping an empty mask.
+                    if (!valid_cluster_states.has_value()) {
+                        rt->scheduler.ready_queues[static_cast<int32_t>(shape)].push_batch(&batch[bi], got - bi);
+                        break;
+                    }
                     // For block_num=1 the inner body executes exactly once (no overhead).
                     do {
                         auto current_valid_cluster_offset = valid_cluster_states.pop_first();

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/aic/kernel_write.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/aic/kernel_write.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * AIC kernel: writes float(block_idx) at cache line (base_cl + block_idx*3 + 0).
+ *
+ * Args:
+ *   args[0] = output Tensor* (INOUT)
+ *   args[1] = scalar: base_cl
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+static constexpr int32_t SLOTS_PER_BLOCK = 3;
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int32_t base_cl = static_cast<int32_t>(args[1]);
+    int32_t block_idx = get_block_idx(args);
+    int32_t offset = (base_cl + block_idx * SLOTS_PER_BLOCK + 0) * FLOATS_PER_CACHE_LINE;
+
+    out[offset] = static_cast<float>(block_idx);
+
+    dcci(&out[offset], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/aiv/kernel_write.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/aiv/kernel_write.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * AIV kernel: writes float(block_idx) at cache line
+ *   (base_cl + block_idx*3 + 1 + sub_block_id).
+ *
+ * Args:
+ *   args[0] = output Tensor* (INOUT)
+ *   args[1] = scalar: base_cl
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+static constexpr int32_t FLOATS_PER_CACHE_LINE = 16;
+static constexpr int32_t SLOTS_PER_BLOCK = 3;
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int32_t base_cl = static_cast<int32_t>(args[1]);
+    int32_t block_idx = get_block_idx(args);
+    int32_t sub_block_id = get_sub_block_id(args);
+    int32_t offset = (base_cl + block_idx * SLOTS_PER_BLOCK + 1 + sub_block_id) * FLOATS_PER_CACHE_LINE;
+
+    out[offset] = static_cast<float>(block_idx);
+
+    dcci(&out[offset], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Regression test for batch dispatch OOB (issue #565).
+ *
+ * Submits two MIX tasks with block_num=48 back-to-back so they are both
+ * in the ready queue when the scheduler runs pop_ready_tasks_batch.
+ *
+ * Args layout: [output]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_AIC 0
+#define FUNC_AIV0 1
+#define FUNC_AIV1 2
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 1,
+    };
+}
+
+static void submit_spmd_mix(Tensor &out, int16_t block_num, int64_t base_cl) {
+    MixedKernels mk;
+    mk.aic_kernel_id = FUNC_AIC;
+    mk.aiv0_kernel_id = FUNC_AIV0;
+    mk.aiv1_kernel_id = FUNC_AIV1;
+
+    Arg args;
+    args.add_inout(out);
+    args.add_scalar(base_cl);
+    args.launch_spec.set_block_num(block_num);
+    pto2_rt_submit_task(mk, args);
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+
+    // Two back-to-back tasks with block_num=48 (2x cluster count).
+    // Both land in the ready queue simultaneously, triggering got=2 in
+    // pop_ready_tasks_batch — the scenario that causes OOB without the fix.
+    submit_spmd_mix(ext_output, 48, 0);
+    submit_spmd_mix(ext_output, 48, 144);
+
+    LOG_ALWAYS("[spmd_batch_dispatch_oob] Submitted 2 MIX tasks: block_num=48,48");
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/test_spmd_batch_dispatch_oob.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/test_spmd_batch_dispatch_oob.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Regression test for batch dispatch OOB (issue #565).
+
+Submits two back-to-back MIX tasks each with block_num=48 (>> 24 clusters).
+When both tasks enter the ready queue simultaneously, pop_ready_tasks_batch
+returns got=2.  Without the fix, the first task's do-while drains all idle
+clusters, and the second task's do-while calls pop_first() on an empty mask,
+returning -1 as cluster_offset — an out-of-bounds array index.
+
+Each block writes float(block_idx) at 3 cache lines (AIC, AIV0, AIV1).
+Output tensor: 2 * 48 * 3 = 288 cache lines = 4608 float32.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+FLOATS_PER_CACHE_LINE = 16
+SLOTS_PER_BLOCK = 3
+TASKS = [(48, 0), (48, 144)]
+TOTAL_CL = sum(bn * SLOTS_PER_BLOCK for bn, _ in TASKS)
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestSpmdBatchDispatchOob(SceneTestCase):
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT],
+        },
+        "incores": [
+            {"func_id": 0, "source": "kernels/aic/kernel_write.cpp", "core_type": "aic"},
+            {"func_id": 1, "source": "kernels/aiv/kernel_write.cpp", "core_type": "aiv"},
+            {"func_id": 2, "source": "kernels/aiv/kernel_write.cpp", "core_type": "aiv"},
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "Case1",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 24},
+            "params": {},
+        }
+    ]
+
+    def generate_args(self, params):
+        return TaskArgsBuilder(Tensor("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)))
+
+    def compute_golden(self, args, params):
+        out = args.output
+        for block_num, base_cl in TASKS:
+            for block_idx in range(block_num):
+                for slot in range(SLOTS_PER_BLOCK):
+                    cl = base_cl + block_idx * SLOTS_PER_BLOCK + slot
+                    out[cl * FLOATS_PER_CACHE_LINE] = float(block_idx)
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## Summary

Fixes #565 — out-of-bounds `core_id_map_[-1]` access in the idle-dispatch batch loop.

- When `pop_ready_tasks_batch` returns multiple tasks (`got > 1`) and the first task's do-while drains all idle clusters (common when `logical_block_num >> cluster_count`, e.g. paged-attention with block_num=256 on 24 clusters), subsequent tasks enter the do-while unconditionally — because `do { ... } while(...)` executes the body before checking the guard — calling `pop_first()` on an empty bitmask, which returns -1
- `-1` is used as `cluster_offset` → `core_id_map_[-1]` (OOB read) and `1ULL << -1` (undefined shift), corrupting `core_states_` and stalling the scheduler
- **Fix**: add `has_value()` guard before the do-while; when clusters are exhausted mid-batch, re-enqueue the current and remaining tasks and `break`. Zero overhead on the common path (single predicted-taken branch)
- Applied to both `a2a3` and `a5` variants

## Test plan

- [x] New test `spmd_batch_dispatch_oob`: submits 2 back-to-back MIX tasks with `block_num=48` (2x cluster count) to force `got=2` and trigger the OOB scenario — passes with fix, would crash/stall without
- [x] Existing `spmd_multiblock_mix` test: passes (no regression)
- [ ] Hardware device test on a2a3