### PR TITLE
feat(backend): Add per-thread execution context for PTO CPU simulator

### DIFF
--- a/src/a2a3/platform/sim/aicore/kernel.cpp
+++ b/src/a2a3/platform/sim/aicore/kernel.cpp
@@ -47,13 +47,19 @@ uint32_t sim_get_physical_core_id() {
 // These point into cpu_sim_context.cpp (host_runtime SO) and set per-thread
 // subblock_id and cluster_id for pto-isa's TPUSH/TPOP hooks.
 using SimSetUint32Fn = void (*)(uint32_t);
+using SimSetExecutionContextFn = void (*)(uint32_t, uint32_t, uint32_t);
 
 static SimSetUint32Fn g_set_subblock_id_fn = nullptr;
 static SimSetUint32Fn g_set_cluster_id_fn = nullptr;
+static SimSetExecutionContextFn g_set_execution_context_fn = nullptr;
 
 extern "C" void set_sim_core_identity_helpers(void *set_subblock_id, void *set_cluster_id) {
     g_set_subblock_id_fn = reinterpret_cast<SimSetUint32Fn>(set_subblock_id);
     g_set_cluster_id_fn = reinterpret_cast<SimSetUint32Fn>(set_cluster_id);
+}
+
+extern "C" void set_sim_execution_context_helper(void *set_execution_context) {
+    g_set_execution_context_fn = reinterpret_cast<SimSetExecutionContextFn>(set_execution_context);
 }
 
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
@@ -85,13 +91,16 @@ extern "C" void aicore_execute_wrapper(
     uint32_t block_dim = static_cast<uint32_t>(runtime->worker_count) / PLATFORM_CORES_PER_BLOCKDIM;
     uint32_t cluster_id;
     uint32_t subblock_id;
+    uint32_t subblock_dim;
     if (core_type == CoreType::AIC) {
         cluster_id = physical_core_id;
         subblock_id = 0;
+        subblock_dim = 1;
     } else {
         uint32_t aiv_idx = physical_core_id - block_dim;
         cluster_id = aiv_idx / 2;
         subblock_id = aiv_idx % 2;
+        subblock_dim = PLATFORM_CORES_PER_BLOCKDIM - 1;
     }
 
     if (g_set_subblock_id_fn != nullptr) {
@@ -99,6 +108,9 @@ extern "C" void aicore_execute_wrapper(
     }
     if (g_set_cluster_id_fn != nullptr) {
         g_set_cluster_id_fn(cluster_id);
+    }
+    if (g_set_execution_context_fn != nullptr) {
+        g_set_execution_context_fn(static_cast<uint32_t>(block_idx), subblock_id, subblock_dim);
     }
 
     aicore_execute(runtime, block_idx, core_type);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -197,6 +197,12 @@ int DeviceRunner::ensure_binaries_loaded(
                 reinterpret_cast<void *>(sim_context_set_cluster_id)
             );
         }
+        auto set_execution_context_helper = reinterpret_cast<void (*)(void *)>(
+            dlsym(aicore_so_handle_, "set_sim_execution_context_helper")
+        );
+        if (set_execution_context_helper != nullptr) {
+            set_execution_context_helper(reinterpret_cast<void *>(pto_cpu_sim_set_execution_context));
+        }
     }
 
     return 0;

--- a/src/a5/platform/sim/aicore/kernel.cpp
+++ b/src/a5/platform/sim/aicore/kernel.cpp
@@ -47,13 +47,19 @@ uint32_t sim_get_physical_core_id() {
 // These point into cpu_sim_context.cpp (host_runtime SO) and set per-thread
 // subblock_id and cluster_id for pto-isa's TPUSH/TPOP hooks.
 using SimSetUint32Fn = void (*)(uint32_t);
+using SimSetExecutionContextFn = void (*)(uint32_t, uint32_t, uint32_t);
 
 static SimSetUint32Fn g_set_subblock_id_fn = nullptr;
 static SimSetUint32Fn g_set_cluster_id_fn = nullptr;
+static SimSetExecutionContextFn g_set_execution_context_fn = nullptr;
 
 extern "C" void set_sim_core_identity_helpers(void *set_subblock_id, void *set_cluster_id) {
     g_set_subblock_id_fn = reinterpret_cast<SimSetUint32Fn>(set_subblock_id);
     g_set_cluster_id_fn = reinterpret_cast<SimSetUint32Fn>(set_cluster_id);
+}
+
+extern "C" void set_sim_execution_context_helper(void *set_execution_context) {
+    g_set_execution_context_fn = reinterpret_cast<SimSetExecutionContextFn>(set_execution_context);
 }
 
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
@@ -85,13 +91,16 @@ extern "C" void aicore_execute_wrapper(
     uint32_t block_dim = static_cast<uint32_t>(runtime->worker_count) / PLATFORM_CORES_PER_BLOCKDIM;
     uint32_t cluster_id;
     uint32_t subblock_id;
+    uint32_t subblock_dim;
     if (core_type == CoreType::AIC) {
         cluster_id = physical_core_id;
         subblock_id = 0;
+        subblock_dim = 1;
     } else {
         uint32_t aiv_idx = physical_core_id - block_dim;
         cluster_id = aiv_idx / 2;
         subblock_id = aiv_idx % 2;
+        subblock_dim = PLATFORM_CORES_PER_BLOCKDIM - 1;
     }
 
     if (g_set_subblock_id_fn != nullptr) {
@@ -99,6 +108,9 @@ extern "C" void aicore_execute_wrapper(
     }
     if (g_set_cluster_id_fn != nullptr) {
         g_set_cluster_id_fn(cluster_id);
+    }
+    if (g_set_execution_context_fn != nullptr) {
+        g_set_execution_context_fn(static_cast<uint32_t>(block_idx), subblock_id, subblock_dim);
     }
 
     aicore_execute(runtime, block_idx, core_type);

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -196,6 +196,12 @@ int DeviceRunner::ensure_binaries_loaded(
                 reinterpret_cast<void *>(sim_context_set_cluster_id)
             );
         }
+        auto set_execution_context_helper = reinterpret_cast<void (*)(void *)>(
+            dlsym(aicore_so_handle_, "set_sim_execution_context_helper")
+        );
+        if (set_execution_context_helper != nullptr) {
+            set_execution_context_helper(reinterpret_cast<void *>(pto_cpu_sim_set_execution_context));
+        }
     }
 
     return 0;

--- a/src/common/sim_context/cpu_sim_context.cpp
+++ b/src/common/sim_context/cpu_sim_context.cpp
@@ -120,7 +120,9 @@ DeviceSimContext *get_current_device_context() {
 // ---------------------------------------------------------------------------
 
 std::mutex g_identity_key_mutex;
+pthread_key_t g_block_idx_key{};
 pthread_key_t g_subblock_id_key{};
+pthread_key_t g_subblock_dim_key{};
 pthread_key_t g_cluster_id_key{};
 std::atomic<bool> g_identity_keys_initialized{false};
 
@@ -132,11 +134,22 @@ void ensure_identity_keys() {
     if (g_identity_keys_initialized.load(std::memory_order_relaxed)) {
         return;
     }
+    if (pthread_key_create(&g_block_idx_key, nullptr) != 0) {
+        return;
+    }
     if (pthread_key_create(&g_subblock_id_key, nullptr) != 0) {
+        pthread_key_delete(g_block_idx_key);
+        return;
+    }
+    if (pthread_key_create(&g_subblock_dim_key, nullptr) != 0) {
+        pthread_key_delete(g_block_idx_key);
+        pthread_key_delete(g_subblock_id_key);
         return;
     }
     if (pthread_key_create(&g_cluster_id_key, nullptr) != 0) {
+        pthread_key_delete(g_block_idx_key);
         pthread_key_delete(g_subblock_id_key);
+        pthread_key_delete(g_subblock_dim_key);
         return;
     }
     g_identity_keys_initialized.store(true, std::memory_order_release);
@@ -213,6 +226,15 @@ void sim_context_set_subblock_id(uint32_t subblock_id) {
     pthread_setspecific(g_subblock_id_key, reinterpret_cast<void *>(static_cast<uintptr_t>(subblock_id)));
 }
 
+void sim_context_set_execution_context(uint32_t block_idx, uint32_t subblock_id, uint32_t subblock_dim) {
+    ensure_identity_keys();
+    pthread_setspecific(g_block_idx_key, reinterpret_cast<void *>(static_cast<uintptr_t>(block_idx)));
+    pthread_setspecific(g_subblock_id_key, reinterpret_cast<void *>(static_cast<uintptr_t>(subblock_id)));
+    pthread_setspecific(
+        g_subblock_dim_key, reinterpret_cast<void *>(static_cast<uintptr_t>((subblock_dim == 0) ? 1 : subblock_dim))
+    );
+}
+
 void sim_context_set_cluster_id(uint32_t cluster_id) {
     ensure_identity_keys();
     pthread_setspecific(g_cluster_id_key, reinterpret_cast<void *>(static_cast<uintptr_t>(cluster_id)));
@@ -227,6 +249,31 @@ extern "C" uint32_t pto_sim_get_subblock_id() {
         return 0;
     }
     return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(pthread_getspecific(g_subblock_id_key)));
+}
+
+extern "C" void pto_cpu_sim_set_execution_context(uint32_t block_idx, uint32_t subblock_id, uint32_t subblock_dim) {
+    sim_context_set_execution_context(block_idx, subblock_id, subblock_dim);
+}
+
+extern "C" void pto_cpu_sim_get_execution_context(
+    uint32_t *block_idx, uint32_t *subblock_id, uint32_t *subblock_dim
+) {
+    if (block_idx == nullptr || subblock_id == nullptr || subblock_dim == nullptr) {
+        return;
+    }
+
+    if (!g_identity_keys_initialized.load(std::memory_order_acquire)) {
+        *block_idx = 0;
+        *subblock_id = 0;
+        *subblock_dim = 1;
+        return;
+    }
+
+    *block_idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(pthread_getspecific(g_block_idx_key)));
+    *subblock_id = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(pthread_getspecific(g_subblock_id_key)));
+    const uint32_t stored_subblock_dim =
+        static_cast<uint32_t>(reinterpret_cast<uintptr_t>(pthread_getspecific(g_subblock_dim_key)));
+    *subblock_dim = (stored_subblock_dim == 0) ? 1 : stored_subblock_dim;
 }
 
 extern "C" void *pto_sim_get_pipe_shared_state(uint64_t pipe_key, size_t size) {

--- a/src/common/sim_context/cpu_sim_context.h
+++ b/src/common/sim_context/cpu_sim_context.h
@@ -54,6 +54,12 @@ uint32_t pto_sim_get_subblock_id(void);
  */
 void *pto_sim_get_pipe_shared_state(uint64_t pipe_key, size_t size);
 
+/** Set the current thread's execution context for PTO ISA cpu_stub.hpp. */
+void pto_cpu_sim_set_execution_context(uint32_t block_idx, uint32_t subblock_id, uint32_t subblock_dim);
+
+/** Read the current thread's execution context for PTO ISA cpu_stub.hpp. */
+void pto_cpu_sim_get_execution_context(uint32_t *block_idx, uint32_t *subblock_id, uint32_t *subblock_dim);
+
 #ifdef __cplusplus
 }
 #endif
@@ -65,6 +71,9 @@ void *pto_sim_get_pipe_shared_state(uint64_t pipe_key, size_t size);
  * Called by aicore_execute_wrapper (via function pointer injection).
  */
 void sim_context_set_subblock_id(uint32_t subblock_id);
+
+/** Set the current thread's simulated execution context. */
+void sim_context_set_execution_context(uint32_t block_idx, uint32_t subblock_id, uint32_t subblock_dim);
 
 /**
  * Set the current thread's simulated cluster_id.


### PR DESCRIPTION
## Summary
- Add `SimSetExecutionContextFn` callback and `set_sim_execution_context_helper` in aicore kernel.cpp (a2a3 and a5 platforms) to propagate block_idx, subblock_id, and subblock_dim from `aicore_execute_wrapper` to the host runtime via function-pointer injection
- Compute `subblock_dim` based on CoreType (1 for AIC, PLATFORM_CORES_PER_BLOCKDIM-1 for AIV) and pass it alongside block_idx and subblock_id
- Wire up the new helper in device_runner.cpp (a2a3 and a5) by dlsym-ing `set_sim_execution_context_helper` and binding it to `pto_cpu_sim_set_execution_context`
- Add `g_block_idx_key` and `g_subblock_dim_key` pthread thread-local keys in cpu_sim_context.cpp with proper creation/cleanup ordering in `ensure_identity_keys()`
- Implement `sim_context_set_execution_context()`, `pto_cpu_sim_set_execution_context()`, and `pto_cpu_sim_get_execution_context()` for PTO ISA cpu_stub.hpp to read the current thread's execution context