### PR TITLE
Refactor: split ready queue per WorkerType (Strict-4)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,8 +88,11 @@ get if I pip install `main` today", this page.
   the L2 ABI `ChipStorageTaskArgs` POD from the view right before
   `pto2_run_runtime` — the slot itself stores only the tagged
   `TaskArgs` (single) or `task_args_list` (group).
-- `Scheduler` dispatches slot ids via a single ready queue into
-  `WorkerManager` pools (next-level + sub); for group slots it pushes
+- `Scheduler` dispatches slot ids via **per-worker-type ready queues**
+  (Strict-4; one `DistReadyQueue` for `NEXT_LEVEL`, one for `SUB`) into
+  `WorkerManager` pools (next-level + sub). `dispatch_ready` drains each
+  queue with its own head-of-line break, so a saturated pool of one
+  type cannot stall dispatch for the other. For group slots it pushes
   a `WorkerDispatch { slot, group_index }` per member onto N idle
   threads.
 - `DistChipProcess` / `DistSubWorker` are separate classes today;
@@ -110,11 +113,11 @@ get if I pip install `main` today", this page.
 
 ## In flight / not yet landed
 
-### PR-D: WorkerThread unification + per-shape ready queues
+### PR-D-2: WorkerThread unification (PROCESS mode)
 
 - Fold `DistChipProcess` / `DistSubWorker` into `WorkerThread` with
-  `Mode = THREAD | PROCESS`.
-- Strict-4: 3 ready queues (AIC / AIV / MIX) instead of a single queue.
+  `Mode = THREAD | PROCESS` (no separate fork-proxy classes). Strict-4
+  per-worker-type ready queues already landed in PR-D-1.
 
 ### PR-E: uniform `Worker.run` + callable registry unification
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -2,8 +2,11 @@
 
 > **Status**: target design. `IWorker::run(uint64_t callable, TaskArgsView,
 > ChipCallConfig)` is the live dispatch signature; per-worker-type ready
-> queue split (Strict-4) is not yet implemented (lands in PR-D). See
-> [roadmap.md](roadmap.md) for the full landed-vs-planned breakdown.
+> queue split (Strict-4) is landed — each `WorkerType` has its own
+> `DistReadyQueue` and `dispatch_ready` walks them independently, so a
+> saturated pool of one type cannot head-of-line-block dispatch for the
+> other. See [roadmap.md](roadmap.md) for the full landed-vs-planned
+> breakdown.
 
 The Scheduler is the **DAG executor**. A dedicated C++ thread that consumes
 submitted slots, wires fanout edges, dispatches ready tasks to worker threads,
@@ -37,16 +40,21 @@ consults scheduling metadata (`fanin_count`, `fanout_consumers`, `state`).
 
 ---
 
-## 2. The three queues
+## 2. The queues
 
 ```cpp
 class Scheduler {
     // Producer: Orchestrator.submit_*. Consumer: Scheduler's own loop, Phase 0.
     LockFreeQueue<WiringEntry> wiring_queue_;       // {slot, producers}
 
-    // Producer: Scheduler Phase 0 (newly-ready) + Phase 2 (fanout-released).
-    // Consumer: Scheduler's own loop, Phase 1.
-    LockFreeQueue<TaskSlot> ready_queue_;
+    // Strict-4 — per-worker-type ready queues.
+    // Producers: Orchestrator.submit_* (routes by slot.worker_type) +
+    //            Scheduler Phase 0 / Phase 2 (fanout-released; routes by
+    //            consumer worker_type).
+    // Consumer: Scheduler's own loop, Phase 1 (one drain loop per queue,
+    //           each with its own head-of-line break).
+    DistReadyQueue *ready_next_level_queue_;
+    DistReadyQueue *ready_sub_queue_;
 
     // Producer: WorkerThread (on worker->run() return).
     // Consumer: Scheduler's own loop, Phase 2.
@@ -72,7 +80,27 @@ struct WiringEntry {
 ### Ready queue
 
 Slots whose `fanin_count == fanin_released` are ready to dispatch. The queue
-holds just the slot id; dispatch reads task data from `slots_[sid]`.
+holds just the slot id; dispatch reads task data from the
+`ring.slot_state(sid)` pool.
+
+**Strict-4 — per-worker-type split.** In practice the ready queue is two
+`DistReadyQueue` instances, one per `WorkerType`:
+
+```cpp
+DistReadyQueue ready_next_level_queue_;   // WorkerType::NEXT_LEVEL tasks
+DistReadyQueue ready_sub_queue_;          // WorkerType::SUB tasks
+```
+
+Matching L2's per-shape ready buffer (`PTO2_LocalReadyBuffer` fan-out to
+AIC / AIV / MIX queues), with the L3+ exception that we use `std::queue`
+(Allowed Exception 3: dynamic data structures on host) and only two
+worker types (Allowed Exception 2: `NEXT_LEVEL` + `SUB` at L3+, not
+AIC / AIV / MIX). `Orchestrator::submit_*` routes each slot to the queue
+matching `slot.worker_type`; `Scheduler::on_task_complete` routes a
+newly-ready consumer the same way, based on the *consumer's* worker
+type. `Scheduler::dispatch_ready` drains each queue with its own
+head-of-line break so a saturated pool of one type cannot stall dispatch
+for the other.
 
 ### Completion queue
 
@@ -93,11 +121,8 @@ void Scheduler::run() {
             wire_fanout(w);   // see §4
         }
 
-        // Phase 1: dispatch
-        TaskSlot sid;
-        while (ready_queue_.try_pop(sid)) {
-            dispatch_ready(sid);   // see §5
-        }
+        // Phase 1: dispatch (drains BOTH per-type queues; see §5)
+        dispatch_ready();
 
         // Phase 2: completion
         while (completion_queue_.try_pop(sid)) {
@@ -144,7 +169,12 @@ void Scheduler::wire_fanout(const WiringEntry &w) {
     // Update consumer's fanin to the actual live count (producers already
     // finished don't count).
     c.fanin_count = actual_live;
-    if (actual_live == 0) ready_queue_.push(csid);
+    if (actual_live == 0) {
+        // Strict-4: wiring promotes directly to the per-type queue.
+        auto *q = (c.worker_type == WorkerType::NEXT_LEVEL) ? ready_next_level_queue_
+                                                            : ready_sub_queue_;
+        q->push(csid);
+    }
 }
 ```
 
@@ -160,35 +190,44 @@ The `lock_guard(p.fanout_mu)` + `p.state.load()` check ensures we either:
 
 ## 5. Phase 1 — dispatch
 
-```cpp
-void Scheduler::dispatch_ready(TaskSlot sid) {
-    TaskSlotState &s = slots_[sid];
-    s.state.store(TaskState::READY);
+`dispatch_ready` drains each per-type ready queue with its own
+head-of-line break so one saturated pool cannot stall the other:
 
-    if (s.group_size == 0) {
-        // Single-worker task
-        WorkerThread *wt = manager_->pick_idle(s.worker_type);
-        wt->dispatch(sid);
-    } else {
-        // Group task — reserve N idle workers
-        auto wts = manager_->pick_n_idle(s.worker_type, s.group_size);
-        s.state.store(TaskState::RUNNING);
-        for (size_t i = 0; i < wts.size(); i++) {
-            wts[i]->dispatch(sid, /*group_index=*/static_cast<int32_t>(i));
+```cpp
+void Scheduler::dispatch_ready() {
+    auto drain_one = [&](DistReadyQueue *q) {
+        DistTaskSlot slot;
+        while (q->try_pop(slot)) {
+            TaskSlotState &s = slots_[slot];
+            int N = s.group_size();  // 1 for single-task slots
+
+            auto workers = manager_->pick_n_idle(s.worker_type, N);
+            if (static_cast<int>(workers.size()) < N) {
+                q->push(slot);   // put back; try again after a completion
+                break;
+            }
+            s.state.store(TaskState::RUNNING);
+            for (int i = 0; i < N; i++) {
+                workers[i]->dispatch({slot, i});
+            }
         }
-    }
+    };
+    drain_one(ready_next_level_queue_);
+    drain_one(ready_sub_queue_);
 }
 ```
 
-Dispatch hands off the slot id to a `WorkerThread`. The WorkerThread reads
-`slots_[sid].{callable, task_args, config}` on its own thread and executes —
-see [worker-manager.md](worker-manager.md) §3 for THREAD mode and §4 for
-PROCESS mode.
+Dispatch hands off a `WorkerDispatch {slot, group_index}` to a
+`WorkerThread`. The WorkerThread reads
+`ring.slot_state(slot).{callable, task_args, config}` on its own thread
+and executes — see [worker-manager.md](worker-manager.md) §3 for THREAD
+mode and §4 for PROCESS mode.
 
-**Pick-idle back-pressure**: if no idle worker exists in the pool,
-`pick_idle` blocks. The Scheduler thread is then stalled, which is fine —
-ready tasks pile up in the queue until a worker frees up. The ring's
-back-pressure at the Orch side already caps the number of in-flight tasks.
+**Pick-idle back-pressure**: when `pick_n_idle` returns fewer workers
+than the task needs, the slot is pushed back onto *its* queue and that
+queue's drain halts; the other-type queue's drain continues. The ring's
+back-pressure at the Orch side already caps the total number of
+in-flight tasks across both types.
 
 ---
 
@@ -217,7 +256,12 @@ void Scheduler::on_task_complete(TaskSlot sid) {
     for (TaskSlot csid : consumers) {
         TaskSlotState &c = slots_[csid];
         if (++c.fanin_released == c.fanin_count) {
-            ready_queue_.push(csid);       // consumer now ready
+            // Strict-4: push to the queue matching the *consumer's*
+            // worker type. A consumer of a NEXT_LEVEL producer can itself
+            // be SUB, so we pick based on `c.worker_type`, not `s`.
+            auto *q = (c.worker_type == WorkerType::NEXT_LEVEL) ? ready_next_level_queue_
+                                                                : ready_sub_queue_;
+            q->push(csid);
         }
     }
 

--- a/src/common/distributed/dist_orchestrator.cpp
+++ b/src/common/distributed/dist_orchestrator.cpp
@@ -16,12 +16,14 @@
 #include <stdexcept>
 
 void DistOrchestrator::init(
-    DistTensorMap *tensormap, DistRing *allocator, DistScope *scope, DistReadyQueue *ready_queue
+    DistTensorMap *tensormap, DistRing *allocator, DistScope *scope, DistReadyQueue *ready_next_level_queue,
+    DistReadyQueue *ready_sub_queue
 ) {
     tensormap_ = tensormap;
     allocator_ = allocator;
     scope_ = scope;
-    ready_queue_ = ready_queue;
+    ready_next_level_queue_ = ready_next_level_queue;
+    ready_sub_queue_ = ready_sub_queue;
     active_tasks_.store(0, std::memory_order_relaxed);
 }
 
@@ -218,9 +220,11 @@ DistSubmitResult DistOrchestrator::submit_impl(
     if (scope_ref > 0) scope_->register_task(slot);
 
     // --- Step 6: If no live fanins → READY ---
+    // Strict-4: push to the queue dedicated to this task's worker type so a
+    // saturated sub pool cannot stall next-level dispatch (and vice versa).
     if (live_fanins == 0) {
         s.state.store(TaskState::READY, std::memory_order_release);
-        ready_queue_->push(slot);
+        ready_queue_for(worker_type)->push(slot);
     } else {
         s.state.store(TaskState::PENDING, std::memory_order_release);
     }

--- a/src/common/distributed/dist_orchestrator.h
+++ b/src/common/distributed/dist_orchestrator.h
@@ -64,7 +64,14 @@ struct DistSubmitResult {
 
 class DistOrchestrator {
 public:
-    void init(DistTensorMap *tensormap, DistRing *allocator, DistScope *scope, DistReadyQueue *ready_queue);
+    // Strict-4: the engine keeps one DistReadyQueue per WorkerType so a
+    // saturated sub pool cannot head-of-line-block chip dispatch (and vice
+    // versa). Submit routes to the queue matching the task's worker_type;
+    // the Scheduler's dispatch_ready walks each queue independently.
+    void init(
+        DistTensorMap *tensormap, DistRing *allocator, DistScope *scope, DistReadyQueue *ready_next_level_queue,
+        DistReadyQueue *ready_sub_queue
+    );
 
     // Allocate an intermediate buffer from the Worker's HeapRing (MAP_SHARED,
     // visible to forked child workers). Returns a ContinuousTensor whose
@@ -122,7 +129,18 @@ private:
     DistTensorMap *tensormap_ = nullptr;
     DistRing *allocator_ = nullptr;
     DistScope *scope_ = nullptr;
-    DistReadyQueue *ready_queue_ = nullptr;
+    // Strict-4 per-worker-type ready queues. Each queue handles tasks of
+    // exactly one WorkerType so the Scheduler can dispatch from an idle pool
+    // without being blocked by another pool's saturation.
+    DistReadyQueue *ready_next_level_queue_ = nullptr;
+    DistReadyQueue *ready_sub_queue_ = nullptr;
+
+    // Returns the ready queue that owns tasks of the given worker type.
+    // The method itself does not mutate the Orchestrator (hence `const`);
+    // the returned pointer is non-const because callers push into the queue.
+    DistReadyQueue *ready_queue_for(WorkerType t) const {
+        return t == WorkerType::NEXT_LEVEL ? ready_next_level_queue_ : ready_sub_queue_;
+    }
 
     // --- Drain support (owned here, not on Worker) ---
     std::atomic<int32_t> active_tasks_{0};

--- a/src/common/distributed/dist_scheduler.cpp
+++ b/src/common/distributed/dist_scheduler.cpp
@@ -26,7 +26,8 @@
 // =============================================================================
 
 void DistScheduler::start(const Config &cfg) {
-    if (cfg.ring == nullptr || cfg.ready_queue == nullptr || cfg.manager == nullptr)
+    if (cfg.ring == nullptr || cfg.ready_next_level_queue == nullptr || cfg.ready_sub_queue == nullptr ||
+        cfg.manager == nullptr)
         throw std::invalid_argument("DistScheduler::start: null config fields");
     cfg_ = cfg;
 
@@ -38,7 +39,9 @@ void DistScheduler::start(const Config &cfg) {
 void DistScheduler::stop() {
     stop_requested_.store(true, std::memory_order_release);
     completion_cv_.notify_all();
-    cfg_.ready_queue->shutdown();
+    // Shut down both per-type ready queues so any wait_pop waiters unblock.
+    cfg_.ready_next_level_queue->shutdown();
+    cfg_.ready_sub_queue->shutdown();
 
     if (sched_thread_.joinable()) sched_thread_.join();
 
@@ -135,7 +138,11 @@ void DistScheduler::on_task_complete(DistTaskSlot slot) {
         if (released >= cs.fanin_count) {
             TaskState expected = TaskState::PENDING;
             if (cs.state.compare_exchange_strong(expected, TaskState::READY, std::memory_order_acq_rel)) {
-                cfg_.ready_queue->push(consumer);
+                // Strict-4: route the freshly-ready consumer to the queue
+                // matching its own worker type.
+                auto *q =
+                    (cs.worker_type == WorkerType::NEXT_LEVEL) ? cfg_.ready_next_level_queue : cfg_.ready_sub_queue;
+                q->push(consumer);
                 completion_cv_.notify_one();
             }
         }
@@ -174,23 +181,31 @@ void DistScheduler::try_consume(DistTaskSlot slot) {
 // =============================================================================
 
 void DistScheduler::dispatch_ready() {
-    DistTaskSlot slot;
-    while (cfg_.ready_queue->try_pop(slot)) {
-        DistTaskSlotState &s = *cfg_.ring->slot_state(slot);
-        int N = s.group_size();  // 1 for normal tasks
+    // Strict-4: drain each per-type queue with its OWN head-of-line break.
+    // A saturated pool of one type only stalls its own queue; the other
+    // type continues to dispatch from its pool of idle workers.
+    auto drain_one = [this](DistReadyQueue *q) {
+        DistTaskSlot slot;
+        while (q->try_pop(slot)) {
+            DistTaskSlotState &s = *cfg_.ring->slot_state(slot);
+            int N = s.group_size();  // 1 for normal tasks
 
-        auto workers = cfg_.manager->pick_n_idle(s.worker_type, N);
-        if (static_cast<int>(workers.size()) < N) {
-            cfg_.ready_queue->push(slot);
-            break;
-        }
+            auto workers = cfg_.manager->pick_n_idle(s.worker_type, N);
+            if (static_cast<int>(workers.size()) < N) {
+                q->push(slot);
+                break;
+            }
 
-        s.state.store(TaskState::RUNNING, std::memory_order_release);
-        for (int i = 0; i < N; i++) {
-            WorkerDispatch d;
-            d.task_slot = slot;
-            d.group_index = i;
-            workers[i]->dispatch(d);
+            s.state.store(TaskState::RUNNING, std::memory_order_release);
+            for (int i = 0; i < N; i++) {
+                WorkerDispatch d;
+                d.task_slot = slot;
+                d.group_index = i;
+                workers[i]->dispatch(d);
+            }
         }
-    }
+    };
+
+    drain_one(cfg_.ready_next_level_queue);
+    drain_one(cfg_.ready_sub_queue);
 }

--- a/src/common/distributed/dist_scheduler.h
+++ b/src/common/distributed/dist_scheduler.h
@@ -53,7 +53,11 @@ class DistScheduler {
 public:
     struct Config {
         DistRing *ring;  // owns slot state storage; Scheduler reads via ring->slot_state(id)
-        DistReadyQueue *ready_queue;
+        // Strict-4 per-worker-type ready queues. `dispatch_ready` walks each
+        // queue independently so a saturated pool of one worker type cannot
+        // head-of-line-block dispatch for the other.
+        DistReadyQueue *ready_next_level_queue;
+        DistReadyQueue *ready_sub_queue;
         DistWorkerManager *manager;  // not owned — Scheduler calls manager for dispatch
         // Called when a task reaches CONSUMED (TensorMap cleanup + ring release).
         std::function<void(DistTaskSlot)> on_consumed_cb;

--- a/src/common/distributed/dist_worker.cpp
+++ b/src/common/distributed/dist_worker.cpp
@@ -128,7 +128,7 @@ void DistWorker::add_worker(WorkerType type, IWorker *worker) {
 void DistWorker::init() {
     if (initialized_) throw std::runtime_error("DistWorker: already initialized");
 
-    orchestrator_.init(&tensormap_, &allocator_, &scope_, &ready_queue_);
+    orchestrator_.init(&tensormap_, &allocator_, &scope_, &ready_next_level_queue_, &ready_sub_queue_);
 
     // Start WorkerManager first — creates WorkerThreads.
     // The on_complete callback routes through the Scheduler's worker_done().
@@ -138,7 +138,8 @@ void DistWorker::init() {
 
     DistScheduler::Config cfg;
     cfg.ring = &allocator_;
-    cfg.ready_queue = &ready_queue_;
+    cfg.ready_next_level_queue = &ready_next_level_queue_;
+    cfg.ready_sub_queue = &ready_sub_queue_;
     cfg.manager = &manager_;
     cfg.on_consumed_cb = [this](DistTaskSlot slot) {
         orchestrator_.on_consumed(slot);

--- a/src/common/distributed/dist_worker.h
+++ b/src/common/distributed/dist_worker.h
@@ -94,7 +94,11 @@ private:
     DistTensorMap tensormap_;
     DistRing allocator_;
     DistScope scope_;
-    DistReadyQueue ready_queue_;
+    // Strict-4: one ready queue per WorkerType. Submit routes by
+    // s.worker_type; the Scheduler drains each queue independently so
+    // saturation of one pool cannot head-of-line-block the other.
+    DistReadyQueue ready_next_level_queue_;
+    DistReadyQueue ready_sub_queue_;
     DistOrchestrator orchestrator_;
     DistScheduler scheduler_;
     DistWorkerManager manager_;

--- a/tests/ut/cpp/test_dist_orchestrator.cpp
+++ b/tests/ut/cpp/test_dist_orchestrator.cpp
@@ -29,13 +29,21 @@ struct OrchestratorFixture : public ::testing::Test {
     DistTensorMap tm;
     DistRing allocator;
     DistScope scope;
-    DistReadyQueue rq;
+    // Strict-4: per-type ready queues.
+    DistReadyQueue rq_next_level;
+    DistReadyQueue rq_sub;
     DistOrchestrator orch;
     ChipCallConfig cfg;
 
+    // Tests in this file only submit NEXT_LEVEL tasks, so `rq` is a
+    // convenience alias for the next-level queue. Kept public so existing
+    // `rq.try_pop(...)` / `EXPECT_TRUE(rq.try_pop(...))` lines continue to
+    // work without rewriting every assertion.
+    DistReadyQueue &rq = rq_next_level;
+
     void SetUp() override {
         allocator.init(/*heap_bytes=*/1ULL << 20);
-        orch.init(&tm, &allocator, &scope, &rq);
+        orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub);
     }
 
     void TearDown() override { allocator.shutdown(); }

--- a/tests/ut/cpp/test_dist_scheduler.cpp
+++ b/tests/ut/cpp/test_dist_scheduler.cpp
@@ -106,7 +106,9 @@ struct SchedulerFixture : public ::testing::Test {
     DistTensorMap tm;
     DistRing allocator;
     DistScope scope;
-    DistReadyQueue rq;
+    // Strict-4: per-type ready queues.
+    DistReadyQueue rq_next_level;
+    DistReadyQueue rq_sub;
     DistOrchestrator orch;
     MockWorker mock_worker;
     DistWorkerManager manager;
@@ -120,7 +122,7 @@ struct SchedulerFixture : public ::testing::Test {
 
     void SetUp() override {
         allocator.init(/*heap_bytes=*/1ULL << 20);
-        orch.init(&tm, &allocator, &scope, &rq);
+        orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub);
 
         manager.add_next_level(&mock_worker);
         manager.start(&allocator, [this](DistTaskSlot slot) {
@@ -129,7 +131,8 @@ struct SchedulerFixture : public ::testing::Test {
 
         DistScheduler::Config c;
         c.ring = &allocator;
-        c.ready_queue = &rq;
+        c.ready_next_level_queue = &rq_next_level;
+        c.ready_sub_queue = &rq_sub;
         c.manager = &manager;
         c.on_consumed_cb = [this](DistTaskSlot s) {
             orch.on_consumed(s);
@@ -209,7 +212,9 @@ struct GroupSchedulerFixture : public ::testing::Test {
     DistTensorMap tm;
     DistRing allocator;
     DistScope scope;
-    DistReadyQueue rq;
+    // Strict-4: per-type ready queues.
+    DistReadyQueue rq_next_level;
+    DistReadyQueue rq_sub;
     DistOrchestrator orch;
     MockWorker worker_a;
     MockWorker worker_b;
@@ -224,7 +229,7 @@ struct GroupSchedulerFixture : public ::testing::Test {
 
     void SetUp() override {
         allocator.init(/*heap_bytes=*/1ULL << 20);
-        orch.init(&tm, &allocator, &scope, &rq);
+        orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub);
 
         manager.add_next_level(&worker_a);
         manager.add_next_level(&worker_b);
@@ -234,7 +239,8 @@ struct GroupSchedulerFixture : public ::testing::Test {
 
         DistScheduler::Config c;
         c.ring = &allocator;
-        c.ready_queue = &rq;
+        c.ready_next_level_queue = &rq_next_level;
+        c.ready_sub_queue = &rq_sub;
         c.manager = &manager;
         c.on_consumed_cb = [this](DistTaskSlot s) {
             orch.on_consumed(s);
@@ -305,6 +311,107 @@ TEST_F(GroupSchedulerFixture, GroupCompletesOnlyWhenAllDone) {
 
     worker_b.complete();
     wait_consumed(slot);
+}
+
+// ===========================================================================
+// Strict-4: per-worker-type ready queues (no head-of-line blocking across
+// types). Covered here with one NEXT_LEVEL worker + one SUB worker: with a
+// saturated NEXT_LEVEL pool, a SUB task submitted afterwards must still
+// dispatch immediately instead of waiting behind the stuck next-level task.
+// ===========================================================================
+
+struct MixedTypeSchedulerFixture : public ::testing::Test {
+    DistTensorMap tm;
+    DistRing allocator;
+    DistScope scope;
+    DistReadyQueue rq_next_level;
+    DistReadyQueue rq_sub;
+    DistOrchestrator orch;
+    MockWorker next_level_worker;
+    MockWorker sub_worker;
+    DistWorkerManager manager;
+    DistScheduler sched;
+    ChipCallConfig cfg;
+
+    std::vector<DistTaskSlot> consumed_slots;
+    std::mutex consumed_mu;
+
+    DistTaskSlotState &S(DistTaskSlot id) { return *allocator.slot_state(id); }
+
+    void SetUp() override {
+        allocator.init(/*heap_bytes=*/1ULL << 20);
+        orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub);
+
+        manager.add_next_level(&next_level_worker);
+        manager.add_sub(&sub_worker);
+        manager.start(&allocator, [this](DistTaskSlot slot) {
+            sched.worker_done(slot);
+        });
+
+        DistScheduler::Config c;
+        c.ring = &allocator;
+        c.ready_next_level_queue = &rq_next_level;
+        c.ready_sub_queue = &rq_sub;
+        c.manager = &manager;
+        c.on_consumed_cb = [this](DistTaskSlot s) {
+            orch.on_consumed(s);
+            std::lock_guard<std::mutex> lk(consumed_mu);
+            consumed_slots.push_back(s);
+        };
+        sched.start(c);
+    }
+
+    void TearDown() override {
+        sched.stop();
+        manager.stop();
+        allocator.shutdown();
+    }
+
+    bool is_consumed(DistTaskSlot slot) {
+        std::lock_guard<std::mutex> lk(consumed_mu);
+        for (DistTaskSlot s : consumed_slots)
+            if (s == slot) return true;
+        return false;
+    }
+
+    void wait_consumed(DistTaskSlot slot, int timeout_ms = 500) {
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (is_consumed(slot)) return;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        FAIL() << "Timed out waiting for slot " << slot << " to be consumed";
+    }
+};
+
+TEST_F(MixedTypeSchedulerFixture, SubTaskDispatchesWhileNextLevelPoolSaturated) {
+    // Submit a next-level task; the only chip worker begins running it and
+    // stays blocked until we call complete() on it.
+    auto chip_args = single_tensor_args(0xAAA, TensorArgType::OUTPUT);
+    auto chip = orch.submit_next_level(0xCDCD, chip_args, cfg);
+    next_level_worker.wait_running();
+    ASSERT_TRUE(next_level_worker.is_running.load());
+
+    // Now submit a sub task while the chip pool is saturated. With a single
+    // shared ready queue this would block behind any next-level task sitting
+    // at the queue head waiting for a free chip worker. With per-type
+    // queues (Strict-4) it must dispatch immediately to the idle sub
+    // worker.
+    auto sub_args = single_tensor_args(0xBBB, TensorArgType::OUTPUT);
+    auto sub = orch.submit_sub(/*callable_id=*/7, sub_args);
+
+    sub_worker.wait_running();
+    EXPECT_TRUE(sub_worker.is_running.load());
+    EXPECT_TRUE(next_level_worker.is_running.load()) << "chip worker must still be busy";
+
+    // Complete the sub task first; it reaches CONSUMED while the chip task
+    // is still running — demonstrating independent per-type dispatch.
+    sub_worker.complete();
+    wait_consumed(sub.task_slot);
+    EXPECT_FALSE(is_consumed(chip.task_slot));
+
+    next_level_worker.complete();
+    wait_consumed(chip.task_slot);
 }
 
 TEST_F(GroupSchedulerFixture, GroupDependencyChain) {


### PR DESCRIPTION
## Summary

Strict-4 alignment with L2. The single `DistReadyQueue` today head-of-line-blocks cross-type dispatch: a NEXT_LEVEL task at the queue head with all chip workers busy blocks any SUB task behind it from dispatching even when sub workers are idle (and vice versa). This PR partitions the queue by `WorkerType`, mirroring L2's per-shape ready buffer; each per-type queue has its own head-of-line break.

First half of the old PR-D (now split into PR-D-1 here + PR-D-2 follow-up). PR-D-2 will fold `DistChipProcess` / `DistSubWorker` into a unified `WorkerThread` with `Mode = THREAD | PROCESS` — kept separate because it changes the Python-facing API and deserves its own review.

## What changed

- **`DistOrchestrator`** — `init()` takes two `DistReadyQueue *` (one per `WorkerType`); `submit_impl` pushes through a new `ready_queue_for(worker_type)` helper.
- **`DistScheduler`** — `Config` carries both queue pointers. `dispatch_ready` refactors into a `drain_one(queue)` closure that runs once per queue, each with its own head-of-line break. `on_task_complete` routes a newly-ready consumer by the *consumer's* `worker_type`. `stop` shuts down both queues.
- **`DistWorker`** — owns `ready_next_level_queue_` + `ready_sub_queue_` members in place of the single `ready_queue_`.
- **Tests** — C++ fixtures wire both queues. New `MixedTypeSchedulerFixture::SubTaskDispatchesWhileNextLevelPoolSaturated` pins the invariant: with the single chip worker blocked on a NEXT_LEVEL task, a subsequently-submitted SUB task reaches CONSUMED without waiting for the chip task to finish.
- **Docs** — `scheduler.md` §2 / §3 / §5 / §6 now describe per-type queues and the new `dispatch_ready` shape; `roadmap.md` splits the old PR-D entry into D-1 (this PR) and D-2 (PROCESS-mode WorkerThread unification).

## L2 alignment

Diverges from L2 only on already-allowed exceptions:

- **Allowed Exception 3** — data structure is `std::queue` on host, not a lock-free MPMC ring.
- **Allowed Exception 2** — two queues (`NEXT_LEVEL` + `SUB`) at L3+, not three (AIC / AIV / MIX) at L2, because worker types differ across layers.

The per-shape partitioning itself now aligns.

## Test plan

- [x] `pip install --no-build-isolation -e .` builds cleanly in the worktree venv.
- [x] `ctest --test-dir tests/ut/cpp/build -LE requires_hardware` — 7 targets pass, including the new `MixedTypeSchedulerFixture` test.
- [x] `pytest tests/ut/py/test_dist_worker/` — 21 pass.
- [ ] CI sim pipeline (`ci.py -p a2a3sim`) — run by reviewers / CI.
- [ ] Hardware L3 scene tests — run by reviewers / CI.