### PR TITLE
Refactor: partition DistRing into 4 per-scope rings, expose user scope API

### DIFF
--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -119,7 +119,7 @@ SubmitResult Orchestrator::submit_next_level(Callable cb,
 
 ### Step details
 
-**Step 1 — `ring_.alloc()`**: See [§5 Ring](#5-ring-slot--heap-allocator). Blocks the Orch thread
+**Step 1 — `ring_.alloc()`**: See [§5 Ring](#5-ring-slot--per-scope-heap-allocator). Blocks the Orch thread
 if all slots are in-flight; this is the system's back-pressure mechanism.
 
 **Step 2 — store task data**: `TaskArgs` is moved (not copied). `config` is a
@@ -246,137 +246,201 @@ SubmitResult Orchestrator::submit_sub(Callable cb, TaskArgs args, const CallConf
 
 ---
 
-## 5. Ring (slot + heap allocator)
+## 5. Ring (slot + per-scope heap allocator)
 
 `DistRing` owns three correlated per-task resources:
 
-1. A **monotonic task id** — allocated by the Orchestrator, incremented
-   on every `alloc()`. There is no fixed window and no modulo wrap at
-   L3: slot state lives in parent-process heap (never crossed into
-   child workers), so the ring index L2 uses to address shmem
-   descriptors buys us nothing here (see plan Allowed Exception #6).
-   A monotonic `int32_t` gives ~2 billion ids per `reset_to_empty()`
-   interval, reset back to 0 at the end of every `Worker.run()`.
-2. A **shared-memory heap slab** — bump-allocated under the same mutex,
-   FIFO-reclaimed via `last_alive_`. This still mirrors L2 (Strict-2):
-   the heap must be `mmap(MAP_SHARED)` and forked into child workers,
-   so it has to be pre-sized. `heap_ring_size` on the Worker ctor
-   controls the total bytes (default 1 GiB).
-3. The **per-task slot state** (`DistTaskSlotState`) — stored in a
-   `std::deque<std::unique_ptr<...>>`. `std::deque::push_back` never
-   invalidates pointers to existing elements, so the pointer returned
-   by `slot_state(id)` stays valid until `reset_to_empty()` drops the
-   whole deque.
+1. A **monotonic task id** — allocated on every `alloc()`, shared across
+   all rings. There is no fixed window and no modulo wrap at L3: slot
+   state lives in parent-process heap (never crossed into child workers),
+   so the ring index L2 uses to address shmem descriptors buys us nothing
+   here (see plan Allowed Exception #6). A monotonic `int32_t` gives ~2
+   billion ids per `reset_to_empty()` interval, reset to 0 at the end of
+   every `Worker.run()`.
+2. **`DIST_MAX_RING_DEPTH = 4` independent shared-memory heap slabs**
+   (Strict-1; matches L2's `PTO2_MAX_RING_DEPTH`). Each slab has its own
+   `mmap(MAP_SHARED | MAP_ANONYMOUS)` region, bump cursor, FIFO
+   reclamation pointer, and mutex / cv. A task's ring is chosen by
+   **scope depth**:
+
+   ```cpp
+   ring_idx = std::min(scope_depth, DIST_MAX_RING_DEPTH - 1);
+   ```
+
+   so nested-scope tasks never share a FIFO head with outer-scope
+   long-lived allocations. The mapping is taken in the Worker ctor —
+   *before* any fork — so forked child workers inherit every ring at
+   the same virtual address range. `heap_ring_size` on the Worker ctor
+   is the **per-ring** size (default 1 GiB → 4 GiB total VA reservation;
+   physical pages stay lazy).
+3. The **per-task slot state** (`DistTaskSlotState`) — stored in a single
+   `std::deque<std::unique_ptr<...>>` shared across rings. Each slot
+   records its `ring_idx` and `ring_slot_idx` (position within that
+   ring's FIFO order). `std::deque::push_back` never invalidates pointers
+   to existing elements, so the pointer returned by `slot_state(id)`
+   stays valid until `reset_to_empty()` drops the whole deque.
 
 ```cpp
 struct DistAllocResult {
     TaskSlot slot;
     void    *heap_ptr;          // nullptr when alloc(0)
-    uint64_t heap_end_offset;   // recorded per-slot for FIFO reclamation
+    uint64_t heap_end_offset;   // byte offset within the selected ring
+    int32_t  ring_idx;          // which of the DIST_MAX_RING_DEPTH rings was used
 };
 
 class DistRing {
 public:
-    void  init(uint64_t heap_bytes,       // default 1 GiB, Worker-configurable
-               uint32_t timeout_ms);      // default 10 s
+    // Initialise DIST_MAX_RING_DEPTH heap rings, each of heap_bytes.
+    // Total VA = DIST_MAX_RING_DEPTH * heap_bytes.
+    void init(uint64_t heap_bytes,       // per-ring, default 1 GiB
+              uint32_t timeout_ms);      // default 10 s
 
-    DistAllocResult      alloc(uint64_t bytes = 0);  // blocks on heap full, throws on timeout
-    void                 release(TaskSlot sid);      // FIFO-advances last_alive
-    DistTaskSlotState   *slot_state(TaskSlot sid);   // pointer-stable until reset_to_empty
-    void                 reset_to_empty();           // drop per-task state at drain boundary
-    void                 shutdown();
+    // Pick ring = min(scope_depth, DIST_MAX_RING_DEPTH - 1); reserve a
+    // slab from that ring (blocks on its cv) and stamp the slot state
+    // with ring_idx / ring_slot_idx.
+    DistAllocResult alloc(uint64_t bytes = 0, int32_t scope_depth = 0);
+    void            release(TaskSlot sid);      // FIFO-advances THAT slot's ring
+    DistTaskSlotState *slot_state(TaskSlot sid);
+    void            reset_to_empty();           // rewinds every ring
+    void            shutdown();
 
-    void    *heap_base()  const;
-    uint64_t heap_size()  const;
+    // Per-ring introspection
+    void    *heap_base(int32_t ring_idx) const;
+    uint64_t heap_size(int32_t ring_idx) const;
+    uint64_t heap_top (int32_t ring_idx) const;
+    uint64_t heap_tail(int32_t ring_idx) const;
 };
 ```
 
-**Back-pressure rationale**: only the heap can be full at L3. `alloc()`
-spin-waits on a cv; if `timeout_ms` elapses with no progress, it throws
-`std::runtime_error`. That surfaces as a Python exception so users can
-enlarge `heap_ring_size` on the `Worker` instead of deadlocking.
+**Back-pressure is per-ring**: only the selected ring's heap can be full
+for a given `alloc()`. `alloc()` spin-waits on that ring's cv while
+other rings remain fully usable; if `timeout_ms` elapses with no
+progress, it throws `std::runtime_error`. That surfaces as a Python
+exception so users can enlarge `heap_ring_size` on the `Worker` instead
+of deadlocking.
 
 **Alignment**: every heap allocation is rounded up to `DIST_HEAP_ALIGN = 1024 B`
 (matches L2's `PTO2_PACKED_OUTPUT_ALIGN`, Strict-3).
 
-**Heap mapping**: the heap region is a single `mmap(MAP_SHARED | MAP_ANONYMOUS)`
-taken in the `DistWorker` ctor — *before* any fork — so forked child workers
-inherit the same virtual address range.
+**FIFO reclamation per ring**: each `alloc()` appends the slot's
+`heap_end_offset` onto the selected ring's `slot_heap_end[]` vector, and
+pushes a `released=0` byte. `release(slot)` looks up the slot's ring via
+`slot.ring_idx` and advances **that ring's** `last_alive` as long as the
+next-oldest in-ring slot is released, walking the ring's `heap_tail`
+forward. Rings never touch each other — inner-scope tasks reclaim
+without waiting for an outer-scope task to finish.
 
-**FIFO reclamation**: each `alloc()` records the slot's `heap_end_offset`.
-`release(slot)` flags that slot consumed and advances `last_alive_` as long
-as the next-oldest slot is also released, walking the `heap_tail_` forward
-accordingly. Heap space is reclaimed implicitly; no per-slot `munmap` runs.
+**End-of-run reset**: `DistOrchestrator::drain()` waits for
+`active_tasks_` to hit 0, then calls `ring.reset_to_empty()` which
+drops the whole slot-state deque *and* rewinds every ring's cursors /
+`released[]` / `slot_heap_end[]` back to 0. Memory per `Worker.run()`
+is bounded by that run's peak alive task count; nothing accumulates
+across runs.
 
-**End-of-run reset**: `DistOrchestrator::drain()` waits for `active_tasks_`
-to hit 0, then calls `ring.reset_to_empty()` which clears the deque of
-slot states, zeroes the heap cursors, and resets `next_task_id_` to 0.
-Memory per `Worker.run()` is bounded by that run's peak alive task count;
-nothing accumulates across runs.
+**Locking**: each ring has its own `mu` / `cv`; the shared
+`next_task_id_` and slot deque are guarded by a separate `slots_mu_`.
+`alloc()` holds ring.mu (back-pressure wait + reserve in-ring position),
+releases it, then takes `slots_mu_` briefly to publish the new slot —
+no nested locking. `reset_to_empty()` takes `slots_mu_` first and each
+ring's mu sequentially (nested, outer is `slots_mu_`); readers that
+need both lock in the same order.
 
 **Ownership by role**:
 
 | Field | Writer | Reader |
 | ----- | ------ | ------ |
-| `next_task_id_`, `heap_top_` | Orch (`alloc`, under `mu_`) | Allocator only |
-| `last_alive_`, `heap_tail_`, `released_[]` | `release` (scheduler or Orch thread) | Allocator only |
-| `slot_heap_end_[]`, `slot_states_[]` | Orch at alloc | `release` / `slot_state()` readers |
-
-All shared state is guarded by a single mutex. The Orch thread is the only
-writer of `next_task_id_` / `heap_top_`, so the mutex serves primarily to
-coordinate with `release` and to protect the back-pressure condition
-variable. `slot_state()` takes the mutex briefly to read the deque cell, but
-the returned pointer is safe to dereference without the mutex because
-`std::deque::push_back` doesn't invalidate existing elements.
+| `next_task_id_`, `slot_states_` | `alloc` under `slots_mu_` | `slot_state`, `next_task_id`, `reset_to_empty` |
+| `rings_[r].top`, `rings_[r].released[]`, `rings_[r].slot_heap_end[]` | `alloc` under `rings_[r].mu` | `release` under `rings_[r].mu`, introspection accessors |
+| `rings_[r].tail`, `rings_[r].last_alive` | `release` under `rings_[r].mu` | same; `reset_to_empty` |
+| `slot.ring_idx`, `slot.ring_slot_idx` | `alloc` (stamped before return) | `release` |
 
 ---
 
 ## 6. Scope
 
-Scope solves: **"how do we release a task's ring slot if it has no downstream
-consumer?"**
+Scope solves two concerns at once:
 
-Every slot has a `fanout_total` counter: the number of outstanding references
-(downstream consumers + any scope refs). A slot transitions to `CONSUMED`
-(ring slot freed) only when `fanout_total == fanout_released`.
+1. **Lifetime anchoring** — release a task's ring slot even when it has no
+   downstream consumer, so leaf tasks don't strand heap bytes.
+2. **Per-scope reclamation** — tasks submitted inside an inner scope bind
+   to a deeper HeapRing (§5), so a long-lived outer-scope task cannot hold
+   the FIFO head against inner-scope churn.
+
+Every slot has a `fanout_total` counter: the number of outstanding
+references (downstream consumers + any scope refs). A slot transitions to
+`CONSUMED` (slot + heap slab freed) only when `fanout_released` meets the
+threshold (`>= total + 1`; see §8 fanout-release threshold).
 
 Without scope, a leaf task (no consumers, `fanout_total = 0`) would reach
-COMPLETED but never transition further — but then all its outputs have been
-observed at the earliest moment, so it's actually fine in this degenerate
-case. The problem appears when user code does this:
-
-```python
-def my_orch(orch, args, cfg):
-    r = orch.submit_next_level(...)    # produces tensor X
-    # no one consumes X within this DAG
-    # without scope: slot stays, ring fills up eventually
-```
-
-Scope adds a deferred reference that releases at `scope_end`:
+COMPLETED but never transition further. Scope adds a deferred reference
+that releases at `scope_end`:
 
 ```cpp
-class Scope {
+class DistScope {
 public:
-    void scope_begin();
-    void scope_end(const std::function<void(TaskSlot)> &release_ref);
-    void register_task(TaskSlot sid);       // called by Orchestrator.submit_*
+    void    scope_begin();
+    void    scope_end(const std::function<void(TaskSlot)> &release_ref);
+    void    register_task(TaskSlot sid);    // called by Orchestrator.submit_*
+    int32_t depth()         const;          // 1-based: 0 = no open scope
+    int32_t current_depth() const;          // 0-based: L2-style; used for ring selection
 private:
-    std::vector<std::vector<TaskSlot>> depth_;   // stack of scope levels
+    std::vector<std::vector<TaskSlot>> stack_;
 };
 ```
 
+`Worker::run` always opens one outer scope; user orch fns may nest up to
+`DIST_MAX_SCOPE_DEPTH = 64` additional scopes on top. Ring selection uses
+the 0-based `current_depth()`:
+
+| Where you are | `depth()` | `current_depth()` | Ring |
+| ------------- | --------- | ----------------- | ---- |
+| outer (Worker.run-only) scope | 1 | 0 | 0 |
+| `with orch.scope():` | 2 | 1 | 1 |
+| nested x 2 | 3 | 2 | 2 |
+| nested x 3 | 4 | 3 | 3 |
+| nested x 4 or deeper | >= 5 | >= 4 | 3 (clamp) |
+
 Flow:
 
-1. `scope_begin` pushes an empty vector onto the depth stack
-2. Each `submit_*` calls `scope.register_task(sid)`, appending to the top
-   vector and bumping `slots_[sid].fanout_total` by 1
-3. `scope_end` pops the top vector; for each `sid`, releases the scope ref
-   (`release_ref(sid)` decrements `fanout_total` bookkeeping and may
-   transition the slot to CONSUMED)
+1. `scope_begin` pushes an empty frame onto `stack_`.
+2. Each `submit_*` calls `scope.register_task(sid)`; the Orchestrator
+   has already set `slot.fanout_total = scope_ref` (1 when `depth() > 0`)
+   and stamped `slot.ring_idx = dist_ring_idx_for_scope(current_depth())`
+   before the call.
+3. `scope_end` pops the frame; for each `sid`, invokes the release
+   callback (`Orchestrator::release_ref`) which bumps `fanout_released`
+   by 1 and transitions the slot to CONSUMED if the threshold is met.
 
-Nested scopes are supported (the stack structure). For now only `Worker::run`
-opens a single top-level scope; nested scopes would be a future extension for
-explicit user scoping.
+### User-facing API
+
+```python
+def my_orch(orch, args, cfg):
+    with orch.scope():                             # ring 1
+        orch.submit_next_level(chip_a, a_args, cfg)
+        orch.submit_next_level(chip_b, b_args, cfg)
+    # Inner tasks are now eligible for reclamation on ring 1,
+    # without waiting for any outer-scope task.
+    orch.submit_next_level(chip_c, c_args, cfg)    # ring 0 (outer)
+```
+
+`with orch.scope():` is the recommended form. Raw `orch.scope_begin()` /
+`orch.scope_end()` are exposed too, primarily for advanced use where the
+context manager would be awkward (e.g., scopes that span a user-level
+state machine).
+
+### Why `scope_end` is non-blocking
+
+`scope_end` walks the scope's tasks and bumps each one's `fanout_released`
+counter, then returns. A task whose `fanout_released` now meets the
+threshold transitions to CONSUMED inline; others stay COMPLETED / RUNNING /
+PENDING until the scheduler and consumers finish their own releases. This
+mirrors L2's `pto2_scope_end`.
+
+Users who need a synchronous wait for *all* in-flight tasks must call
+`drain()` (or let `Worker::run` finish — its outer `scope_end` is followed
+by `drain()` before the call returns). There is deliberately no
+per-scope drain primitive: the extra machinery (per-scope active counter
+and cv) would only pay for itself in patterns we do not have yet.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,12 +41,11 @@ get if I pip install `main` today", this page.
   `Orchestrator._scope_begin` / `_scope_end` / `_drain` are invoked by
   the Python `Worker.run` facade only.
 - **`orch.alloc(shape, dtype)`** — runtime-owned intermediate buffer
-  carved out of the Worker's HeapRing (a single
-  `mmap(MAP_SHARED | MAP_ANONYMOUS)` region taken in the `DistWorker`
-  ctor, before fork, inherited by child workers at the same virtual
-  address). Lifetime follows a synthetic task slot; the slab is
-  reclaimed implicitly by the allocator once all downstream consumers
-  have completed and `last_alive` sweeps over it (see
+  carved out of the Worker's HeapRing (per-scope ring chosen by the
+  caller's scope depth; see "Per-scope HeapRing" below). Lifetime
+  follows a synthetic task slot; the slab is reclaimed implicitly by
+  the allocator once all downstream consumers have completed and the
+  ring's `last_alive` sweeps over it (see
   [orchestrator.md](orchestrator.md) §8b).
 - **`OUTPUT` auto-allocation** — `OUTPUT`-tagged tensors submitted with
   `data == 0` are auto-allocated from the same HeapRing as part of the
@@ -59,11 +58,24 @@ get if I pip install `main` today", this page.
   (see [orchestrator.md](orchestrator.md) §8b "Tag semantics for
   write-after-write"). `OUTPUT_EXISTING` is never auto-allocated.
 - **`heap_ring_size` knob** — `Worker(level=3, heap_ring_size=...)`
-  selects the HeapRing size (default 1 GiB). The underlying
-  `DistWorker(level, heap_ring_size)` ctor also installs fork hygiene
-  (setenv of `OMP/BLIS/OPENBLAS/MKL_NUM_THREADS=1`, plus
+  selects the **per-ring** HeapRing size (default 1 GiB; total VA
+  reservation is `heap_ring_size * DIST_MAX_RING_DEPTH`). The
+  underlying `DistWorker(level, heap_ring_size)` ctor also installs
+  fork hygiene (setenv of `OMP/BLIS/OPENBLAS/MKL_NUM_THREADS=1`, plus
   `KMP_DUPLICATE_LIB_OK=TRUE` on macOS, and a `pthread_atfork` landing
   pad).
+- **Per-scope HeapRing (Strict-1) + user-facing nested scope** —
+  `DistRing` owns `DIST_MAX_RING_DEPTH = 4` independent HeapRing
+  instances, each its own `mmap(MAP_SHARED | MAP_ANONYMOUS)` taken
+  before fork. Ring selection is driven by scope depth
+  (`min(scope_depth, DIST_MAX_RING_DEPTH - 1)`); every ring has its own
+  `mu` / `cv` / `last_alive`, so inner-scope tasks reclaim independently
+  of outer-scope tasks. `Orchestrator::scope_begin` / `scope_end` are
+  now user-facing (bound on the nanobind `DistOrchestrator`); the
+  Python facade adds a `with orch.scope():` context manager. Outermost
+  scope is still opened by `Worker::run`. Max user nesting is
+  `DIST_MAX_SCOPE_DEPTH = 64`; scopes deeper than the ring depth share
+  the innermost ring.
 
 ### Dispatch internals
 
@@ -97,15 +109,6 @@ get if I pip install `main` today", this page.
 ---
 
 ## In flight / not yet landed
-
-### PR-Scope: user-facing nested scope + Strict-1 per-scope rings
-
-- Expose `Orchestrator.scope_begin` / `scope_end` to the user's orch fn
-  (allow nesting up to `DIST_MAX_SCOPE_DEPTH = 64`).
-- Refactor `DistRing` into `DIST_MAX_RING_DEPTH = 4` independent
-  HeapRing instances; `alloc_for_scope(depth)` picks one. Per-ring
-  `last_alive` so deeply nested scopes never contend on a single
-  reclamation pointer.
 
 ### PR-D: WorkerThread unification + per-shape ready queues
 

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -343,7 +343,7 @@ The mailbox layout, fork ordering, and child loop are in
 | `DistRing` slot-state pool (`std::deque<unique_ptr<TaskSlotState>>`) | parent heap | Orchestrator, Scheduler, WorkerThread parent side | monotonic task-id; reset at `Worker.run` drain |
 | `slot.task_args` (single) or `task_args_list[N]` (group, vector-backed) | parent heap | same | until slot reaches CONSUMED |
 | per-WT mailbox (PROCESS only) | shm MAP_SHARED | parent WorkerThread writes, child reads | lifetime of WorkerThread |
-| HeapRing (user OUTPUT auto-alloc + `orch.alloc`) | shm MAP_SHARED | output to user code; inherited by forked children | FIFO reclaimed via `last_alive` |
+| **HeapRing[0..3]** (user OUTPUT auto-alloc + `orch.alloc`) | **4 separate shm MAP_SHARED mmaps**, one per scope-layer ring | output to user code; inherited by forked children | per-ring FIFO via `rings_[r].last_alive`; scope depth picks the ring |
 | tensor data bytes (user-provided) | torch shm (`share_memory_()` or equiv) | kernel reads/writes | user-managed |
 | `Callable` target (ChipCallable / OrchFn / Python fn) | parent heap | child via fork COW | pre-fork registered |
 
@@ -353,6 +353,18 @@ Slot state lives inside `DistRing` as `std::deque<std::unique_ptr<…>>` so
 pointer for every live slot; `drain()` calls `ring.reset_to_empty()` to
 drop all slot state at the end of each `Worker.run`, bounding per-run
 memory.
+
+The HeapRing is **partitioned into `DIST_MAX_RING_DEPTH = 4` independent
+rings** (Strict-1; matches L2's `PTO2_MAX_RING_DEPTH`). Each ring is its
+own `mmap(MAP_SHARED | MAP_ANONYMOUS)` taken before fork, so children
+inherit all four at the same virtual addresses. The `heap_ring_size`
+knob on `Worker(...)` is the **per-ring** size (default 1 GiB → 4 GiB
+total VA reservation); physical pages remain lazy under
+`MAP_ANONYMOUS`. A task's ring is chosen by scope depth,
+`min(scope_depth, DIST_MAX_RING_DEPTH - 1)`, so inner-scope tasks
+reclaim independently of outer-scope tasks. See
+[orchestrator.md §5](orchestrator.md) for the allocator internals and
+[orchestrator.md §6](orchestrator.md) for the scope → ring mapping.
 
 **Child never reads the slot.** Child only sees:
 

--- a/python/bindings/dist_worker_bind.h
+++ b/python/bindings/dist_worker_bind.h
@@ -136,8 +136,19 @@ inline void bind_dist_worker(nb::module_ &m) {
             "Allocate an intermediate ContinuousTensor from the orchestrator's MAP_SHARED "
             "pool (visible to forked child workers). Lifetime: until the next Worker.run() call."
         )
-        // Internal lifecycle hooks invoked by Worker::run (Python facade) only.
-        // Not part of the user-facing orch-fn API.
+        // User-facing nested scope (Strict-1). Tasks submitted between
+        // `scope_begin` and `scope_end` bind to a heap ring chosen by the
+        // current nesting depth (`min(depth, DIST_MAX_RING_DEPTH - 1)`),
+        // reclaiming independently of outer-scope tasks. Non-blocking:
+        // `scope_end` releases scope refs and returns; use `_drain()` for
+        // a synchronous wait.
+        .def(
+            "scope_begin", &DistOrchestrator::scope_begin,
+            "Open a nested scope. Max nesting depth = DIST_MAX_SCOPE_DEPTH (64)."
+        )
+        .def("scope_end", &DistOrchestrator::scope_end, "Close the innermost scope. Non-blocking.")
+        // Aliases used by the Python `Worker.run` facade to open/close the
+        // outermost scope without looking like a user-facing API.
         .def("_scope_begin", &DistOrchestrator::scope_begin)
         .def("_scope_end", &DistOrchestrator::scope_end)
         .def(
@@ -201,4 +212,6 @@ inline void bind_dist_worker(nb::module_ &m) {
         );
 
     m.attr("DIST_DEFAULT_HEAP_RING_SIZE") = static_cast<uint64_t>(DIST_DEFAULT_HEAP_RING_SIZE);
+    m.attr("DIST_MAX_RING_DEPTH") = static_cast<int32_t>(DIST_MAX_RING_DEPTH);
+    m.attr("DIST_MAX_SCOPE_DEPTH") = static_cast<int32_t>(DIST_MAX_SCOPE_DEPTH);
 }

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -29,7 +29,8 @@ Scope/drain lifecycle is managed by ``Worker.run()``; users never call those
 directly.
 """
 
-from collections.abc import Sequence
+import contextlib
+from collections.abc import Iterator, Sequence
 from typing import Any, Optional
 
 from .task_interface import (
@@ -88,6 +89,44 @@ class Orchestrator:
     def submit_sub_group(self, callable_id: int, args_list: list):
         """Submit a group of SUB tasks (N TaskArgs → N workers, 1 DAG node)."""
         return self._o.submit_sub_group(int(callable_id), args_list)
+
+    # ------------------------------------------------------------------
+    # Nested scope (Strict-1 per-scope rings)
+    # ------------------------------------------------------------------
+    #
+    # Tasks and allocations inside a nested ``with orch.scope():`` bind to a
+    # deeper heap ring (``min(depth, DIST_MAX_RING_DEPTH-1)``) so their
+    # memory reclaims independently of the outer scope. ``scope_end`` is
+    # non-blocking — it releases scope refs and returns; call
+    # ``Worker.run``/``drain`` for a synchronous wait.
+    #
+    # Usage::
+    #
+    #     def my_orch(orch, args):
+    #         with orch.scope():
+    #             orch.submit_next_level(a, ...)
+    #             orch.submit_next_level(b, ...)
+    #         orch.submit_next_level(c, ...)   # back on outer-scope ring
+
+    def scope_begin(self) -> None:
+        self._o.scope_begin()
+
+    def scope_end(self) -> None:
+        self._o.scope_end()
+
+    @contextlib.contextmanager
+    def scope(self) -> Iterator["Orchestrator"]:
+        """Open a nested scope for the ``with`` block.
+
+        Tasks submitted inside the block use a deeper heap ring so they
+        reclaim independently of the outer scope (see Strict-1 in
+        ``.claude/plans/HIERARCHICAL_RUNTIME_REFACTOR.md``).
+        """
+        self._o.scope_begin()
+        try:
+            yield self
+        finally:
+            self._o.scope_end()
 
     def alloc(self, shape: Sequence[int], dtype: DataType) -> ContinuousTensor:
         """Allocate a runtime-managed intermediate buffer.

--- a/src/common/distributed/dist_orchestrator.cpp
+++ b/src/common/distributed/dist_orchestrator.cpp
@@ -54,7 +54,12 @@ ContinuousTensor DistOrchestrator::alloc(const std::vector<uint32_t> &shape, Dat
     // allocator as a slot-only claim — matches reserve_outputs_and_slot.
     // Skip tensormap registration when the returned heap_ptr is nullptr,
     // since 0 is the sentinel for "no tensor" in infer_deps.
-    DistAllocResult ar = allocator_->alloc(aligned);
+    //
+    // Inherit the caller's scope depth so alloc buffers land in the same
+    // ring as any tasks submitted inside that scope — an alloc inside a
+    // nested `with orch.scope():` uses the nested ring and reclaims
+    // independently of the outer ring (Strict-1).
+    DistAllocResult ar = allocator_->alloc(aligned, scope_->current_depth());
     if (ar.slot == DIST_INVALID_SLOT) {
         throw std::runtime_error("DistOrchestrator::alloc: allocator shutdown");
     }
@@ -244,7 +249,7 @@ DistAllocResult DistOrchestrator::reserve_outputs_and_slot(std::vector<TaskArgs>
         }
     }
 
-    DistAllocResult ar = allocator_->alloc(total_bytes);
+    DistAllocResult ar = allocator_->alloc(total_bytes, scope_->current_depth());
     if (ar.slot == DIST_INVALID_SLOT) return ar;
 
     // Hand slabs out in the same order we counted them.

--- a/src/common/distributed/dist_orchestrator.h
+++ b/src/common/distributed/dist_orchestrator.h
@@ -91,7 +91,18 @@ public:
     // Submit a group of SUB tasks: N args -> N workers, 1 DAG node.
     DistSubmitResult submit_sub_group(int32_t callable_id, const std::vector<TaskArgs> &args_list);
 
-    // Internal — invoked by Worker::run only.
+    // Open a nested scope. Every task submitted between this call and the
+    // matching `scope_end()` picks a heap ring based on the current scope
+    // depth (`min(depth, DIST_MAX_RING_DEPTH - 1)`) so its slab reclaims
+    // independently of the outer scope's slabs (Strict-1). `Worker::run`
+    // opens the outermost scope automatically; user orch fns may nest up
+    // to `DIST_MAX_SCOPE_DEPTH` additional scopes.
+    //
+    // Non-blocking: `scope_end` walks the scope's tasks and releases one
+    // ref per task, returning immediately. Actual CONSUMED transitions
+    // happen asynchronously as each task's consumer count reaches
+    // threshold (mirrors L2's `pto2_scope_end`). Callers that need a
+    // synchronous wait must call `drain()` separately.
     void scope_begin();
     void scope_end();
 

--- a/src/common/distributed/dist_ring.cpp
+++ b/src/common/distributed/dist_ring.cpp
@@ -17,107 +17,163 @@
 #include <stdexcept>
 
 DistRing::~DistRing() {
-    if (heap_mapped_ && heap_base_) {
-        munmap(heap_base_, heap_size_);
-        heap_base_ = nullptr;
-        heap_mapped_ = false;
+    for (HeapRing &r : rings_) {
+        if (r.mapped && r.base) {
+            munmap(r.base, r.size);
+            r.base = nullptr;
+            r.mapped = false;
+        }
     }
 }
 
 void DistRing::init(uint64_t heap_bytes, uint32_t timeout_ms) {
-    if (heap_mapped_) {
-        throw std::logic_error("DistRing::init called twice");
+    for (const HeapRing &r : rings_) {
+        if (r.mapped) {
+            throw std::logic_error("DistRing::init called twice");
+        }
     }
 
     timeout_ms_ = timeout_ms == 0 ? DIST_ALLOC_TIMEOUT_MS : timeout_ms;
 
-    next_task_id_ = 0;
-    last_alive_ = 0;
-    heap_top_ = 0;
-    heap_tail_ = 0;
-    shutdown_ = false;
+    {
+        std::lock_guard<std::mutex> lk(slots_mu_);
+        next_task_id_ = 0;
+        slot_states_.clear();
+    }
+    shutdown_.store(false, std::memory_order_relaxed);
 
-    released_.clear();
-    slot_heap_end_.clear();
-    slot_states_.clear();
+    for (HeapRing &r : rings_) {
+        r.top = 0;
+        r.tail = 0;
+        r.last_alive = 0;
+        r.released.clear();
+        r.slot_heap_end.clear();
 
-    if (heap_bytes > 0) {
-        heap_size_ = heap_bytes;
-        heap_base_ = mmap(nullptr, heap_size_, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-        if (heap_base_ == MAP_FAILED) {
-            heap_base_ = nullptr;
-            heap_size_ = 0;
-            throw std::runtime_error("DistRing: heap mmap failed");
+        if (heap_bytes > 0) {
+            void *base = mmap(nullptr, heap_bytes, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+            if (base == MAP_FAILED) {
+                // Unwind any rings already mapped so destruction stays clean.
+                for (HeapRing &rr : rings_) {
+                    if (rr.mapped && rr.base) {
+                        munmap(rr.base, rr.size);
+                        rr.base = nullptr;
+                        rr.size = 0;
+                        rr.mapped = false;
+                    }
+                }
+                throw std::runtime_error("DistRing: per-ring heap mmap failed");
+            }
+            r.base = base;
+            r.size = heap_bytes;
+            r.mapped = true;
+        } else {
+            r.base = nullptr;
+            r.size = 0;
         }
-        heap_mapped_ = true;
-    } else {
-        heap_base_ = nullptr;
-        heap_size_ = 0;
     }
 }
 
 // ---------------------------------------------------------------------------
-// alloc — slot + heap under a single mutex
+// alloc — picks a ring by scope depth, reserves slot + heap slab
 // ---------------------------------------------------------------------------
 
-DistAllocResult DistRing::alloc(uint64_t bytes) {
-    if (bytes > 0 && heap_size_ == 0) {
+DistAllocResult DistRing::alloc(uint64_t bytes, int32_t scope_depth) {
+    int32_t ring_idx = dist_ring_idx_for_scope(scope_depth);
+    HeapRing &ring = rings_[static_cast<size_t>(ring_idx)];
+
+    if (bytes > 0 && ring.size == 0) {
         throw std::runtime_error("DistRing: heap disabled (heap_bytes=0) but alloc(bytes>0) requested");
     }
     uint64_t aligned = bytes > 0 ? dist_align_up(bytes, DIST_HEAP_ALIGN) : 0;
-    if (aligned > heap_size_) {
-        throw std::runtime_error("DistRing: requested allocation exceeds heap size");
+    if (aligned > ring.size) {
+        throw std::runtime_error("DistRing: requested allocation exceeds per-ring heap size");
     }
 
-    std::unique_lock<std::mutex> lk(mu_);
-
-    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms_);
-
+    // --- Phase 1: wait for heap space + reserve in-ring bookkeeping ---
+    // Holds only the target ring's mu. Back-pressure on ring A cannot block
+    // alloc calls targeting a different ring, and it cannot block readers of
+    // `slots_mu_` (`slot_state`, `next_task_id`, or `release` on a slot that
+    // already exists in another ring).
     void *heap_ptr = nullptr;
-    uint64_t heap_end = heap_top_;
-    while (true) {
-        if (shutdown_) return DistAllocResult{DIST_INVALID_SLOT, nullptr, 0};
+    uint64_t heap_end = 0;
+    int32_t ring_slot_idx = 0;
+    {
+        std::unique_lock<std::mutex> rlk(ring.mu);
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms_);
 
-        if (aligned == 0) {
-            heap_ptr = nullptr;
-            heap_end = heap_top_;
-            break;
-        }
-        if (try_bump_heap_locked(aligned, heap_ptr, heap_end)) {
-            break;
+        while (true) {
+            if (shutdown_.load(std::memory_order_acquire)) {
+                return DistAllocResult{DIST_INVALID_SLOT, nullptr, 0, ring_idx};
+            }
+            if (aligned == 0) {
+                heap_ptr = nullptr;
+                heap_end = ring.top;
+                break;
+            }
+            if (try_bump_ring_heap_locked(ring, aligned, heap_ptr, heap_end)) {
+                break;
+            }
+            // Heap full on THIS ring. Wait for a release on this ring (other
+            // rings stay usable) or a shutdown.
+            if (ring.cv.wait_until(rlk, deadline) == std::cv_status::timeout) {
+                if (shutdown_.load(std::memory_order_acquire)) {
+                    return DistAllocResult{DIST_INVALID_SLOT, nullptr, 0, ring_idx};
+                }
+                throw std::runtime_error(
+                    "DistRing: per-ring heap exhausted (timed out waiting). "
+                    "Increase heap_ring_size on Worker."
+                );
+            }
         }
 
-        // Heap full. Wait for a release to advance last_alive_ / heap_tail_,
-        // or for shutdown. Timing out surfaces as a Python exception so the
-        // user can enlarge `heap_ring_size` instead of deadlocking.
-        if (cv_.wait_until(lk, deadline) == std::cv_status::timeout) {
-            if (shutdown_) return DistAllocResult{DIST_INVALID_SLOT, nullptr, 0};
-            throw std::runtime_error(
-                "DistRing: heap exhausted (timed out waiting). Increase heap_ring_size on Worker."
-            );
-        }
+        // Capture the in-ring FIFO position BEFORE releasing ring.mu so
+        // concurrent allocs on the same ring get strictly ordered positions.
+        ring_slot_idx = static_cast<int32_t>(ring.released.size());
+        ring.released.push_back(0);
+        ring.slot_heap_end.push_back(heap_end);
     }
 
-    int32_t task_id = next_task_id_++;
-    released_.push_back(0);
-    slot_heap_end_.push_back(heap_end);
-    slot_states_.emplace_back(std::make_unique<DistTaskSlotState>());
-    return DistAllocResult{task_id, heap_ptr, heap_end};
+    // --- Phase 2: assign a global task id and park the slot state ---
+    // Holds only `slots_mu_`. Deliberately separate from Phase 1 so we never
+    // nest `ring.mu` inside `slots_mu_` or vice versa (see `reset_to_empty`,
+    // which nests them the other way).
+    int32_t task_id;
+    {
+        std::lock_guard<std::mutex> slk(slots_mu_);
+        task_id = next_task_id_++;
+        slot_states_.emplace_back(std::make_unique<DistTaskSlotState>());
+        auto *s = slot_states_.back().get();
+        s->ring_idx = ring_idx;
+        s->ring_slot_idx = ring_slot_idx;
+    }
+    return DistAllocResult{task_id, heap_ptr, heap_end, ring_idx};
 }
 
 // ---------------------------------------------------------------------------
-// release — mark consumed and FIFO-advance last_alive_
+// release — mark consumed in the slot's own ring and FIFO-advance that ring
 // ---------------------------------------------------------------------------
 
 void DistRing::release(DistTaskSlot slot) {
+    int32_t ring_idx = 0;
+    int32_t ring_slot_idx = 0;
     {
-        std::lock_guard<std::mutex> lk(mu_);
-        if (slot < 0 || slot >= next_task_id_) return;
-        if (released_[static_cast<size_t>(slot)] != 0) return;  // idempotent
-        released_[static_cast<size_t>(slot)] = 1;
-        advance_last_alive_locked();
+        std::lock_guard<std::mutex> slk(slots_mu_);
+        if (slot < 0 || slot >= static_cast<int32_t>(slot_states_.size())) return;
+        DistTaskSlotState *s = slot_states_[static_cast<size_t>(slot)].get();
+        if (!s) return;
+        ring_idx = s->ring_idx;
+        ring_slot_idx = s->ring_slot_idx;
     }
-    cv_.notify_all();
+
+    HeapRing &ring = rings_[static_cast<size_t>(ring_idx)];
+    {
+        std::lock_guard<std::mutex> rlk(ring.mu);
+        if (ring_slot_idx < 0 || ring_slot_idx >= static_cast<int32_t>(ring.released.size())) return;
+        if (ring.released[static_cast<size_t>(ring_slot_idx)] != 0) return;  // idempotent
+        ring.released[static_cast<size_t>(ring_slot_idx)] = 1;
+        advance_last_alive_locked(ring);
+    }
+    ring.cv.notify_all();
 }
 
 // ---------------------------------------------------------------------------
@@ -125,30 +181,45 @@ void DistRing::release(DistTaskSlot slot) {
 // ---------------------------------------------------------------------------
 
 DistTaskSlotState *DistRing::slot_state(DistTaskSlot slot) {
-    std::lock_guard<std::mutex> lk(mu_);
+    std::lock_guard<std::mutex> slk(slots_mu_);
     if (slot < 0 || slot >= static_cast<int32_t>(slot_states_.size())) return nullptr;
     return slot_states_[static_cast<size_t>(slot)].get();
 }
 
 // ---------------------------------------------------------------------------
-// reset_to_empty — drop all per-task state, return counters to zero
+// reset_to_empty — rewind every ring and drop all slot state
 // ---------------------------------------------------------------------------
 
 void DistRing::reset_to_empty() {
-    std::lock_guard<std::mutex> lk(mu_);
-    if (last_alive_ != next_task_id_) {
-        throw std::logic_error(
-            "DistRing::reset_to_empty: tasks still live "
-            "(last_alive_ != next_task_id_). Did drain() complete?"
-        );
+    std::lock_guard<std::mutex> slk(slots_mu_);
+
+    // Validate: every ring must be fully drained. Checking each ring under
+    // its own mu_ is the cheapest way to stay race-free with in-flight
+    // releases — we take the locks one at a time (no nesting between rings).
+    for (HeapRing &r : rings_) {
+        std::lock_guard<std::mutex> rlk(r.mu);
+        if (r.last_alive != static_cast<int32_t>(r.released.size())) {
+            throw std::logic_error(
+                "DistRing::reset_to_empty: tasks still live on at least one ring. "
+                "Did drain() complete?"
+            );
+        }
     }
+
     next_task_id_ = 0;
-    last_alive_ = 0;
-    heap_top_ = 0;
-    heap_tail_ = 0;
-    released_.clear();
-    slot_heap_end_.clear();
     slot_states_.clear();
+
+    // Re-take each ring's mu and rewind. Safe to do one at a time — no
+    // in-flight caller should be touching the rings at this point
+    // (active_count() == 0 was the drain precondition).
+    for (HeapRing &r : rings_) {
+        std::lock_guard<std::mutex> rlk(r.mu);
+        r.top = 0;
+        r.tail = 0;
+        r.last_alive = 0;
+        r.released.clear();
+        r.slot_heap_end.clear();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -156,48 +227,85 @@ void DistRing::reset_to_empty() {
 // ---------------------------------------------------------------------------
 
 int32_t DistRing::active_count() const {
-    std::lock_guard<std::mutex> lk(mu_);
-    return next_task_id_ - last_alive_;
+    // total_allocated - total_released. Reads the two halves under separate
+    // critical sections to avoid nesting locks (reset_to_empty holds
+    // slots_mu_ while iterating each ring's mu, so a reader that nested
+    // them the other way could deadlock). A concurrent alloc between the
+    // reads can make the number off by a couple — acceptable for a
+    // monitoring accessor.
+    int32_t total_tasks;
+    {
+        std::lock_guard<std::mutex> slk(slots_mu_);
+        total_tasks = next_task_id_;
+    }
+    int32_t total_released = 0;
+    for (const HeapRing &r : rings_) {
+        std::lock_guard<std::mutex> rlk(r.mu);
+        total_released += r.last_alive;
+    }
+    return total_tasks - total_released;
 }
 
 int32_t DistRing::next_task_id() const {
-    std::lock_guard<std::mutex> lk(mu_);
+    std::lock_guard<std::mutex> slk(slots_mu_);
     return next_task_id_;
 }
 
-void DistRing::shutdown() {
-    {
-        std::lock_guard<std::mutex> lk(mu_);
-        shutdown_ = true;
+const DistRing::HeapRing &DistRing::ring_at(int32_t ring_idx) const {
+    if (ring_idx < 0 || ring_idx >= DIST_MAX_RING_DEPTH) {
+        throw std::out_of_range("DistRing: ring_idx out of range");
     }
-    cv_.notify_all();
+    return rings_[static_cast<size_t>(ring_idx)];
+}
+
+void *DistRing::heap_base(int32_t ring_idx) const { return ring_at(ring_idx).base; }
+
+uint64_t DistRing::heap_size(int32_t ring_idx) const { return ring_at(ring_idx).size; }
+
+uint64_t DistRing::heap_top(int32_t ring_idx) const {
+    const HeapRing &r = ring_at(ring_idx);
+    std::lock_guard<std::mutex> rlk(r.mu);
+    return r.top;
+}
+
+uint64_t DistRing::heap_tail(int32_t ring_idx) const {
+    const HeapRing &r = ring_at(ring_idx);
+    std::lock_guard<std::mutex> rlk(r.mu);
+    return r.tail;
+}
+
+void DistRing::shutdown() {
+    shutdown_.store(true, std::memory_order_release);
+    for (HeapRing &r : rings_) {
+        r.cv.notify_all();
+    }
 }
 
 // ---------------------------------------------------------------------------
-// Internal helpers (all called under mu_)
+// Internal helpers — all called under the respective ring's mu
 // ---------------------------------------------------------------------------
 
-bool DistRing::try_bump_heap_locked(uint64_t aligned, void *&out_ptr, uint64_t &out_end) {
-    uint64_t top = heap_top_;
-    uint64_t tail = heap_tail_;
+bool DistRing::try_bump_ring_heap_locked(HeapRing &r, uint64_t aligned, void *&out_ptr, uint64_t &out_end) {
+    uint64_t top = r.top;
+    uint64_t tail = r.tail;
 
     // Case 1: heap fully live forward (top >= tail). Space either after top
     // to the end of the region, or (after wrap) from 0 to tail-1.
     if (top >= tail) {
-        uint64_t at_end = heap_size_ - top;
+        uint64_t at_end = r.size - top;
         if (at_end >= aligned) {
-            out_ptr = static_cast<char *>(heap_base_) + top;
-            heap_top_ = top + aligned;
-            out_end = heap_top_;
+            out_ptr = static_cast<char *>(r.base) + top;
+            r.top = top + aligned;
+            out_end = r.top;
             return true;
         }
         // Wrap only when there is real space at the start. Must be strictly >,
         // not ==: leaving a single byte gap prevents top==tail being ambiguous
         // between "full" and "empty".
         if (tail > aligned) {
-            out_ptr = heap_base_;
-            heap_top_ = aligned;
-            out_end = heap_top_;
+            out_ptr = r.base;
+            r.top = aligned;
+            out_end = r.top;
             return true;
         }
         return false;
@@ -205,22 +313,22 @@ bool DistRing::try_bump_heap_locked(uint64_t aligned, void *&out_ptr, uint64_t &
 
     // Case 2: wrapped (top < tail). Allocate in the gap only.
     if (tail - top > aligned) {
-        out_ptr = static_cast<char *>(heap_base_) + top;
-        heap_top_ = top + aligned;
-        out_end = heap_top_;
+        out_ptr = static_cast<char *>(r.base) + top;
+        r.top = top + aligned;
+        out_end = r.top;
         return true;
     }
     return false;
 }
 
-void DistRing::advance_last_alive_locked() {
-    // Advance last_alive_ while the next-oldest task is already released.
-    // Slot state and heap_end entries stay in their vectors — memory is
-    // only reclaimed by reset_to_empty() at drain time — so we don't have
-    // to worry about invalidating pointers that other threads may still
-    // hold to in-flight slots.
-    while (last_alive_ < next_task_id_ && released_[static_cast<size_t>(last_alive_)] == 1) {
-        heap_tail_ = slot_heap_end_[static_cast<size_t>(last_alive_)];
-        last_alive_++;
+void DistRing::advance_last_alive_locked(HeapRing &r) {
+    // Walk forward as long as the next-oldest in-ring slot is released.
+    // Slot-state entries and heap_end entries stay in their vectors — memory
+    // is reclaimed only by reset_to_empty() at drain time — so we never
+    // invalidate pointers that other threads may still hold.
+    while (r.last_alive < static_cast<int32_t>(r.released.size()) &&
+           r.released[static_cast<size_t>(r.last_alive)] == 1) {
+        r.tail = r.slot_heap_end[static_cast<size_t>(r.last_alive)];
+        r.last_alive++;
     }
 }

--- a/src/common/distributed/dist_ring.h
+++ b/src/common/distributed/dist_ring.h
@@ -12,42 +12,47 @@
 /**
  * DistRing — unified slot + heap allocator for L3+ distributed workers.
  *
- * A single structure owns three correlated, per-task resources:
+ * A single structure owns three correlated per-task resources:
  *
  *   1. A monotonic task id (`next_task_id_`), allocated by the Orchestrator.
  *      Unlike L2's `PTO2TaskAllocator` the id is NOT masked into a fixed-size
  *      window — slot state lives in parent-process heap (never crossed into
  *      child workers), so a ring index buys us nothing at L3 (see the plan's
  *      L2 Consistency Audit, allowed exception #6).
- *   2. A shared-memory heap slab (bump-allocated under one mutex, FIFO
- *      reclaimed via `last_alive_`). This part still mirrors L2 (Strict-2):
- *      the heap must be `mmap(MAP_SHARED)` and forked into child workers,
- *      which forces a pre-sized region.
+ *   2. `DIST_MAX_RING_DEPTH` independent shared-memory heap slabs (Strict-1,
+ *      matches L2's `PTO2_MAX_RING_DEPTH = 4`). Each slab has its own
+ *      `mmap(MAP_SHARED)` region, bump cursor, FIFO reclamation pointer,
+ *      mutex and cv. Slot → ring mapping is driven by scope depth:
+ *         ring_idx = min(scope_depth, DIST_MAX_RING_DEPTH - 1)
+ *      so tasks inside nested scopes reclaim independently of the outer
+ *      scope's long-lived allocations. A mapping taken before any fork is
+ *      inherited by every child process at the same virtual address.
  *   3. The per-task scheduling state (`DistTaskSlotState`). Stored in a
  *      `std::deque<std::unique_ptr<...>>` so push_back never invalidates
  *      pointers, and destruction happens only at `reset_to_empty()` /
- *      process teardown, giving callers stable references to a slot until
- *      it is consumed.
+ *      process teardown. Slot state records its `ring_idx` and
+ *      `ring_slot_idx` so `release(slot)` knows which ring to advance.
  *
- * Back-pressure: only the heap can be full. `alloc(bytes)` spin-waits on a
- * cv; if no progress is made for `timeout_ms` it throws `std::runtime_error`
- * so Python callers see an exception rather than a silent deadlock.
+ * Back-pressure: only the heap can be full, and per-ring. `alloc(bytes,
+ * scope_depth)` picks a ring, spin-waits on that ring's cv; if no progress
+ * is made for `timeout_ms` it throws `std::runtime_error`. Other rings
+ * remain usable while one ring is full.
  *
  * Lifecycle:
  *
  *   Worker.run() → orch submits N tasks → each submit calls
- *   `ring.alloc()` (task id allocated, slot state constructed) → scheduler
- *   dispatches → workers run → on_consumed calls `ring.release(id)` which
- *   marks the slot consumed and advances `last_alive_` FIFO-wise → drain
- *   waits until `active_count() == 0` → `ring.reset_to_empty()` resets
- *   counters and drops all slot states so the next run starts fresh.
- *
- *   Memory footprint per Worker.run() is bounded by the peak alive task
- *   count; no state accumulates across runs.
+ *   `ring.alloc(bytes, scope_depth)` (task id allocated, slot state
+ *   constructed, ring slab carved) → scheduler dispatches → workers run →
+ *   on_consumed calls `ring.release(id)` which advances the slot's ring's
+ *   `last_alive` FIFO-wise → drain waits until `active_count() == 0` →
+ *   `ring.reset_to_empty()` resets every ring's cursors and drops all slot
+ *   states so the next run starts fresh.
  */
 
 #pragma once
 
+#include <array>
+#include <atomic>
 #include <condition_variable>
 #include <cstdint>
 #include <deque>
@@ -60,20 +65,29 @@
 // User-facing output alignment (Strict-3; matches L2 PTO2_PACKED_OUTPUT_ALIGN).
 static constexpr uint64_t DIST_HEAP_ALIGN = 1024;
 
-// Default heap ring size for L3+ Worker: 1 GiB, overridable per-Worker.
+// Default PER-RING heap size. Total VA reservation is this value times
+// DIST_MAX_RING_DEPTH (default 4 GiB across 4 rings of 1 GiB each).
 static constexpr uint64_t DIST_DEFAULT_HEAP_RING_SIZE = 1ULL << 30;
 
 // Default back-pressure timeout (ms). Surfaces as std::runtime_error when the
-// allocator makes no progress for this long — acts as a deadlock detector.
+// target ring makes no progress for this long — acts as a deadlock detector.
 static constexpr uint32_t DIST_ALLOC_TIMEOUT_MS = 10000;
 
 // Align an unsigned value up to the next multiple of `align` (must be power of 2).
 inline uint64_t dist_align_up(uint64_t v, uint64_t align) { return (v + align - 1) & ~(align - 1); }
 
+// Scope-depth → ring-index mapping. `scope_depth` is L2-style 0-based (the
+// outermost open scope is 0); deeper scopes share the innermost ring.
+inline int32_t dist_ring_idx_for_scope(int32_t scope_depth) {
+    if (scope_depth < 0) scope_depth = 0;
+    return scope_depth < DIST_MAX_RING_DEPTH ? scope_depth : DIST_MAX_RING_DEPTH - 1;
+}
+
 struct DistAllocResult {
     DistTaskSlot slot{DIST_INVALID_SLOT};
     void *heap_ptr{nullptr};
-    uint64_t heap_end_offset{0};  // absolute byte offset in the heap region
+    uint64_t heap_end_offset{0};  // byte offset within the selected ring's heap
+    int32_t ring_idx{0};
 };
 
 class DistRing {
@@ -84,76 +98,107 @@ public:
     DistRing(const DistRing &) = delete;
     DistRing &operator=(const DistRing &) = delete;
 
-    // Initialise. `heap_bytes == 0` disables the heap — `alloc(0)` still
-    // hands out slots, but any `alloc(bytes>0)` throws. `timeout_ms == 0`
-    // selects the default. Must be called before any fork if the heap is
-    // to be inherited by children.
+    // Initialise `DIST_MAX_RING_DEPTH` heap rings, each of `heap_bytes`
+    // (MAP_SHARED | MAP_ANONYMOUS). Total VA reservation is
+    //   DIST_MAX_RING_DEPTH * heap_bytes.
+    // `heap_bytes == 0` disables all heaps — `alloc(0, …)` still hands out
+    // slots but any `alloc(bytes>0, …)` throws. `timeout_ms == 0` selects the
+    // default. Must be called before any fork if the heaps are to be
+    // inherited by children.
     void init(uint64_t heap_bytes = DIST_DEFAULT_HEAP_RING_SIZE, uint32_t timeout_ms = DIST_ALLOC_TIMEOUT_MS);
 
-    // Allocate a slot (and, if `bytes > 0`, a heap slab). Blocks on the
-    // heap cv; throws `std::runtime_error` on timeout. Returns the sentinel
-    // `{DIST_INVALID_SLOT, nullptr, 0}` on `shutdown()`.
+    // Allocate a slot and, if `bytes > 0`, a heap slab from the ring chosen
+    // by `scope_depth` (L2-style 0-based: 0 is the outermost scope). The
+    // slot's `ring_idx` / `ring_slot_idx` are stamped into the slot state
+    // before this call returns.
     //
-    // `bytes` is rounded up to `DIST_HEAP_ALIGN`. Passing `0` skips the heap
-    // bump entirely (slot-only allocation).
-    DistAllocResult alloc(uint64_t bytes = 0);
+    // Blocks on the selected ring's cv; throws `std::runtime_error` on
+    // timeout. Returns the sentinel `{DIST_INVALID_SLOT, nullptr, 0, 0}` on
+    // `shutdown()`. `bytes` is rounded up to `DIST_HEAP_ALIGN`. Passing `0`
+    // skips the heap bump entirely (slot-only allocation).
+    DistAllocResult alloc(uint64_t bytes = 0, int32_t scope_depth = 0);
 
-    // Release a slot. Marks the slot consumed; advances `last_alive_` (and
-    // `heap_tail_`) as far as the FIFO ordering allows. Safe to call from
-    // any thread; safe under concurrent `alloc()`.
+    // Release a slot. Reads the slot's `ring_idx` / `ring_slot_idx` to find
+    // its ring, marks the slot consumed, and advances that ring's
+    // `last_alive_` (and `heap_tail`) as far as FIFO order allows. Other
+    // rings are untouched. Safe from any thread.
     void release(DistTaskSlot slot);
 
     // Pointer to the slot's state. Stable for the slot's lifetime (i.e.
     // until `reset_to_empty()` drops it). Returns nullptr for invalid ids.
-    //
-    // Thread safety: the pointer refers to heap-allocated storage held by a
-    // `std::deque<std::unique_ptr<...>>`. `std::deque::push_back` never
-    // invalidates pointers to existing elements, so once a slot id has been
-    // handed out by `alloc()`, `slot_state(id)` stays valid across concurrent
-    // allocs. The caller is responsible for not using the pointer across a
-    // matching `reset_to_empty()` call.
     DistTaskSlotState *slot_state(DistTaskSlot slot);
 
-    // Clear all per-task state and return to `next_task_id_ = last_alive_ = 0`.
-    // Requires that no slots are currently live (`active_count() == 0`) —
-    // typically called by `DistOrchestrator::drain()` right after the active
-    // count hits zero.
+    // Rewind every ring's cursors + released/slot_heap_end vectors and drop
+    // all slot states. Requires that no slots are currently live
+    // (`active_count() == 0`) — typically called by `DistOrchestrator::drain`
+    // right after the active count hits zero.
     void reset_to_empty();
 
     int32_t active_count() const;
     int32_t next_task_id() const;
-    void *heap_base() const { return heap_base_; }
-    uint64_t heap_size() const { return heap_size_; }
+
+    // Per-ring introspection (tests + tooling).
+    void *heap_base(int32_t ring_idx) const;
+    uint64_t heap_size(int32_t ring_idx) const;
+    uint64_t heap_top(int32_t ring_idx) const;
+    uint64_t heap_tail(int32_t ring_idx) const;
 
     void shutdown();
 
 private:
+    // One scope-layer heap ring. `DIST_MAX_RING_DEPTH` instances live side by
+    // side; the slot deque and `next_task_id_` remain global (parent-heap
+    // bookkeeping — see docs/orchestrator.md §5).
+    struct HeapRing {
+        // mmap region
+        void *base{nullptr};
+        uint64_t size{0};
+        uint64_t top{0};   // next free byte (bump head, can wrap)
+        uint64_t tail{0};  // oldest live byte (derived from last_alive_)
+        bool mapped{false};
+
+        // Per-ring FIFO ordering — vectors are indexed by a slot's
+        // ring_slot_idx (the order it was allocated into this ring).
+        std::vector<uint8_t> released;        // 0 = live, 1 = consumed
+        std::vector<uint64_t> slot_heap_end;  // byte-offset high-water within this ring
+        int32_t last_alive{0};                // FIFO frontier over released/slot_heap_end
+
+        mutable std::mutex mu;
+        std::condition_variable cv;
+
+        HeapRing() = default;
+        HeapRing(const HeapRing &) = delete;
+        HeapRing &operator=(const HeapRing &) = delete;
+    };
+
     uint32_t timeout_ms_{DIST_ALLOC_TIMEOUT_MS};
 
-    // Monotonic within a run. Reset to 0 by `reset_to_empty()`.
+    // Monotonic across all rings within a run. Reset to 0 by `reset_to_empty`.
     int32_t next_task_id_{0};
 
-    // FIFO consumption frontier. `[last_alive_, next_task_id_)` are live.
-    int32_t last_alive_{0};
-
-    // Per-slot bookkeeping, indexed directly by task id (0..next_task_id_).
-    // All three grow together under `mu_`; no erase while the run is live.
-    std::vector<uint8_t> released_;        // 0 = live, 1 = consumed
-    std::vector<uint64_t> slot_heap_end_;  // byte-offset high-water of each slot's allocation
+    // Parent-heap slot-state pool. push_back never invalidates pointers to
+    // existing elements, so slot_state(id) remains stable for every live id.
     std::deque<std::unique_ptr<DistTaskSlotState>> slot_states_;
 
-    // Heap region.
-    void *heap_base_{nullptr};
-    uint64_t heap_size_{0};
-    uint64_t heap_top_{0};   // next free byte (bump head, can wrap)
-    uint64_t heap_tail_{0};  // oldest live byte (derived from last_alive_)
+    // Guards `next_task_id_` and `slot_states_`. Taken briefly during
+    // `alloc()` (between picking the task id and pushing the state) and by
+    // `slot_state()` / `reset_to_empty()` / `next_task_id()` readers. Not
+    // held during the per-ring back-pressure wait — each HeapRing has its
+    // own mu / cv for that.
+    mutable std::mutex slots_mu_;
 
-    mutable std::mutex mu_;
-    std::condition_variable cv_;
-    bool shutdown_{false};
-    bool heap_mapped_{false};
+    // The 4 scope-layer heap rings (Strict-1).
+    std::array<HeapRing, DIST_MAX_RING_DEPTH> rings_;
 
-    // Helpers — all called under mu_.
-    bool try_bump_heap_locked(uint64_t aligned_bytes, void *&out_ptr, uint64_t &out_end);
-    void advance_last_alive_locked();
+    // Process-wide shutdown flag (atomic so every ring's waiter sees it
+    // without holding that ring's mu_).
+    std::atomic<bool> shutdown_{false};
+
+    // Helpers — `try_bump_ring_heap_locked` runs under `ring.mu`;
+    // `advance_last_alive_locked` runs under `ring.mu`.
+    bool try_bump_ring_heap_locked(HeapRing &ring, uint64_t aligned_bytes, void *&out_ptr, uint64_t &out_end);
+    void advance_last_alive_locked(HeapRing &ring);
+
+    // Ring-index validation for the public introspection accessors.
+    const HeapRing &ring_at(int32_t ring_idx) const;
 };

--- a/src/common/distributed/dist_scope.h
+++ b/src/common/distributed/dist_scope.h
@@ -46,6 +46,19 @@ public:
     // Current nesting depth (0 = no open scope).
     int32_t depth() const { return static_cast<int32_t>(stack_.size()); }
 
+    // L2-style 0-based scope index: the innermost open scope, or 0 when
+    // none is open. Used by DistRing::alloc to choose a heap ring:
+    //   ring_idx = min(current_depth(), DIST_MAX_RING_DEPTH - 1)
+    // Matches `PTO2OrchestratorState::current_ring_id` semantics: the
+    // first scope opened (depth()==1) maps to ring 0, the next nested
+    // scope maps to ring 1, and so on. Returns 0 when no scope is open
+    // so tasks submitted outside `Worker::run` still have a deterministic
+    // ring assignment.
+    int32_t current_depth() const {
+        int32_t d = depth();
+        return d > 0 ? d - 1 : 0;
+    }
+
 private:
     struct ScopeFrame {
         std::vector<DistTaskSlot> tasks;

--- a/src/common/distributed/dist_types.cpp
+++ b/src/common/distributed/dist_types.cpp
@@ -34,6 +34,10 @@ void DistTaskSlotState::reset() {
     task_args.clear();
     task_args_list.clear();
     is_group_ = false;
+    // ring_idx / ring_slot_idx are deliberately NOT cleared here: DistRing
+    // stamps them at alloc() before the Orchestrator ever calls reset(),
+    // and DistRing::release() needs to read them for the FIFO advance. The
+    // fields are rewritten on every alloc, so stale values never escape.
     sub_complete_count.store(0, std::memory_order_relaxed);
 }
 

--- a/src/common/distributed/dist_types.h
+++ b/src/common/distributed/dist_types.h
@@ -45,7 +45,15 @@
 // Constants
 // =============================================================================
 
+// User-visible scope-nesting cap. Matches L2 PTO2_MAX_SCOPE_DEPTH.
 static constexpr int32_t DIST_MAX_SCOPE_DEPTH = 64;
+
+// Number of independent HeapRing layers inside DistRing. Scope depth maps
+// to ring index via `min(depth, DIST_MAX_RING_DEPTH - 1)` (L2-style);
+// scopes deeper than DIST_MAX_RING_DEPTH share the innermost ring.
+// Matches L2's PTO2_MAX_RING_DEPTH (Strict-1).
+static constexpr int32_t DIST_MAX_RING_DEPTH = 4;
+
 static constexpr int32_t DIST_INVALID_SLOT = -1;
 
 // =============================================================================
@@ -125,6 +133,14 @@ struct DistTaskSlotState {
     // Runtime-owned OUTPUT slabs live in the Worker's HeapRing and are
     // reclaimed implicitly by DistRing::release(slot) — no per-slot
     // munmap is needed. See docs/orchestrator.md §8b.
+
+    // --- HeapRing layer membership (Strict-1 per-scope rings) ---
+    // Set by DistRing::alloc from the caller's scope depth. ring_idx picks
+    // which of the DIST_MAX_RING_DEPTH heaps holds this slot's slab;
+    // ring_slot_idx is the slot's position within that ring's FIFO order
+    // and indexes the ring's per-slot released/heap_end vectors.
+    int32_t ring_idx{0};
+    int32_t ring_slot_idx{0};
 
     // --- Group bookkeeping ---
     std::atomic<int32_t> sub_complete_count{0};

--- a/tests/ut/cpp/test_dist_orchestrator.cpp
+++ b/tests/ut/cpp/test_dist_orchestrator.cpp
@@ -197,9 +197,9 @@ TEST_F(OrchestratorFixture, OutputAutoAllocsFromHeapRing) {
 
     uint64_t data = S(res.task_slot).task_args.tensor(0).data;
     ASSERT_NE(data, 0u);
-    uintptr_t base = reinterpret_cast<uintptr_t>(allocator.heap_base());
+    uintptr_t base = reinterpret_cast<uintptr_t>(allocator.heap_base(0));
     EXPECT_GE(data, base);
-    EXPECT_LT(data, base + allocator.heap_size());
+    EXPECT_LT(data, base + allocator.heap_size(0));
     EXPECT_EQ(data % DIST_HEAP_ALIGN, 0u);
 
     EXPECT_EQ(tm.lookup(data), res.task_slot);

--- a/tests/ut/cpp/test_dist_ring.cpp
+++ b/tests/ut/cpp/test_dist_ring.cpp
@@ -20,7 +20,8 @@
 namespace {
 
 // Most tests only need a small heap to exercise wrap/back-pressure quickly.
-constexpr uint64_t kSmallHeap = 8ULL * DIST_HEAP_ALIGN;  // 8 KiB
+// This is the PER-RING size now that DistRing owns DIST_MAX_RING_DEPTH rings.
+constexpr uint64_t kSmallHeap = 8ULL * DIST_HEAP_ALIGN;  // 8 KiB per ring
 constexpr uint32_t kQuickTimeoutMs = 500;
 
 }  // namespace
@@ -113,7 +114,7 @@ TEST(DistRing, HeapWrapsAroundWhenTailLeadsTop) {
     auto wrapped = a.alloc(DIST_HEAP_ALIGN);
     ASSERT_NE(wrapped.heap_ptr, nullptr);
     // Wrapped allocation lives at the base of the region.
-    EXPECT_EQ(wrapped.heap_ptr, a.heap_base());
+    EXPECT_EQ(wrapped.heap_ptr, a.heap_base(0));
 
     a.release(r2.slot);
     a.release(r3.slot);
@@ -207,4 +208,177 @@ TEST(DistRing, ShutdownUnblocksAlloc) {
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
     a.shutdown();
     t.join();
+}
+
+// ---------------------------------------------------------------------------
+// Per-scope ring tests (Strict-1)
+// ---------------------------------------------------------------------------
+
+TEST(DistRing, ScopeDepthMapsToRingIdx) {
+    EXPECT_EQ(dist_ring_idx_for_scope(0), 0);
+    EXPECT_EQ(dist_ring_idx_for_scope(1), 1);
+    EXPECT_EQ(dist_ring_idx_for_scope(2), 2);
+    EXPECT_EQ(dist_ring_idx_for_scope(3), 3);
+    // Scopes deeper than MAX_RING_DEPTH share the innermost ring.
+    EXPECT_EQ(dist_ring_idx_for_scope(4), DIST_MAX_RING_DEPTH - 1);
+    EXPECT_EQ(dist_ring_idx_for_scope(64), DIST_MAX_RING_DEPTH - 1);
+    // Negative scope depths clamp to 0 (defensive).
+    EXPECT_EQ(dist_ring_idx_for_scope(-1), 0);
+}
+
+TEST(DistRing, PerRingHeapsAreDistinctMmaps) {
+    // Total VA = 4 × 4 KiB; verify each ring has its own mapping.
+    DistRing a;
+    a.init(kSmallHeap, kQuickTimeoutMs);
+
+    std::vector<uintptr_t> bases;
+    for (int r = 0; r < DIST_MAX_RING_DEPTH; ++r) {
+        void *b = a.heap_base(r);
+        ASSERT_NE(b, nullptr);
+        EXPECT_EQ(a.heap_size(r), kSmallHeap);
+        bases.push_back(reinterpret_cast<uintptr_t>(b));
+    }
+    for (int i = 0; i < DIST_MAX_RING_DEPTH; ++i) {
+        for (int j = i + 1; j < DIST_MAX_RING_DEPTH; ++j) {
+            EXPECT_NE(bases[i], bases[j])
+                << "rings " << i << " and " << j << " share a mapping — expected 4 separate mmaps";
+        }
+    }
+}
+
+TEST(DistRing, AllocRoutesToRingChosenByScopeDepth) {
+    DistRing a;
+    a.init(kSmallHeap, kQuickTimeoutMs);
+
+    auto r0 = a.alloc(100, /*scope_depth=*/0);
+    auto r1 = a.alloc(100, /*scope_depth=*/1);
+    auto r2 = a.alloc(100, /*scope_depth=*/2);
+    auto r3 = a.alloc(100, /*scope_depth=*/3);
+    auto rd = a.alloc(100, /*scope_depth=*/7);  // clamps to ring 3
+
+    EXPECT_EQ(r0.ring_idx, 0);
+    EXPECT_EQ(r1.ring_idx, 1);
+    EXPECT_EQ(r2.ring_idx, 2);
+    EXPECT_EQ(r3.ring_idx, 3);
+    EXPECT_EQ(rd.ring_idx, 3);
+
+    // The allocation lives in the ring's own mmap region.
+    for (const auto *res : {&r0, &r1, &r2, &r3}) {
+        uintptr_t base = reinterpret_cast<uintptr_t>(a.heap_base(res->ring_idx));
+        uintptr_t ptr = reinterpret_cast<uintptr_t>(res->heap_ptr);
+        EXPECT_GE(ptr, base);
+        EXPECT_LT(ptr, base + a.heap_size(res->ring_idx));
+    }
+
+    // Slot state remembers the ring assignment.
+    EXPECT_EQ(a.slot_state(r0.slot)->ring_idx, 0);
+    EXPECT_EQ(a.slot_state(r3.slot)->ring_idx, 3);
+
+    a.release(r0.slot);
+    a.release(r1.slot);
+    a.release(r2.slot);
+    a.release(r3.slot);
+    a.release(rd.slot);
+}
+
+TEST(DistRing, RingsReclaimIndependently) {
+    // Fill ring 1 but keep ring 0 empty. A subsequent alloc on ring 0
+    // must not be blocked by ring 1's fullness.
+    DistRing a;
+    a.init(2 * DIST_HEAP_ALIGN, /*timeout_ms=*/100);
+
+    auto r1a = a.alloc(DIST_HEAP_ALIGN, /*scope_depth=*/1);
+    auto r1b = a.alloc(DIST_HEAP_ALIGN, /*scope_depth=*/1);  // ring 1 full
+    EXPECT_EQ(r1a.ring_idx, 1);
+    EXPECT_EQ(r1b.ring_idx, 1);
+
+    // Ring 0 is untouched — this must succeed instantly, not time out.
+    auto r0 = a.alloc(DIST_HEAP_ALIGN, /*scope_depth=*/0);
+    EXPECT_EQ(r0.ring_idx, 0);
+    ASSERT_NE(r0.heap_ptr, nullptr);
+
+    // Ring 3 is also untouched.
+    auto r3 = a.alloc(DIST_HEAP_ALIGN, /*scope_depth=*/3);
+    EXPECT_EQ(r3.ring_idx, 3);
+
+    // Now verify ring 1 still times out (no release on ring 1 yet).
+    EXPECT_THROW(a.alloc(DIST_HEAP_ALIGN, /*scope_depth=*/1), std::runtime_error);
+
+    a.release(r1a.slot);
+    a.release(r1b.slot);
+    a.release(r0.slot);
+    a.release(r3.slot);
+}
+
+TEST(DistRing, InnerRingReclaimsWhileOuterHolds) {
+    // Simulate nested scope: outer task on ring 0 holds an allocation while
+    // inner tasks on ring 1 churn through their heap. Ring 1's heap_top /
+    // heap_tail advance as tasks cycle; ring 0's cursors stay put because
+    // the outer task is still alive.
+    DistRing a;
+    a.init(4 * DIST_HEAP_ALIGN, /*timeout_ms=*/500);
+
+    auto outer = a.alloc(DIST_HEAP_ALIGN, /*scope_depth=*/0);
+    EXPECT_EQ(a.heap_top(0), DIST_HEAP_ALIGN);
+    EXPECT_EQ(a.heap_tail(0), 0u);
+
+    // Churn on the inner ring — allocate, release, allocate, release, ...
+    for (int i = 0; i < 8; ++i) {
+        auto inner = a.alloc(DIST_HEAP_ALIGN, /*scope_depth=*/1);
+        a.release(inner.slot);
+    }
+
+    // Outer ring unchanged (one live slab at offset 0).
+    EXPECT_EQ(a.heap_top(0), DIST_HEAP_ALIGN);
+    EXPECT_EQ(a.heap_tail(0), 0u);
+    // Inner ring reclaimed each slab — tail caught up to top.
+    EXPECT_EQ(a.heap_tail(1), a.heap_top(1));
+
+    a.release(outer.slot);
+}
+
+TEST(DistRing, ResetRewindsAllRings) {
+    DistRing a;
+    a.init(kSmallHeap, kQuickTimeoutMs);
+
+    auto r0 = a.alloc(100, /*scope_depth=*/0);
+    auto r1 = a.alloc(100, /*scope_depth=*/1);
+    auto r2 = a.alloc(100, /*scope_depth=*/3);
+
+    a.release(r0.slot);
+    a.release(r1.slot);
+    a.release(r2.slot);
+
+    a.reset_to_empty();
+
+    EXPECT_EQ(a.next_task_id(), 0);
+    for (int r = 0; r < DIST_MAX_RING_DEPTH; ++r) {
+        EXPECT_EQ(a.heap_top(r), 0u) << "ring " << r << " heap_top not rewound";
+        EXPECT_EQ(a.heap_tail(r), 0u) << "ring " << r << " heap_tail not rewound";
+    }
+}
+
+TEST(DistRing, NewSlotStatesCarryRingMetadata) {
+    DistRing a;
+    a.init(kSmallHeap, kQuickTimeoutMs);
+
+    auto r = a.alloc(100, /*scope_depth=*/2);
+    auto *s = a.slot_state(r.slot);
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(s->ring_idx, 2);
+    EXPECT_EQ(s->ring_slot_idx, 0);  // first allocation on ring 2
+
+    auto r2 = a.alloc(100, /*scope_depth=*/2);
+    auto *s2 = a.slot_state(r2.slot);
+    EXPECT_EQ(s2->ring_idx, 2);
+    EXPECT_EQ(s2->ring_slot_idx, 1);  // second allocation on the same ring
+
+    auto r3 = a.alloc(100, /*scope_depth=*/0);
+    auto *s3 = a.slot_state(r3.slot);
+    EXPECT_EQ(s3->ring_idx, 0);
+    EXPECT_EQ(s3->ring_slot_idx, 0);  // ring 0's own in-ring index resets to 0
+
+    a.release(r.slot);
+    a.release(r2.slot);
+    a.release(r3.slot);
 }

--- a/tests/ut/py/test_dist_worker/test_host_worker.py
+++ b/tests/ut/py/test_dist_worker/test_host_worker.py
@@ -192,6 +192,83 @@ class TestScope:
             counter_shm.close()
             counter_shm.unlink()
 
+    def test_user_nested_scope_runs_to_completion(self):
+        """User opens a nested scope with ``with orch.scope():``; all tasks run."""
+        counter_shm, counter_buf = _make_shared_counter()
+        try:
+            # Use one sub worker so the increments serialize — _increment_counter
+            # is a non-atomic RMW and races across parallel SubWorker processes.
+            hw = Worker(level=3, num_sub_workers=1)
+            cid = hw.register(lambda: _increment_counter(counter_buf))
+            hw.init()
+
+            def orch(o, _args):
+                with o.scope():
+                    o.submit_sub(cid)
+                    o.submit_sub(cid)
+                o.submit_sub(cid)  # back on outer-scope ring
+
+            hw.run(Task(orch=orch))
+            hw.close()
+
+            assert _read_counter(counter_buf) == 3
+        finally:
+            counter_shm.close()
+            counter_shm.unlink()
+
+    def test_user_nested_scope_binding_is_exposed(self):
+        """The scope context manager and raw scope_begin / scope_end are bound."""
+        from simpler.task_interface import DistOrchestrator  # noqa: PLC0415
+
+        # Binding carries the new accessors.
+        assert hasattr(DistOrchestrator, "scope_begin")
+        assert hasattr(DistOrchestrator, "scope_end")
+
+        hw = Worker(level=3, num_sub_workers=1)
+        hw.register(lambda: None)
+        hw.init()
+
+        def orch(o, _args):
+            # Raw calls — match L2's pto2_scope_begin / pto2_scope_end.
+            o.scope_begin()
+            o.scope_end()
+            # Context-manager form.
+            with o.scope():
+                pass
+            # Mixed with submits.
+            with o.scope():
+                inner = o.alloc((32,), DataType.FLOAT32)
+                assert inner.data != 0
+
+        hw.run(Task(orch=orch))
+        hw.close()
+
+    def test_user_nested_scope_three_deep(self):
+        """Three levels of nested scopes drain cleanly (no leaked refs)."""
+        counter_shm, counter_buf = _make_shared_counter()
+        try:
+            hw = Worker(level=3, num_sub_workers=1)
+            cid = hw.register(lambda: _increment_counter(counter_buf))
+            hw.init()
+
+            def orch(o, _args):
+                o.submit_sub(cid)  # outer scope (ring 0)
+                with o.scope():
+                    o.submit_sub(cid)  # ring 1
+                    with o.scope():
+                        o.submit_sub(cid)  # ring 2
+                        with o.scope():
+                            o.submit_sub(cid)  # ring 3
+                            with o.scope():
+                                o.submit_sub(cid)  # clamps to ring 3
+
+            hw.run(Task(orch=orch))
+            hw.close()
+            assert _read_counter(counter_buf) == 5
+        finally:
+            counter_shm.close()
+            counter_shm.unlink()
+
 
 # ---------------------------------------------------------------------------
 # Test: orch.alloc — runtime-managed intermediate buffer lifecycle


### PR DESCRIPTION
## Summary

Strict-1 alignment with L2 (matches `PTO2_MAX_RING_DEPTH = 4`): a long-running outer-scope task no longer holds the FIFO head against inner-scope churn. Each scope-layer heap is its own `mmap(MAP_SHARED)` with its own `mu`/`cv`/`last_alive`; ring selection is driven by scope depth `min(scope_depth, DIST_MAX_RING_DEPTH - 1)`. `DistOrchestrator::scope_begin` / `scope_end` are now user-facing, plus a `with orch.scope():` context manager on the Python side. Resolves Q10 / audit correction 2026-04-15 in `.claude/plans/HIERARCHICAL_RUNTIME_REFACTOR.md`.

## What changed

- **`DistRing`** — array of 4 `HeapRing` structs (per-ring `heap_base/top/tail`, `released[]`, `slot_heap_end[]`, `mu`/`cv`). Shared: one `std::deque<unique_ptr<DistTaskSlotState>>` + monotonic `next_task_id_`. `alloc(bytes, scope_depth)` picks the ring; `release(slot)` reads `slot.ring_idx` / `slot.ring_slot_idx` to advance the right ring. `reset_to_empty` rewinds every ring. Locking is split into two phases so `ring.mu` and `slots_mu_` are never nested the same direction twice — per-ring back-pressure cannot block other rings or slot-state readers.
- **`DistTaskSlotState`** — gains `ring_idx` / `ring_slot_idx`, stamped by `DistRing::alloc` before return; `reset()` preserves them.
- **`DistScope`** — adds `current_depth()` (0-based, L2-style) used for ring selection.
- **`DistOrchestrator`** — `scope_begin` / `scope_end` made public; `alloc()` and `reserve_outputs_and_slot()` now pass `scope_->current_depth()` so allocs inside a nested scope land in the nested ring.
- **Nanobind** — binds `scope_begin` / `scope_end` (no underscore); keeps `_scope_begin` / `_scope_end` aliases for the `Worker.run` facade. Exposes `DIST_MAX_RING_DEPTH` / `DIST_MAX_SCOPE_DEPTH`.
- **Python `Orchestrator`** — adds `scope_begin` / `scope_end` plus `with orch.scope():` context manager.
- **`Worker(heap_ring_size=N)`** — is now **per-ring**. Total VA reservation = `4 × N` (default 4 GiB across 4 × 1 GiB). Physical pages stay lazy under `MAP_ANONYMOUS`.
- **Docs** — rewrites `orchestrator.md` §5 (per-scope ring) and §6 (Scope: user-facing API + ring table + non-blocking `scope_end` rationale); updates `task-flow.md` §7 memory partitioning to describe 4 separate `MAP_SHARED` mmaps; moves "per-scope HeapRing / user nested scope" from "In flight" to "Landed" in `roadmap.md`.

## Design decisions (recorded in plan Design Decision Log)

1. `scope_end` is **non-blocking** — matches L2; `drain()` is the synchronous wait.
2. Python API: both raw `scope_begin` / `scope_end` and `with orch.scope():` context manager.
3. `heap_ring_size` is **per-ring** (total VA = 4 × N).
4. `alloc(shape, dtype)` **inherits** caller's scope depth.
5. `reset_to_empty` rewinds every ring.

## Test plan

- [x] `pip install --no-build-isolation -e .` builds cleanly in a fresh worktree venv.
- [x] `ctest --test-dir tests/ut/cpp/build -LE requires_hardware` — 7 targets pass (including new `DistRing` scope tests: ring-idx mapping, distinct mmaps per ring, routing by scope_depth, independent reclamation while another ring is full, inner-ring churn while outer holds, reset rewinds all rings, slot metadata).
- [x] `pytest tests/ut/py/test_dist_worker/` — 21 pass (including 3 new scope tests: binding exposed, 3-deep nesting completes, basic with-scope run).
- [ ] CI sim pipeline (`ci.py -p a2a3sim`) — run by reviewers / CI.
- [ ] Hardware L3 scene tests (`pytest tests/st/a2a3/tensormap_and_ringbuffer/test_l3_*.py --platform a2a3`) — run by reviewers / CI.