### PR TITLE
Add: parallel test execution and ChipWorker reuse

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,11 +30,15 @@ TIMEOUT_EXIT_CODE = 124
 
 
 def _parse_device_range(s: str) -> list[int]:
-    """Parse '4-7' -> [4,5,6,7] or '0' -> [0]."""
-    if "-" in s:
-        start, end = s.split("-", 1)
-        return list(range(int(start), int(end) + 1))
-    return [int(s)]
+    """Parse a --device spec into a sorted list of ints.
+
+    Delegates to :func:`simpler_setup.parallel_scheduler.device_range_to_list`
+    so both conftest and standalone share the same parser (supports ``0``,
+    ``0-7``, ``0,2,5``, and mixed ``0,2-4,7``).
+    """
+    from simpler_setup.parallel_scheduler import device_range_to_list  # noqa: PLC0415
+
+    return device_range_to_list(s)
 
 
 class DevicePool:
@@ -79,6 +83,27 @@ def pytest_addoption(parser):
         help="Manual case handling: exclude (default), include, only",
     )
     parser.addoption("--runtime", action="store", default=None, help="Only run tests for this runtime")
+    parser.addoption(
+        "--level",
+        action="store",
+        type=int,
+        default=None,
+        choices=[2, 3],
+        help="Only run tests for this SceneTestCase level (2 or 3); default: all levels",
+    )
+    parser.addoption(
+        "--max-parallel",
+        action="store",
+        default="auto",
+        help=(
+            "Max in-flight subprocesses (make-style); decouples the device pool size "
+            "from parallelism. 'auto' = min(nproc, len(--device)) on sim, "
+            "len(--device) on hardware. Use '--max-parallel 2' to throttle sim on a "
+            "CPU-constrained CI runner without shrinking --device. pytest reserves "
+            "lowercase short options for itself, so no '-j' short is registered — "
+            "use the long form in both pytest and standalone."
+        ),
+    )
     parser.addoption("--rounds", type=int, default=1, help="Run each case N times (default: 1)")
     parser.addoption(
         "--skip-golden", action="store_true", default=False, help="Skip golden comparison (benchmark mode)"
@@ -161,11 +186,65 @@ def pytest_configure(config):
     if timeout and timeout > 0:
         _install_session_timeout(timeout)
 
+    # xdist worker: bind this process to a single device id from the --device range.
+    # The orchestrator (or the user) supplies --device 0-7; xdist spawns N workers
+    # labelled gw0..gwN-1. We slice device_ids[worker_index] so each worker owns
+    # exactly one device. L2 Worker is session-scoped inside xdist children, so
+    # all tests on this worker share one ChipWorker init().
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id and worker_id.startswith("gw"):
+        try:
+            idx = int(worker_id[2:])
+        except ValueError:
+            idx = 0
+        device_spec = config.getoption("--device", default="0")
+        ids = _parse_device_range(device_spec)
+        if 0 <= idx < len(ids):
+            config.option.device = str(ids[idx])
+        # else: more xdist workers than devices — fall through with original range;
+        # DevicePool will fail clearly if the test tries to allocate.
+
+    # Parallel + profiling is unsafe (perf files are process-global). Block it
+    # at the parent (non-xdist-worker) level. What matters is concurrent
+    # subprocess count, not device pool size — respect -j.
+    if config.getoption("--enable-profiling", default=False) and not worker_id:
+        device_spec = config.getoption("--device", default="0")
+        ids = _parse_device_range(device_spec)
+        platform = config.getoption("--platform", default="") or ""
+        raw_j = config.getoption("--max-parallel", default="auto")
+        if raw_j in (None, "", "auto"):
+            from simpler_setup.parallel_scheduler import default_max_parallel  # noqa: PLC0415
+
+            j = default_max_parallel(platform, ids)
+        else:
+            try:
+                j = max(1, int(raw_j))
+            except (TypeError, ValueError):
+                j = 1
+        if j > 1:
+            raise pytest.UsageError(
+                f"--enable-profiling is incompatible with --max-parallel {j}; "
+                "profiling writes process-global files that collide under "
+                "parallelism. Either pass '--max-parallel 1' or drop --enable-profiling."
+            )
+
 
 def pytest_collection_modifyitems(session, config, items):
-    """Skip ST tests based on --platform and --runtime filters, and order L3 before L2."""
+    """Skip ST tests based on --platform, --runtime, --level filters; order L3 before L2."""
     platform = config.getoption("--platform")
     runtime_filter = config.getoption("--runtime")
+    level_filter = config.getoption("--level")
+
+    # Orchestrator L3 children set PTO_TARGET_NODEID to the single case they
+    # were dispatched for. Pytest's --case filter runs inside test_run (too
+    # late — other classes' st_worker fixtures already fired at setup). Skip
+    # everything except the target nodeid so the child stays narrow even when
+    # the parent invocation had broad positional args like ``examples tests/st``.
+    target_nodeid = os.environ.get("PTO_TARGET_NODEID")
+    if target_nodeid:
+        for item in items:
+            if item.nodeid != target_nodeid:
+                item.add_marker(pytest.mark.skip(reason=f"orchestrator target is {target_nodeid}"))
 
     # Sort: L3 tests first (they fork child processes that inherit main process CANN state,
     # so they must run before L2 tests pollute the CANN context).
@@ -187,6 +266,8 @@ def pytest_collection_modifyitems(session, config, items):
                 item.add_marker(
                     pytest.mark.skip(reason=f"Runtime {getattr(cls, '_st_runtime', '?')} != {runtime_filter}")
                 )
+            elif level_filter is not None and getattr(cls, "_st_level", None) != level_filter:
+                item.add_marker(pytest.mark.skip(reason=f"Level {getattr(cls, '_st_level', '?')} != {level_filter}"))
             continue
         platforms_marker = item.get_closest_marker("platforms")
         if platforms_marker:
@@ -205,65 +286,240 @@ def pytest_collection_modifyitems(session, config, items):
 
 
 # ---------------------------------------------------------------------------
-# Runtime isolation: spawn subprocess per runtime
+# Orchestrator: L3 phase (device-aware parallel subprocesses) + L2 phase
+# (per-runtime subprocess). Activated only when neither --runtime nor --level
+# is set by the caller. Orchestrator-spawned children set both, so they fall
+# through to pytest's default runtestloop without recursing.
 # ---------------------------------------------------------------------------
 
 
-def _collect_st_runtimes(items):
-    """Return sorted list of unique runtimes from collected SceneTestCase items."""
+def _collect_st_runtimes(items, level=None):
+    """Return sorted list of unique runtimes from items, optionally filtered by level."""
     runtimes = set()
     for item in items:
         cls = getattr(item, "cls", None)
-        rt = getattr(cls, "_st_runtime", None) if cls else None
-        if rt:
+        if not cls:
+            continue
+        rt = getattr(cls, "_st_runtime", None)
+        lvl = getattr(cls, "_st_level", None)
+        if rt and (level is None or lvl == level):
             runtimes.add(rt)
     return sorted(runtimes)
 
 
-def pytest_runtestloop(session):
-    """Override test execution to isolate runtimes in subprocesses.
+def _collect_l3_cases(items, platform):
+    """Collect one job per L3 class (not per case).
 
-    If --runtime is specified (or only one runtime collected), run normally.
-    Otherwise, spawn one subprocess per runtime and aggregate results.
+    Returns a list of tuples ``(nodeid, cls_name, runtime, max_device_count)``
+    where ``max_device_count`` is the maximum ``device_count`` across the
+    class's matching cases. Per-class dispatch matches the ``st_worker``
+    fixture's contract (it allocates ``max(CASES.device_count)`` for the whole
+    class) — dispatching per-case with a smaller device budget would trip the
+    fixture whenever the class also has a case that needs more devices.
+
+    Cases within a class still run in the child process via the existing
+    ``test_run`` case loop, reusing the Worker (layer-4 reuse).
     """
-    runtime_filter = session.config.getoption("--runtime")
-    if runtime_filter:
-        return  # single runtime — let pytest run normally
+    by_nodeid: dict[str, tuple[str, str, int]] = {}
+    for item in items:
+        cls = getattr(item, "cls", None)
+        if not cls or getattr(cls, "_st_level", None) != 3:
+            continue
+        if any(m.name == "skip" for m in item.iter_markers()):
+            continue
+        rt = getattr(cls, "_st_runtime", None)
+        if not rt:
+            continue
+        max_dev = 1
+        saw_case = False
+        for case in getattr(cls, "CASES", []):
+            if platform and platform not in case.get("platforms", []):
+                continue
+            if case.get("manual"):
+                continue  # --manual exclude is the default; children honor the flag
+            saw_case = True
+            max_dev = max(max_dev, int(case.get("config", {}).get("device_count", 1)))
+        if saw_case:
+            by_nodeid[item.nodeid] = (cls.__name__, rt, max_dev)
+    return [(nodeid, cls_name, rt, dev) for nodeid, (cls_name, rt, dev) in by_nodeid.items()]
 
-    runtimes = _collect_st_runtimes(session.items)
-    if len(runtimes) <= 1:
-        return  # zero or one runtime — no isolation needed
 
-    # Multiple runtimes: spawn subprocess per runtime
-    # Re-invoke pytest with the same args + --runtime <rt> for each runtime
-    base_args = [sys.executable, "-m", "pytest"]
+def _base_pytest_argv(session):
+    """Inherit the user's original pytest invocation args."""
+    base = [sys.executable, "-m", "pytest"]
     for arg in session.config.invocation_params.args:
-        base_args.append(str(arg))
+        base.append(str(arg))
+    return base
 
-    failed = False
-    for rt in runtimes:
-        # Build subprocess command: inject --runtime <rt>
-        cmd = base_args + ["--runtime", rt]
-        header = f"  Runtime: {rt}"
-        print(f"\n{'=' * 60}\n{header}\n{'=' * 60}\n", flush=True)
 
-        result = subprocess.run(cmd, check=False, cwd=session.config.invocation_params.dir)
+def _resolve_max_parallel(cfg, platform: str, device_ids: list[int]) -> int:
+    """Parse the -j/--max-parallel CLI value; 'auto' → platform-aware default."""
+    from simpler_setup.parallel_scheduler import default_max_parallel  # noqa: PLC0415
+
+    raw = cfg.getoption("--max-parallel", default="auto")
+    if raw in (None, "", "auto"):
+        return default_max_parallel(platform or "", device_ids)
+    try:
+        val = int(raw)
+    except (TypeError, ValueError) as e:
+        raise pytest.UsageError(f"--max-parallel must be 'auto' or an integer, got {raw!r}") from e
+    if val < 1:
+        raise pytest.UsageError(f"--max-parallel must be >= 1, got {val}")
+    return val
+
+
+def _orchestrate(session):
+    """Run L3 phase (device-parallel) then L2 phase (per-runtime subprocess)."""
+    from simpler_setup import parallel_scheduler as _ps  # noqa: PLC0415
+
+    cfg = session.config
+    device_spec = cfg.getoption("--device", default="0")
+    device_ids = _parse_device_range(device_spec)
+    # pytest registers -x as an alias of --exitfirst; both resolve via this name.
+    fail_fast = bool(cfg.getoption("--exitfirst", default=False))
+    platform = cfg.getoption("--platform")
+    max_parallel = _resolve_max_parallel(cfg, platform or "", device_ids)
+
+    base_args = _base_pytest_argv(session)
+    cwd = session.config.invocation_params.dir
+
+    # ----- Phase 1: L3 classes (device-bin-packed subprocesses, one per class) -----
+    l3_cases = _collect_l3_cases(session.items, platform)
+    l3_failed = False
+    if l3_cases:
+        # Static check happens inside run_jobs; we translate errors into session failure.
+        jobs = []
+        for nodeid, cls_name, rt, dev_count in l3_cases:
+            label = f"L3 {cls_name} (rt={rt}, dev={dev_count})"
+
+            def _build(ids, _nodeid=nodeid, _rt=rt):
+                return base_args + [
+                    _nodeid,
+                    "--runtime",
+                    _rt,
+                    "--level",
+                    "3",
+                    "--device",
+                    _ps.format_device_range(ids),
+                ]
+
+            # PTO_TARGET_NODEID makes the child skip every item except this
+            # nodeid — defends against inherited positional args (``examples``,
+            # ``tests/st``) collecting unrelated classes whose fixtures would
+            # then fire at setup and fail on the narrower child device pool.
+            child_env = {**os.environ, "PTO_TARGET_NODEID": nodeid}
+            jobs.append(_ps.Job(label=label, device_count=dev_count, build_cmd=_build, cwd=str(cwd), env=child_env))
+
+        def _on_done(res):
+            tag = "PASSED" if res.returncode == 0 else f"FAILED (rc={res.returncode})"
+            print(f"\n--- {res.label}: {tag} on devices {res.device_ids} ---\n", flush=True)
+
+        print(
+            f"\n{'=' * 60}\n  L3 phase: {len(jobs)} case(s), "
+            f"pool={device_ids}, max_parallel={max_parallel}\n{'=' * 60}\n",
+            flush=True,
+        )
+        try:
+            results = _ps.run_jobs(
+                jobs,
+                device_ids,
+                max_parallel=max_parallel,
+                fail_fast=fail_fast,
+                on_job_done=_on_done,
+            )
+        except ValueError as e:
+            print(f"\n*** L3 phase ABORTED: {e} ***\n", flush=True)
+            session.testsfailed = 1
+            return True
+        l3_failed = any(r.returncode != 0 for r in results)
+        if any(r.returncode == TIMEOUT_EXIT_CODE for r in results):
+            print("\n*** L3 phase: TIMED OUT ***\n", flush=True)
+            os._exit(TIMEOUT_EXIT_CODE)
+
+        # Fail-fast: stop before L2 phase if any L3 failed.
+        if l3_failed and fail_fast:
+            session.testsfailed = 1
+            return True
+
+    # ----- Phase 2: L2 per-runtime subprocess -----
+    l2_runtimes = _collect_st_runtimes(session.items, level=2)
+    l2_failed = False
+    # When we have more than one device, enable pytest-xdist so the L2 phase
+    # spreads classes across devices. Each xdist worker slices --device 0-7
+    # down to one id in its own pytest_configure (above) and the st_worker
+    # fixture is session-scoped inside the worker — one ChipWorker per (runtime,
+    # device), reused across every class assigned to that worker.
+    xdist_available = False
+    if max_parallel > 1:
+        try:
+            import xdist  # noqa: F401,PLC0415
+
+            xdist_available = True
+        except ImportError:
+            print(
+                "\n[warning] -j > 1 but pytest-xdist not installed; "
+                "falling back to serial L2 phase. pip install pytest-xdist to enable.\n",
+                flush=True,
+            )
+    for rt in l2_runtimes:
+        cmd = base_args + ["--runtime", rt, "--level", "2"]
+        if xdist_available:
+            cmd += ["-n", str(max_parallel), "--dist", "loadfile"]
+        print(
+            f"\n{'=' * 60}\n  L2 Runtime: {rt}"
+            + (f" [-n {max_parallel}]" if xdist_available else "")
+            + f"\n{'=' * 60}\n",
+            flush=True,
+        )
+        result = subprocess.run(cmd, check=False, cwd=cwd)
         if result.returncode == TIMEOUT_EXIT_CODE:
-            print(f"\n*** Runtime {rt}: TIMED OUT ***\n", flush=True)
+            print(f"\n*** L2 runtime {rt}: TIMED OUT ***\n", flush=True)
             os._exit(TIMEOUT_EXIT_CODE)
         if result.returncode != 0:
-            failed = True
-            print(f"\n*** Runtime {rt}: FAILED ***\n", flush=True)
+            l2_failed = True
+            print(f"\n*** L2 runtime {rt}: FAILED ***\n", flush=True)
+            if fail_fast:
+                break
         else:
-            print(f"\n--- Runtime {rt}: PASSED ---\n", flush=True)
+            print(f"\n--- L2 runtime {rt}: PASSED ---\n", flush=True)
 
-    if failed:
-        session.testsfailed = 1
-    else:
+    session.testsfailed = 1 if (l3_failed or l2_failed) else 0
+    if not (l3_failed or l2_failed):
         session.testscollected = sum(1 for _ in session.items)
-        session.testsfailed = 0
-
     return True  # returning True prevents default runtestloop
+
+
+def pytest_runtestloop(session):
+    """Orchestrate L3+L2 phases unless caller is already in child mode.
+
+    Child mode (both --runtime and --level set, or --collect-only) skips the
+    orchestrator and falls through to pytest's default runtestloop.
+    """
+    runtime_filter = session.config.getoption("--runtime")
+    level_filter = session.config.getoption("--level")
+
+    # Child mode: the orchestrator's spawned subprocesses carry both flags.
+    if runtime_filter is not None and level_filter is not None:
+        return
+
+    # User explicitly asked for collect-only / scoped-run — don't orchestrate.
+    if session.config.getoption("--collect-only", default=False):
+        return
+
+    # If there are no items, nothing to orchestrate.
+    if not session.items:
+        return
+
+    # If only L2 items exist in a single runtime, the orchestrator reduces to a
+    # single L2 subprocess — not worth the extra fork overhead vs. letting
+    # pytest run directly. Skip orchestration in that trivial case.
+    level_filter_explicit = level_filter is not None
+    runtimes_all = _collect_st_runtimes(session.items)
+    has_l3 = any(getattr(getattr(i, "cls", None), "_st_level", None) == 3 for i in session.items)
+    if not has_l3 and len(runtimes_all) <= 1 and not level_filter_explicit:
+        return
+
+    return _orchestrate(session)
 
 
 # ---------------------------------------------------------------------------
@@ -290,12 +546,33 @@ def st_platform(request):
     return p
 
 
-@pytest.fixture()
-def st_worker(request, st_platform, device_pool):
-    """Per-test Worker with devices allocated from pool.
+@pytest.fixture(scope="session")
+def _l2_worker_pool(request, st_platform):
+    """Session-scoped L2 worker pool keyed by (runtime, device_id).
 
-    Reads _st_level and CASES from the test class to determine
-    how many devices and sub-workers to allocate.
+    Under xdist, each worker process owns one device (slicing done in
+    pytest_configure), so this pool typically ends up with one entry per
+    runtime. Tests on the same worker that share a runtime reuse the same
+    ``ChipWorker`` — amortizing the init cost (three dlopens + device
+    acquire) over every class on that device.
+    """
+    pool: dict[tuple[str, int], object] = {}
+    yield pool
+    # Session teardown: close every Worker we minted.
+    for w in pool.values():
+        try:
+            w.close()
+        except Exception:  # noqa: BLE001
+            pass
+    pool.clear()
+
+
+@pytest.fixture()
+def st_worker(request, st_platform, device_pool, _l2_worker_pool):
+    """Per-test Worker.
+
+    L2: session-scoped, reused across classes with the same (runtime, device).
+    L3: per-test (registers sub-callables at init, can't be reused).
     """
     cls = request.node.cls
     if cls is None or not hasattr(cls, "_st_level"):
@@ -306,18 +583,33 @@ def st_worker(request, st_platform, device_pool):
     build = request.config.getoption("--build", default=False)
 
     if level == 2:
+        # L2 share: reuse any Worker already created for this runtime in the
+        # current process. Under xdist, each worker process is sliced to a
+        # single device so there's at most one matching entry. On first call
+        # we allocate a device from the pool and immediately release it back —
+        # the pool is a process-scoped counter for other fixtures (e.g.
+        # st_device_ids) that also draw from it; retaining the id would drain
+        # the pool and break any non-st_worker test that runs afterward on the
+        # same xdist worker.
+        for (rt, dev_id), existing in _l2_worker_pool.items():
+            if rt == runtime:
+                yield existing
+                return
+
         ids = device_pool.allocate(1)
         if not ids:
             pytest.fail(f"no devices available in --device pool (requested 1, pool has {len(device_pool._available)})")
-
+        dev_id = ids[0]
+        device_pool.release(ids)
+        key = (runtime, dev_id)
         from simpler.worker import Worker  # noqa: PLC0415
 
-        w = Worker(level=2, device_id=ids[0], platform=st_platform, runtime=runtime, build=build)
-        w._st_device_id = ids[0]  # expose primary device to test_run for profiling snapshots
+        w = Worker(level=2, device_id=dev_id, platform=st_platform, runtime=runtime, build=build)
+        w._st_device_id = dev_id
         w.init()
+        _l2_worker_pool[key] = w
         yield w
-        w.close()
-        device_pool.release(ids)
+        # No close here — pool handles teardown at session end.
 
     elif level == 3:
         max_devices = max((c.get("config", {}).get("device_count", 1) for c in cls.CASES), default=1)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -52,6 +52,52 @@ PullRequest
 | `ut-cpp-a5` | a5 self-hosted | `ctest --test-dir tests/ut/cpp/build -L "^requires_hardware(_a5)?$"` |
 | `st-a5` | a5 self-hosted | `pytest examples tests/st --platform a5` + `ci.py -p a5 -d ...` |
 
+### Parallel ST runs on hardware
+
+For self-hosted jobs with multiple NPUs, pass a `--device` range (and
+optionally pytest's `-x` for fail-fast) to get the full orchestrator
+benefit — device bin-packing for L3, xdist fanout for L2, and a shared
+`ChipWorker` per `(runtime, device)`:
+
+```bash
+# Recommended CI invocation
+pytest examples tests/st --platform a2a3 --device 4-7 -x
+
+# Same for a5
+pytest examples tests/st --platform a5 --device 0-7 -x
+```
+
+`-x` (`--exitfirst`) is appropriate for CI, where aborting on first
+failure saves runner minutes. Local development usually wants the opposite
+(let every failure surface) — just drop the flag. The short form is the
+same in both pytest and standalone on purpose; see
+[testing.md §CLI Design Principles](testing.md#cli-design-principles).
+
+`pytest-xdist` is pulled in via the `test` extra. See
+[testing.md §Parallel Test Execution](testing.md#parallel-test-execution-and-resource-reuse)
+for the full hierarchy, fail-fast semantics, and the
+profiling-vs-parallelism trade-off.
+
+### Sim jobs on CPU-constrained runners
+
+Sim jobs (`st-sim-a2a3`, `st-sim-a5`) run on `ubuntu-latest`, which typically
+has 2 vCPUs. `--device 0-15` is still the right choice for the **pool size**
+(some L3 cases need several virtual ids), but the default `--max-parallel auto`
+caps the in-flight subprocess count to `min(nproc, len(--device))` — on a
+2-core runner that becomes `2`, avoiding CPU thrashing:
+
+```bash
+# Sim: --max-parallel auto resolves to 2 on ubuntu-latest
+pytest examples tests/st --platform a2a3sim --device 0-15
+
+# Or pin explicitly if your runner has a different CPU count
+pytest examples tests/st --platform a2a3sim --device 0-15 --max-parallel 2
+```
+
+On hardware jobs the `auto` default is `len(--device)` because each subprocess
+is device-bound (host CPU mostly waits on the NPU), so hardware runners do
+not need `--max-parallel` manually.
+
 ### Scheduling constraints
 
 - Sim scene tests and no-hardware unit tests run on github-hosted runners (no hardware).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,7 +45,7 @@ python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example
 
 # Benchmark mode (100 rounds, skip golden comparison)
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py \
-    -p a2a3 -d 0 -n 100 --skip-golden
+    -p a2a3 -d 0 --rounds 100 --skip-golden
 
 # Profiling (first round only)
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py \
@@ -97,7 +97,7 @@ pytest --platform a2a3sim --log-level debug                        # verbose C++
 
 ```bash
 python test_xxx.py -p a2a3sim                                    # default: 1 round + golden
-python test_xxx.py -p a2a3 -d 0 -n 100 --skip-golden            # benchmark mode
+python test_xxx.py -p a2a3 -d 0 --rounds 100 --skip-golden       # benchmark mode
 python test_xxx.py -p a2a3 --enable-profiling                    # profiling (first round)
 python test_xxx.py -p a2a3 --dump-tensor                         # dump per-task tensor I/O
 python test_xxx.py -p a2a3sim --build                            # compile runtime from source
@@ -108,14 +108,155 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 
 | Option | Short | Default | Description |
 | ------ | ----- | ------- | ----------- |
-| `--rounds N` | `-n` | 1 | Run each case N times |
+| `--rounds N` | | 1 | Run each case N times (reuses the same Worker across rounds) |
+| `--device IDS` | `-d` | `0` | Single id (`0`), range (`0-7`), or list (`0,2,5`). Sets the device-id pool for L3 cases and the available slots for L2 fanout. |
+| `--max-parallel N` | | `auto` | Max in-flight subprocesses (make-style). `auto` = `min(nproc, len(--device))` on sim, `len(--device)` on hardware. Decouples device-id pool size from parallelism; use to throttle sim on a CPU-constrained runner. |
+| `--runtime NAME` | | (all) | Restrict to one runtime (also used internally as the child-mode marker) |
+| `--level {2,3}` | | (all) | Restrict to one SceneTestCase level (also the child-mode marker) |
+| `--case SEL` | | (all) | Case selector, repeatable: `Foo`, `ClassA::Foo`, `ClassA::` |
+| `--manual` | | `exclude` | `exclude`/`include`/`only` for manual cases |
 | `--skip-golden` | | false | Skip golden comparison (for benchmarking) |
-| `--enable-profiling` | | false | Enable profiling on first round only |
+| `--enable-profiling` | | false | Enable profiling on first round only. Blocked when `--max-parallel > 1`. |
 | `--dump-tensor` | | false | Dump per-task tensor I/O during runtime execution |
 | `--build` | | false | Compile runtime from source (not pre-built) |
+| `--exitfirst` | `-x` | false | Stop on first failing test (fail-fast, primarily for CI) |
 | `--log-level LEVEL` | | (none) | Set `PTO_LOG_LEVEL` env var (`error`/`warn`/`info`/`debug`) |
 
 Profiling is enabled only on the first round to avoid overhead on subsequent iterations. Output tensors are reset to their initial values between rounds.
+
+## CLI Design Principles
+
+The same set of flags must work in both pytest and standalone (`python test_*.py`). Two rules govern which short forms we register:
+
+1. **Mirror pytest.** If pytest (or a pytest plugin the project depends on) exposes a flag with a particular short form, standalone must register the same short for the same meaning. Users routinely copy commands between the two entry points; letter-level semantic drift is the fastest way to create confusing bugs.
+2. **Never create a collision with pytest's ecosystem.** If pytest (or one of its plugins) already uses a short letter for a *different* concept, standalone must not reuse that letter for anything else, even if pytest doesn't use that letter for the flag we're adding. The goal is that `-X` in both worlds either does the same thing or is unused.
+
+Worked examples:
+
+| Flag | Long form | Short | Why |
+| ---- | --------- | ----- | --- |
+| `--platform` | both | `-p` | No pytest collision; high-frequency user flag. |
+| `--device` | both | `-d` | Same. |
+| `--exitfirst` | both | `-x` | pytest ships `-x` → standalone mirrors it so the flag behaves identically across entry points. |
+| `--rounds` | both | **(none)** | pytest-xdist already uses `-n` for worker count. Standalone originally had `-n` for `--rounds`, creating a letter-level collision whenever a user switched between pytest (`-n 8` = 8 workers) and standalone (`-n 8` = 8 rounds). Removed in [#574](https://github.com/hw-native-sys/simpler/pull/574); do not reintroduce. |
+| `--max-parallel` | both | **(none)** | `-j` would be the natural make-style short, but pytest reserves all lowercase single letters (`parser.addoption` rejects lowercase shorts). Standalone mirrors this to keep both CLIs identical — no short in either, always spell out `--max-parallel`. |
+| `--runtime` / `--level` | both | **(none)** | Internal child-mode markers; users rarely type them. No short keeps them distinctive. |
+| `--build`, `--skip-golden`, `--enable-profiling`, `--dump-tensor`, `--manual`, `--case`, `--log-level` | both | **(none)** | Low-frequency; long form reads better in scripts and docs. Not worth reserving letters. |
+
+Practical guidance when adding a new CLI option:
+
+- First decide the long name and semantics. Register it on **both** `conftest.py::pytest_addoption` and `simpler_setup/scene_test.py::run_module`.
+- Check pytest's built-in shorts (`pytest --help`) and loaded plugins (`pytest-xdist`, `pytest-timeout`, etc.) for any letter you're considering.
+  - If pytest uses the letter for a matching concept → register the same short in standalone.
+  - If pytest uses the letter for anything else → pick a different short, or drop the short entirely.
+  - If the letter is free and the flag is high-frequency user-facing → a short is OK; otherwise skip it.
+
+## Parallel Test Execution and Resource Reuse
+
+Tests are dispatched through an **orchestrator** that pipelines work along two complementary axes:
+
+1. **Resource reuse** — every `ChipWorker` init costs three `dlopen`s plus a device-context acquire. The orchestrator keeps one worker alive for the lifetime of a test group so every class, case, and round on that device reuses the same worker.
+2. **Parallelism** — when `--device` names more than one id, independent work is spread across subprocesses so N devices do N-way work.
+
+Both pytest and standalone (`python test_*.py`) walk the same 6-layer hierarchy:
+
+```text
+Layer 1  Level axis
+│
+├─ L3 phase (runs first)
+│   One isolated subprocess per case; scheduled by device_count, bin-packed
+│   against the --device pool. CANN isolation is automatic (each case is its
+│   own process). Cross-runtime L3 cases can overlap when their devices don't.
+│
+└─ L2 phase (runs after L3 drains)
+    │
+    ├─ Layer 2  Runtime — serial subprocess per runtime (CANN isolation)
+    │   └─ Layer 3  Device — parallel subprocess per device (xdist for pytest,
+    │               custom fanout for standalone). Capacity bounded by --device size
+    │       └─ Layer 4  Class — one ChipWorker per (runtime, device), reused
+    │                   across every class assigned to that device
+    │           └─ Layer 5  Case — serial within a class
+    │               └─ Layer 6  Rounds — `--rounds N` loop, reuses Worker
+```
+
+### Quick examples
+
+```bash
+# Serial, single device — identical to pre-parallel behavior
+pytest tests/st --platform a2a3sim --device 0
+python test_foo.py -p a2a3sim -d 0
+
+# 8-device box: L3 cases bin-pack; L2 fanned out across 8 xdist workers
+# (hardware default: --max-parallel auto = 8)
+pytest tests/st --platform a2a3 --device 0-7
+python test_foo.py -p a2a3 -d 0-7
+
+# Non-contiguous devices (e.g. devices 0, 2, 5 free)
+pytest tests/st --platform a2a3 --device 0,2,5
+python test_foo.py -p a2a3 -d 0,2,5
+
+# CPU-constrained sim: pool of 16 virtual ids (needed by an L3 case with
+# device_count=8), but only 2 subprocesses running at once to avoid thrashing.
+# --max-parallel auto would pick this automatically on a 2-core CI runner.
+pytest tests/st --platform a2a3sim --device 0-15 --max-parallel 2
+python test_foo.py -p a2a3sim -d 0-15 --max-parallel 2
+
+# Fail-fast for CI: stop at the first failing case
+pytest tests/st --platform a2a3 --device 0-7 -x
+python test_foo.py -p a2a3 -d 0-7 -x
+
+# Narrow run: one level, one runtime, one case
+pytest tests/st --platform a2a3sim --level 2 --runtime tensormap_and_ringbuffer --case TestFoo::default
+python test_foo.py -p a2a3sim --level 2 --runtime tensormap_and_ringbuffer --case TestFoo::default
+```
+
+### Fail-fast (`-x` / `--exitfirst`)
+
+- Default: all cases run; the orchestrator summarizes pass/fail at the end. This is the right mode for local development — you want every failure surfaced at once.
+- With `-x` / `--exitfirst`: first failure cancels the pending queue, sends `SIGTERM` to running children, and **skips the L2 phase if L3 failed**. Intended for CI. The short form mirrors pytest's built-in `-x` so the flag behaves identically across pytest and standalone.
+
+### Device-count constraints
+
+If any L3 case declares `device_count > len(--device pool)` the orchestrator fails the whole batch up front rather than deadlocking the scheduler. Either widen `--device` or reduce the case's `device_count`. When `device_count` exceeds the *currently free* pool (but fits within the total), the case waits for an in-flight job to finish and then claims its slot.
+
+### `--device` vs `--max-parallel` (two separate knobs)
+
+On hardware these two concepts collapse: one device = one subprocess's worth of host CPU, so `--device 0-7` naturally implies 8-way parallelism. On sim they diverge:
+
+| `--device` controls | `--max-parallel` controls |
+| ------------------- | ------------------------- |
+| Size of the virtual device-id pool | Max simultaneous `subprocess.Popen` |
+| Must be ≥ any L3 case's `device_count` | Should be ~nproc on sim (CPU-bound) |
+
+This matters on CPU-constrained CI runners. Example: an L3 case needs `device_count=8` but the runner has 2 CPUs.
+
+- `--device 0-1` — can't run the L3 case; static check fails.
+- `--device 0-15` (no `--max-parallel`) — L3 case fits, but the orchestrator would also spawn 15 concurrent L2 xdist workers and potentially multiple concurrent L3 cases, thrashing the 2 CPUs.
+- `--device 0-15 --max-parallel 2` — L3 case fits in the pool; at most 2 subprocesses run at a time. This is what the `auto` default computes on a 2-core runner.
+
+`--max-parallel` counts top-level subprocesses, like `make -j`. A single L3 case subprocess internally forks N chip-processes for its `device_count`; those forks do **not** count toward `--max-parallel`. One case = one unit regardless of how many devices it uses.
+
+### Mixed L2 + L3 in one file
+
+A single file can declare both L2 and L3 classes; they're grouped by `(runtime, level)` internally. L3 classes run in the L3 phase (subprocess-per-case), L2 classes run in the L2 phase (shared Worker per device).
+
+### Profiling and parallelism are mutually exclusive
+
+`--enable-profiling` writes process-global files (`outputs/perf_swimlane_*.json` and CANN device logs) that collide under parallel runs. The orchestrator errors out up front when `--max-parallel > 1`. Profile on a single device:
+
+```bash
+pytest tests/st --platform a2a3 --device 0 --enable-profiling
+# Or widen the pool but force serial execution:
+pytest tests/st --platform a2a3 --device 0-7 --max-parallel 1 --enable-profiling
+```
+
+### Orchestrator skip conditions (normal pytest runs)
+
+The orchestrator only takes over when there's actual work to parallelize or isolate. It falls through to plain pytest when:
+
+- `--collect-only`
+- Only one runtime is present and no L3 cases are collected (single L2 batch)
+- Both `--runtime` and `--level` are set (child-mode marker — used internally by spawned subprocesses)
 
 ## Hardware Classification
 
@@ -445,8 +586,8 @@ def compute_golden(self, args, params):
 | Single run (sim) | `python examples/scripts/run_example.py -k kernels/ -g golden.py -p a2a3sim` | `python test_*.py -p a2a3sim` |
 | Single run (hardware) | `python examples/scripts/run_example.py -k kernels/ -g golden.py -p a2a3 -d 0` | `python test_*.py -p a2a3 -d 0` |
 | Batch (pytest) | `python examples/scripts/ci.py` | `pytest examples tests/st --platform a2a3sim` |
-| Multi-round | Not supported | `python test_*.py -p a2a3sim -n 3` |
-| Benchmark | Manual | `python test_*.py -p a2a3 -d 0 -n 100 --skip-golden --case CaseName` |
+| Multi-round | Not supported | `python test_*.py -p a2a3sim --rounds 3` |
+| Benchmark | Manual | `python test_*.py -p a2a3 -d 0 --rounds 100 --skip-golden --case CaseName` |
 | Profiling | `--enable-profiling` flag on run_example.py | `python test_*.py -p a2a3 -d 0 --enable-profiling` (auto-runs `tools/swimlane_converter.py` per case at end) |
 
 ##### `--case` selector and `--manual`
@@ -494,48 +635,41 @@ When a second runtime launches on the same device (same CANN process context), t
 | Different runtime, different device | Works (separate CANN context per device) |
 | Different runtime, different process, same device | Works (`rtDeviceReset` between processes clears context) |
 
-### Mitigation in pytest
+### Mitigation
 
-The `conftest.py` device allocator groups tests by runtime and assigns each runtime group to exclusive devices. See "Device Allocation Algorithm" below.
+The orchestrator spawns a separate subprocess per runtime for L2 work and a separate subprocess per case for L3 work. Every subprocess starts from a clean CANN state, so the stale-`.so` hang is structurally impossible.
 
-## Device Allocation Algorithm (Onboard pytest)
+## Device Allocation (Orchestrator + xdist)
 
-When running `pytest --platform a2a3 --device 8-11`, the fixture must allocate devices to tests such that:
+When running `pytest --platform a2a3 --device 8-11`, the orchestrator does this:
 
-1. **Runtime isolation**: A device used by runtime A must not be reused by runtime B in the same process.
-2. **L3 multi-device**: L3 tests may need 2+ contiguous devices.
-3. **Efficiency**: Devices freed by one test of the same runtime can be reused by the next.
+### L3 phase — device bin-packing
 
-### Algorithm
+For every collected L3 case, the scheduler (`simpler_setup/parallel_scheduler.py`) maintains a free-device set starting at `[8, 9, 10, 11]`. It pops the next queued case and, if the free set can cover its `device_count`, grabs that many ids and spawns:
 
 ```text
-Phase 1: Group tests by runtime
-  tensormap_and_ringbuffer: [TestVectorExample, TestScalarData, TestL3Dependency, ...]
-  aicpu_build_graph:        [TestPagedAttentionAicpuBuildGraph]
-  host_build_graph:         [TestPagedAttentionHostBuildGraph]
-
-Phase 2: Partition devices across runtime groups
-  Available: [8, 9, 10, 11]
-  tensormap_and_ringbuffer (6 tests, needs max 2 for L3 group): devices [8, 9]
-  aicpu_build_graph (1 test, needs 1):                          devices [10]
-  host_build_graph (1 test, needs 1):                           devices [11]
-
-Phase 3: Within each group, allocate from group's device pool
-  TestVectorExample:       dev 8 → run → release → dev 8 available again
-  TestScalarData:          dev 8 → run → release → OK (same runtime)
-  TestL3Dependency:        dev 8 → run → release
-  TestL3Group:             dev [8, 9] → run → release
-  TestPagedAttentionAicpuBuildGraph: dev 10 → run → release
-  TestPagedAttentionHostBuildGraph:  dev 11 → run → release
+pytest <nodeid> --runtime <rt> --level 3 --case <Class::case> --device <alloc-range>
 ```
 
-### Implementation
+When a subprocess completes, its devices return to the free set and the queue is re-tried. Cases that need more devices than currently free **wait**; cases that need more than the whole pool **fail the batch up front**.
 
-The `DevicePool` in `conftest.py` is extended with runtime-aware partitioning. The `st_worker` fixture checks the test class's `_st_runtime` and allocates from the corresponding partition.
+### L2 phase — xdist fanout per device
+
+After L3 drains, one subprocess is spawned per runtime:
+
+```text
+pytest --runtime <rt> --level 2 --device 8-11 -n 4 --dist loadfile
+```
+
+`pytest-xdist` starts 4 workers (`gw0`..`gw3`). Each worker's `pytest_configure` slices `--device 8-11` down to a single id (`gw0` → `8`, `gw1` → `9`, ...), and `st_worker` is session-scoped, so the worker initializes exactly one `ChipWorker(device=N)` and reuses it for every L2 class routed to it. `--dist loadfile` keeps all cases from one test file on the same worker, amortizing any file-level setup cost.
+
+### L2 phase — standalone fanout
+
+Standalone (`python test_*.py -d 8-11`) uses the same scheduler module: classes are round-robin assigned to `len(device_ids)` chunks, one subprocess per chunk launched with a single device and explicit `--case ClassName::` selectors.
 
 ### Sim platforms
 
-On sim (`a2a3sim`, `a5sim`), device IDs are virtual — no hardware state, no isolation constraint. All tests share a single virtual pool with auto-incrementing IDs.
+On sim (`a2a3sim`, `a5sim`), device IDs are virtual — no hardware state, no isolation constraint. All tests share a single virtual pool with auto-incrementing IDs. The same orchestrator + xdist path is used; speedup on sim comes from actual CPU parallelism, not hardware parallelism.
 
 ## Per-Case Device Filtering
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ version = "0.1.0"
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
-test = ["pytest>=6.0"]
+test = ["pytest>=6.0", "pytest-xdist>=3.0"]
 
 [tool.ruff]
 line-length = 120

--- a/simpler_setup/parallel_scheduler.py
+++ b/simpler_setup/parallel_scheduler.py
@@ -1,0 +1,310 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Device-aware subprocess scheduler for parallel L3 test dispatch.
+
+Given a list of jobs, each declaring how many devices it needs, this module
+runs them as isolated subprocesses in parallel up to the device pool's
+capacity. Used by the pytest orchestrator (conftest.py) and the standalone
+runner (scene_test.run_module) to parallelize Level-3 test cases.
+
+Concurrency bound: the caller's ``device_ids`` list size. No separate
+``--max-parallel`` knob — shrink ``-d`` to throttle.
+
+Static safety: any job where ``device_count > len(device_ids)`` fails the
+whole batch up front (otherwise it would deadlock on the wait queue).
+
+Fail-fast: when ``fail_fast=True`` and any job fails, cancel the pending
+queue, SIGTERM running children, and return promptly.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import threading
+from dataclasses import dataclass, field
+from typing import Callable
+
+
+@dataclass
+class Job:
+    """A single scheduled subprocess.
+
+    ``build_cmd`` receives the list of device ids allocated to this job and
+    must return the argv. We build the command lazily so the caller can
+    substitute the allocated ``--device <range>`` at launch time.
+    """
+
+    label: str  # Human label for logs
+    device_count: int  # Devices required
+    build_cmd: Callable[[list[int]], list[str]]  # Given allocated ids → argv
+    cwd: str | None = None
+    env: dict | None = None
+
+
+@dataclass
+class JobResult:
+    label: str
+    returncode: int
+    device_ids: list[int]
+
+
+@dataclass
+class _RunState:
+    free_devices: list[int]
+    running: dict[subprocess.Popen, tuple[Job, list[int]]] = field(default_factory=dict)
+    results: list[JobResult] = field(default_factory=list)
+    failed: bool = False
+    cancelled: bool = False
+
+
+def _device_range_str(ids: list[int]) -> str:
+    """Format a device-id list as a CLI-friendly range or comma list.
+
+    [0,1,2,3] -> "0-3"   (contiguous ascending)
+    [4]       -> "4"
+    [0,2,5]   -> "0,2,5" (non-contiguous)
+    """
+    if not ids:
+        return ""
+    if len(ids) == 1:
+        return str(ids[0])
+    s = sorted(ids)
+    contiguous = all(s[i + 1] - s[i] == 1 for i in range(len(s) - 1))
+    if contiguous:
+        return f"{s[0]}-{s[-1]}"
+    return ",".join(str(i) for i in s)
+
+
+def _acquire_devices(state: _RunState, count: int) -> list[int] | None:
+    """Try to grab ``count`` device ids from the free pool; None if short."""
+    if len(state.free_devices) < count:
+        return None
+    allocated = state.free_devices[:count]
+    state.free_devices = state.free_devices[count:]
+    return allocated
+
+
+def _release_devices(state: _RunState, ids: list[int]) -> None:
+    state.free_devices.extend(ids)
+
+
+def _terminate_all(state: _RunState, timeout_s: float = 5.0) -> None:
+    """SIGTERM all running children, wait briefly, then SIGKILL stragglers."""
+    for p in list(state.running):
+        if p.poll() is None:
+            try:
+                p.send_signal(signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+    for p in list(state.running):
+        try:
+            p.wait(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            try:
+                p.kill()
+                p.wait(timeout=1.0)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def run_jobs(
+    jobs: list[Job],
+    device_ids: list[int],
+    *,
+    max_parallel: int | None = None,
+    fail_fast: bool = False,
+    poll_interval_s: float = 0.1,
+    on_job_done: Callable[[JobResult], None] | None = None,
+) -> list[JobResult]:
+    """Run jobs concurrently up to the device-pool capacity.
+
+    Scheduling is FIFO: jobs are popped in order; if the head can't be placed
+    (not enough free devices right now, or ``max_parallel`` already reached),
+    we wait for a running job to finish rather than skip ahead. Simple and
+    predictable.
+
+    Args:
+        jobs: jobs to dispatch, in preferred order.
+        device_ids: full pool of available device ids. ``len(device_ids)`` is
+            the device-side hard cap — a single job is still capped by its
+            own ``device_count``, and the sum of running jobs' ``device_count``
+            can never exceed the pool.
+        max_parallel: max number of subprocesses in flight simultaneously
+            (``-j`` semantics, same as ``make -j``). ``None`` means "no
+            extra cap" and the only bound is the device pool. Use this to
+            throttle CPU contention on sim where one subprocess can already
+            fork many internal workers.
+        fail_fast: on first non-zero return code, cancel remaining queue and
+            terminate running children.
+        poll_interval_s: how often to check for finished children.
+        on_job_done: called (thread-safe w.r.t. this function — which is
+            single-threaded) whenever a job completes, useful for streaming
+            pytest reports or printing PASS/FAIL lines.
+
+    Returns:
+        List of JobResult in completion order. Jobs cancelled under
+        ``fail_fast`` do not appear.
+    """
+    # Static check: no job can ever be placed if its device_count exceeds the
+    # total pool. Fail the batch before dispatching anything.
+    for j in jobs:
+        if j.device_count > len(device_ids):
+            raise ValueError(
+                f"job {j.label!r} needs {j.device_count} devices but pool has "
+                f"{len(device_ids)}; widen --device range or shrink the case's device_count"
+            )
+
+    state = _RunState(free_devices=list(device_ids))
+    queue = list(jobs)
+
+    def _try_launch_head() -> bool:
+        """Launch queue[0] if it fits; return True if launched or queue empty/blocked."""
+        if not queue:
+            return False
+        # Respect the in-flight subprocess cap if one is set.
+        if max_parallel is not None and len(state.running) >= max_parallel:
+            return False
+        head = queue[0]
+        allocated = _acquire_devices(state, head.device_count)
+        if allocated is None:
+            return False
+        queue.pop(0)
+        cmd = head.build_cmd(allocated)
+        try:
+            p = subprocess.Popen(cmd, cwd=head.cwd, env=head.env)
+        except Exception:
+            _release_devices(state, allocated)
+            raise
+        state.running[p] = (head, allocated)
+        return True
+
+    def _reap_one() -> JobResult | None:
+        """Poll for one finished child; return its JobResult or None."""
+        for p in list(state.running):
+            rc = p.poll()
+            if rc is None:
+                continue
+            job, ids = state.running.pop(p)
+            _release_devices(state, ids)
+            res = JobResult(label=job.label, returncode=rc, device_ids=ids)
+            state.results.append(res)
+            if rc != 0:
+                state.failed = True
+            return res
+        return None
+
+    try:
+        # Fill until blocked
+        while queue and _try_launch_head():
+            pass
+
+        while state.running or queue:
+            # If cancelled, stop pulling from queue
+            if state.cancelled:
+                queue.clear()
+
+            reaped = _reap_one()
+            if reaped is not None:
+                if on_job_done is not None:
+                    on_job_done(reaped)
+                if fail_fast and state.failed and not state.cancelled:
+                    state.cancelled = True
+                    queue.clear()
+                    continue
+                # Fill freed slot
+                while queue and _try_launch_head():
+                    pass
+                continue
+
+            # Nothing to reap; wait briefly
+            try:
+                # Block on the first running child up to poll_interval_s
+                first = next(iter(state.running), None)
+                if first is None:
+                    break
+                first.wait(timeout=poll_interval_s)
+            except subprocess.TimeoutExpired:
+                pass
+    finally:
+        if state.cancelled and state.running:
+            _terminate_all(state)
+            # Sweep final results for the terminated ones
+            for p in list(state.running):
+                rc = p.poll()
+                if rc is None:
+                    rc = -signal.SIGTERM
+                job, ids = state.running.pop(p)
+                _release_devices(state, ids)
+                state.results.append(JobResult(label=job.label, returncode=rc, device_ids=ids))
+
+    return state.results
+
+
+# ---------------------------------------------------------------------------
+# Lock used by callers that share a scheduler across threads (reserved for
+# future use; the current single-threaded scheduler above does not need it).
+# ---------------------------------------------------------------------------
+
+_scheduler_lock = threading.Lock()
+
+
+def default_max_parallel(platform: str, device_ids: list[int]) -> int:
+    """Compute the ``-j auto`` default for this invocation.
+
+    - Hardware (platform does not end in ``"sim"``): bound is the device count.
+      Host CPU is mostly idle waiting on the NPU, so no further cap is useful.
+    - Sim: bound is ``min(nproc, len(device_ids))``. Each sim subprocess
+      already multiplexes many internal threads onto CPUs; running one
+      subprocess per CPU is the practical ceiling.
+    """
+    n_dev = len(device_ids)
+    if not platform.endswith("sim"):
+        return max(n_dev, 1)
+    try:
+        cpu = os.cpu_count() or 1
+    except Exception:  # noqa: BLE001
+        cpu = 1
+    return max(1, min(n_dev, cpu))
+
+
+def device_range_to_list(spec: str) -> list[int]:
+    """Parse a --device spec into a sorted deduplicated list of ints.
+
+    Supports comma-separated mixed forms including ranges:
+
+      ``"0"``        → ``[0]``
+      ``"0-3"``      → ``[0, 1, 2, 3]``
+      ``"0,2,5"``    → ``[0, 2, 5]``
+      ``"0,2-4,7"``  → ``[0, 2, 3, 4, 7]``
+
+    Whitespace inside comma-separated parts is trimmed. Empty input returns
+    an empty list so callers can uniformly handle the unset case.
+    Kept here (rather than in conftest.py) so standalone can share the same
+    parsing.
+    """
+    if not spec:
+        return []
+    ids: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start, end = part.split("-", 1)
+            ids.update(range(int(start), int(end) + 1))
+        else:
+            ids.add(int(part))
+    return sorted(ids)
+
+
+def format_device_range(ids: list[int]) -> str:
+    """Inverse of device_range_to_list — public wrapper around _device_range_str."""
+    return _device_range_str(ids)

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -613,6 +613,53 @@ def _convert_case_swimlane(
     )
 
 
+def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI surface
+    worker,
+    cls_inst,
+    cases,
+    *,
+    callable_obj,
+    sub_ids,
+    primary_device_id,
+    is_hardware,
+    rounds,
+    skip_golden,
+    enable_profiling,
+    enable_dump_tensor,
+):
+    """Execute a pre-filtered list of cases for one class (layers 5-6).
+
+    Caller is responsible for platform/selector/manual filtering. Profiling
+    snapshots wrap each case. Validation failures propagate; caller decides
+    fail-fast vs collect semantics.
+    """
+    cls_name = type(cls_inst).__name__
+    callable_spec = getattr(type(cls_inst), "CALLABLE", None)
+    for case in cases:
+        before_perf = _snapshot_perf_files() if enable_profiling else set()
+        before_device = _snapshot_device_logs(primary_device_id) if enable_profiling and is_hardware else None
+        try:
+            cls_inst._run_and_validate(
+                worker,
+                callable_obj,
+                case,
+                sub_ids=sub_ids,
+                rounds=rounds,
+                skip_golden=skip_golden,
+                enable_profiling=enable_profiling,
+                enable_dump_tensor=enable_dump_tensor,
+            )
+        finally:
+            if enable_profiling:
+                _convert_case_swimlane(
+                    f"{cls_name}_{case['name']}",
+                    primary_device_id,
+                    before_perf,
+                    before_device,
+                    callable_spec=callable_spec,
+                )
+
+
 def _compare_outputs(test_args, golden_args, output_names, rtol, atol):
     """Compare output tensors against golden values."""
     import torch  # noqa: PLC0415
@@ -967,7 +1014,7 @@ class SceneTestCase:
             primary_device_id = raw_device.split("-", 1)[0] if "-" in raw_device else raw_device
         is_hardware = not st_platform.endswith("sim")
 
-        ran_any = False
+        matched = []
         for case in self.CASES:
             if st_platform not in case["platforms"]:
                 continue
@@ -978,47 +1025,52 @@ class SceneTestCase:
                 continue
             if manual_mode == "only" and not is_manual:
                 continue
-            before_perf = _snapshot_perf_files() if enable_profiling else set()
-            before_device = _snapshot_device_logs(primary_device_id) if enable_profiling and is_hardware else None
-            try:
-                self._run_and_validate(
-                    st_worker,
-                    callable_obj,
-                    case,
-                    sub_ids=sub_ids,
-                    rounds=rounds,
-                    skip_golden=skip_golden,
-                    enable_profiling=enable_profiling,
-                    enable_dump_tensor=enable_dump_tensor,
-                )
-            finally:
-                if enable_profiling:
-                    _convert_case_swimlane(
-                        f"{cls_name}_{case['name']}",
-                        primary_device_id,
-                        before_perf,
-                        before_device,
-                        callable_spec=self.CALLABLE,
-                    )
-            ran_any = True
+            matched.append(case)
 
-        if not ran_any:
+        if not matched:
             import pytest  # noqa: PLC0415
 
             pytest.skip(f"No cases matched {cls_name} (platform={st_platform}, manual={manual_mode})")
+
+        run_class_cases(
+            st_worker,
+            self,
+            matched,
+            callable_obj=callable_obj,
+            sub_ids=sub_ids,
+            primary_device_id=primary_device_id,
+            is_hardware=is_hardware,
+            rounds=rounds,
+            skip_golden=skip_golden,
+            enable_profiling=enable_profiling,
+            enable_dump_tensor=enable_dump_tensor,
+        )
 
     # ------------------------------------------------------------------
     # Standalone entry point
     # ------------------------------------------------------------------
 
     @staticmethod
-    def run_module(module_name):
-        """Standalone entry: ``if __name__ == "__main__": SceneTestCase.run_module(__name__)``."""
+    def run_module(module_name):  # noqa: PLR0912 -- CLI parsing + dispatch; branches map to user-facing flags
+        """Standalone entry: ``if __name__ == "__main__": SceneTestCase.run_module(__name__)``.
+
+        Supports -d as either a single id or a range ("0-7"). When more than
+        one device is provided (or any L3 case needs more than its single
+        device), the outer invocation becomes an orchestrator that spawns
+        per-case subprocesses via ``parallel_scheduler``; each child re-enters
+        this function in single-group mode via ``--runtime`` + ``--level``.
+        """
         import argparse  # noqa: PLC0415
 
         parser = argparse.ArgumentParser()
         parser.add_argument("-p", "--platform", required=True)
-        parser.add_argument("-d", "--device", type=int, default=0)
+        parser.add_argument(
+            "-d",
+            "--device",
+            type=str,
+            default="0",
+            help="Device id or range ('0', '4-7', '0,2,5')",
+        )
         parser.add_argument(
             "--case",
             action="append",
@@ -1037,6 +1089,32 @@ class SceneTestCase:
         parser.add_argument("--dump-tensor", action="store_true", help="Dump per-task tensor I/O at runtime")
         parser.add_argument("--build", action="store_true", help="Compile runtime from source")
         parser.add_argument(
+            "--runtime",
+            default=None,
+            help="Only run classes with this _st_runtime (child-mode marker when combined with --level)",
+        )
+        parser.add_argument(
+            "--level",
+            type=int,
+            choices=[2, 3],
+            default=None,
+            help="Only run classes with this _st_level (child-mode marker when combined with --runtime)",
+        )
+        parser.add_argument(
+            "-x", "--exitfirst", action="store_true", help="Stop on first failing case (matches pytest -x)"
+        )
+        parser.add_argument(
+            "--max-parallel",
+            default="auto",
+            help=(
+                "Max in-flight subprocesses (make-style); decouples -d pool size from "
+                "parallelism. 'auto' = min(nproc, len(-d)) on sim, len(-d) on hardware. "
+                "Use e.g. '--max-parallel 2' to throttle sim on a CPU-constrained CI "
+                "runner without shrinking -d. No short form — pytest reserves lowercase "
+                "shorts; standalone mirrors that restriction for consistency."
+            ),
+        )
+        parser.add_argument(
             "--log-level",
             choices=LOG_LEVEL_CHOICES,
             default=DEFAULT_LOG_LEVEL,
@@ -1049,12 +1127,59 @@ class SceneTestCase:
             logger.warning("Profiling disabled: --rounds > 1")
             args.enable_profiling = False
 
+        from .parallel_scheduler import default_max_parallel, device_range_to_list  # noqa: PLC0415
+
+        device_ids = device_range_to_list(args.device)
+        if not device_ids:
+            print("ERROR: --device must be a non-empty id or range", file=sys.stderr)
+            sys.exit(2)
+        args.device_ids = device_ids
+        # Keep ``args.device`` as an int for paths that expect a single id
+        # (profiling snapshots, device-id binding inside one worker). In child
+        # mode this is the single allocated id; in parent mode we use the first
+        # slot but the orchestrator doesn't actually run tests here.
+        args.device = device_ids[0]
+
+        # Resolve -j (max parallel) — 'auto' is CPU-aware on sim, device-count on hardware.
+        if args.max_parallel in (None, "", "auto"):
+            args.max_parallel = default_max_parallel(args.platform, device_ids)
+        else:
+            try:
+                args.max_parallel = int(args.max_parallel)
+            except (TypeError, ValueError):
+                print(f"ERROR: -j must be 'auto' or an integer, got {args.max_parallel!r}", file=sys.stderr)
+                sys.exit(2)
+            if args.max_parallel < 1:
+                print(f"ERROR: -j must be >= 1, got {args.max_parallel}", file=sys.stderr)
+                sys.exit(2)
+        if args.enable_profiling and args.max_parallel > 1:
+            print(
+                f"ERROR: --enable-profiling is incompatible with --max-parallel {args.max_parallel}; "
+                "profiling writes process-global files that collide under parallelism. "
+                "Either pass '--max-parallel 1' or drop --enable-profiling.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
         module = sys.modules[module_name]
         test_classes = [
             v
             for v in vars(module).values()
             if isinstance(v, type) and issubclass(v, SceneTestCase) and v is not SceneTestCase and hasattr(v, "CASES")
         ]
+
+        # Apply --runtime/--level filters (child mode sets both; parent may also
+        # use them when the user wants a narrow run).
+        if args.runtime is not None:
+            test_classes = [c for c in test_classes if getattr(c, "_st_runtime", None) == args.runtime]
+        if args.level is not None:
+            test_classes = [c for c in test_classes if getattr(c, "_st_level", None) == args.level]
+        if not test_classes:
+            print(
+                f"No matching classes (runtime={args.runtime}, level={args.level})",
+                file=sys.stderr,
+            )
+            sys.exit(0)
 
         selectors = [_parse_case_selector(v) for v in (args.case or [])]
         try:
@@ -1067,9 +1192,27 @@ class SceneTestCase:
         for cls, case in selected:
             selected_by_cls.setdefault(cls, []).append(case)
 
-        by_runtime: dict[str, list[type]] = {}
+        # Child mode: both --runtime and --level set. Run inline without
+        # spawning further subprocesses; this is the path orchestrator
+        # children take after we re-enter run_module.
+        child_mode = args.runtime is not None and args.level is not None
+
+        if not child_mode:
+            has_multi_dev_case = any(
+                int(case.get("config", {}).get("device_count", 1)) > 1
+                for cases in selected_by_cls.values()
+                for case in cases
+            )
+            has_multiple_groups = len({(cls._st_runtime, cls._st_level) for cls in selected_by_cls}) > 1
+            needs_orchestration = len(device_ids) > 1 or has_multi_dev_case or has_multiple_groups
+            if needs_orchestration:
+                ok = _orchestrate_standalone(module_name, selected_by_cls, args)
+                sys.exit(0 if ok else 1)
+
+        # ----- Inline execution (single group or child mode) -----
+        by_rt_level: dict[tuple[str, int], list[type]] = {}
         for cls in selected_by_cls:
-            by_runtime.setdefault(cls._st_runtime, []).append(cls)
+            by_rt_level.setdefault((cls._st_runtime, cls._st_level), []).append(cls)
 
         is_hardware = not args.platform.endswith("sim")
         if args.enable_profiling and is_hardware and "-d" not in sys.argv and "--device" not in sys.argv:
@@ -1080,9 +1223,9 @@ class SceneTestCase:
             )
 
         ok = True
-        for runtime, group in by_runtime.items():
-            print(f"\n=== Runtime: {runtime} ===")
-            worker, per_class_sub_ids = _create_standalone_worker(group, args)
+        for (runtime, level), group in by_rt_level.items():
+            print(f"\n=== Runtime: {runtime}  Level: {level} ===")
+            worker, per_class_sub_ids = _create_standalone_worker(group, level, args)
             try:
                 for cls in group:
                     inst = cls()
@@ -1091,36 +1234,28 @@ class SceneTestCase:
                     for case in selected_by_cls[cls]:
                         label = f"{cls.__name__}::{case['name']}"
                         print(f"  {label} ... ", end="", flush=True)
-                        before_perf = _snapshot_perf_files() if args.enable_profiling else set()
-                        before_device = (
-                            _snapshot_device_logs(args.device) if args.enable_profiling and is_hardware else None
-                        )
                         try:
-                            inst._run_and_validate(
+                            run_class_cases(
                                 worker,
-                                callable_obj,
-                                case,
+                                inst,
+                                [case],
+                                callable_obj=callable_obj,
                                 sub_ids=sub_ids,
+                                primary_device_id=args.device,
+                                is_hardware=is_hardware,
                                 rounds=args.rounds,
                                 skip_golden=args.skip_golden,
                                 enable_profiling=args.enable_profiling,
                                 enable_dump_tensor=args.dump_tensor,
                             )
                             print("PASSED")
-                        except Exception as e:
+                        except Exception as e:  # noqa: BLE001
                             print(f"FAILED: {e}")
                             ok = False
-                        finally:
-                            if args.enable_profiling:
-                                _convert_case_swimlane(
-                                    f"{cls.__name__}_{case['name']}",
-                                    args.device,
-                                    before_perf,
-                                    before_device,
-                                    callable_spec=cls.CALLABLE,
-                                )
+                            if args.exitfirst:
+                                raise SystemExit(1) from None
             finally:
-                if group[0]._st_level == 2:
+                if level == 2:
                     worker.finalize()
                 else:
                     worker.close()
@@ -1128,10 +1263,197 @@ class SceneTestCase:
         sys.exit(0 if ok else 1)
 
 
-def _create_standalone_worker(group, args):
-    """Create a Worker for standalone run_module entry point."""
+def _orchestrate_standalone(module_name, selected_by_cls, args):  # noqa: PLR0912 -- L3 + L2 phases + chunking + fail-fast
+    """Parent-mode dispatch for run_module.
+
+    L3 phase: one subprocess per (class, case), scheduled by device count.
+    L2 phase: for CS2, serial per-(runtime) subprocess on device_ids[0].
+    (CS4 adds device fanout for L2.)
+
+    Returns True on full success, False if any child failed.
+    """
+    from .parallel_scheduler import Job, format_device_range, run_jobs  # noqa: PLC0415
+
+    module = sys.modules[module_name]
+    # Path to the user's test script — sys.argv[0] is the script they invoked.
+    script = os.path.abspath(getattr(module, "__file__", sys.argv[0]))
+
+    common = ["-p", args.platform, "--manual", args.manual, "--log-level", args.log_level]
+    if args.rounds != 1:
+        common += ["--rounds", str(args.rounds)]
+    if args.skip_golden:
+        common.append("--skip-golden")
+    if args.enable_profiling:
+        common.append("--enable-profiling")
+    if args.dump_tensor:
+        common.append("--dump-tensor")
+    if args.build:
+        common.append("--build")
+
+    # ----- L3 phase: one subprocess per class (not per case).
+    # The child's _create_standalone_worker allocates max(cls.CASES.device_count)
+    # for the whole class, so the scheduler must grant the class-level max,
+    # otherwise a class with a 4-device case can't run any of its 1-device
+    # cases when we dispatch them individually with --device <1>. Cases inside
+    # a class still run serially in the child, reusing the L3 Worker.
+    l3_jobs = []
+    for cls, cases in selected_by_cls.items():
+        if cls._st_level != 3:
+            continue
+        if not cases:
+            continue
+        class_dev_count = max(int(c.get("config", {}).get("device_count", 1)) for c in cases)
+        label = f"L3 {cls.__name__} (rt={cls._st_runtime}, dev={class_dev_count})"
+
+        def _build(ids, _cls=cls.__name__, _rt=cls._st_runtime):
+            return [
+                sys.executable,
+                script,
+                *common,
+                "-d",
+                format_device_range(ids),
+                "--case",
+                f"{_cls}::",
+                "--runtime",
+                _rt,
+                "--level",
+                "3",
+            ]
+
+        l3_jobs.append(Job(label=label, device_count=class_dev_count, build_cmd=_build))
+
+    l3_failed = False
+    if l3_jobs:
+        print(
+            f"\n{'=' * 60}\n  L3 phase: {len(l3_jobs)} case(s), pool={args.device_ids}, "
+            f"max_parallel={args.max_parallel}\n{'=' * 60}\n"
+        )
+
+        def _on_done(res):
+            tag = "PASSED" if res.returncode == 0 else f"FAILED (rc={res.returncode})"
+            print(f"  {res.label}: {tag} on devices {res.device_ids}", flush=True)
+
+        try:
+            results = run_jobs(
+                l3_jobs,
+                args.device_ids,
+                max_parallel=args.max_parallel,
+                fail_fast=args.exitfirst,
+                on_job_done=_on_done,
+            )
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return False
+        l3_failed = any(r.returncode != 0 for r in results)
+        if l3_failed and args.exitfirst:
+            return False
+
+    # ----- L2 phase: runtimes serial (CANN isolation); within a runtime, fan
+    # out classes across device_ids as one subprocess per device. Each child
+    # owns one ChipWorker and runs its chunk of classes back-to-back (layer-4
+    # reuse). Single-device case reduces to one subprocess per runtime.
+    l2_by_runtime: dict[str, list[type]] = {}
+    for cls in selected_by_cls:
+        if cls._st_level == 2:
+            l2_by_runtime.setdefault(cls._st_runtime, []).append(cls)
+
+    l2_failed = False
+    for rt in sorted(l2_by_runtime):
+        classes = l2_by_runtime[rt]
+        # Chunk count = min(-j, number of classes). We intentionally do NOT
+        # include len(device_ids) here: each chunk uses 1 device and at most
+        # max_parallel chunks run concurrently, so a pool bigger than -j just
+        # leaves unused ids. Fewer, larger chunks also amortize ChipWorker
+        # init (layer-4 reuse) over more cases.
+        n = min(args.max_parallel, len(classes))
+        if n == 0:
+            continue
+        # Round-robin distribute classes to N children.
+        chunks: list[list[type]] = [[] for _ in range(n)]
+        for i, cls in enumerate(classes):
+            chunks[i % n].append(cls)
+
+        header = f"  L2 Runtime: {rt}" + (f"  [fanout n={n}]" if n > 1 else "")
+        print(f"\n{'=' * 60}\n{header}\n{'=' * 60}\n")
+
+        l2_jobs = []
+        for i, chunk in enumerate(chunks):
+            if not chunk:
+                continue
+            dev = args.device_ids[i]
+            case_filters: list[str] = []
+            for cls in chunk:
+                # User-supplied selectors still filter; we scope to this chunk's
+                # classes using "ClassName::<case>" or "ClassName::" (whole class).
+                for sel in args.case or []:
+                    if "::" in sel:
+                        sel_cls, sel_case = sel.split("::", 1)
+                        if not sel_cls or sel_cls == cls.__name__:
+                            case_filters.append(f"{cls.__name__}::{sel_case}" if sel_case else f"{cls.__name__}::")
+                    else:
+                        # Bare selector "Foo" = case name in any class — forward as-is,
+                        # but still scope to this chunk's classes.
+                        case_filters.append(f"{cls.__name__}::{sel}")
+                if not args.case:
+                    case_filters.append(f"{cls.__name__}::")
+            label = f"L2 {rt} dev={dev} ({len(chunk)} class(es))"
+
+            def _build(ids, _rt=rt, _dev=dev, _filters=tuple(case_filters)):
+                cmd = [
+                    sys.executable,
+                    script,
+                    *common,
+                    "-d",
+                    str(_dev),
+                    "--runtime",
+                    _rt,
+                    "--level",
+                    "2",
+                ]
+                for f in _filters:
+                    cmd += ["--case", f]
+                return cmd
+
+            # device_count=1 for L2 fanout children (each child uses one slot).
+            l2_jobs.append(Job(label=label, device_count=1, build_cmd=_build))
+
+        # Use the same scheduler: pool=device_ids, fail_fast=exitfirst. This
+        # gives us automatic parallelism + SIGTERM on fail-fast.
+        def _on_l2_done(res):
+            tag = "PASSED" if res.returncode == 0 else f"FAILED (rc={res.returncode})"
+            print(f"  {res.label}: {tag}", flush=True)
+
+        try:
+            results = run_jobs(
+                l2_jobs,
+                args.device_ids,
+                max_parallel=args.max_parallel,
+                fail_fast=args.exitfirst,
+                on_job_done=_on_l2_done,
+            )
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            l2_failed = True
+            if args.exitfirst:
+                break
+            continue
+
+        if any(r.returncode != 0 for r in results):
+            l2_failed = True
+            if args.exitfirst:
+                break
+
+    return not (l3_failed or l2_failed)
+
+
+def _create_standalone_worker(group, level, args):
+    """Create a Worker for a (runtime, level) group in run_module.
+
+    ``level`` is passed explicitly by the caller; do not read it from
+    ``group[0]._st_level`` because groups are now keyed on (runtime, level)
+    and mixed-level files are allowed.
+    """
     first_cls = group[0]
-    level = first_cls._st_level
     build = getattr(args, "build", False)
     if level == 2:
         return first_cls._create_worker(args.platform, args.device, build=build), {}
@@ -1140,7 +1462,13 @@ def _create_standalone_worker(group, args):
 
     max_devices = max((c.get("config", {}).get("device_count", 1) for cls in group for c in cls.CASES), default=1)
     max_subs = max((c.get("config", {}).get("num_sub_workers", 0) for cls in group for c in cls.CASES), default=0)
-    device_ids = list(range(args.device, args.device + max_devices))
+    # Prefer the allocated list (orchestrator child mode), fall back to
+    # contiguous range starting at args.device (legacy inline path).
+    allocated = getattr(args, "device_ids", None)
+    if allocated and len(allocated) >= max_devices:
+        device_ids = allocated[:max_devices]
+    else:
+        device_ids = list(range(args.device, args.device + max_devices))
     worker = Worker(
         level=3,
         device_ids=device_ids,


### PR DESCRIPTION
## Summary

Restructures pytest and standalone runners around a 6-layer reuse hierarchy: **Level → Runtime → Device → Class → Case → Rounds**. The orchestrator dispatches L3 cases as isolated per-case subprocesses scheduled by device count, and runs L2 work under `pytest-xdist` with one `ChipWorker` per `(runtime, device)` shared across every class on that device.

On an N-device box this turns a serial run into N-way parallel work. It also drops `ChipWorker` init (3 `dlopen`s + device acquire) from once-per-class to once-per-device, which matters on sim where init dominates short tests.

## Changes

- **New** `simpler_setup/parallel_scheduler.py` — FIFO device bin-packing scheduler with `Popen` pool, static check (`device_count > pool` fails up front), and `SIGTERM` cancellation under `-x/--exitfirst`.
- **`conftest.py`** — `pytest_runtestloop` becomes an orchestrator: L3 phase via the scheduler, L2 phase with `pytest-xdist -n N --dist loadfile`. `pytest_configure` slices `--device 0-7` down to a single id per xdist worker. `st_worker` is session-scoped via a `(runtime, device)`-keyed pool so cross-class L2 reuse works inside an xdist worker process. Adds `--level {2,3}` (also the child-mode marker used to avoid orchestrator recursion).
- **`simpler_setup/scene_test.py`** — `run_module` accepts `-d` as range/list, adds `--runtime`, `--level`, `-x/--exitfirst`. New `_orchestrate_standalone` mirrors the pytest orchestrator for standalone (L3 per-case via the scheduler; L2 round-robin class chunks, one subprocess per device). Extracts `run_class_cases` as the shared layer-5 helper. Fixes an existing bug where mixed L2+L3 classes in one file got the wrong `Worker` type: groups are now keyed on `(runtime, level)` instead of `first_cls._st_level`.
- **Guard** `--enable-profiling` + multi-device combination — clear usage error instead of silent file collisions.
- **`pyproject.toml`** — adds `pytest-xdist>=3.0` to the `test` extra.
- **Docs** — `docs/testing.md` gains a \"Parallel Test Execution and Resource Reuse\" section with the hierarchy diagram, fail-fast semantics, device-count constraints, and orchestrator skip conditions. `docs/ci.md` gets the recommended CI invocation.

## Test plan

- [x] All Python unit tests pass locally (`pytest tests/ut --platform a2a3sim` — 174 passed).
- [x] Scheduler unit behaviors verified: parallel bin-packing hits near-ideal wall clock, static check rejects oversized `device_count`, `fail_fast=True` terminates running children and cancels the queue.
- [x] `--level 2`/`--level 3` filter correctly include/skip at collection time.
- [x] `--enable-profiling --device 0-3` errors out (`pytest.UsageError`) before any test runs.
- [ ] Linux CI: full ST suite on `a2a3sim` and `a5sim` — `pytest examples tests/st --platform a2a3sim` / `a5sim`.
- [ ] `a2a3` self-hosted: `pytest examples tests/st --platform a2a3 --device 4-7 -x` — confirm ≥3× speedup vs `--device 4 -x`.
- [ ] L3 parallelism on hardware: pick a file with multiple `device_count=1` L3 cases and compare `--device 4-7` vs `--device 4` wall clock.
- [ ] Standalone fanout: pick any test file and compare `python .../test_*.py -p a2a3sim -d 0-3` vs `-d 0`.

## Backward compatibility

- `pytest ... --device 0` / `python test_*.py -d 0`: the orchestrator short-circuits and falls through to the prior code path. Single-device behavior is preserved bit-for-bit.
- `--runtime rt` alone (no `--level`): orchestrator still runs, filtering both phases to that runtime. Identical outcome, extra subprocess boundary only when there are L3 items.
- `--runtime rt --level 2/3`: child-mode marker — pytest/run_module run inline without spawning further subprocesses.

## Notes on what's intentionally out of scope

- Intra-test-class case parallelism (running cases within one class in parallel) — would require GIL-release work in the nanobind bindings; deferred.
- Profiling under parallelism — perf and device-log paths are process-global; fixing this properly is a separate task, the guard buys time.
- Sim C API changes — the existing `pthread_key` per-thread device binding was already sufficient; no C++ changes needed.