### PR TITLE
Refactor: remove numpy and ml_dtypes dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install Python dependencies
-        run: pip install numpy ml_dtypes
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install package (for pyright C extension symbol resolution)
         run: pip install .
@@ -90,8 +90,7 @@ jobs:
           python3 -m venv .venv
           . .venv/bin/activate
           pip install --upgrade pip
-          pip install scikit-build-core nanobind cmake
-          pip install numpy ml_dtypes pytest
+          pip install scikit-build-core nanobind cmake pytest
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Run packaging matrix (5 modes × 4 entry points, fully isolated)
@@ -126,13 +125,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install numpy
-          pip install ml_dtypes
-          pip install pytest
           pip install torch --index-url https://download.pytorch.org/whl/cpu
-
-      - name: Build nanobind extension
-        run: pip install .
+          pip install '.[test]'
 
       - name: Run unit tests
         run: pytest tests -m "not requires_hardware" -v
@@ -210,13 +204,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install numpy
-          pip install ml_dtypes
-          pip install pytest
           pip install torch --index-url https://download.pytorch.org/whl/cpu
-
-      - name: Build nanobind extension
-        run: pip install .
+          pip install '.[test]'
 
       - name: Run simulation examples (a2a3sim)
         run: python ci.py -p a2a3sim -c d96c8784 -t 600 --clone-protocol https
@@ -274,13 +263,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install numpy
-          pip install ml_dtypes
-          pip install pytest
           pip install torch --index-url https://download.pytorch.org/whl/cpu
-
-      - name: Build nanobind extension
-        run: pip install .
+          pip install '.[test]'
 
       - name: Run simulation examples (a5sim)
         run: python ci.py -p a5sim -c d96c8784 -t 600 --clone-protocol https

--- a/ci.py
+++ b/ci.py
@@ -425,7 +425,6 @@ def run_single_task(
     """Run all cases in a compiled task on a given worker. Returns True if all pass."""
     import ctypes  # noqa: PLC0415
 
-    import numpy as np  # noqa: PLC0415
     import torch  # noqa: PLC0415
 
     from simpler_setup.code_runner import _kernel_config_runtime_env, _temporary_env  # noqa: PLC0415
@@ -449,12 +448,8 @@ def run_single_task(
 
             for item in result:
                 name, value = item
-                if isinstance(value, (torch.Tensor, np.ndarray)):
-                    tensor = (
-                        torch.as_tensor(value).cpu().contiguous()
-                        if not isinstance(value, torch.Tensor)
-                        else value.cpu().contiguous()
-                    )
+                if isinstance(value, torch.Tensor):
+                    tensor = value.cpu().contiguous()
                     args[name] = tensor
                     orch_args.add_tensor(make_tensor_arg(tensor))
                     if name in output_set:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,7 +88,7 @@ All workflows assume an activated project-local venv (see [`.claude/rules/venv-i
 ```bash
 python3 -m venv --system-site-packages .venv
 source .venv/bin/activate
-pip install --no-build-isolation scikit-build-core nanobind cmake pytest numpy ml_dtypes torch
+pip install --no-build-isolation scikit-build-core nanobind cmake pytest torch
 pip install --no-build-isolation -e .
 ```
 
@@ -217,7 +217,7 @@ python examples/scripts/run_example.py -k <kernels> -g <golden.py> -p a2a3 --dev
 - **Handshake cores**: Usually 3 (1c2v configuration: 1 core, 2 vector units)
 - **Kernel compilation**: Requires `ASCEND_HOME_PATH` environment variable
 - **Memory management**: MemoryAllocator automatically tracks allocations
-- **Python requirement**: NumPy for efficient array operations
+- **Python requirement**: PyTorch for tensor operations in golden scripts
 
 ## Logging
 

--- a/docs/python-packaging.md
+++ b/docs/python-packaging.md
@@ -47,6 +47,17 @@ _task_interface.*.so      nanobind extension at site-packages root
 
 Internal coupling: `simpler_setup.toolchain`, `simpler_setup.kernel_compiler`, and `simpler_setup.runtime_compiler` import `simpler.env_manager`. This is the only direction allowed (`simpler_setup → simpler`); never the reverse. `simpler` must not depend on `simpler_setup`.
 
+### Dependencies
+
+| Category | Packages |
+| -------- | -------- |
+| `simpler` runtime | No third-party Python deps. Requires platform backend: simulation (`a*sim`) or NPU hardware (`a2a3`/`a5` with CANN toolkit) |
+| `simpler_setup` runtime | `torch` (tensor operations in golden scripts, test comparison) |
+| Build | `scikit-build-core`, `nanobind`, `cmake` |
+| Test | `pytest` (ut-py, st), `googletest` + `ctest` (ut-cpp) |
+
+`pyproject.toml` declares no `[project.dependencies]` — both `torch` and `pytest` are environment prerequisites, not pip-installed transitively. This is intentional: torch's index URL (`--index-url https://download.pytorch.org/whl/cpu`) and hardware-specific builds make automatic resolution impractical.
+
 ### `PROJECT_ROOT` resolution
 
 `simpler_setup.environment.PROJECT_ROOT` auto-detects between:
@@ -107,7 +118,7 @@ For developers who don't want to use pip at all:
 
 ```bash
 . .venv/bin/activate
-pip install scikit-build-core nanobind cmake pytest numpy ml_dtypes torch  # one-time
+pip install scikit-build-core nanobind cmake pytest torch  # one-time
 cmake -S . -B build/cmake_only -Dnanobind_DIR=$(python -c 'import nanobind; print(nanobind.cmake_dir())')
 cmake --build build/cmake_only
 export PYTHONPATH=$(pwd):$(pwd)/python
@@ -125,7 +136,7 @@ The cmake build places `_task_interface.cpython-XYZ.so` directly into `python/` 
 | `python ci.py` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `python examples/scripts/run_example.py` | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-On macOS, set `KMP_DUPLICATE_LIB_OK=TRUE` to silence the homebrew-numpy + pip-torch libomp collision (also documented in `ci.py`).
+On macOS with `--system-site-packages`, set `KMP_DUPLICATE_LIB_OK=TRUE` if the system numpy is present and its libomp collides with torch's (see `docs/macos-libomp-collision.md`).
 
 ## Verification protocol when changing package structure
 
@@ -144,7 +155,7 @@ Any change that touches:
 ```bash
 # Locally — same script CI runs.
 source .venv/bin/activate
-pip install scikit-build-core nanobind cmake pytest numpy ml_dtypes torch  # one-time
+pip install scikit-build-core nanobind cmake pytest torch  # one-time
 bash tools/verify_packaging.sh
 ```
 

--- a/examples/scripts/run_example.py
+++ b/examples/scripts/run_example.py
@@ -95,8 +95,8 @@ Examples:
 
 Golden.py interface:
     def generate_inputs(params: dict) -> dict:
-        '''Return dict of numpy arrays (inputs + outputs)'''
-        return {"a": np.array(...), "out_f": np.zeros(...)}
+        '''Return dict of torch tensors (inputs + outputs)'''
+        return {"a": torch.tensor(...), "out_f": torch.zeros(...)}
 
     def compute_golden(tensors: dict, params: dict) -> None:
         '''Compute expected outputs in-place'''

--- a/simpler_setup/code_runner.py
+++ b/simpler_setup/code_runner.py
@@ -100,16 +100,8 @@ def _to_torch(tensor) -> torch.Tensor:
         # Already a torch tensor, ensure it's on CPU and contiguous
         return tensor.cpu().contiguous()
 
-    # For any non-torch tensor, try direct torch conversion first
-    # This handles most array-like objects including numpy arrays
-    try:
-        return torch.as_tensor(tensor)
-    except (TypeError, RuntimeError):
-        # If direct conversion fails, fall back to numpy path
-        import numpy as np  # noqa: PLC0415  # type: ignore[import-not-found]
-
-        arr = np.asarray(tensor)
-        return torch.from_numpy(arr)
+    # For any non-torch tensor, convert directly
+    return torch.as_tensor(tensor).cpu().contiguous()
 
 
 def _load_module_from_path(module_path: Path, module_name: str):
@@ -307,7 +299,7 @@ class CodeRunner:
         Build ChipStorageTaskArgs from an explicit argument list returned by generate_inputs.
 
         Every element must be a (name, value) pair where value is either:
-        - torch.Tensor / numpy array: a tensor argument
+        - torch.Tensor: a tensor argument
         - ctypes scalar (ctypes.c_int64, ctypes.c_float, etc.): a scalar argument
 
         All named items (tensors and scalars) are collected into the args dict
@@ -317,8 +309,6 @@ class CodeRunner:
             Tuple of (orch_args, args, inputs, outputs)
             where args contains all named items, inputs/outputs contain tensor-only subsets.
         """
-        import numpy as np  # noqa: PLC0415  # type: ignore[import-not-found]
-
         if not self.output_names:
             raise ValueError("No output tensors identified. Define __outputs__ = ['tensor_name'] in golden.py")
         output_set = set(self.output_names)
@@ -338,9 +328,8 @@ class CodeRunner:
 
             name, value = item
 
-            if isinstance(value, (torch.Tensor, np.ndarray)):
+            if isinstance(value, torch.Tensor):
                 tensor = _to_torch(value)
-                tensor = tensor.cpu().contiguous()
                 args[name] = tensor
 
                 orch_args.add_tensor(make_tensor_arg(tensor))
@@ -357,7 +346,7 @@ class CodeRunner:
             else:
                 raise TypeError(
                     f"Unsupported value type for arg '{name}': {type(value)}\n"
-                    f"Expected torch.Tensor, numpy array, or ctypes scalar (ctypes.c_int64, ctypes.c_float, etc.)"
+                    f"Expected torch.Tensor or ctypes scalar (ctypes.c_int64, ctypes.c_float, etc.)"
                 )
 
         if not outputs:

--- a/tools/verify_packaging.sh
+++ b/tools/verify_packaging.sh
@@ -80,7 +80,7 @@ print('simpler_setup:', simpler_setup.__file__)
 # ---------------------------------------------------------------------------
 python -c "import scikit_build_core, nanobind, cmake, torch, pytest" 2>/dev/null || {
     echo "ERROR: venv missing required deps. Install with:" >&2
-    echo "  pip install scikit-build-core nanobind cmake pytest numpy ml_dtypes torch" >&2
+    echo "  pip install scikit-build-core nanobind cmake pytest torch" >&2
     exit 1
 }
 


### PR DESCRIPTION
## Summary

Project now uses torch exclusively for tensor operations. numpy was only used as a fallback conversion path and isinstance check; ml_dtypes had no remaining call sites.

- Remove numpy fallback in `_to_torch()` and isinstance checks in `code_runner.py` and `ci.py`
- Ensure `_to_torch()` always returns cpu+contiguous tensors; remove redundant `.cpu().contiguous()` at call sites
- Remove `pip install numpy`/`ml_dtypes` from all CI workflow jobs; sim jobs now use `pip install '.[test]'`
- Add Dependencies section to `python-packaging.md` documenting the `simpler` vs `simpler_setup` dependency split
- Update `getting-started.md` install commands and docstrings

## Testing

- [x] Simulation tests pass (a2a3sim: 25 passed, 80 skipped, 0 failed)
- [ ] Hardware tests pass (if applicable)