### PR TITLE
Add: Add the synchronization statement for the a5 use case

### DIFF
--- a/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -87,6 +87,9 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t *pij_raw, __gm__ uint8_t *v
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(oiGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -88,6 +88,9 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t *qi_raw, __gm__ uint8_t *kj
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(sijGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -210,6 +210,9 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -89,6 +89,9 @@ static __aicore__ void softmax_prepare_impl(
     TSTORE(mijGlobal, maxTile);
     TSTORE(lijGlobal, sumTile);
     TSTORE(pijGlobal, pijF16Tile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/mix/kernel_bgemm.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/mix/kernel_bgemm.cpp
@@ -150,6 +150,9 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
         // Push result directly to vector core's UB (replaces TSTORE to GM)
         TPUSH<PipeT, AccTileT, TileSplitAxis::TILE_UP_DOWN>(mPipe, accTile);
+
+        set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+        wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
     }
 
     // =========================================================================
@@ -196,5 +199,8 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
         // Store result back to GM
         TSTORE(outGlobal, outTile);
+
+        set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+        wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
     }
 }

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
@@ -106,6 +106,9 @@ static __aicore__ void matmul_impl(__gm__ float *input_a, __gm__ float *input_b,
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(dstGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
@@ -70,6 +70,9 @@ static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
@@ -64,6 +64,9 @@ static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
@@ -71,6 +71,9 @@ static __aicore__ void mul_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
@@ -64,6 +64,9 @@ static __aicore__ void mul_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -88,6 +88,9 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __g
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(oiGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -89,6 +89,9 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(sijGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -213,6 +213,9 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -109,6 +109,9 @@ static __aicore__ void softmax_prepare_impl(
     TSTORE(mijGlobal, maxTile);
     TSTORE(lijGlobal, sumTile);
     TSTORE(pijGlobal, pijF16Tile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -88,6 +88,9 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t *pij_raw, __gm__ uint8_t *v
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(oiGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -89,6 +89,9 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t *qi_raw, __gm__ uint8_t *kj
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(sijGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -213,6 +213,9 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -110,6 +110,9 @@ static __aicore__ void softmax_prepare_impl(
     TSTORE(mijGlobal, maxTile);
     TSTORE(lijGlobal, sumTile);
     TSTORE(pijGlobal, pijBf16Tile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -92,6 +92,9 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __g
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(oiGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -93,6 +93,9 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(sijGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -220,6 +220,9 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -120,6 +120,9 @@ static __aicore__ void softmax_prepare_impl(
     TSTORE(mijGlobal, maxTile);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
     TSTORE(lijGlobal, sumTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -138,6 +138,9 @@ static __aicore__ void pv_matmul_n_impl(
     set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     TSTORE(oiGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -103,6 +103,9 @@ static __aicore__ void qk_matmul_n_impl(
             pipe_barrier(PIPE_ALL);
         }
     }
+
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -220,6 +220,9 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -221,6 +221,9 @@ static __aicore__ void softmax_prepare_n_impl(
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(lijGlobalDN, sumDN);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {


### PR DESCRIPTION
- Add synchronization statements in the relevant kernels of host_build_graph and tensormap_and_ringbuffer
- Make sure that the synchronization statements will be executed before the process ends