### PR TITLE
Refactor: cacheline-aligned field layout for scheduler/orchestrator

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -242,14 +242,7 @@ static bool pto2_append_fanin_or_fail(
 
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state);
 
-struct PTO2OutputLayout {
-    uint64_t offsets[MAX_TENSOR_ARGS] = {};
-    uint64_t buffer_sizes[MAX_TENSOR_ARGS] = {};
-    int32_t total_output_size = 0;
-};
-
 struct PTO2PreparedTask {
-    PTO2SchedulerState *sched = nullptr;
     PTO2TaskId task_id = PTO2TaskId::invalid();
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
     PTO2TaskDescriptor *task = nullptr;
@@ -328,45 +321,36 @@ static bool pto2_prepare_task(
         return false;
     }
 
-    out->sched = orch->scheduler;
+    auto sched = orch->scheduler;
     out->alloc_result = allocator.alloc(total_output_size);
     if (out->alloc_result.failed()) {
         pto2_orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
 
+    auto &rs = sched->ring_sched_states[ring_id];
     out->task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
-    out->task = &allocator.task_by_slot(out->alloc_result.slot);
+    out->slot_state = &rs.get_slot_state_by_slot(out->alloc_result.slot);
+    out->task = &orch->sm_handle->task_descriptors[ring_id][out->alloc_result.slot];
     out->payload = &orch->sm_handle->task_payloads[ring_id][out->alloc_result.slot];
 
     pto2_prefetch_payload(out->payload, args.tensor_count(), args.scalar_count());
 
-    if (out->sched) {
-        auto &rs = out->sched->ring_sched_states[ring_id];
-        out->slot_state = &rs.get_slot_state_by_slot(out->alloc_result.slot);
-        PTO2TaskSlotState &slot_state = *out->slot_state;
-        slot_state.fanout_head = nullptr;
-        slot_state.fanout_lock.store(0, std::memory_order_relaxed);
-        slot_state.fanout_count = 1;
-        slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
-        slot_state.fanin_refcount.store(0, std::memory_order_relaxed);
-        slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
-        slot_state.completed_subtasks.store(0, std::memory_order_relaxed);
-        slot_state.subtask_done_mask.store(0, std::memory_order_relaxed);
-        int16_t block_num = args.launch_spec.block_num();
-        slot_state.total_required_subtasks =
-            static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
-        slot_state.logical_block_num = block_num;
-        slot_state.next_block_idx = 0;
-        slot_state.payload = out->payload;
-        slot_state.task = out->task;
-        slot_state.active_mask = active_mask;
-        slot_state.ring_id = ring_id;
-        // fanin_count is set by scheduler during wiring
-        scope_tasks_push(orch, &slot_state);
-    } else {
-        scope_tasks_push(orch, nullptr);
-    }
+    // Fields already reset by advance_ring_pointers (eager reset after CONSUMED):
+    //   fanout_lock=0, fanout_count=1, fanout_head=nullptr,
+    //   fanin_refcount=0, fanout_refcount=0, completed_subtasks=0, next_block_idx=0
+    // Fields immutable after RingSchedState::init():
+    //   payload, task, ring_id
+    // task_state left as CONSUMED by eager reset (safe for stale wait_for_tensor
+    // observers); set to PENDING here when orchestrator actually reuses the slot.
+    out->slot_state->task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
+    int16_t block_num = args.launch_spec.block_num();
+    out->slot_state->total_required_subtasks =
+        static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
+    out->slot_state->logical_block_num = block_num;
+    out->slot_state->active_mask = active_mask;
+    // fanin_count is set by scheduler during wiring
+    scope_tasks_push(orch, out->slot_state);
 
     return true;
 }
@@ -544,6 +528,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         return result;
     }
 
+    always_assert(orch->scheduler != nullptr);
     // === Validate submit inputs ===
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
     always_assert(active_mask != 0 && "MixedKernels must have at least one active slot");
@@ -588,12 +573,13 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         return result;
     }
     uint8_t ring_id = prepared.task_id.ring();
-    PTO2SchedulerState *sched = prepared.sched;
+    PTO2SchedulerState *sched = orch->scheduler;
     PTO2RingFlowControl &fc = orch->sm_handle->header->rings[ring_id].fc;
     PTO2TaskId task_id = prepared.task_id;
+    PTO2TaskSlotState &cur_slot_state = *prepared.slot_state;
     PTO2TaskDescriptor &task = *prepared.task;
-    PTO2TaskPayload *payload = prepared.payload;
-    int32_t slot = prepared.alloc_result.slot;
+    PTO2TaskPayload &payload = *prepared.payload;
+    result.set_task_id(task_id);
 
     PTO2FaninBuilder fanin_builder;
     fanin_builder.count = 0;
@@ -629,7 +615,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
 
         // Step A: creator retention — all existing tensors extend their creator lifetime.
         PTO2TaskId owner = tensor->owner_task_id;
-        if (owner.is_valid() && sched != nullptr) {
+        if (owner.is_valid()) {
             PTO2TaskSlotState *prod_state =
                 &sched->ring_sched_states[owner.ring()].get_slot_state_by_task_id(owner.local());
             if (!pto2_append_fanin_or_fail(
@@ -694,15 +680,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     task.packed_buffer_base = prepared.alloc_result.packed_base;
     task.packed_buffer_end = prepared.alloc_result.packed_end;
 
-    payload->init(args, result, prepared.alloc_result.packed_base, layout.offsets, layout.buffer_sizes);
-
-    // Write owner_task_id into materialized OUTPUT tensors so creator-only dependency
-    // tracking remains available even when manual_dep skips OverlapMap publication.
-    for (int i = 0; i < args.tensor_count(); i++) {
-        if (args.tag(i) == TensorArgType::OUTPUT) {
-            payload->tensors[i].owner_task_id = prepared.task_id;
-        }
-    }
+    payload.init(args, result, prepared.alloc_result, layout);
 
     CYCLE_COUNT_LAP_RECORD(g_orch_args_cycle, AicpuPhaseId::ORCH_PARAMS, task_id.raw);
 #if PTO2_ORCH_PROFILING
@@ -713,34 +691,27 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     // Deferred wiring: orchestrator only stores dependency metadata and increments
     // fanout_count. The actual fanout_head wiring (lock + dep_pool + early_finished)
     // is handled asynchronously by scheduler thread 0 via the wiring queue.
-    if (sched) {
-        auto &rs = sched->ring_sched_states[ring_id];
-        PTO2TaskSlotState &cur_slot_state = rs.get_slot_state_by_slot(slot);
-        int32_t fanin_count = fanin_builder.count;
-        int32_t inline_count = std::min(fanin_count, PTO2_FANIN_INLINE_CAP);
-        int32_t spill_count = fanin_count - inline_count;
+    int32_t fanin_count = fanin_builder.count;
+    int32_t inline_count = std::min(fanin_count, PTO2_FANIN_INLINE_CAP);
+    int32_t spill_count = fanin_count - inline_count;
 
-        // Store fanin metadata in payload for scheduler to iterate
-        payload->fanin_actual_count = fanin_count;
-        payload->fanin_spill_start = (spill_count > 0) ? fanin_builder.spill_start : 0;
-        payload->fanin_spill_pool = (spill_count > 0) ? fanin_builder.spill_pool : nullptr;
-        for (int i = 0; i < inline_count; i++) {
-            payload->fanin_inline_slot_states[i] = fanin_builder.inline_slots[i];
-        }
+    // Store fanin metadata in payload for scheduler to iterate
+    payload.fanin_actual_count = fanin_count;
+    payload.fanin_spill_start = (spill_count > 0) ? fanin_builder.spill_start : 0;
+    payload.fanin_spill_pool = (spill_count > 0) ? fanin_builder.spill_pool : nullptr;
+    for (int i = 0; i < inline_count; i++) {
+        payload.fanin_inline_slot_states[i] = fanin_builder.inline_slots[i];
+    }
 
-        // Increment fanout_count on each producer (no lock — only orch writes this field).
-        // Prevents premature CONSUMED: scope_end's release_producer checks fanout_refcount == fanout_count.
-        pto2_for_each_fanin_slot_state(*payload, [](PTO2TaskSlotState *producer) {
-            producer->fanout_count += 1;
-        });
+    // Increment fanout_count on each producer (no lock — only orch writes this field).
+    // Prevents premature CONSUMED: scope_end's release_producer checks fanout_refcount == fanout_count.
+    pto2_for_each_fanin_slot_state(payload, [](PTO2TaskSlotState *producer) {
+        producer->fanout_count += 1;
+    });
 
-        // Push to global wiring queue — scheduler sets fanin_count, wires fanout, checks readiness
-        while (!sched->wiring_queue.push(&cur_slot_state)) {
-            SPIN_WAIT_HINT();
-        }
-#if PTO2_ORCH_PROFILING
-        g_orch_fanin_atomic_count += 0;  // No lock/atomic ops in submit hot path
-#endif
+    // Push to global wiring queue — scheduler sets fanin_count, wires fanout, checks readiness
+    while (!sched->wiring.queue.push(&cur_slot_state)) {
+        SPIN_WAIT_HINT();
     }
 
     CYCLE_COUNT_LAP_RECORD(g_orch_fanin_cycle, AicpuPhaseId::ORCH_FANIN, task_id.raw);
@@ -799,10 +770,8 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
         return TaskOutputTensors{};
     }
 
-    uint8_t ring_id = prepared.task_id.ring();
-    PTO2RingFlowControl &fc = orch->sm_handle->header->rings[ring_id].fc;
     PTO2TaskDescriptor &task = *prepared.task;
-    PTO2TaskPayload *payload = prepared.payload;
+    PTO2TaskPayload &payload = *prepared.payload;
 
     CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, prepared.task_id.raw);
 
@@ -813,10 +782,6 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
     }
 #endif
 
-    int32_t sm_last_task_alive = fc.last_task_alive.load(std::memory_order_acquire);
-    orch->tensor_map.sync_tensormap(prepared.task_id, sm_last_task_alive);
-    CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, prepared.task_id.raw);
-
     task.task_id = prepared.task_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)] = INVALID_KERNEL_ID;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = INVALID_KERNEL_ID;
@@ -825,13 +790,11 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
     task.packed_buffer_end = prepared.alloc_result.packed_end;
 
     TaskOutputTensors outputs;
-    payload->init(args, outputs, prepared.alloc_result.packed_base, layout.offsets, layout.buffer_sizes);
-    payload->fanin_actual_count = 0;
-    payload->fanin_spill_start = 0;
-    payload->fanin_spill_pool = nullptr;
-    for (int32_t i = 0; i < args.tensor_count(); i++) {
-        payload->tensors[i].owner_task_id = prepared.task_id;
-    }
+    outputs.set_task_id(prepared.task_id);
+    payload.init(args, outputs, prepared.alloc_result, layout);
+    payload.fanin_actual_count = 0;
+    payload.fanin_spill_start = 0;
+    payload.fanin_spill_pool = nullptr;
 
     CYCLE_COUNT_LAP_RECORD(g_orch_args_cycle, AicpuPhaseId::ORCH_PARAMS, prepared.task_id.raw);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -62,18 +62,6 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 // =============================================================================
 
 /**
- * Result of a unified task allocation.
- */
-struct PTO2TaskAllocResult {
-    int32_t task_id;    // Absolute task ID (not wrapped), -1 on failure
-    int32_t slot;       // task_id & (window_size - 1)
-    void *packed_base;  // Heap allocation result (nullptr if output_size == 0)
-    void *packed_end;   // packed_base + aligned output_size
-
-    bool failed() const { return task_id < 0; }
-};
-
-/**
  * Unified task slot + heap buffer allocator.
  *
  * Since task and heap are always allocated together and the orchestrator is

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -111,7 +111,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     // Signal scheduler: orchestrator is about to block, bypass wiring backoff
     bool signaled = slot_count > 0 && orch.scheduler;
     if (signaled) {
-        orch.scheduler->orch_needs_drain.store(true, std::memory_order_release);
+        orch.scheduler->wiring.orch_needs_drain.store(true, std::memory_order_release);
     }
 
     // Wait for each producer
@@ -126,7 +126,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
                 if (signaled) {
-                    orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+                    orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
                 }
                 pto2_orch_report_fatal(
                     &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
@@ -144,7 +144,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
                 SPIN_WAIT_HINT();
                 if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
                     if (signaled) {
-                        orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+                        orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
                     }
                     pto2_orch_report_fatal(
                         &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
@@ -159,7 +159,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
 
     // Clear urgency flag: orchestrator no longer blocking
     if (signaled) {
-        orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+        orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
     }
 
     return true;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -177,6 +177,24 @@ typedef enum {
 #define PTO2_MAX_LAYOUT_DEPTH 8
 
 /**
+ * Result of a unified task allocation.
+ */
+struct PTO2TaskAllocResult {
+    int32_t task_id;    // Absolute task ID (not wrapped)
+    int32_t slot;       // task_id & (window_size - 1)
+    void *packed_base;  // Heap allocation result (nullptr if failure)
+    void *packed_end;   // packed_base + aligned output_size
+
+    bool failed() const { return task_id < 0; }
+};
+
+struct PTO2OutputLayout {
+    uint64_t offsets[MAX_TENSOR_ARGS] = {};
+    uint64_t buffer_sizes[MAX_TENSOR_ARGS] = {};
+    int32_t total_output_size = 0;
+};
+
+/**
  * Layout operation type for HBB
  */
 typedef enum {
@@ -368,10 +386,9 @@ struct PTO2TaskPayload {
      * - INPUT / INOUT -> use refs[i].tensor
      *
      * @param args                Task arguments (tensors + scalars)
-     * @param materialized_outputs  Materialized output tensors (from TensorCreateInfo path)
+     * @param result  Materialized output tensors (from TensorCreateInfo path)
      */
-    void
-    init(const Arg &args, TaskOutputTensors &result, void *base_addr, uint64_t offsets[], uint64_t buffer_sizes[]) {
+    void init(const Arg &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
@@ -382,8 +399,10 @@ struct PTO2TaskPayload {
             } else {
                 tensors[i].init_from_create_info(
                     *args.tensor(i).create_info,
-                    reinterpret_cast<void *>(reinterpret_cast<char *>(base_addr) + offsets[i]), buffer_sizes[i]
+                    reinterpret_cast<void *>(reinterpret_cast<char *>(alloc_result.packed_base) + layout.offsets[i]),
+                    layout.buffer_sizes[i]
                 );
+                tensors[i].owner_task_id = result.task_id();
                 result.materialize_output(tensors[i]);
             }
             tensors[i].update_start_offset();
@@ -428,26 +447,57 @@ struct alignas(64) PTO2TaskSlotState {
 
     // Fanin (accessed together in release_fanin_and_check_ready)
     std::atomic<int32_t> fanin_refcount;  // Dynamic: counts completed producers
-    int32_t fanin_count;                  // Number of producer dependencies (set once)
+    int32_t fanin_count;                  // Number of producer dependencies (set once by wiring)
 
     // Fanout refcount (accessed with fanout_count in check_and_handle_consumed)
     std::atomic<int32_t> fanout_refcount;  // Dynamic: counts released references
 
+    // --- Immutable after RingSchedState::init() (same value on every slot reuse) ---
     PTO2TaskPayload *payload;
-
     PTO2TaskDescriptor *task;
 
-    // Hot-path completion fields (moved from TaskDescriptor to avoid cross-struct access)
+    // --- Set per-submit (depend on task inputs) ---
     uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
     std::atomic<uint8_t> subtask_done_mask;  // Deprecated: superseded by completed_subtasks
-    uint8_t ring_id;                         // Ring layer this task belongs to (for per-ring reclamation)
-    int32_t dep_pool_mark{0};  // Dep pool top after this task's submission (orchestrator-only, local memory)
+    uint8_t ring_id;                         // Ring layer (immutable after init)
+    int32_t dep_pool_mark{0};                // Dep pool top after wiring (thread-0-only)
 
-    // SPMD multi-block (occupies the 8 tail bytes previously implicit padding)
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
     int16_t total_required_subtasks{0};          // = logical_block_num * popcount(active_mask)
     int16_t logical_block_num{1};                // Total logical blocks (set by orchestrator)
     int16_t next_block_idx{0};                   // Next block to dispatch (scheduler state)
+
+    /**
+     * One-time binding of slot-invariant fields.
+     * Called during RingSchedState::init() — these values are determined by
+     * the slot's position in the ring and never change across reuses.
+     */
+    void bind(PTO2TaskPayload *p, PTO2TaskDescriptor *t, uint8_t rid) {
+        payload = p;
+        task = t;
+        ring_id = rid;
+    }
+
+    /**
+     * Reset dynamic scheduling fields for slot reuse.
+     * Called by advance_ring_pointers() after a slot transitions to CONSUMED
+     * and last_task_alive advances past it, but before sync_to_sm() publishes
+     * the new last_task_alive to the orchestrator.
+     *
+     * Skips payload, task, ring_id (immutable, bound once at init).
+     * Skips task_state: left as CONSUMED so that wait_for_tensor_ready()
+     * callers holding stale owner_task_id still observe a completed state.
+     * task_state is set to PENDING by the orchestrator when it reuses the slot.
+     */
+    void reset_for_reuse() {
+        fanout_lock.store(0, std::memory_order_relaxed);
+        fanout_count = 1;
+        fanout_head = nullptr;
+        fanin_refcount.store(0, std::memory_order_relaxed);
+        fanout_refcount.store(0, std::memory_order_relaxed);
+        completed_subtasks.store(0, std::memory_order_relaxed);
+        next_block_idx = 0;
+    }
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -132,20 +132,18 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHandle *sm_handle,
         return false;
     }
 
-    // Zero-initialize all per-task slot state fields.
+    // Initialize all per-task slot state fields.
+    // bind() sets payload, task, ring_id — immutable after init, bound once
+    // to their fixed shared-memory addresses.
+    // reset_for_reuse() sets dynamic fields to reclaim defaults (fanout_count=1,
+    // rest zero) so the first submit needs no reset.
+    PTO2TaskPayload *payloads = sm_handle->task_payloads[ring_id];
     for (uint64_t i = 0; i < task_window_size; i++) {
-        slot_states[i].fanout_lock.store(0, std::memory_order_relaxed);
-        slot_states[i].fanout_count = 0;
-        slot_states[i].fanout_head = nullptr;
-        slot_states[i].task_state.store(static_cast<PTO2TaskState>(0), std::memory_order_relaxed);
-        slot_states[i].fanin_refcount.store(0, std::memory_order_relaxed);
+        slot_states[i].bind(&payloads[i], &task_descriptors[i], static_cast<uint8_t>(ring_id));
+        slot_states[i].reset_for_reuse();
         slot_states[i].fanin_count = 0;
-        slot_states[i].fanout_refcount.store(0, std::memory_order_relaxed);
-        slot_states[i].payload = nullptr;
-        slot_states[i].task = nullptr;
         slot_states[i].active_mask = 0;
         slot_states[i].subtask_done_mask.store(0, std::memory_order_relaxed);
-        slot_states[i].ring_id = 0;
     }
 
     return true;
@@ -199,7 +197,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
             for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
                 pto2_ready_queue_destroy(&sched->ready_queues[i]);
             }
-            sched->wiring_queue.destroy();
+            sched->wiring.queue.destroy();
             for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
                 sched->ring_sched_states[rr].destroy();
             }
@@ -209,7 +207,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
     }
 
     // Initialize global wiring queue (SPSC: orchestrator pushes, scheduler thread 0 drains)
-    if (!sched->wiring_queue.init(PTO2_WRIRING_QUEUE_SIZE)) {
+    if (!sched->wiring.queue.init(PTO2_WRIRING_QUEUE_SIZE)) {
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             free(sched->ring_sched_states[r].dep_pool.base);
         }
@@ -221,9 +219,9 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
         }
         return false;
     }
-    sched->wiring_batch_count = 0;
-    sched->wiring_batch_index = 0;
-    sched->wiring_backoff_counter = 0;
+    sched->wiring.batch_count = 0;
+    sched->wiring.batch_index = 0;
+    sched->wiring.backoff_counter = 0;
 
     return true;
 }
@@ -235,7 +233,7 @@ void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
         sched->ring_sched_states[r].dep_pool.base = nullptr;
     }
 
-    sched->wiring_queue.destroy();
+    sched->wiring.queue.destroy();
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         pto2_ready_queue_destroy(&sched->ready_queues[i]);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -418,7 +418,7 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue *queue);
 //
 // Memory layout: 4 cache-line-aligned fields ensure zero false sharing.
 
-struct PTO2SpscQueue {
+struct alignas(64) PTO2SpscQueue {
     // --- Producer cache lines (orchestrator thread) ---
     alignas(64) std::atomic<uint64_t> head_{0};
     alignas(64) uint64_t tail_cached_{0};
@@ -495,8 +495,7 @@ struct PTO2SpscQueue {
     }
 };
 
-// =============================================================================
-// Scheduler State
+static_assert(sizeof(PTO2SpscQueue) == 256, "PTO2SpscQueue must be exactly 4 cache lines (256B)");
 // =============================================================================
 
 /**
@@ -521,16 +520,18 @@ struct PTO2SchedulerState {
     PTO2SharedMemoryHandle *sm_handle;
 
     // Per-ring state
-    struct RingSchedState {
-        // --- Completion/dispatch hot path (all scheduler threads) ---
+    struct alignas(64) RingSchedState {
+        // --- Cache Line 0: Read-only after init (pointers + config) ---
         PTO2TaskDescriptor *task_descriptors;
         PTO2TaskSlotState *slot_states;
-        int32_t last_task_alive;
         int32_t task_window_mask;
         uint64_t task_window_size;
+
+        // --- Cache Line 1: Multi-thread hot path (advance) ---
+        alignas(64) int32_t last_task_alive;
         std::atomic<int32_t> advance_lock;  // multi-thread CAS
 
-        // --- Wiring hot path (thread 0 only, isolated from completion traffic) ---
+        // --- Cache Line 2+: Thread 0 only (wiring dep_pool) ---
         alignas(64) PTO2DepListPool dep_pool;
 
         bool init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id);
@@ -547,6 +548,7 @@ struct PTO2SchedulerState {
 
         void advance_ring_pointers(PTO2SharedMemoryRingHeader &ring) {
             int32_t current_task_index = ring.fc.current_task_index.load(std::memory_order_acquire);
+            int32_t old_last_task_alive = last_task_alive;
 
             while (last_task_alive < current_task_index) {
                 PTO2TaskSlotState &slot_state = get_slot_state_by_task_id(last_task_alive);
@@ -556,6 +558,15 @@ struct PTO2SchedulerState {
                 last_task_alive++;
             }
 
+            // Eager reset: prepare reclaimed slots for reuse while still hot in cache.
+            // Safe because last_task_alive has advanced past these slots but
+            // sync_to_sm has not yet published — the orchestrator cannot reuse
+            // them until the release store below.
+            // Skips payload, task, ring_id — immutable after RingSchedState::init().
+            for (int32_t id = old_last_task_alive; id < last_task_alive; id++) {
+                get_slot_state_by_task_id(id).reset_for_reuse();
+            }
+
             sync_to_sm(ring);
         }
     } ring_sched_states[PTO2_MAX_RING_DEPTH];
@@ -563,30 +574,37 @@ struct PTO2SchedulerState {
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
-    // Global wiring batch buffer — thread 0 only, tight layout for cache locality.
-    // count(4B) + index(4B) + batch[31](248B) = 256B = exactly 4 cache lines.
-    int wiring_batch_count = 0;
-    int wiring_batch_index = 0;
-    static constexpr uint64_t WIRING_BATCH_SIZE = 31;
-    PTO2TaskSlotState *wiring_batch[WIRING_BATCH_SIZE];
+    // Wiring subsystem — groups all wiring-related state for cache-line isolation.
+    //
+    // Three cache-line regions by writer:
+    //   1. batch_*  / backoff — thread 0 exclusive (local batch buffer)
+    //   2. queue    — SPSC: orchestrator push, thread 0 pop
+    //   3. orch_needs_drain — orchestrator write, thread 0 read
+    struct alignas(64) WiringState {
+        static constexpr uint64_t BATCH_SIZE = 30;
+        static constexpr int BACKOFF_LIMIT = 32;
 
-    // Global wiring queue — refill path only (every BATCH_SIZE tasks), separate cache line.
-    alignas(64) PTO2SpscQueue wiring_queue;
+        // --- Thread 0 exclusive: local batch buffer + backoff ---
+        int batch_count = 0;
+        int batch_index = 0;
+        int backoff_counter = 0;
+        PTO2TaskSlotState *batch[BATCH_SIZE];
 
-    // Orchestrator urgency flag: set by orchestrator before spin-waiting on
-    // tensor data, cleared after wait completes. When true, scheduler bypasses
-    // wiring backoff to ensure pending tasks are wired promptly.
-    alignas(64) std::atomic<bool> orch_needs_drain{false};
+        // --- SPSC queue: orchestrator (push) ↔ thread 0 (pop) ---
+        PTO2SpscQueue queue;
 
-    // Backoff counter: when queue size < WIRING_BATCH_SIZE, increment instead
-    // of popping. After WIRING_BACKOFF_LIMIT consecutive deferrals, force a pop
-    // to prevent deadlock (allocator may be waiting for wiring to advance ring).
-    static constexpr int WIRING_BACKOFF_LIMIT = 32;
-    int wiring_backoff_counter;
+        // --- Orchestrator write, thread 0 read ---
+        alignas(64) std::atomic<bool> orch_needs_drain{false};
+    } wiring;
 
-    // Statistics
+    static_assert(
+        offsetof(WiringState, queue) == 256, "WiringState: batch region must be exactly 4 cache lines before queue"
+    );
+    static_assert(sizeof(WiringState) == 576, "WiringState must be exactly 9 cache lines (576B)");
+
+    // Statistics (cold path, isolated from hot-path fields)
 #if PTO2_SCHED_PROFILING
-    std::atomic<int64_t> tasks_completed;
+    alignas(64) std::atomic<int64_t> tasks_completed;
     std::atomic<int64_t> tasks_consumed;
 #endif
     // =========================================================================
@@ -606,25 +624,25 @@ struct PTO2SchedulerState {
         int wired = 0;
 
         // Refill local batch buffer when exhausted.
-        if (wiring_batch_index >= wiring_batch_count) {
+        if (wiring.batch_index >= wiring.batch_count) {
             // Backoff: defer pop when queue holds fewer than a full batch,
             // unless force_drain, orch_needs_drain, or backoff limit reached.
-            if (!force_drain && wiring_queue.size() < WIRING_BATCH_SIZE) {
-                if (!orch_needs_drain.load(std::memory_order_acquire) &&
-                    wiring_backoff_counter < WIRING_BACKOFF_LIMIT) {
-                    wiring_backoff_counter++;
+            if (!force_drain && wiring.queue.size() < WiringState::BATCH_SIZE) {
+                if (!wiring.orch_needs_drain.load(std::memory_order_acquire) &&
+                    wiring.backoff_counter < WiringState::BACKOFF_LIMIT) {
+                    wiring.backoff_counter++;
                     return 0;
                 }
             }
-            wiring_backoff_counter = 0;
-            wiring_batch_count = wiring_queue.pop_batch(wiring_batch, WIRING_BATCH_SIZE);
-            wiring_batch_index = 0;
-            if (wiring_batch_count == 0) return 0;
+            wiring.backoff_counter = 0;
+            wiring.batch_count = wiring.queue.pop_batch(wiring.batch, WiringState::BATCH_SIZE);
+            wiring.batch_index = 0;
+            if (wiring.batch_count == 0) return 0;
         }
 
         // Process tasks from local buffer in strict FIFO order.
-        while (wiring_batch_index < wiring_batch_count) {
-            PTO2TaskSlotState *ws = wiring_batch[wiring_batch_index];
+        while (wiring.batch_index < wiring.batch_count) {
+            PTO2TaskSlotState *ws = wiring.batch[wiring.batch_index];
             int ring_id = ws->ring_id;
             auto &rss = ring_sched_states[ring_id];
             int32_t wfanin = ws->payload->fanin_actual_count;
@@ -636,7 +654,7 @@ struct PTO2SchedulerState {
                 }
             }
 
-            wiring_batch_index++;
+            wiring.batch_index++;
             wire_task(rss, ws, wfanin);
             wired++;
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -221,8 +221,6 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle) {
             "  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")", h->rings[r].task_descriptors_offset,
             h->rings[r].task_descriptors_offset
         );
-        LOG_INFO("  heap_top:         %" PRIu64, h->rings[r].fc.heap_top.load(std::memory_order_acquire));
-        LOG_INFO("  heap_tail:        %" PRIu64, h->rings[r].fc.heap_tail.load(std::memory_order_acquire));
         LOG_INFO("  current_task_idx: %d", h->rings[r].fc.current_task_index.load(std::memory_order_acquire));
         LOG_INFO("  last_task_alive:  %d", h->rings[r].fc.last_task_alive.load(std::memory_order_acquire));
     }
@@ -265,12 +263,8 @@ bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle, int32_t ring_
     // Check flow control pointer sanity
     int32_t current = current_task_index.load(std::memory_order_acquire);
     int32_t last_alive = last_task_alive.load(std::memory_order_acquire);
-    uint64_t top = heap_top.load(std::memory_order_acquire);
-    uint64_t tail = heap_tail.load(std::memory_order_acquire);
     if (current < 0) return false;
     if (last_alive < 0) return false;
-    if (top > h->rings[ring_id].heap_size) return false;
-    if (tail > h->rings[ring_id].heap_size) return false;
 
     return true;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -53,26 +53,22 @@ struct PTO2SharedMemoryHandle;
  * Per-ring flow control state in shared memory.
  * Written/read by Orchestrator and Scheduler for synchronization.
  */
-struct PTO2RingFlowControl {
-    // Written by Orchestrator, Read by Scheduler
-    std::atomic<uint64_t> heap_top;           // Heap ring allocation pointer
-    std::atomic<int32_t> current_task_index;  // Task ring head (next to allocate)
-    int32_t _pad0;                            // Alignment padding
+struct alignas(64) PTO2RingFlowControl {
+    // === Cache Line 0: Written by Orchestrator, Read by Scheduler ===
+    alignas(64) std::atomic<int32_t> current_task_index;  // Task ring head (next to allocate)
 
-    // Written by Scheduler, Read by Orchestrator (for back-pressure)
-    std::atomic<uint64_t> heap_tail;       // Heap ring free pointer
-    std::atomic<int32_t> last_task_alive;  // Task ring tail (oldest active task)
-    int32_t _pad1;                         // Alignment padding
+    // === Cache Line 1: Written by Scheduler, Read by Orchestrator (for back-pressure) ===
+    alignas(64) std::atomic<int32_t> last_task_alive;  // Task ring tail (oldest active task)
 
     void init() {
-        heap_top.store(0, std::memory_order_relaxed);
         current_task_index.store(0, std::memory_order_relaxed);
-        heap_tail.store(0, std::memory_order_relaxed);
         last_task_alive.store(0, std::memory_order_relaxed);
     }
 
     bool validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const;
 };
+
+static_assert(sizeof(PTO2RingFlowControl) == 128, "PTO2RingFlowControl must be exactly 2 cache lines (128B)");
 
 /**
  * Per-ring shared memory header section.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -63,6 +63,7 @@
 class TaskOutputTensors {
 public:
     TaskOutputTensors() :
+        task_id_(PTO2TaskId::invalid()),
         output_count_(0) {}
 
     bool empty() const { return output_count_ == 0; }
@@ -81,7 +82,12 @@ public:
         tensors_[output_count_++] = &tensor;
     }
 
+    void set_task_id(PTO2TaskId id) { task_id_ = id; }
+
+    PTO2TaskId task_id() const { return task_id_; }
+
 private:
+    PTO2TaskId task_id_;
     uint32_t output_count_;
     const Tensor *tensors_[PTO2_MAX_OUTPUTS];
 };

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -242,14 +242,7 @@ static bool pto2_append_fanin_or_fail(
 
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state);
 
-struct PTO2OutputLayout {
-    uint64_t offsets[MAX_TENSOR_ARGS] = {};
-    uint64_t buffer_sizes[MAX_TENSOR_ARGS] = {};
-    int32_t total_output_size = 0;
-};
-
 struct PTO2PreparedTask {
-    PTO2SchedulerState *sched = nullptr;
     PTO2TaskId task_id = PTO2TaskId::invalid();
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
     PTO2TaskDescriptor *task = nullptr;
@@ -328,45 +321,36 @@ static bool pto2_prepare_task(
         return false;
     }
 
-    out->sched = orch->scheduler;
+    auto sched = orch->scheduler;
     out->alloc_result = allocator.alloc(total_output_size);
     if (out->alloc_result.failed()) {
         pto2_orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
 
+    auto &rs = sched->ring_sched_states[ring_id];
     out->task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
-    out->task = &allocator.task_by_slot(out->alloc_result.slot);
+    out->slot_state = &rs.get_slot_state_by_slot(out->alloc_result.slot);
+    out->task = &orch->sm_handle->task_descriptors[ring_id][out->alloc_result.slot];
     out->payload = &orch->sm_handle->task_payloads[ring_id][out->alloc_result.slot];
 
     pto2_prefetch_payload(out->payload, args.tensor_count(), args.scalar_count());
 
-    if (out->sched) {
-        auto &rs = out->sched->ring_sched_states[ring_id];
-        out->slot_state = &rs.get_slot_state_by_slot(out->alloc_result.slot);
-        PTO2TaskSlotState &slot_state = *out->slot_state;
-        slot_state.fanout_head = nullptr;
-        slot_state.fanout_lock.store(0, std::memory_order_relaxed);
-        slot_state.fanout_count = 1;
-        slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
-        slot_state.fanin_refcount.store(0, std::memory_order_relaxed);
-        slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
-        slot_state.completed_subtasks.store(0, std::memory_order_relaxed);
-        slot_state.subtask_done_mask.store(0, std::memory_order_relaxed);
-        int16_t block_num = args.launch_spec.core_num();
-        slot_state.total_required_subtasks =
-            static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
-        slot_state.logical_block_num = block_num;
-        slot_state.next_block_idx = 0;
-        slot_state.payload = out->payload;
-        slot_state.task = out->task;
-        slot_state.active_mask = active_mask;
-        slot_state.ring_id = ring_id;
-        // fanin_count is set by scheduler during wiring
-        scope_tasks_push(orch, &slot_state);
-    } else {
-        scope_tasks_push(orch, nullptr);
-    }
+    // Fields already reset by advance_ring_pointers (eager reset after CONSUMED):
+    //   fanout_lock=0, fanout_count=1, fanout_head=nullptr,
+    //   fanin_refcount=0, fanout_refcount=0, completed_subtasks=0, next_block_idx=0
+    // Fields immutable after RingSchedState::init():
+    //   payload, task, ring_id
+    // task_state left as CONSUMED by eager reset (safe for stale wait_for_tensor
+    // observers); set to PENDING here when orchestrator actually reuses the slot.
+    out->slot_state->task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
+    int16_t block_num = args.launch_spec.core_num();
+    out->slot_state->total_required_subtasks =
+        static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
+    out->slot_state->logical_block_num = block_num;
+    out->slot_state->active_mask = active_mask;
+    // fanin_count is set by scheduler during wiring
+    scope_tasks_push(orch, out->slot_state);
 
     return true;
 }
@@ -543,11 +527,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         return result;
     }
 
-    // Determine which ring this task belongs to
-    uint8_t ring_id = orch->current_ring_id();
-    auto &allocator = orch->rings[ring_id].task_allocator;
-    PTO2SchedulerState *sched = orch->scheduler;
-    PTO2RingFlowControl &fc = orch->sm_handle->header->rings[ring_id].fc;
+    always_assert(orch->scheduler != nullptr);
 
     // === Validate submit inputs ===
     uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
@@ -588,101 +568,19 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         active_mask |= PTO2_SUBTASK_FLAG_SYNC_START;
     }
 
-    // Submission without an open scope is illegal
-    always_assert(orch->scope_stack_top >= 0 && "Cannot submit task outside a scope");
-
-    // === Scope deadlock pre-check ===
-    // Tasks within a scope hold a fanout_count reference released only at scope_end.
-    // If scope task count >= window_size, no slots can ever be reclaimed → deadlock.
-    {
-        int32_t scope_task_count = orch->scope_tasks_size - orch->scope_begins[orch->scope_stack_top];
-        if (scope_task_count >= allocator.window_size() - 1) {
-            int32_t active_count = allocator.active_count();
-
-            LOG_ERROR("========================================");
-            LOG_ERROR("FATAL: Scope Deadlock Detected! (ring %d)", ring_id);
-            LOG_ERROR("========================================");
-            LOG_ERROR(
-                "Tasks in current scope (%d) >= task_window_size (%d).", scope_task_count, allocator.window_size()
-            );
-            LOG_ERROR("  scope_depth:        %d", orch->scope_stack_top + 1);
-            LOG_ERROR("  ring_id:            %d", ring_id);
-            LOG_ERROR("  scope_task_count:   %d", scope_task_count);
-            LOG_ERROR("  active_tasks:       %d / %d", active_count, allocator.window_size());
-            LOG_ERROR("Root Cause:");
-            LOG_ERROR("  Tasks within a scope hold a fanout_count reference that is only");
-            LOG_ERROR("  released at scope_end. When scope task count >= window_size,");
-            LOG_ERROR("  no slots can be reclaimed -> deadlock.");
-            LOG_ERROR("Solution:");
-            LOG_ERROR("  1. Reduce tasks per scope (use batching/unroll)");
-            LOG_ERROR("  2. Increase task window (current: %d)", allocator.window_size());
-            LOG_ERROR("     Compile-time: PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");
-            LOG_ERROR("     Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2>");
-            LOG_ERROR("  3. Split work across multiple scopes");
-            LOG_ERROR("========================================");
-            orch->sm_handle->header->orch_error_code.store(PTO2_ERROR_SCOPE_DEADLOCK, std::memory_order_release);
-            orch->fatal = true;
-            return result;
-        }
-    }
-
-    // === Calculate output size (from runtime-created OUTPUT args) ===
-    uint64_t offsets[MAX_TENSOR_ARGS] = {};
-    uint64_t buffer_sizes[MAX_TENSOR_ARGS] = {};
-    int32_t total_output_size = 0;
-    for (int i = 0; i < args.tensor_count(); i++) {
-        if (args.tag(i) == TensorArgType::OUTPUT) {
-            offsets[i] = total_output_size;
-            buffer_sizes[i] = PTO2_ALIGN_UP(args.tensor(i).create_info->buffer_size_bytes(), PTO2_PACKED_OUTPUT_ALIGN);
-            total_output_size += buffer_sizes[i];
-        }
-    }
-
-    // === STEP 1: Unified alloc — task slot + packed output buffer (blocks until available) ===
-    PTO2TaskAllocResult alloc_result = allocator.alloc(total_output_size);
-    if (alloc_result.failed()) {
-        orch->fatal = true;
+    PTO2OutputLayout layout = pto2_calculate_output_layout(args);
+    PTO2PreparedTask prepared;
+    if (!pto2_prepare_task(orch, args, layout.total_output_size, active_mask, &prepared)) {
         return result;
     }
-
-    int32_t local_id = alloc_result.task_id;
-    int32_t slot = alloc_result.slot;
-    PTO2TaskId task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(local_id));
-
-    PTO2TaskDescriptor &task = allocator.task_by_slot(slot);
-    PTO2TaskPayload *payload = &orch->sm_handle->task_payloads[ring_id][slot];
-
-    // Early write-prefetch payload GM cache lines to issue RFO in background.
-    // ~130 lines of computation (lookup, insert) follow before
-    // param_copy writes, giving ample time for prefetch to complete.
-    // Use locality=3 (PSTL1KEEP) so prefetched CLs survive lookup/insert eviction.
-    pto2_prefetch_payload(payload, args.tensor_count(), args.scalar_count());
-
-    // Initialize slot state (scheduler-private)
-    if (sched) {
-        auto &rs = sched->ring_sched_states[ring_id];
-        PTO2TaskSlotState &slot_state = rs.get_slot_state_by_slot(slot);
-        slot_state.fanout_head = nullptr;
-        slot_state.fanout_lock.store(0, std::memory_order_relaxed);
-        slot_state.fanout_count = 1;
-        slot_state.fanout_refcount.store(0, std::memory_order_relaxed);
-        slot_state.fanin_refcount.store(0, std::memory_order_relaxed);
-        slot_state.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
-        slot_state.completed_subtasks.store(0, std::memory_order_relaxed);
-        slot_state.subtask_done_mask.store(0, std::memory_order_relaxed);
-        slot_state.total_required_subtasks =
-            static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
-        slot_state.logical_block_num = block_num;
-        slot_state.next_block_idx = 0;
-        slot_state.payload = payload;
-        slot_state.task = &task;
-        slot_state.active_mask = active_mask;
-        slot_state.ring_id = ring_id;
-        // fanin_count is set by scheduler during wiring
-        scope_tasks_push(orch, &slot_state);
-    } else {
-        scope_tasks_push(orch, nullptr);
-    }
+    uint8_t ring_id = prepared.task_id.ring();
+    PTO2SchedulerState *sched = orch->scheduler;
+    PTO2RingFlowControl &fc = orch->sm_handle->header->rings[ring_id].fc;
+    PTO2TaskId task_id = prepared.task_id;
+    PTO2TaskSlotState &cur_slot_state = *prepared.slot_state;
+    PTO2TaskDescriptor &task = *prepared.task;
+    PTO2TaskPayload &payload = *prepared.payload;
+    result.set_task_id(task_id);
 
     PTO2FaninBuilder fanin_builder;
     fanin_builder.count = 0;
@@ -692,9 +590,9 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, task_id.raw);
 
 #if PTO2_PROFILING
-    if (total_output_size > 0) {
+    if (layout.total_output_size > 0) {
         orch->buffers_allocated++;
-        orch->bytes_allocated += total_output_size;
+        orch->bytes_allocated += layout.total_output_size;
     }
 #endif
 
@@ -718,7 +616,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
 
         // Step A: creator retention — all existing tensors extend their creator lifetime.
         PTO2TaskId owner = tensor->owner_task_id;
-        if (owner.is_valid() && sched != nullptr) {
+        if (owner.is_valid()) {
             PTO2TaskSlotState *prod_state =
                 &sched->ring_sched_states[owner.ring()].get_slot_state_by_task_id(owner.local());
             if (!pto2_append_fanin_or_fail(
@@ -780,18 +678,10 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)] = normalized.aic_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;
-    task.packed_buffer_base = alloc_result.packed_base;
-    task.packed_buffer_end = alloc_result.packed_end;
+    task.packed_buffer_base = prepared.alloc_result.packed_base;
+    task.packed_buffer_end = prepared.alloc_result.packed_end;
 
-    payload->init(args, result, alloc_result.packed_base, offsets, buffer_sizes);
-
-    // Write owner_task_id into materialized OUTPUT tensors so creator-only dependency
-    // tracking remains available even when manual_dep skips OverlapMap publication.
-    for (int i = 0; i < args.tensor_count(); i++) {
-        if (args.tag(i) == TensorArgType::OUTPUT) {
-            payload->tensors[i].owner_task_id = task_id;
-        }
-    }
+    payload.init(args, result, prepared.alloc_result, layout);
 
     CYCLE_COUNT_LAP_RECORD(g_orch_args_cycle, AicpuPhaseId::ORCH_PARAMS, task_id.raw);
 #if PTO2_ORCH_PROFILING
@@ -802,29 +692,27 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
     // Deferred wiring: orchestrator only stores dependency metadata and increments
     // fanout_count. The actual fanout_head wiring (lock + dep_pool + early_finished)
     // is handled asynchronously by scheduler thread 0 via the wiring queue.
-    if (sched) {
-        auto &rs = sched->ring_sched_states[ring_id];
-        PTO2TaskSlotState &cur_slot_state = rs.get_slot_state_by_slot(slot);
+    {
         int32_t fanin_count = fanin_builder.count;
         int32_t inline_count = std::min(fanin_count, PTO2_FANIN_INLINE_CAP);
         int32_t spill_count = fanin_count - inline_count;
 
         // Store fanin metadata in payload for scheduler to iterate
-        payload->fanin_actual_count = fanin_count;
-        payload->fanin_spill_start = (spill_count > 0) ? fanin_builder.spill_start : 0;
-        payload->fanin_spill_pool = (spill_count > 0) ? fanin_builder.spill_pool : nullptr;
+        payload.fanin_actual_count = fanin_count;
+        payload.fanin_spill_start = (spill_count > 0) ? fanin_builder.spill_start : 0;
+        payload.fanin_spill_pool = (spill_count > 0) ? fanin_builder.spill_pool : nullptr;
         for (int i = 0; i < inline_count; i++) {
-            payload->fanin_inline_slot_states[i] = fanin_builder.inline_slots[i];
+            payload.fanin_inline_slot_states[i] = fanin_builder.inline_slots[i];
         }
 
         // Increment fanout_count on each producer (no lock — only orch writes this field).
         // Prevents premature CONSUMED: scope_end's release_producer checks fanout_refcount == fanout_count.
-        pto2_for_each_fanin_slot_state(*payload, [](PTO2TaskSlotState *producer) {
+        pto2_for_each_fanin_slot_state(payload, [](PTO2TaskSlotState *producer) {
             producer->fanout_count += 1;
         });
 
         // Push to global wiring queue — scheduler sets fanin_count, wires fanout, checks readiness
-        while (!sched->wiring_queue.push(&cur_slot_state)) {
+        while (!sched->wiring.queue.push(&cur_slot_state)) {
             SPIN_WAIT_HINT();
         }
 #if PTO2_ORCH_PROFILING
@@ -886,10 +774,8 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
         return TaskOutputTensors{};
     }
 
-    uint8_t ring_id = prepared.task_id.ring();
-    PTO2RingFlowControl &fc = orch->sm_handle->header->rings[ring_id].fc;
     PTO2TaskDescriptor &task = *prepared.task;
-    PTO2TaskPayload *payload = prepared.payload;
+    PTO2TaskPayload &payload = *prepared.payload;
 
     CYCLE_COUNT_LAP_RECORD(g_orch_alloc_cycle, AicpuPhaseId::ORCH_ALLOC, prepared.task_id.raw);
 
@@ -900,10 +786,6 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
     }
 #endif
 
-    int32_t sm_last_task_alive = fc.last_task_alive.load(std::memory_order_acquire);
-    orch->tensor_map.sync_tensormap(prepared.task_id, sm_last_task_alive);
-    CYCLE_COUNT_LAP_RECORD(g_orch_sync_cycle, AicpuPhaseId::ORCH_SYNC, prepared.task_id.raw);
-
     task.task_id = prepared.task_id;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)] = INVALID_KERNEL_ID;
     task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = INVALID_KERNEL_ID;
@@ -912,13 +794,11 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
     task.packed_buffer_end = prepared.alloc_result.packed_end;
 
     TaskOutputTensors outputs;
-    payload->init(args, outputs, prepared.alloc_result.packed_base, layout.offsets, layout.buffer_sizes);
-    payload->fanin_actual_count = 0;
-    payload->fanin_spill_start = 0;
-    payload->fanin_spill_pool = nullptr;
-    for (int32_t i = 0; i < args.tensor_count(); i++) {
-        payload->tensors[i].owner_task_id = prepared.task_id;
-    }
+    outputs.set_task_id(prepared.task_id);
+    payload.init(args, outputs, prepared.alloc_result, layout);
+    payload.fanin_actual_count = 0;
+    payload.fanin_spill_start = 0;
+    payload.fanin_spill_pool = nullptr;
 
     CYCLE_COUNT_LAP_RECORD(g_orch_args_cycle, AicpuPhaseId::ORCH_PARAMS, prepared.task_id.raw);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -62,18 +62,6 @@ struct PTO2SchedulerState;  // Forward declaration for dep_pool reclaim
 // =============================================================================
 
 /**
- * Result of a unified task allocation.
- */
-struct PTO2TaskAllocResult {
-    int32_t task_id;    // Absolute task ID (not wrapped), -1 on failure
-    int32_t slot;       // task_id & (window_size - 1)
-    void *packed_base;  // Heap allocation result (nullptr if output_size == 0)
-    void *packed_end;   // packed_base + aligned output_size
-
-    bool failed() const { return task_id < 0; }
-};
-
-/**
  * Unified task slot + heap buffer allocator.
  *
  * Since task and heap are always allocated together and the orchestrator is

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -111,7 +111,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     // Signal scheduler: orchestrator is about to block, bypass wiring backoff
     bool signaled = slot_count > 0 && orch.scheduler;
     if (signaled) {
-        orch.scheduler->orch_needs_drain.store(true, std::memory_order_release);
+        orch.scheduler->wiring.orch_needs_drain.store(true, std::memory_order_release);
     }
 
     // Wait for each producer
@@ -126,7 +126,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
                 if (signaled) {
-                    orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+                    orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
                 }
                 pto2_orch_report_fatal(
                     &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
@@ -144,7 +144,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
                 SPIN_WAIT_HINT();
                 if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
                     if (signaled) {
-                        orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+                        orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
                     }
                     pto2_orch_report_fatal(
                         &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
@@ -159,7 +159,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
 
     // Clear urgency flag: orchestrator no longer blocking
     if (signaled) {
-        orch.scheduler->orch_needs_drain.store(false, std::memory_order_release);
+        orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
     }
 
     return true;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -177,6 +177,24 @@ typedef enum {
 #define PTO2_MAX_LAYOUT_DEPTH 8
 
 /**
+ * Result of a unified task allocation.
+ */
+struct PTO2TaskAllocResult {
+    int32_t task_id;    // Absolute task ID (not wrapped)
+    int32_t slot;       // task_id & (window_size - 1)
+    void *packed_base;  // Heap allocation result (nullptr if failure)
+    void *packed_end;   // packed_base + aligned output_size
+
+    bool failed() const { return task_id < 0; }
+};
+
+struct PTO2OutputLayout {
+    uint64_t offsets[MAX_TENSOR_ARGS] = {};
+    uint64_t buffer_sizes[MAX_TENSOR_ARGS] = {};
+    int32_t total_output_size = 0;
+};
+
+/**
  * Layout operation type for HBB
  */
 typedef enum {
@@ -366,8 +384,7 @@ struct PTO2TaskPayload {
      * @param args                Task arguments (tensors + scalars)
      * @param materialized_outputs  Materialized output tensors (from TensorCreateInfo path)
      */
-    void
-    init(const Arg &args, TaskOutputTensors &result, void *base_addr, uint64_t offsets[], uint64_t buffer_sizes[]) {
+    void init(const Arg &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
@@ -378,8 +395,10 @@ struct PTO2TaskPayload {
             } else {
                 tensors[i].init_from_create_info(
                     *args.tensor(i).create_info,
-                    reinterpret_cast<void *>(reinterpret_cast<char *>(base_addr) + offsets[i]), buffer_sizes[i]
+                    reinterpret_cast<void *>(reinterpret_cast<char *>(alloc_result.packed_base) + layout.offsets[i]),
+                    layout.buffer_sizes[i]
                 );
+                tensors[i].owner_task_id = result.task_id();
                 result.materialize_output(tensors[i]);
             }
             tensors[i].update_start_offset();
@@ -424,26 +443,57 @@ struct alignas(64) PTO2TaskSlotState {
 
     // Fanin (accessed together in release_fanin_and_check_ready)
     std::atomic<int32_t> fanin_refcount;  // Dynamic: counts completed producers
-    int32_t fanin_count;                  // Number of producer dependencies (set once)
+    int32_t fanin_count;                  // Number of producer dependencies (set once by wiring)
 
     // Fanout refcount (accessed with fanout_count in check_and_handle_consumed)
     std::atomic<int32_t> fanout_refcount;  // Dynamic: counts released references
 
+    // --- Immutable after RingSchedState::init() (same value on every slot reuse) ---
     PTO2TaskPayload *payload;
-
     PTO2TaskDescriptor *task;
 
-    // Hot-path completion fields (moved from TaskDescriptor to avoid cross-struct access)
+    // --- Set per-submit (depend on task inputs) ---
     uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
     std::atomic<uint8_t> subtask_done_mask;  // Deprecated: superseded by completed_subtasks
-    uint8_t ring_id;                         // Ring layer this task belongs to (for per-ring reclamation)
-    int32_t dep_pool_mark{0};  // Dep pool top after this task's submission (orchestrator-only, local memory)
+    uint8_t ring_id;                         // Ring layer (immutable after init)
+    int32_t dep_pool_mark{0};                // Dep pool top after wiring (thread-0-only)
 
-    // SPMD multi-block (occupies the 8 tail bytes previously implicit padding)
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
     int16_t total_required_subtasks{0};          // = logical_block_num * popcount(active_mask)
     int16_t logical_block_num{1};                // Total logical blocks (set by orchestrator)
     int16_t next_block_idx{0};                   // Next block to dispatch (scheduler state)
+
+    /**
+     * One-time binding of slot-invariant fields.
+     * Called during RingSchedState::init() — these values are determined by
+     * the slot's position in the ring and never change across reuses.
+     */
+    void bind(PTO2TaskPayload *p, PTO2TaskDescriptor *t, uint8_t rid) {
+        payload = p;
+        task = t;
+        ring_id = rid;
+    }
+
+    /**
+     * Reset dynamic scheduling fields for slot reuse.
+     * Called by advance_ring_pointers() after a slot transitions to CONSUMED
+     * and last_task_alive advances past it, but before sync_to_sm() publishes
+     * the new last_task_alive to the orchestrator.
+     *
+     * Skips payload, task, ring_id (immutable, bound once at init).
+     * Skips task_state: left as CONSUMED so that wait_for_tensor_ready()
+     * callers holding stale owner_task_id still observe a completed state.
+     * task_state is set to PENDING by the orchestrator when it reuses the slot.
+     */
+    void reset_for_reuse() {
+        fanout_lock.store(0, std::memory_order_relaxed);
+        fanout_count = 1;
+        fanout_head = nullptr;
+        fanin_refcount.store(0, std::memory_order_relaxed);
+        fanout_refcount.store(0, std::memory_order_relaxed);
+        completed_subtasks.store(0, std::memory_order_relaxed);
+        next_block_idx = 0;
+    }
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.cpp
@@ -132,20 +132,18 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHandle *sm_handle,
         return false;
     }
 
-    // Zero-initialize all per-task slot state fields.
+    // Initialize all per-task slot state fields.
+    // bind() sets payload, task, ring_id — immutable after init, bound once
+    // to their fixed shared-memory addresses.
+    // reset_for_reuse() sets dynamic fields to reclaim defaults (fanout_count=1,
+    // rest zero) so the first submit needs no reset.
+    PTO2TaskPayload *payloads = sm_handle->task_payloads[ring_id];
     for (uint64_t i = 0; i < task_window_size; i++) {
-        slot_states[i].fanout_lock.store(0, std::memory_order_relaxed);
-        slot_states[i].fanout_count = 0;
-        slot_states[i].fanout_head = nullptr;
-        slot_states[i].task_state.store(static_cast<PTO2TaskState>(0), std::memory_order_relaxed);
-        slot_states[i].fanin_refcount.store(0, std::memory_order_relaxed);
+        slot_states[i].bind(&payloads[i], &task_descriptors[i], static_cast<uint8_t>(ring_id));
+        slot_states[i].reset_for_reuse();
         slot_states[i].fanin_count = 0;
-        slot_states[i].fanout_refcount.store(0, std::memory_order_relaxed);
-        slot_states[i].payload = nullptr;
-        slot_states[i].task = nullptr;
         slot_states[i].active_mask = 0;
         slot_states[i].subtask_done_mask.store(0, std::memory_order_relaxed);
-        slot_states[i].ring_id = 0;
     }
 
     return true;
@@ -199,7 +197,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
             for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
                 pto2_ready_queue_destroy(&sched->ready_queues[i]);
             }
-            sched->wiring_queue.destroy();
+            sched->wiring.queue.destroy();
             for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
                 sched->ring_sched_states[rr].destroy();
             }
@@ -209,7 +207,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
     }
 
     // Initialize global wiring queue (SPSC: orchestrator pushes, scheduler thread 0 drains)
-    if (!sched->wiring_queue.init(PTO2_WRIRING_QUEUE_SIZE)) {
+    if (!sched->wiring.queue.init(PTO2_WRIRING_QUEUE_SIZE)) {
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             free(sched->ring_sched_states[r].dep_pool.base);
         }
@@ -221,9 +219,9 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHandle *sm_h
         }
         return false;
     }
-    sched->wiring_batch_count = 0;
-    sched->wiring_batch_index = 0;
-    sched->wiring_backoff_counter = 0;
+    sched->wiring.batch_count = 0;
+    sched->wiring.batch_index = 0;
+    sched->wiring.backoff_counter = 0;
 
     return true;
 }
@@ -235,7 +233,7 @@ void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
         sched->ring_sched_states[r].dep_pool.base = nullptr;
     }
 
-    sched->wiring_queue.destroy();
+    sched->wiring.queue.destroy();
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         pto2_ready_queue_destroy(&sched->ready_queues[i]);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -418,7 +418,7 @@ void pto2_ready_queue_destroy(PTO2ReadyQueue *queue);
 //
 // Memory layout: 4 cache-line-aligned fields ensure zero false sharing.
 
-struct PTO2SpscQueue {
+struct alignas(64) PTO2SpscQueue {
     // --- Producer cache lines (orchestrator thread) ---
     alignas(64) std::atomic<uint64_t> head_{0};
     alignas(64) uint64_t tail_cached_{0};
@@ -495,6 +495,8 @@ struct PTO2SpscQueue {
     }
 };
 
+static_assert(sizeof(PTO2SpscQueue) == 256, "PTO2SpscQueue must be exactly 4 cache lines (256B)");
+
 // =============================================================================
 // Scheduler State
 // =============================================================================
@@ -521,16 +523,18 @@ struct PTO2SchedulerState {
     PTO2SharedMemoryHandle *sm_handle;
 
     // Per-ring state
-    struct RingSchedState {
-        // --- Completion/dispatch hot path (all scheduler threads) ---
+    struct alignas(64) RingSchedState {
+        // --- Cache Line 0: Read-only after init (pointers + config) ---
         PTO2TaskDescriptor *task_descriptors;
         PTO2TaskSlotState *slot_states;
-        int32_t last_task_alive;
         int32_t task_window_mask;
         uint64_t task_window_size;
+
+        // --- Cache Line 1: Multi-thread hot path (advance) ---
+        alignas(64) int32_t last_task_alive;
         std::atomic<int32_t> advance_lock;  // multi-thread CAS
 
-        // --- Wiring hot path (thread 0 only, isolated from completion traffic) ---
+        // --- Cache Line 2+: Thread 0 only (wiring dep_pool) ---
         alignas(64) PTO2DepListPool dep_pool;
 
         bool init(PTO2SharedMemoryHandle *sm_handle, int32_t ring_id);
@@ -547,6 +551,7 @@ struct PTO2SchedulerState {
 
         void advance_ring_pointers(PTO2SharedMemoryRingHeader &ring) {
             int32_t current_task_index = ring.fc.current_task_index.load(std::memory_order_acquire);
+            int32_t old_last_task_alive = last_task_alive;
 
             while (last_task_alive < current_task_index) {
                 PTO2TaskSlotState &slot_state = get_slot_state_by_task_id(last_task_alive);
@@ -556,6 +561,15 @@ struct PTO2SchedulerState {
                 last_task_alive++;
             }
 
+            // Eager reset: prepare reclaimed slots for reuse while still hot in cache.
+            // Safe because last_task_alive has advanced past these slots but
+            // sync_to_sm has not yet published — the orchestrator cannot reuse
+            // them until the release store below.
+            // Skips payload, task, ring_id — immutable after RingSchedState::init().
+            for (int32_t id = old_last_task_alive; id < last_task_alive; id++) {
+                get_slot_state_by_task_id(id).reset_for_reuse();
+            }
+
             sync_to_sm(ring);
         }
     } ring_sched_states[PTO2_MAX_RING_DEPTH];
@@ -563,30 +577,37 @@ struct PTO2SchedulerState {
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
-    // Global wiring batch buffer — thread 0 only, tight layout for cache locality.
-    // count(4B) + index(4B) + batch[31](248B) = 256B = exactly 4 cache lines.
-    int wiring_batch_count = 0;
-    int wiring_batch_index = 0;
-    static constexpr uint64_t WIRING_BATCH_SIZE = 31;
-    PTO2TaskSlotState *wiring_batch[WIRING_BATCH_SIZE];
+    // Wiring subsystem — groups all wiring-related state for cache-line isolation.
+    //
+    // Three cache-line regions by writer:
+    //   1. batch_*  / backoff — thread 0 exclusive (local batch buffer)
+    //   2. queue    — SPSC: orchestrator push, thread 0 pop
+    //   3. orch_needs_drain — orchestrator write, thread 0 read
+    struct alignas(64) WiringState {
+        static constexpr uint64_t BATCH_SIZE = 30;
+        static constexpr int BACKOFF_LIMIT = 32;
 
-    // Global wiring queue — refill path only (every BATCH_SIZE tasks), separate cache line.
-    alignas(64) PTO2SpscQueue wiring_queue;
+        // --- Thread 0 exclusive: local batch buffer + backoff ---
+        int batch_count = 0;
+        int batch_index = 0;
+        int backoff_counter = 0;
+        PTO2TaskSlotState *batch[BATCH_SIZE];
 
-    // Orchestrator urgency flag: set by orchestrator before spin-waiting on
-    // tensor data, cleared after wait completes. When true, scheduler bypasses
-    // wiring backoff to ensure pending tasks are wired promptly.
-    alignas(64) std::atomic<bool> orch_needs_drain{false};
+        // --- SPSC queue: orchestrator (push) ↔ thread 0 (pop) ---
+        alignas(64) PTO2SpscQueue queue;
 
-    // Backoff counter: when queue size < WIRING_BATCH_SIZE, increment instead
-    // of popping. After WIRING_BACKOFF_LIMIT consecutive deferrals, force a pop
-    // to prevent deadlock (allocator may be waiting for wiring to advance ring).
-    static constexpr int WIRING_BACKOFF_LIMIT = 32;
-    int wiring_backoff_counter;
+        // --- Orchestrator write, thread 0 read ---
+        alignas(64) std::atomic<bool> orch_needs_drain{false};
+    } wiring;
 
-    // Statistics
+    static_assert(
+        offsetof(WiringState, queue) == 256, "WiringState: batch region must be exactly 4 cache lines before queue"
+    );
+    static_assert(sizeof(WiringState) == 576, "WiringState must be exactly 9 cache lines (576B)");
+
+    // Statistics (cold path, isolated from hot-path fields)
 #if PTO2_SCHED_PROFILING
-    std::atomic<int64_t> tasks_completed;
+    alignas(64) std::atomic<int64_t> tasks_completed;
     std::atomic<int64_t> tasks_consumed;
 #endif
     // =========================================================================
@@ -606,25 +627,25 @@ struct PTO2SchedulerState {
         int wired = 0;
 
         // Refill local batch buffer when exhausted.
-        if (wiring_batch_index >= wiring_batch_count) {
+        if (wiring.batch_index >= wiring.batch_count) {
             // Backoff: defer pop when queue holds fewer than a full batch,
             // unless force_drain, orch_needs_drain, or backoff limit reached.
-            if (!force_drain && wiring_queue.size() < WIRING_BATCH_SIZE) {
-                if (!orch_needs_drain.load(std::memory_order_acquire) &&
-                    wiring_backoff_counter < WIRING_BACKOFF_LIMIT) {
-                    wiring_backoff_counter++;
+            if (!force_drain && wiring.queue.size() < WiringState::BATCH_SIZE) {
+                if (!wiring.orch_needs_drain.load(std::memory_order_acquire) &&
+                    wiring.backoff_counter < WiringState::BACKOFF_LIMIT) {
+                    wiring.backoff_counter++;
                     return 0;
                 }
             }
-            wiring_backoff_counter = 0;
-            wiring_batch_count = wiring_queue.pop_batch(wiring_batch, WIRING_BATCH_SIZE);
-            wiring_batch_index = 0;
-            if (wiring_batch_count == 0) return 0;
+            wiring.backoff_counter = 0;
+            wiring.batch_count = wiring.queue.pop_batch(wiring.batch, WiringState::BATCH_SIZE);
+            wiring.batch_index = 0;
+            if (wiring.batch_count == 0) return 0;
         }
 
         // Process tasks from local buffer in strict FIFO order.
-        while (wiring_batch_index < wiring_batch_count) {
-            PTO2TaskSlotState *ws = wiring_batch[wiring_batch_index];
+        while (wiring.batch_index < wiring.batch_count) {
+            PTO2TaskSlotState *ws = wiring.batch[wiring.batch_index];
             int ring_id = ws->ring_id;
             auto &rss = ring_sched_states[ring_id];
             int32_t wfanin = ws->payload->fanin_actual_count;
@@ -636,7 +657,7 @@ struct PTO2SchedulerState {
                 }
             }
 
-            wiring_batch_index++;
+            wiring.batch_index++;
             wire_task(rss, ws, wfanin);
             wired++;
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.cpp
@@ -221,8 +221,6 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle) {
             "  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")", h->rings[r].task_descriptors_offset,
             h->rings[r].task_descriptors_offset
         );
-        LOG_INFO("  heap_top:         %" PRIu64, h->rings[r].fc.heap_top.load(std::memory_order_acquire));
-        LOG_INFO("  heap_tail:        %" PRIu64, h->rings[r].fc.heap_tail.load(std::memory_order_acquire));
         LOG_INFO("  current_task_idx: %d", h->rings[r].fc.current_task_index.load(std::memory_order_acquire));
         LOG_INFO("  last_task_alive:  %d", h->rings[r].fc.last_task_alive.load(std::memory_order_acquire));
     }
@@ -265,12 +263,8 @@ bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle, int32_t ring_
     // Check flow control pointer sanity
     int32_t current = current_task_index.load(std::memory_order_acquire);
     int32_t last_alive = last_task_alive.load(std::memory_order_acquire);
-    uint64_t top = heap_top.load(std::memory_order_acquire);
-    uint64_t tail = heap_tail.load(std::memory_order_acquire);
     if (current < 0) return false;
     if (last_alive < 0) return false;
-    if (top > h->rings[ring_id].heap_size) return false;
-    if (tail > h->rings[ring_id].heap_size) return false;
 
     return true;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -53,26 +53,22 @@ struct PTO2SharedMemoryHandle;
  * Per-ring flow control state in shared memory.
  * Written/read by Orchestrator and Scheduler for synchronization.
  */
-struct PTO2RingFlowControl {
-    // Written by Orchestrator, Read by Scheduler
-    std::atomic<uint64_t> heap_top;           // Heap ring allocation pointer
+struct alignas(64) PTO2RingFlowControl {
+    // === Cache Line 0: Written by Orchestrator, Read by Scheduler ===
     std::atomic<int32_t> current_task_index;  // Task ring head (next to allocate)
-    int32_t _pad0;                            // Alignment padding
 
-    // Written by Scheduler, Read by Orchestrator (for back-pressure)
-    std::atomic<uint64_t> heap_tail;       // Heap ring free pointer
-    std::atomic<int32_t> last_task_alive;  // Task ring tail (oldest active task)
-    int32_t _pad1;                         // Alignment padding
+    // === Cache Line 1: Written by Scheduler, Read by Orchestrator (for back-pressure) ===
+    alignas(64) std::atomic<int32_t> last_task_alive;  // Task ring tail (oldest active task)
 
     void init() {
-        heap_top.store(0, std::memory_order_relaxed);
         current_task_index.store(0, std::memory_order_relaxed);
-        heap_tail.store(0, std::memory_order_relaxed);
         last_task_alive.store(0, std::memory_order_relaxed);
     }
 
     bool validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const;
 };
+
+static_assert(sizeof(PTO2RingFlowControl) == 128, "PTO2RingFlowControl must be exactly 2 cache lines (128B)");
 
 /**
  * Per-ring shared memory header section.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -63,6 +63,7 @@
 class TaskOutputTensors {
 public:
     TaskOutputTensors() :
+        task_id_(PTO2TaskId::invalid()),
         output_count_(0) {}
 
     bool empty() const { return output_count_ == 0; }
@@ -81,7 +82,12 @@ public:
         tensors_[output_count_++] = &tensor;
     }
 
+    void set_task_id(PTO2TaskId id) { task_id_ = id; }
+
+    PTO2TaskId task_id() const { return task_id_; }
+
 private:
+    PTO2TaskId task_id_;
     uint32_t output_count_;
     const Tensor *tensors_[PTO2_MAX_OUTPUTS];
 };


### PR DESCRIPTION
- PTO2RingFlowControl: isolate current_task_index (orch-write) and last_task_alive (sched-write) onto separate cache lines, remove unused heap_top/heap_tail fields, add alignas(64) and static_assert
- PTO2SchedulerState: encapsulate wiring fields into WiringState struct with per-writer cacheline regions (thread-0 batch, SPSC queue, orch_needs_drain), add PTO2SpscQueue alignas(64)
- RingSchedState: separate read-only init fields (cache line 0) from multi-thread advance_lock/last_task_alive (cache line 1) and thread-0 dep_pool (cache line 2+)
- PTO2TaskSlotState: add bind() for init-once fields (payload, task, ring_id) and reset_for_reuse() for eager slot reclaim in advance_ring_pointers, reducing orchestrator submit overhead
- Move PTO2TaskAllocResult/PTO2OutputLayout from pto_ring_buffer.h to pto_runtime2_types.h, add TaskOutputTensors::task_id tracking
- Sync all changes to a5 runtime