### PR TITLE
Add: child_memory + TensorKey + scheduler affinity for device-resident tensors

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -81,7 +81,7 @@ NB_MODULE(_task_interface, m) {
 
         .def_static(
             "make",
-            [](uint64_t data, nb::tuple shapes, DataType dtype) -> ContinuousTensor {
+            [](uint64_t data, nb::tuple shapes, DataType dtype, bool child_memory) -> ContinuousTensor {
                 size_t n = nb::len(shapes);
                 if (n > CONTINUOUS_TENSOR_MAX_DIMS)
                     throw std::invalid_argument("shapes length exceeds CONTINUOUS_TENSOR_MAX_DIMS");
@@ -89,12 +89,14 @@ NB_MODULE(_task_interface, m) {
                 arg.data = data;
                 arg.dtype = dtype;
                 arg.ndims = static_cast<uint32_t>(n);
+                arg.child_memory = child_memory ? 1 : 0;
                 for (size_t i = 0; i < n; ++i)
                     arg.shapes[i] = nb::cast<uint32_t>(shapes[i]);
                 return arg;
             },
-            nb::arg("data"), nb::arg("shapes"), nb::arg("dtype"),
-            "Create a ContinuousTensor from a data pointer, shape tuple, and dtype."
+            nb::arg("data"), nb::arg("shapes"), nb::arg("dtype"), nb::arg("child_memory") = false,
+            "Create a ContinuousTensor. Set child_memory=True when data is a device pointer "
+            "allocated by the child process (skips H2D copy in init_runtime_impl)."
         )
 
         .def_prop_rw(
@@ -150,6 +152,16 @@ NB_MODULE(_task_interface, m) {
             }
         )
 
+        .def_prop_rw(
+            "child_memory",
+            [](const ContinuousTensor &self) -> bool {
+                return self.is_child_memory();
+            },
+            [](ContinuousTensor &self, bool v) {
+                self.child_memory = v ? 1 : 0;
+            }
+        )
+
         .def(
             "nbytes",
             [](const ContinuousTensor &self) -> uint64_t {
@@ -165,7 +177,9 @@ NB_MODULE(_task_interface, m) {
                 if (i) os << ", ";
                 os << self.shapes[i];
             }
-            os << "), dtype=" << get_dtype_name(self.dtype) << ")";
+            os << "), dtype=" << get_dtype_name(self.dtype);
+            if (self.is_child_memory()) os << ", child_memory=True";
+            os << ")";
             return os.str();
         });
 
@@ -600,7 +614,11 @@ NB_MODULE(_task_interface, m) {
         )
         .def_prop_ro("device_id", &ChipWorker::device_id)
         .def_prop_ro("initialized", &ChipWorker::initialized)
-        .def_prop_ro("device_set", &ChipWorker::device_set);
+        .def_prop_ro("device_set", &ChipWorker::device_set)
+        .def("malloc", &ChipWorker::malloc, nb::arg("size"))
+        .def("free", &ChipWorker::free, nb::arg("ptr"))
+        .def("copy_to", &ChipWorker::copy_to, nb::arg("dst"), nb::arg("src"), nb::arg("size"))
+        .def("copy_from", &ChipWorker::copy_from, nb::arg("dst"), nb::arg("src"), nb::arg("size"));
 
     // --- Standalone blob helpers ---
     m.def(

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -64,20 +64,21 @@ inline void bind_worker(nb::module_ &m) {
     nb::class_<Orchestrator>(m, "_Orchestrator")
         .def(
             "submit_next_level",
-            [](Orchestrator &self, uint64_t callable, const TaskArgs &args, const ChipCallConfig &config) {
-                return self.submit_next_level(callable, args, config);
+            [](Orchestrator &self, uint64_t callable, const TaskArgs &args, const ChipCallConfig &config,
+               int8_t worker) {
+                return self.submit_next_level(callable, args, config, worker);
             },
-            nb::arg("callable"), nb::arg("args"), nb::arg("config"),
-            "Submit a NEXT_LEVEL (chip) task. Tags inside `args` drive dependency inference."
+            nb::arg("callable"), nb::arg("args"), nb::arg("config"), nb::arg("worker") = int8_t(-1),
+            "Submit a NEXT_LEVEL (chip) task. worker= pins to a specific next-level worker (-1 = any)."
         )
         .def(
             "submit_next_level_group",
             [](Orchestrator &self, uint64_t callable, const std::vector<TaskArgs> &args_list,
-               const ChipCallConfig &config) {
-                return self.submit_next_level_group(callable, args_list, config);
+               const ChipCallConfig &config, const std::vector<int8_t> &workers) {
+                return self.submit_next_level_group(callable, args_list, config, workers);
             },
-            nb::arg("callable"), nb::arg("args_list"), nb::arg("config"),
-            "Submit a group of NEXT_LEVEL tasks: N args -> N workers, 1 DAG node."
+            nb::arg("callable"), nb::arg("args_list"), nb::arg("config"), nb::arg("workers") = std::vector<int8_t>{},
+            "Submit a group of NEXT_LEVEL tasks. workers= per-args affinity (empty = any)."
         )
         .def(
             "submit_sub",
@@ -94,6 +95,34 @@ inline void bind_worker(nb::module_ &m) {
             },
             nb::arg("callable_id"), nb::arg("args_list"),
             "Submit a group of SUB tasks: N args -> N workers, 1 DAG node."
+        )
+        .def(
+            "malloc",
+            [](Orchestrator &self, int worker_id, size_t size) {
+                return self.malloc(worker_id, size);
+            },
+            nb::arg("worker_id"), nb::arg("size"), "Allocate memory on next-level worker."
+        )
+        .def(
+            "free",
+            [](Orchestrator &self, int worker_id, uint64_t ptr) {
+                self.free(worker_id, ptr);
+            },
+            nb::arg("worker_id"), nb::arg("ptr"), "Free memory on next-level worker."
+        )
+        .def(
+            "copy_to",
+            [](Orchestrator &self, int worker_id, uint64_t dst, uint64_t src, size_t size) {
+                self.copy_to(worker_id, dst, src, size);
+            },
+            nb::arg("worker_id"), nb::arg("dst"), nb::arg("src"), nb::arg("size"), "Copy host src to worker dst."
+        )
+        .def(
+            "copy_from",
+            [](Orchestrator &self, int worker_id, uint64_t dst, uint64_t src, size_t size) {
+                self.copy_from(worker_id, dst, src, size);
+            },
+            nb::arg("worker_id"), nb::arg("dst"), nb::arg("src"), nb::arg("size"), "Copy worker src to host dst."
         )
         .def(
             "alloc",

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -67,15 +67,31 @@ class Orchestrator:
     # User-facing submit API
     # ------------------------------------------------------------------
 
-    def submit_next_level(self, callable_: Any, args: TaskArgs, config: Optional[ChipCallConfig] = None):
-        """Submit a NEXT_LEVEL (chip) task. Tags inside ``args`` drive deps."""
-        cfg = config if config is not None else ChipCallConfig()
-        return self._o.submit_next_level(_resolve_callable_ptr(callable_), args, cfg)
+    def submit_next_level(
+        self, callable_: Any, args: TaskArgs, config: Optional[ChipCallConfig] = None, *, worker: int = -1
+    ):
+        """Submit a NEXT_LEVEL (chip) task. Tags inside ``args`` drive deps.
 
-    def submit_next_level_group(self, callable_: Any, args_list: list, config: Optional[ChipCallConfig] = None):
-        """Submit a group of NEXT_LEVEL tasks (N TaskArgs → N workers, 1 DAG node)."""
+        ``worker``: logical worker id for affinity (-1 = unconstrained).
+        """
         cfg = config if config is not None else ChipCallConfig()
-        return self._o.submit_next_level_group(_resolve_callable_ptr(callable_), args_list, cfg)
+        return self._o.submit_next_level(_resolve_callable_ptr(callable_), args, cfg, int(worker))
+
+    def submit_next_level_group(
+        self,
+        callable_: Any,
+        args_list: list,
+        config: Optional[ChipCallConfig] = None,
+        *,
+        workers: Optional[list] = None,
+    ):
+        """Submit a group of NEXT_LEVEL tasks (N TaskArgs → N workers, 1 DAG node).
+
+        ``workers``: per-args affinity list (None/empty = all unconstrained).
+        """
+        cfg = config if config is not None else ChipCallConfig()
+        w = [int(x) for x in workers] if workers else []
+        return self._o.submit_next_level_group(_resolve_callable_ptr(callable_), args_list, cfg, w)
 
     def submit_sub(self, callable_id: int, args: Optional[TaskArgs] = None):
         """Submit a SUB task by registered callable id.
@@ -127,6 +143,22 @@ class Orchestrator:
             yield self
         finally:
             self._o.scope_end()
+
+    def malloc(self, worker_id: int, size: int) -> int:
+        """Allocate memory on next-level worker *worker_id*. Returns a pointer."""
+        return int(self._o.malloc(int(worker_id), int(size)))
+
+    def free(self, worker_id: int, ptr: int) -> None:
+        """Free memory on next-level worker *worker_id*."""
+        self._o.free(int(worker_id), int(ptr))
+
+    def copy_to(self, worker_id: int, dst: int, src: int, size: int) -> None:
+        """Copy *size* bytes from host *src* to worker *dst*."""
+        self._o.copy_to(int(worker_id), int(dst), int(src), int(size))
+
+    def copy_from(self, worker_id: int, dst: int, src: int, size: int) -> None:
+        """Copy *size* bytes from worker *src* to host *dst*."""
+        self._o.copy_from(int(worker_id), int(dst), int(src), int(size))
 
     def alloc(self, shape: Sequence[int], dtype: DataType) -> ContinuousTensor:
         """Allocate a runtime-managed intermediate buffer.

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -209,6 +209,22 @@ class ChipWorker:
             setattr(config, k, v)
         self._impl.run(callable, args, config)
 
+    def malloc(self, size):
+        """Allocate memory. Returns a pointer (uint64)."""
+        return int(self._impl.malloc(int(size)))
+
+    def free(self, ptr):
+        """Free memory allocated by ``malloc()``."""
+        self._impl.free(int(ptr))
+
+    def copy_to(self, dst, src, size):
+        """Copy *size* bytes from host *src* to worker *dst*."""
+        self._impl.copy_to(int(dst), int(src), int(size))
+
+    def copy_from(self, dst, src, size):
+        """Copy *size* bytes from worker *src* to host *dst*."""
+        self._impl.copy_from(int(dst), int(src), int(size))
+
     @property
     def device_id(self):
         return self._impl.device_id

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -86,6 +86,25 @@ _IDLE = 0
 _TASK_READY = 1
 _TASK_DONE = 2
 _SHUTDOWN = 3
+_CONTROL_REQUEST = 4
+_CONTROL_DONE = 5
+
+# Control sub-commands (written at _OFF_CALLABLE as uint64)
+_CTRL_MALLOC = 0
+_CTRL_FREE = 1
+_CTRL_COPY_TO = 2
+_CTRL_COPY_FROM = 3
+
+# Control args layout (reuses task mailbox fields when state == _CONTROL_*):
+#   offset  8 (_OFF_CALLABLE):  uint64  sub-command
+#   offset 16:                  uint64  arg0 (size for malloc; dev_ptr for free/copy)
+#   offset 24:                  uint64  arg1 (host_ptr for copy)
+#   offset 32:                  uint64  arg2 (nbytes for copy)
+#   offset 40:                  uint64  result (returned ptr from malloc)
+_CTRL_OFF_ARG0 = 16
+_CTRL_OFF_ARG1 = 24
+_CTRL_OFF_ARG2 = 32
+_CTRL_OFF_RESULT = 40
 
 
 def _mailbox_addr(shm: SharedMemory) -> int:
@@ -189,6 +208,31 @@ def _chip_process_loop(
                 error = 1
             struct.pack_into("i", buf, _OFF_ERROR, error)
             struct.pack_into("i", buf, _OFF_STATE, _TASK_DONE)
+        elif state == _CONTROL_REQUEST:
+            sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
+            error = 0
+            try:
+                if sub_cmd == _CTRL_MALLOC:
+                    size = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
+                    ptr = cw.malloc(size)
+                    struct.pack_into("Q", buf, _CTRL_OFF_RESULT, ptr)
+                elif sub_cmd == _CTRL_FREE:
+                    ptr = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
+                    cw.free(ptr)
+                elif sub_cmd == _CTRL_COPY_TO:
+                    dst = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
+                    src = struct.unpack_from("Q", buf, _CTRL_OFF_ARG1)[0]
+                    n = struct.unpack_from("Q", buf, _CTRL_OFF_ARG2)[0]
+                    cw.copy_to(dst, src, n)
+                elif sub_cmd == _CTRL_COPY_FROM:
+                    dst = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
+                    src = struct.unpack_from("Q", buf, _CTRL_OFF_ARG1)[0]
+                    n = struct.unpack_from("Q", buf, _CTRL_OFF_ARG2)[0]
+                    cw.copy_from(dst, src, n)
+            except Exception:  # noqa: BLE001
+                error = 1
+            struct.pack_into("i", buf, _OFF_ERROR, error)
+            struct.pack_into("i", buf, _OFF_STATE, _CONTROL_DONE)
         elif state == _SHUTDOWN:
             cw.finalize()
             break
@@ -473,6 +517,62 @@ class Worker:
         dw.init()
 
         self._orch = Orchestrator(dw.get_orchestrator())
+
+    # ------------------------------------------------------------------
+    # memory management
+    # ------------------------------------------------------------------
+
+    def _chip_control(self, worker_id: int, sub_cmd: int, arg0: int = 0, arg1: int = 0, arg2: int = 0) -> int:
+        """Send a control command to chip child *worker_id* via mailbox IPC."""
+        if worker_id < 0 or worker_id >= len(self._chip_shms):
+            raise IndexError(f"worker_id {worker_id} out of range (have {len(self._chip_shms)} chips)")
+        shm = self._chip_shms[worker_id]
+        buf = shm.buf
+        assert buf is not None
+        struct.pack_into("Q", buf, _OFF_CALLABLE, sub_cmd)
+        struct.pack_into("Q", buf, _CTRL_OFF_ARG0, arg0)
+        struct.pack_into("Q", buf, _CTRL_OFF_ARG1, arg1)
+        struct.pack_into("Q", buf, _CTRL_OFF_ARG2, arg2)
+        struct.pack_into("i", buf, _OFF_STATE, _CONTROL_REQUEST)
+        while struct.unpack_from("i", buf, _OFF_STATE)[0] != _CONTROL_DONE:
+            pass
+        error = struct.unpack_from("i", buf, _OFF_ERROR)[0]
+        if error != 0:
+            raise RuntimeError(f"chip control command {sub_cmd} failed on worker {worker_id}")
+        result = struct.unpack_from("Q", buf, _CTRL_OFF_RESULT)[0]
+        struct.pack_into("i", buf, _OFF_STATE, _IDLE)
+        return result
+
+    def malloc(self, size: int, worker_id: int = 0) -> int:
+        """Allocate memory on next-level worker *worker_id*. Returns a pointer."""
+        if self.level == 2:
+            assert self._chip_worker is not None
+            return self._chip_worker.malloc(size)
+        return self._chip_control(worker_id, _CTRL_MALLOC, arg0=size)
+
+    def free(self, ptr: int, worker_id: int = 0) -> None:
+        """Free memory allocated by ``malloc()``."""
+        if self.level == 2:
+            assert self._chip_worker is not None
+            self._chip_worker.free(ptr)
+            return
+        self._chip_control(worker_id, _CTRL_FREE, arg0=ptr)
+
+    def copy_to(self, dst: int, src: int, size: int, worker_id: int = 0) -> None:
+        """Copy *size* bytes from host *src* to worker *dst*."""
+        if self.level == 2:
+            assert self._chip_worker is not None
+            self._chip_worker.copy_to(dst, src, size)
+            return
+        self._chip_control(worker_id, _CTRL_COPY_TO, arg0=dst, arg1=src, arg2=size)
+
+    def copy_from(self, dst: int, src: int, size: int, worker_id: int = 0) -> None:
+        """Copy *size* bytes from worker *src* to host *dst*."""
+        if self.level == 2:
+            assert self._chip_worker is not None
+            self._chip_worker.copy_from(dst, src, size)
+            return
+        self._chip_control(worker_id, _CTRL_COPY_FROM, arg0=dst, arg1=src, arg2=size)
 
     # ------------------------------------------------------------------
     # run — uniform entry point

--- a/src/a2a3/platform/include/host/memory_allocator.h
+++ b/src/a2a3/platform/include/host/memory_allocator.h
@@ -30,6 +30,7 @@
 #define PLATFORM_MEMORY_ALLOCATOR_H_
 
 #include <cstddef>
+#include <mutex>
 #include <set>
 
 /**
@@ -95,9 +96,13 @@ public:
      *
      * @return Number of currently tracked pointers
      */
-    size_t get_allocation_count() const { return ptr_set_.size(); }
+    size_t get_allocation_count() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return ptr_set_.size();
+    }
 
 private:
+    mutable std::mutex mu_;
     std::set<void *> ptr_set_;
 };
 

--- a/src/a2a3/platform/onboard/host/memory_allocator.cpp
+++ b/src/a2a3/platform/onboard/host/memory_allocator.cpp
@@ -31,7 +31,7 @@ void *MemoryAllocator::alloc(size_t size) {
         return nullptr;
     }
 
-    // Track the pointer
+    std::lock_guard<std::mutex> lk(mu_);
     ptr_set_.insert(ptr);
     return ptr;
 }
@@ -41,29 +41,25 @@ int MemoryAllocator::free(void *ptr) {
         return 0;
     }
 
-    // Check if we're tracking this pointer
+    std::lock_guard<std::mutex> lk(mu_);
     auto it = ptr_set_.find(ptr);
     if (it == ptr_set_.end()) {
-        // Not tracked by us, don't free
         return 0;
     }
 
-    // Free the memory
     int rc = rtFree(ptr);
     if (rc != 0) {
         LOG_ERROR("rtFree failed: %d", rc);
         return rc;
     }
 
-    // Remove from tracking set
     ptr_set_.erase(it);
     return 0;
 }
 
 int MemoryAllocator::finalize() {
+    std::lock_guard<std::mutex> lk(mu_);
     int last_error = 0;
-
-    // Free all remaining tracked pointers
     for (void *ptr : ptr_set_) {
         int rc = rtFree(ptr);
         if (rc != 0) {
@@ -71,9 +67,6 @@ int MemoryAllocator::finalize() {
             last_error = rc;
         }
     }
-
-    // Clear the set (empty set makes subsequent finalize() calls a no-op)
     ptr_set_.clear();
-
     return last_error;
 }

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -119,6 +119,40 @@ int set_device(DeviceContextHandle ctx, int device_id) {
     return 0;
 }
 
+void *device_malloc_ctx(DeviceContextHandle ctx, size_t size) {
+    if (ctx == NULL) return NULL;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->allocate_tensor(size);
+    } catch (...) {
+        return NULL;
+    }
+}
+
+void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr) {
+    if (ctx == NULL || dev_ptr == NULL) return;
+    try {
+        static_cast<DeviceRunner *>(ctx)->free_tensor(dev_ptr);
+    } catch (...) {}
+}
+
+int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size) {
+    if (ctx == NULL || dev_ptr == NULL || host_ptr == NULL) return -1;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->copy_to_device(dev_ptr, host_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *dev_ptr, size_t size) {
+    if (ctx == NULL || host_ptr == NULL || dev_ptr == NULL) return -1;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->copy_from_device(host_ptr, dev_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
 int run_runtime(
     DeviceContextHandle ctx, RuntimeHandle runtime, const void *callable, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,

--- a/src/a2a3/platform/sim/host/memory_allocator.cpp
+++ b/src/a2a3/platform/sim/host/memory_allocator.cpp
@@ -28,7 +28,7 @@ void *MemoryAllocator::alloc(size_t size) {
         return nullptr;
     }
 
-    // Track the pointer
+    std::lock_guard<std::mutex> lk(mu_);
     ptr_set_.insert(ptr);
     return ptr;
 }
@@ -38,29 +38,22 @@ int MemoryAllocator::free(void *ptr) {
         return 0;
     }
 
-    // Check if we're tracking this pointer
+    std::lock_guard<std::mutex> lk(mu_);
     auto it = ptr_set_.find(ptr);
     if (it == ptr_set_.end()) {
-        // Not tracked by us, don't free
         return 0;
     }
 
-    // Free the memory
     std::free(ptr);
-
-    // Remove from tracking set
     ptr_set_.erase(it);
     return 0;
 }
 
 int MemoryAllocator::finalize() {
-    // Free all remaining tracked pointers
+    std::lock_guard<std::mutex> lk(mu_);
     for (void *ptr : ptr_set_) {
         std::free(ptr);
     }
-
-    // Clear the set (empty set makes subsequent finalize() calls a no-op)
     ptr_set_.clear();
-
     return 0;
 }

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -121,6 +121,40 @@ int set_device(DeviceContextHandle ctx, int device_id) {
     return 0;
 }
 
+void *device_malloc_ctx(DeviceContextHandle ctx, size_t size) {
+    if (ctx == NULL) return NULL;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->allocate_tensor(size);
+    } catch (...) {
+        return NULL;
+    }
+}
+
+void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr) {
+    if (ctx == NULL || dev_ptr == NULL) return;
+    try {
+        static_cast<DeviceRunner *>(ctx)->free_tensor(dev_ptr);
+    } catch (...) {}
+}
+
+int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size) {
+    if (ctx == NULL || dev_ptr == NULL || host_ptr == NULL) return -1;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->copy_to_device(dev_ptr, host_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *dev_ptr, size_t size) {
+    if (ctx == NULL || host_ptr == NULL || dev_ptr == NULL) return -1;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->copy_from_device(host_ptr, dev_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
 int run_runtime(
     DeviceContextHandle ctx, RuntimeHandle runtime, const void *callable, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,

--- a/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
@@ -136,6 +136,12 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
     for (int i = 0; i < tensor_count; i++) {
         ContinuousTensor t = orch_args->tensor(i);
 
+        if (t.is_child_memory()) {
+            LOG_INFO("  Tensor %d: child memory, pass-through (0x%" PRIx64 ")", i, t.data);
+            device_args.add_tensor(t);
+            continue;
+        }
+
         void *host_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(t.data));
         size_t size = static_cast<size_t>(t.nbytes());
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -160,6 +160,12 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
     for (int i = 0; i < tensor_count; i++) {
         ContinuousTensor t = orch_args->tensor(i);
 
+        if (t.is_child_memory()) {
+            LOG_INFO("  Tensor %d: child memory, pass-through (0x%" PRIx64 ")", i, t.data);
+            device_args.add_tensor(t);
+            continue;
+        }
+
         void *host_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(t.data));
         size_t size = static_cast<size_t>(t.nbytes());
 

--- a/src/a5/platform/include/host/memory_allocator.h
+++ b/src/a5/platform/include/host/memory_allocator.h
@@ -30,6 +30,7 @@
 #define PLATFORM_MEMORY_ALLOCATOR_H_
 
 #include <cstddef>
+#include <mutex>
 #include <set>
 
 /**
@@ -95,9 +96,13 @@ public:
      *
      * @return Number of currently tracked pointers
      */
-    size_t get_allocation_count() const { return ptr_set_.size(); }
+    size_t get_allocation_count() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return ptr_set_.size();
+    }
 
 private:
+    mutable std::mutex mu_;
     std::set<void *> ptr_set_;
 };
 

--- a/src/a5/platform/onboard/host/memory_allocator.cpp
+++ b/src/a5/platform/onboard/host/memory_allocator.cpp
@@ -31,7 +31,7 @@ void *MemoryAllocator::alloc(size_t size) {
         return nullptr;
     }
 
-    // Track the pointer
+    std::lock_guard<std::mutex> lk(mu_);
     ptr_set_.insert(ptr);
     return ptr;
 }
@@ -41,29 +41,25 @@ int MemoryAllocator::free(void *ptr) {
         return 0;
     }
 
-    // Check if we're tracking this pointer
+    std::lock_guard<std::mutex> lk(mu_);
     auto it = ptr_set_.find(ptr);
     if (it == ptr_set_.end()) {
-        // Not tracked by us, don't free
         return 0;
     }
 
-    // Free the memory
     int rc = rtFree(ptr);
     if (rc != 0) {
         LOG_ERROR("rtFree failed: %d", rc);
         return rc;
     }
 
-    // Remove from tracking set
     ptr_set_.erase(it);
     return 0;
 }
 
 int MemoryAllocator::finalize() {
+    std::lock_guard<std::mutex> lk(mu_);
     int last_error = 0;
-
-    // Free all remaining tracked pointers
     for (void *ptr : ptr_set_) {
         int rc = rtFree(ptr);
         if (rc != 0) {
@@ -71,9 +67,6 @@ int MemoryAllocator::finalize() {
             last_error = rc;
         }
     }
-
-    // Clear the set (empty set makes subsequent finalize() calls a no-op)
     ptr_set_.clear();
-
     return last_error;
 }

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -119,6 +119,40 @@ int set_device(DeviceContextHandle ctx, int device_id) {
     return 0;
 }
 
+void *device_malloc_ctx(DeviceContextHandle ctx, size_t size) {
+    if (ctx == NULL) return NULL;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->allocate_tensor(size);
+    } catch (...) {
+        return NULL;
+    }
+}
+
+void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr) {
+    if (ctx == NULL || dev_ptr == NULL) return;
+    try {
+        static_cast<DeviceRunner *>(ctx)->free_tensor(dev_ptr);
+    } catch (...) {}
+}
+
+int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size) {
+    if (ctx == NULL || dev_ptr == NULL || host_ptr == NULL) return -1;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->copy_to_device(dev_ptr, host_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *dev_ptr, size_t size) {
+    if (ctx == NULL || host_ptr == NULL || dev_ptr == NULL) return -1;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->copy_from_device(host_ptr, dev_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
 int run_runtime(
     DeviceContextHandle ctx, RuntimeHandle runtime, const void *callable, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,

--- a/src/a5/platform/sim/host/memory_allocator.cpp
+++ b/src/a5/platform/sim/host/memory_allocator.cpp
@@ -28,7 +28,7 @@ void *MemoryAllocator::alloc(size_t size) {
         return nullptr;
     }
 
-    // Track the pointer
+    std::lock_guard<std::mutex> lk(mu_);
     ptr_set_.insert(ptr);
     return ptr;
 }
@@ -38,29 +38,22 @@ int MemoryAllocator::free(void *ptr) {
         return 0;
     }
 
-    // Check if we're tracking this pointer
+    std::lock_guard<std::mutex> lk(mu_);
     auto it = ptr_set_.find(ptr);
     if (it == ptr_set_.end()) {
-        // Not tracked by us, don't free
         return 0;
     }
 
-    // Free the memory
     std::free(ptr);
-
-    // Remove from tracking set
     ptr_set_.erase(it);
     return 0;
 }
 
 int MemoryAllocator::finalize() {
-    // Free all remaining tracked pointers
+    std::lock_guard<std::mutex> lk(mu_);
     for (void *ptr : ptr_set_) {
         std::free(ptr);
     }
-
-    // Clear the set (empty set makes subsequent finalize() calls a no-op)
     ptr_set_.clear();
-
     return 0;
 }

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -121,6 +121,40 @@ int set_device(DeviceContextHandle ctx, int device_id) {
     return 0;
 }
 
+void *device_malloc_ctx(DeviceContextHandle ctx, size_t size) {
+    if (ctx == NULL) return NULL;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->allocate_tensor(size);
+    } catch (...) {
+        return NULL;
+    }
+}
+
+void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr) {
+    if (ctx == NULL || dev_ptr == NULL) return;
+    try {
+        static_cast<DeviceRunner *>(ctx)->free_tensor(dev_ptr);
+    } catch (...) {}
+}
+
+int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size) {
+    if (ctx == NULL || dev_ptr == NULL || host_ptr == NULL) return -1;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->copy_to_device(dev_ptr, host_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
+int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *dev_ptr, size_t size) {
+    if (ctx == NULL || host_ptr == NULL || dev_ptr == NULL) return -1;
+    try {
+        return static_cast<DeviceRunner *>(ctx)->copy_from_device(host_ptr, dev_ptr, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
 int run_runtime(
     DeviceContextHandle ctx, RuntimeHandle runtime, const void *callable, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -160,6 +160,12 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
     for (int i = 0; i < tensor_count; i++) {
         ContinuousTensor t = orch_args->tensor(i);
 
+        if (t.is_child_memory()) {
+            LOG_INFO("  Tensor %d: child memory, pass-through (0x%" PRIx64 ")", i, t.data);
+            device_args.add_tensor(t);
+            continue;
+        }
+
         void *host_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(t.data));
         size_t size = static_cast<size_t>(t.nbytes());
 

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -15,15 +15,43 @@
 #include <cstring>
 #include <stdexcept>
 
+#include "worker_manager.h"
+
 void Orchestrator::init(
-    TensorMap *tensormap, Ring *allocator, Scope *scope, ReadyQueue *ready_next_level_queue, ReadyQueue *ready_sub_queue
+    TensorMap *tensormap, Ring *allocator, Scope *scope, ReadyQueue *ready_next_level_queue,
+    ReadyQueue *ready_sub_queue, WorkerManager *manager
 ) {
     tensormap_ = tensormap;
     allocator_ = allocator;
     scope_ = scope;
     ready_next_level_queue_ = ready_next_level_queue;
     ready_sub_queue_ = ready_sub_queue;
+    manager_ = manager;
     active_tasks_.store(0, std::memory_order_relaxed);
+}
+
+uint64_t Orchestrator::malloc(int worker_id, size_t size) {
+    auto *wt = manager_->get_worker(WorkerType::NEXT_LEVEL, worker_id);
+    if (!wt) throw std::runtime_error("Orchestrator::malloc: invalid worker_id");
+    return wt->control_malloc(size);
+}
+
+void Orchestrator::free(int worker_id, uint64_t ptr) {
+    auto *wt = manager_->get_worker(WorkerType::NEXT_LEVEL, worker_id);
+    if (!wt) throw std::runtime_error("Orchestrator::free: invalid worker_id");
+    wt->control_free(ptr);
+}
+
+void Orchestrator::copy_to(int worker_id, uint64_t dst, uint64_t src, size_t size) {
+    auto *wt = manager_->get_worker(WorkerType::NEXT_LEVEL, worker_id);
+    if (!wt) throw std::runtime_error("Orchestrator::copy_to: invalid worker_id");
+    wt->control_copy_to(dst, src, size);
+}
+
+void Orchestrator::copy_from(int worker_id, uint64_t dst, uint64_t src, size_t size) {
+    auto *wt = manager_->get_worker(WorkerType::NEXT_LEVEL, worker_id);
+    if (!wt) throw std::runtime_error("Orchestrator::copy_from: invalid worker_id");
+    wt->control_copy_from(dst, src, size);
 }
 
 TaskSlotState &Orchestrator::slot_state(TaskSlot s) {
@@ -66,8 +94,9 @@ ContinuousTensor Orchestrator::alloc(const std::vector<uint32_t> &shape, DataTyp
     TaskSlotState &s = slot_state(ar.slot);
     s.reset();
 
-    uint64_t key = reinterpret_cast<uint64_t>(ar.heap_ptr);
-    if (key != 0) {
+    uint64_t ptr = reinterpret_cast<uint64_t>(ar.heap_ptr);
+    if (ptr != 0) {
+        TensorKey key{ptr, -1};  // alloc is always host memory
         tensormap_->insert(key, ar.slot);
         s.output_keys.push_back(key);
     }
@@ -95,7 +124,7 @@ ContinuousTensor Orchestrator::alloc(const std::vector<uint32_t> &shape, DataTyp
     active_tasks_.fetch_add(1, std::memory_order_relaxed);
 
     ContinuousTensor t{};
-    t.data = key;
+    t.data = ptr;
     t.dtype = dtype;
     t.ndims = static_cast<uint32_t>(shape.size());
     for (size_t i = 0; i < shape.size(); ++i)
@@ -107,14 +136,18 @@ ContinuousTensor Orchestrator::alloc(const std::vector<uint32_t> &shape, DataTyp
 // User-facing submit_* — thin wrappers around submit_impl
 // =============================================================================
 
-SubmitResult Orchestrator::submit_next_level(uint64_t callable, const TaskArgs &args, const ChipCallConfig &config) {
-    return submit_impl(WorkerType::NEXT_LEVEL, callable, /*callable_id=*/-1, config, {args});
+SubmitResult
+Orchestrator::submit_next_level(uint64_t callable, const TaskArgs &args, const ChipCallConfig &config, int8_t worker) {
+    std::vector<int8_t> affinities;
+    if (worker >= 0) affinities = {worker};
+    return submit_impl(WorkerType::NEXT_LEVEL, callable, /*callable_id=*/-1, config, {args}, std::move(affinities));
 }
 
 SubmitResult Orchestrator::submit_next_level_group(
-    uint64_t callable, const std::vector<TaskArgs> &args_list, const ChipCallConfig &config
+    uint64_t callable, const std::vector<TaskArgs> &args_list, const ChipCallConfig &config,
+    const std::vector<int8_t> &workers
 ) {
-    return submit_impl(WorkerType::NEXT_LEVEL, callable, /*callable_id=*/-1, config, args_list);
+    return submit_impl(WorkerType::NEXT_LEVEL, callable, /*callable_id=*/-1, config, args_list, workers);
 }
 
 SubmitResult Orchestrator::submit_sub(int32_t callable_id, const TaskArgs &args) {
@@ -131,7 +164,7 @@ SubmitResult Orchestrator::submit_sub_group(int32_t callable_id, const std::vect
 
 SubmitResult Orchestrator::submit_impl(
     WorkerType worker_type, uint64_t callable_ptr, int32_t callable_id, const ChipCallConfig &config,
-    std::vector<TaskArgs> args_list
+    std::vector<TaskArgs> args_list, std::vector<int8_t> affinities
 ) {
     if (args_list.empty()) throw std::invalid_argument("Orchestrator: args_list must not be empty");
 
@@ -163,7 +196,7 @@ SubmitResult Orchestrator::submit_impl(
     // (outputs). Must happen before we move args_list into the slot because
     // infer_deps reads tensor data pointers and tags from it.
     std::vector<TaskSlot> producers;
-    infer_deps(slot, args_list, producers, s.output_keys);
+    infer_deps(slot, args_list, affinities, producers, s.output_keys);
 
     // --- Step 3: Store TaskArgs directly (no chip-storage pre-build) ---
     // Dispatch builds a TaskArgsView on demand via `slot.args_view(i)`
@@ -177,6 +210,7 @@ SubmitResult Orchestrator::submit_impl(
         s.is_group_ = true;
         s.task_args_list = std::move(args_list);
     }
+    s.affinities = std::move(affinities);
 
     // --- Step 5: Finalize fanin — lock each producer's fanout_mu, attach ---
     //
@@ -273,8 +307,8 @@ AllocResult Orchestrator::reserve_outputs_and_slot(std::vector<TaskArgs> &args_l
 // =============================================================================
 
 void Orchestrator::infer_deps(
-    TaskSlot slot, const std::vector<TaskArgs> &args_list, std::vector<TaskSlot> &producers,
-    std::vector<uint64_t> &output_keys
+    TaskSlot slot, const std::vector<TaskArgs> &args_list, const std::vector<int8_t> &affinities,
+    std::vector<TaskSlot> &producers, std::vector<TensorKey> &output_keys
 ) {
     auto add_unique_producer = [&](TaskSlot p) {
         // Group submits walk many TaskArgs under one slot: if two entries in
@@ -299,10 +333,13 @@ void Orchestrator::infer_deps(
     //                      needed, the data ptr is assigned in
     //                      reserve_outputs_and_slot before this step)
     //   NO_DEP           → skip
-    for (const TaskArgs &a : args_list) {
+    for (size_t g = 0; g < args_list.size(); ++g) {
+        int8_t worker_id = (g < affinities.size()) ? affinities[g] : int8_t(-1);
+        const TaskArgs &a = args_list[g];
         for (int32_t i = 0; i < a.tensor_count(); ++i) {
-            uint64_t key = a.tensor(i).data;
-            if (key == 0) continue;  // null tensor — nothing to track
+            const ContinuousTensor &t = a.tensor(i);
+            if (t.data == 0) continue;  // null tensor — nothing to track
+            TensorKey key{t.data, t.is_child_memory() ? worker_id : int8_t(-1)};
             TensorArgType tag = a.tag(i);
             switch (tag) {
             case TensorArgType::INPUT: {

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -46,6 +46,8 @@
 #include "tensormap.h"
 #include "types.h"
 
+class WorkerManager;
+
 // ---------------------------------------------------------------------------
 // SubmitResult — just the slot id
 // ---------------------------------------------------------------------------
@@ -70,7 +72,7 @@ public:
     // the Scheduler's dispatch_ready walks each queue independently.
     void init(
         TensorMap *tensormap, Ring *allocator, Scope *scope, ReadyQueue *ready_next_level_queue,
-        ReadyQueue *ready_sub_queue
+        ReadyQueue *ready_sub_queue, WorkerManager *manager = nullptr
     );
 
     // Allocate an intermediate buffer from the Worker's HeapRing (MAP_SHARED,
@@ -82,15 +84,28 @@ public:
     // pointer has reached CONSUMED and scope_end has released the scope ref.
     ContinuousTensor alloc(const std::vector<uint32_t> &shape, DataType dtype);
 
+    // Memory management on a specific next-level worker. Thread-safe:
+    // can be called from the orch thread while the target worker is
+    // running a task (MemoryAllocator is mutex-protected).
+    uint64_t malloc(int worker_id, size_t size);
+    void free(int worker_id, uint64_t ptr);
+    void copy_to(int worker_id, uint64_t dst, uint64_t src, size_t size);
+    void copy_from(int worker_id, uint64_t dst, uint64_t src, size_t size);
+
     // Submit a NEXT_LEVEL task. `callable` is the chip callable buffer pointer
     // (uint64_t handle from Python — typically ChipCallable.buffer_ptr()).
     // Tags inside `args` drive dependency inference; OUTPUT tensors with null
     // data are auto-allocated from the HeapRing.
-    SubmitResult submit_next_level(uint64_t callable, const TaskArgs &args, const ChipCallConfig &config);
+    // `worker`: logical worker id for affinity (-1 = unconstrained).
+    SubmitResult
+    submit_next_level(uint64_t callable, const TaskArgs &args, const ChipCallConfig &config, int8_t worker = -1);
 
     // Submit a group of NEXT_LEVEL tasks: N args -> N workers, 1 DAG node.
-    SubmitResult
-    submit_next_level_group(uint64_t callable, const std::vector<TaskArgs> &args_list, const ChipCallConfig &config);
+    // `workers`: per-args affinity (empty = all unconstrained).
+    SubmitResult submit_next_level_group(
+        uint64_t callable, const std::vector<TaskArgs> &args_list, const ChipCallConfig &config,
+        const std::vector<int8_t> &workers = {}
+    );
 
     // Submit a SUB task by registered callable id.
     SubmitResult submit_sub(int32_t callable_id, const TaskArgs &args);
@@ -129,6 +144,7 @@ private:
     TensorMap *tensormap_ = nullptr;
     Ring *allocator_ = nullptr;
     Scope *scope_ = nullptr;
+    WorkerManager *manager_ = nullptr;
     // Strict-4 per-worker-type ready queues. Each queue handles tasks of
     // exactly one WorkerType so the Scheduler can dispatch from an idle pool
     // without being blocked by another pool's saturation.
@@ -156,7 +172,7 @@ private:
     // can patch `tensor.data` on OUTPUT tensors flagged for auto-allocation.
     SubmitResult submit_impl(
         WorkerType worker_type, uint64_t callable_ptr, int32_t callable_id, const ChipCallConfig &config,
-        std::vector<TaskArgs> args_list
+        std::vector<TaskArgs> args_list, std::vector<int8_t> affinities = {}
     );
 
     // Size, in aligned bytes, an OUTPUT tensor should occupy in the HeapRing.
@@ -172,9 +188,10 @@ private:
     // Walk the tags of each TaskArgs in `args_list`, accumulating producer
     // slots (for INPUT/INOUT tags) and registering outputs in the tensormap
     // (for OUTPUT/INOUT/OUTPUT_EXISTING tags). NO_DEP tags are skipped.
+    // `affinities` maps args_list[i] → worker id for TensorKey construction.
     void infer_deps(
-        TaskSlot slot, const std::vector<TaskArgs> &args_list, std::vector<TaskSlot> &producers,
-        std::vector<uint64_t> &output_keys
+        TaskSlot slot, const std::vector<TaskArgs> &args_list, const std::vector<int8_t> &affinities,
+        std::vector<TaskSlot> &producers, std::vector<TensorKey> &output_keys
     );
 
     // Release one fanout reference on 'slot'.

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -190,8 +190,38 @@ void Scheduler::dispatch_ready() {
             TaskSlotState &s = *cfg_.ring->slot_state(slot);
             int N = s.group_size();  // 1 for normal tasks
 
-            auto workers = cfg_.manager->pick_n_idle(s.worker_type, N);
-            if (static_cast<int>(workers.size()) < N) {
+            // Affinity-aware dispatch: pin args[i] to worker affinities[i]
+            // when set, fill remaining slots from the idle pool.
+            std::vector<WorkerThread *> workers(static_cast<size_t>(N), nullptr);
+            bool ok = true;
+
+            // Pass 1: satisfy affinity constraints
+            for (int i = 0; i < N; i++) {
+                int8_t aff = s.get_affinity(i);
+                if (aff >= 0) {
+                    auto *wt = cfg_.manager->get_worker(s.worker_type, aff);
+                    if (!wt || !wt->idle()) {
+                        ok = false;
+                        break;
+                    }
+                    workers[static_cast<size_t>(i)] = wt;
+                }
+            }
+
+            // Pass 2: fill unconstrained slots from idle pool
+            if (ok) {
+                for (int i = 0; i < N; i++) {
+                    if (workers[static_cast<size_t>(i)] != nullptr) continue;
+                    auto *wt = cfg_.manager->pick_idle_excluding(s.worker_type, workers);
+                    if (!wt) {
+                        ok = false;
+                        break;
+                    }
+                    workers[static_cast<size_t>(i)] = wt;
+                }
+            }
+
+            if (!ok) {
                 q->push(slot);
                 break;
             }
@@ -201,7 +231,7 @@ void Scheduler::dispatch_ready() {
                 WorkerDispatch d;
                 d.task_slot = slot;
                 d.group_index = i;
-                workers[i]->dispatch(d);
+                workers[static_cast<size_t>(i)]->dispatch(d);
             }
         }
     };

--- a/src/common/hierarchical/tensormap.cpp
+++ b/src/common/hierarchical/tensormap.cpp
@@ -11,16 +11,16 @@
 
 #include "tensormap.h"
 
-TaskSlot TensorMap::lookup(uint64_t base_ptr) const {
-    auto it = map_.find(base_ptr);
+TaskSlot TensorMap::lookup(TensorKey key) const {
+    auto it = map_.find(key);
     if (it == map_.end()) return INVALID_SLOT;
     return it->second;
 }
 
-void TensorMap::insert(uint64_t base_ptr, TaskSlot producer) { map_[base_ptr] = producer; }
+void TensorMap::insert(TensorKey key, TaskSlot producer) { map_[key] = producer; }
 
-void TensorMap::erase_task_outputs(const std::vector<uint64_t> &keys) {
-    for (uint64_t key : keys)
+void TensorMap::erase_task_outputs(const std::vector<TensorKey> &keys) {
+    for (const auto &key : keys)
         map_.erase(key);
 }
 

--- a/src/common/hierarchical/tensormap.h
+++ b/src/common/hierarchical/tensormap.h
@@ -10,16 +10,17 @@
  */
 
 /**
- * TensorMap — base_ptr → producer task slot mapping.
+ * TensorMap — TensorKey → producer task slot mapping.
  *
- * At the distributed host level, every tensor is identified by its base pointer.
- * When a task produces an output, it registers the output's base_ptr here.
- * When a later task lists an input, lookup() finds the producer and creates a
- * fanin dependency edge.
+ * At the hierarchical host level, every tensor is identified by a TensorKey
+ * consisting of (ptr, worker).  Host tensors (HeapRing) use worker=-1 because
+ * their addresses are globally unique; child_memory tensors use the owning
+ * worker's logical id (0..N-1) to disambiguate identical device addresses
+ * across different NPUs.
  *
  * Unlike the L2 PTO2TensorMap, this implementation:
  *   - Uses std::unordered_map (no ring buffer entry pool)
- *   - Does not perform overlap detection (each base_ptr maps to one producer)
+ *   - Does not perform overlap detection (each key maps to one producer)
  *   - Cleans up entries actively when a task is CONSUMED
  *
  * Owned exclusively by the Orchestrator (main thread); no locking required.
@@ -27,7 +28,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include <unordered_map>
 #include <vector>
 
@@ -35,21 +35,21 @@
 
 class TensorMap {
 public:
-    // Look up the producer for tensor base_ptr.
+    // Look up the producer for a tensor key.
     // Returns INVALID_SLOT when not found.
-    TaskSlot lookup(uint64_t base_ptr) const;
+    TaskSlot lookup(TensorKey key) const;
 
-    // Register base_ptr → producer mapping.
+    // Register key → producer mapping.
     // Overwrites any existing entry (re-use of the same buffer by a new producer).
-    void insert(uint64_t base_ptr, TaskSlot producer);
+    void insert(TensorKey key, TaskSlot producer);
 
     // Remove all entries whose key appears in 'keys'.
     // Called when a producer task transitions to CONSUMED.
-    void erase_task_outputs(const std::vector<uint64_t> &keys);
+    void erase_task_outputs(const std::vector<TensorKey> &keys);
 
     // Number of entries currently tracked.
     int32_t size() const;
 
 private:
-    std::unordered_map<uint64_t, TaskSlot> map_;
+    std::unordered_map<TensorKey, TaskSlot, TensorKeyHash> map_;
 };

--- a/src/common/hierarchical/types.cpp
+++ b/src/common/hierarchical/types.cpp
@@ -34,6 +34,7 @@ void TaskSlotState::reset() {
     task_args.clear();
     task_args_list.clear();
     is_group_ = false;
+    affinities.clear();
     // ring_idx / ring_slot_idx are deliberately NOT cleared here: Ring
     // stamps them at alloc() before the Orchestrator ever calls reset(),
     // and Ring::release() needs to read them for the FIFO advance. The

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -42,6 +42,25 @@
 #include "../task_interface/task_args.h"
 
 // =============================================================================
+// TensorKey — compound key for TensorMap dependency tracking
+// =============================================================================
+
+struct TensorKey {
+    uint64_t ptr;
+    int8_t worker;  // -1 = host (globally unique), 0..N-1 = next-level worker logical id
+
+    bool operator==(const TensorKey &o) const { return ptr == o.ptr && worker == o.worker; }
+};
+
+struct TensorKeyHash {
+    size_t operator()(const TensorKey &k) const {
+        size_t h = std::hash<uint64_t>{}(k.ptr);
+        h ^= std::hash<int>{}(k.worker) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        return h;
+    }
+};
+
+// =============================================================================
 // Constants
 // =============================================================================
 
@@ -108,7 +127,17 @@ struct TaskSlotState {
     std::atomic<int32_t> fanout_released{0};  // incremented as each ref is released
 
     // --- TensorMap keys registered by this task (for cleanup on CONSUMED) ---
-    std::vector<uint64_t> output_keys;
+    std::vector<TensorKey> output_keys;
+
+    // --- Worker affinity (set by submit_next_level with worker= parameter) ---
+    // Empty = unconstrained (any idle worker). Otherwise affinities[i] gives
+    // the logical worker id for args[i] (-1 = unconstrained for that slot).
+    std::vector<int8_t> affinities;
+
+    int8_t get_affinity(int i) const {
+        if (affinities.empty()) return -1;
+        return affinities[static_cast<size_t>(i)];
+    }
 
     // --- Producer tasks this task depends on (for deferred release) ---
     // When this task reaches COMPLETED, the Scheduler releases one fanout ref

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -134,7 +134,7 @@ void Worker::add_process_worker(WorkerType type, void *mailbox) {
 void Worker::init() {
     if (initialized_) throw std::runtime_error("Worker: already initialized");
 
-    orchestrator_.init(&tensormap_, &allocator_, &scope_, &ready_next_level_queue_, &ready_sub_queue_);
+    orchestrator_.init(&tensormap_, &allocator_, &scope_, &ready_next_level_queue_, &ready_sub_queue_, &manager_);
 
     // Start WorkerManager first — creates WorkerThreads.
     // The on_complete callback routes through the Scheduler's worker_done().

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -11,8 +11,10 @@
 
 #include "worker_manager.h"
 
+#include <cstring>
 #include <stdexcept>
 
+#include "../worker/chip_worker.h"
 #include "ring.h"
 
 // =============================================================================
@@ -238,6 +240,101 @@ std::vector<WorkerThread *> WorkerManager::pick_n_idle(WorkerType type, int n) c
         }
     }
     return result;
+}
+
+WorkerThread *WorkerManager::get_worker(WorkerType type, int logical_id) const {
+    auto &threads = (type == WorkerType::NEXT_LEVEL) ? next_level_threads_ : sub_threads_;
+    if (logical_id < 0 || static_cast<size_t>(logical_id) >= threads.size()) return nullptr;
+    return threads[static_cast<size_t>(logical_id)].get();
+}
+
+WorkerThread *WorkerManager::pick_idle_excluding(WorkerType type, const std::vector<WorkerThread *> &exclude) const {
+    auto &threads = (type == WorkerType::NEXT_LEVEL) ? next_level_threads_ : sub_threads_;
+    for (auto &wt : threads) {
+        if (!wt->idle()) continue;
+        bool excluded = false;
+        for (auto *ex : exclude) {
+            if (ex == wt.get()) {
+                excluded = true;
+                break;
+            }
+        }
+        if (!excluded) return wt.get();
+    }
+    return nullptr;
+}
+
+// =============================================================================
+// WorkerThread — memory control (orch thread, concurrent with worker thread)
+// =============================================================================
+
+static void write_control_args(char *mbox, uint64_t sub_cmd, uint64_t a0 = 0, uint64_t a1 = 0, uint64_t a2 = 0) {
+    std::memcpy(mbox + MAILBOX_OFF_CALLABLE, &sub_cmd, sizeof(uint64_t));
+    std::memcpy(mbox + CTRL_OFF_ARG0, &a0, sizeof(uint64_t));
+    std::memcpy(mbox + CTRL_OFF_ARG1, &a1, sizeof(uint64_t));
+    std::memcpy(mbox + CTRL_OFF_ARG2, &a2, sizeof(uint64_t));
+}
+
+static uint64_t read_control_result(const char *mbox) {
+    uint64_t r;
+    std::memcpy(&r, mbox + CTRL_OFF_RESULT, sizeof(uint64_t));
+    return r;
+}
+
+uint64_t WorkerThread::control_malloc(size_t size) {
+    if (mode_ == Mode::THREAD) {
+        auto *cw = dynamic_cast<ChipWorker *>(worker_);
+        if (!cw) throw std::runtime_error("control_malloc: worker is not a ChipWorker");
+        return cw->malloc(size);
+    }
+    write_control_args(mbox(), CTRL_MALLOC, static_cast<uint64_t>(size));
+    write_mailbox_state(MailboxState::CONTROL_REQUEST);
+    while (read_mailbox_state() != MailboxState::CONTROL_DONE) {}
+    int32_t err;
+    std::memcpy(&err, mbox() + MAILBOX_OFF_ERROR, sizeof(int32_t));
+    if (err != 0) throw std::runtime_error("control_malloc failed on child");
+    uint64_t result = read_control_result(mbox());
+    write_mailbox_state(MailboxState::IDLE);
+    return result;
+}
+
+void WorkerThread::control_free(uint64_t ptr) {
+    if (mode_ == Mode::THREAD) {
+        auto *cw = dynamic_cast<ChipWorker *>(worker_);
+        if (!cw) throw std::runtime_error("control_free: worker is not a ChipWorker");
+        cw->free(ptr);
+        return;
+    }
+    write_control_args(mbox(), CTRL_FREE, ptr);
+    write_mailbox_state(MailboxState::CONTROL_REQUEST);
+    while (read_mailbox_state() != MailboxState::CONTROL_DONE) {}
+    write_mailbox_state(MailboxState::IDLE);
+}
+
+void WorkerThread::control_copy_to(uint64_t dst, uint64_t src, size_t size) {
+    if (mode_ == Mode::THREAD) {
+        auto *cw = dynamic_cast<ChipWorker *>(worker_);
+        if (!cw) throw std::runtime_error("control_copy_to: worker is not a ChipWorker");
+        cw->copy_to(dst, src, size);
+        return;
+    }
+    write_control_args(mbox(), CTRL_COPY_TO, dst, src, static_cast<uint64_t>(size));
+    write_mailbox_state(MailboxState::CONTROL_REQUEST);
+    while (read_mailbox_state() != MailboxState::CONTROL_DONE) {}
+    write_mailbox_state(MailboxState::IDLE);
+}
+
+void WorkerThread::control_copy_from(uint64_t dst, uint64_t src, size_t size) {
+    if (mode_ == Mode::THREAD) {
+        auto *cw = dynamic_cast<ChipWorker *>(worker_);
+        if (!cw) throw std::runtime_error("control_copy_from: worker is not a ChipWorker");
+        cw->copy_from(dst, src, size);
+        return;
+    }
+    write_control_args(mbox(), CTRL_COPY_FROM, dst, src, static_cast<uint64_t>(size));
+    write_mailbox_state(MailboxState::CONTROL_REQUEST);
+    while (read_mailbox_state() != MailboxState::CONTROL_DONE) {}
+    write_mailbox_state(MailboxState::IDLE);
 }
 
 bool WorkerManager::any_busy() const {

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -62,19 +62,37 @@ enum class MailboxState : int32_t {
     TASK_READY = 1,
     TASK_DONE = 2,
     SHUTDOWN = 3,
+    CONTROL_REQUEST = 4,
+    CONTROL_DONE = 5,
 };
 
 static constexpr size_t MAILBOX_SIZE = 4096;
 
 static constexpr ptrdiff_t MAILBOX_OFF_STATE = 0;
 static constexpr ptrdiff_t MAILBOX_OFF_ERROR = 4;
-static constexpr ptrdiff_t MAILBOX_OFF_CALLABLE = 8;
+static constexpr ptrdiff_t MAILBOX_OFF_CALLABLE = 8;  // also: control sub-command (uint64)
 static constexpr ptrdiff_t MAILBOX_OFF_BLOCK_DIM = 16;
 static constexpr ptrdiff_t MAILBOX_OFF_AICPU_THREAD_NUM = 20;
 static constexpr ptrdiff_t MAILBOX_OFF_ENABLE_PROFILING = 24;
 static constexpr ptrdiff_t MAILBOX_OFF_ENABLE_DUMP_TENSOR = 28;
 static constexpr ptrdiff_t MAILBOX_OFF_ARGS = 64;
 static constexpr size_t MAILBOX_ARGS_CAPACITY = MAILBOX_SIZE - static_cast<size_t>(MAILBOX_OFF_ARGS);
+
+// Control sub-commands (written at MAILBOX_OFF_CALLABLE when state == CONTROL_*)
+static constexpr uint64_t CTRL_MALLOC = 0;
+static constexpr uint64_t CTRL_FREE = 1;
+static constexpr uint64_t CTRL_COPY_TO = 2;
+static constexpr uint64_t CTRL_COPY_FROM = 3;
+
+// Control args reuse the task mailbox region (mutually exclusive with task dispatch):
+//   offset 16: uint64 arg0 (size for malloc; ptr for free; dst for copy)
+//   offset 24: uint64 arg1 (src for copy)
+//   offset 32: uint64 arg2 (nbytes for copy)
+//   offset 40: uint64 result (returned ptr from malloc)
+static constexpr ptrdiff_t CTRL_OFF_ARG0 = 16;
+static constexpr ptrdiff_t CTRL_OFF_ARG1 = 24;
+static constexpr ptrdiff_t CTRL_OFF_ARG2 = 32;
+static constexpr ptrdiff_t CTRL_OFF_RESULT = 40;
 
 // =============================================================================
 // WorkerDispatch — per-dispatch handle handed to a WorkerThread.
@@ -133,6 +151,15 @@ public:
     // the Python facade owns the child PID.
     void shutdown_child();
 
+    // Memory control — callable from the orch thread while the worker
+    // thread may be running a task (MemoryAllocator is mutex-protected).
+    // THREAD mode: direct call on the ChipWorker.
+    // PROCESS mode: control command via mailbox (blocks until child responds).
+    uint64_t control_malloc(size_t size);
+    void control_free(uint64_t ptr);
+    void control_copy_to(uint64_t dst, uint64_t src, size_t size);
+    void control_copy_from(uint64_t dst, uint64_t src, size_t size);
+
 private:
     Mode mode_{Mode::THREAD};
     IWorker *worker_{nullptr};
@@ -178,6 +205,13 @@ public:
 
     WorkerThread *pick_idle(WorkerType type) const;
     std::vector<WorkerThread *> pick_n_idle(WorkerType type, int n) const;
+
+    // Direct index into the worker pool by logical id (0-based).
+    WorkerThread *get_worker(WorkerType type, int logical_id) const;
+
+    // Pick one idle worker NOT in `exclude`. Returns nullptr if none available.
+    WorkerThread *pick_idle_excluding(WorkerType type, const std::vector<WorkerThread *> &exclude) const;
+
     bool any_busy() const;
 
     // Write SHUTDOWN to every PROCESS-mode mailbox.

--- a/src/common/task_interface/tensor_arg.h
+++ b/src/common/task_interface/tensor_arg.h
@@ -28,6 +28,7 @@ struct ContinuousTensor {
     uint32_t shapes[CONTINUOUS_TENSOR_MAX_DIMS];  // Shape per dim (element count)
     uint32_t ndims;                               // Number of dimensions (1..5)
     DataType dtype;                               // DataType : uint8_t
+    uint8_t child_memory;                         // 0 = host (default), 1 = child-managed device memory
 
     [[nodiscard]] uint64_t nbytes() const {
         uint64_t total = 1;
@@ -40,11 +41,13 @@ struct ContinuousTensor {
     T *data_as() const {
         return reinterpret_cast<T *>(static_cast<uintptr_t>(data));
     }
+
+    [[nodiscard]] bool is_child_memory() const { return child_memory != 0; }
 };
 
 static_assert(std::is_trivially_copyable_v<ContinuousTensor>, "ContinuousTensor must be trivially copyable for DMA");
 static_assert(
-    sizeof(ContinuousTensor) == 40, "ContinuousTensor size must be exactly 40B (33B fields + 7B tail padding)"
+    sizeof(ContinuousTensor) == 40, "ContinuousTensor size must be exactly 40B (34B fields + 6B tail padding)"
 );
 
 /**

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -114,6 +114,10 @@ void ChipWorker::init(
         create_device_context_fn_ = load_symbol<CreateDeviceContextFn>(handle, "create_device_context");
         destroy_device_context_fn_ = load_symbol<DestroyDeviceContextFn>(handle, "destroy_device_context");
         set_device_fn_ = load_symbol<SetDeviceFn>(handle, "set_device");
+        device_malloc_ctx_fn_ = load_symbol<DeviceMallocCtxFn>(handle, "device_malloc_ctx");
+        device_free_ctx_fn_ = load_symbol<DeviceFreeCtxFn>(handle, "device_free_ctx");
+        copy_to_device_ctx_fn_ = load_symbol<CopyToDeviceCtxFn>(handle, "copy_to_device_ctx");
+        copy_from_device_ctx_fn_ = load_symbol<CopyFromDeviceCtxFn>(handle, "copy_from_device_ctx");
         get_runtime_size_fn_ = load_symbol<GetRuntimeSizeFn>(handle, "get_runtime_size");
         run_runtime_fn_ = load_symbol<RunRuntimeFn>(handle, "run_runtime");
         finalize_device_fn_ = load_symbol<FinalizeDeviceFn>(handle, "finalize_device");
@@ -177,6 +181,10 @@ void ChipWorker::finalize() {
     create_device_context_fn_ = nullptr;
     destroy_device_context_fn_ = nullptr;
     set_device_fn_ = nullptr;
+    device_malloc_ctx_fn_ = nullptr;
+    device_free_ctx_fn_ = nullptr;
+    copy_to_device_ctx_fn_ = nullptr;
+    copy_from_device_ctx_fn_ = nullptr;
     get_runtime_size_fn_ = nullptr;
     run_runtime_fn_ = nullptr;
     finalize_device_fn_ = nullptr;
@@ -210,5 +218,45 @@ void ChipWorker::run(const void *callable, const void *args, const ChipCallConfi
     );
     if (rc != 0) {
         throw std::runtime_error("run_runtime failed with code " + std::to_string(rc));
+    }
+}
+
+uint64_t ChipWorker::malloc(size_t size) {
+    if (!device_set_) {
+        throw std::runtime_error("ChipWorker device not set; call set_device() first");
+    }
+    void *ptr = device_malloc_ctx_fn_(device_ctx_, size);
+    if (ptr == nullptr) {
+        throw std::runtime_error("malloc failed");
+    }
+    return reinterpret_cast<uint64_t>(ptr);
+}
+
+void ChipWorker::free(uint64_t ptr) {
+    if (!device_set_) {
+        throw std::runtime_error("ChipWorker device not set; call set_device() first");
+    }
+    device_free_ctx_fn_(device_ctx_, reinterpret_cast<void *>(ptr));
+}
+
+void ChipWorker::copy_to(uint64_t dst, uint64_t src, size_t size) {
+    if (!device_set_) {
+        throw std::runtime_error("ChipWorker device not set; call set_device() first");
+    }
+    int rc =
+        copy_to_device_ctx_fn_(device_ctx_, reinterpret_cast<void *>(dst), reinterpret_cast<const void *>(src), size);
+    if (rc != 0) {
+        throw std::runtime_error("copy_to failed with code " + std::to_string(rc));
+    }
+}
+
+void ChipWorker::copy_from(uint64_t dst, uint64_t src, size_t size) {
+    if (!device_set_) {
+        throw std::runtime_error("ChipWorker device not set; call set_device() first");
+    }
+    int rc =
+        copy_from_device_ctx_fn_(device_ctx_, reinterpret_cast<void *>(dst), reinterpret_cast<const void *>(src), size);
+    if (rc != 0) {
+        throw std::runtime_error("copy_from failed with code " + std::to_string(rc));
     }
 }

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -56,6 +56,11 @@ public:
     // the TaskArgsView path and takes a ready-made ChipStorageTaskArgs POD.
     void run(const void *callable, const void *args, const ChipCallConfig &config);
 
+    uint64_t malloc(size_t size);
+    void free(uint64_t ptr);
+    void copy_to(uint64_t dst, uint64_t src, size_t size);
+    void copy_from(uint64_t dst, uint64_t src, size_t size);
+
     int device_id() const { return device_id_; }
     bool initialized() const { return initialized_; }
     bool device_set() const { return device_set_; }
@@ -64,6 +69,10 @@ private:
     using CreateDeviceContextFn = void *(*)();
     using DestroyDeviceContextFn = void (*)(void *);
     using SetDeviceFn = int (*)(void *, int);
+    using DeviceMallocCtxFn = void *(*)(void *, size_t);
+    using DeviceFreeCtxFn = void (*)(void *, void *);
+    using CopyToDeviceCtxFn = int (*)(void *, void *, const void *, size_t);
+    using CopyFromDeviceCtxFn = int (*)(void *, void *, const void *, size_t);
     using GetRuntimeSizeFn = size_t (*)();
     using RunRuntimeFn = int (*)(
         void *, void *, const void *, const void *, int, int, int, const uint8_t *, size_t, const uint8_t *, size_t,
@@ -75,6 +84,10 @@ private:
     CreateDeviceContextFn create_device_context_fn_ = nullptr;
     DestroyDeviceContextFn destroy_device_context_fn_ = nullptr;
     SetDeviceFn set_device_fn_ = nullptr;
+    DeviceMallocCtxFn device_malloc_ctx_fn_ = nullptr;
+    DeviceFreeCtxFn device_free_ctx_fn_ = nullptr;
+    CopyToDeviceCtxFn copy_to_device_ctx_fn_ = nullptr;
+    CopyFromDeviceCtxFn copy_from_device_ctx_fn_ = nullptr;
     GetRuntimeSizeFn get_runtime_size_fn_ = nullptr;
     RunRuntimeFn run_runtime_fn_ = nullptr;
     FinalizeDeviceFn finalize_device_fn_ = nullptr;

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -17,7 +17,8 @@
  *
  * Public API — resolved by ChipWorker via dlsym:
  *   create_device_context, destroy_device_context,
- *   get_runtime_size, set_device, run_runtime, finalize_device
+ *   get_runtime_size, set_device, run_runtime, finalize_device,
+ *   device_malloc_ctx, device_free_ctx, copy_to_device_ctx, copy_from_device_ctx
  *
  * Memory management: caller allocates a buffer of get_runtime_size() bytes
  * and passes it to run_runtime(). Error codes: 0 = success, negative = error.
@@ -58,6 +59,18 @@ size_t get_runtime_size(void);
 
 /** Set the target device. Must be called before the first run_runtime(). */
 int set_device(DeviceContextHandle ctx, int device_id);
+
+/** Allocate device memory in the given device context. */
+void *device_malloc_ctx(DeviceContextHandle ctx, size_t size);
+
+/** Free device memory previously allocated in the given device context. */
+void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr);
+
+/** Copy host memory to a device pointer within the given device context. */
+int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size);
+
+/** Copy device memory to a host pointer within the given device context. */
+int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *dev_ptr, size_t size);
 
 /**
  * Build the task graph, execute on device, copy results back, and clean up.

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_child_memory.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_child_memory.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L3 child_memory — orch.malloc weight on worker, invoke kernel twice.
+
+Allocates a weight buffer on worker 0 via ``orch.malloc()``, uploads
+host data with ``orch.copy_to()``, then creates a ``ContinuousTensor``
+with ``child_memory=True``.  Both kernel invocations pin to ``worker=0``.
+
+The second invocation proves the weight was not freed after the first
+task — ``init_runtime_impl`` skips malloc + H2D copy for child_memory
+tensors and does not record them in tensor_pairs.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import ContinuousTensor, DataType, TaskArgs, TensorArgType, make_tensor_arg
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+KERNELS_BASE = "../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
+
+
+def run_dag(orch, callables, task_args, config):
+    """L3 orchestration: malloc weight on worker 0, run kernel twice."""
+    SIZE = task_args.a.numel()
+    nbytes = SIZE * 4  # float32
+
+    # Allocate on worker 0 and upload weight data.
+    # task_args.w is share_memory_() so its data_ptr is valid in the child.
+    dev_ptr = orch.malloc(worker_id=0, size=nbytes)
+    orch.copy_to(worker_id=0, dst=dev_ptr, src=task_args.w.data_ptr(), size=nbytes)
+
+    # Build child_memory tensor from the worker pointer
+    w_dev = ContinuousTensor.make(dev_ptr, (SIZE,), DataType.FLOAT32, child_memory=True)
+
+    # Run 1: f1 = kernel(a, w_dev)
+    args1 = TaskArgs()
+    args1.add_tensor(make_tensor_arg(task_args.a), TensorArgType.INPUT)
+    args1.add_tensor(w_dev, TensorArgType.INPUT)
+    args1.add_tensor(make_tensor_arg(task_args.f1), TensorArgType.OUTPUT_EXISTING)
+    callables.keep(args1)
+    orch.submit_next_level(callables.vector_kernel, args1, config, worker=0)
+
+    # Run 2: f2 = kernel(a, w_dev) — same weight, same worker
+    args2 = TaskArgs()
+    args2.add_tensor(make_tensor_arg(task_args.a), TensorArgType.INPUT)
+    args2.add_tensor(w_dev, TensorArgType.INPUT)
+    args2.add_tensor(make_tensor_arg(task_args.f2), TensorArgType.OUTPUT_EXISTING)
+    callables.keep(args2)
+    orch.submit_next_level(callables.vector_kernel, args2, config, worker=0)
+
+    # dev_ptr is freed by DeviceRunner::finalize on worker shutdown
+
+
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestL3ChildMemory(SceneTestCase):
+    """L3: orch.malloc weight, child_memory, two kernel invocations with worker affinity."""
+
+    CALLABLE = {
+        "orchestration": run_dag,
+        "callables": [
+            {
+                "name": "vector_kernel",
+                "orchestration": {
+                    "source": f"{KERNELS_BASE}/orchestration/example_orchestration.cpp",
+                    "function_name": "aicpu_orchestration_entry",
+                    "signature": [D.IN, D.IN, D.OUT],
+                },
+                "incores": [
+                    {
+                        "func_id": 0,
+                        "source": f"{KERNELS_BASE}/aiv/kernel_add.cpp",
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.IN, D.OUT],
+                    },
+                    {
+                        "func_id": 1,
+                        "source": f"{KERNELS_BASE}/aiv/kernel_add_scalar.cpp",
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.OUT],
+                    },
+                    {
+                        "func_id": 2,
+                        "source": f"{KERNELS_BASE}/aiv/kernel_mul.cpp",
+                        "core_type": "aiv",
+                        "signature": [D.IN, D.IN, D.OUT],
+                    },
+                ],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "default",
+            "platforms": ["a2a3sim"],
+            "config": {"device_count": 1, "num_sub_workers": 0, "block_dim": 3, "aicpu_thread_num": 4},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        SIZE = 128 * 128
+        return TaskArgsBuilder(
+            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32).share_memory_()),
+            Tensor("w", torch.full((SIZE,), 3.0, dtype=torch.float32).share_memory_()),
+            Tensor("f1", torch.zeros(SIZE, dtype=torch.float32).share_memory_()),
+            Tensor("f2", torch.zeros(SIZE, dtype=torch.float32).share_memory_()),
+        )
+
+    def compute_golden(self, args, params):
+        # vector_example: f = (a + b + 1) * (a + b + 2) + (a + b)
+        s = args.a + args.w
+        expected = (s + 1) * (s + 2) + s
+        args.f1[:] = expected
+        args.f2[:] = expected
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -37,6 +37,8 @@ find_library(GTEST_MAIN_LIB gtest_main PATHS ${GTEST_SEARCH_PATHS} REQUIRED)
 # ---------------------------------------------------------------------------
 set(HIERARCHICAL_SRC_DIR ${CMAKE_SOURCE_DIR}/../../../src/common/hierarchical)
 
+set(WORKER_SRC_DIR ${CMAKE_SOURCE_DIR}/../../../src/common/worker)
+
 set(HIERARCHICAL_SOURCES
     ${HIERARCHICAL_SRC_DIR}/types.cpp
     ${HIERARCHICAL_SRC_DIR}/tensormap.cpp
@@ -46,6 +48,7 @@ set(HIERARCHICAL_SOURCES
     ${HIERARCHICAL_SRC_DIR}/worker_manager.cpp
     ${HIERARCHICAL_SRC_DIR}/scheduler.cpp
     ${HIERARCHICAL_SRC_DIR}/worker.cpp
+    ${WORKER_SRC_DIR}/chip_worker.cpp
 )
 
 # ---------------------------------------------------------------------------
@@ -57,6 +60,7 @@ function(add_hierarchical_test name src)
         ${GTEST_INCLUDE_DIRS}
         ${HIERARCHICAL_SRC_DIR}
         ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+        ${WORKER_SRC_DIR}
     )
     target_compile_options(${name} PRIVATE -D_GLIBCXX_USE_CXX11_ABI=0)
     target_link_libraries(${name} PRIVATE
@@ -112,5 +116,21 @@ add_hierarchical_test(test_ring  test_ring.cpp)
 add_hierarchical_test(test_scope      test_scope.cpp)
 add_hierarchical_test(test_orchestrator test_orchestrator.cpp)
 add_hierarchical_test(test_scheduler  test_scheduler.cpp)
+function(add_task_interface_test name src)
+    add_executable(${name} ${src})
+    target_include_directories(${name} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+    )
+    target_compile_options(${name} PRIVATE -D_GLIBCXX_USE_CXX11_ABI=0)
+    target_link_libraries(${name} PRIVATE
+        ${GTEST_MAIN_LIB}
+        ${GTEST_LIB}
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+endfunction()
+
+add_task_interface_test(test_child_memory test_child_memory.cpp)
 add_a2a3_pto2_test(test_a2a3_pto2_fatal test_a2a3_pto2_fatal.cpp)
 add_a5_pto2_test(test_a5_pto2_fatal test_a5_pto2_fatal.cpp)

--- a/tests/ut/cpp/test_child_memory.cpp
+++ b/tests/ut/cpp/test_child_memory.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstring>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "task_args.h"
+
+// ---------------------------------------------------------------------------
+// ContinuousTensor layout
+// ---------------------------------------------------------------------------
+
+TEST(ChildMemory, SizeofUnchanged) { EXPECT_EQ(sizeof(ContinuousTensor), 40u); }
+
+TEST(ChildMemory, DefaultIsZero) {
+    ContinuousTensor t{};
+    EXPECT_EQ(t.child_memory, 0);
+    EXPECT_FALSE(t.is_child_memory());
+}
+
+TEST(ChildMemory, SetChildMemory) {
+    ContinuousTensor t{};
+    t.data = 0xDEAD0000;
+    t.shapes[0] = 16;
+    t.ndims = 1;
+    t.dtype = DataType::FLOAT32;
+    t.child_memory = 1;
+
+    EXPECT_TRUE(t.is_child_memory());
+    EXPECT_EQ(t.data, 0xDEAD0000u);
+    EXPECT_EQ(t.nbytes(), 16u * 4u);
+}
+
+// ---------------------------------------------------------------------------
+// write_blob / read_blob roundtrip preserves child_memory
+// ---------------------------------------------------------------------------
+
+TEST(ChildMemory, BlobRoundtripPreservesChildMemory) {
+    TaskArgs args;
+
+    ContinuousTensor host_t{};
+    host_t.data = 0x1000;
+    host_t.shapes[0] = 4;
+    host_t.ndims = 1;
+    host_t.dtype = DataType::FLOAT32;
+    host_t.child_memory = 0;
+    args.add_tensor(host_t, TensorArgType::INPUT);
+
+    ContinuousTensor dev_t{};
+    dev_t.data = 0x2000;
+    dev_t.shapes[0] = 8;
+    dev_t.ndims = 1;
+    dev_t.dtype = DataType::FLOAT16;
+    dev_t.child_memory = 1;
+    args.add_tensor(dev_t, TensorArgType::INPUT);
+
+    args.add_scalar(42);
+
+    // Serialize
+    size_t blob_size = task_args_blob_size(args);
+    std::vector<uint8_t> buf(blob_size);
+    write_blob(buf.data(), args);
+
+    // Deserialize
+    TaskArgsView view = read_blob(buf.data());
+    ASSERT_EQ(view.tensor_count, 2);
+    ASSERT_EQ(view.scalar_count, 1);
+
+    EXPECT_EQ(view.tensors[0].child_memory, 0);
+    EXPECT_FALSE(view.tensors[0].is_child_memory());
+
+    EXPECT_EQ(view.tensors[1].child_memory, 1);
+    EXPECT_TRUE(view.tensors[1].is_child_memory());
+    EXPECT_EQ(view.tensors[1].data, 0x2000u);
+}
+
+// ---------------------------------------------------------------------------
+// view_to_chip_storage preserves child_memory
+// ---------------------------------------------------------------------------
+
+TEST(ChildMemory, ViewToChipStoragePreservesChildMemory) {
+    ContinuousTensor tensors[2] = {};
+    tensors[0].data = 0xA000;
+    tensors[0].shapes[0] = 1;
+    tensors[0].ndims = 1;
+    tensors[0].dtype = DataType::INT32;
+    tensors[0].child_memory = 0;
+
+    tensors[1].data = 0xB000;
+    tensors[1].shapes[0] = 2;
+    tensors[1].ndims = 1;
+    tensors[1].dtype = DataType::INT32;
+    tensors[1].child_memory = 1;
+
+    uint64_t scalars[] = {99};
+    TaskArgsView view{2, 1, tensors, scalars};
+
+    ChipStorageTaskArgs chip = view_to_chip_storage(view);
+
+    ASSERT_EQ(chip.tensor_count(), 2);
+    EXPECT_FALSE(chip.tensor(0).is_child_memory());
+    EXPECT_TRUE(chip.tensor(1).is_child_memory());
+    EXPECT_EQ(chip.tensor(1).data, 0xB000u);
+}
+
+// ---------------------------------------------------------------------------
+// Mixed: child_memory tensors should NOT be recorded as tensor pairs
+// (simulates what init_runtime_impl should do)
+// ---------------------------------------------------------------------------
+
+TEST(ChildMemory, SkipLogicSimulation) {
+    // Simulate the init_runtime_impl loop: count how many tensors would be
+    // malloc'd vs passed-through.
+    ChipStorageTaskArgs args;
+
+    ContinuousTensor host_t{};
+    host_t.data = 0x1000;
+    host_t.shapes[0] = 4;
+    host_t.ndims = 1;
+    host_t.dtype = DataType::FLOAT32;
+    host_t.child_memory = 0;
+    args.add_tensor(host_t);
+
+    ContinuousTensor dev_t{};
+    dev_t.data = 0x2000;
+    dev_t.shapes[0] = 8;
+    dev_t.ndims = 1;
+    dev_t.dtype = DataType::FLOAT32;
+    dev_t.child_memory = 1;
+    args.add_tensor(dev_t);
+
+    int malloc_count = 0;
+    int passthrough_count = 0;
+
+    for (int i = 0; i < args.tensor_count(); i++) {
+        ContinuousTensor t = args.tensor(i);
+        if (t.is_child_memory()) {
+            passthrough_count++;
+        } else {
+            malloc_count++;
+        }
+    }
+
+    EXPECT_EQ(malloc_count, 1);
+    EXPECT_EQ(passthrough_count, 1);
+}

--- a/tests/ut/cpp/test_orchestrator.cpp
+++ b/tests/ut/cpp/test_orchestrator.cpp
@@ -102,7 +102,7 @@ TEST_F(OrchestratorFixture, TensorMapTracksProducer) {
     TaskSlot drain_slot;
     rq.try_pop(drain_slot);
 
-    EXPECT_EQ(tm.lookup(0x1234), a.task_slot);
+    EXPECT_EQ(tm.lookup(TensorKey{0x1234, -1}), a.task_slot);
 }
 
 TEST_F(OrchestratorFixture, OnConsumedCleansUpTensorMap) {
@@ -111,12 +111,12 @@ TEST_F(OrchestratorFixture, OnConsumedCleansUpTensorMap) {
     TaskSlot slot;
     rq.try_pop(slot);
 
-    EXPECT_EQ(tm.lookup(0x42), slot);
+    EXPECT_EQ(tm.lookup(TensorKey{0x42, -1}), slot);
 
     S(slot).state.store(TaskState::COMPLETED, std::memory_order_relaxed);
     orch.on_consumed(slot);
 
-    EXPECT_EQ(tm.lookup(0x42), INVALID_SLOT);
+    EXPECT_EQ(tm.lookup(TensorKey{0x42, -1}), INVALID_SLOT);
     EXPECT_EQ(S(slot).state.load(), TaskState::CONSUMED);
 }
 
@@ -173,8 +173,8 @@ TEST_F(OrchestratorFixture, GroupTaskStoresArgsListPerMember) {
     EXPECT_EQ(S(res.task_slot).args_view(1).tensors[0].data, 0xA1u);
 
     // Both keys registered as producers for the group slot.
-    EXPECT_EQ(tm.lookup(0xA0), res.task_slot);
-    EXPECT_EQ(tm.lookup(0xA1), res.task_slot);
+    EXPECT_EQ(tm.lookup(TensorKey{0xA0, -1}), res.task_slot);
+    EXPECT_EQ(tm.lookup(TensorKey{0xA1, -1}), res.task_slot);
 }
 
 TEST_F(OrchestratorFixture, SingleTaskStoresTaskArgsDirectly) {
@@ -210,7 +210,7 @@ TEST_F(OrchestratorFixture, OutputAutoAllocsFromHeapRing) {
     EXPECT_LT(data, base + allocator.heap_size(0));
     EXPECT_EQ(data % HEAP_ALIGN, 0u);
 
-    EXPECT_EQ(tm.lookup(data), res.task_slot);
+    EXPECT_EQ(tm.lookup(TensorKey{data, -1}), res.task_slot);
 }
 
 TEST_F(OrchestratorFixture, InoutWiresCreatorAsFanin) {
@@ -233,7 +233,7 @@ TEST_F(OrchestratorFixture, InoutWiresCreatorAsFanin) {
     rq.try_pop(writer_slot);
 
     // TensorMap now points at the new writer.
-    EXPECT_EQ(tm.lookup(0xFEED), writer.task_slot);
+    EXPECT_EQ(tm.lookup(TensorKey{0xFEED, -1}), writer.task_slot);
     // Writer has the creator recorded as a fanin producer (via INOUT
     // lookup) but no *live* fanin since the creator is already COMPLETED.
     EXPECT_EQ(S(writer.task_slot).fanin_count, 0);
@@ -267,7 +267,7 @@ TEST_F(OrchestratorFixture, OutputAndOutputExistingAreInsertOnly) {
         auto writer_args = single_tensor_args(c.key, c.tag);
         auto writer = orch.submit_next_level(0xDEAD, writer_args, cfg);
 
-        EXPECT_EQ(tm.lookup(c.key), writer.task_slot);
+        EXPECT_EQ(tm.lookup(TensorKey{c.key, -1}), writer.task_slot);
         EXPECT_EQ(S(writer.task_slot).fanin_count, 0);
         EXPECT_TRUE(S(writer.task_slot).fanin_producers.empty()) << "tag=" << static_cast<int>(c.tag);
         {

--- a/tests/ut/cpp/test_tensormap.cpp
+++ b/tests/ut/cpp/test_tensormap.cpp
@@ -13,53 +13,89 @@
 
 #include "tensormap.h"
 
+// Helper: host key (worker=-1)
+static TensorKey hk(uint64_t ptr) { return {ptr, -1}; }
+
+// Helper: child key (worker=w)
+static TensorKey ck(uint64_t ptr, int8_t w) { return {ptr, w}; }
+
 TEST(TensorMap, LookupEmptyReturnsInvalid) {
     TensorMap tm;
-    EXPECT_EQ(tm.lookup(0xDEADBEEF), INVALID_SLOT);
+    EXPECT_EQ(tm.lookup(hk(0xDEADBEEF)), INVALID_SLOT);
 }
 
 TEST(TensorMap, InsertAndLookup) {
     TensorMap tm;
-    tm.insert(0x1000, 5);
-    EXPECT_EQ(tm.lookup(0x1000), 5);
-    EXPECT_EQ(tm.lookup(0x2000), INVALID_SLOT);
+    tm.insert(hk(0x1000), 5);
+    EXPECT_EQ(tm.lookup(hk(0x1000)), 5);
+    EXPECT_EQ(tm.lookup(hk(0x2000)), INVALID_SLOT);
     EXPECT_EQ(tm.size(), 1);
 }
 
 TEST(TensorMap, OverwriteExistingEntry) {
     TensorMap tm;
-    tm.insert(0x1000, 3);
-    tm.insert(0x1000, 7);  // new producer reuses same buffer
-    EXPECT_EQ(tm.lookup(0x1000), 7);
+    tm.insert(hk(0x1000), 3);
+    tm.insert(hk(0x1000), 7);  // new producer reuses same buffer
+    EXPECT_EQ(tm.lookup(hk(0x1000)), 7);
     EXPECT_EQ(tm.size(), 1);
 }
 
 TEST(TensorMap, EraseTaskOutputs) {
     TensorMap tm;
-    tm.insert(0x1000, 0);
-    tm.insert(0x2000, 0);
-    tm.insert(0x3000, 1);
+    tm.insert(hk(0x1000), 0);
+    tm.insert(hk(0x2000), 0);
+    tm.insert(hk(0x3000), 1);
 
-    tm.erase_task_outputs({0x1000, 0x2000});
+    tm.erase_task_outputs({hk(0x1000), hk(0x2000)});
 
-    EXPECT_EQ(tm.lookup(0x1000), INVALID_SLOT);
-    EXPECT_EQ(tm.lookup(0x2000), INVALID_SLOT);
-    EXPECT_EQ(tm.lookup(0x3000), 1);
+    EXPECT_EQ(tm.lookup(hk(0x1000)), INVALID_SLOT);
+    EXPECT_EQ(tm.lookup(hk(0x2000)), INVALID_SLOT);
+    EXPECT_EQ(tm.lookup(hk(0x3000)), 1);
     EXPECT_EQ(tm.size(), 1);
 }
 
 TEST(TensorMap, EraseWithEmptyKeyList) {
     TensorMap tm;
-    tm.insert(0x1000, 2);
+    tm.insert(hk(0x1000), 2);
     tm.erase_task_outputs({});
-    EXPECT_EQ(tm.lookup(0x1000), 2);
+    EXPECT_EQ(tm.lookup(hk(0x1000)), 2);
 }
 
 TEST(TensorMap, MultipleEntries) {
     TensorMap tm;
     for (int i = 0; i < 100; ++i)
-        tm.insert(static_cast<uint64_t>(i) * 0x1000, i % 16);
+        tm.insert(hk(static_cast<uint64_t>(i) * 0x1000), i % 16);
     EXPECT_EQ(tm.size(), 100);
     for (int i = 0; i < 100; ++i)
-        EXPECT_EQ(tm.lookup(static_cast<uint64_t>(i) * 0x1000), i % 16);
+        EXPECT_EQ(tm.lookup(hk(static_cast<uint64_t>(i) * 0x1000)), i % 16);
+}
+
+// --- TensorKey compound key tests ---
+
+TEST(TensorMap, SamePtrDifferentWorkerAreDistinct) {
+    TensorMap tm;
+    tm.insert(ck(0xABC, 0), 10);
+    tm.insert(ck(0xABC, 1), 20);
+    EXPECT_EQ(tm.lookup(ck(0xABC, 0)), 10);
+    EXPECT_EQ(tm.lookup(ck(0xABC, 1)), 20);
+    EXPECT_EQ(tm.size(), 2);
+}
+
+TEST(TensorMap, HostAndChildKeyAreDistinct) {
+    TensorMap tm;
+    tm.insert(hk(0x1000), 5);     // host (worker=-1)
+    tm.insert(ck(0x1000, 0), 6);  // child worker 0
+    EXPECT_EQ(tm.lookup(hk(0x1000)), 5);
+    EXPECT_EQ(tm.lookup(ck(0x1000, 0)), 6);
+    EXPECT_EQ(tm.size(), 2);
+}
+
+TEST(TensorMap, EraseChildKeyLeavesHostKey) {
+    TensorMap tm;
+    tm.insert(hk(0x1000), 5);
+    tm.insert(ck(0x1000, 0), 6);
+    tm.erase_task_outputs({ck(0x1000, 0)});
+    EXPECT_EQ(tm.lookup(hk(0x1000)), 5);
+    EXPECT_EQ(tm.lookup(ck(0x1000, 0)), INVALID_SLOT);
+    EXPECT_EQ(tm.size(), 1);
 }

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -621,3 +621,49 @@ class TestChipCallable:
         assert "ChipCallable" in r
         assert "sig_count=2" in r
         assert "child_count=1" in r
+
+
+# ============================================================================
+# ContinuousTensor.child_memory
+# ============================================================================
+
+
+class TestChildMemory:
+    def test_default_is_false(self):
+        t = ContinuousTensor()
+        assert t.child_memory is False
+
+    def test_make_default_is_false(self):
+        t = ContinuousTensor.make(0x1000, (4,), DataType.FLOAT32)
+        assert t.child_memory is False
+
+    def test_make_child_memory_true(self):
+        t = ContinuousTensor.make(0xDEAD, (8,), DataType.FLOAT16, child_memory=True)
+        assert t.child_memory is True
+        assert t.data == 0xDEAD
+        assert t.shapes == (8,)
+        assert t.dtype == DataType.FLOAT16
+
+    def test_set_child_memory(self):
+        t = ContinuousTensor.make(0x1000, (4,), DataType.FLOAT32)
+        assert t.child_memory is False
+        t.child_memory = True
+        assert t.child_memory is True
+
+    def test_repr_shows_child_memory_when_set(self):
+        t = ContinuousTensor.make(0x1000, (4,), DataType.FLOAT32, child_memory=True)
+        r = repr(t)
+        assert "child_memory=True" in r
+
+    def test_repr_hides_child_memory_when_default(self):
+        t = ContinuousTensor.make(0x1000, (4,), DataType.FLOAT32)
+        r = repr(t)
+        assert "child_memory" not in r
+
+    def test_chip_storage_preserves_child_memory(self):
+        args = ChipStorageTaskArgs()
+        t = ContinuousTensor.make(0x2000, (16,), DataType.INT32, child_memory=True)
+        args.add_tensor(t)
+        out = args.tensor(0)
+        assert out.child_memory is True
+        assert out.data == 0x2000


### PR DESCRIPTION
## Summary

Enable device-resident tensor buffers to flow through the L3 task pipeline without redundant H2D copies. Adds memory allocation on next-level workers via `orch.malloc`, scheduler worker affinity, and TensorMap compound keys for cross-NPU address disambiguation.

### 1. `child_memory` flag on `ContinuousTensor`

A 1-byte field in existing tail padding (`sizeof` stays 40B). When set, `init_runtime_impl` passes the tensor pointer through as-is instead of `device_malloc` + `copy_to_device` + `record_tensor_pair`.

### 2. `device_malloc_ctx` C API

Export `device_malloc_ctx` / `device_free_ctx` / `copy_to_device_ctx` / `copy_from_device_ctx` from `pto_runtime_c_api` (all 4 platforms). Wired through `ChipWorker.malloc/free/copy_to/copy_from`.

### 3. `orch.malloc(worker_id, size)` — memory allocation on next-level workers

Full path: `Orchestrator → WorkerManager → WorkerThread → ChipWorker`.
- **THREAD mode**: direct call on ChipWorker (MemoryAllocator is mutex-protected for thread safety)
- **PROCESS mode**: control command via mailbox IPC (CONTROL_REQUEST/CONTROL_DONE states)

### 4. `TensorKey` compound key for TensorMap

Replace `uint64_t` key with `{uint64_t ptr, int8_t worker}` struct. Disambiguates identical device addresses across different NPUs.

### 5. Scheduler worker affinity

- `submit_next_level(worker=0)` / `submit_next_level_group(workers=[0,1])` store per-args affinities
- `Scheduler::dispatch_ready` two-pass: satisfy affinity constraints first, then fill unconstrained slots from idle pool

### 6. Thread-safe MemoryAllocator

Add `std::mutex` to MemoryAllocator (all 4 platform implementations) so `orch.malloc` from the orch thread can run concurrently with `init_runtime_impl` on the worker thread.

## Testing

- [x] C++ unit tests pass (8/8) — child_memory roundtrip + TensorKey compound key + orchestrator
- [x] Python unit tests pass (7/7 new + existing)
- [x] L3 scene test passes on a2a3sim — `orch.malloc` → `orch.copy_to` → `child_memory=True` → `submit_next_level(worker=0)` × 2
- [ ] Hardware tests (requires device)

Related: #571