### PR TITLE
Fix: AICore Phase 1 stale L1 cache read on aicpu_ready

### DIFF
--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -140,4 +140,9 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     // Flush all dirty cache lines to HBM before kernel exit.
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
+
+    // Invalidate our Handshake L1 line on exit so the next case on this core
+    // sees a fresh aicpu_ready=0 on its first load instead of an L1-resident 1
+    // left over from this case (no rtDeviceReset between cases).
+    dcci(my_hank, SINGLE_CACHE_LINE);
 }

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -98,4 +98,9 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     // Flush all dirty cache lines to HBM before kernel exit.
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
+
+    // Invalidate our Handshake L1 line on exit so the next case on this core
+    // sees a fresh aicpu_ready=0 on its first load instead of an L1-resident 1
+    // left over from this case (no rtDeviceReset between cases).
+    dcci(my_hank, SINGLE_CACHE_LINE);
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -145,4 +145,9 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     // Flush all dirty cache lines to HBM before kernel exit.
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
+
+    // Invalidate our Handshake L1 line on exit so the next case on this core
+    // sees a fresh aicpu_ready=0 on its first load instead of an L1-resident 1
+    // left over from this case (no rtDeviceReset between cases).
+    dcci(my_hank, SINGLE_CACHE_LINE);
 }

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -98,4 +98,9 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     // Flush all dirty cache lines to HBM before kernel exit.
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
+
+    // Invalidate our Handshake L1 line on exit so the next case on this core
+    // sees a fresh aicpu_ready=0 on its first load instead of an L1-resident 1
+    // left over from this case (no rtDeviceReset between cases).
+    dcci(my_hank, SINGLE_CACHE_LINE);
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -145,4 +145,9 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     // Flush all dirty cache lines to HBM before kernel exit.
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
+
+    // Invalidate our Handshake L1 line on exit so the next case on this core
+    // sees a fresh aicpu_ready=0 on its first load instead of an L1-resident 1
+    // left over from this case (no rtDeviceReset between cases).
+    dcci(my_hank, SINGLE_CACHE_LINE);
 }


### PR DESCRIPTION
Without rtDeviceReset between runs (removed in https://github.com/hw-native-sys/simpler/commit/8be358b592def6ae96132a591ca3564704f64471), the first load of aicpu_ready in aicore_execute()'s Phase 1 spin can L1-hit a residual 1 from a prior run. The while-loop body's dcci never runs, AICore proceeds before AICPU finishes init, and downstream task dispatch scrambles -- producing ~5% precision failures on paged_attention
Case1 -> small1 (max_diff ~ 0.3).

Fix by invalidating our Handshake L1 cache line at AICore kernel exit, right after the existing flush (CACHELINE_OUT). Placing the invalidate at the writer's exit (instead of the reader's entry) keeps state reset self-contained within the case that produced it, so the next case's first load of aicpu_ready is guaranteed to miss L1 and read HBM.

Applied identically to all five AICore executors (a2a3 host_build_graph / aicpu_build_graph / tensormap_and_ringbuffer; a5 host_build_graph / tensormap_and_ringbuffer).

Validated: 100/100 PASS on host_build_graph paged_attention (was ~5% fail).