### PR TITLE
Support: parallel-safe profiling via per-subprocess output dir

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -208,7 +208,7 @@ def pytest_configure(config):
         _install_session_timeout(timeout)
 
     # xdist worker: bind this process to a single device id from the --device range.
-    # The orchestrator (or the user) supplies --device 0-7; xdist spawns N workers
+    # The dispatcher (or the user) supplies --device 0-7; xdist spawns N workers
     # labelled gw0..gwN-1. We slice device_ids[worker_index] so each worker owns
     # exactly one device. L2 Worker is session-scoped inside xdist children, so
     # all tests on this worker share one ChipWorker init().
@@ -222,32 +222,23 @@ def pytest_configure(config):
         ids = _parse_device_range(device_spec)
         if 0 <= idx < len(ids):
             config.option.device = str(ids[idx])
+        # Each xdist worker gets its own perf output dir so parallel profiling
+        # runs don't fight over the same perf_swimlane_*.json filename (the
+        # runtime's timestamp is second-precision). Anchor to config.rootpath
+        # so the C++ runtime (which resolves the path against its own CWD) and
+        # Python post-processing always point at the same filesystem location
+        # regardless of where pytest was invoked. Only set if the parent
+        # hasn't already scoped us into a subprocess dir.
+        if "SIMPLER_PERF_OUTPUT_DIR" not in os.environ:
+            os.environ["SIMPLER_PERF_OUTPUT_DIR"] = str(config.rootpath / "outputs" / f"perf_{worker_id}")
         # else: more xdist workers than devices — fall through with original range;
         # DevicePool will fail clearly if the test tries to allocate.
 
-    # Parallel + profiling is unsafe (perf files are process-global). Block it
-    # at the parent (non-xdist-worker) level. What matters is concurrent
-    # subprocess count, not device pool size — respect -j.
-    if config.getoption("--enable-profiling", default=False) and not worker_id:
-        device_spec = config.getoption("--device", default="0")
-        ids = _parse_device_range(device_spec)
-        platform = config.getoption("--platform", default="") or ""
-        raw_j = config.getoption("--max-parallel", default="auto")
-        if raw_j in (None, "", "auto"):
-            from simpler_setup.parallel_scheduler import default_max_parallel  # noqa: PLC0415
-
-            j = default_max_parallel(platform, ids)
-        else:
-            try:
-                j = max(1, int(raw_j))
-            except (TypeError, ValueError):
-                j = 1
-        if j > 1:
-            raise pytest.UsageError(
-                f"--enable-profiling is incompatible with --max-parallel {j}; "
-                "profiling writes process-global files that collide under "
-                "parallelism. Either pass '--max-parallel 1' or drop --enable-profiling."
-            )
+    # Note: profiling + parallelism used to be blocked here because perf files
+    # shared a process-global directory. The test dispatcher now scopes each
+    # subprocess to its own SIMPLER_PERF_OUTPUT_DIR (see _dispatch_test_phases and
+    # the xdist slicing above) and flatten_perf_subdirs reassembles outputs/
+    # at the end, so the combination is now safe.
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -265,7 +256,7 @@ def pytest_collection_modifyitems(session, config, items):
     if target_nodeid:
         for item in items:
             if item.nodeid != target_nodeid:
-                item.add_marker(pytest.mark.skip(reason=f"orchestrator target is {target_nodeid}"))
+                item.add_marker(pytest.mark.skip(reason=f"dispatcher target is {target_nodeid}"))
 
     # Sort: L3 tests first (they fork child processes that inherit main process CANN state,
     # so they must run before L2 tests pollute the CANN context).
@@ -305,11 +296,32 @@ def pytest_collection_modifyitems(session, config, items):
         if runtime_marker and runtime_marker.args and runtime_filter and runtime_marker.args[0] != runtime_filter:
             item.add_marker(pytest.mark.skip(reason=f"Runtime {runtime_marker.args[0]} != {runtime_filter}"))
 
+    # L3 profiling is not supported yet: a single L3 case forks N chip-processes
+    # that all write perf_swimlane_<ts>.json to the same directory with
+    # second-precision timestamps, so they trample each other. Block the
+    # combination up front; waiting for a proper device-id-in-filename fix.
+    if config.getoption("--enable-profiling", default=False):
+        l3_items = [
+            i
+            for i in items
+            if getattr(getattr(i, "cls", None), "_st_level", None) == 3
+            and not any(m.name == "skip" for m in i.iter_markers())
+        ]
+        if l3_items:
+            sample = ", ".join(sorted({i.nodeid for i in l3_items})[:3])
+            more = "" if len(l3_items) <= 3 else f" (+{len(l3_items) - 3} more)"
+            raise pytest.UsageError(
+                f"--enable-profiling is not supported for L3 tests yet — "
+                f"multi-chip-process filename collision unresolved. "
+                f"L3 items in this session: {sample}{more}. "
+                f"Either drop --enable-profiling or scope to L2 with --level 2."
+            )
+
 
 # ---------------------------------------------------------------------------
-# Orchestrator: L3 phase (device-aware parallel subprocesses) + L2 phase
+# Test dispatcher: L3 phase (device-aware parallel subprocesses) + L2 phase
 # (per-runtime subprocess). Activated only when neither --runtime nor --level
-# is set by the caller. Orchestrator-spawned children set both, so they fall
+# is set by the caller. Dispatcher-spawned children set both, so they fall
 # through to pytest's default runtestloop without recursing.
 # ---------------------------------------------------------------------------
 
@@ -389,7 +401,7 @@ def _resolve_max_parallel(cfg, platform: str, device_ids: list[int]) -> int:
     return val
 
 
-def _orchestrate(session):
+def _dispatch_test_phases(session):
     """Run L3 phase (device-parallel) then L2 phase (per-runtime subprocess)."""
     from simpler_setup import parallel_scheduler as _ps  # noqa: PLC0415
 
@@ -428,7 +440,18 @@ def _orchestrate(session):
             # nodeid — defends against inherited positional args (``examples``,
             # ``tests/st``) collecting unrelated classes whose fixtures would
             # then fire at setup and fail on the narrower child device pool.
-            child_env = {**os.environ, "PTO_TARGET_NODEID": nodeid}
+            # SIMPLER_PERF_OUTPUT_DIR scopes this L3 case's perf files to its own
+            # subdir so concurrent L3 cases can't collide on filename (the
+            # runtime's timestamp is second-precision). Anchor to cfg.rootpath
+            # so the C++ runtime and Python post-processing agree regardless
+            # of the child's CWD. Use a nodeid-derived sanitized label so the
+            # dir name stays readable for post-mortem.
+            safe_nodeid = nodeid.replace("/", "_").replace(":", "_").replace(".", "_")
+            child_env = {
+                **os.environ,
+                "PTO_TARGET_NODEID": nodeid,
+                "SIMPLER_PERF_OUTPUT_DIR": str(cfg.rootpath / "outputs" / f"perf_l3_{safe_nodeid}"),
+            }
             jobs.append(_ps.Job(label=label, device_count=dev_count, build_cmd=_build, cwd=str(cwd), env=child_env))
 
         def _on_done(res):
@@ -504,6 +527,13 @@ def _orchestrate(session):
         else:
             print(f"\n--- L2 runtime {rt}: PASSED ---\n", flush=True)
 
+    # Flatten per-subprocess outputs/perf_*/ subdirs back to outputs/ so
+    # downstream tools (swimlane_converter.py, CI artifact upload) find
+    # everything in the historical location. Anchor to config.rootpath (not
+    # invocation_params.dir) so a user running pytest from a subdirectory
+    # still flushes files into the project's top-level outputs/.
+    _ps.flatten_perf_subdirs(cfg.rootpath / "outputs")
+
     session.testsfailed = 1 if (l3_failed or l2_failed) else 0
     if not (l3_failed or l2_failed):
         session.testscollected = sum(1 for _ in session.items)
@@ -511,15 +541,15 @@ def _orchestrate(session):
 
 
 def pytest_runtestloop(session):
-    """Orchestrate L3+L2 phases unless caller is already in child mode.
+    """Dispatch L3+L2 phases unless caller is already in child mode.
 
     Child mode (both --runtime and --level set, or --collect-only) skips the
-    orchestrator and falls through to pytest's default runtestloop.
+    dispatcher and falls through to pytest's default runtestloop.
     """
     runtime_filter = session.config.getoption("--runtime")
     level_filter = session.config.getoption("--level")
 
-    # Child mode: the orchestrator's spawned subprocesses carry both flags.
+    # Child mode: the dispatcher's spawned subprocesses carry both flags.
     if runtime_filter is not None and level_filter is not None:
         return
 
@@ -531,16 +561,16 @@ def pytest_runtestloop(session):
     if not session.items:
         return
 
-    # If only L2 items exist in a single runtime, the orchestrator reduces to a
+    # If only L2 items exist in a single runtime, the dispatcher reduces to a
     # single L2 subprocess — not worth the extra fork overhead vs. letting
-    # pytest run directly. Skip orchestration in that trivial case.
+    # pytest run directly. Skip dispatching in that trivial case.
     level_filter_explicit = level_filter is not None
     runtimes_all = _collect_st_runtimes(session.items)
     has_l3 = any(getattr(getattr(i, "cls", None), "_st_level", None) == 3 for i in session.items)
     if not has_l3 and len(runtimes_all) <= 1 and not level_filter_explicit:
         return
 
-    return _orchestrate(session)
+    return _dispatch_test_phases(session)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -55,7 +55,7 @@ PullRequest
 ### Parallel ST runs on hardware
 
 For self-hosted jobs with multiple NPUs, pass a `--device` range (and
-optionally pytest's `-x` for fail-fast) to get the full orchestrator
+optionally pytest's `-x` for fail-fast) to get the full dispatcher
 benefit — device bin-packing for L3, xdist fanout for L2, and a shared
 `ChipWorker` per `(runtime, device)`:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -105,7 +105,7 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 | `--case SEL` | | (all) | Case selector, repeatable: `Foo`, `ClassA::Foo`, `ClassA::` |
 | `--manual` | | `exclude` | `exclude`/`include`/`only` for manual cases |
 | `--skip-golden` | | false | Skip golden comparison (for benchmarking) |
-| `--enable-profiling` | | false | Enable profiling on first round only. Blocked when `--max-parallel > 1`. |
+| `--enable-profiling` | | false | Enable profiling on first round only. Works under parallelism — each subprocess writes to its own `outputs/perf_*/` subdir, flattened back to `outputs/` on completion. |
 | `--dump-tensor` | | false | Dump per-task tensor I/O during runtime execution |
 | `--build` | | false | Compile runtime from source (not pre-built) |
 | `--exitfirst` | `-x` | false | Stop on first failing test (fail-fast, primarily for CI) |
@@ -142,9 +142,9 @@ Practical guidance when adding a new CLI option:
 
 ## Parallel Test Execution and Resource Reuse
 
-Tests are dispatched through an **orchestrator** that pipelines work along two complementary axes:
+Tests are dispatched through a **test dispatcher** (`conftest.py::_dispatch_test_phases` and `scene_test.py::_dispatch_test_phases_standalone`) that pipelines work along two complementary axes:
 
-1. **Resource reuse** — every `ChipWorker` init costs three `dlopen`s plus a device-context acquire. The orchestrator keeps one worker alive for the lifetime of a test group so every class, case, and round on that device reuses the same worker.
+1. **Resource reuse** — every `ChipWorker` init costs three `dlopen`s plus a device-context acquire. The dispatcher keeps one worker alive for the lifetime of a test group so every class, case, and round on that device reuses the same worker.
 2. **Parallelism** — when `--device` names more than one id, independent work is spread across subprocesses so N devices do N-way work.
 
 Both pytest and standalone (`python test_*.py`) walk the same 6-layer hierarchy:
@@ -201,12 +201,12 @@ python test_foo.py -p a2a3sim --level 2 --runtime tensormap_and_ringbuffer --cas
 
 ### Fail-fast (`-x` / `--exitfirst`)
 
-- Default: all cases run; the orchestrator summarizes pass/fail at the end. This is the right mode for local development — you want every failure surfaced at once.
+- Default: all cases run; the dispatcher summarizes pass/fail at the end. This is the right mode for local development — you want every failure surfaced at once.
 - With `-x` / `--exitfirst`: first failure cancels the pending queue, sends `SIGTERM` to running children, and **skips the L2 phase if L3 failed**. Intended for CI. The short form mirrors pytest's built-in `-x` so the flag behaves identically across pytest and standalone.
 
 ### Device-count constraints
 
-If any L3 case declares `device_count > len(--device pool)` the orchestrator fails the whole batch up front rather than deadlocking the scheduler. Either widen `--device` or reduce the case's `device_count`. When `device_count` exceeds the *currently free* pool (but fits within the total), the case waits for an in-flight job to finish and then claims its slot.
+If any L3 case declares `device_count > len(--device pool)` the dispatcher fails the whole batch up front rather than deadlocking the scheduler. Either widen `--device` or reduce the case's `device_count`. When `device_count` exceeds the *currently free* pool (but fits within the total), the case waits for an in-flight job to finish and then claims its slot.
 
 ### `--device` vs `--max-parallel` (two separate knobs)
 
@@ -220,7 +220,7 @@ On hardware these two concepts collapse: one device = one subprocess's worth of 
 This matters on CPU-constrained CI runners. Example: an L3 case needs `device_count=8` but the runner has 2 CPUs.
 
 - `--device 0-1` — can't run the L3 case; static check fails.
-- `--device 0-15` (no `--max-parallel`) — L3 case fits, but the orchestrator would also spawn 15 concurrent L2 xdist workers and potentially multiple concurrent L3 cases, thrashing the 2 CPUs.
+- `--device 0-15` (no `--max-parallel`) — L3 case fits, but the dispatcher would also spawn 15 concurrent L2 xdist workers and potentially multiple concurrent L3 cases, thrashing the 2 CPUs.
 - `--device 0-15 --max-parallel 2` — L3 case fits in the pool; at most 2 subprocesses run at a time. This is what the `auto` default computes on a 2-core runner.
 
 `--max-parallel` counts top-level subprocesses, like `make -j`. A single L3 case subprocess internally forks N chip-processes for its `device_count`; those forks do **not** count toward `--max-parallel`. One case = one unit regardless of how many devices it uses.
@@ -229,19 +229,24 @@ This matters on CPU-constrained CI runners. Example: an L3 case needs `device_co
 
 A single file can declare both L2 and L3 classes; they're grouped by `(runtime, level)` internally. L3 classes run in the L3 phase (subprocess-per-case), L2 classes run in the L2 phase (shared Worker per device).
 
-### Profiling and parallelism are mutually exclusive
+### Profiling under parallelism
 
-`--enable-profiling` writes process-global files (`outputs/perf_swimlane_*.json` and CANN device logs) that collide under parallel runs. The orchestrator errors out up front when `--max-parallel > 1`. Profile on a single device:
+`--enable-profiling` writes `outputs/perf_swimlane_*.json`; the runtime's filename has second-precision timestamps, so two subprocesses producing perf files in the same second would collide on one path. The dispatcher sidesteps this by giving each subprocess its own directory via the `SIMPLER_PERF_OUTPUT_DIR` env var:
 
-```bash
-pytest tests/st --platform a2a3 --device 0 --enable-profiling
-# Or widen the pool but force serial execution:
-pytest tests/st --platform a2a3 --device 0-7 --max-parallel 1 --enable-profiling
-```
+| Subprocess | Scoped directory |
+| ---------- | ---------------- |
+| xdist worker `gwK` (L2 phase) | `outputs/perf_gwK/` |
+| L3 case (pytest path) | `outputs/perf_l3_<nodeid-sanitized>/` |
+| Standalone L3 class | `outputs/perf_l3_<ClassName>/` |
+| Standalone L2 fanout child | `outputs/perf_l2_<runtime>_dev<N>/` |
 
-### Orchestrator skip conditions (normal pytest runs)
+After all phases drain, `flatten_perf_subdirs()` moves the contents of every `outputs/perf_*/` subdir back to `outputs/` so downstream tools (`swimlane_converter.py`, CI artifact upload) still find everything in one place. Name collisions on the destination keep the first writer and suffix the loser with the subdir tag (e.g. `perf_swimlane_…__gw1.json`) so nothing is silently overwritten.
 
-The orchestrator only takes over when there's actual work to parallelize or isolate. It falls through to plain pytest when:
+The C++ runtime honors `SIMPLER_PERF_OUTPUT_DIR` at `PerformanceCollector::export_swimlane_json` — empty/unset falls through to the caller-supplied path (historical `outputs/` default), so standalone invocations that don't set the env var behave exactly as before.
+
+### Dispatcher skip conditions (normal pytest runs)
+
+The dispatcher only takes over when there's actual work to parallelize or isolate. It falls through to plain pytest when:
 
 - `--collect-only`
 - Only one runtime is present and no L3 cases are collected (single L2 batch)
@@ -557,11 +562,11 @@ When a second runtime launches on the same device (same CANN process context), t
 
 ### Mitigation
 
-The orchestrator spawns a separate subprocess per runtime for L2 work and a separate subprocess per case for L3 work. Every subprocess starts from a clean CANN state, so the stale-`.so` hang is structurally impossible.
+The dispatcher spawns a separate subprocess per runtime for L2 work and a separate subprocess per class for L3 work. Every subprocess starts from a clean CANN state, so the stale-`.so` hang is structurally impossible.
 
 ## Device Allocation (Orchestrator + xdist)
 
-When running `pytest --platform a2a3 --device 8-11`, the orchestrator does this:
+When running `pytest --platform a2a3 --device 8-11`, the dispatcher does this:
 
 ### L3 phase — device bin-packing
 
@@ -589,7 +594,7 @@ Standalone (`python test_*.py -d 8-11`) uses the same scheduler module: classes 
 
 ### Sim platforms
 
-On sim (`a2a3sim`, `a5sim`), device IDs are virtual — no hardware state, no isolation constraint. All tests share a single virtual pool with auto-incrementing IDs. The same orchestrator + xdist path is used; speedup on sim comes from actual CPU parallelism, not hardware parallelism.
+On sim (`a2a3sim`, `a5sim`), device IDs are virtual — no hardware state, no isolation constraint. All tests share a single virtual pool with auto-incrementing IDs. The same dispatcher + xdist path is used; speedup on sim comes from actual CPU parallelism, not hardware parallelism.
 
 ## Per-Case Device Filtering
 

--- a/simpler_setup/parallel_scheduler.py
+++ b/simpler_setup/parallel_scheduler.py
@@ -10,7 +10,7 @@
 
 Given a list of jobs, each declaring how many devices it needs, this module
 runs them as isolated subprocesses in parallel up to the device pool's
-capacity. Used by the pytest orchestrator (conftest.py) and the standalone
+capacity. Used by the pytest test dispatcher (conftest.py) and the standalone
 runner (scene_test.run_module) to parallelize Level-3 test cases.
 
 Concurrency bound: the caller's ``device_ids`` list size. No separate
@@ -308,3 +308,49 @@ def device_range_to_list(spec: str) -> list[int]:
 def format_device_range(ids: list[int]) -> str:
     """Inverse of device_range_to_list — public wrapper around _device_range_str."""
     return _device_range_str(ids)
+
+
+def flatten_perf_subdirs(outputs_dir: str | os.PathLike = "outputs") -> int:
+    """Move files from ``outputs/perf_*`` subdirs back up to ``outputs/``.
+
+    The test dispatcher scopes each subprocess's ``SIMPLER_PERF_OUTPUT_DIR`` to a
+    distinct ``outputs/perf_<tag>/`` subdir so concurrent perf file writes
+    can't collide on second-precision filenames. After all phases drain,
+    call this to flatten the subdirs back to the historical ``outputs/``
+    layout so downstream tools (swimlane_converter.py stand-alone, artifact
+    uploaders) still find everything in one place.
+
+    - Files are moved (not copied); empty subdirs are removed.
+    - Filename collisions on the destination keep the first writer and prefix
+      the loser with the subdir tag, so nothing is silently overwritten.
+
+    Returns the number of files moved.
+    """
+    import shutil  # noqa: PLC0415
+    from pathlib import Path  # noqa: PLC0415
+
+    root = Path(outputs_dir)
+    if not root.exists():
+        return 0
+    moved = 0
+    for sub in sorted(root.glob("perf_*")):
+        if not sub.is_dir():
+            continue
+        tag = sub.name[len("perf_") :] if sub.name.startswith("perf_") else sub.name
+        for f in list(sub.iterdir()):
+            if not f.is_file():
+                continue
+            dest = root / f.name
+            if dest.exists():
+                dest = root / f"{dest.stem}__{tag}{dest.suffix}"
+            try:
+                shutil.move(str(f), str(dest))
+                moved += 1
+            except OSError:
+                pass
+        # Remove the subdir if now empty; tolerate non-empty (e.g. nested dirs).
+        try:
+            sub.rmdir()
+        except OSError:
+            pass
+    return moved

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -468,6 +468,17 @@ def _project_root() -> Path:
 
 
 def _outputs_dir() -> Path:
+    """Return the directory where perf_swimlane_*.json lands.
+
+    Honors ``SIMPLER_PERF_OUTPUT_DIR`` so the parallel test dispatcher can give each
+    subprocess its own isolated output directory. Absolute paths pass through;
+    relative paths are interpreted against the project root. Empty/unset env
+    var falls back to ``<project>/outputs`` (the historical default).
+    """
+    env = os.environ.get("SIMPLER_PERF_OUTPUT_DIR")
+    if env:
+        p = Path(env)
+        return p if p.is_absolute() else _project_root() / p
     return _project_root() / "outputs"
 
 
@@ -936,6 +947,18 @@ class SceneTestCase:
         enable_profiling=False,
         enable_dump_tensor=False,
     ):
+        # Defensive belt-and-braces: the pytest dispatcher and run_module both
+        # block --enable-profiling for L3 at the CLI boundary. Catch any code
+        # path that reaches here with the flag on anyway (direct API use,
+        # future refactors) so we fail loud rather than produce garbage perf
+        # files. Lift once the runtime embeds device_id in the perf filename.
+        if enable_profiling:
+            raise NotImplementedError(
+                "L3 profiling is not supported yet (multi-chip-process perf "
+                "filename collision). Gate at the CLI level in "
+                "conftest.pytest_collection_modifyitems / scene_test.run_module."
+            )
+
         params = case.get("params", {})
         config_dict = case.get("config", {})
 
@@ -1056,7 +1079,7 @@ class SceneTestCase:
 
         Supports -d as either a single id or a range ("0-7"). When more than
         one device is provided (or any L3 case needs more than its single
-        device), the outer invocation becomes an orchestrator that spawns
+        device), the outer invocation becomes a test dispatcher that spawns
         per-case subprocesses via ``parallel_scheduler``; each child re-enters
         this function in single-group mode via ``--runtime`` + ``--level``.
         """
@@ -1158,7 +1181,7 @@ class SceneTestCase:
         # Keep ``args.device`` as an int for paths that expect a single id
         # (profiling snapshots, device-id binding inside one worker). In child
         # mode this is the single allocated id; in parent mode we use the first
-        # slot but the orchestrator doesn't actually run tests here.
+        # slot but the dispatcher doesn't actually run tests here.
         args.device = device_ids[0]
 
         # Resolve -j (max parallel) — 'auto' is CPU-aware on sim, device-count on hardware.
@@ -1173,14 +1196,10 @@ class SceneTestCase:
             if args.max_parallel < 1:
                 print(f"ERROR: -j must be >= 1, got {args.max_parallel}", file=sys.stderr)
                 sys.exit(2)
-        if args.enable_profiling and args.max_parallel > 1:
-            print(
-                f"ERROR: --enable-profiling is incompatible with --max-parallel {args.max_parallel}; "
-                "profiling writes process-global files that collide under parallelism. "
-                "Either pass '--max-parallel 1' or drop --enable-profiling.",
-                file=sys.stderr,
-            )
-            sys.exit(2)
+        # Note: profiling + parallelism used to be blocked here because perf
+        # files shared a process-global directory. The test dispatcher now scopes
+        # each subprocess to its own SIMPLER_PERF_OUTPUT_DIR so the combination
+        # is safe.
 
         module = sys.modules[module_name]
         test_classes = [
@@ -1213,8 +1232,22 @@ class SceneTestCase:
         for cls, case in selected:
             selected_by_cls.setdefault(cls, []).append(case)
 
+        # L3 profiling not supported yet (multi-chip-process filename collision).
+        # Mirror the pytest-side guard so standalone users get the same early-fail.
+        if args.enable_profiling:
+            l3_classes = sorted(cls.__name__ for cls in selected_by_cls if cls._st_level == 3)
+            if l3_classes:
+                print(
+                    f"ERROR: --enable-profiling is not supported for L3 tests yet — "
+                    f"multi-chip-process filename collision unresolved. "
+                    f"L3 classes selected: {', '.join(l3_classes)}. "
+                    f"Either drop --enable-profiling or scope to L2 with --level 2.",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+
         # Child mode: both --runtime and --level set. Run inline without
-        # spawning further subprocesses; this is the path orchestrator
+        # spawning further subprocesses; this is the path dispatcher
         # children take after we re-enter run_module.
         child_mode = args.runtime is not None and args.level is not None
 
@@ -1227,7 +1260,7 @@ class SceneTestCase:
             has_multiple_groups = len({(cls._st_runtime, cls._st_level) for cls in selected_by_cls}) > 1
             needs_orchestration = len(device_ids) > 1 or has_multi_dev_case or has_multiple_groups
             if needs_orchestration:
-                ok = _orchestrate_standalone(module_name, selected_by_cls, args)
+                ok = _dispatch_test_phases_standalone(module_name, selected_by_cls, args)
                 sys.exit(0 if ok else 1)
 
         # ----- Inline execution (single group or child mode) -----
@@ -1246,7 +1279,7 @@ class SceneTestCase:
         ok = True
         for (runtime, level), group in by_rt_level.items():
             print(f"\n=== Runtime: {runtime}  Level: {level} ===")
-            worker, per_class_sub_ids = _create_standalone_worker(group, level, args)
+            worker, per_class_sub_ids = _create_standalone_worker(group, level, args, selected_by_cls)
             try:
                 for cls in group:
                     inst = cls()
@@ -1284,12 +1317,12 @@ class SceneTestCase:
         sys.exit(0 if ok else 1)
 
 
-def _orchestrate_standalone(module_name, selected_by_cls, args):  # noqa: PLR0912 -- L3 + L2 phases + chunking + fail-fast
-    """Parent-mode dispatch for run_module.
+def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noqa: PLR0912 -- L3 + L2 phases + chunking + fail-fast
+    """Parent-mode test dispatcher for run_module.
 
-    L3 phase: one subprocess per (class, case), scheduled by device count.
-    L2 phase: for CS2, serial per-(runtime) subprocess on device_ids[0].
-    (CS4 adds device fanout for L2.)
+    L3 phase: one subprocess per class, scheduled by device count.
+    L2 phase: per-runtime fanout — up to max_parallel concurrent subprocesses,
+    each owning one device and running its round-robin chunk of classes.
 
     Returns True on full success, False if any child failed.
     """
@@ -1341,7 +1374,15 @@ def _orchestrate_standalone(module_name, selected_by_cls, args):  # noqa: PLR091
                 "3",
             ]
 
-        l3_jobs.append(Job(label=label, device_count=class_dev_count, build_cmd=_build))
+        # Each L3 class gets its own perf output subdir so two concurrent L3
+        # cases can't collide on a per_swimlane_<second-precision-ts>.json.
+        # Anchor to _project_root() so the C++ runtime (resolved against its
+        # own CWD) and Python post-processing agree on the location.
+        child_env = {
+            **os.environ,
+            "SIMPLER_PERF_OUTPUT_DIR": str(_project_root() / "outputs" / f"perf_l3_{cls.__name__}"),
+        }
+        l3_jobs.append(Job(label=label, device_count=class_dev_count, build_cmd=_build, env=child_env))
 
     l3_failed = False
     if l3_jobs:
@@ -1436,7 +1477,15 @@ def _orchestrate_standalone(module_name, selected_by_cls, args):  # noqa: PLR091
                 return cmd
 
             # device_count=1 for L2 fanout children (each child uses one slot).
-            l2_jobs.append(Job(label=label, device_count=1, build_cmd=_build))
+            # Scope perf output to this fanout child's own subdir so concurrent
+            # L2 children don't collide on the second-precision perf filename.
+            # Absolute path anchored to _project_root() so the C++ runtime and
+            # Python post-processing agree on the filesystem location.
+            child_env = {
+                **os.environ,
+                "SIMPLER_PERF_OUTPUT_DIR": str(_project_root() / "outputs" / f"perf_l2_{rt}_dev{dev}"),
+            }
+            l2_jobs.append(Job(label=label, device_count=1, build_cmd=_build, env=child_env))
 
         # Use the same scheduler: pool=device_ids, fail_fast=exitfirst. This
         # gives us automatic parallelism + SIGTERM on fail-fast.
@@ -1464,15 +1513,28 @@ def _orchestrate_standalone(module_name, selected_by_cls, args):  # noqa: PLR091
             if args.exitfirst:
                 break
 
+    # Flatten per-subprocess outputs/perf_*/ subdirs back to outputs/.
+    # Anchor to _project_root() so flushing works when the user runs a
+    # standalone test from a subdirectory.
+    from .parallel_scheduler import flatten_perf_subdirs  # noqa: PLC0415
+
+    flatten_perf_subdirs(_project_root() / "outputs")
+
     return not (l3_failed or l2_failed)
 
 
-def _create_standalone_worker(group, level, args):
+def _create_standalone_worker(group, level, args, selected_by_cls):
     """Create a Worker for a (runtime, level) group in run_module.
 
     ``level`` is passed explicitly by the caller; do not read it from
     ``group[0]._st_level`` because groups are now keyed on (runtime, level)
     and mixed-level files are allowed.
+
+    ``selected_by_cls`` is the dict of the cases that will actually run (after
+    ``--case`` / ``--manual`` / platform filtering). L3 ``max_devices`` /
+    ``max_sub_workers`` must be computed from these, not from ``cls.CASES``:
+    otherwise a manual case with a larger ``device_count`` inflates the
+    allocation even when it isn't scheduled.
     """
     first_cls = group[0]
     build = getattr(args, "build", False)
@@ -1481,9 +1543,15 @@ def _create_standalone_worker(group, level, args):
 
     from simpler.worker import Worker  # noqa: PLC0415
 
-    max_devices = max((c.get("config", {}).get("device_count", 1) for cls in group for c in cls.CASES), default=1)
-    max_subs = max((c.get("config", {}).get("num_sub_workers", 0) for cls in group for c in cls.CASES), default=0)
-    # Prefer the allocated list (orchestrator child mode), fall back to
+    max_devices = max(
+        (c.get("config", {}).get("device_count", 1) for cls in group for c in selected_by_cls.get(cls, [])),
+        default=1,
+    )
+    max_subs = max(
+        (c.get("config", {}).get("num_sub_workers", 0) for cls in group for c in selected_by_cls.get(cls, [])),
+        default=0,
+    )
+    # Prefer the allocated list (dispatcher child mode), fall back to
     # contiguous range starting at args.device (legacy inline path).
     allocated = getattr(args, "device_ids", None)
     if allocated and len(allocated) >= max_devices:

--- a/src/a2a3/platform/src/host/performance_collector.cpp
+++ b/src/a2a3/platform/src/host/performance_collector.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cinttypes>
+#include <cstdlib>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
@@ -77,7 +78,7 @@ void ProfMemoryManager::stop() {
 
     // Drain remaining done_queue and free buffers
     {
-        std::lock_guard<std::mutex> lock(done_mutex_);
+        std::scoped_lock<std::mutex> lock(done_mutex_);
         while (!done_queue_.empty()) {
             CopyDoneInfo info = done_queue_.front();
             done_queue_.pop();
@@ -99,7 +100,7 @@ void ProfMemoryManager::stop() {
 }
 
 bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo &info) {
-    std::lock_guard<std::mutex> lock(ready_mutex_);
+    std::scoped_lock<std::mutex> lock(ready_mutex_);
     if (ready_queue_.empty()) {
         return false;
     }
@@ -121,7 +122,7 @@ bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo &info, std::chrono::milli
 }
 
 void ProfMemoryManager::notify_copy_done(const CopyDoneInfo &info) {
-    std::lock_guard<std::mutex> lock(done_mutex_);
+    std::scoped_lock<std::mutex> lock(done_mutex_);
     done_queue_.push(info);
 }
 
@@ -210,7 +211,7 @@ void ProfMemoryManager::process_ready_entry(
                 host_ptr = resolve_host_ptr(new_dev_ptr);
             }
             if (new_dev_ptr == nullptr) {
-                std::lock_guard<std::mutex> lock(done_mutex_);
+                std::scoped_lock<std::mutex> lock(done_mutex_);
                 while (!done_queue_.empty()) {
                     CopyDoneInfo dinfo = done_queue_.front();
                     done_queue_.pop();
@@ -258,7 +259,7 @@ void ProfMemoryManager::process_ready_entry(
         info.buffer_seq = seq;
 
         {
-            std::lock_guard<std::mutex> lock(ready_mutex_);
+            std::scoped_lock<std::mutex> lock(ready_mutex_);
             ready_queue_.push(info);
         }
         ready_cv_.notify_one();
@@ -289,7 +290,7 @@ void ProfMemoryManager::process_ready_entry(
                 host_ptr = resolve_host_ptr(new_dev_ptr);
             }
             if (new_dev_ptr == nullptr) {
-                std::lock_guard<std::mutex> lock(done_mutex_);
+                std::scoped_lock<std::mutex> lock(done_mutex_);
                 while (!done_queue_.empty()) {
                     CopyDoneInfo dinfo = done_queue_.front();
                     done_queue_.pop();
@@ -335,7 +336,7 @@ void ProfMemoryManager::process_ready_entry(
         info.buffer_seq = seq;
 
         {
-            std::lock_guard<std::mutex> lock(ready_mutex_);
+            std::scoped_lock<std::mutex> lock(ready_mutex_);
             ready_queue_.push(info);
         }
         ready_cv_.notify_one();
@@ -348,7 +349,7 @@ void ProfMemoryManager::mgmt_loop() {
     while (running_.load()) {
         // 1. Recycle done queue: move completed buffers to recycled pools for reuse
         {
-            std::lock_guard<std::mutex> lock(done_mutex_);
+            std::scoped_lock<std::mutex> lock(done_mutex_);
             while (!done_queue_.empty()) {
                 CopyDoneInfo info = done_queue_.front();
                 done_queue_.pop();
@@ -1159,7 +1160,15 @@ void PerformanceCollector::collect_phase_data() {
     );
 }
 
-int PerformanceCollector::export_swimlane_json(const std::string &output_path) {
+int PerformanceCollector::export_swimlane_json(const std::string &output_path_arg) {
+    // Step 0: Resolve effective output directory. SIMPLER_PERF_OUTPUT_DIR (when set)
+    // overrides the caller-supplied path so the parallel test orchestrator can
+    // give each subprocess its own directory — avoids filename collisions when
+    // two concurrent runs produce a perf_swimlane_*.json with the same
+    // second-precision timestamp. Empty env var is treated as unset.
+    const char *env_dir = std::getenv("SIMPLER_PERF_OUTPUT_DIR");
+    const std::string output_path = (env_dir != nullptr && env_dir[0] != '\0') ? std::string(env_dir) : output_path_arg;
+
     // Step 1: Validate collected data
     bool has_any_records = false;
     for (const auto &core_records : collected_perf_records_) {

--- a/src/a5/platform/src/host/performance_collector.cpp
+++ b/src/a5/platform/src/host/performance_collector.cpp
@@ -320,7 +320,15 @@ int PerformanceCollector::collect_all() {
     return 0;
 }
 
-int PerformanceCollector::export_swimlane_json(const std::string &output_path) {
+int PerformanceCollector::export_swimlane_json(const std::string &output_path_arg) {
+    // Step 0: Resolve effective output directory. SIMPLER_PERF_OUTPUT_DIR (when set)
+    // overrides the caller-supplied path so the parallel test orchestrator can
+    // give each subprocess its own directory — avoids filename collisions when
+    // two concurrent runs produce a perf_swimlane_*.json with the same
+    // second-precision timestamp. Empty env var is treated as unset.
+    const char *env_dir = std::getenv("SIMPLER_PERF_OUTPUT_DIR");
+    const std::string output_path = (env_dir != nullptr && env_dir[0] != '\0') ? std::string(env_dir) : output_path_arg;
+
     // Step 1: Validate collected data
     bool has_any_records = false;
     for (const auto &core_records : collected_perf_records_) {


### PR DESCRIPTION
## Summary

Replaces the hard error for \`--enable-profiling\` under parallelism (introduced in #591) with a real fix: each subprocess gets its own \`SIMPLER_PERF_OUTPUT_DIR\`, so the runtime's second-precision \`perf_swimlane_*.json\` filenames can't collide across concurrent children. After phases drain, a flatten step moves everything back to \`outputs/\` so downstream tooling (\`swimlane_converter.py\`, CI artifact upload) sees the historical layout.

L2 profiling now works under all dispatcher paths (xdist fanout, standalone L2 fanout). L3 profiling is still unsafe because N chip-processes within one L3 case all write to the same directory — blocked explicitly pending a follow-up that embeds \`device_id\` in the runtime's perf filename.

## Changes

- **Runtime** (\`src/{a2a3,a5}/platform/src/host/performance_collector.cpp\`): \`export_swimlane_json\` reads \`SIMPLER_PERF_OUTPUT_DIR\` and overrides the caller-supplied path. Empty/unset → historical \`outputs\`.
- **Test dispatcher** (\`conftest.py\`, \`simpler_setup/scene_test.py\`) scopes per subprocess:
  - xdist worker \`gwK\` → \`outputs/perf_gwK/\`
  - pytest L3 child → \`outputs/perf_l3_<sanitized-nodeid>/\`
  - standalone L3 class → \`outputs/perf_l3_<ClassName>/\`
  - standalone L2 fanout child → \`outputs/perf_l2_<runtime>_dev<N>/\`
- **Merge on completion** (\`parallel_scheduler.flatten_perf_subdirs\`): moves files from \`outputs/perf_*/\` back to \`outputs/\`, suffixing on collision rather than overwriting.
- **L3 profiling guard** (three layers):
  - \`conftest.pytest_collection_modifyitems\`: \`pytest.UsageError\` when any L3 item is collected with \`--enable-profiling\`
  - \`run_module\`: error + \`sys.exit(2)\` for the same combination
  - \`_run_and_validate_l3\`: defensive \`NotImplementedError\` for direct API users bypassing the CLI
- **Naming cleanup**: the pytest-collection-level test dispatch code is renamed from \"orchestrator\" to \"dispatcher\" (\`_dispatch_test_phases\`, \`_dispatch_test_phases_standalone\`, comments, docs) to avoid colliding with the runtime \`Orchestrator\` concept (\`simpler.orchestrator\`, \`CALLABLE[\"orchestration\"]\`).
- **Latent bug fix** in \`_create_standalone_worker\`: \`max_devices\` used to read from \`cls.CASES\` (full set) instead of the filtered \`selected_by_cls\`, over-allocating when a class had a manual case with a larger \`device_count\`. No current tests hit this but the fix is a 5-line change.
- **Pre-existing lint cleanup**: \`clang-tidy modernize-use-scoped-lock\` warnings in \`a2a3 performance_collector.cpp\` now surface because this PR touches the file; converted all 8 \`std::lock_guard<std::mutex>\` to \`std::scoped_lock<std::mutex>\` there.
- Docs (\`testing.md\`, \`ci.md\`): updated profiling section and renamed terminology.

## Testing

- [x] 174 Python unit tests pass locally (\`pytest tests/ut --platform a2a3sim\`).
- [x] L3 + \`--enable-profiling\` is rejected early with \`UsageError\` (pytest exit 4).
- [x] L2 + \`--enable-profiling --device 0\` still collects & runs (not blocked).
- [x] \`flatten_perf_subdirs\` unit-tested: moves files, suffixes on collision, removes empty subdirs, preserves pre-existing files in \`outputs/\`.
- [x] \`_outputs_dir()\` honors env var for absolute and project-relative paths; unset falls back to \`outputs\`.
- [ ] sim CI: confirm rename + env-var plumbing works in the dispatcher's happy paths.
- [ ] hardware CI: confirm the L3 guard fires with real L3 classes without regressing L2.
- [ ] Hardware run with \`--device 0-7 --enable-profiling --level 2\`: verify per-\`gwK\` subdirs produced, flattened to \`outputs/\` with no collisions.

## Backward compatibility

- \`--enable-profiling --device 0\` (single device): dispatcher short-circuits, behavior bit-identical to before this PR.
- \`--enable-profiling --device 0-7 --level 2\`: previously errored; now works.
- \`--enable-profiling\` with any L3 test collected: previously errored (generic); now errors with a more targeted message referencing the L3 design gap.
- Standalone calls to \`_run_and_validate_l3(..., enable_profiling=True)\` now raise \`NotImplementedError\` (previously silently produced colliding files).

## Follow-up (not in this PR)

L3 within-case profiling — N chip-processes per L3 case write to the same subdir with second-precision filenames and collide. Needs runtime-side fix: embed \`device_id\` in \`performance_collector.cpp:1238\`'s filename. Lift the L3 guard at that point.