### PR TITLE
Refactor: drop dead sys.path hacks in tests/ut/py/

### DIFF
--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -6,19 +6,9 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ruff: noqa: E402
 """Tests for ChipCallConfig and ChipWorker state machine."""
 
-import sys
-from pathlib import Path
-
 import pytest
-
-# Ensure python/ is on the import path so _task_interface and task_interface resolve
-_python_dir = str(Path(__file__).resolve().parent.parent.parent / "python")
-if _python_dir not in sys.path:
-    sys.path.insert(0, _python_dir)
-
 from _task_interface import ChipCallConfig, _ChipWorker  # pyright: ignore[reportMissingImports]
 
 # ============================================================================

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -6,21 +6,13 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ruff: noqa: E402, PLC0415
+# ruff: noqa: PLC0415
 """Tests for the _task_interface nanobind extension and task_interface wrapper."""
 
 import ctypes
 import struct
-import sys
-from pathlib import Path
 
 import pytest
-
-# Ensure python/ is on the import path so _task_interface and task_interface resolve
-_python_dir = str(Path(__file__).resolve().parent.parent.parent / "python")
-if _python_dir not in sys.path:
-    sys.path.insert(0, _python_dir)
-
 from _task_interface import (  # pyright: ignore[reportMissingImports]
     CONTINUOUS_TENSOR_MAX_DIMS,
     ArgDirection,

--- a/tests/ut/py/test_worker/test_platform_comm.py
+++ b/tests/ut/py/test_worker/test_platform_comm.py
@@ -40,19 +40,10 @@ from __future__ import annotations
 import ctypes
 import multiprocessing as mp
 import os
-import sys
 import traceback
 import warnings
-from pathlib import Path
 
 import pytest
-
-_ROOT = Path(__file__).resolve().parents[4]
-for _p in (_ROOT, _ROOT / "python"):
-    _s = str(_p)
-    if _s not in sys.path:
-        sys.path.insert(0, _s)
-
 
 # ---------------------------------------------------------------------------
 # CommContext layout — must stay byte-compatible with


### PR DESCRIPTION
## Summary

Three test files under \`tests/ut/py\` carried their own \`sys.path.insert\` blocks that duplicated what the sibling \`tests/ut/py/conftest.py\` already does — and, under any \`pip install\` mode, they're redundant with site-packages anyway.

### What's dropped

| File | What it did | Why it's dead |
| ---- | ----------- | ------------- |
| \`tests/ut/py/test_chip_worker.py\` | Inserted \`python/\` to find \`_task_interface\` | Already on \`sys.path\` via \`tests/ut/py/conftest.py\`; installed at wheel root under \`pip install\`. |
| \`tests/ut/py/test_task_interface.py\` | Same hack, same reason | Ditto. |
| \`tests/ut/py/test_worker/test_platform_comm.py\` | Inserted project root + \`python/\` | Inherited from the PR #571 stash (standalone-execution pattern); PR #597 (L1b) always relies on conftest / installed package. |

### Intentionally NOT touched

- **\`tests/ut/py/conftest.py\`** — upstream PR #600 (\`1e6660f\`) just refreshed this file's \`sys.path\` list when \`build_runtimes.py\` moved. That's a maintained design choice for the no-install workflow (\"importable without installing the package\"), so I let it stand. The per-test dupes are the only load-bearing-free leftovers.
- **\`tests/conftest.py\`** — still uses \`sys.path.insert(tools/)\` to import \`test_catalog\`. \`tools/\` isn't a Python package at all; cleaning that up requires moving \`test_catalog\` into \`simpler_setup/\` or similar. Separate PR.

### Verification

\`pytest tests/ut/py --ignore=tests/ut/py/test_hostsub_fork_shm.py\` before and after: **170 passed, 6 skipped** in both cases.

### Net diff

\`3 files changed, 1 insertion(+), 28 deletions(-)\`

## Test plan
- [x] \`pytest tests/ut/py --ignore=tests/ut/py/test_hostsub_fork_shm.py\` — 170 pass, 6 skip on macOS 3.14
- [ ] CI \`ut (ubuntu-latest, 3.10)\` / \`ut (macos-latest, 3.10)\` green
- [ ] CI \`ut-a2a3\` (hardware) still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)