### PR TITLE
Refactor: unify Worker.run(callable, args, config), delete Task

### DIFF
--- a/docs/distributed_level_runtime.md
+++ b/docs/distributed_level_runtime.md
@@ -108,12 +108,17 @@ See [scheduler.md](scheduler.md) for the dispatch loop and coordination.
 The **execution layer**. `WorkerManager` holds two pools of `WorkerThread`s
 (next-level pool and sub pool). Each `WorkerThread`:
 
-- owns one `IWorker` (`ChipWorker`, `SubWorker`, or nested `Worker`)
+- owns one `IWorker` (`ChipWorker` or nested `Worker`) for next-level workers
 - has its own `std::thread`
 - runs in one of two modes:
   - `THREAD`: calls `worker->run(callable, view, config)` directly in-process
   - `PROCESS`: forks a child at init; each dispatch writes task data to a shm
     mailbox, the child decodes and runs
+
+SUB workers are Python-only: the forked child process runs a Python loop
+(``_sub_worker_loop``) that reads the args blob from the mailbox, decodes it
+into a ``TaskArgs``, and calls the registered callable as ``fn(args)``.
+There is no C++ ``SubWorker`` class.
 
 See [worker-manager.md](worker-manager.md) for thread/process mechanics, fork
 ordering, and mailbox layout. See [task-flow.md](task-flow.md) for what flows
@@ -177,7 +182,7 @@ w4 = Worker(level=4, child_mode=WorkerManager.Mode.THREAD)
 w4.add_worker(NEXT_LEVEL, w3)         # w3 is an IWorker
 w4.init()
 
-w4.run(Task(orch=my_l4_orch, task_args=..., config=...))
+w4.run(my_l4_orch, my_args, my_config)
 ```
 
 When L4's `WorkerThread` dispatches to L3, L3's `Worker::run` opens its own

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,6 +77,21 @@ get if I pip install `main` today", this page.
   `DIST_MAX_SCOPE_DEPTH = 64`; scopes deeper than the ring depth share
   the innermost ring.
 
+### Uniform `Worker.run(callable, args, config)`
+
+- **`Task` dataclass deleted** — `Worker.run` now takes
+  `(callable, args=None, config=None)` directly. For L3+, `callable` is
+  the orch function; for L2, it is a `ChipCallable`. `config` defaults
+  to `ChipCallConfig()` if omitted.
+- **Orch fn signature is 3-param**: `def orch(o, args, cfg)` — receives
+  the `Orchestrator`, `TaskArgs`, and `ChipCallConfig` passed to
+  `Worker.run`.
+- **Sub callable signature is `fn(args)`** — registered callables now
+  receive the `TaskArgs` decoded from the mailbox blob. The Python child
+  loop (`_sub_worker_loop`) reads the blob at `_OFF_ARGS` and constructs
+  a `TaskArgs` via `_read_args_from_mailbox`. Callable registry stays
+  Python-only (`dict[int, Callable]`).
+
 ### Dispatch internals
 
 - `IWorker::run(uint64_t callable, TaskArgsView args, ChipCallConfig cfg)`
@@ -118,14 +133,6 @@ get if I pip install `main` today", this page.
 - Fold `DistChipProcess` / `DistSubWorker` into `WorkerThread` with
   `Mode = THREAD | PROCESS` (no separate fork-proxy classes). Strict-4
   per-worker-type ready queues already landed in PR-D-1.
-
-### PR-E: uniform `Worker.run` + callable registry unification
-
-- Python `Worker.run` drops the `if level==2` branch.
-- Callable registry moves fully into C++
-  (`unordered_map<uint64_t, nb::object>` owned by `Worker`) so
-  `ChipCallable` and Python `sub` callables share one lookup path.
-  This unblocks L4+ recursion.
 
 ### PR-F: C++ `Worker::run(Task)` for L4+ recursion
 

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -244,12 +244,19 @@ void ChipWorker::run(Callable cb, TaskArgsView view, const CallConfig &config) o
 
 ### `SubWorker` (Python callable leaf)
 
-```cpp
-void SubWorker::run(Callable cb, TaskArgsView view, const CallConfig &config) override {
-    uint64_t cid = cb;                     // no cast
-    py_registry_[cid](view);               // invoke Python callable with view
-}
+SubWorker execution is handled entirely in Python. The forked child process
+runs ``_sub_worker_loop`` which reads the args blob from the shared-memory
+mailbox, decodes it into a ``TaskArgs`` object, and passes it to the
+registered callable:
+
+```python
+fn(args)    # args: TaskArgs decoded from the mailbox blob
 ```
+
+The callable receives the same `TaskArgs` that was submitted via
+`orch.submit_sub(cid, args)`, with tags stripped (tags are consumed by the
+Orchestrator at submit time). There is no C++ `SubWorker` class — the
+Python child loop and callable registry are the entire implementation.
 
 Child inherits the Python registry through fork COW; the registry lookup works
 with no IPC.
@@ -332,6 +339,12 @@ slot.callable   ─┐
 slot.config     ─┼─► memcpy into shm mailbox ─► child reads view ─► worker_->run(cb, view, config)
 slot.task_args  ─┘    (write_blob)                (read_blob)
 ```
+
+For SUB workers in PROCESS mode, the child is a Python process running
+``_sub_worker_loop``. The mailbox carries the same blob format, but the
+Python child decodes it via ``_read_args_from_mailbox`` into a ``TaskArgs``
+object and calls ``fn(args)`` directly — the dispatch path bypasses
+``IWorker`` entirely.
 
 The mailbox layout, fork ordering, and child loop are in
 [worker-manager.md](worker-manager.md) §4.
@@ -418,7 +431,7 @@ def my_l3_orch(orch3, args, cfg):
 def my_l4_orch(orch4, args, cfg):
     orch4.submit_next_level(my_l3_orch_handle, args, cfg)
 
-w4.run(Task(orch=my_l4_orch, task_args=..., config=...))
+w4.run(my_l4_orch, my_args, my_config)
 ```
 
 L4's WorkerThread dispatches to `w3` via `IWorker::run`. `Worker::run`
@@ -463,14 +476,14 @@ w3 = Worker(level=3, child_mode=PROCESS)
 w3.add_worker(NEXT_LEVEL, chip_worker_0)
 w3.init()    # fork chip_0 here
 
-w3.run(Task(orch=my_orch, task_args=args, config=CallConfig(block_dim=3)))
+w3.run(my_orch, args, CallConfig(block_dim=3))
 ```
 
 Step-by-step (PROCESS mode, one chip worker):
 
 | Step | Where | What happens |
 | ---- | ----- | ------------ |
-| 1 | parent Python | user builds `args: TaskArgs`, calls `w3.run(Task)` |
+| 1 | parent Python | user builds `args: TaskArgs`, calls `w3.run(my_orch, args, config)` |
 | 2 | `Worker::run` | `scope_begin` → call `my_orch(&orch_, args.view(), cfg)` |
 | 3 | `Orchestrator::submit_next_level` | `slot = ring.alloc()`; move `chip_args` into `slot.task_args`; walk tags → `tensormap.lookup(a.data)`, `tensormap.lookup(b.data)`, `tensormap.insert(c.data, slot)`; push ready |
 | 4 | Scheduler thread | pop `slot`; `wt = manager.pick_idle(NEXT_LEVEL)` (WT_chip_0); `wt->dispatch(slot)` |
@@ -481,7 +494,7 @@ Step-by-step (PROCESS mode, one chip worker):
 | 9 | chip_0 child | `run` returns; write `TASK_DONE` |
 | 10 | WT_chip_0 parent | see `TASK_DONE`; call `on_complete_(slot)` |
 | 11 | Scheduler | mark slot COMPLETED; fanout release (none in this DAG); scope_end will release scope ref |
-| 12 | `Worker::run` returns | user's `w3.run(Task)` returns; `c` contains result in shm, visible to user |
+| 12 | `Worker::run` returns | user's `w3.run(...)` returns; `c` contains result in shm, visible to user |
 
 ---
 

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -156,15 +156,20 @@ void WorkerThread::dispatch_thread(WorkerDispatch d) {
   `IWorker` casts back appropriately.
 - `IWorker::run` dispatches polymorphically based on the actual worker type.
 
+Note: SUB workers in PROCESS mode bypass `IWorker` entirely — the Python
+child loop (``_sub_worker_loop``) reads the args blob from the mailbox,
+decodes it into a ``TaskArgs``, and calls the registered callable as
+``fn(args)``. The C++ dispatch path writes the same mailbox format for
+both worker types.
+
 **When is THREAD mode safe?**
 
 - The IWorker implementation must be thread-safe relative to other concurrent
   calls and other system state
 - `ChipWorker` (dlsym'd runtime.so) is safe when the runtime `.so` and its
   device driver support concurrent use
-- `SubWorker` in THREAD mode is constrained by Python's GIL (all SubWorkers
-  in the pool effectively serialize), but this is often fine for light
-  Python callables
+- SUB workers run in Python child processes (PROCESS mode) where the
+  callable receives ``TaskArgs`` as its sole argument
 
 ---
 

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -12,18 +12,18 @@ A thin Python facade over the C++ ``DistOrchestrator``. The Worker creates one
 Orchestrator handle at init, retrieves the C++ object via ``DistWorker.get_orchestrator()``,
 and passes the handle to the user's orch function::
 
-    def my_orch(orch, args):
+    def my_orch(orch, args, cfg):
         # build the args object yourself; tags drive dependency inference
         a = TaskArgs()
         a.add_tensor(make_tensor_arg(input_tensor),  TensorArgType.INPUT)
         a.add_tensor(make_tensor_arg(output_tensor), TensorArgType.OUTPUT)
-        orch.submit_next_level(chip_callable, a, config)
+        orch.submit_next_level(chip_callable, a, cfg)
 
         sub_args = TaskArgs()
         sub_args.add_tensor(make_tensor_arg(output_tensor), TensorArgType.INPUT)
         orch.submit_sub(cid, sub_args)
 
-    w.run(Task(orch=my_orch, args=my_args))
+    w.run(my_orch, my_args, my_config)
 
 Scope/drain lifecycle is managed by ``Worker.run()``; users never call those
 directly.

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -13,20 +13,20 @@ Usage::
     # L2: one NPU chip
     w = Worker(level=2, device_id=8, platform="a2a3", runtime="tensormap_and_ringbuffer")
     w.init()
-    w.run(chip_callable, chip_args, block_dim=24)
+    w.run(chip_callable, chip_args, config)
     w.close()
 
     # L3: multiple chips + SubWorkers, auto-discovery in init()
     w = Worker(level=3, device_ids=[8, 9], num_sub_workers=2,
                platform="a2a3", runtime="tensormap_and_ringbuffer")
-    cid = w.register(lambda: postprocess())
+    cid = w.register(lambda args: postprocess())
     w.init()
 
-    def my_orch(orch, args):
-        r = orch.submit_next_level(chip_callable, chip_args_ptr, config, outputs=[64])
-        orch.submit_sub(cid, inputs=[r.outputs[0].ptr])
+    def my_orch(orch, args, cfg):
+        r = orch.submit_next_level(chip_callable, chip_args_ptr, cfg)
+        orch.submit_sub(cid, sub_args)
 
-    w.run(Task(orch=my_orch, args=my_args))
+    w.run(my_orch, my_args, my_config)
     w.close()
 """
 
@@ -34,43 +34,28 @@ import ctypes
 import os
 import struct
 import sys
-from dataclasses import dataclass, field
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Callable, Optional
 
 from .orchestrator import Orchestrator
 from .task_interface import (
     DIST_MAILBOX_SIZE,
+    ChipCallConfig,
     ChipWorker,
+    ContinuousTensor,
+    DataType,
     DistWorker,
+    TaskArgs,
     _ChipWorker,
 )
-
-# ---------------------------------------------------------------------------
-# Task
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class Task:
-    """Execution unit for Worker.run() at any level.
-
-    For L2: call ``Worker.run(chip_callable, chip_args, config)`` directly.
-    For L3+: provide an orch function ``fn(orchestrator, args)`` that builds
-    the DAG via ``orchestrator.submit_*``.
-    """
-
-    orch: Callable
-    args: Any = field(default=None)
-
 
 # ---------------------------------------------------------------------------
 # Unified mailbox layout (must match dist_worker_manager.h MAILBOX_OFF_*)
 # ---------------------------------------------------------------------------
 #
 # One layout for both NEXT_LEVEL (chip) and SUB workers. SUB children
-# read `callable` as a uint64 encoding the callable_id and ignore the
-# config + args_blob region.
+# read `callable` as a uint64 encoding the callable_id and decode the
+# args_blob region to pass TaskArgs to the registered callable.
 
 _OFF_STATE = 0
 _OFF_ERROR = 4
@@ -93,6 +78,35 @@ def _mailbox_addr(shm: SharedMemory) -> int:
     return ctypes.addressof(ctypes.c_char.from_buffer(buf))
 
 
+def _read_args_from_mailbox(buf) -> TaskArgs:
+    """Decode the TaskArgs blob written by C++ write_blob from the mailbox.
+
+    Blob layout at _OFF_ARGS:
+      int32 tensor_count (T), int32 scalar_count (S),
+      ContinuousTensor[T] (40 B each), uint64_t[S] (8 B each).
+    """
+    base = _OFF_ARGS
+    t_count = struct.unpack_from("i", buf, base)[0]
+    s_count = struct.unpack_from("i", buf, base + 4)[0]
+
+    args = TaskArgs()
+    ct_off = base + 8
+    for i in range(t_count):
+        off = ct_off + i * 40
+        data = struct.unpack_from("Q", buf, off)[0]
+        shapes = struct.unpack_from("5I", buf, off + 8)
+        ndims = struct.unpack_from("I", buf, off + 28)[0]
+        dtype_val = struct.unpack_from("B", buf, off + 32)[0]
+        ct = ContinuousTensor.make(data, tuple(shapes[:ndims]), DataType(dtype_val))
+        args.add_tensor(ct)
+
+    sc_off = ct_off + t_count * 40
+    for i in range(s_count):
+        args.add_scalar(struct.unpack_from("Q", buf, sc_off + i * 8)[0])
+
+    return args
+
+
 def _sub_worker_loop(buf, registry: dict) -> None:
     """Runs in forked child process. Reads unified mailbox layout."""
     while True:
@@ -105,7 +119,8 @@ def _sub_worker_loop(buf, registry: dict) -> None:
                 error = 1
             else:
                 try:
-                    fn()
+                    args = _read_args_from_mailbox(buf)
+                    fn(args)
                 except Exception:  # noqa: BLE001
                     error = 2
             struct.pack_into("i", buf, _OFF_ERROR, error)
@@ -351,25 +366,26 @@ class Worker:
     # run — uniform entry point
     # ------------------------------------------------------------------
 
-    def run(self, task_or_callable, args=None, **kwargs) -> None:
-        """Execute one task synchronously.
+    def run(self, callable, args=None, config=None) -> None:
+        """Execute one task (L2) or one DAG (L3+) synchronously.
 
-        L2: run(chip_callable, chip_args, block_dim=N)
-        L3: run(Task(orch=fn, args=...))
+        callable: ChipCallable (L2) or Python orch fn (L3+)
+        args:     TaskArgs (optional)
+        config:   ChipCallConfig (optional, default-constructed if None)
         """
         assert self._initialized, "Worker not initialized; call init() first"
+        cfg = config if config is not None else ChipCallConfig()
 
         if self.level == 2:
             assert self._chip_worker is not None
-            self._chip_worker.run(task_or_callable, args, **kwargs)
+            self._chip_worker.run(callable, args, cfg)
         else:
             self._start_level3()
             assert self._orch is not None
             assert self._dist_worker is not None
-            task = task_or_callable
             self._orch._scope_begin()
             try:
-                task.orch(self._orch, task.args)
+                callable(self._orch, args, cfg)
             finally:
                 # Always release scope refs and drain so ring slots aren't
                 # stranded when the orch fn raises mid-DAG.

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -815,8 +815,6 @@ class SceneTestCase:
         enable_profiling=False,
         enable_dump_tensor=False,
     ):
-        from simpler.worker import Task  # noqa: PLC0415
-
         params = case.get("params", {})
         config_dict = case.get("config", {})
 
@@ -854,12 +852,13 @@ class SceneTestCase:
                 enable_dump_tensor=enable_dump_tensor,
             )
 
-            # Wrap in Task — user orch signature: (orch, callables, task_args, config)
-            def task_orch(orch, _unused, _ns=ns, _test_args=test_args, _config=config):
+            # Orch fn signature: (orch, args, cfg) — inner fn forwards to
+            # the user's scene orch which takes (orch, callables, task_args, config).
+            def task_orch(orch, _args, _cfg, _ns=ns, _test_args=test_args, _config=config):
                 orch_fn(orch, _ns, _test_args, _config)
 
             with _temporary_env(self._resolve_env()):
-                worker.run(Task(orch=task_orch))
+                worker.run(task_orch)
 
             if not skip_golden:
                 _compare_outputs(test_args, golden_args, all_tensor_names, self.RTOL, self.ATOL)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py
@@ -24,7 +24,7 @@ from simpler_setup.scene_test import _build_l3_task_args
 KERNELS_BASE = "../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
 
 
-def verify():
+def verify(args):
     """SubCallable — dependency target, runs after ChipTask completes."""
 
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py
@@ -24,7 +24,7 @@ from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 KERNELS_BASE = "../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
 
 
-def verify():
+def verify(args):
     """SubCallable — runs after group completes."""
 
 

--- a/tests/ut/py/test_dist_worker/test_group_task.py
+++ b/tests/ut/py/test_dist_worker/test_group_task.py
@@ -33,7 +33,7 @@ from simpler.task_interface import (
     TaskArgs,
     TensorArgType,
 )
-from simpler.worker import Task, Worker
+from simpler.worker import Worker
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -75,17 +75,17 @@ class TestGroupBasic:
 
         hw = Worker(level=3, num_sub_workers=2)
 
-        def inc():
+        def inc(args):
             with counter.get_lock():
                 counter.value += 1
 
         cid = hw.register(inc)
         hw.init()
 
-        def orch(o, _args):
+        def orch(o, args, cfg):
             o.submit_sub_group(cid, [TaskArgs(), TaskArgs()])
 
-        hw.run(Task(orch=orch))
+        hw.run(orch)
         hw.close()
 
         assert counter.value == 2, f"Expected 2, got {counter.value}"
@@ -96,17 +96,17 @@ class TestGroupBasic:
 
         hw = Worker(level=3, num_sub_workers=1)
 
-        def inc():
+        def inc(args):
             with counter.get_lock():
                 counter.value += 1
 
         cid = hw.register(inc)
         hw.init()
 
-        def orch(o, _args):
+        def orch(o, args, cfg):
             o.submit_sub_group(cid, [TaskArgs()])
 
-        hw.run(Task(orch=orch))
+        hw.run(orch)
         hw.close()
 
         assert counter.value == 1
@@ -136,11 +136,11 @@ class TestGroupDependency:
             assert gb is not None and db is not None
 
             hw = Worker(level=3, num_sub_workers=3)
-            group_cid = hw.register(lambda: struct.pack_into("i", gb, 0, 1))
-            dep_cid = hw.register(lambda: struct.pack_into("i", db, 0, 1))
+            group_cid = hw.register(lambda args: struct.pack_into("i", gb, 0, 1))
+            dep_cid = hw.register(lambda args: struct.pack_into("i", db, 0, 1))
             hw.init()
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 # Group: both members tag the synthetic ptr as OUTPUT — the
                 # second insert overwrites the first with the same slot id.
                 o.submit_sub_group(
@@ -154,7 +154,7 @@ class TestGroupDependency:
                 # a fanin on the group slot.
                 o.submit_sub(dep_cid, _sync_args(_SYNC_PTR, TensorArgType.INPUT))
 
-            hw.run(Task(orch=orch))
+            hw.run(orch)
             hw.close()
 
             assert _read(group_marker) == 1, "Group task didn't run"

--- a/tests/ut/py/test_dist_worker/test_host_worker.py
+++ b/tests/ut/py/test_dist_worker/test_host_worker.py
@@ -17,7 +17,7 @@ from multiprocessing.shared_memory import SharedMemory
 
 import pytest
 from simpler.task_interface import DataType, TaskArgs, TensorArgType
-from simpler.worker import Task, Worker
+from simpler.worker import Worker
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -60,14 +60,14 @@ class TestLifecycle:
 
     def test_context_manager(self):
         with Worker(level=3, num_sub_workers=1) as hw:
-            hw.register(lambda: None)
+            hw.register(lambda args: None)
         # close() called by __exit__, no exception
 
     def test_register_after_init_raises(self):
         hw = Worker(level=3, num_sub_workers=0)
         hw.init()
         with pytest.raises(RuntimeError, match="before init"):
-            hw.register(lambda: None)
+            hw.register(lambda args: None)
         hw.close()
 
 
@@ -82,13 +82,13 @@ class TestSingleSubTask:
 
         try:
             hw = Worker(level=3, num_sub_workers=1)
-            cid = hw.register(lambda: _increment_counter(counter_buf))
+            cid = hw.register(lambda args: _increment_counter(counter_buf))
             hw.init()
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 o.submit_sub(cid)
 
-            hw.run(Task(orch=orch))
+            hw.run(orch)
             hw.close()
 
             assert _read_counter(counter_buf) == 1
@@ -101,14 +101,14 @@ class TestSingleSubTask:
 
         try:
             hw = Worker(level=3, num_sub_workers=1)
-            cid = hw.register(lambda: _increment_counter(counter_buf))
+            cid = hw.register(lambda args: _increment_counter(counter_buf))
             hw.init()
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 for _ in range(3):
                     o.submit_sub(cid)
 
-            hw.run(Task(orch=orch))
+            hw.run(orch)
             hw.close()
 
             assert _read_counter(counter_buf) == 3
@@ -143,16 +143,16 @@ class TestSubmitResult:
         counter_shm, counter_buf = _make_shared_counter()
         try:
             hw = Worker(level=3, num_sub_workers=1)
-            cid = hw.register(lambda: _increment_counter(counter_buf))
+            cid = hw.register(lambda args: _increment_counter(counter_buf))
             hw.init()
 
             captured = []
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 result = o.submit_sub(cid)
                 captured.append(result)
 
-            hw.run(Task(orch=orch))
+            hw.run(orch)
             hw.close()
 
             assert len(captured) == 1
@@ -178,13 +178,13 @@ class TestScope:
 
         try:
             hw = Worker(level=3, num_sub_workers=1)
-            cid = hw.register(lambda: _increment_counter(counter_buf))
+            cid = hw.register(lambda args: _increment_counter(counter_buf))
             hw.init()
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 o.submit_sub(cid)
 
-            hw.run(Task(orch=orch))
+            hw.run(orch)
             hw.close()
 
             assert _read_counter(counter_buf) == 1
@@ -199,16 +199,16 @@ class TestScope:
             # Use one sub worker so the increments serialize — _increment_counter
             # is a non-atomic RMW and races across parallel SubWorker processes.
             hw = Worker(level=3, num_sub_workers=1)
-            cid = hw.register(lambda: _increment_counter(counter_buf))
+            cid = hw.register(lambda args: _increment_counter(counter_buf))
             hw.init()
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 with o.scope():
                     o.submit_sub(cid)
                     o.submit_sub(cid)
                 o.submit_sub(cid)  # back on outer-scope ring
 
-            hw.run(Task(orch=orch))
+            hw.run(orch)
             hw.close()
 
             assert _read_counter(counter_buf) == 3
@@ -225,10 +225,10 @@ class TestScope:
         assert hasattr(DistOrchestrator, "scope_end")
 
         hw = Worker(level=3, num_sub_workers=1)
-        hw.register(lambda: None)
+        hw.register(lambda args: None)
         hw.init()
 
-        def orch(o, _args):
+        def orch(o, args, cfg):
             # Raw calls — match L2's pto2_scope_begin / pto2_scope_end.
             o.scope_begin()
             o.scope_end()
@@ -240,7 +240,7 @@ class TestScope:
                 inner = o.alloc((32,), DataType.FLOAT32)
                 assert inner.data != 0
 
-        hw.run(Task(orch=orch))
+        hw.run(orch)
         hw.close()
 
     def test_user_nested_scope_three_deep(self):
@@ -248,10 +248,10 @@ class TestScope:
         counter_shm, counter_buf = _make_shared_counter()
         try:
             hw = Worker(level=3, num_sub_workers=1)
-            cid = hw.register(lambda: _increment_counter(counter_buf))
+            cid = hw.register(lambda args: _increment_counter(counter_buf))
             hw.init()
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 o.submit_sub(cid)  # outer scope (ring 0)
                 with o.scope():
                     o.submit_sub(cid)  # ring 1
@@ -262,7 +262,7 @@ class TestScope:
                             with o.scope():
                                 o.submit_sub(cid)  # clamps to ring 3
 
-            hw.run(Task(orch=orch))
+            hw.run(orch)
             hw.close()
             assert _read_counter(counter_buf) == 5
         finally:
@@ -281,10 +281,10 @@ class TestOrchAlloc:
         captured = []
 
         hw = Worker(level=3, num_sub_workers=1)
-        cid = hw.register(lambda: None)  # sub callable doesn't actually read
+        cid = hw.register(lambda args: None)  # sub callable doesn't actually read
         hw.init()
 
-        def orch(o, _args):
+        def orch(o, args, cfg):
             inter = o.alloc((64,), DataType.FLOAT32)
             captured.append((inter.data, inter.ndims, inter.shapes[0]))
 
@@ -294,7 +294,7 @@ class TestOrchAlloc:
             sub_args.add_tensor(inter, TensorArgType.INPUT)
             o.submit_sub(cid, sub_args)
 
-        hw.run(Task(orch=orch))
+        hw.run(orch)
         hw.close()
 
         assert len(captured) == 1
@@ -309,11 +309,11 @@ class TestOrchAlloc:
 
         try:
             hw = Worker(level=3, num_sub_workers=2)
-            producer_cid = hw.register(lambda: _increment_counter(marker_buf))
-            consumer_cid = hw.register(lambda: _increment_counter(marker_buf))
+            producer_cid = hw.register(lambda args: _increment_counter(marker_buf))
+            consumer_cid = hw.register(lambda args: _increment_counter(marker_buf))
             hw.init()
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 inter = o.alloc((128,), DataType.FLOAT32)
 
                 # Producer writes into the alloc'd slab and must depend on
@@ -332,7 +332,7 @@ class TestOrchAlloc:
                 c_args.add_tensor(inter, TensorArgType.INPUT)
                 o.submit_sub(consumer_cid, c_args)
 
-            hw.run(Task(orch=orch))
+            hw.run(orch)
             hw.close()
 
             # Both ran (we don't assert order strictly — relies on dep enforcement
@@ -348,13 +348,13 @@ class TestOrchAlloc:
         hw = Worker(level=3, num_sub_workers=0)
         hw.init()
 
-        def orch(o, _args):
+        def orch(o, args, cfg):
             o.alloc((16,), DataType.UINT8)
             o.alloc((32,), DataType.FLOAT32)
             # No submits using these — synthetic slots' fanout_total = 1 (scope only)
             # scope_end's release_ref alone hits the threshold (sim self + scope = 2 = total + 1).
 
-        hw.run(Task(orch=orch))
+        hw.run(orch)
         hw.close()
         # If munmap leaks or the slot doesn't reach CONSUMED, drain hangs above.
 
@@ -364,20 +364,112 @@ class TestOrchAlloc:
 
         try:
             hw = Worker(level=3, num_sub_workers=1)
-            cid = hw.register(lambda: _increment_counter(marker_buf))
+            cid = hw.register(lambda args: _increment_counter(marker_buf))
             hw.init()
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 inter = o.alloc((64,), DataType.FLOAT32)
                 args = TaskArgs()
                 args.add_tensor(inter, TensorArgType.INPUT)
                 o.submit_sub(cid, args)
 
             for _ in range(8):
-                hw.run(Task(orch=orch))
+                hw.run(orch)
 
             hw.close()
             assert _read_counter(marker_buf) == 8
         finally:
             marker_shm.close()
             marker_shm.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Test: sub callable receives args blob correctly
+# ---------------------------------------------------------------------------
+
+
+class TestSubCallableArgs:
+    def test_sub_callable_receives_tensor_metadata(self):
+        """Sub callable receives TaskArgs with correct tensor count and shape."""
+        from simpler.task_interface import ContinuousTensor  # noqa: PLC0415
+
+        result_shm, result_buf = _make_shared_counter()
+        try:
+            hw = Worker(level=3, num_sub_workers=1)
+
+            def check_args(args):
+                # Verify args decoded correctly: 1 tensor, shape (4,), FLOAT32
+                if args.tensor_count() == 1 and args.scalar_count() == 0:
+                    t = args.tensor(0)
+                    if t.ndims == 1 and t.shapes[0] == 4:
+                        _increment_counter(result_buf)
+
+            cid = hw.register(check_args)
+            hw.init()
+
+            # Use a synthetic non-zero pointer — sub callable only checks metadata,
+            # doesn't dereference the pointer.
+            ct = ContinuousTensor.make(0xCAFE0000, (4,), DataType.FLOAT32)
+
+            def orch(o, args, cfg):
+                sub_args = TaskArgs()
+                sub_args.add_tensor(ct, TensorArgType.INPUT)
+                o.submit_sub(cid, sub_args)
+
+            hw.run(orch)
+            hw.close()
+
+            assert _read_counter(result_buf) == 1, "Sub callable did not receive correct args"
+        finally:
+            result_shm.close()
+            result_shm.unlink()
+
+    def test_sub_callable_receives_scalar(self):
+        """Sub callable receives TaskArgs with a scalar value."""
+        result_shm, result_buf = _make_shared_counter()
+        try:
+            hw = Worker(level=3, num_sub_workers=1)
+
+            def check_scalar(args):
+                if args.scalar_count() == 1 and args.scalar(0) == 42:
+                    _increment_counter(result_buf)
+
+            cid = hw.register(check_scalar)
+            hw.init()
+
+            def orch(o, args, cfg):
+                sub_args = TaskArgs()
+                sub_args.add_scalar(42)
+                o.submit_sub(cid, sub_args)
+
+            hw.run(orch)
+            hw.close()
+
+            assert _read_counter(result_buf) == 1, "Sub callable did not receive correct scalar"
+        finally:
+            result_shm.close()
+            result_shm.unlink()
+
+    def test_sub_callable_empty_args(self):
+        """Sub callable receives empty TaskArgs when no args submitted."""
+        result_shm, result_buf = _make_shared_counter()
+        try:
+            hw = Worker(level=3, num_sub_workers=1)
+
+            def check_empty(args):
+                if args.tensor_count() == 0 and args.scalar_count() == 0:
+                    _increment_counter(result_buf)
+
+            cid = hw.register(check_empty)
+            hw.init()
+
+            def orch(o, args, cfg):
+                o.submit_sub(cid)
+
+            hw.run(orch)
+            hw.close()
+
+            assert _read_counter(result_buf) == 1, "Sub callable did not receive empty args"
+        finally:
+            result_shm.close()
+            result_shm.unlink()

--- a/tests/ut/py/test_dist_worker/test_multi_worker.py
+++ b/tests/ut/py/test_dist_worker/test_multi_worker.py
@@ -18,7 +18,7 @@ No NPU device required; SubWorker (fork/shm) is used as the execution backend.
 import struct
 from multiprocessing.shared_memory import SharedMemory
 
-from simpler.worker import Task, Worker
+from simpler.worker import Worker
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -65,7 +65,7 @@ class TestTwoWorkersParallel:
                 buf = counters[i].buf
                 assert buf is not None
                 hw = Worker(level=3, num_sub_workers=1)
-                cid = hw.register(lambda b=buf: _inc(b))
+                cid = hw.register(lambda args, b=buf: _inc(b))
                 hw.init()
                 workers.append((hw, cid))
 
@@ -73,12 +73,12 @@ class TestTwoWorkersParallel:
             for hw, cid in workers:
 
                 def make_orch(c):
-                    def orch(o, _args):
+                    def orch(o, args, cfg):
                         o.submit_sub(c)
 
                     return orch
 
-                hw.run(Task(orch=make_orch(cid)))
+                hw.run(make_orch(cid))
 
             # Each counter must be incremented exactly once
             assert _read(counters[0]) == 1
@@ -110,14 +110,14 @@ class TestManyTasksNoLeak:
             hw = Worker(level=3, num_sub_workers=1)
             buf = counter.buf
             assert buf is not None
-            cid = hw.register(lambda: _inc(buf))
+            cid = hw.register(lambda args: _inc(buf))
             hw.init()
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 for _ in range(n_tasks):
                     o.submit_sub(cid)
 
-            hw.run(Task(orch=orch))
+            hw.run(orch)
             hw.close()
 
             assert _read(counter) == n_tasks
@@ -136,14 +136,14 @@ class TestManyTasksNoLeak:
             cids = []
             for i in range(n_tasks):
                 buf = counters[i].buf
-                cids.append(hw.register(lambda b=buf: _inc(b)))
+                cids.append(hw.register(lambda args, b=buf: _inc(b)))
             hw.init()
 
-            def orch(o, _args):
+            def orch(o, args, cfg):
                 for i in range(n_tasks):
                     o.submit_sub(cids[i])
 
-            hw.run(Task(orch=orch))
+            hw.run(orch)
             hw.close()
 
             # Every task's dedicated counter must be exactly 1


### PR DESCRIPTION
## Summary

- Delete `Task` dataclass — `Worker.run` now takes `(callable, args=None, config=None)` directly instead of `Task(orch=fn, args=...)`
- Orch fn signature changes from `(o, args)` to `(o, args, cfg)` — receives the `ChipCallConfig` passed to `Worker.run`
- Sub callable signature changes from `fn()` to `fn(args)` — receives `TaskArgs` decoded from the mailbox blob via `_read_args_from_mailbox`
- Add `_read_args_from_mailbox()` to decode the C++ `write_blob` format (tensor_count + scalar_count + ContinuousTensor[T] + uint64_t[S])
- Add 3 new tests verifying args pass-through: tensor metadata, scalar values, and empty args
- Update `scene_test.py`, all L3 unit tests, L3 scene tests
- Update docs: `task-flow.md`, `distributed_level_runtime.md`, `worker-manager.md`, `roadmap.md`, `orchestrator.py` docstring

## Testing

- [x] `pip install .` builds cleanly
- [x] `grep -rn "class Task" python/simpler/` returns 0 matches
- [x] `grep -rn "Task(orch" tests/ simpler_setup/ python/` returns 0 matches
- [x] `pytest tests/ut/py/test_dist_worker/ -v` — 24/24 passed (includes 3 new args tests)
- [ ] L3 scene tests (`test_l3_dependency.py`, `test_l3_group.py`) — requires sim/hardware
- [ ] Hardware tests (if applicable)