### PR TITLE
Support: add func_id-to-name mapping for SceneTest swimlane visualization

### DIFF
--- a/docs/profiling-name-map.md
+++ b/docs/profiling-name-map.md
@@ -1,0 +1,165 @@
+# Profiling Name Map
+
+## Problem
+
+Profiling data (`perf_swimlane_*.json`) identifies tasks by numeric IDs
+(e.g., `func_id: 0`).  Without a mapping, swimlane visualizations show
+opaque labels like `func_0_a(t0)` instead of human-readable names like
+`QK(t0)`.
+
+## Design Principle: Each Level Owns Its Own Mapping
+
+The runtime is organized in hierarchical levels (L2, L3, ...).  Each
+level independently exports profiling data and a name mapping that
+describes **its own tasks and the next level down**:
+
+- **Perf data** declares which level it comes from.
+- **Name map** declares which level it describes.
+- The visualization tool matches them by level.  No cross-level
+  merging or recursive expansion.
+
+This keeps each level self-contained.  L3 treats L2 as an opaque
+callable; L2 treats individual cores as opaque executors.
+
+## Name Map Format
+
+Every level uses the same structure:
+
+```json
+{
+  "level": <int>,
+  "orchestrator_name": "<display name or null>",
+  "callable_id_to_name": {
+    "<id>": "<name>",
+    ...
+  }
+}
+```
+
+| Field | Meaning |
+| ----- | ------- |
+| `level` | Which level this mapping describes |
+| `orchestrator_name` | Display name for the orchestrator at this level (optional, from `"name"` in CALLABLE) |
+| `callable_id_to_name` | Maps next-level-down callable IDs to human-readable names |
+
+### L2 (Orchestration + Incores)
+
+`callable_id` = incore `func_id` (the integer assigned in the CALLABLE
+spec).  These are the same IDs that appear in L2 perf data.
+
+```json
+{
+  "level": 2,
+  "orchestrator_name": "PagedAttn",
+  "callable_id_to_name": {
+    "0": "QK",
+    "1": "SF",
+    "2": "PV",
+    "3": "UP"
+  }
+}
+```
+
+### L3 (Callables List)
+
+`callable_id` = index in the `callables` list (0-based).  Both
+ChipCallable entries and SubWorker entries share this index space.
+
+```json
+{
+  "level": 3,
+  "orchestrator_name": "run_dag",
+  "callable_id_to_name": {
+    "0": "vector_kernel",
+    "1": "verify"
+  }
+}
+```
+
+## How to Define Names in SceneTest
+
+Add optional `"name"` fields to the CALLABLE spec.  Entries without
+`"name"` are omitted from the mapping and display with default labels.
+
+### L2 Example
+
+```python
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestPagedAttention(SceneTestCase):
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/orch.cpp",
+            "function_name": "build_paged_attention_graph",
+            "name": "PagedAttn",                          # optional
+            "signature": [D.IN, D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {"func_id": 0, "name": "QK",  "source": "kernels/aic/qk.cpp",  "core_type": "aic"},
+            {"func_id": 1, "name": "SF",  "source": "kernels/aiv/sf.cpp",  "core_type": "aiv"},
+            {"func_id": 2, "name": "PV",  "source": "kernels/aic/pv.cpp",  "core_type": "aic"},
+            {"func_id": 3, "name": "UP",  "source": "kernels/aiv/up.cpp",  "core_type": "aiv"},
+        ],
+    }
+```
+
+### L3 Example
+
+At L3, callable entries already have a `"name"` field (used by
+`CallableNamespace`).  These names are automatically included in the
+mapping:
+
+```python
+@scene_test(level=3, runtime="tensormap_and_ringbuffer")
+class TestL3Group(SceneTestCase):
+    CALLABLE = {
+        "orchestration": run_dag,
+        "callables": [
+            {
+                "name": "vector_kernel",                  # already required at L3
+                "orchestration": {"source": "...", "function_name": "build_vec"},
+                "incores": [{"func_id": 0, "source": "...", "core_type": "aiv"}],
+            },
+            {
+                "name": "verify",                         # already required at L3
+                "callable": verify_fn,
+            },
+        ],
+    }
+```
+
+## Automatic Dump and Consumption
+
+When `--enable-profiling` is used, SceneTest automatically:
+
+1. Extracts the name mapping from `CALLABLE` via `_extract_name_map()`.
+2. Writes `outputs/name_map_<ClassName_casename>.json`.
+3. Passes the file to `swimlane_converter.py` via `--func-names`.
+
+No manual steps are needed.  If no `"name"` fields are defined, no
+mapping file is written and the tools fall back to default labels.
+
+## Tool Usage
+
+The `--func-names` flag is available on both visualization tools.  It
+takes precedence over `-k` (kernel_config.py):
+
+```bash
+# Automatic (via SceneTest profiling)
+pytest tests/st/... --platform a5onboard --enable-profiling
+
+# Manual
+python3 tools/swimlane_converter.py outputs/perf_swimlane_*.json \
+    --func-names outputs/name_map_TestPA_basic.json
+
+python3 tools/perf_to_mermaid.py outputs/perf_swimlane_*.json \
+    --func-names outputs/name_map_TestPA_basic.json
+```
+
+## File Layout
+
+```text
+outputs/
+  perf_swimlane_20260416_151301_TestPA_basic.json   # perf data (runtime)
+  name_map_TestPA_basic.json                        # name mapping (SceneTest)
+  merged_swimlane_20260416_151301_TestPA_basic.json # Perfetto trace (converter)
+```

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -340,6 +340,63 @@ def _resolve_chip_entry_paths(entry, cls_dir):
         entry["incores"] = resolved
 
 
+def _extract_name_map(callable_spec: dict) -> dict:
+    """Extract name mapping from a CALLABLE spec.
+
+    Each level exports only its own ``callable_id_to_name`` — the mapping
+    from next-level-down IDs to human-readable names.  No cross-level
+    nesting: the perf data declares its level, the mapping declares its
+    level, and the tool matches them.
+
+    * **L2** — ``callable_id`` = incore ``func_id``::
+
+        {"level": 2, "orchestrator_name": "PagedAttn",
+         "callable_id_to_name": {"0": "QK", "1": "SF"}}
+
+    * **L3** — ``callable_id`` = index in ``callables`` list::
+
+        {"level": 3, "orchestrator_name": "run_dag",
+         "callable_id_to_name": {"0": "vec_kernel", "1": "verify"}}
+    """
+    if "callables" not in callable_spec:
+        # L2: orchestration + incores
+        callable_id_to_name: dict[str, str] = {}
+        orch = callable_spec.get("orchestration", {})
+        orchestrator_name = orch.get("name") if isinstance(orch, dict) else None
+        for k in callable_spec.get("incores", []):
+            if "name" in k and "func_id" in k:
+                callable_id_to_name[str(k["func_id"])] = k["name"]
+        result: dict = {"level": 2, "orchestrator_name": orchestrator_name}
+        if callable_id_to_name:
+            result["callable_id_to_name"] = callable_id_to_name
+        return result
+
+    # L3: Python orch function + callables list
+    orch = callable_spec.get("orchestration")
+    orchestrator_name = getattr(orch, "__name__", None) if callable(orch) else None
+
+    callable_id_to_name = {}
+    for idx, entry in enumerate(callable_spec["callables"]):
+        callable_id_to_name[str(idx)] = entry.get("name", f"callable_{idx}")
+
+    result = {"level": 3, "orchestrator_name": orchestrator_name}
+    if callable_id_to_name:
+        result["callable_id_to_name"] = callable_id_to_name
+    return result
+
+
+def _dump_name_map(mapping: dict, output_path: Path) -> Path | None:
+    """Write name mapping to JSON if it contains any names. Returns path or None."""
+    import json as _json  # noqa: PLC0415
+
+    if not mapping.get("callable_id_to_name") and not mapping.get("orchestrator_name"):
+        return None
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        _json.dump(mapping, f, indent=2)
+    return output_path
+
+
 def _parse_case_selector(value: str) -> tuple[str | None, str | None]:
     """Parse one ``--case`` value into ``(class_name, case_name)``.
 
@@ -466,6 +523,7 @@ def _run_swimlane_converter(
     input_path: Path | None = None,
     device_id=None,
     device_log: Path | None = None,
+    func_names_path: Path | None = None,
 ) -> None:
     """Invoke ``tools/swimlane_converter.py``.
 
@@ -484,6 +542,8 @@ def _run_swimlane_converter(
     cmd = [sys.executable, str(script)]
     if input_path is not None:
         cmd.append(str(input_path))
+    if func_names_path is not None:
+        cmd += ["--func-names", str(func_names_path)]
     if device_log is not None:
         cmd += ["--device-log", str(device_log)]
     elif device_id is not None:
@@ -510,12 +570,17 @@ def _convert_case_swimlane(
     device_id,
     before_perf: set[Path],
     before_device: set[Path] | None,
+    callable_spec: dict | None = None,
 ) -> None:
     """Post-case: rename the new perf file to include ``case_label`` (guarding against
     the runtime's second-precision filename collisions), then invoke the converter.
 
     The ``perf_swimlane_`` prefix is preserved so the converter's stem-based output
     naming still strips it and produces ``merged_swimlane_<ts>_<case_label>.json``.
+
+    When ``callable_spec`` is provided and contains ``"name"`` entries on incores,
+    a ``func_id_names_<label>.json`` sidecar is written and passed to the converter
+    so that swimlane visualizations display human-readable kernel names.
     """
     import logging  # noqa: PLC0415
 
@@ -531,12 +596,21 @@ def _convert_case_swimlane(
         logger.warning(f"[{case_label}] target {renamed.name} already exists; overwriting")
         renamed.unlink()
     perf_file.rename(renamed)
+
+    # Dump callable name mapping if the CALLABLE spec provides names
+    func_names_path = None
+    if callable_spec:
+        mapping = _extract_name_map(callable_spec)
+        func_names_path = _dump_name_map(mapping, renamed.parent / f"name_map_{safe_label}.json")
+
     device_log = None
     if before_device is not None:
         device_log = _wait_new_device_log(device_id, before_device)
         if device_log is None:
             logger.warning(f"[{case_label}] no new device log found; scheduler deep-dive may use stale log")
-    _run_swimlane_converter(input_path=renamed, device_id=device_id, device_log=device_log)
+    _run_swimlane_converter(
+        input_path=renamed, device_id=device_id, device_log=device_log, func_names_path=func_names_path
+    )
 
 
 def _compare_outputs(test_args, golden_args, output_names, rtol, atol):
@@ -919,7 +993,13 @@ class SceneTestCase:
                 )
             finally:
                 if enable_profiling:
-                    _convert_case_swimlane(f"{cls_name}_{case['name']}", primary_device_id, before_perf, before_device)
+                    _convert_case_swimlane(
+                        f"{cls_name}_{case['name']}",
+                        primary_device_id,
+                        before_perf,
+                        before_device,
+                        callable_spec=self.CALLABLE,
+                    )
             ran_any = True
 
         if not ran_any:
@@ -1037,6 +1117,7 @@ class SceneTestCase:
                                     args.device,
                                     before_perf,
                                     before_device,
+                                    callable_spec=cls.CALLABLE,
                                 )
             finally:
                 if group[0]._st_level == 2:

--- a/tools/perf_to_mermaid.py
+++ b/tools/perf_to_mermaid.py
@@ -115,6 +115,23 @@ def load_kernel_config(config_path):
     return func_id_to_name
 
 
+def load_func_names_json(json_path):
+    """Load name mapping from a SceneTest JSON file.
+
+    Each mapping carries ``callable_id_to_name`` and a ``level`` tag.
+    Used directly — no cross-level merging.
+
+    Returns:
+        tuple: (callable_id_to_name dict, orchestrator_name str or None)
+    """
+    path = Path(json_path)
+    if not path.exists():
+        raise ValueError(f"Func names JSON not found: {path}")
+    with open(path) as f:
+        data = json.load(f)
+    return data.get("callable_id_to_name", {}), data.get("orchestrator_name")
+
+
 def generate_mermaid_flowchart(tasks, func_id_to_name=None, style="detailed", direction="LR", verbose=False):
     """Generate Mermaid flowchart from task data.
 
@@ -235,6 +252,10 @@ View the Mermaid diagram:
         help="Path to kernel_config.py for func_id -> name mapping",
     )
     parser.add_argument(
+        "--func-names",
+        help="Path to func_id_names_*.json (SceneTest format) for func_id to function name mapping",
+    )
+    parser.add_argument(
         "--style",
         choices=["detailed", "compact"],
         default="detailed",
@@ -306,7 +327,16 @@ def main():
             print()
 
         func_names = {}
-        if args.kernel_config:
+        if args.func_names:
+            if args.verbose:
+                print(f"Loading func names from: {args.func_names}")
+            func_names, _ = load_func_names_json(args.func_names)
+            if args.verbose:
+                print(f"  Loaded {len(func_names)} func_id name mappings")
+                for func_id, name in sorted(func_names.items(), key=lambda x: int(x[0])):
+                    print(f"    func_id={func_id}: {name}")
+                print()
+        elif args.kernel_config:
             if args.verbose:
                 print(f"Loading kernel config: {args.kernel_config}")
             func_names = load_kernel_config(args.kernel_config)

--- a/tools/swimlane_converter.py
+++ b/tools/swimlane_converter.py
@@ -186,6 +186,24 @@ def load_kernel_config(config_path):
     return func_id_to_name
 
 
+def load_func_names_json(json_path):
+    """Load name mapping from a SceneTest JSON file.
+
+    Each level's mapping carries ``callable_id_to_name`` for its
+    next-level-down callables and a ``level`` tag.  The tool uses
+    ``callable_id_to_name`` directly — no cross-level merging.
+
+    Returns:
+        tuple: (callable_id_to_name dict, orchestrator_name str or None)
+    """
+    path = Path(json_path)
+    if not path.exists():
+        raise ValueError(f"Func names JSON not found: {path}")
+    with open(path) as f:
+        data = json.load(f)
+    return data.get("callable_id_to_name", {}), data.get("orchestrator_name")
+
+
 def parse_sched_cpu_from_device_log(log_path, task_count):
     """Parse device log for PTO2 scheduler stats and return scheduler CPU time per task (us).
 
@@ -392,6 +410,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
     orchestrator_data=None,
     orchestrator_phases=None,
     core_to_thread=None,
+    orchestrator_name=None,
 ):
     """Generate Chrome Trace Event Format JSON from task data.
 
@@ -744,8 +763,9 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
     # AICPU Orchestrator event (version 2)
     if orchestrator_phases or orchestrator_data:
         # Process metadata
+        orch_process_label = f"AICPU {orchestrator_name}" if orchestrator_name else "AICPU Orchestrator"
         events.append(
-            {"args": {"name": "AICPU Orchestrator"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 4}
+            {"args": {"name": orch_process_label}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 4}
         )
         events.append(
             {"args": {"sort_index": 1}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 4}
@@ -765,7 +785,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
         if not orch_threads and orchestrator_data:
             events.append(
                 {
-                    "args": {"name": "Orchestrator"},
+                    "args": {"name": orchestrator_name or "Orchestrator"},
                     "cat": "__metadata",
                     "name": "thread_name",
                     "ph": "M",
@@ -1121,6 +1141,10 @@ Examples:
         "--kernel-config",
         help="Path to kernel_config.py file for func_id to function name mapping",
     )
+    parser.add_argument(
+        "--func-names",
+        help="Path to func_id_names_*.json (SceneTest format) for func_id to function name mapping",
+    )
     parser.add_argument("--device-log", help="Device log file/path/glob override used for scheduler analysis")
     parser.add_argument("-d", "--device-id", help="Device id for auto-selection from device-<id>")
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
@@ -1210,6 +1234,39 @@ def _report_device_log(resolved_device_log, log_strategy):
         print(f"Selection: {log_strategy}")
 
 
+def _load_func_names(args):
+    """Load func_id→name mapping from --func-names JSON or -k kernel_config.py.
+
+    Returns:
+        tuple: (func_id_to_name dict, orchestrator_name str or None)
+    """
+    if args.func_names:
+        if args.verbose:
+            print(f"Loading func names from: {args.func_names}")
+        func_names, orchestrator_name = load_func_names_json(args.func_names)
+        if args.verbose:
+            print(f"  Loaded {len(func_names)} function name mappings:")
+            for func_id, name in sorted(func_names.items(), key=lambda x: int(x[0])):
+                print(f"    func_id={func_id}: {name}")
+            if orchestrator_name:
+                print(f"  Orchestrator: {orchestrator_name}")
+            print()
+        return func_names, orchestrator_name
+
+    if args.kernel_config:
+        if args.verbose:
+            print(f"Loading kernel config from: {args.kernel_config}")
+        func_names = load_kernel_config(args.kernel_config)
+        if args.verbose:
+            print(f"  Loaded {len(func_names)} function name mappings from kernel_config.py:")
+            for func_id, name in sorted(func_names.items(), key=lambda x: int(x[0])):
+                print(f"    func_id={func_id}: {name}")
+            print()
+        return func_names, None
+
+    return {}, None
+
+
 def main():
     args = _build_parser().parse_args()
 
@@ -1223,16 +1280,7 @@ def main():
         data = read_perf_data(input_path)
         _print_verbose_data_info(data, args.verbose)
 
-        func_names = {}
-        if args.kernel_config:
-            if args.verbose:
-                print(f"Loading kernel config from: {args.kernel_config}")
-            func_names = load_kernel_config(args.kernel_config)
-            if args.verbose:
-                print(f"  Loaded {len(func_names)} function name mappings from kernel_config.py:")
-                for func_id, name in sorted(func_names.items(), key=lambda x: int(x[0])):
-                    print(f"    func_id={func_id}: {name}")
-                print()
+        func_names, orchestrator_name = _load_func_names(args)
 
         output_path = _resolve_output_path(args, input_path)
 
@@ -1247,6 +1295,7 @@ def main():
             str(output_path),
             func_names,
             args.verbose,
+            orchestrator_name=orchestrator_name,
             scheduler_phases=data.get("aicpu_scheduler_phases"),
             orchestrator_data=data.get("aicpu_orchestrator"),
             orchestrator_phases=data.get("aicpu_orchestrator_phases"),


### PR DESCRIPTION
## Summary

SceneTest incores lacked human-readable names in profiling swimlanes, showing only numeric func_ids (e.g., `func_0_a(t0)` instead of `QK(t0)`).

- Add optional `"name"` field on CALLABLE incore and orchestration entries
- Add `_extract_func_id_names` / `_dump_func_id_names` helpers in `scene_test.py` that dump a `func_id_names_<case>.json` sidecar during profiling runs
- Add `--func-names` flag on `swimlane_converter.py` and `perf_to_mermaid.py` to consume the JSON mapping (existing `-k kernel_config.py` kept as-is)
- Thread `orchestrator_name` into Perfetto trace process labels

### Usage

Add optional `"name"` to CALLABLE incores/orchestration:

```python
CALLABLE = {
    "orchestration": {
        "source": "orch.cpp",
        "function_name": "build_graph",
        "name": "PagedAttn",  # optional
        ...
    },
    "incores": [
        {"func_id": 0, "name": "QK", "source": "qk.cpp", "core_type": "aic"},
        {"func_id": 1, "name": "SF", "source": "sf.cpp", "core_type": "aiv"},
    ],
}
```

When `--enable-profiling` is used, `func_id_names_<ClassName_casename>.json` is auto-dumped to `outputs/` and passed to the swimlane converter. Tests without `"name"` fields continue to work unchanged.

## Testing

- [x] Syntax check passes on all three files
- [x] Unit tests for `_extract_func_id_names` (L2/L3 with/without names) and `_dump_func_id_names` (empty/non-empty)
- [x] `load_func_names_json` tested in both swimlane_converter and perf_to_mermaid
- [x] `--func-names` appears in CLI help for both tools
- [x] All pre-commit hooks pass (ruff check/format, pyright, headers)
- [ ] Hardware profiling end-to-end (requires device)