### PR TITLE
Support: retune chip and core arg budgets

### DIFF
--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_types.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_types.h
@@ -40,7 +40,7 @@
 
 // Task arguments
 #define MAX_TENSOR_ARGS 16   // Maximum tensor parameters per task
-#define MAX_SCALAR_ARGS 128  // Maximum scalar parameters per task
+#define MAX_SCALAR_ARGS 32   // Maximum scalar parameters per task
 #define PTO2_MAX_OUTPUTS 16  // Maximum outputs per task
 #define PTO2_MAX_INPUTS 16   // Maximum inputs per task
 #define PTO2_MAX_INOUTS 8    // Maximum in-out args per task
@@ -211,7 +211,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     void add_scalar(T value) {
         static_assert(is_supported_scalar_arg_v<T>, "add_scalar: type must be arithmetic or enum");
         if (scalar_count_ >= MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         scalars_[scalar_count_++] = to_u64(value);
@@ -219,7 +219,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     void add_scalars(const uint64_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         memcpy(&scalars_[scalar_count_], values, count * sizeof(uint64_t));
@@ -234,7 +234,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      */
     void add_scalars_i32(const int32_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         uint64_t *dst = &scalars_[scalar_count_];
@@ -268,7 +268,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -65,11 +65,11 @@ static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
 
 /**
  * Args[] suffix indices for context pointers.
- * Derived from MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(128).
+ * Derived from MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(32).
  * Users should not depend on these values; use the Get* functions below.
  */
-static constexpr int32_t SPMD_LOCAL_CONTEXT_INDEX = 144;
-static constexpr int32_t SPMD_GLOBAL_CONTEXT_INDEX = 145;
+static constexpr int32_t SPMD_LOCAL_CONTEXT_INDEX = 48;
+static constexpr int32_t SPMD_GLOBAL_CONTEXT_INDEX = 49;
 
 /**
  * Per-core global context, stored in PTO2DispatchPayload.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -39,7 +39,7 @@
 #include "intrinsic.h"
 #include "pto_types.h"
 
-/** Max dispatch arguments: 128 scalars + up to 16 tensor pointers + ext params */
+/** Max dispatch arguments: 32 scalars + up to 16 tensor pointers + ext params */
 #ifndef PTO2_DISPATCH_MAX_ARGS
 #define PTO2_DISPATCH_MAX_ARGS (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS + PTO2_EXT_PARAMS_COUNT)
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -353,12 +353,12 @@ struct PTO2TaskPayload {
     PTO2TaskSlotState *fanin_inline_slot_states[PTO2_FANIN_INLINE_CAP];
     // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
-    // === Cache lines 35-50 (1024B) — scalars ===
+    // === Cache lines 35-38 (256B) — scalars ===
     uint64_t scalars[MAX_SCALAR_ARGS];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(Tensor) == 128, "Tensor must be 2 cache lines");
-    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 1024, "scalar region must be 1024B (16 cache lines)");
+    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 256, "scalar region must be 256B (4 cache lines)");
 
     /**
      * Initialize payload: copy tensors, store scalars.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -39,7 +39,7 @@
 
 // Task arguments
 #define MAX_TENSOR_ARGS 16   // Maximum tensor arguments per task
-#define MAX_SCALAR_ARGS 128  // Maximum scalar arguments per task
+#define MAX_SCALAR_ARGS 32   // Maximum scalar arguments per task
 #define PTO2_MAX_OUTPUTS 16  // Maximum outputs per task
 #define PTO2_MAX_INPUTS 16   // Maximum inputs per task
 #define PTO2_MAX_INOUTS 8    // Maximum in-out args per task
@@ -196,7 +196,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         static_assert(sizeof...(Args) >= 1, "add_scalar: at least one argument required");
         static_assert((is_supported_scalar_arg_v<Args> && ...), "add_scalar: all types must be arithmetic or enum");
         if (scalar_count_ + sizeof...(Args) > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         ((scalars_[scalar_count_++] = to_u64(args)), ...);
@@ -204,7 +204,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     void add_scalars(const uint64_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         memcpy(&scalars_[scalar_count_], values, count * sizeof(uint64_t));
@@ -219,7 +219,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      */
     void add_scalars_i32(const int32_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         uint64_t *dst = &scalars_[scalar_count_];
@@ -253,7 +253,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -65,11 +65,11 @@ static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
 
 /**
  * Args[] suffix indices for context pointers.
- * Derived from MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(128).
+ * Derived from MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(32).
  * Users should not depend on these values; use the Get* functions below.
  */
-static constexpr int32_t SPMD_LOCAL_CONTEXT_INDEX = 144;
-static constexpr int32_t SPMD_GLOBAL_CONTEXT_INDEX = 145;
+static constexpr int32_t SPMD_LOCAL_CONTEXT_INDEX = 48;
+static constexpr int32_t SPMD_GLOBAL_CONTEXT_INDEX = 49;
 
 /**
  * Per-core global context, stored in PTO2DispatchPayload.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -39,7 +39,7 @@
 #include "intrinsic.h"
 #include "pto_types.h"
 
-/** Max dispatch arguments: 128 scalars + up to 16 tensor pointers + ext params */
+/** Max dispatch arguments: 32 scalars + up to 16 tensor pointers + ext params */
 #ifndef PTO2_DISPATCH_MAX_ARGS
 #define PTO2_DISPATCH_MAX_ARGS (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS + PTO2_EXT_PARAMS_COUNT)
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -349,12 +349,12 @@ struct PTO2TaskPayload {
     PTO2TaskSlotState *fanin_inline_slot_states[PTO2_FANIN_INLINE_CAP];
     // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
-    // === Cache lines 35-50 (1024B) — scalars ===
+    // === Cache lines 35-38 (256B) — scalars ===
     uint64_t scalars[MAX_SCALAR_ARGS];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(Tensor) == 128, "Tensor must be 2 cache lines");
-    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 1024, "scalar region must be 1024B (16 cache lines)");
+    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 256, "scalar region must be 256B (4 cache lines)");
 
     /**
      * Initialize payload: copy tensors, store scalars.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -39,7 +39,7 @@
 
 // Task arguments
 #define MAX_TENSOR_ARGS 16   // Maximum tensor arguments per task
-#define MAX_SCALAR_ARGS 128  // Maximum scalar arguments per task
+#define MAX_SCALAR_ARGS 32   // Maximum scalar arguments per task
 #define PTO2_MAX_OUTPUTS 16  // Maximum outputs per task
 #define PTO2_MAX_INPUTS 16   // Maximum inputs per task
 #define PTO2_MAX_INOUTS 8    // Maximum in-out args per task
@@ -196,7 +196,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         static_assert(sizeof...(Args) >= 1, "add_scalar: at least one argument required");
         static_assert((is_supported_scalar_arg_v<Args> && ...), "add_scalar: all types must be arithmetic or enum");
         if (scalar_count_ + sizeof...(Args) > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         ((scalars_[scalar_count_++] = to_u64(args)), ...);
@@ -204,7 +204,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     void add_scalars(const uint64_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         memcpy(&scalars_[scalar_count_], values, count * sizeof(uint64_t));
@@ -219,7 +219,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      */
     void add_scalars_i32(const int32_t *values, int count) {
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         uint64_t *dst = &scalars_[scalar_count_];
@@ -253,7 +253,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=128)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));

--- a/src/common/task_interface/arg_direction.h
+++ b/src/common/task_interface/arg_direction.h
@@ -27,7 +27,9 @@ enum class ArgDirection : int32_t {
 };
 
 inline constexpr int CORE_MAX_TENSOR_ARGS = 16;
-inline constexpr int CHIP_MAX_TENSOR_ARGS = 16;
+inline constexpr int CHIP_MAX_TENSOR_ARGS = 64;
+inline constexpr int CORE_MAX_SCALAR_ARGS = 32;
+inline constexpr int CHIP_MAX_SCALAR_ARGS = 128;
 inline constexpr uint32_t CALLABLE_ALIGN = 64;
 
 static inline uint32_t callable_align_up(uint32_t size) { return (size + CALLABLE_ALIGN - 1) & ~(CALLABLE_ALIGN - 1); }

--- a/src/common/task_interface/task_args.h
+++ b/src/common/task_interface/task_args.h
@@ -176,7 +176,7 @@ using TaskArgs = TaskArgsTpl<ContinuousTensor, uint64_t, 0, 0, TensorArgType>;
 
 // L2 runtime ABI: fixed POD matching runtime.so byte-for-byte.
 // Assembled from a TaskArgsView on the child side just before pto2_run_runtime.
-using ChipStorageTaskArgs = TaskArgsTpl<ContinuousTensor, uint64_t, CHIP_MAX_TENSOR_ARGS, 128>;
+using ChipStorageTaskArgs = TaskArgsTpl<ContinuousTensor, uint64_t, CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS>;
 
 // ============================================================================
 // TaskArgsView — zero-copy view used by IWorker::run and the wire format
@@ -262,8 +262,8 @@ inline ChipStorageTaskArgs view_to_chip_storage(TaskArgsView view) {
     if (static_cast<size_t>(view.tensor_count) > CHIP_MAX_TENSOR_ARGS) {
         throw std::out_of_range("view_to_chip_storage: tensor_count exceeds CHIP_MAX_TENSOR_ARGS");
     }
-    if (view.scalar_count > 128) {
-        throw std::out_of_range("view_to_chip_storage: scalar_count exceeds 128");
+    if (static_cast<size_t>(view.scalar_count) > CHIP_MAX_SCALAR_ARGS) {
+        throw std::out_of_range("view_to_chip_storage: scalar_count exceeds CHIP_MAX_SCALAR_ARGS");
     }
     out.tensor_count_ = view.tensor_count;
     out.scalar_count_ = view.scalar_count;


### PR DESCRIPTION
## Summary

Retune per-level tensor and scalar argument budgets so that the CHIP-level task interface carries more args than the CORE-level kernel ABI.

| Level | Tensors | Scalars |
|-------|---------|---------|
| CORE  | 16      | 32      |
| CHIP  | 64      | 128     |

**Common layer** (`src/common/task_interface/`)
- Add named constants `CORE_MAX_SCALAR_ARGS=32`, `CHIP_MAX_SCALAR_ARGS=128` alongside `CORE_MAX_TENSOR_ARGS`/`CHIP_MAX_TENSOR_ARGS` in `arg_direction.h`
- `ChipStorageTaskArgs` scalar capacity and `view_to_chip_storage` bounds check now go through `CHIP_MAX_SCALAR_ARGS` (was literal `128`)

**Runtime layer** (a2a3 aicpu_build_graph, a2a3 tensormap_and_ringbuffer, a5 tensormap_and_ringbuffer)
- `MAX_SCALAR_ARGS 128 → 32` in `pto_types.h`; stale `=128` error strings refreshed
- `SPMD_LOCAL_CONTEXT_INDEX 144 → 48`, `SPMD_GLOBAL_CONTEXT_INDEX 145 → 49` in `intrinsic.h` (derived from `MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(32)`)
- Relax `PTO2TaskPayload` scalar region `static_assert` from `1024B (16 cache lines)` → `256B (4 cache lines)`
- Doc comments in `pto2_dispatch_payload.h` updated to `"32 scalars"`

## Breaking Changes

- **AICore ABI**: The SPMD context tail offset shifts from 144 → 48. Kernels compiled against the old layout that read `args[144]` for the local context pointer will miss after this change. A full toolchain + runtime + kernel rebuild is required end-to-end.
- **CORE scalar budget**: Any kernel passing more than 32 scalars now trips the `MAX_SCALAR_ARGS` guard.
- **Scalar region size**: Reserved AICore scalar region shrinks from 1024B → 256B.

## Testing

- [ ] Simulation tests pass (`test-all-sim`)
- [ ] Hardware tests pass on a2a3 (`test-all-device` with full rebuild)
- [ ] Hardware tests pass on a5 (`test-all-device` with full rebuild)
- [ ] Spot-check a kernel that uses >32 scalars — expect a clean error from the runtime guard