### PR TITLE
Refactor: Optimize the AICPU scheduler hot loop

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -397,6 +397,43 @@ struct AicpuExecutor {
 
     CoreTracker core_trackers_[MAX_AICPU_THREADS];
 
+#if PTO2_PROFILING
+    // Per-thread scheduler profiling counters.
+    // Stored as member to avoid passing 20+ counters through function signatures.
+    // Each thread accesses only its own slot via thread_idx — no cross-thread access.
+    struct alignas(64) SchedProfilingCounters {
+        bool profiling_enabled{false};
+        uint64_t sched_start_ts{0};
+        uint64_t sched_scan_cycle{0};
+        uint64_t sched_complete_cycle{0};
+        uint64_t sched_dispatch_cycle{0};
+        uint64_t sched_wiring_cycle{0};
+        uint64_t sched_idle_cycle{0};
+        uint64_t sched_loop_count{0};
+        uint32_t phase_complete_count{0};
+        uint32_t phase_dispatch_count{0};
+#if PTO2_SCHED_PROFILING
+        uint32_t phase_wiring_count{0};
+        uint64_t complete_probe_count{0};
+        uint64_t complete_hit_count{0};
+        uint64_t notify_edges_total{0};
+        int32_t notify_max_degree{0};
+        uint64_t notify_tasks_enqueued{0};
+        uint64_t fanin_edges_total{0};
+        int32_t fanin_max_degree{0};
+        uint64_t pop_hit{0};
+        uint64_t pop_miss{0};
+        uint64_t local_dispatch_count{0};
+        uint64_t local_overflow_count{0};
+        uint64_t sched_complete_perf_cycle{0};
+        uint64_t sched_dispatch_pop_cycle{0};
+        uint64_t sched_dispatch_setup_cycle{0};
+#endif
+        void reset() { *this = SchedProfilingCounters{}; }
+    };
+    SchedProfilingCounters sched_perf_[MAX_AICPU_THREADS];
+#endif
+
     // ===== sync_start drain coordination =====
 
     // When sync_start_pending != 0, all scheduler threads skip Phase 2 dispatch
@@ -622,40 +659,29 @@ struct AicpuExecutor {
     }
 
 #if PTO2_PROFILING
-    __attribute__((noinline, cold)) void log_profiling_summary(
-        int32_t thread_idx, int32_t cur_thread_completed, uint64_t sched_start_ts, uint64_t sched_scan_cycle,
-        uint64_t sched_complete_cycle, uint64_t sched_dispatch_cycle, uint64_t sched_wiring_cycle,
-        uint64_t sched_idle_cycle, uint64_t sched_loop_count
-#if PTO2_SCHED_PROFILING
-        ,
-        uint64_t complete_probe_count, uint64_t complete_hit_count, uint64_t notify_edges_total,
-        int32_t notify_max_degree, uint64_t notify_tasks_enqueued, uint64_t fanin_edges_total, int32_t fanin_max_degree,
-        uint64_t pop_hit, uint64_t pop_miss, uint64_t local_dispatch_count, uint64_t local_overflow_count,
-        uint64_t sched_complete_perf_cycle, uint64_t sched_dispatch_pop_cycle, uint64_t sched_dispatch_setup_cycle,
-        uint32_t phase_wiring_count
-#endif
-    ) {
+    __attribute__((noinline, cold)) void log_profiling_summary(int32_t thread_idx, int32_t cur_thread_completed) {
+        auto &perf = sched_perf_[thread_idx];
         uint64_t sched_end_ts = get_sys_cnt_aicpu();
         DEV_ALWAYS(
             "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
-            static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_end_ts),
-            cycles_to_us(sched_end_ts - sched_start_ts)
+            static_cast<uint64_t>(perf.sched_start_ts), static_cast<uint64_t>(sched_end_ts),
+            cycles_to_us(sched_end_ts - perf.sched_start_ts)
         );
 
-        uint64_t sched_total =
-            sched_wiring_cycle + sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
+        uint64_t sched_total = perf.sched_wiring_cycle + perf.sched_complete_cycle + perf.sched_scan_cycle +
+                               perf.sched_dispatch_cycle + perf.sched_idle_cycle;
         if (sched_total == 0) sched_total = 1;
 
 #if PTO2_SCHED_PROFILING
         {
             PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
             uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
-            uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle) ?
-                                         (sched_complete_cycle - otc_total - sched_complete_perf_cycle) :
+            uint64_t complete_poll = (perf.sched_complete_cycle > otc_total + perf.sched_complete_perf_cycle) ?
+                                         (perf.sched_complete_cycle - otc_total - perf.sched_complete_perf_cycle) :
                                          0;
             uint64_t dispatch_poll =
-                (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle) ?
-                    (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) :
+                (perf.sched_dispatch_cycle > perf.sched_dispatch_pop_cycle + perf.sched_dispatch_setup_cycle) ?
+                    (perf.sched_dispatch_cycle - perf.sched_dispatch_pop_cycle - perf.sched_dispatch_setup_cycle) :
                     0;
 
             DEV_ALWAYS(
@@ -664,27 +690,29 @@ struct AicpuExecutor {
             );
 
             double notify_avg =
-                cur_thread_completed > 0 ? static_cast<double>(notify_edges_total) / cur_thread_completed : 0.0;
+                cur_thread_completed > 0 ? static_cast<double>(perf.notify_edges_total) / cur_thread_completed : 0.0;
             double fanin_avg =
-                cur_thread_completed > 0 ? static_cast<double>(fanin_edges_total) / cur_thread_completed : 0.0;
+                cur_thread_completed > 0 ? static_cast<double>(perf.fanin_edges_total) / cur_thread_completed : 0.0;
             DEV_ALWAYS(
                 "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
                 ", max_degree=%d, avg=%.1f]  [fanin: "
                 "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
-                thread_idx, cycles_to_us(sched_complete_cycle), sched_complete_cycle * 100.0 / sched_total,
-                static_cast<uint64_t>(notify_edges_total), notify_max_degree, notify_avg,
-                static_cast<uint64_t>(fanin_edges_total), fanin_max_degree, fanin_avg
+                thread_idx, cycles_to_us(perf.sched_complete_cycle), perf.sched_complete_cycle * 100.0 / sched_total,
+                static_cast<uint64_t>(perf.notify_edges_total), perf.notify_max_degree, notify_avg,
+                static_cast<uint64_t>(perf.fanin_edges_total), perf.fanin_max_degree, fanin_avg
             );
 
-            uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
-            uint64_t complete_miss_count =
-                (complete_probe_count > complete_hit_count) ? (complete_probe_count - complete_hit_count) : 0;
+            uint64_t c_parent = perf.sched_complete_cycle > 0 ? perf.sched_complete_cycle : 1;
+            uint64_t complete_miss_count = (perf.complete_probe_count > perf.complete_hit_count) ?
+                                               (perf.complete_probe_count - perf.complete_hit_count) :
+                                               0;
             double complete_hit_rate =
-                complete_probe_count > 0 ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
+                perf.complete_probe_count > 0 ? perf.complete_hit_count * 100.0 / perf.complete_probe_count : 0.0;
             DEV_ALWAYS(
                 "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
                 thread_idx, cycles_to_us(complete_poll), complete_poll * 100.0 / c_parent,
-                static_cast<uint64_t>(complete_hit_count), static_cast<uint64_t>(complete_miss_count), complete_hit_rate
+                static_cast<uint64_t>(perf.complete_hit_count), static_cast<uint64_t>(complete_miss_count),
+                complete_hit_rate
             );
             DEV_ALWAYS(
                 "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
@@ -709,77 +737,80 @@ struct AicpuExecutor {
                 static_cast<uint64_t>(sp.self_atomic_count)
             );
             DEV_ALWAYS(
-                "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_complete_perf_cycle),
-                sched_complete_perf_cycle * 100.0 / c_parent
+                "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx,
+                cycles_to_us(perf.sched_complete_perf_cycle), perf.sched_complete_perf_cycle * 100.0 / c_parent
             );
 
-            uint64_t pop_total = pop_hit + pop_miss;
-            double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
+            uint64_t pop_total = perf.pop_hit + perf.pop_miss;
+            double pop_hit_rate = pop_total > 0 ? perf.pop_hit * 100.0 / pop_total : 0.0;
             DEV_ALWAYS(
                 "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64
                 ", hit_rate=%.1f%%]",
-                thread_idx, cycles_to_us(sched_dispatch_cycle), sched_dispatch_cycle * 100.0 / sched_total,
-                static_cast<uint64_t>(pop_hit), static_cast<uint64_t>(pop_miss), pop_hit_rate
+                thread_idx, cycles_to_us(perf.sched_dispatch_cycle), perf.sched_dispatch_cycle * 100.0 / sched_total,
+                static_cast<uint64_t>(perf.pop_hit), static_cast<uint64_t>(perf.pop_miss), pop_hit_rate
             );
-            uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
-            uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
-            double local_hit_rate = total_dispatched > 0 ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
+            uint64_t global_dispatch_count = perf.pop_hit - perf.local_dispatch_count;
+            uint64_t total_dispatched = perf.local_dispatch_count + global_dispatch_count;
+            double local_hit_rate = total_dispatched > 0 ? perf.local_dispatch_count * 100.0 / total_dispatched : 0.0;
             DEV_ALWAYS(
                 "Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
                 ", local_rate=%.1f%%",
-                thread_idx, static_cast<uint64_t>(local_dispatch_count), static_cast<uint64_t>(global_dispatch_count),
-                static_cast<uint64_t>(local_overflow_count), local_hit_rate
+                thread_idx, static_cast<uint64_t>(perf.local_dispatch_count),
+                static_cast<uint64_t>(global_dispatch_count), static_cast<uint64_t>(perf.local_overflow_count),
+                local_hit_rate
             );
 
-            uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
+            uint64_t d_parent = perf.sched_dispatch_cycle > 0 ? perf.sched_dispatch_cycle : 1;
             DEV_ALWAYS(
                 "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
                 dispatch_poll * 100.0 / d_parent
             );
             DEV_ALWAYS(
                 "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-                thread_idx, cycles_to_us(sched_dispatch_pop_cycle), sched_dispatch_pop_cycle * 100.0 / d_parent,
-                cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+                thread_idx, cycles_to_us(perf.sched_dispatch_pop_cycle),
+                perf.sched_dispatch_pop_cycle * 100.0 / d_parent,
+                cycles_to_us(perf.sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
                 static_cast<uint64_t>(sp.pop_atomic_count)
             );
             DEV_ALWAYS(
-                "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
-                sched_dispatch_setup_cycle * 100.0 / d_parent
+                "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx,
+                cycles_to_us(perf.sched_dispatch_setup_cycle), perf.sched_dispatch_setup_cycle * 100.0 / d_parent
             );
 
             DEV_ALWAYS(
-                "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_scan_cycle),
-                sched_scan_cycle * 100.0 / sched_total
+                "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(perf.sched_scan_cycle),
+                perf.sched_scan_cycle * 100.0 / sched_total
             );
 
 #if PTO2_SCHED_PROFILING
             DEV_ALWAYS(
-                "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx, cycles_to_us(sched_wiring_cycle),
-                sched_wiring_cycle * 100.0 / sched_total, phase_wiring_count
+                "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx,
+                cycles_to_us(perf.sched_wiring_cycle), perf.sched_wiring_cycle * 100.0 / sched_total,
+                perf.phase_wiring_count
             );
 #else
             DEV_ALWAYS(
-                "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_wiring_cycle),
-                sched_wiring_cycle * 100.0 / sched_total
+                "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(perf.sched_wiring_cycle),
+                perf.sched_wiring_cycle * 100.0 / sched_total
             );
 #endif
 
             DEV_ALWAYS(
-                "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_idle_cycle),
-                sched_idle_cycle * 100.0 / sched_total
+                "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(perf.sched_idle_cycle),
+                perf.sched_idle_cycle * 100.0 / sched_total
             );
 
             if (cur_thread_completed > 0) {
                 DEV_ALWAYS(
                     "Thread %d:   avg/complete   : %.3fus", thread_idx,
-                    cycles_to_us(sched_complete_cycle) / cur_thread_completed
+                    cycles_to_us(perf.sched_complete_cycle) / cur_thread_completed
                 );
             }
         }
 #endif
         DEV_ALWAYS(
             "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
-            cycles_to_us(sched_total), static_cast<uint64_t>(sched_loop_count), cur_thread_completed
+            cycles_to_us(sched_total), static_cast<uint64_t>(perf.sched_loop_count), cur_thread_completed
         );
     }
 #endif
@@ -836,17 +867,11 @@ struct AicpuExecutor {
         PTO2LocalReadyBuffer *local_bufs, CoreType ct
 #if PTO2_PROFILING
         ,
-        bool profiling_enabled, uint32_t &phase_complete_count, uint64_t dispatch_ts
-#endif
-#if PTO2_SCHED_PROFILING
-        ,
-        uint64_t &notify_edges_total, int32_t &notify_max_degree, uint64_t &notify_tasks_enqueued,
-        uint64_t &fanin_edges_total, int32_t &fanin_max_degree, uint64_t &sched_complete_perf_cycle
+        uint64_t dispatch_ts
 #endif
     ) {
-#if !PTO2_PROFILING
-        (void)hank;
-        (void)ct;
+#if PTO2_PROFILING
+        auto &perf = sched_perf_[thread_idx];
 #endif
         bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state);
         if (mixed_complete) {
@@ -865,14 +890,14 @@ struct AicpuExecutor {
 #endif
 #if PTO2_SCHED_PROFILING
             PTO2CompletionStats cstats = rt->scheduler.on_mixed_task_complete(slot_state, thread_idx, local_bufs);
-            notify_edges_total += cstats.fanout_edges;
-            if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
-            notify_tasks_enqueued += cstats.tasks_enqueued;
-            phase_complete_count++;
+            perf.notify_edges_total += cstats.fanout_edges;
+            if (cstats.fanout_edges > perf.notify_max_degree) perf.notify_max_degree = cstats.fanout_edges;
+            perf.notify_tasks_enqueued += cstats.tasks_enqueued;
+            perf.phase_complete_count++;
 #else
             rt->scheduler.on_mixed_task_complete(slot_state, local_bufs);
 #if PTO2_PROFILING
-            phase_complete_count++;
+            perf.phase_complete_count++;
 #endif
 #endif
             if (deferred_release_count < 256) {
@@ -884,13 +909,10 @@ struct AicpuExecutor {
                     int32_t fe = rt->scheduler.on_task_release(
                         *deferred_release_slot_states[--deferred_release_count], thread_idx
                     );
+                    perf.fanin_edges_total += fe;
+                    if (fe > perf.fanin_max_degree) perf.fanin_max_degree = fe;
 #else
-                    int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
-#endif
-                    (void)fe;
-#if PTO2_SCHED_PROFILING
-                    fanin_edges_total += fe;
-                    if (fe > fanin_max_degree) fanin_max_degree = fe;
+                    rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
                 }
                 deferred_release_slot_states[deferred_release_count++] = &slot_state;
@@ -899,13 +921,13 @@ struct AicpuExecutor {
         }
 
 #if PTO2_PROFILING
-        if (profiling_enabled) {
+        if (perf.profiling_enabled) {
 #if PTO2_SCHED_PROFILING
             uint64_t t_perf_start = get_sys_cnt_aicpu();
 #endif
             Handshake *h = &hank[core_id];
             uint64_t finish_ts = get_sys_cnt_aicpu();
-            PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
+            PerfBuffer *pbuf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
 
             uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
             int32_t fanout_n = 0;
@@ -917,7 +939,7 @@ struct AicpuExecutor {
 
             int32_t perf_slot_idx = static_cast<int32_t>(subslot);
             if (perf_aicpu_complete_record(
-                    perf_buf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
+                    pbuf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
                     slot_state.task->kernel_id[perf_slot_idx], ct, dispatch_ts, finish_ts, fanout_arr, fanout_n
                 ) != 0) {
                 DEV_ERROR(
@@ -926,7 +948,7 @@ struct AicpuExecutor {
                 );
             }
 #if PTO2_SCHED_PROFILING
-            sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
+            perf.sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
 #endif
         }
 #endif
@@ -955,17 +977,10 @@ struct AicpuExecutor {
         int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
         bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
         PTO2LocalReadyBuffer *local_bufs
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled, uint32_t &phase_complete_count
-#endif
-#if PTO2_SCHED_PROFILING
-        ,
-        uint64_t &complete_probe_count, uint64_t &complete_hit_count, uint64_t &notify_edges_total,
-        int32_t &notify_max_degree, uint64_t &notify_tasks_enqueued, uint64_t &fanin_edges_total,
-        int32_t &fanin_max_degree, uint64_t &sched_complete_perf_cycle
-#endif
     ) {
+#if PTO2_SCHED_PROFILING
+        auto &perf = sched_perf_[thread_idx];
+#endif
         CoreTracker &tracker = core_trackers_[thread_idx];
         auto running_core_states = tracker.get_running_cores<CT>();
         while (running_core_states.has_value()) {
@@ -979,8 +994,8 @@ struct AicpuExecutor {
             int32_t reg_state = EXTRACT_TASK_STATE(reg_val);
 
 #if PTO2_SCHED_PROFILING
-            if (profiling_enabled) {
-                complete_probe_count++;
+            if (perf.profiling_enabled) {
+                perf.complete_probe_count++;
             }
 #endif
 
@@ -989,8 +1004,8 @@ struct AicpuExecutor {
             if (!t.matched) continue;
 
 #if PTO2_SCHED_PROFILING
-            if (profiling_enabled && (t.running_done || t.pending_done)) {
-                complete_hit_count++;
+            if (perf.profiling_enabled && (t.running_done || t.pending_done)) {
+                perf.complete_hit_count++;
             }
 #endif
 
@@ -1003,12 +1018,7 @@ struct AicpuExecutor {
                     completed_this_turn, deferred_release_slot_states, deferred_release_count, local_bufs, CT
 #if PTO2_PROFILING
                     ,
-                    profiling_enabled, phase_complete_count, core.pending_dispatch_timestamp
-#endif
-#if PTO2_SCHED_PROFILING
-                    ,
-                    notify_edges_total, notify_max_degree, notify_tasks_enqueued, fanin_edges_total, fanin_max_degree,
-                    sched_complete_perf_cycle
+                    core.pending_dispatch_timestamp
 #endif
                 );
                 cur_thread_completed++;
@@ -1019,12 +1029,7 @@ struct AicpuExecutor {
                     completed_this_turn, deferred_release_slot_states, deferred_release_count, local_bufs, CT
 #if PTO2_PROFILING
                     ,
-                    profiling_enabled, phase_complete_count, core.running_dispatch_timestamp
-#endif
-#if PTO2_SCHED_PROFILING
-                    ,
-                    notify_edges_total, notify_max_degree, notify_tasks_enqueued, fanin_edges_total, fanin_max_degree,
-                    sched_complete_perf_cycle
+                    core.running_dispatch_timestamp
 #endif
                 );
                 cur_thread_completed++;
@@ -1102,26 +1107,23 @@ struct AicpuExecutor {
     int pop_ready_tasks_batch(
         PTO2ResourceShape shape, int32_t thread_idx, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out,
         int max_count
-#if PTO2_SCHED_PROFILING
-        ,
-        uint64_t &pop_hit, uint64_t &pop_miss, uint64_t &local_dispatch_count, uint64_t &sched_dispatch_pop_cycle
-#endif
     ) {
-        (void)thread_idx;
 #if PTO2_SCHED_PROFILING
+        auto &perf = sched_perf_[thread_idx];
         extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
         uint64_t t_pop_start = get_sys_cnt_aicpu();
         int count = rt->scheduler.get_ready_tasks_batch(
             shape, local_buf, out, max_count, g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx],
-            local_dispatch_count
+            perf.local_dispatch_count
         );
-        sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
+        perf.sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
         if (count > 0) {
-            pop_hit += count;
+            perf.pop_hit += count;
         } else {
-            pop_miss++;
+            perf.pop_miss++;
         }
 #else
+        (void)thread_idx;
         int count = rt->scheduler.get_ready_tasks_batch(shape, local_buf, out, max_count);
 #endif
         return count;
@@ -1164,14 +1166,12 @@ struct AicpuExecutor {
     void dispatch_subtask_to_core(
         Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,
         PTO2SubtaskSlot subslot, bool to_pending
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled
-#endif
     ) {
         CoreTracker &tracker = core_trackers_[thread_idx];
         auto core_id = tracker.get_core_id_by_offset(core_offset);
-#if !PTO2_PROFILING
+#if PTO2_PROFILING
+        auto &perf = sched_perf_[thread_idx];
+#else
         (void)runtime;
 #endif
         CoreExecState &core_exec_state = core_exec_states_[core_id];
@@ -1206,7 +1206,7 @@ struct AicpuExecutor {
             core_exec_state.pending_slot_state = &slot_state;
             core_exec_state.pending_reg_task_id = static_cast<int32_t>(reg_task_id);
 #if PTO2_PROFILING
-            if (profiling_enabled) {
+            if (perf.profiling_enabled) {
                 core_exec_state.pending_dispatch_timestamp = get_sys_cnt_aicpu();
             }
 #endif
@@ -1215,7 +1215,7 @@ struct AicpuExecutor {
             core_exec_state.running_slot_state = &slot_state;
             core_exec_state.running_reg_task_id = static_cast<int32_t>(reg_task_id);
 #if PTO2_PROFILING
-            if (profiling_enabled) {
+            if (perf.profiling_enabled) {
                 core_exec_state.running_dispatch_timestamp = get_sys_cnt_aicpu();
             }
 #endif
@@ -1223,7 +1223,7 @@ struct AicpuExecutor {
             tracker.change_core_state(core_offset);
         }
 #if PTO2_PROFILING
-        if (profiling_enabled) {
+        if (perf.profiling_enabled) {
             if (core_exec_state.dispatch_count >= PLATFORM_PROF_BUFFER_SIZE) {
                 perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
                 core_exec_state.dispatch_count = 0;
@@ -1243,10 +1243,6 @@ struct AicpuExecutor {
     // Reads slot_state.next_block_idx as block_idx; caller increments it afterwards.
     void dispatch_mix_block_to_cluster(
         Runtime *runtime, int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state, bool to_pending
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled
-#endif
     ) {
         CoreTracker &tracker = core_trackers_[thread_idx];
         uint8_t core_mask = pto2_core_mask(slot_state.active_mask);
@@ -1258,10 +1254,6 @@ struct AicpuExecutor {
             dispatch_subtask_to_core(
                 runtime, thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC,
                 aic_to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
             );
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV0) {
@@ -1269,10 +1261,6 @@ struct AicpuExecutor {
             dispatch_subtask_to_core(
                 runtime, thread_idx, tracker.get_aiv0_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV0,
                 aiv0_to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
             );
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV1) {
@@ -1280,10 +1268,6 @@ struct AicpuExecutor {
             dispatch_subtask_to_core(
                 runtime, thread_idx, tracker.get_aiv1_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV1,
                 aiv1_to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
             );
         }
     }
@@ -1321,10 +1305,6 @@ struct AicpuExecutor {
     void dispatch_block(
         Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,
         PTO2ResourceShape shape, bool to_pending
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled, uint32_t &phase_dispatch_count
-#endif
     ) {
 #if PTO2_PROFILING
         if (get_enable_dump_tensor()) {
@@ -1340,32 +1320,14 @@ struct AicpuExecutor {
         }
 #endif
         if (shape == PTO2ResourceShape::MIX) {
-            dispatch_mix_block_to_cluster(
-                runtime, thread_idx, core_offset, slot_state, to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
-            );
+            dispatch_mix_block_to_cluster(runtime, thread_idx, core_offset, slot_state, to_pending);
         } else if (shape == PTO2ResourceShape::AIC) {
-            dispatch_subtask_to_core(
-                runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIC, to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
-            );
+            dispatch_subtask_to_core(runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIC, to_pending);
         } else {  // AIV — core_offset already resolved by caller in both phases
-            dispatch_subtask_to_core(
-                runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIV0, to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
-            );
+            dispatch_subtask_to_core(runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIV0, to_pending);
         }
 #if PTO2_PROFILING
-        phase_dispatch_count += __builtin_popcount(pto2_core_mask(slot_state.active_mask));
+        sched_perf_[thread_idx].phase_dispatch_count += __builtin_popcount(pto2_core_mask(slot_state.active_mask));
 #endif
     }
 
@@ -1376,16 +1338,10 @@ struct AicpuExecutor {
         Runtime *runtime, int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase,
         PTO2LocalReadyBuffer &local_buf, CoreTracker &tracker, bool &entered_drain, bool &made_progress,
         bool &try_pushed
-#if PTO2_SCHED_PROFILING
-        ,
-        uint64_t &pop_hit, uint64_t &pop_miss, uint64_t &local_dispatch_count, uint64_t &sched_dispatch_pop_cycle,
-        uint64_t &sched_dispatch_setup_cycle
-#endif
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled, uint32_t &phase_dispatch_count
-#endif
     ) {
+#if PTO2_SCHED_PROFILING
+        auto &perf = sched_perf_[thread_idx];
+#endif
         if (entered_drain) return;
 
         bool is_pending = (phase == CoreTracker::DispatchPhase::PENDING);
@@ -1395,13 +1351,7 @@ struct AicpuExecutor {
         while (cores.has_value() && !entered_drain) {
             int want = cores.count();
             PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
-            int got = pop_ready_tasks_batch(
-                shape, thread_idx, local_buf, batch, want
-#if PTO2_SCHED_PROFILING
-                ,
-                pop_hit, pop_miss, local_dispatch_count, sched_dispatch_pop_cycle
-#endif
-            );
+            int got = pop_ready_tasks_batch(shape, thread_idx, local_buf, batch, want);
             if (got == 0) break;
 
             bool dispatched_any = false;
@@ -1443,13 +1393,7 @@ struct AicpuExecutor {
                 // Dispatch as many blocks as possible for this task.
                 do {
                     auto core_offset = cores.pop_first();
-                    dispatch_block(
-                        runtime, thread_idx, core_offset, *slot_state, shape, is_pending
-#if PTO2_PROFILING
-                        ,
-                        profiling_enabled, phase_dispatch_count
-#endif
-                    );
+                    dispatch_block(runtime, thread_idx, core_offset, *slot_state, shape, is_pending);
                     slot_state->next_block_idx++;
                     DEV_DEBUG(
                         "Thread %d: Dispatched %s %s task %" PRId64 " block %d/%d to core_offset %d", thread_idx,
@@ -1464,7 +1408,7 @@ struct AicpuExecutor {
                 }
                 made_progress = true;
 #if PTO2_SCHED_PROFILING
-                sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
+                perf.sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
             }
 
@@ -1491,13 +1435,7 @@ struct AicpuExecutor {
     // Drain worker: dispatch all blocks in one pass across all threads' trackers.
     // Called only when global resources >= block_num, so one pass always suffices.
     // All other threads are spinning — the drain worker has exclusive tracker access.
-    void drain_worker_dispatch(
-        Runtime *runtime, int32_t block_num
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled, uint32_t &phase_dispatch_count
-#endif
-    ) {
+    void drain_worker_dispatch(Runtime *runtime, int32_t block_num) {
         PTO2TaskSlotState *slot_state = drain_state_.pending_task;
         if (!slot_state) {
             drain_state_.sync_start_pending.store(0, std::memory_order_release);
@@ -1508,13 +1446,7 @@ struct AicpuExecutor {
         for (int32_t t = 0; t < active_sched_threads_ && slot_state->next_block_idx < block_num; t++) {
             auto valid = core_trackers_[t].get_idle_core_offset_states(shape);
             while (valid.has_value() && slot_state->next_block_idx < block_num) {
-                dispatch_block(
-                    runtime, t, valid.pop_first(), *slot_state, shape, false
-#if PTO2_PROFILING
-                    ,
-                    profiling_enabled, phase_dispatch_count
-#endif
-                );
+                dispatch_block(runtime, t, valid.pop_first(), *slot_state, shape, false);
                 slot_state->next_block_idx++;
                 if (slot_state->next_block_idx < block_num)
                     valid = core_trackers_[t].get_idle_core_offset_states(shape);
@@ -1543,13 +1475,7 @@ struct AicpuExecutor {
     //   3. Dispatch: elected thread dispatches all blocks (one pass, resources guaranteed).
     //      Non-elected threads spin-wait until sync_start_pending == 0.
     //      During dispatch the elected thread has exclusive tracker access.
-    void handle_drain_mode(
-        Runtime *runtime, int32_t thread_idx
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled, uint32_t &phase_dispatch_count
-#endif
-    ) {
+    void handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
         // Spin until drain is fully initialized (sentinel -1 → block_num > 0).
         int32_t block_num;
         do {
@@ -1600,13 +1526,7 @@ struct AicpuExecutor {
         }
 
         // Dispatch — all other threads are spinning, elected thread has exclusive tracker access.
-        drain_worker_dispatch(
-            runtime, block_num
-#if PTO2_PROFILING
-            ,
-            profiling_enabled, phase_dispatch_count
-#endif
-        );
+        drain_worker_dispatch(runtime, block_num);
     }
 };
 
@@ -2023,36 +1943,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     int32_t idle_iterations = 0;
     int32_t last_progress_count = 0;
 #if PTO2_PROFILING
-    bool profiling_enabled = runtime->enable_profiling;
-#endif
-
-    // Scheduler profiling counters
-#if PTO2_PROFILING
-    uint64_t sched_scan_cycle = 0;
-    uint64_t sched_complete_cycle = 0;
-    uint64_t sched_dispatch_cycle = 0;
-    uint64_t sched_wiring_cycle = 0;
-    uint64_t sched_idle_cycle = 0;
-    uint64_t sched_loop_count = 0;
-    uint32_t phase_complete_count = 0;
-    uint32_t phase_dispatch_count = 0;
-#if PTO2_SCHED_PROFILING
-    uint32_t phase_wiring_count = 0;
-    uint64_t complete_probe_count = 0;
-    uint64_t complete_hit_count = 0;
-    uint64_t notify_edges_total = 0;
-    int32_t notify_max_degree = 0;
-    uint64_t notify_tasks_enqueued = 0;
-    uint64_t fanin_edges_total = 0;
-    int32_t fanin_max_degree = 0;
-    uint64_t pop_hit = 0;
-    uint64_t pop_miss = 0;
-    uint64_t local_dispatch_count = 0;
-    uint64_t local_overflow_count = 0;
-    uint64_t sched_complete_perf_cycle = 0;
-    uint64_t sched_dispatch_pop_cycle = 0;
-    uint64_t sched_dispatch_setup_cycle = 0;
-#endif
+    auto &perf = sched_perf_[thread_idx];
+    perf.reset();
+    perf.profiling_enabled = runtime->enable_profiling;
 #endif
 
     // Local-first dispatch buffers (stack-allocated, one per CoreType per scheduling thread).
@@ -2069,14 +1962,14 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     bool cores_released = false;
 
 #if PTO2_PROFILING
-    uint64_t sched_start_ts = get_sys_cnt_aicpu();
+    perf.sched_start_ts = get_sys_cnt_aicpu();
 #endif
 
     while (true) {
         bool made_progress = false;
 #if PTO2_PROFILING
         CYCLE_COUNT_START();
-        sched_loop_count++;
+        perf.sched_loop_count++;
         uint64_t _t0_phase = _t0;
 #endif
         int32_t task_count = 0;
@@ -2092,7 +1985,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         }
 
 #if PTO2_PROFILING
-        CYCLE_COUNT_LAP(sched_idle_cycle);
+        CYCLE_COUNT_LAP(perf.sched_idle_cycle);
 #endif
 
         // Process completed and dispatch FIRST to minimize Sched (dispatch→finish) latency.
@@ -2109,15 +2002,6 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             check_running_cores_for_completion<CoreType::AIC>(
                 thread_idx, hank, completed_this_turn, cur_thread_completed, made_progress,
                 deferred_release_slot_states, deferred_release_count, local_bufs
-#if PTO2_PROFILING
-                ,
-                profiling_enabled, phase_complete_count
-#endif
-#if PTO2_SCHED_PROFILING
-                ,
-                complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
-#endif
             );
         }
 
@@ -2127,15 +2011,6 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             check_running_cores_for_completion<CoreType::AIV>(
                 thread_idx, hank, completed_this_turn, cur_thread_completed, made_progress,
                 deferred_release_slot_states, deferred_release_count, local_bufs
-#if PTO2_PROFILING
-                ,
-                profiling_enabled, phase_complete_count
-#endif
-#if PTO2_SCHED_PROFILING
-                ,
-                complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
-#endif
             );
         }
         if (completed_this_turn > 0) {
@@ -2158,15 +2033,16 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 
 #if PTO2_PROFILING
         if (!try_completed) {
-            CYCLE_COUNT_LAP(sched_idle_cycle);
+            CYCLE_COUNT_LAP(perf.sched_idle_cycle);
         } else {
-            CYCLE_COUNT_LAP(sched_complete_cycle);
-            if (profiling_enabled && phase_complete_count > 0) {
+            CYCLE_COUNT_LAP(perf.sched_complete_cycle);
+            if (perf.profiling_enabled && perf.phase_complete_count > 0) {
                 perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, sched_loop_count, phase_complete_count
+                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, perf.sched_loop_count,
+                    perf.phase_complete_count
                 );
                 _t0_phase = _t1;
-                phase_complete_count = 0;
+                perf.phase_complete_count = 0;
             }
         }
 #endif
@@ -2176,13 +2052,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         // Phase 2 drain check: if a sync_start task is waiting for resources,
         // pause normal dispatch and let the drain protocol run.
         if (drain_state_.sync_start_pending.load(std::memory_order_acquire) != 0) {
-            handle_drain_mode(
-                runtime, thread_idx
-#if PTO2_PROFILING
-                ,
-                profiling_enabled, phase_dispatch_count
-#endif
-            );
+            handle_drain_mode(runtime, thread_idx);
             continue;
         }
 
@@ -2193,12 +2063,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             if (wired > 0) {
                 made_progress = true;
 #if PTO2_SCHED_PROFILING
-                phase_wiring_count += wired;
+                perf.phase_wiring_count += wired;
 #endif
             }
         }
 #if PTO2_PROFILING
-        CYCLE_COUNT_LAP(sched_wiring_cycle);
+        CYCLE_COUNT_LAP(perf.sched_wiring_cycle);
 #endif
 
         // Phase 4: Dispatch
@@ -2212,14 +2082,6 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                 dispatch_shape(
                     runtime, thread_idx, shape, phase, local_bufs[static_cast<int32_t>(shape)], tracker, entered_drain,
                     made_progress, try_pushed
-#if PTO2_SCHED_PROFILING
-                    ,
-                    pop_hit, pop_miss, local_dispatch_count, sched_dispatch_pop_cycle, sched_dispatch_setup_cycle
-#endif
-#if PTO2_PROFILING
-                    ,
-                    profiling_enabled, phase_dispatch_count
-#endif
                 );
             }
         }
@@ -2230,7 +2092,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             auto &local_buf = local_bufs[static_cast<int32_t>(shape)];
             auto &ready_queue = rt->scheduler.ready_queues[static_cast<int32_t>(shape)];
 #if PTO2_SCHED_PROFILING
-            local_overflow_count += local_buf.count;
+            perf.local_overflow_count += local_buf.count;
 #endif
             if (local_buf.count > 0) {
                 ready_queue.push_batch(local_buf.slot_states, local_buf.count);
@@ -2240,15 +2102,16 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 
 #if PTO2_PROFILING
         if (!try_pushed) {
-            CYCLE_COUNT_LAP(sched_idle_cycle);
+            CYCLE_COUNT_LAP(perf.sched_idle_cycle);
         } else {
-            CYCLE_COUNT_LAP(sched_dispatch_cycle);
-            if (profiling_enabled && phase_dispatch_count > 0) {
+            CYCLE_COUNT_LAP(perf.sched_dispatch_cycle);
+            if (perf.profiling_enabled && perf.phase_dispatch_count > 0) {
                 perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, sched_loop_count, phase_dispatch_count
+                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, perf.sched_loop_count,
+                    perf.phase_dispatch_count
                 );
                 _t0_phase = _t1;
-                phase_dispatch_count = 0;
+                perf.phase_dispatch_count = 0;
             }
         }
 #endif
@@ -2268,13 +2131,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 #if PTO2_SCHED_PROFILING
                 int32_t fe =
                     rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
+
+                perf.fanin_edges_total += fe;
+                if (fe > perf.fanin_max_degree) perf.fanin_max_degree = fe;
 #else
-                int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
-#endif
-                (void)fe;
-#if PTO2_SCHED_PROFILING
-                fanin_edges_total += fe;
-                if (fe > fanin_max_degree) fanin_max_degree = fe;
+                rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
             }
             idle_iterations++;
@@ -2295,16 +2156,18 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                     thread_idx, idle_iterations
 #if PTO2_PROFILING
                     ,
-                    sched_start_ts
+                    perf.sched_start_ts
 #endif
                 );
             } else {
                 SPIN_WAIT_HINT();
             }
 #if PTO2_PROFILING
-            CYCLE_COUNT_LAP(sched_idle_cycle);
-            if (profiling_enabled) {
-                perf_aicpu_record_phase(thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT, _t0_phase, _t1, sched_loop_count, 0);
+            CYCLE_COUNT_LAP(perf.sched_idle_cycle);
+            if (perf.profiling_enabled) {
+                perf_aicpu_record_phase(
+                    thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT, _t0_phase, _t1, perf.sched_loop_count, 0
+                );
                 _t0_phase = _t1;
             }
 #endif
@@ -2312,21 +2175,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     }
 
 #if PTO2_PROFILING
-    log_profiling_summary(
-        thread_idx, cur_thread_completed, sched_start_ts, sched_scan_cycle, sched_complete_cycle, sched_dispatch_cycle,
-        sched_wiring_cycle, sched_idle_cycle, sched_loop_count
-#if PTO2_SCHED_PROFILING
-        ,
-        complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-        fanin_edges_total, fanin_max_degree, pop_hit, pop_miss, local_dispatch_count, local_overflow_count,
-        sched_complete_perf_cycle, sched_dispatch_pop_cycle, sched_dispatch_setup_cycle, phase_wiring_count
-#endif
-    );
+    log_profiling_summary(thread_idx, cur_thread_completed);
 #endif
 
 #if PTO2_PROFILING
     // Flush performance buffers for cores managed by this thread
-    if (profiling_enabled) {
+    if (perf.profiling_enabled) {
         perf_aicpu_flush_buffers(runtime, thread_idx, core_assignments_[thread_idx], core_num);
         perf_aicpu_flush_phase_buffers(thread_idx);
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -2050,7 +2050,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         // Phase 3: Drain wiring queue — wire fanout edges for newly submitted tasks.
         // Only thread 0 does wiring to keep dep_pool single-threaded.
         if (thread_idx == 0) {
-            int wired = rt->scheduler.drain_wiring_queue();
+            int wired = rt->scheduler.drain_wiring_queue(orchestrator_done_);
             if (wired > 0) {
                 made_progress = true;
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -864,7 +864,7 @@ struct AicpuExecutor {
         PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
         int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
         PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
-        PTO2LocalReadyBuffer *local_bufs, CoreType ct
+        PTO2LocalReadyBuffer *local_bufs
 #if PTO2_PROFILING
         ,
         uint64_t dispatch_ts
@@ -872,6 +872,8 @@ struct AicpuExecutor {
     ) {
 #if PTO2_PROFILING
         auto &perf = sched_perf_[thread_idx];
+#else
+        (void)hank;
 #endif
         bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state);
         if (mixed_complete) {
@@ -940,7 +942,8 @@ struct AicpuExecutor {
             int32_t perf_slot_idx = static_cast<int32_t>(subslot);
             if (perf_aicpu_complete_record(
                     pbuf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
-                    slot_state.task->kernel_id[perf_slot_idx], ct, dispatch_ts, finish_ts, fanout_arr, fanout_n
+                    slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts,
+                    fanout_arr, fanout_n
                 ) != 0) {
                 DEV_ERROR(
                     "Core %d: perf_aicpu_complete_record failed for task 0x%" PRIx64, core_id,
@@ -972,7 +975,6 @@ struct AicpuExecutor {
         core.running_reg_task_id = AICPU_TASK_INVALID;
     }
 
-    template <CoreType CT>
     void check_running_cores_for_completion(
         int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
         bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
@@ -982,7 +984,7 @@ struct AicpuExecutor {
         auto &perf = sched_perf_[thread_idx];
 #endif
         CoreTracker &tracker = core_trackers_[thread_idx];
-        auto running_core_states = tracker.get_running_cores<CT>();
+        auto running_core_states = tracker.get_all_running_cores();
         while (running_core_states.has_value()) {
             int32_t bit_pos = running_core_states.pop_first();
             int32_t core_id = tracker.get_core_id_by_offset(bit_pos);
@@ -1015,7 +1017,7 @@ struct AicpuExecutor {
             if (t.pending_done) {
                 complete_slot_task(
                     *core.pending_slot_state, core.pending_reg_task_id, core.pending_subslot, thread_idx, core_id, hank,
-                    completed_this_turn, deferred_release_slot_states, deferred_release_count, local_bufs, CT
+                    completed_this_turn, deferred_release_slot_states, deferred_release_count, local_bufs
 #if PTO2_PROFILING
                     ,
                     core.pending_dispatch_timestamp
@@ -1026,7 +1028,7 @@ struct AicpuExecutor {
             if (t.running_done) {
                 complete_slot_task(
                     *core.running_slot_state, core.running_reg_task_id, core.running_subslot, thread_idx, core_id, hank,
-                    completed_this_turn, deferred_release_slot_states, deferred_release_count, local_bufs, CT
+                    completed_this_turn, deferred_release_slot_states, deferred_release_count, local_bufs
 #if PTO2_PROFILING
                     ,
                     core.running_dispatch_timestamp
@@ -1995,20 +1997,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         // Phase 1: Check running cores for completion, process and move to idle
         int32_t completed_this_turn = 0;
 
-        // Check AIC running cores
-        bool try_completed = false;
-        if (tracker.has_running_cores<CoreType::AIC>()) {
-            try_completed = true;
-            check_running_cores_for_completion<CoreType::AIC>(
-                thread_idx, hank, completed_this_turn, cur_thread_completed, made_progress,
-                deferred_release_slot_states, deferred_release_count, local_bufs
-            );
-        }
-
-        // Check AIV running cores
-        if (tracker.has_running_cores<CoreType::AIV>()) {
-            try_completed = true;
-            check_running_cores_for_completion<CoreType::AIV>(
+        bool try_completed = tracker.has_any_running_cores();
+        if (try_completed) {
+            check_running_cores_for_completion(
                 thread_idx, hank, completed_this_turn, cur_thread_completed, made_progress,
                 deferred_release_slot_states, deferred_release_count, local_bufs
             );

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -92,6 +92,12 @@ constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions a
 constexpr const char *DEFAULT_ORCH_ENTRY_SYMBOL = "aicpu_orchestration_entry";
 constexpr const char *DEFAULT_ORCH_CONFIG_SYMBOL = "aicpu_orchestration_config";
 
+// Control flow signal from cold-path helpers back to the main dispatch loop.
+enum class LoopAction : int8_t {
+    NONE,        // cold path did not trigger; proceed normally
+    BREAK_LOOP,  // equivalent to 'break' from the while(true) loop
+};
+
 static int32_t read_pto2_runtime_status(Runtime *runtime) {
     if (runtime == nullptr) {
         return 0;
@@ -452,6 +458,331 @@ struct AicpuExecutor {
     void diagnose_stuck_state(
         Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
     );
+
+    // --- Cold-path helpers for resolve_and_dispatch_pto2 (noinline to reduce hot-loop icache) ---
+
+    __attribute__((noinline, cold)) LoopAction handle_orchestrator_exit(
+        int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t &task_count
+    ) {
+        bool orch_done = orchestrator_done_;
+        if (!orch_done) return LoopAction::NONE;
+
+        int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
+        if (orch_err != PTO2_ERROR_NONE) {
+            DEV_ERROR(
+                "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
+                "completed_tasks=%d, total_tasks=%d",
+                thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
+            );
+            emergency_shutdown(runtime);
+            completed_.store(true, std::memory_order_release);
+            return LoopAction::BREAK_LOOP;
+        }
+
+        task_count = total_tasks_;
+        if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
+            completed_.store(true, std::memory_order_release);
+            DEV_INFO(
+                "Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed),
+                task_count
+            );
+            return LoopAction::BREAK_LOOP;
+        }
+        return LoopAction::NONE;
+    }
+
+    __attribute__((noinline, cold)) LoopAction handle_core_transition(bool &cores_released) {
+        if (!transition_requested_.load(std::memory_order_acquire)) return LoopAction::NONE;
+        if (!reassigned_.load(std::memory_order_acquire)) {
+            wait_reassign_.fetch_add(1, std::memory_order_release);
+            while (!reassigned_.load(std::memory_order_acquire)) {
+                if (completed_.load(std::memory_order_acquire)) {
+                    return LoopAction::BREAK_LOOP;
+                }
+                SPIN_WAIT_HINT();
+            }
+        }
+        cores_released = true;
+        return LoopAction::NONE;
+    }
+
+    __attribute__((noinline, cold)) LoopAction
+    check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime) {
+        int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
+        if (orch_err != PTO2_ERROR_NONE) {
+            DEV_ERROR(
+                "Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx, orch_err
+            );
+            emergency_shutdown(runtime);
+            completed_.store(true, std::memory_order_release);
+            return LoopAction::BREAK_LOOP;
+        }
+        return LoopAction::NONE;
+    }
+
+    __attribute__((noinline, cold)) void log_stall_diagnostics(
+        int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count, void *sm_base
+    ) {
+        int32_t c = completed_tasks_.load(std::memory_order_relaxed);
+        DEV_ALWAYS(
+            "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)", idle_iterations,
+            c, task_count, last_progress_count
+        );
+        CoreTracker &tracker = core_trackers_[thread_idx];
+        PTO2SchedulerState *sched = &rt->scheduler;
+        PTO2SharedMemoryHeader *sm_header_diag = static_cast<PTO2SharedMemoryHeader *>(sm_base);
+        int32_t cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            int32_t ring_task_count = sm_header_diag->rings[r].fc.current_task_index.load(std::memory_order_relaxed);
+            for (int32_t si = 0; si < ring_task_count; si++) {
+                PTO2TaskSlotState &slot_state = sched->get_slot_state(r, si);
+                PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
+                int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
+                int32_t fi = slot_state.fanin_count;
+                int32_t kid = slot_state.task->kernel_id[0];
+                if (st >= PTO2_TASK_COMPLETED) continue;
+                if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) {
+                    cnt_inflight++;
+                    continue;
+                }
+                if (rc >= fi) {
+                    cnt_ready++;
+                    if (cnt_ready <= STALL_DUMP_READY_MAX) {
+                        DEV_ALWAYS(
+                            "  STUCK-READY  ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
+                            static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
+                        );
+                    }
+                } else {
+                    cnt_waiting++;
+                    if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
+                        DEV_ALWAYS(
+                            "  STUCK-WAIT   ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
+                            static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
+                        );
+                    }
+                }
+            }
+        }
+        DEV_ALWAYS("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight);
+        int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
+        int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
+        int32_t total_running = aic_running + aiv_running;
+        int32_t core_num = core_count_per_thread_[thread_idx];
+        DEV_ALWAYS(
+            "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running,
+            aiv_running, core_num
+        );
+        auto all_running = tracker.get_all_running_cores();
+        int32_t dump_count = 0;
+        int32_t bp;
+        while (dump_count < STALL_DUMP_CORE_MAX && (bp = all_running.pop_first()) >= 0) {
+            dump_count++;
+            int32_t cid = tracker.get_core_id_by_offset(bp);
+            int32_t sw_tid = core_exec_states_[cid].running_reg_task_id;
+            int32_t hw_kernel = -1;
+            if (sw_tid >= 0 && core_exec_states_[cid].running_slot_state) {
+                int32_t diag_slot = static_cast<int32_t>(core_exec_states_[cid].running_subslot);
+                hw_kernel = core_exec_states_[cid].running_slot_state->task->kernel_id[diag_slot];
+            }
+            uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
+            DEV_ALWAYS(
+                "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid, static_cast<unsigned>(cond_reg),
+                EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg), sw_tid, hw_kernel
+            );
+        }
+        for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
+            int32_t offset = cli * 3;
+            DEV_ALWAYS(
+                "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
+                tracker.is_aic_core_idle(offset) ? "idle" : "busy", tracker.get_aiv0_core_id(offset),
+                tracker.is_aiv0_core_idle(offset) ? "idle" : "busy", tracker.get_aiv1_core_id(offset),
+                tracker.is_aiv1_core_idle(offset) ? "idle" : "busy"
+            );
+        }
+    }
+
+    __attribute__((noinline, cold)) int32_t handle_timeout_exit(
+        int32_t thread_idx, int32_t idle_iterations
+#if PTO2_PROFILING
+        ,
+        uint64_t sched_start_ts
+#endif
+    ) {
+        DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+#if PTO2_PROFILING
+        uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
+        DEV_ALWAYS(
+            "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+            static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_timeout_ts),
+            cycles_to_us(sched_timeout_ts - sched_start_ts)
+        );
+#endif
+        return -1;
+    }
+
+#if PTO2_PROFILING
+    __attribute__((noinline, cold)) void log_profiling_summary(
+        int32_t thread_idx, int32_t cur_thread_completed, uint64_t sched_start_ts, uint64_t sched_scan_cycle,
+        uint64_t sched_complete_cycle, uint64_t sched_dispatch_cycle, uint64_t sched_wiring_cycle,
+        uint64_t sched_idle_cycle, uint64_t sched_loop_count
+#if PTO2_SCHED_PROFILING
+        ,
+        uint64_t complete_probe_count, uint64_t complete_hit_count, uint64_t notify_edges_total,
+        int32_t notify_max_degree, uint64_t notify_tasks_enqueued, uint64_t fanin_edges_total, int32_t fanin_max_degree,
+        uint64_t pop_hit, uint64_t pop_miss, uint64_t local_dispatch_count, uint64_t local_overflow_count,
+        uint64_t sched_complete_perf_cycle, uint64_t sched_dispatch_pop_cycle, uint64_t sched_dispatch_setup_cycle,
+        uint32_t phase_wiring_count
+#endif
+    ) {
+        uint64_t sched_end_ts = get_sys_cnt_aicpu();
+        DEV_ALWAYS(
+            "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+            static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_end_ts),
+            cycles_to_us(sched_end_ts - sched_start_ts)
+        );
+
+        uint64_t sched_total =
+            sched_wiring_cycle + sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
+        if (sched_total == 0) sched_total = 1;
+
+#if PTO2_SCHED_PROFILING
+        {
+            PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
+            uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
+            uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle) ?
+                                         (sched_complete_cycle - otc_total - sched_complete_perf_cycle) :
+                                         0;
+            uint64_t dispatch_poll =
+                (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle) ?
+                    (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) :
+                    0;
+
+            DEV_ALWAYS(
+                "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
+                cycles_to_us(sched_total), cur_thread_completed
+            );
+
+            double notify_avg =
+                cur_thread_completed > 0 ? static_cast<double>(notify_edges_total) / cur_thread_completed : 0.0;
+            double fanin_avg =
+                cur_thread_completed > 0 ? static_cast<double>(fanin_edges_total) / cur_thread_completed : 0.0;
+            DEV_ALWAYS(
+                "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
+                ", max_degree=%d, avg=%.1f]  [fanin: "
+                "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
+                thread_idx, cycles_to_us(sched_complete_cycle), sched_complete_cycle * 100.0 / sched_total,
+                static_cast<uint64_t>(notify_edges_total), notify_max_degree, notify_avg,
+                static_cast<uint64_t>(fanin_edges_total), fanin_max_degree, fanin_avg
+            );
+
+            uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
+            uint64_t complete_miss_count =
+                (complete_probe_count > complete_hit_count) ? (complete_probe_count - complete_hit_count) : 0;
+            double complete_hit_rate =
+                complete_probe_count > 0 ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
+            DEV_ALWAYS(
+                "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
+                thread_idx, cycles_to_us(complete_poll), complete_poll * 100.0 / c_parent,
+                static_cast<uint64_t>(complete_hit_count), static_cast<uint64_t>(complete_miss_count), complete_hit_rate
+            );
+            DEV_ALWAYS(
+                "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
+                cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
+                static_cast<uint64_t>(sp.lock_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
+                cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
+                static_cast<uint64_t>(sp.fanout_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+                cycles_to_us(sp.fanin_cycle), sp.fanin_cycle * 100.0 / c_parent,
+                static_cast<uint64_t>(sp.fanin_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+                cycles_to_us(sp.self_consumed_cycle), sp.self_consumed_cycle * 100.0 / c_parent,
+                static_cast<uint64_t>(sp.self_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_complete_perf_cycle),
+                sched_complete_perf_cycle * 100.0 / c_parent
+            );
+
+            uint64_t pop_total = pop_hit + pop_miss;
+            double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
+            DEV_ALWAYS(
+                "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64
+                ", hit_rate=%.1f%%]",
+                thread_idx, cycles_to_us(sched_dispatch_cycle), sched_dispatch_cycle * 100.0 / sched_total,
+                static_cast<uint64_t>(pop_hit), static_cast<uint64_t>(pop_miss), pop_hit_rate
+            );
+            uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
+            uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
+            double local_hit_rate = total_dispatched > 0 ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
+            DEV_ALWAYS(
+                "Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
+                ", local_rate=%.1f%%",
+                thread_idx, static_cast<uint64_t>(local_dispatch_count), static_cast<uint64_t>(global_dispatch_count),
+                static_cast<uint64_t>(local_overflow_count), local_hit_rate
+            );
+
+            uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
+            DEV_ALWAYS(
+                "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
+                dispatch_poll * 100.0 / d_parent
+            );
+            DEV_ALWAYS(
+                "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(sched_dispatch_pop_cycle), sched_dispatch_pop_cycle * 100.0 / d_parent,
+                cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+                static_cast<uint64_t>(sp.pop_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
+                sched_dispatch_setup_cycle * 100.0 / d_parent
+            );
+
+            DEV_ALWAYS(
+                "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_scan_cycle),
+                sched_scan_cycle * 100.0 / sched_total
+            );
+
+#if PTO2_SCHED_PROFILING
+            DEV_ALWAYS(
+                "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx, cycles_to_us(sched_wiring_cycle),
+                sched_wiring_cycle * 100.0 / sched_total, phase_wiring_count
+            );
+#else
+            DEV_ALWAYS(
+                "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_wiring_cycle),
+                sched_wiring_cycle * 100.0 / sched_total
+            );
+#endif
+
+            DEV_ALWAYS(
+                "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_idle_cycle),
+                sched_idle_cycle * 100.0 / sched_total
+            );
+
+            if (cur_thread_completed > 0) {
+                DEV_ALWAYS(
+                    "Thread %d:   avg/complete   : %.3fus", thread_idx,
+                    cycles_to_us(sched_complete_cycle) / cur_thread_completed
+                );
+            }
+        }
+#endif
+        DEV_ALWAYS(
+            "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
+            cycles_to_us(sched_total), static_cast<uint64_t>(sched_loop_count), cur_thread_completed
+        );
+    }
+#endif
 
     // --- Dual-slot state machine helpers ---
 
@@ -1750,49 +2081,14 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 #endif
         int32_t task_count = 0;
         if (!tracker.has_any_running_cores()) {
-            bool orch_done = orchestrator_done_;
-            if (orch_done) {
-                // Check for orchestrator fatal error — exit immediately
-                int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
-                if (orch_err != PTO2_ERROR_NONE) {
-                    DEV_ERROR(
-                        "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
-                        "completed_tasks=%d, total_tasks=%d",
-                        thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
-                    );
-                    emergency_shutdown(runtime);
-                    completed_.store(true, std::memory_order_release);
-                    break;
-                }
-
-                // Normal exit: all tasks complete
-                task_count = total_tasks_;
-                if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
-                    completed_.store(true, std::memory_order_release);
-                    DEV_INFO(
-                        "Thread %d: PTO2 completed tasks %d/%d", thread_idx,
-                        completed_tasks_.load(std::memory_order_relaxed), task_count
-                    );
-                    break;
-                }
-            }
+            LoopAction action = handle_orchestrator_exit(thread_idx, header, runtime, task_count);
+            if (action == LoopAction::BREAK_LOOP) break;
         }
 
         // Check for core transition request (execute once per thread)
-        if (!cores_released && orch_to_sched_ && transition_requested_.load(std::memory_order_acquire)) {
-            if (!reassigned_.load(std::memory_order_acquire)) {
-                wait_reassign_.fetch_add(1, std::memory_order_release);
-                while (!reassigned_.load(std::memory_order_acquire)) {
-                    if (completed_.load(std::memory_order_acquire)) {
-                        break;
-                    }
-                    SPIN_WAIT_HINT();
-                }
-                if (completed_.load(std::memory_order_acquire)) {
-                    break;
-                }
-            }
-            cores_released = true;
+        if (!cores_released && orch_to_sched_) {
+            LoopAction action = handle_core_transition(cores_released);
+            if (action == LoopAction::BREAK_LOOP) break;
         }
 
 #if PTO2_PROFILING
@@ -1987,121 +2283,21 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             // orch_error_code is set in shared memory by the orchestrator's spin loop
             // BEFORE orchestrator_done_ is set, so this catches errors earlier.
             if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
-                int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
-                if (orch_err != PTO2_ERROR_NONE) {
-                    DEV_ERROR(
-                        "Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx,
-                        orch_err
-                    );
-                    emergency_shutdown(runtime);
-                    completed_.store(true, std::memory_order_release);
-                    break;
-                }
+                LoopAction action = check_idle_fatal_error(thread_idx, header, runtime);
+                if (action == LoopAction::BREAK_LOOP) break;
             }
 
             if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
-                int32_t c = completed_tasks_.load(std::memory_order_relaxed);
-                DEV_ALWAYS(
-                    "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
-                    idle_iterations, c, task_count, last_progress_count
-                );
-                // Scan all task slots to find truly stuck tasks using scheduler state
-                PTO2SchedulerState *sched = &rt->scheduler;
-                PTO2SharedMemoryHeader *sm_header_diag = static_cast<PTO2SharedMemoryHeader *>(sm_base);
-                int32_t cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
-                for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                    int32_t ring_task_count =
-                        sm_header_diag->rings[r].fc.current_task_index.load(std::memory_order_relaxed);
-                    for (int32_t si = 0; si < ring_task_count; si++) {
-                        PTO2TaskSlotState &slot_state = sched->get_slot_state(r, si);
-                        PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
-                        int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
-                        int32_t fi = slot_state.fanin_count;
-                        int32_t kid = slot_state.task->kernel_id[0];
-                        if (st >= PTO2_TASK_COMPLETED) continue;  // Already done
-                        if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) {
-                            cnt_inflight++;
-                            continue;
-                        }
-                        // PENDING
-                        if (rc >= fi) {
-                            // Ready (all deps satisfied) but not enqueued — this is the real bug
-                            cnt_ready++;
-                            if (cnt_ready <= STALL_DUMP_READY_MAX) {
-                                DEV_ALWAYS(
-                                    "  STUCK-READY  ring=%d task_id=%" PRId64
-                                    " kernel_id=%d refcount=%d fanin=%d state=%d",
-                                    r, static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi,
-                                    static_cast<int32_t>(st)
-                                );
-                            }
-                        } else {
-                            cnt_waiting++;
-                            if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
-                                DEV_ALWAYS(
-                                    "  STUCK-WAIT   ring=%d task_id=%" PRId64
-                                    " kernel_id=%d refcount=%d fanin=%d state=%d",
-                                    r, static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi,
-                                    static_cast<int32_t>(st)
-                                );
-                            }
-                        }
-                    }
-                }
-                DEV_ALWAYS(
-                    "  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight
-                );
-                // Log this thread's dispatch state
-                int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
-                int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
-                int32_t total_running = aic_running + aiv_running;
-                DEV_ALWAYS(
-                    "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running,
-                    aiv_running, core_num
-                );
-                // Dump running cores
-                auto all_running = tracker.get_all_running_cores();
-                int32_t dump_count = 0;
-                int32_t bp;
-                while (dump_count < STALL_DUMP_CORE_MAX && (bp = all_running.pop_first()) >= 0) {
-                    dump_count++;
-                    int32_t cid = tracker.get_core_id_by_offset(bp);
-                    int32_t sw_tid = core_exec_states_[cid].running_reg_task_id;
-                    int32_t hw_kernel = -1;
-                    if (sw_tid >= 0 && core_exec_states_[cid].running_slot_state) {
-                        int32_t diag_slot = static_cast<int32_t>(core_exec_states_[cid].running_subslot);
-                        hw_kernel = core_exec_states_[cid].running_slot_state->task->kernel_id[diag_slot];
-                    }
-                    uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
-                    DEV_ALWAYS(
-                        "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid,
-                        static_cast<unsigned>(cond_reg), EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
-                        sw_tid, hw_kernel
-                    );
-                }
-                // Dump cluster state
-                for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
-                    int32_t offset = cli * 3;
-                    DEV_ALWAYS(
-                        "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
-                        tracker.is_aic_core_idle(offset) ? "idle" : "busy", tracker.get_aiv0_core_id(offset),
-                        tracker.is_aiv0_core_idle(offset) ? "idle" : "busy", tracker.get_aiv1_core_id(offset),
-                        tracker.is_aiv1_core_idle(offset) ? "idle" : "busy"
-                    );
-                }
+                log_stall_diagnostics(thread_idx, task_count, idle_iterations, last_progress_count, sm_base);
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
-                DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+                return handle_timeout_exit(
+                    thread_idx, idle_iterations
 #if PTO2_PROFILING
-                // Benchmark: scheduler lifetime end timestamp on timeout path
-                uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
-                DEV_ALWAYS(
-                    "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
-                    static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_timeout_ts),
-                    cycles_to_us(sched_timeout_ts - sched_start_ts)
-                );
+                    ,
+                    sched_start_ts
 #endif
-                return -1;
+                );
             } else {
                 SPIN_WAIT_HINT();
             }
@@ -2116,160 +2312,15 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     }
 
 #if PTO2_PROFILING
-    // Record sched_end before any DEV_ALWAYS to avoid init cost contamination
-    uint64_t sched_end_ts = get_sys_cnt_aicpu();
-    DEV_ALWAYS(
-        "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
-        static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_end_ts),
-        cycles_to_us(sched_end_ts - sched_start_ts)
-    );
-
-    // Scheduler summary logging (always print when PTO2_PROFILING=1)
-    uint64_t sched_total =
-        sched_wiring_cycle + sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
-    if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
-
+    log_profiling_summary(
+        thread_idx, cur_thread_completed, sched_start_ts, sched_scan_cycle, sched_complete_cycle, sched_dispatch_cycle,
+        sched_wiring_cycle, sched_idle_cycle, sched_loop_count
 #if PTO2_SCHED_PROFILING
-    // Two-level tree display: sub-phase breakdown within complete and dispatch
-    {
-        PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
-        uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
-        uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle) ?
-                                     (sched_complete_cycle - otc_total - sched_complete_perf_cycle) :
-                                     0;
-        uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle) ?
-                                     (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) :
-                                     0;
-
-        DEV_ALWAYS(
-            "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
-            cycles_to_us(sched_total), cur_thread_completed
-        );
-
-        // Level 1: complete
-        double notify_avg =
-            cur_thread_completed > 0 ? static_cast<double>(notify_edges_total) / cur_thread_completed : 0.0;
-        double fanin_avg =
-            cur_thread_completed > 0 ? static_cast<double>(fanin_edges_total) / cur_thread_completed : 0.0;
-        DEV_ALWAYS(
-            "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
-            ", max_degree=%d, avg=%.1f]  [fanin: "
-            "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
-            thread_idx, cycles_to_us(sched_complete_cycle), sched_complete_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(notify_edges_total), notify_max_degree, notify_avg,
-            static_cast<uint64_t>(fanin_edges_total), fanin_max_degree, fanin_avg
-        );
-
-        // Level 2: complete sub-phases (percentage relative to complete)
-        uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
-        uint64_t complete_miss_count =
-            (complete_probe_count > complete_hit_count) ? (complete_probe_count - complete_hit_count) : 0;
-        double complete_hit_rate = complete_probe_count > 0 ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
-        DEV_ALWAYS(
-            "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
-            thread_idx, cycles_to_us(complete_poll), complete_poll * 100.0 / c_parent,
-            static_cast<uint64_t>(complete_hit_count), static_cast<uint64_t>(complete_miss_count), complete_hit_rate
-        );
-        DEV_ALWAYS(
-            "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
-            cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
-            static_cast<uint64_t>(sp.lock_atomic_count)
-        );
-        DEV_ALWAYS(
-            "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
-            cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
-            static_cast<uint64_t>(sp.fanout_atomic_count)
-        );
-        DEV_ALWAYS(
-            "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
-            cycles_to_us(sp.fanin_cycle), sp.fanin_cycle * 100.0 / c_parent,
-            static_cast<uint64_t>(sp.fanin_atomic_count)
-        );
-        DEV_ALWAYS(
-            "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
-            cycles_to_us(sp.self_consumed_cycle), sp.self_consumed_cycle * 100.0 / c_parent,
-            static_cast<uint64_t>(sp.self_atomic_count)
-        );
-        DEV_ALWAYS(
-            "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_complete_perf_cycle),
-            sched_complete_perf_cycle * 100.0 / c_parent
-        );
-
-        // Level 1: dispatch
-        uint64_t pop_total = pop_hit + pop_miss;
-        double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
-        DEV_ALWAYS(
-            "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%]",
-            thread_idx, cycles_to_us(sched_dispatch_cycle), sched_dispatch_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(pop_hit), static_cast<uint64_t>(pop_miss), pop_hit_rate
-        );
-        uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
-        uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
-        double local_hit_rate = total_dispatched > 0 ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
-        DEV_ALWAYS(
-            "Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
-            ", local_rate=%.1f%%",
-            thread_idx, static_cast<uint64_t>(local_dispatch_count), static_cast<uint64_t>(global_dispatch_count),
-            static_cast<uint64_t>(local_overflow_count), local_hit_rate
-        );
-
-        // Level 2: dispatch sub-phases (percentage relative to dispatch)
-        uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
-        DEV_ALWAYS(
-            "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
-            dispatch_poll * 100.0 / d_parent
-        );
-        DEV_ALWAYS(
-            "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
-            cycles_to_us(sched_dispatch_pop_cycle), sched_dispatch_pop_cycle * 100.0 / d_parent,
-            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
-            static_cast<uint64_t>(sp.pop_atomic_count)
-        );
-        DEV_ALWAYS(
-            "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
-            sched_dispatch_setup_cycle * 100.0 / d_parent
-        );
-
-        // Level 1: scan
-        DEV_ALWAYS(
-            "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_scan_cycle),
-            sched_scan_cycle * 100.0 / sched_total
-        );
-
-        // Level 1: wiring
-#if PTO2_SCHED_PROFILING
-        DEV_ALWAYS(
-            "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx, cycles_to_us(sched_wiring_cycle),
-            sched_wiring_cycle * 100.0 / sched_total, phase_wiring_count
-        );
-#else
-        DEV_ALWAYS(
-            "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_wiring_cycle),
-            sched_wiring_cycle * 100.0 / sched_total
-        );
+        ,
+        complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
+        fanin_edges_total, fanin_max_degree, pop_hit, pop_miss, local_dispatch_count, local_overflow_count,
+        sched_complete_perf_cycle, sched_dispatch_pop_cycle, sched_dispatch_setup_cycle, phase_wiring_count
 #endif
-
-        // Level 1: idle
-        DEV_ALWAYS(
-            "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_idle_cycle),
-            sched_idle_cycle * 100.0 / sched_total
-        );
-
-        // Average per completion
-        if (cur_thread_completed > 0) {
-            DEV_ALWAYS(
-                "Thread %d:   avg/complete   : %.3fus", thread_idx,
-                cycles_to_us(sched_complete_cycle) / cur_thread_completed
-            );
-        }
-    }
-#endif
-    // Summary line (always print when PTO2_PROFILING=1)
-    DEV_ALWAYS(
-        "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
-        cycles_to_us(sched_total), static_cast<uint64_t>(sched_loop_count), cur_thread_completed
     );
 #endif
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -114,11 +114,11 @@ struct RingSchedState {
     int32_t task_window_size;
     int32_t task_window_mask;
     std::atomic<int32_t> advance_lock;
-    PTO2DepListPool dep_pool;  // fanout wiring dep pool (exclusively managed by scheduler thread 0)
+    alignas(64) PTO2DepListPool dep_pool;  // fanout wiring dep pool (thread 0 only, cache-isolated)
 };
 
 RingSchedState ring_sched_states[PTO2_MAX_RING_DEPTH];
-PTO2ReadyQueue wiring_queue;  // deferred fanout wiring from orchestrator
+PTO2SpscQueue wiring_queue;  // global SPSC queue: orchestrator pushes, scheduler thread 0 drains
 ```
 
 ### 4.6 PTO2TensorMap (modified)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -405,7 +405,7 @@ Key members:
 
 ### 7.3 Deferred Fanout Wiring (Scheduler Wiring Queue)
 
-The orchestrator pushes each submitted task to the global `scheduler->wiring_queue` (a wait-free SPSC queue). Scheduler thread 0 drains this queue in batches (with backoff until batch-size items are queued), and for each task:
+The orchestrator pushes each submitted task to the global `scheduler->wiring_queue` (a wait-free SPSC queue). Scheduler thread 0 drains this queue in batches, deferring if the queue holds fewer than a full batch of items to reduce contention (unless a final flush is needed at end of execution). For each task:
 
 1. Sets `fanin_count = N + 1` (+1 redundance to prevent premature readiness)
 2. For each producer in `payload->fanin_slot_states[]`:

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -396,16 +396,16 @@ Key members:
 | 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers; collect producer pointers in `PTO2FaninBuilder` |
 | 4 | **Insert**: register OUTPUT/INOUT args in TensorMap |
 | 5 | **Record fanin metadata**: store producer pointers in `payload->fanin_inline_slot_states[]` (+ spill pool if >16); increment each producer's `fanout_count` (no lock needed — single writer) |
-| 6 | **Push to wiring queue**: scheduler thread 0 asynchronously wires fanout edges (lock + dep_pool + early_finished check + ready push) |
+| 6 | **Push to wiring queue**: push to global `PTO2SpscQueue`; scheduler thread 0 asynchronously wires fanout edges (lock + dep_pool + early_finished check + ready push) |
 
 > **Note**: Fanout wiring (Steps 4–7 in earlier versions) has been moved from the
-> orchestrator submit hot path to the scheduler's `wiring_queue`. This reduces the
+> orchestrator submit hot path to the scheduler's global `wiring_queue` (SPSC). This reduces the
 > orchestrator's shared L2 cache / memory bus pressure, as the orchestrator no longer
 > acquires `fanout_lock` or allocates from `dep_pool` during submission.
 
 ### 7.3 Deferred Fanout Wiring (Scheduler Wiring Queue)
 
-The orchestrator pushes each submitted task to `scheduler->wiring_queue`. Scheduler thread 0 drains this queue and, for each task:
+The orchestrator pushes each submitted task to the global `scheduler->wiring_queue` (a wait-free SPSC queue). Scheduler thread 0 drains this queue in batches (with backoff until batch-size items are queued), and for each task:
 
 1. Sets `fanin_count = N + 1` (+1 redundance to prevent premature readiness)
 2. For each producer in `payload->fanin_slot_states[]`:

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -734,8 +734,8 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
             producer->fanout_count += 1;
         });
 
-        // Push to per-ring wiring queue — scheduler sets fanin_count, wires fanout, checks readiness
-        while (!sched->ring_sched_states[ring_id].wiring_queue.push(&cur_slot_state)) {
+        // Push to global wiring queue — scheduler sets fanin_count, wires fanout, checks readiness
+        while (!sched->wiring_queue.push(&cur_slot_state)) {
             SPIN_WAIT_HINT();
         }
 #if PTO2_ORCH_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -561,8 +561,8 @@ struct PTO2DepListPool {
     std::atomic<int32_t> *error_code_ptr = nullptr;
 
     /**
-     * Initialize dependency list pool
      *
+     * Initialize dependency list pool
      * @param base      Pool base address from shared memory
      * @param capacity  Total number of entries
      */

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -108,6 +108,12 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         }
     }
 
+    // Signal scheduler: orchestrator is about to block, bypass wiring backoff
+    bool signaled = slot_count > 0 && orch.scheduler;
+    if (signaled) {
+        orch.scheduler->orch_needs_drain.store(true, std::memory_order_release);
+    }
+
     // Wait for each producer
     for (int p = 0; p < slot_count; p++) {
         PTO2TaskSlotState &slot = *slots[p];
@@ -119,6 +125,9 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+                if (signaled) {
+                    orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+                }
                 pto2_orch_report_fatal(
                     &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
                     "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
@@ -134,6 +143,9 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
             while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
                 SPIN_WAIT_HINT();
                 if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+                    if (signaled) {
+                        orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+                    }
                     pto2_orch_report_fatal(
                         &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
                         "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
@@ -144,6 +156,12 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
             }
         }
     }
+
+    // Clear urgency flag: orchestrator no longer blocking
+    if (signaled) {
+        orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+    }
+
     return true;
 }
 MAYBE_UNINITIALIZED_END

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -199,7 +199,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
             for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
                 pto2_ready_queue_destroy(&sched->ready_queues[i]);
             }
-            pto2_ready_queue_destroy(&sched->wiring_queue);
+            sched->wiring_queue.destroy();
             for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
                 sched->ring_sched_states[rr].destroy();
             }
@@ -208,8 +208,8 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
         sched->ring_sched_states[r].dep_pool.init(dep_entries, dep_pool_capacity, &sm_handle->header->orch_error_code);
     }
 
-    // Initialize global wiring queue (orchestrator pushes, scheduler thread 0 drains)
-    if (!pto2_ready_queue_init(&sched->wiring_queue, PTO2_WRIRING_QUEUE_SIZE)) {
+    // Initialize global wiring queue (SPSC: orchestrator pushes, scheduler thread 0 drains)
+    if (!sched->wiring_queue.init(PTO2_WRIRING_QUEUE_SIZE)) {
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             free(sched->ring_sched_states[r].dep_pool.base);
         }
@@ -234,7 +234,7 @@ void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
         sched->ring_sched_states[r].dep_pool.base = nullptr;
     }
 
-    pto2_ready_queue_destroy(&sched->wiring_queue);
+    sched->wiring_queue.destroy();
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         pto2_ready_queue_destroy(&sched->ready_queues[i]);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -223,6 +223,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
     }
     sched->wiring_batch_count = 0;
     sched->wiring_batch_index = 0;
+    sched->wiring_backoff_counter = 0;
 
     return true;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -148,9 +148,6 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHandle *sm_handle,
         slot_states[i].ring_id = 0;
     }
 
-    wiring_batch_count = 0;
-    wiring_batch_index = 0;
-
     return true;
 }
 
@@ -193,30 +190,16 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
 
     // Initialize per-ring wiring queues and dep pools (exclusively managed by scheduler thread 0)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (!pto2_ready_queue_init(&sched->ring_sched_states[r].wiring_queue, PTO2_WRIRING_QUEUE_SIZE)) {
-            for (int j = 0; j < r; j++) {
-                pto2_ready_queue_destroy(&sched->ring_sched_states[j].wiring_queue);
-                free(sched->ring_sched_states[j].dep_pool.base);
-            }
-            for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-                pto2_ready_queue_destroy(&sched->ready_queues[i]);
-            }
-            for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
-                sched->ring_sched_states[rr].destroy();
-            }
-            return false;
-        }
         PTO2DepListEntry *dep_entries =
             reinterpret_cast<PTO2DepListEntry *>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
         if (!dep_entries) {
-            pto2_ready_queue_destroy(&sched->ring_sched_states[r].wiring_queue);
             for (int j = 0; j < r; j++) {
-                pto2_ready_queue_destroy(&sched->ring_sched_states[j].wiring_queue);
                 free(sched->ring_sched_states[j].dep_pool.base);
             }
             for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
                 pto2_ready_queue_destroy(&sched->ready_queues[i]);
             }
+            pto2_ready_queue_destroy(&sched->wiring_queue);
             for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
                 sched->ring_sched_states[rr].destroy();
             }
@@ -224,6 +207,22 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
         }
         sched->ring_sched_states[r].dep_pool.init(dep_entries, dep_pool_capacity, &sm_handle->header->orch_error_code);
     }
+
+    // Initialize global wiring queue (orchestrator pushes, scheduler thread 0 drains)
+    if (!pto2_ready_queue_init(&sched->wiring_queue, PTO2_WRIRING_QUEUE_SIZE)) {
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            free(sched->ring_sched_states[r].dep_pool.base);
+        }
+        for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+            pto2_ready_queue_destroy(&sched->ready_queues[i]);
+        }
+        for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
+            sched->ring_sched_states[rr].destroy();
+        }
+        return false;
+    }
+    sched->wiring_batch_count = 0;
+    sched->wiring_batch_index = 0;
 
     return true;
 }
@@ -233,8 +232,9 @@ void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
         sched->ring_sched_states[r].destroy();
         free(sched->ring_sched_states[r].dep_pool.base);
         sched->ring_sched_states[r].dep_pool.base = nullptr;
-        pto2_ready_queue_destroy(&sched->ring_sched_states[r].wiring_queue);
     }
+
+    pto2_ready_queue_destroy(&sched->wiring_queue);
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         pto2_ready_queue_destroy(&sched->ready_queues[i]);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -451,10 +451,11 @@ struct PTO2SpscQueue {
     }
 
     // Push one item (producer only). Returns false if queue is full.
-    // Full condition: next_h - tail > mask_ (i.e. > capacity-1), meaning all
-    // capacity slots are occupied. This uses strict '>' so all capacity slots
-    // are usable (no wasted sentinel slot). uint64_t wrapping is safe since
-    // head and tail are monotonically increasing and subtraction wraps correctly.
+    // Full condition: next_h - tail > mask_ (i.e. > capacity-1), so the
+    // effective usable capacity is capacity-1 (one slot is wasted as a
+    // sentinel to distinguish full from empty). uint64_t wrapping is safe
+    // since head and tail are monotonically increasing and subtraction
+    // wraps correctly.
     bool push(PTO2TaskSlotState *item) {
         uint64_t h = head_.load(std::memory_order_relaxed);
         uint64_t next_h = h + 1;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -498,10 +498,10 @@ struct PTO2SchedulerState {
      *
      * @return Number of tasks wired this call.
      */
-    int drain_wiring_queue() {
+    int drain_wiring_queue(bool force_drain = false) {
         int wired = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            wired += drain_ring_wiring_queue(r);
+            wired += drain_ring_wiring_queue(r, force_drain);
         }
         return wired;
     }
@@ -510,12 +510,18 @@ struct PTO2SchedulerState {
      * Drain the wiring queue for a single ring. See drain_wiring_queue() for
      * the peek/pop_batch FIFO protocol. Returns the number of tasks wired.
      */
-    int drain_ring_wiring_queue(int ring_id) {
+    static constexpr int WIRING_BACKOFF_THRESHOLD = 16;
+
+    int drain_ring_wiring_queue(int ring_id, bool force_drain = false) {
         auto &rss = ring_sched_states[ring_id];
         int wired = 0;
 
         // Refill local batch buffer when exhausted.
         if (rss.wiring_batch_index >= rss.wiring_batch_count) {
+            // Backoff: skip pop when fewer than WIRING_BACKOFF_THRESHOLD tasks
+            // are queued, reducing contention with the orchestrator's push path.
+            // Bypassed when force_drain is set (orchestrator done — must flush tail).
+            if (!force_drain && rss.wiring_queue.size() < WIRING_BACKOFF_THRESHOLD) return 0;
             rss.wiring_batch_count = rss.wiring_queue.pop_batch(rss.wiring_batch, RingSchedState::WIRING_BATCH_SIZE);
             rss.wiring_batch_index = 0;
             if (rss.wiring_batch_count == 0) return 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -430,26 +430,16 @@ struct PTO2SchedulerState {
 
     // Per-ring state
     struct RingSchedState {
+        // --- Completion/dispatch hot path (all scheduler threads) ---
         PTO2TaskDescriptor *task_descriptors;
         PTO2TaskSlotState *slot_states;
         int32_t last_task_alive;
         int32_t task_window_mask;
         uint64_t task_window_size;
-        // Try-lock used to advance this ring's last_task_alive pointer.
-        std::atomic<int32_t> advance_lock;
+        std::atomic<int32_t> advance_lock;  // multi-thread CAS
 
-        // Dep pool for fanout wiring (exclusively managed by scheduler thread 0)
-        PTO2DepListPool dep_pool;
-
-        // Per-ring wiring queue: orchestrator pushes tasks, scheduler thread 0 pops and wires.
-        PTO2ReadyQueue wiring_queue;
-
-        // Local batch buffer for drain_wiring_queue (scheduler thread 0 only).
-        // Persists across calls so partially-consumed batches resume next call.
-        static constexpr int WIRING_BATCH_SIZE = 32;
-        PTO2TaskSlotState *wiring_batch[WIRING_BATCH_SIZE];
-        int wiring_batch_count = 0;
-        int wiring_batch_index = 0;
+        // --- Wiring hot path (thread 0 only, isolated from completion traffic) ---
+        alignas(64) PTO2DepListPool dep_pool;
 
         bool init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id);
         void destroy();
@@ -481,6 +471,16 @@ struct PTO2SchedulerState {
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
+    // Global wiring batch buffer — thread 0 only, tight layout for cache locality.
+    // count(4B) + index(4B) + batch[15](120B) = 128B = exactly 2 cache lines.
+    int wiring_batch_count = 0;
+    int wiring_batch_index = 0;
+    static constexpr int WIRING_BATCH_SIZE = 15;
+    PTO2TaskSlotState *wiring_batch[WIRING_BATCH_SIZE];
+
+    // Global wiring queue — refill path only (every BATCH_SIZE tasks), separate cache line.
+    alignas(64) PTO2ReadyQueue wiring_queue;
+
     // Statistics
 #if PTO2_SCHED_PROFILING
     std::atomic<int64_t> tasks_completed;
@@ -498,38 +498,26 @@ struct PTO2SchedulerState {
      *
      * @return Number of tasks wired this call.
      */
+
     int drain_wiring_queue(bool force_drain = false) {
-        int wired = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            wired += drain_ring_wiring_queue(r, force_drain);
-        }
-        return wired;
-    }
-
-    /**
-     * Drain the wiring queue for a single ring. See drain_wiring_queue() for
-     * the peek/pop_batch FIFO protocol. Returns the number of tasks wired.
-     */
-    static constexpr int WIRING_BACKOFF_THRESHOLD = 16;
-
-    int drain_ring_wiring_queue(int ring_id, bool force_drain = false) {
-        auto &rss = ring_sched_states[ring_id];
         int wired = 0;
 
         // Refill local batch buffer when exhausted.
-        if (rss.wiring_batch_index >= rss.wiring_batch_count) {
+        if (wiring_batch_index >= wiring_batch_count) {
             // Backoff: skip pop when fewer than WIRING_BACKOFF_THRESHOLD tasks
             // are queued, reducing contention with the orchestrator's push path.
             // Bypassed when force_drain is set (orchestrator done — must flush tail).
-            if (!force_drain && rss.wiring_queue.size() < WIRING_BACKOFF_THRESHOLD) return 0;
-            rss.wiring_batch_count = rss.wiring_queue.pop_batch(rss.wiring_batch, RingSchedState::WIRING_BATCH_SIZE);
-            rss.wiring_batch_index = 0;
-            if (rss.wiring_batch_count == 0) return 0;
+            if (!force_drain && wiring_queue.size() < WIRING_BATCH_SIZE) return 0;
+            wiring_batch_count = wiring_queue.pop_batch(wiring_batch, WIRING_BATCH_SIZE);
+            wiring_batch_index = 0;
+            if (wiring_batch_count == 0) return 0;
         }
 
         // Process tasks from local buffer in strict FIFO order.
-        while (rss.wiring_batch_index < rss.wiring_batch_count) {
-            PTO2TaskSlotState *ws = rss.wiring_batch[rss.wiring_batch_index];
+        while (wiring_batch_index < wiring_batch_count) {
+            PTO2TaskSlotState *ws = wiring_batch[wiring_batch_index];
+            int ring_id = ws->ring_id;
+            auto &rss = ring_sched_states[ring_id];
             int32_t wfanin = ws->payload->fanin_actual_count;
 
             if (wfanin > 0 && rss.dep_pool.available() < wfanin) {
@@ -539,8 +527,8 @@ struct PTO2SchedulerState {
                 }
             }
 
-            rss.wiring_batch_index++;
-            wire_task(ring_id, ws);
+            wiring_batch_index++;
+            wire_task(rss, ws, wfanin);
             wired++;
         }
 
@@ -552,10 +540,8 @@ struct PTO2SchedulerState {
      * producer's fanout_lock, allocates dep_pool entries for live producers,
      * pushes the task to the ready queue once its fanin refcount is satisfied.
      */
-    void wire_task(int ring_id, PTO2TaskSlotState *ws) {
-        auto &rss = ring_sched_states[ring_id];
+    void wire_task(RingSchedState &rss, PTO2TaskSlotState *ws, int32_t wfanin) {
         PTO2TaskPayload *wp = ws->payload;
-        int32_t wfanin = wp->fanin_actual_count;
         ws->fanin_count = wfanin + 1;
 
         if (wfanin != 0) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -432,6 +432,7 @@ struct PTO2SpscQueue {
     uint64_t mask_{0};
 
     bool init(uint64_t capacity) {
+        if (capacity == 0 || (capacity & (capacity - 1)) != 0) return false;
         buffer_ = static_cast<PTO2TaskSlotState **>(calloc(capacity, sizeof(PTO2TaskSlotState *)));
         if (!buffer_) return false;
         mask_ = capacity - 1;
@@ -450,6 +451,10 @@ struct PTO2SpscQueue {
     }
 
     // Push one item (producer only). Returns false if queue is full.
+    // Full condition: next_h - tail > mask_ (i.e. > capacity-1), meaning all
+    // capacity slots are occupied. This uses strict '>' so all capacity slots
+    // are usable (no wasted sentinel slot). uint64_t wrapping is safe since
+    // head and tail are monotonically increasing and subtraction wraps correctly.
     bool push(PTO2TaskSlotState *item) {
         uint64_t h = head_.load(std::memory_order_relaxed);
         uint64_t next_h = h + 1;
@@ -558,10 +563,10 @@ struct PTO2SchedulerState {
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
     // Global wiring batch buffer — thread 0 only, tight layout for cache locality.
-    // count(4B) + index(4B) + batch[15](120B) = 128B = exactly 2 cache lines.
+    // count(4B) + index(4B) + batch[31](248B) = 256B = exactly 4 cache lines.
     int wiring_batch_count = 0;
     int wiring_batch_index = 0;
-    static constexpr int WIRING_BATCH_SIZE = 31;
+    static constexpr uint64_t WIRING_BATCH_SIZE = 31;
     PTO2TaskSlotState *wiring_batch[WIRING_BATCH_SIZE];
 
     // Global wiring queue — refill path only (every BATCH_SIZE tasks), separate cache line.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -578,6 +578,12 @@ struct PTO2SchedulerState {
     // wiring backoff to ensure pending tasks are wired promptly.
     alignas(64) std::atomic<bool> orch_needs_drain{false};
 
+    // Backoff counter: when queue size < WIRING_BATCH_SIZE, increment instead
+    // of popping. After WIRING_BACKOFF_LIMIT consecutive deferrals, force a pop
+    // to prevent deadlock (allocator may be waiting for wiring to advance ring).
+    static constexpr int WIRING_BACKOFF_LIMIT = 32;
+    int wiring_backoff_counter;
+
     // Statistics
 #if PTO2_SCHED_PROFILING
     std::atomic<int64_t> tasks_completed;
@@ -601,13 +607,16 @@ struct PTO2SchedulerState {
 
         // Refill local batch buffer when exhausted.
         if (wiring_batch_index >= wiring_batch_count) {
-            // Backoff: skip pop when fewer than WIRING_BACKOFF_THRESHOLD tasks
-            // are queued, reducing contention with the orchestrator's push path.
-            // Bypassed when force_drain is set (orchestrator done — must flush tail)
-            // or when orch_needs_drain is set (orchestrator is spin-waiting on tensor data).
-            if (!force_drain && !orch_needs_drain.load(std::memory_order_acquire) &&
-                wiring_queue.size() < WIRING_BATCH_SIZE)
-                return 0;
+            // Backoff: defer pop when queue holds fewer than a full batch,
+            // unless force_drain, orch_needs_drain, or backoff limit reached.
+            if (!force_drain && wiring_queue.size() < WIRING_BATCH_SIZE) {
+                if (!orch_needs_drain.load(std::memory_order_acquire) &&
+                    wiring_backoff_counter < WIRING_BACKOFF_LIMIT) {
+                    wiring_backoff_counter++;
+                    return 0;
+                }
+            }
+            wiring_backoff_counter = 0;
             wiring_batch_count = wiring_queue.pop_batch(wiring_batch, WIRING_BATCH_SIZE);
             wiring_batch_index = 0;
             if (wiring_batch_count == 0) return 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -404,6 +404,92 @@ bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity);
 void pto2_ready_queue_destroy(PTO2ReadyQueue *queue);
 
 // =============================================================================
+// SPSC Queue (Single-Producer Single-Consumer, wait-free)
+// =============================================================================
+//
+// Bounded ring buffer optimized for the wiring queue use case:
+//   - Producer: orchestrator thread (push)
+//   - Consumer: scheduler thread 0 (pop_batch)
+//
+// Design based on Rigtorp's cached-index technique: each side caches
+// the other's index locally, avoiding cross-core cache line bouncing
+// on the hot path. Only when the local cache says "full" or "empty"
+// does the thread issue an acquire load on the remote index.
+//
+// Memory layout: 4 cache-line-aligned fields ensure zero false sharing.
+
+struct PTO2SpscQueue {
+    // --- Producer cache lines (orchestrator thread) ---
+    alignas(64) std::atomic<uint64_t> head_{0};
+    alignas(64) uint64_t tail_cached_{0};
+
+    // --- Consumer cache lines (scheduler thread 0) ---
+    alignas(64) std::atomic<uint64_t> tail_{0};
+    alignas(64) uint64_t head_cached_{0};
+
+    // --- Shared (immutable after init) ---
+    PTO2TaskSlotState **buffer_{nullptr};
+    uint64_t mask_{0};
+
+    bool init(uint64_t capacity) {
+        buffer_ = static_cast<PTO2TaskSlotState **>(calloc(capacity, sizeof(PTO2TaskSlotState *)));
+        if (!buffer_) return false;
+        mask_ = capacity - 1;
+        head_.store(0, std::memory_order_relaxed);
+        tail_.store(0, std::memory_order_relaxed);
+        tail_cached_ = 0;
+        head_cached_ = 0;
+        return true;
+    }
+
+    void destroy() {
+        if (buffer_) {
+            free(buffer_);
+            buffer_ = nullptr;
+        }
+    }
+
+    // Push one item (producer only). Returns false if queue is full.
+    bool push(PTO2TaskSlotState *item) {
+        uint64_t h = head_.load(std::memory_order_relaxed);
+        uint64_t next_h = h + 1;
+        if (next_h - tail_cached_ > mask_) {
+            tail_cached_ = tail_.load(std::memory_order_acquire);
+            if (next_h - tail_cached_ > mask_) {
+                return false;
+            }
+        }
+        buffer_[h & mask_] = item;
+        head_.store(next_h, std::memory_order_release);
+        return true;
+    }
+
+    // Pop up to max_count items (consumer only). Returns actual count.
+    int pop_batch(PTO2TaskSlotState **out, int max_count) {
+        uint64_t t = tail_.load(std::memory_order_relaxed);
+        uint64_t avail = head_cached_ - t;
+        if (avail == 0) {
+            head_cached_ = head_.load(std::memory_order_acquire);
+            avail = head_cached_ - t;
+            if (avail == 0) return 0;
+        }
+        int count = (avail < static_cast<uint64_t>(max_count)) ? static_cast<int>(avail) : max_count;
+        for (int i = 0; i < count; i++) {
+            out[i] = buffer_[(t + i) & mask_];
+        }
+        tail_.store(t + count, std::memory_order_release);
+        return count;
+    }
+
+    // Approximate size (used for backoff decisions, not exact).
+    uint64_t size() const {
+        uint64_t h = head_.load(std::memory_order_acquire);
+        uint64_t t = tail_.load(std::memory_order_acquire);
+        return h - t;
+    }
+};
+
+// =============================================================================
 // Scheduler State
 // =============================================================================
 
@@ -475,11 +561,11 @@ struct PTO2SchedulerState {
     // count(4B) + index(4B) + batch[15](120B) = 128B = exactly 2 cache lines.
     int wiring_batch_count = 0;
     int wiring_batch_index = 0;
-    static constexpr int WIRING_BATCH_SIZE = 15;
+    static constexpr int WIRING_BATCH_SIZE = 31;
     PTO2TaskSlotState *wiring_batch[WIRING_BATCH_SIZE];
 
     // Global wiring queue — refill path only (every BATCH_SIZE tasks), separate cache line.
-    alignas(64) PTO2ReadyQueue wiring_queue;
+    alignas(64) PTO2SpscQueue wiring_queue;
 
     // Statistics
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -573,6 +573,11 @@ struct PTO2SchedulerState {
     // Global wiring queue — refill path only (every BATCH_SIZE tasks), separate cache line.
     alignas(64) PTO2SpscQueue wiring_queue;
 
+    // Orchestrator urgency flag: set by orchestrator before spin-waiting on
+    // tensor data, cleared after wait completes. When true, scheduler bypasses
+    // wiring backoff to ensure pending tasks are wired promptly.
+    alignas(64) std::atomic<bool> orch_needs_drain{false};
+
     // Statistics
 #if PTO2_SCHED_PROFILING
     std::atomic<int64_t> tasks_completed;
@@ -598,8 +603,11 @@ struct PTO2SchedulerState {
         if (wiring_batch_index >= wiring_batch_count) {
             // Backoff: skip pop when fewer than WIRING_BACKOFF_THRESHOLD tasks
             // are queued, reducing contention with the orchestrator's push path.
-            // Bypassed when force_drain is set (orchestrator done — must flush tail).
-            if (!force_drain && wiring_queue.size() < WIRING_BATCH_SIZE) return 0;
+            // Bypassed when force_drain is set (orchestrator done — must flush tail)
+            // or when orch_needs_drain is set (orchestrator is spin-waiting on tensor data).
+            if (!force_drain && !orch_needs_drain.load(std::memory_order_acquire) &&
+                wiring_queue.size() < WIRING_BATCH_SIZE)
+                return 0;
             wiring_batch_count = wiring_queue.pop_batch(wiring_batch, WIRING_BATCH_SIZE);
             wiring_batch_index = 0;
             if (wiring_batch_count == 0) return 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -92,6 +92,12 @@ constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions a
 constexpr const char *DEFAULT_ORCH_ENTRY_SYMBOL = "aicpu_orchestration_entry";
 constexpr const char *DEFAULT_ORCH_CONFIG_SYMBOL = "aicpu_orchestration_config";
 
+// Control flow signal from cold-path helpers back to the main dispatch loop.
+enum class LoopAction : int8_t {
+    NONE,        // cold path did not trigger; proceed normally
+    BREAK_LOOP,  // equivalent to 'break' from the while(true) loop
+};
+
 static int32_t read_pto2_runtime_status(Runtime *runtime) {
     if (runtime == nullptr) {
         return 0;
@@ -390,6 +396,43 @@ struct AicpuExecutor {
 
     CoreTracker core_trackers_[MAX_AICPU_THREADS];
 
+#if PTO2_PROFILING
+    // Per-thread scheduler profiling counters.
+    // Stored as member to avoid passing 20+ counters through function signatures.
+    // Each thread accesses only its own slot via thread_idx — no cross-thread access.
+    struct alignas(64) SchedProfilingCounters {
+        bool profiling_enabled{false};
+        uint64_t sched_start_ts{0};
+        uint64_t sched_scan_cycle{0};
+        uint64_t sched_complete_cycle{0};
+        uint64_t sched_dispatch_cycle{0};
+        uint64_t sched_wiring_cycle{0};
+        uint64_t sched_idle_cycle{0};
+        uint64_t sched_loop_count{0};
+        uint32_t phase_complete_count{0};
+        uint32_t phase_dispatch_count{0};
+#if PTO2_SCHED_PROFILING
+        uint32_t phase_wiring_count{0};
+        uint64_t complete_probe_count{0};
+        uint64_t complete_hit_count{0};
+        uint64_t notify_edges_total{0};
+        int32_t notify_max_degree{0};
+        uint64_t notify_tasks_enqueued{0};
+        uint64_t fanin_edges_total{0};
+        int32_t fanin_max_degree{0};
+        uint64_t pop_hit{0};
+        uint64_t pop_miss{0};
+        uint64_t local_dispatch_count{0};
+        uint64_t local_overflow_count{0};
+        uint64_t sched_complete_perf_cycle{0};
+        uint64_t sched_dispatch_pop_cycle{0};
+        uint64_t sched_dispatch_setup_cycle{0};
+#endif
+        void reset() { *this = SchedProfilingCounters{}; }
+    };
+    SchedProfilingCounters sched_perf_[MAX_AICPU_THREADS];
+#endif
+
     // ===== sync_start drain coordination =====
 
     // When sync_start_pending != 0, all scheduler threads skip Phase 2 dispatch
@@ -452,6 +495,325 @@ struct AicpuExecutor {
         Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
     );
 
+    // --- Cold-path helpers for resolve_and_dispatch_pto2 (noinline to reduce hot-loop icache) ---
+
+    __attribute__((noinline, cold)) LoopAction handle_orchestrator_exit(
+        int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t &task_count
+    ) {
+        bool orch_done = orchestrator_done_;
+        if (!orch_done) return LoopAction::NONE;
+
+        int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
+        if (orch_err != PTO2_ERROR_NONE) {
+            DEV_ERROR(
+                "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
+                "completed_tasks=%d, total_tasks=%d",
+                thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
+            );
+            emergency_shutdown(runtime);
+            completed_.store(true, std::memory_order_release);
+            return LoopAction::BREAK_LOOP;
+        }
+
+        task_count = total_tasks_;
+        if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
+            completed_.store(true, std::memory_order_release);
+            DEV_INFO(
+                "Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed),
+                task_count
+            );
+            return LoopAction::BREAK_LOOP;
+        }
+        return LoopAction::NONE;
+    }
+
+    __attribute__((noinline, cold)) LoopAction handle_core_transition(bool &cores_released) {
+        if (!transition_requested_.load(std::memory_order_acquire)) return LoopAction::NONE;
+        if (!reassigned_.load(std::memory_order_acquire)) {
+            wait_reassign_.fetch_add(1, std::memory_order_release);
+            while (!reassigned_.load(std::memory_order_acquire)) {
+                if (completed_.load(std::memory_order_acquire)) {
+                    return LoopAction::BREAK_LOOP;
+                }
+                SPIN_WAIT_HINT();
+            }
+        }
+        cores_released = true;
+        return LoopAction::NONE;
+    }
+
+    __attribute__((noinline, cold)) LoopAction
+    check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime) {
+        int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
+        if (orch_err != PTO2_ERROR_NONE) {
+            DEV_ERROR(
+                "Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx, orch_err
+            );
+            emergency_shutdown(runtime);
+            completed_.store(true, std::memory_order_release);
+            return LoopAction::BREAK_LOOP;
+        }
+        return LoopAction::NONE;
+    }
+
+    __attribute__((noinline, cold)) void log_stall_diagnostics(
+        int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count, void *sm_base
+    ) {
+        int32_t c = completed_tasks_.load(std::memory_order_relaxed);
+        DEV_ALWAYS(
+            "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)", idle_iterations,
+            c, task_count, last_progress_count
+        );
+        CoreTracker &tracker = core_trackers_[thread_idx];
+        PTO2SchedulerState *sched = &rt->scheduler;
+        PTO2SharedMemoryHeader *sm_header_diag = static_cast<PTO2SharedMemoryHeader *>(sm_base);
+        int32_t cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            int32_t ring_task_count = sm_header_diag->rings[r].fc.current_task_index.load(std::memory_order_relaxed);
+            for (int32_t si = 0; si < ring_task_count; si++) {
+                PTO2TaskSlotState &slot_state = sched->get_slot_state(r, si);
+                PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
+                int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
+                int32_t fi = slot_state.fanin_count;
+                int32_t kid = slot_state.task->kernel_id[0];
+                if (st >= PTO2_TASK_COMPLETED) continue;
+                if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) {
+                    cnt_inflight++;
+                    continue;
+                }
+                if (rc >= fi) {
+                    cnt_ready++;
+                    if (cnt_ready <= STALL_DUMP_READY_MAX) {
+                        DEV_ALWAYS(
+                            "  STUCK-READY  ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
+                            static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
+                        );
+                    }
+                } else {
+                    cnt_waiting++;
+                    if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
+                        DEV_ALWAYS(
+                            "  STUCK-WAIT   ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
+                            static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
+                        );
+                    }
+                }
+            }
+        }
+        DEV_ALWAYS("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight);
+        int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
+        int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
+        int32_t total_running = aic_running + aiv_running;
+        int32_t core_num = core_count_per_thread_[thread_idx];
+        DEV_ALWAYS(
+            "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running,
+            aiv_running, core_num
+        );
+        auto all_running = tracker.get_all_running_cores();
+        int32_t dump_count = 0;
+        int32_t bp;
+        while (dump_count < STALL_DUMP_CORE_MAX && (bp = all_running.pop_first()) >= 0) {
+            dump_count++;
+            int32_t cid = tracker.get_core_id_by_offset(bp);
+            int32_t sw_tid = core_exec_states_[cid].running_reg_task_id;
+            int32_t hw_kernel = -1;
+            if (sw_tid >= 0 && core_exec_states_[cid].running_slot_state) {
+                int32_t diag_slot = static_cast<int32_t>(core_exec_states_[cid].running_subslot);
+                hw_kernel = core_exec_states_[cid].running_slot_state->task->kernel_id[diag_slot];
+            }
+            uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
+            DEV_ALWAYS(
+                "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid, static_cast<unsigned>(cond_reg),
+                EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg), sw_tid, hw_kernel
+            );
+        }
+        for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
+            int32_t offset = cli * 3;
+            DEV_ALWAYS(
+                "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
+                tracker.is_aic_core_idle(offset) ? "idle" : "busy", tracker.get_aiv0_core_id(offset),
+                tracker.is_aiv0_core_idle(offset) ? "idle" : "busy", tracker.get_aiv1_core_id(offset),
+                tracker.is_aiv1_core_idle(offset) ? "idle" : "busy"
+            );
+        }
+    }
+
+    __attribute__((noinline, cold)) int32_t handle_timeout_exit(
+        int32_t thread_idx, int32_t idle_iterations
+#if PTO2_PROFILING
+        ,
+        uint64_t sched_start_ts
+#endif
+    ) {
+        DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+#if PTO2_PROFILING
+        uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
+        DEV_ALWAYS(
+            "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+            static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_timeout_ts),
+            cycles_to_us(sched_timeout_ts - sched_start_ts)
+        );
+#endif
+        return -1;
+    }
+
+#if PTO2_PROFILING
+    __attribute__((noinline, cold)) void log_profiling_summary(int32_t thread_idx, int32_t cur_thread_completed) {
+        auto &perf = sched_perf_[thread_idx];
+        uint64_t sched_end_ts = get_sys_cnt_aicpu();
+        DEV_ALWAYS(
+            "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+            static_cast<uint64_t>(perf.sched_start_ts), static_cast<uint64_t>(sched_end_ts),
+            cycles_to_us(sched_end_ts - perf.sched_start_ts)
+        );
+
+        uint64_t sched_total = perf.sched_wiring_cycle + perf.sched_complete_cycle + perf.sched_scan_cycle +
+                               perf.sched_dispatch_cycle + perf.sched_idle_cycle;
+        if (sched_total == 0) sched_total = 1;
+
+#if PTO2_SCHED_PROFILING
+        {
+            PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
+            uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
+            uint64_t complete_poll = (perf.sched_complete_cycle > otc_total + perf.sched_complete_perf_cycle) ?
+                                         (perf.sched_complete_cycle - otc_total - perf.sched_complete_perf_cycle) :
+                                         0;
+            uint64_t dispatch_poll =
+                (perf.sched_dispatch_cycle > perf.sched_dispatch_pop_cycle + perf.sched_dispatch_setup_cycle) ?
+                    (perf.sched_dispatch_cycle - perf.sched_dispatch_pop_cycle - perf.sched_dispatch_setup_cycle) :
+                    0;
+
+            DEV_ALWAYS(
+                "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
+                cycles_to_us(sched_total), cur_thread_completed
+            );
+
+            double notify_avg =
+                cur_thread_completed > 0 ? static_cast<double>(perf.notify_edges_total) / cur_thread_completed : 0.0;
+            double fanin_avg =
+                cur_thread_completed > 0 ? static_cast<double>(perf.fanin_edges_total) / cur_thread_completed : 0.0;
+            DEV_ALWAYS(
+                "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
+                ", max_degree=%d, avg=%.1f]  [fanin: "
+                "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
+                thread_idx, cycles_to_us(perf.sched_complete_cycle), perf.sched_complete_cycle * 100.0 / sched_total,
+                static_cast<uint64_t>(perf.notify_edges_total), perf.notify_max_degree, notify_avg,
+                static_cast<uint64_t>(perf.fanin_edges_total), perf.fanin_max_degree, fanin_avg
+            );
+
+            uint64_t c_parent = perf.sched_complete_cycle > 0 ? perf.sched_complete_cycle : 1;
+            uint64_t complete_miss_count = (perf.complete_probe_count > perf.complete_hit_count) ?
+                                               (perf.complete_probe_count - perf.complete_hit_count) :
+                                               0;
+            double complete_hit_rate =
+                perf.complete_probe_count > 0 ? perf.complete_hit_count * 100.0 / perf.complete_probe_count : 0.0;
+            DEV_ALWAYS(
+                "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
+                thread_idx, cycles_to_us(complete_poll), complete_poll * 100.0 / c_parent,
+                static_cast<uint64_t>(perf.complete_hit_count), static_cast<uint64_t>(complete_miss_count),
+                complete_hit_rate
+            );
+            DEV_ALWAYS(
+                "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
+                cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
+                static_cast<uint64_t>(sp.lock_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
+                cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
+                static_cast<uint64_t>(sp.fanout_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+                cycles_to_us(sp.fanin_cycle), sp.fanin_cycle * 100.0 / c_parent,
+                static_cast<uint64_t>(sp.fanin_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+                cycles_to_us(sp.self_consumed_cycle), sp.self_consumed_cycle * 100.0 / c_parent,
+                static_cast<uint64_t>(sp.self_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx,
+                cycles_to_us(perf.sched_complete_perf_cycle), perf.sched_complete_perf_cycle * 100.0 / c_parent
+            );
+
+            uint64_t pop_total = perf.pop_hit + perf.pop_miss;
+            double pop_hit_rate = pop_total > 0 ? perf.pop_hit * 100.0 / pop_total : 0.0;
+            DEV_ALWAYS(
+                "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64
+                ", hit_rate=%.1f%%]",
+                thread_idx, cycles_to_us(perf.sched_dispatch_cycle), perf.sched_dispatch_cycle * 100.0 / sched_total,
+                static_cast<uint64_t>(perf.pop_hit), static_cast<uint64_t>(perf.pop_miss), pop_hit_rate
+            );
+            uint64_t global_dispatch_count = perf.pop_hit - perf.local_dispatch_count;
+            uint64_t total_dispatched = perf.local_dispatch_count + global_dispatch_count;
+            double local_hit_rate = total_dispatched > 0 ? perf.local_dispatch_count * 100.0 / total_dispatched : 0.0;
+            DEV_ALWAYS(
+                "Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
+                ", local_rate=%.1f%%",
+                thread_idx, static_cast<uint64_t>(perf.local_dispatch_count),
+                static_cast<uint64_t>(global_dispatch_count), static_cast<uint64_t>(perf.local_overflow_count),
+                local_hit_rate
+            );
+
+            uint64_t d_parent = perf.sched_dispatch_cycle > 0 ? perf.sched_dispatch_cycle : 1;
+            DEV_ALWAYS(
+                "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
+                dispatch_poll * 100.0 / d_parent
+            );
+            DEV_ALWAYS(
+                "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+                thread_idx, cycles_to_us(perf.sched_dispatch_pop_cycle),
+                perf.sched_dispatch_pop_cycle * 100.0 / d_parent,
+                cycles_to_us(perf.sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
+                static_cast<uint64_t>(sp.pop_atomic_count)
+            );
+            DEV_ALWAYS(
+                "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx,
+                cycles_to_us(perf.sched_dispatch_setup_cycle), perf.sched_dispatch_setup_cycle * 100.0 / d_parent
+            );
+
+            DEV_ALWAYS(
+                "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(perf.sched_scan_cycle),
+                perf.sched_scan_cycle * 100.0 / sched_total
+            );
+
+#if PTO2_SCHED_PROFILING
+            DEV_ALWAYS(
+                "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx,
+                cycles_to_us(perf.sched_wiring_cycle), perf.sched_wiring_cycle * 100.0 / sched_total,
+                perf.phase_wiring_count
+            );
+#else
+            DEV_ALWAYS(
+                "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(perf.sched_wiring_cycle),
+                perf.sched_wiring_cycle * 100.0 / sched_total
+            );
+#endif
+
+            DEV_ALWAYS(
+                "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(perf.sched_idle_cycle),
+                perf.sched_idle_cycle * 100.0 / sched_total
+            );
+
+            if (cur_thread_completed > 0) {
+                DEV_ALWAYS(
+                    "Thread %d:   avg/complete   : %.3fus", thread_idx,
+                    cycles_to_us(perf.sched_complete_cycle) / cur_thread_completed
+                );
+            }
+        }
+#endif
+        DEV_ALWAYS(
+            "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
+            cycles_to_us(sched_total), static_cast<uint64_t>(perf.sched_loop_count), cur_thread_completed
+        );
+    }
+#endif
+
     // --- Dual-slot state machine helpers ---
 
     // SlotTransition: pure event signals from a single register poll.
@@ -501,20 +863,16 @@ struct AicpuExecutor {
         PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
         int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
         PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
-        PTO2LocalReadyBuffer *local_bufs, CoreType ct
+        PTO2LocalReadyBuffer *local_bufs
 #if PTO2_PROFILING
         ,
-        bool profiling_enabled, uint32_t &phase_complete_count, uint64_t dispatch_ts
-#endif
-#if PTO2_SCHED_PROFILING
-        ,
-        uint64_t &notify_edges_total, int32_t &notify_max_degree, uint64_t &notify_tasks_enqueued,
-        uint64_t &fanin_edges_total, int32_t &fanin_max_degree, uint64_t &sched_complete_perf_cycle
+        uint64_t dispatch_ts
 #endif
     ) {
-#if !PTO2_PROFILING
+#if PTO2_PROFILING
+        auto &perf = sched_perf_[thread_idx];
+#else
         (void)hank;
-        (void)ct;
 #endif
         bool mixed_complete = rt->scheduler.on_subtask_complete(slot_state);
         if (mixed_complete) {
@@ -533,14 +891,14 @@ struct AicpuExecutor {
 #endif
 #if PTO2_SCHED_PROFILING
             PTO2CompletionStats cstats = rt->scheduler.on_mixed_task_complete(slot_state, thread_idx, local_bufs);
-            notify_edges_total += cstats.fanout_edges;
-            if (cstats.fanout_edges > notify_max_degree) notify_max_degree = cstats.fanout_edges;
-            notify_tasks_enqueued += cstats.tasks_enqueued;
-            phase_complete_count++;
+            perf.notify_edges_total += cstats.fanout_edges;
+            if (cstats.fanout_edges > perf.notify_max_degree) perf.notify_max_degree = cstats.fanout_edges;
+            perf.notify_tasks_enqueued += cstats.tasks_enqueued;
+            perf.phase_complete_count++;
 #else
             rt->scheduler.on_mixed_task_complete(slot_state, local_bufs);
 #if PTO2_PROFILING
-            phase_complete_count++;
+            perf.phase_complete_count++;
 #endif
 #endif
             if (deferred_release_count < 256) {
@@ -552,13 +910,10 @@ struct AicpuExecutor {
                     int32_t fe = rt->scheduler.on_task_release(
                         *deferred_release_slot_states[--deferred_release_count], thread_idx
                     );
+                    perf.fanin_edges_total += fe;
+                    if (fe > perf.fanin_max_degree) perf.fanin_max_degree = fe;
 #else
-                    int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
-#endif
-                    (void)fe;
-#if PTO2_SCHED_PROFILING
-                    fanin_edges_total += fe;
-                    if (fe > fanin_max_degree) fanin_max_degree = fe;
+                    rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
                 }
                 deferred_release_slot_states[deferred_release_count++] = &slot_state;
@@ -567,13 +922,13 @@ struct AicpuExecutor {
         }
 
 #if PTO2_PROFILING
-        if (profiling_enabled) {
+        if (perf.profiling_enabled) {
 #if PTO2_SCHED_PROFILING
             uint64_t t_perf_start = get_sys_cnt_aicpu();
 #endif
             Handshake *h = &hank[core_id];
             uint64_t finish_ts = get_sys_cnt_aicpu();
-            PerfBuffer *perf_buf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
+            PerfBuffer *pbuf = reinterpret_cast<PerfBuffer *>(h->perf_records_addr);
 
             uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
             int32_t fanout_n = 0;
@@ -585,8 +940,9 @@ struct AicpuExecutor {
 
             int32_t perf_slot_idx = static_cast<int32_t>(subslot);
             if (perf_aicpu_complete_record(
-                    perf_buf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
-                    slot_state.task->kernel_id[perf_slot_idx], ct, dispatch_ts, finish_ts, fanout_arr, fanout_n
+                    pbuf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
+                    slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts,
+                    fanout_arr, fanout_n
                 ) != 0) {
                 DEV_ERROR(
                     "Core %d: perf_aicpu_complete_record failed for task 0x%" PRIx64, core_id,
@@ -594,7 +950,7 @@ struct AicpuExecutor {
                 );
             }
 #if PTO2_SCHED_PROFILING
-            sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
+            perf.sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
 #endif
         }
 #endif
@@ -618,24 +974,16 @@ struct AicpuExecutor {
         core.running_reg_task_id = AICPU_TASK_INVALID;
     }
 
-    template <CoreType CT>
     void check_running_cores_for_completion(
         int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
         bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
         PTO2LocalReadyBuffer *local_bufs
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled, uint32_t &phase_complete_count
-#endif
-#if PTO2_SCHED_PROFILING
-        ,
-        uint64_t &complete_probe_count, uint64_t &complete_hit_count, uint64_t &notify_edges_total,
-        int32_t &notify_max_degree, uint64_t &notify_tasks_enqueued, uint64_t &fanin_edges_total,
-        int32_t &fanin_max_degree, uint64_t &sched_complete_perf_cycle
-#endif
     ) {
+#if PTO2_SCHED_PROFILING
+        auto &perf = sched_perf_[thread_idx];
+#endif
         CoreTracker &tracker = core_trackers_[thread_idx];
-        auto running_core_states = tracker.get_running_cores<CT>();
+        auto running_core_states = tracker.get_all_running_cores();
         while (running_core_states.has_value()) {
             int32_t bit_pos = running_core_states.pop_first();
             int32_t core_id = tracker.get_core_id_by_offset(bit_pos);
@@ -647,8 +995,8 @@ struct AicpuExecutor {
             int32_t reg_state = EXTRACT_TASK_STATE(reg_val);
 
 #if PTO2_SCHED_PROFILING
-            if (profiling_enabled) {
-                complete_probe_count++;
+            if (perf.profiling_enabled) {
+                perf.complete_probe_count++;
             }
 #endif
 
@@ -657,8 +1005,8 @@ struct AicpuExecutor {
             if (!t.matched) continue;
 
 #if PTO2_SCHED_PROFILING
-            if (profiling_enabled && (t.running_done || t.pending_done)) {
-                complete_hit_count++;
+            if (perf.profiling_enabled && (t.running_done || t.pending_done)) {
+                perf.complete_hit_count++;
             }
 #endif
 
@@ -668,15 +1016,10 @@ struct AicpuExecutor {
             if (t.pending_done) {
                 complete_slot_task(
                     *core.pending_slot_state, core.pending_reg_task_id, core.pending_subslot, thread_idx, core_id, hank,
-                    completed_this_turn, deferred_release_slot_states, deferred_release_count, local_bufs, CT
+                    completed_this_turn, deferred_release_slot_states, deferred_release_count, local_bufs
 #if PTO2_PROFILING
                     ,
-                    profiling_enabled, phase_complete_count, core.pending_dispatch_timestamp
-#endif
-#if PTO2_SCHED_PROFILING
-                    ,
-                    notify_edges_total, notify_max_degree, notify_tasks_enqueued, fanin_edges_total, fanin_max_degree,
-                    sched_complete_perf_cycle
+                    core.pending_dispatch_timestamp
 #endif
                 );
                 cur_thread_completed++;
@@ -684,15 +1027,10 @@ struct AicpuExecutor {
             if (t.running_done) {
                 complete_slot_task(
                     *core.running_slot_state, core.running_reg_task_id, core.running_subslot, thread_idx, core_id, hank,
-                    completed_this_turn, deferred_release_slot_states, deferred_release_count, local_bufs, CT
+                    completed_this_turn, deferred_release_slot_states, deferred_release_count, local_bufs
 #if PTO2_PROFILING
                     ,
-                    profiling_enabled, phase_complete_count, core.running_dispatch_timestamp
-#endif
-#if PTO2_SCHED_PROFILING
-                    ,
-                    notify_edges_total, notify_max_degree, notify_tasks_enqueued, fanin_edges_total, fanin_max_degree,
-                    sched_complete_perf_cycle
+                    core.running_dispatch_timestamp
 #endif
                 );
                 cur_thread_completed++;
@@ -770,26 +1108,23 @@ struct AicpuExecutor {
     int pop_ready_tasks_batch(
         PTO2ResourceShape shape, int32_t thread_idx, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out,
         int max_count
-#if PTO2_SCHED_PROFILING
-        ,
-        uint64_t &pop_hit, uint64_t &pop_miss, uint64_t &local_dispatch_count, uint64_t &sched_dispatch_pop_cycle
-#endif
     ) {
-        (void)thread_idx;
 #if PTO2_SCHED_PROFILING
+        auto &perf = sched_perf_[thread_idx];
         extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
         uint64_t t_pop_start = get_sys_cnt_aicpu();
         int count = rt->scheduler.get_ready_tasks_batch(
             shape, local_buf, out, max_count, g_sched_pop_atomic_count[thread_idx], g_sched_pop_wait_cycle[thread_idx],
-            local_dispatch_count
+            perf.local_dispatch_count
         );
-        sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
+        perf.sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
         if (count > 0) {
-            pop_hit += count;
+            perf.pop_hit += count;
         } else {
-            pop_miss++;
+            perf.pop_miss++;
         }
 #else
+        (void)thread_idx;
         int count = rt->scheduler.get_ready_tasks_batch(shape, local_buf, out, max_count);
 #endif
         return count;
@@ -830,14 +1165,15 @@ struct AicpuExecutor {
     }
 
     void dispatch_subtask_to_core(
-        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, bool to_pending
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled
-#endif
+        Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,
+        PTO2SubtaskSlot subslot, bool to_pending
     ) {
         CoreTracker &tracker = core_trackers_[thread_idx];
         auto core_id = tracker.get_core_id_by_offset(core_offset);
+        (void)runtime;
+#if PTO2_PROFILING
+        auto &perf = sched_perf_[thread_idx];
+#endif
         CoreExecState &core_exec_state = core_exec_states_[core_id];
         // Per-core monotonic counter for register protocol uniqueness (32-bit).
         // PTO2 task_id encodes (ring_id << 32 | local_id); truncation to uint32 loses ring_id,
@@ -870,7 +1206,7 @@ struct AicpuExecutor {
             core_exec_state.pending_slot_state = &slot_state;
             core_exec_state.pending_reg_task_id = static_cast<int32_t>(reg_task_id);
 #if PTO2_PROFILING
-            if (profiling_enabled) {
+            if (perf.profiling_enabled) {
                 core_exec_state.pending_dispatch_timestamp = get_sys_cnt_aicpu();
             }
 #endif
@@ -879,7 +1215,7 @@ struct AicpuExecutor {
             core_exec_state.running_slot_state = &slot_state;
             core_exec_state.running_reg_task_id = static_cast<int32_t>(reg_task_id);
 #if PTO2_PROFILING
-            if (profiling_enabled) {
+            if (perf.profiling_enabled) {
                 core_exec_state.running_dispatch_timestamp = get_sys_cnt_aicpu();
             }
 #endif
@@ -897,11 +1233,7 @@ struct AicpuExecutor {
     // Dispatch one SPMD block of a MIX task to the cluster at cluster_offset.
     // Reads slot_state.next_block_idx as block_idx; caller increments it afterwards.
     void dispatch_mix_block_to_cluster(
-        int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state, bool to_pending
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled
-#endif
+        Runtime *runtime, int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state, bool to_pending
     ) {
         CoreTracker &tracker = core_trackers_[thread_idx];
         uint8_t core_mask = pto2_core_mask(slot_state.active_mask);
@@ -911,34 +1243,22 @@ struct AicpuExecutor {
         if (core_mask & PTO2_SUBTASK_MASK_AIC) {
             bool aic_to_pending = to_pending && !tracker.is_aic_core_idle(cluster_offset);
             dispatch_subtask_to_core(
-                thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC,
+                runtime, thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC,
                 aic_to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
             );
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV0) {
             bool aiv0_to_pending = to_pending && !tracker.is_aiv0_core_idle(cluster_offset);
             dispatch_subtask_to_core(
-                thread_idx, tracker.get_aiv0_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV0,
+                runtime, thread_idx, tracker.get_aiv0_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV0,
                 aiv0_to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
             );
         }
         if (core_mask & PTO2_SUBTASK_MASK_AIV1) {
             bool aiv1_to_pending = to_pending && !tracker.is_aiv1_core_idle(cluster_offset);
             dispatch_subtask_to_core(
-                thread_idx, tracker.get_aiv1_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV1,
+                runtime, thread_idx, tracker.get_aiv1_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV1,
                 aiv1_to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
             );
         }
     }
@@ -974,11 +1294,8 @@ struct AicpuExecutor {
     // per-core bit offset (already resolved by the caller in both idle and pending phases).
     // Caller is responsible for incrementing slot_state.next_block_idx after this returns.
     void dispatch_block(
-        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape, bool to_pending
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled, uint32_t &phase_dispatch_count
-#endif
+        Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,
+        PTO2ResourceShape shape, bool to_pending
     ) {
 #if PTO2_PROFILING
         if (get_enable_dump_tensor()) {
@@ -994,32 +1311,14 @@ struct AicpuExecutor {
         }
 #endif
         if (shape == PTO2ResourceShape::MIX) {
-            dispatch_mix_block_to_cluster(
-                thread_idx, core_offset, slot_state, to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
-            );
+            dispatch_mix_block_to_cluster(runtime, thread_idx, core_offset, slot_state, to_pending);
         } else if (shape == PTO2ResourceShape::AIC) {
-            dispatch_subtask_to_core(
-                thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIC, to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
-            );
+            dispatch_subtask_to_core(runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIC, to_pending);
         } else {  // AIV — core_offset already resolved by caller in both phases
-            dispatch_subtask_to_core(
-                thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIV0, to_pending
-#if PTO2_PROFILING
-                ,
-                profiling_enabled
-#endif
-            );
+            dispatch_subtask_to_core(runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIV0, to_pending);
         }
 #if PTO2_PROFILING
-        phase_dispatch_count += __builtin_popcount(pto2_core_mask(slot_state.active_mask));
+        sched_perf_[thread_idx].phase_dispatch_count += __builtin_popcount(pto2_core_mask(slot_state.active_mask));
 #endif
     }
 
@@ -1027,18 +1326,13 @@ struct AicpuExecutor {
     // IDLE: dispatches to idle cores, supports sync_start/drain, multi-block do-while.
     // PENDING: dispatches to pending slots of running cores, skips sync_start tasks.
     void dispatch_shape(
-        int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase, PTO2LocalReadyBuffer &local_buf,
-        CoreTracker &tracker, bool &entered_drain, bool &made_progress, bool &try_pushed
-#if PTO2_SCHED_PROFILING
-        ,
-        uint64_t &pop_hit, uint64_t &pop_miss, uint64_t &local_dispatch_count, uint64_t &sched_dispatch_pop_cycle,
-        uint64_t &sched_dispatch_setup_cycle
-#endif
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled, uint32_t &phase_dispatch_count
-#endif
+        Runtime *runtime, int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase,
+        PTO2LocalReadyBuffer &local_buf, CoreTracker &tracker, bool &entered_drain, bool &made_progress,
+        bool &try_pushed
     ) {
+#if PTO2_SCHED_PROFILING
+        auto &perf = sched_perf_[thread_idx];
+#endif
         if (entered_drain) return;
 
         bool is_pending = (phase == CoreTracker::DispatchPhase::PENDING);
@@ -1048,13 +1342,7 @@ struct AicpuExecutor {
         while (cores.has_value() && !entered_drain) {
             int want = cores.count();
             PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
-            int got = pop_ready_tasks_batch(
-                shape, thread_idx, local_buf, batch, want
-#if PTO2_SCHED_PROFILING
-                ,
-                pop_hit, pop_miss, local_dispatch_count, sched_dispatch_pop_cycle
-#endif
-            );
+            int got = pop_ready_tasks_batch(shape, thread_idx, local_buf, batch, want);
             if (got == 0) break;
 
             bool dispatched_any = false;
@@ -1096,13 +1384,7 @@ struct AicpuExecutor {
                 // Dispatch as many blocks as possible for this task.
                 do {
                     auto core_offset = cores.pop_first();
-                    dispatch_block(
-                        thread_idx, core_offset, *slot_state, shape, is_pending
-#if PTO2_PROFILING
-                        ,
-                        profiling_enabled, phase_dispatch_count
-#endif
-                    );
+                    dispatch_block(runtime, thread_idx, core_offset, *slot_state, shape, is_pending);
                     slot_state->next_block_idx++;
                     DEV_DEBUG(
                         "Thread %d: Dispatched %s %s task %" PRId64 " block %d/%d to core_offset %d", thread_idx,
@@ -1117,7 +1399,7 @@ struct AicpuExecutor {
                 }
                 made_progress = true;
 #if PTO2_SCHED_PROFILING
-                sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
+                perf.sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
             }
 
@@ -1144,13 +1426,7 @@ struct AicpuExecutor {
     // Drain worker: dispatch all blocks in one pass across all threads' trackers.
     // Called only when global resources >= block_num, so one pass always suffices.
     // All other threads are spinning — the drain worker has exclusive tracker access.
-    void drain_worker_dispatch(
-        int32_t block_num
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled, uint32_t &phase_dispatch_count
-#endif
-    ) {
+    void drain_worker_dispatch(Runtime *runtime, int32_t block_num) {
         PTO2TaskSlotState *slot_state = drain_state_.pending_task;
         if (!slot_state) {
             drain_state_.sync_start_pending.store(0, std::memory_order_release);
@@ -1161,13 +1437,7 @@ struct AicpuExecutor {
         for (int32_t t = 0; t < active_sched_threads_ && slot_state->next_block_idx < block_num; t++) {
             auto valid = core_trackers_[t].get_idle_core_offset_states(shape);
             while (valid.has_value() && slot_state->next_block_idx < block_num) {
-                dispatch_block(
-                    t, valid.pop_first(), *slot_state, shape, false
-#if PTO2_PROFILING
-                    ,
-                    profiling_enabled, phase_dispatch_count
-#endif
-                );
+                dispatch_block(runtime, t, valid.pop_first(), *slot_state, shape, false);
                 slot_state->next_block_idx++;
                 if (slot_state->next_block_idx < block_num)
                     valid = core_trackers_[t].get_idle_core_offset_states(shape);
@@ -1196,13 +1466,7 @@ struct AicpuExecutor {
     //   3. Dispatch: elected thread dispatches all blocks (one pass, resources guaranteed).
     //      Non-elected threads spin-wait until sync_start_pending == 0.
     //      During dispatch the elected thread has exclusive tracker access.
-    void handle_drain_mode(
-        int32_t thread_idx
-#if PTO2_PROFILING
-        ,
-        bool profiling_enabled, uint32_t &phase_dispatch_count
-#endif
-    ) {
+    void handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
         // Spin until drain is fully initialized (sentinel -1 → block_num > 0).
         int32_t block_num;
         do {
@@ -1253,13 +1517,7 @@ struct AicpuExecutor {
         }
 
         // Dispatch — all other threads are spinning, elected thread has exclusive tracker access.
-        drain_worker_dispatch(
-            block_num
-#if PTO2_PROFILING
-            ,
-            profiling_enabled, phase_dispatch_count
-#endif
-        );
+        drain_worker_dispatch(runtime, block_num);
     }
 };
 
@@ -1676,36 +1934,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     int32_t idle_iterations = 0;
     int32_t last_progress_count = 0;
 #if PTO2_PROFILING
-    bool profiling_enabled = runtime->enable_profiling;
-#endif
-
-    // Scheduler profiling counters
-#if PTO2_PROFILING
-    uint64_t sched_scan_cycle = 0;
-    uint64_t sched_complete_cycle = 0;
-    uint64_t sched_dispatch_cycle = 0;
-    uint64_t sched_wiring_cycle = 0;
-    uint64_t sched_idle_cycle = 0;
-    uint64_t sched_loop_count = 0;
-    uint32_t phase_complete_count = 0;
-    uint32_t phase_dispatch_count = 0;
-#if PTO2_SCHED_PROFILING
-    uint32_t phase_wiring_count = 0;
-    uint64_t complete_probe_count = 0;
-    uint64_t complete_hit_count = 0;
-    uint64_t notify_edges_total = 0;
-    int32_t notify_max_degree = 0;
-    uint64_t notify_tasks_enqueued = 0;
-    uint64_t fanin_edges_total = 0;
-    int32_t fanin_max_degree = 0;
-    uint64_t pop_hit = 0;
-    uint64_t pop_miss = 0;
-    uint64_t local_dispatch_count = 0;
-    uint64_t local_overflow_count = 0;
-    uint64_t sched_complete_perf_cycle = 0;
-    uint64_t sched_dispatch_pop_cycle = 0;
-    uint64_t sched_dispatch_setup_cycle = 0;
-#endif
+    auto &perf = sched_perf_[thread_idx];
+    perf.reset();
+    perf.profiling_enabled = runtime->enable_profiling;
 #endif
 
     // Local-first dispatch buffers (stack-allocated, one per CoreType per scheduling thread).
@@ -1722,65 +1953,30 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     bool cores_released = false;
 
 #if PTO2_PROFILING
-    uint64_t sched_start_ts = get_sys_cnt_aicpu();
+    perf.sched_start_ts = get_sys_cnt_aicpu();
 #endif
 
     while (true) {
         bool made_progress = false;
 #if PTO2_PROFILING
         CYCLE_COUNT_START();
-        sched_loop_count++;
+        perf.sched_loop_count++;
         uint64_t _t0_phase = _t0;
 #endif
         int32_t task_count = 0;
         if (!tracker.has_any_running_cores()) {
-            bool orch_done = orchestrator_done_;
-            if (orch_done) {
-                // Check for orchestrator fatal error — exit immediately
-                int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
-                if (orch_err != PTO2_ERROR_NONE) {
-                    DEV_ERROR(
-                        "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
-                        "completed_tasks=%d, total_tasks=%d",
-                        thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
-                    );
-                    emergency_shutdown(runtime);
-                    completed_.store(true, std::memory_order_release);
-                    break;
-                }
-
-                // Normal exit: all tasks complete
-                task_count = total_tasks_;
-                if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
-                    completed_.store(true, std::memory_order_release);
-                    DEV_INFO(
-                        "Thread %d: PTO2 completed tasks %d/%d", thread_idx,
-                        completed_tasks_.load(std::memory_order_relaxed), task_count
-                    );
-                    break;
-                }
-            }
+            LoopAction action = handle_orchestrator_exit(thread_idx, header, runtime, task_count);
+            if (action == LoopAction::BREAK_LOOP) break;
         }
 
         // Check for core transition request (execute once per thread)
-        if (!cores_released && orch_to_sched_ && transition_requested_.load(std::memory_order_acquire)) {
-            if (!reassigned_.load(std::memory_order_acquire)) {
-                wait_reassign_.fetch_add(1, std::memory_order_release);
-                while (!reassigned_.load(std::memory_order_acquire)) {
-                    if (completed_.load(std::memory_order_acquire)) {
-                        break;
-                    }
-                    SPIN_WAIT_HINT();
-                }
-                if (completed_.load(std::memory_order_acquire)) {
-                    break;
-                }
-            }
-            cores_released = true;
+        if (!cores_released && orch_to_sched_) {
+            LoopAction action = handle_core_transition(cores_released);
+            if (action == LoopAction::BREAK_LOOP) break;
         }
 
 #if PTO2_PROFILING
-        CYCLE_COUNT_LAP(sched_idle_cycle);
+        CYCLE_COUNT_LAP(perf.sched_idle_cycle);
 #endif
 
         // Process completed and dispatch FIRST to minimize Sched (dispatch→finish) latency.
@@ -1790,40 +1986,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         // Phase 1: Check running cores for completion, process and move to idle
         int32_t completed_this_turn = 0;
 
-        // Check AIC running cores
-        bool try_completed = false;
-        if (tracker.has_running_cores<CoreType::AIC>()) {
-            try_completed = true;
-            check_running_cores_for_completion<CoreType::AIC>(
+        bool try_completed = tracker.has_any_running_cores();
+        if (try_completed) {
+            check_running_cores_for_completion(
                 thread_idx, hank, completed_this_turn, cur_thread_completed, made_progress,
                 deferred_release_slot_states, deferred_release_count, local_bufs
-#if PTO2_PROFILING
-                ,
-                profiling_enabled, phase_complete_count
-#endif
-#if PTO2_SCHED_PROFILING
-                ,
-                complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
-#endif
-            );
-        }
-
-        // Check AIV running cores
-        if (tracker.has_running_cores<CoreType::AIV>()) {
-            try_completed = true;
-            check_running_cores_for_completion<CoreType::AIV>(
-                thread_idx, hank, completed_this_turn, cur_thread_completed, made_progress,
-                deferred_release_slot_states, deferred_release_count, local_bufs
-#if PTO2_PROFILING
-                ,
-                profiling_enabled, phase_complete_count
-#endif
-#if PTO2_SCHED_PROFILING
-                ,
-                complete_probe_count, complete_hit_count, notify_edges_total, notify_max_degree, notify_tasks_enqueued,
-                fanin_edges_total, fanin_max_degree, sched_complete_perf_cycle
-#endif
             );
         }
         if (completed_this_turn > 0) {
@@ -1846,15 +2013,16 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 
 #if PTO2_PROFILING
         if (!try_completed) {
-            CYCLE_COUNT_LAP(sched_idle_cycle);
+            CYCLE_COUNT_LAP(perf.sched_idle_cycle);
         } else {
-            CYCLE_COUNT_LAP(sched_complete_cycle);
-            if (profiling_enabled && phase_complete_count > 0) {
+            CYCLE_COUNT_LAP(perf.sched_complete_cycle);
+            if (perf.profiling_enabled && perf.phase_complete_count > 0) {
                 perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, sched_loop_count, phase_complete_count
+                    thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, perf.sched_loop_count,
+                    perf.phase_complete_count
                 );
                 _t0_phase = _t1;
-                phase_complete_count = 0;
+                perf.phase_complete_count = 0;
             }
         }
 #endif
@@ -1863,32 +2031,24 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 
         // Phase 2 drain check: if a sync_start task is waiting for resources,
         // pause normal dispatch and let the drain protocol run.
-        // relaxed load is enough — drain state only needs to be visible within
-        // a few iterations; exact ordering is enforced inside handle_drain_mode.
         if (drain_state_.sync_start_pending.load(std::memory_order_acquire) != 0) {
-            handle_drain_mode(
-                thread_idx
-#if PTO2_PROFILING
-                ,
-                profiling_enabled, phase_dispatch_count
-#endif
-            );
+            handle_drain_mode(runtime, thread_idx);
             continue;
         }
 
         // Phase 3: Drain wiring queue — wire fanout edges for newly submitted tasks.
         // Only thread 0 does wiring to keep dep_pool single-threaded.
         if (thread_idx == 0) {
-            int wired = rt->scheduler.drain_wiring_queue();
+            int wired = rt->scheduler.drain_wiring_queue(orchestrator_done_);
             if (wired > 0) {
                 made_progress = true;
 #if PTO2_SCHED_PROFILING
-                phase_wiring_count += wired;
+                perf.phase_wiring_count += wired;
 #endif
             }
         }
 #if PTO2_PROFILING
-        CYCLE_COUNT_LAP(sched_wiring_cycle);
+        CYCLE_COUNT_LAP(perf.sched_wiring_cycle);
 #endif
 
         // Phase 4: Dispatch
@@ -1900,16 +2060,8 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             PTO2ResourceShape shape = dispatch_order[si];
             for (auto phase : {CoreTracker::DispatchPhase::IDLE, CoreTracker::DispatchPhase::PENDING}) {
                 dispatch_shape(
-                    thread_idx, shape, phase, local_bufs[static_cast<int32_t>(shape)], tracker, entered_drain,
+                    runtime, thread_idx, shape, phase, local_bufs[static_cast<int32_t>(shape)], tracker, entered_drain,
                     made_progress, try_pushed
-#if PTO2_SCHED_PROFILING
-                    ,
-                    pop_hit, pop_miss, local_dispatch_count, sched_dispatch_pop_cycle, sched_dispatch_setup_cycle
-#endif
-#if PTO2_PROFILING
-                    ,
-                    profiling_enabled, phase_dispatch_count
-#endif
                 );
             }
         }
@@ -1920,7 +2072,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             auto &local_buf = local_bufs[static_cast<int32_t>(shape)];
             auto &ready_queue = rt->scheduler.ready_queues[static_cast<int32_t>(shape)];
 #if PTO2_SCHED_PROFILING
-            local_overflow_count += local_buf.count;
+            perf.local_overflow_count += local_buf.count;
 #endif
             if (local_buf.count > 0) {
                 ready_queue.push_batch(local_buf.slot_states, local_buf.count);
@@ -1930,15 +2082,16 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 
 #if PTO2_PROFILING
         if (!try_pushed) {
-            CYCLE_COUNT_LAP(sched_idle_cycle);
+            CYCLE_COUNT_LAP(perf.sched_idle_cycle);
         } else {
-            CYCLE_COUNT_LAP(sched_dispatch_cycle);
-            if (profiling_enabled && phase_dispatch_count > 0) {
+            CYCLE_COUNT_LAP(perf.sched_dispatch_cycle);
+            if (perf.profiling_enabled && perf.phase_dispatch_count > 0) {
                 perf_aicpu_record_phase(
-                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, sched_loop_count, phase_dispatch_count
+                    thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, perf.sched_loop_count,
+                    perf.phase_dispatch_count
                 );
                 _t0_phase = _t1;
-                phase_dispatch_count = 0;
+                perf.phase_dispatch_count = 0;
             }
         }
 #endif
@@ -1958,13 +2111,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 #if PTO2_SCHED_PROFILING
                 int32_t fe =
                     rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
+
+                perf.fanin_edges_total += fe;
+                if (fe > perf.fanin_max_degree) perf.fanin_max_degree = fe;
 #else
-                int32_t fe = rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
-#endif
-                (void)fe;
-#if PTO2_SCHED_PROFILING
-                fanin_edges_total += fe;
-                if (fe > fanin_max_degree) fanin_max_degree = fe;
+                rt->scheduler.on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
             }
             idle_iterations++;
@@ -1973,128 +2124,30 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
             // orch_error_code is set in shared memory by the orchestrator's spin loop
             // BEFORE orchestrator_done_ is set, so this catches errors earlier.
             if (idle_iterations % FATAL_ERROR_CHECK_INTERVAL == 0) {
-                int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
-                if (orch_err != PTO2_ERROR_NONE) {
-                    DEV_ERROR(
-                        "Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx,
-                        orch_err
-                    );
-                    emergency_shutdown(runtime);
-                    completed_.store(true, std::memory_order_release);
-                    break;
-                }
+                LoopAction action = check_idle_fatal_error(thread_idx, header, runtime);
+                if (action == LoopAction::BREAK_LOOP) break;
             }
 
             if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
-                int32_t c = completed_tasks_.load(std::memory_order_relaxed);
-                DEV_ALWAYS(
-                    "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)",
-                    idle_iterations, c, task_count, last_progress_count
-                );
-                // Scan all task slots to find truly stuck tasks using scheduler state
-                PTO2SchedulerState *sched = &rt->scheduler;
-                PTO2SharedMemoryHeader *sm_header_diag = static_cast<PTO2SharedMemoryHeader *>(sm_base);
-                int32_t cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
-                for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                    int32_t ring_task_count =
-                        sm_header_diag->rings[r].fc.current_task_index.load(std::memory_order_relaxed);
-                    for (int32_t si = 0; si < ring_task_count; si++) {
-                        PTO2TaskSlotState &slot_state = sched->get_slot_state(r, si);
-                        PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
-                        int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
-                        int32_t fi = slot_state.fanin_count;
-                        int32_t kid = slot_state.task->kernel_id[0];
-                        if (st >= PTO2_TASK_COMPLETED) continue;  // Already done
-                        if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) {
-                            cnt_inflight++;
-                            continue;
-                        }
-                        // PENDING
-                        if (rc >= fi) {
-                            // Ready (all deps satisfied) but not enqueued — this is the real bug
-                            cnt_ready++;
-                            if (cnt_ready <= STALL_DUMP_READY_MAX) {
-                                DEV_ALWAYS(
-                                    "  STUCK-READY  ring=%d task_id=%" PRId64
-                                    " kernel_id=%d refcount=%d fanin=%d state=%d",
-                                    r, static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi,
-                                    static_cast<int32_t>(st)
-                                );
-                            }
-                        } else {
-                            cnt_waiting++;
-                            if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
-                                DEV_ALWAYS(
-                                    "  STUCK-WAIT   ring=%d task_id=%" PRId64
-                                    " kernel_id=%d refcount=%d fanin=%d state=%d",
-                                    r, static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi,
-                                    static_cast<int32_t>(st)
-                                );
-                            }
-                        }
-                    }
-                }
-                DEV_ALWAYS(
-                    "  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight
-                );
-                // Log this thread's dispatch state
-                int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
-                int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
-                int32_t total_running = aic_running + aiv_running;
-                DEV_ALWAYS(
-                    "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running,
-                    aiv_running, core_num
-                );
-                // Dump running cores
-                auto all_running = tracker.get_all_running_cores();
-                int32_t dump_count = 0;
-                int32_t bp;
-                while (dump_count < STALL_DUMP_CORE_MAX && (bp = all_running.pop_first()) >= 0) {
-                    dump_count++;
-                    int32_t cid = tracker.get_core_id_by_offset(bp);
-                    int32_t sw_tid = core_exec_states_[cid].running_reg_task_id;
-                    int32_t hw_kernel = -1;
-                    if (sw_tid >= 0 && core_exec_states_[cid].running_slot_state) {
-                        int32_t diag_slot = static_cast<int32_t>(core_exec_states_[cid].running_subslot);
-                        hw_kernel = core_exec_states_[cid].running_slot_state->task->kernel_id[diag_slot];
-                    }
-                    uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
-                    DEV_ALWAYS(
-                        "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid,
-                        static_cast<unsigned>(cond_reg), EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg),
-                        sw_tid, hw_kernel
-                    );
-                }
-                // Dump cluster state
-                for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
-                    int32_t offset = cli * 3;
-                    DEV_ALWAYS(
-                        "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
-                        tracker.is_aic_core_idle(offset) ? "idle" : "busy", tracker.get_aiv0_core_id(offset),
-                        tracker.is_aiv0_core_idle(offset) ? "idle" : "busy", tracker.get_aiv1_core_id(offset),
-                        tracker.is_aiv1_core_idle(offset) ? "idle" : "busy"
-                    );
-                }
+                log_stall_diagnostics(thread_idx, task_count, idle_iterations, last_progress_count, sm_base);
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
-                DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+                return handle_timeout_exit(
+                    thread_idx, idle_iterations
 #if PTO2_PROFILING
-                // Benchmark: scheduler lifetime end timestamp on timeout path
-                uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
-                DEV_ALWAYS(
-                    "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
-                    static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_timeout_ts),
-                    cycles_to_us(sched_timeout_ts - sched_start_ts)
-                );
+                    ,
+                    perf.sched_start_ts
 #endif
-                return -1;
+                );
             } else {
                 SPIN_WAIT_HINT();
             }
 #if PTO2_PROFILING
-            CYCLE_COUNT_LAP(sched_idle_cycle);
-            if (profiling_enabled) {
-                perf_aicpu_record_phase(thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT, _t0_phase, _t1, sched_loop_count, 0);
+            CYCLE_COUNT_LAP(perf.sched_idle_cycle);
+            if (perf.profiling_enabled) {
+                perf_aicpu_record_phase(
+                    thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT, _t0_phase, _t1, perf.sched_loop_count, 0
+                );
                 _t0_phase = _t1;
             }
 #endif
@@ -2102,161 +2155,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     }
 
 #if PTO2_PROFILING
-    // Record sched_end before any DEV_ALWAYS to avoid init cost contamination
-    uint64_t sched_end_ts = get_sys_cnt_aicpu();
-    DEV_ALWAYS(
-        "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
-        static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_end_ts),
-        cycles_to_us(sched_end_ts - sched_start_ts)
-    );
-
-    // Scheduler summary logging (always print when PTO2_PROFILING=1)
-    uint64_t sched_total =
-        sched_wiring_cycle + sched_complete_cycle + sched_scan_cycle + sched_dispatch_cycle + sched_idle_cycle;
-    if (sched_total == 0) sched_total = 1;  // avoid div-by-zero
-
-#if PTO2_SCHED_PROFILING
-    // Two-level tree display: sub-phase breakdown within complete and dispatch
-    {
-        PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
-        uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
-        uint64_t complete_poll = (sched_complete_cycle > otc_total + sched_complete_perf_cycle) ?
-                                     (sched_complete_cycle - otc_total - sched_complete_perf_cycle) :
-                                     0;
-        uint64_t dispatch_poll = (sched_dispatch_cycle > sched_dispatch_pop_cycle + sched_dispatch_setup_cycle) ?
-                                     (sched_dispatch_cycle - sched_dispatch_pop_cycle - sched_dispatch_setup_cycle) :
-                                     0;
-
-        DEV_ALWAYS(
-            "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
-            cycles_to_us(sched_total), cur_thread_completed
-        );
-
-        // Level 1: complete
-        double notify_avg =
-            cur_thread_completed > 0 ? static_cast<double>(notify_edges_total) / cur_thread_completed : 0.0;
-        double fanin_avg =
-            cur_thread_completed > 0 ? static_cast<double>(fanin_edges_total) / cur_thread_completed : 0.0;
-        DEV_ALWAYS(
-            "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
-            ", max_degree=%d, avg=%.1f]  [fanin: "
-            "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
-            thread_idx, cycles_to_us(sched_complete_cycle), sched_complete_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(notify_edges_total), notify_max_degree, notify_avg,
-            static_cast<uint64_t>(fanin_edges_total), fanin_max_degree, fanin_avg
-        );
-
-        // Level 2: complete sub-phases (percentage relative to complete)
-        uint64_t c_parent = sched_complete_cycle > 0 ? sched_complete_cycle : 1;
-        uint64_t complete_miss_count =
-            (complete_probe_count > complete_hit_count) ? (complete_probe_count - complete_hit_count) : 0;
-        double complete_hit_rate = complete_probe_count > 0 ? complete_hit_count * 100.0 / complete_probe_count : 0.0;
-        DEV_ALWAYS(
-            "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
-            thread_idx, cycles_to_us(complete_poll), complete_poll * 100.0 / c_parent,
-            static_cast<uint64_t>(complete_hit_count), static_cast<uint64_t>(complete_miss_count), complete_hit_rate
-        );
-        DEV_ALWAYS(
-            "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
-            cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
-            static_cast<uint64_t>(sp.lock_atomic_count)
-        );
-        DEV_ALWAYS(
-            "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
-            cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
-            cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
-            static_cast<uint64_t>(sp.fanout_atomic_count)
-        );
-        DEV_ALWAYS(
-            "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
-            cycles_to_us(sp.fanin_cycle), sp.fanin_cycle * 100.0 / c_parent,
-            static_cast<uint64_t>(sp.fanin_atomic_count)
-        );
-        DEV_ALWAYS(
-            "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
-            cycles_to_us(sp.self_consumed_cycle), sp.self_consumed_cycle * 100.0 / c_parent,
-            static_cast<uint64_t>(sp.self_atomic_count)
-        );
-        DEV_ALWAYS(
-            "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_complete_perf_cycle),
-            sched_complete_perf_cycle * 100.0 / c_parent
-        );
-
-        // Level 1: dispatch
-        uint64_t pop_total = pop_hit + pop_miss;
-        double pop_hit_rate = pop_total > 0 ? pop_hit * 100.0 / pop_total : 0.0;
-        DEV_ALWAYS(
-            "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%]",
-            thread_idx, cycles_to_us(sched_dispatch_cycle), sched_dispatch_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(pop_hit), static_cast<uint64_t>(pop_miss), pop_hit_rate
-        );
-        uint64_t global_dispatch_count = pop_hit - local_dispatch_count;
-        uint64_t total_dispatched = local_dispatch_count + global_dispatch_count;
-        double local_hit_rate = total_dispatched > 0 ? local_dispatch_count * 100.0 / total_dispatched : 0.0;
-        DEV_ALWAYS(
-            "Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
-            ", local_rate=%.1f%%",
-            thread_idx, static_cast<uint64_t>(local_dispatch_count), static_cast<uint64_t>(global_dispatch_count),
-            static_cast<uint64_t>(local_overflow_count), local_hit_rate
-        );
-
-        // Level 2: dispatch sub-phases (percentage relative to dispatch)
-        uint64_t d_parent = sched_dispatch_cycle > 0 ? sched_dispatch_cycle : 1;
-        DEV_ALWAYS(
-            "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
-            dispatch_poll * 100.0 / d_parent
-        );
-        DEV_ALWAYS(
-            "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
-            cycles_to_us(sched_dispatch_pop_cycle), sched_dispatch_pop_cycle * 100.0 / d_parent,
-            cycles_to_us(sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
-            static_cast<uint64_t>(sp.pop_atomic_count)
-        );
-        DEV_ALWAYS(
-            "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_dispatch_setup_cycle),
-            sched_dispatch_setup_cycle * 100.0 / d_parent
-        );
-
-        // Level 1: scan
-        DEV_ALWAYS(
-            "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_scan_cycle),
-            sched_scan_cycle * 100.0 / sched_total
-        );
-
-        // Level 1: wiring
-#if PTO2_SCHED_PROFILING
-        DEV_ALWAYS(
-            "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx, cycles_to_us(sched_wiring_cycle),
-            sched_wiring_cycle * 100.0 / sched_total, phase_wiring_count
-        );
-#else
-        DEV_ALWAYS(
-            "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_wiring_cycle),
-            sched_wiring_cycle * 100.0 / sched_total
-        );
-#endif
-
-        // Level 1: idle
-        DEV_ALWAYS(
-            "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(sched_idle_cycle),
-            sched_idle_cycle * 100.0 / sched_total
-        );
-
-        // Average per completion
-        if (cur_thread_completed > 0) {
-            DEV_ALWAYS(
-                "Thread %d:   avg/complete   : %.3fus", thread_idx,
-                cycles_to_us(sched_complete_cycle) / cur_thread_completed
-            );
-        }
-    }
-#endif
-    // Summary line (always print when PTO2_PROFILING=1)
-    DEV_ALWAYS(
-        "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
-        cycles_to_us(sched_total), static_cast<uint64_t>(sched_loop_count), cur_thread_completed
-    );
+    log_profiling_summary(thread_idx, cur_thread_completed);
 #endif
 
 #if PTO2_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -114,11 +114,11 @@ struct RingSchedState {
     int32_t task_window_size;
     int32_t task_window_mask;
     std::atomic<int32_t> advance_lock;
-    PTO2DepListPool dep_pool;  // fanout wiring dep pool (exclusively managed by scheduler thread 0)
+    alignas(64) PTO2DepListPool dep_pool;  // fanout wiring dep pool (thread 0 only, cache-isolated)
 };
 
 RingSchedState ring_sched_states[PTO2_MAX_RING_DEPTH];
-PTO2ReadyQueue wiring_queue;  // deferred fanout wiring from orchestrator
+PTO2SpscQueue wiring_queue;  // global SPSC queue: orchestrator pushes, scheduler thread 0 drains
 ```
 
 ### 4.6 PTO2TensorMap (modified)

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -405,7 +405,7 @@ Key members:
 
 ### 7.3 Deferred Fanout Wiring (Scheduler Wiring Queue)
 
-The orchestrator pushes each submitted task to the global `scheduler->wiring_queue` (a wait-free SPSC queue). Scheduler thread 0 drains this queue in batches (with backoff until batch-size items are queued), and for each task:
+The orchestrator pushes each submitted task to the global `scheduler->wiring_queue` (a wait-free SPSC queue). Scheduler thread 0 drains this queue in batches, deferring if the queue holds fewer than a full batch of items to reduce contention (unless a final flush is needed at end of execution). For each task:
 
 1. Sets `fanin_count = N + 1` (+1 redundance to prevent premature readiness)
 2. For each producer in `payload->fanin_slot_states[]`:

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -396,16 +396,16 @@ Key members:
 | 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers; collect producer pointers in `PTO2FaninBuilder` |
 | 4 | **Insert**: register OUTPUT/INOUT args in TensorMap |
 | 5 | **Record fanin metadata**: store producer pointers in `payload->fanin_inline_slot_states[]` (+ spill pool if >16); increment each producer's `fanout_count` (no lock needed — single writer) |
-| 6 | **Push to wiring queue**: scheduler thread 0 asynchronously wires fanout edges (lock + dep_pool + early_finished check + ready push) |
+| 6 | **Push to wiring queue**: push to global `PTO2SpscQueue`; scheduler thread 0 asynchronously wires fanout edges (lock + dep_pool + early_finished check + ready push) |
 
 > **Note**: Fanout wiring (Steps 4–7 in earlier versions) has been moved from the
-> orchestrator submit hot path to the scheduler's `wiring_queue`. This reduces the
+> orchestrator submit hot path to the scheduler's global `wiring_queue` (SPSC). This reduces the
 > orchestrator's shared L2 cache / memory bus pressure, as the orchestrator no longer
 > acquires `fanout_lock` or allocates from `dep_pool` during submission.
 
 ### 7.3 Deferred Fanout Wiring (Scheduler Wiring Queue)
 
-The orchestrator pushes each submitted task to `scheduler->wiring_queue`. Scheduler thread 0 drains this queue and, for each task:
+The orchestrator pushes each submitted task to the global `scheduler->wiring_queue` (a wait-free SPSC queue). Scheduler thread 0 drains this queue in batches (with backoff until batch-size items are queued), and for each task:
 
 1. Sets `fanin_count = N + 1` (+1 redundance to prevent premature readiness)
 2. For each producer in `payload->fanin_slot_states[]`:

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -823,8 +823,8 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
             producer->fanout_count += 1;
         });
 
-        // Push to per-ring wiring queue — scheduler sets fanin_count, wires fanout, checks readiness
-        while (!sched->ring_sched_states[ring_id].wiring_queue.push(&cur_slot_state)) {
+        // Push to global wiring queue — scheduler sets fanin_count, wires fanout, checks readiness
+        while (!sched->wiring_queue.push(&cur_slot_state)) {
             SPIN_WAIT_HINT();
         }
 #if PTO2_ORCH_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -561,8 +561,8 @@ struct PTO2DepListPool {
     std::atomic<int32_t> *error_code_ptr = nullptr;
 
     /**
-     * Initialize dependency list pool
      *
+     * Initialize dependency list pool
      * @param base      Pool base address from shared memory
      * @param capacity  Total number of entries
      */

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -108,6 +108,12 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         }
     }
 
+    // Signal scheduler: orchestrator is about to block, bypass wiring backoff
+    bool signaled = slot_count > 0 && orch.scheduler;
+    if (signaled) {
+        orch.scheduler->orch_needs_drain.store(true, std::memory_order_release);
+    }
+
     // Wait for each producer
     for (int p = 0; p < slot_count; p++) {
         PTO2TaskSlotState &slot = *slots[p];
@@ -119,6 +125,9 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+                if (signaled) {
+                    orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+                }
                 pto2_orch_report_fatal(
                     &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
                     "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
@@ -134,6 +143,9 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
             while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
                 SPIN_WAIT_HINT();
                 if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+                    if (signaled) {
+                        orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+                    }
                     pto2_orch_report_fatal(
                         &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
                         "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
@@ -144,6 +156,12 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
             }
         }
     }
+
+    // Clear urgency flag: orchestrator no longer blocking
+    if (signaled) {
+        orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+    }
+
     return true;
 }
 MAYBE_UNINITIALIZED_END

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -148,9 +148,6 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHandle *sm_handle,
         slot_states[i].ring_id = 0;
     }
 
-    wiring_batch_count = 0;
-    wiring_batch_index = 0;
-
     return true;
 }
 
@@ -193,30 +190,16 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
 
     // Initialize per-ring wiring queues and dep pools (exclusively managed by scheduler thread 0)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (!pto2_ready_queue_init(&sched->ring_sched_states[r].wiring_queue, PTO2_WRIRING_QUEUE_SIZE)) {
-            for (int j = 0; j < r; j++) {
-                pto2_ready_queue_destroy(&sched->ring_sched_states[j].wiring_queue);
-                free(sched->ring_sched_states[j].dep_pool.base);
-            }
-            for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-                pto2_ready_queue_destroy(&sched->ready_queues[i]);
-            }
-            for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
-                sched->ring_sched_states[rr].destroy();
-            }
-            return false;
-        }
         PTO2DepListEntry *dep_entries =
             reinterpret_cast<PTO2DepListEntry *>(calloc(dep_pool_capacity, sizeof(PTO2DepListEntry)));
         if (!dep_entries) {
-            pto2_ready_queue_destroy(&sched->ring_sched_states[r].wiring_queue);
             for (int j = 0; j < r; j++) {
-                pto2_ready_queue_destroy(&sched->ring_sched_states[j].wiring_queue);
                 free(sched->ring_sched_states[j].dep_pool.base);
             }
             for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
                 pto2_ready_queue_destroy(&sched->ready_queues[i]);
             }
+            sched->wiring_queue.destroy();
             for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
                 sched->ring_sched_states[rr].destroy();
             }
@@ -224,6 +207,22 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
         }
         sched->ring_sched_states[r].dep_pool.init(dep_entries, dep_pool_capacity, &sm_handle->header->orch_error_code);
     }
+
+    // Initialize global wiring queue (SPSC: orchestrator pushes, scheduler thread 0 drains)
+    if (!sched->wiring_queue.init(PTO2_WRIRING_QUEUE_SIZE)) {
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            free(sched->ring_sched_states[r].dep_pool.base);
+        }
+        for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+            pto2_ready_queue_destroy(&sched->ready_queues[i]);
+        }
+        for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
+            sched->ring_sched_states[rr].destroy();
+        }
+        return false;
+    }
+    sched->wiring_batch_count = 0;
+    sched->wiring_batch_index = 0;
 
     return true;
 }
@@ -233,8 +232,9 @@ void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
         sched->ring_sched_states[r].destroy();
         free(sched->ring_sched_states[r].dep_pool.base);
         sched->ring_sched_states[r].dep_pool.base = nullptr;
-        pto2_ready_queue_destroy(&sched->ring_sched_states[r].wiring_queue);
     }
+
+    sched->wiring_queue.destroy();
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         pto2_ready_queue_destroy(&sched->ready_queues[i]);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -223,6 +223,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
     }
     sched->wiring_batch_count = 0;
     sched->wiring_batch_index = 0;
+    sched->wiring_backoff_counter = 0;
 
     return true;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -451,10 +451,11 @@ struct PTO2SpscQueue {
     }
 
     // Push one item (producer only). Returns false if queue is full.
-    // Full condition: next_h - tail > mask_ (i.e. > capacity-1), meaning all
-    // capacity slots are occupied. This uses strict '>' so all capacity slots
-    // are usable (no wasted sentinel slot). uint64_t wrapping is safe since
-    // head and tail are monotonically increasing and subtraction wraps correctly.
+    // Full condition: next_h - tail > mask_ (i.e. > capacity-1), so the
+    // effective usable capacity is capacity-1 (one slot is wasted as a
+    // sentinel to distinguish full from empty). uint64_t wrapping is safe
+    // since head and tail are monotonically increasing and subtraction
+    // wraps correctly.
     bool push(PTO2TaskSlotState *item) {
         uint64_t h = head_.load(std::memory_order_relaxed);
         uint64_t next_h = h + 1;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -404,6 +404,97 @@ bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity);
 void pto2_ready_queue_destroy(PTO2ReadyQueue *queue);
 
 // =============================================================================
+// SPSC Queue (Single-Producer Single-Consumer, wait-free)
+// =============================================================================
+//
+// Bounded ring buffer optimized for the wiring queue use case:
+//   - Producer: orchestrator thread (push)
+//   - Consumer: scheduler thread 0 (pop_batch)
+//
+// Design based on Rigtorp's cached-index technique: each side caches
+// the other's index locally, avoiding cross-core cache line bouncing
+// on the hot path. Only when the local cache says "full" or "empty"
+// does the thread issue an acquire load on the remote index.
+//
+// Memory layout: 4 cache-line-aligned fields ensure zero false sharing.
+
+struct PTO2SpscQueue {
+    // --- Producer cache lines (orchestrator thread) ---
+    alignas(64) std::atomic<uint64_t> head_{0};
+    alignas(64) uint64_t tail_cached_{0};
+
+    // --- Consumer cache lines (scheduler thread 0) ---
+    alignas(64) std::atomic<uint64_t> tail_{0};
+    alignas(64) uint64_t head_cached_{0};
+
+    // --- Shared (immutable after init) ---
+    PTO2TaskSlotState **buffer_{nullptr};
+    uint64_t mask_{0};
+
+    bool init(uint64_t capacity) {
+        if (capacity == 0 || (capacity & (capacity - 1)) != 0) return false;
+        buffer_ = static_cast<PTO2TaskSlotState **>(calloc(capacity, sizeof(PTO2TaskSlotState *)));
+        if (!buffer_) return false;
+        mask_ = capacity - 1;
+        head_.store(0, std::memory_order_relaxed);
+        tail_.store(0, std::memory_order_relaxed);
+        tail_cached_ = 0;
+        head_cached_ = 0;
+        return true;
+    }
+
+    void destroy() {
+        if (buffer_) {
+            free(buffer_);
+            buffer_ = nullptr;
+        }
+    }
+
+    // Push one item (producer only). Returns false if queue is full.
+    // Full condition: next_h - tail > mask_ (i.e. > capacity-1), meaning all
+    // capacity slots are occupied. This uses strict '>' so all capacity slots
+    // are usable (no wasted sentinel slot). uint64_t wrapping is safe since
+    // head and tail are monotonically increasing and subtraction wraps correctly.
+    bool push(PTO2TaskSlotState *item) {
+        uint64_t h = head_.load(std::memory_order_relaxed);
+        uint64_t next_h = h + 1;
+        if (next_h - tail_cached_ > mask_) {
+            tail_cached_ = tail_.load(std::memory_order_acquire);
+            if (next_h - tail_cached_ > mask_) {
+                return false;
+            }
+        }
+        buffer_[h & mask_] = item;
+        head_.store(next_h, std::memory_order_release);
+        return true;
+    }
+
+    // Pop up to max_count items (consumer only). Returns actual count.
+    int pop_batch(PTO2TaskSlotState **out, int max_count) {
+        uint64_t t = tail_.load(std::memory_order_relaxed);
+        uint64_t avail = head_cached_ - t;
+        if (avail == 0) {
+            head_cached_ = head_.load(std::memory_order_acquire);
+            avail = head_cached_ - t;
+            if (avail == 0) return 0;
+        }
+        int count = (avail < static_cast<uint64_t>(max_count)) ? static_cast<int>(avail) : max_count;
+        for (int i = 0; i < count; i++) {
+            out[i] = buffer_[(t + i) & mask_];
+        }
+        tail_.store(t + count, std::memory_order_release);
+        return count;
+    }
+
+    // Approximate size (used for backoff decisions, not exact).
+    uint64_t size() const {
+        uint64_t h = head_.load(std::memory_order_acquire);
+        uint64_t t = tail_.load(std::memory_order_acquire);
+        return h - t;
+    }
+};
+
+// =============================================================================
 // Scheduler State
 // =============================================================================
 
@@ -430,26 +521,16 @@ struct PTO2SchedulerState {
 
     // Per-ring state
     struct RingSchedState {
+        // --- Completion/dispatch hot path (all scheduler threads) ---
         PTO2TaskDescriptor *task_descriptors;
         PTO2TaskSlotState *slot_states;
         int32_t last_task_alive;
         int32_t task_window_mask;
         uint64_t task_window_size;
-        // Try-lock used to advance this ring's last_task_alive pointer.
-        std::atomic<int32_t> advance_lock;
+        std::atomic<int32_t> advance_lock;  // multi-thread CAS
 
-        // Dep pool for fanout wiring (exclusively managed by scheduler thread 0)
-        PTO2DepListPool dep_pool;
-
-        // Per-ring wiring queue: orchestrator pushes tasks, scheduler thread 0 pops and wires.
-        PTO2ReadyQueue wiring_queue;
-
-        // Local batch buffer for drain_wiring_queue (scheduler thread 0 only).
-        // Persists across calls so partially-consumed batches resume next call.
-        static constexpr int WIRING_BATCH_SIZE = 16;
-        PTO2TaskSlotState *wiring_batch[WIRING_BATCH_SIZE];
-        int wiring_batch_count = 0;
-        int wiring_batch_index = 0;
+        // --- Wiring hot path (thread 0 only, isolated from completion traffic) ---
+        alignas(64) PTO2DepListPool dep_pool;
 
         bool init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id);
         void destroy();
@@ -457,7 +538,6 @@ struct PTO2SchedulerState {
         PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
             return slot_states[local_id & task_window_mask];
         }
-
         PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
         void sync_to_sm(PTO2SharedMemoryRingHeader &ring) {
@@ -482,6 +562,16 @@ struct PTO2SchedulerState {
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
+    // Global wiring batch buffer — thread 0 only, tight layout for cache locality.
+    // count(4B) + index(4B) + batch[31](248B) = 256B = exactly 4 cache lines.
+    int wiring_batch_count = 0;
+    int wiring_batch_index = 0;
+    static constexpr uint64_t WIRING_BATCH_SIZE = 31;
+    PTO2TaskSlotState *wiring_batch[WIRING_BATCH_SIZE];
+
+    // Global wiring queue — refill path only (every BATCH_SIZE tasks), separate cache line.
+    alignas(64) PTO2SpscQueue wiring_queue;
+
     // Statistics
 #if PTO2_SCHED_PROFILING
     std::atomic<int64_t> tasks_completed;
@@ -499,32 +589,26 @@ struct PTO2SchedulerState {
      *
      * @return Number of tasks wired this call.
      */
-    int drain_wiring_queue() {
-        int wired = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            wired += drain_ring_wiring_queue(r);
-        }
-        return wired;
-    }
 
-    /**
-     * Drain the wiring queue for a single ring. See drain_wiring_queue() for
-     * the peek/pop_batch FIFO protocol. Returns the number of tasks wired.
-     */
-    int drain_ring_wiring_queue(int ring_id) {
-        auto &rss = ring_sched_states[ring_id];
+    int drain_wiring_queue(bool force_drain = false) {
         int wired = 0;
 
         // Refill local batch buffer when exhausted.
-        if (rss.wiring_batch_index >= rss.wiring_batch_count) {
-            rss.wiring_batch_count = rss.wiring_queue.pop_batch(rss.wiring_batch, RingSchedState::WIRING_BATCH_SIZE);
-            rss.wiring_batch_index = 0;
-            if (rss.wiring_batch_count == 0) return 0;
+        if (wiring_batch_index >= wiring_batch_count) {
+            // Backoff: skip pop when fewer than WIRING_BACKOFF_THRESHOLD tasks
+            // are queued, reducing contention with the orchestrator's push path.
+            // Bypassed when force_drain is set (orchestrator done — must flush tail).
+            if (!force_drain && wiring_queue.size() < WIRING_BATCH_SIZE) return 0;
+            wiring_batch_count = wiring_queue.pop_batch(wiring_batch, WIRING_BATCH_SIZE);
+            wiring_batch_index = 0;
+            if (wiring_batch_count == 0) return 0;
         }
 
         // Process tasks from local buffer in strict FIFO order.
-        while (rss.wiring_batch_index < rss.wiring_batch_count) {
-            PTO2TaskSlotState *ws = rss.wiring_batch[rss.wiring_batch_index];
+        while (wiring_batch_index < wiring_batch_count) {
+            PTO2TaskSlotState *ws = wiring_batch[wiring_batch_index];
+            int ring_id = ws->ring_id;
+            auto &rss = ring_sched_states[ring_id];
             int32_t wfanin = ws->payload->fanin_actual_count;
 
             if (wfanin > 0 && rss.dep_pool.available() < wfanin) {
@@ -534,10 +618,11 @@ struct PTO2SchedulerState {
                 }
             }
 
-            rss.wiring_batch_index++;
-            wire_task(ring_id, ws);
+            wiring_batch_index++;
+            wire_task(rss, ws, wfanin);
             wired++;
         }
+
         return wired;
     }
 
@@ -546,10 +631,8 @@ struct PTO2SchedulerState {
      * producer's fanout_lock, allocates dep_pool entries for live producers,
      * pushes the task to the ready queue once its fanin refcount is satisfied.
      */
-    void wire_task(int ring_id, PTO2TaskSlotState *ws) {
-        auto &rss = ring_sched_states[ring_id];
+    void wire_task(RingSchedState &rss, PTO2TaskSlotState *ws, int32_t wfanin) {
         PTO2TaskPayload *wp = ws->payload;
-        int32_t wfanin = wp->fanin_actual_count;
         ws->fanin_count = wfanin + 1;
 
         if (wfanin != 0) {
@@ -581,6 +664,7 @@ struct PTO2SchedulerState {
     PTO2TaskSlotState &get_slot_state(int32_t ring_id, int32_t local_id) {
         return ring_sched_states[ring_id].get_slot_state_by_task_id(local_id);
     }
+
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t ring_id, int32_t slot) {
         return ring_sched_states[ring_id].get_slot_state_by_slot(slot);
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -578,6 +578,12 @@ struct PTO2SchedulerState {
     // wiring backoff to ensure pending tasks are wired promptly.
     alignas(64) std::atomic<bool> orch_needs_drain{false};
 
+    // Backoff counter: when queue size < WIRING_BATCH_SIZE, increment instead
+    // of popping. After WIRING_BACKOFF_LIMIT consecutive deferrals, force a pop
+    // to prevent deadlock (allocator may be waiting for wiring to advance ring).
+    static constexpr int WIRING_BACKOFF_LIMIT = 32;
+    int wiring_backoff_counter;
+
     // Statistics
 #if PTO2_SCHED_PROFILING
     std::atomic<int64_t> tasks_completed;
@@ -601,13 +607,16 @@ struct PTO2SchedulerState {
 
         // Refill local batch buffer when exhausted.
         if (wiring_batch_index >= wiring_batch_count) {
-            // Backoff: skip pop when fewer than WIRING_BACKOFF_THRESHOLD tasks
-            // are queued, reducing contention with the orchestrator's push path.
-            // Bypassed when force_drain is set (orchestrator done — must flush tail)
-            // or when orch_needs_drain is set (orchestrator is spin-waiting on tensor data).
-            if (!force_drain && !orch_needs_drain.load(std::memory_order_acquire) &&
-                wiring_queue.size() < WIRING_BATCH_SIZE)
-                return 0;
+            // Backoff: defer pop when queue holds fewer than a full batch,
+            // unless force_drain, orch_needs_drain, or backoff limit reached.
+            if (!force_drain && wiring_queue.size() < WIRING_BATCH_SIZE) {
+                if (!orch_needs_drain.load(std::memory_order_acquire) &&
+                    wiring_backoff_counter < WIRING_BACKOFF_LIMIT) {
+                    wiring_backoff_counter++;
+                    return 0;
+                }
+            }
+            wiring_backoff_counter = 0;
             wiring_batch_count = wiring_queue.pop_batch(wiring_batch, WIRING_BATCH_SIZE);
             wiring_batch_index = 0;
             if (wiring_batch_count == 0) return 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -573,6 +573,11 @@ struct PTO2SchedulerState {
     // Global wiring queue — refill path only (every BATCH_SIZE tasks), separate cache line.
     alignas(64) PTO2SpscQueue wiring_queue;
 
+    // Orchestrator urgency flag: set by orchestrator before spin-waiting on
+    // tensor data, cleared after wait completes. When true, scheduler bypasses
+    // wiring backoff to ensure pending tasks are wired promptly.
+    alignas(64) std::atomic<bool> orch_needs_drain{false};
+
     // Statistics
 #if PTO2_SCHED_PROFILING
     std::atomic<int64_t> tasks_completed;
@@ -598,8 +603,11 @@ struct PTO2SchedulerState {
         if (wiring_batch_index >= wiring_batch_count) {
             // Backoff: skip pop when fewer than WIRING_BACKOFF_THRESHOLD tasks
             // are queued, reducing contention with the orchestrator's push path.
-            // Bypassed when force_drain is set (orchestrator done — must flush tail).
-            if (!force_drain && wiring_queue.size() < WIRING_BATCH_SIZE) return 0;
+            // Bypassed when force_drain is set (orchestrator done — must flush tail)
+            // or when orch_needs_drain is set (orchestrator is spin-waiting on tensor data).
+            if (!force_drain && !orch_needs_drain.load(std::memory_order_acquire) &&
+                wiring_queue.size() < WIRING_BATCH_SIZE)
+                return 0;
             wiring_batch_count = wiring_queue.pop_batch(wiring_batch, WIRING_BATCH_SIZE);
             wiring_batch_index = 0;
             if (wiring_batch_count == 0) return 0;


### PR DESCRIPTION
## Summary

Optimize the AICPU scheduler hot loop in `resolve_and_dispatch_pto2` for reduced icache pressure, fewer atomic operations, and better cache locality across both a2a3 and a5 platforms.

**Key changes:**

- **Extract cold paths from the main dispatch loop** — 6 `noinline/cold` helper functions (`handle_orchestrator_exit`, `handle_core_transition`, `check_idle_fatal_error`, `log_stall_diagnostics`, `handle_timeout_exit`, `log_profiling_summary`) remove ~328 lines / ~4KB of instructions from the hot loop body, allowing the steady-state completion+dispatch path to fit in L1 icache
- **Consolidate profiling counters into per-thread struct** — Replace 20+ profiling local variables threaded through 10 function signatures with a single `alignas(64) SchedProfilingCounters` member array indexed by `thread_idx`, eliminating all `#if PTO2_PROFILING` / `#if PTO2_SCHED_PROFILING` parameter blocks (net -146 lines)
- **Merge AIC/AIV completion checks** — De-template `check_running_cores_for_completion` to use `get_all_running_cores()` in a single traversal; remove `CoreType ct` parameter from `complete_slot_task` (reads `hank[core_id].core_type` directly)
- **Replace per-ring wiring queues with a single global queue** — Consolidate 4 per-ring `PTO2ReadyQueue` instances into one global queue; `wire_task` derives `ring_id` from `ws->ring_id` for per-ring `dep_pool` access
- **Add wiring queue backoff** — Skip `pop_batch` when fewer than `WIRING_BATCH_SIZE` tasks are queued, reducing contention with the orchestrator's push path; bypassed via `force_drain` when orchestrator is done
- **Replace MPMC queue with wait-free SPSC** — New `PTO2SpscQueue` based on Rigtorp's cached-index technique: push is 1 relaxed load + 1 release store (zero CAS), pop_batch is 1 acquire load + N plain loads + 1 release store; 4 `alignas(64)` fields eliminate false sharing
- **Optimize cache layout** — `RingSchedState`: isolate `dep_pool` with `alignas(64)` from completion-path fields (`advance_lock` CAS traffic); `PTO2SchedulerState`: pack `count+index+batch[31]` tightly, separate `wiring_queue` with `alignas(64)`; `wire_task` accepts pre-resolved `RingSchedState&` and `wfanin` to eliminate 3 redundant pointer dereferences per task