### PR TITLE
Add: L4 error propagation from child workers to Worker.run

### DIFF
--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -141,7 +141,11 @@ inline void bind_worker(nb::module_ &m) {
         .def("_scope_end", &Orchestrator::scope_end)
         .def(
             "_drain", &Orchestrator::drain, nb::call_guard<nb::gil_scoped_release>(),
-            "Block until all submitted tasks are CONSUMED (releases GIL)."
+            "Block until all submitted tasks are CONSUMED (releases GIL). "
+            "Rethrows the first dispatch failure seen in this run, if any."
+        )
+        .def(
+            "_clear_error", &Orchestrator::clear_error, "Clear any stored dispatch error so the next run can proceed."
         );
 
     // --- Worker ---
@@ -230,6 +234,8 @@ inline void bind_worker(nb::module_ &m) {
 
     m.attr("DEFAULT_HEAP_RING_SIZE") = static_cast<uint64_t>(DEFAULT_HEAP_RING_SIZE);
     m.attr("MAILBOX_SIZE") = static_cast<int>(MAILBOX_SIZE);
+    m.attr("MAILBOX_OFF_ERROR_MSG") = static_cast<int>(MAILBOX_OFF_ERROR_MSG);
+    m.attr("MAILBOX_ERROR_MSG_SIZE") = static_cast<int>(MAILBOX_ERROR_MSG_SIZE);
     m.attr("MAX_RING_DEPTH") = static_cast<int32_t>(MAX_RING_DEPTH);
     m.attr("MAX_SCOPE_DEPTH") = static_cast<int32_t>(MAX_SCOPE_DEPTH);
 }

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -187,3 +187,6 @@ class Orchestrator:
 
     def _drain(self) -> None:
         self._o._drain()
+
+    def _clear_error(self) -> None:
+        self._o._clear_error()

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -18,6 +18,8 @@ Usage:
 
 from _task_interface import (  # pyright: ignore[reportMissingImports]
     CONTINUOUS_TENSOR_MAX_DIMS,
+    MAILBOX_ERROR_MSG_SIZE,
+    MAILBOX_OFF_ERROR_MSG,
     MAILBOX_SIZE,
     ArgDirection,
     ChipCallable,
@@ -65,6 +67,8 @@ __all__ = [
     "SubmitResult",
     "_Worker",
     "MAILBOX_SIZE",
+    "MAILBOX_OFF_ERROR_MSG",
+    "MAILBOX_ERROR_MSG_SIZE",
     "read_args_from_blob",
 ]
 

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -55,6 +55,8 @@ from typing import Any, Callable, Optional
 
 from .orchestrator import Orchestrator
 from .task_interface import (
+    MAILBOX_ERROR_MSG_SIZE,
+    MAILBOX_OFF_ERROR_MSG,
     MAILBOX_SIZE,
     ChipCallConfig,
     ChipWorker,
@@ -81,6 +83,8 @@ _OFF_AICPU_THREAD_NUM = 20
 _OFF_ENABLE_PROFILING = 24
 _OFF_ENABLE_DUMP_TENSOR = 28
 _OFF_ARGS = 64
+# MAILBOX_OFF_ERROR_MSG / MAILBOX_ERROR_MSG_SIZE come from the C++
+# nanobind module so the two sides cannot drift.
 
 _IDLE = 0
 _TASK_READY = 1
@@ -113,6 +117,37 @@ def _mailbox_addr(shm: SharedMemory) -> int:
     return ctypes.addressof(ctypes.c_char.from_buffer(buf))
 
 
+def _write_error(buf, code: int, msg: str = "") -> None:
+    """Write an (error code, message) tuple into the mailbox error region.
+
+    The message is UTF-8-encoded and truncated to ``MAILBOX_ERROR_MSG_SIZE - 1``
+    bytes so a NUL terminator always fits — the C++ reader assumes
+    NUL-terminated content. On success (code=0) callers may pass an empty
+    message; the region is zero-padded.
+    """
+    struct.pack_into("i", buf, _OFF_ERROR, code)
+    encoded = msg.encode("utf-8", "replace")
+    n = min(len(encoded), MAILBOX_ERROR_MSG_SIZE - 1)
+    start = MAILBOX_OFF_ERROR_MSG
+    buf[start : start + n] = encoded[:n]
+    # Zero-pad the remaining bytes so stale content from a previous dispatch
+    # never leaks into the current error report.
+    buf[start + n : start + MAILBOX_ERROR_MSG_SIZE] = b"\x00" * (MAILBOX_ERROR_MSG_SIZE - n)
+
+
+def _read_error_msg(buf) -> str:
+    """Read the mailbox error message, trimming at the first NUL."""
+    raw = bytes(buf[MAILBOX_OFF_ERROR_MSG : MAILBOX_OFF_ERROR_MSG + MAILBOX_ERROR_MSG_SIZE])
+    nul = raw.find(b"\x00")
+    if nul >= 0:
+        raw = raw[:nul]
+    return raw.decode("utf-8", "replace")
+
+
+def _format_exc(prefix: str, exc: BaseException) -> str:
+    return f"{prefix}: {type(exc).__name__}: {exc}"
+
+
 def _read_args_from_mailbox(buf) -> TaskArgs:
     """Decode the TaskArgs blob written by C++ write_blob from the mailbox.
 
@@ -143,22 +178,31 @@ def _read_args_from_mailbox(buf) -> TaskArgs:
 
 
 def _sub_worker_loop(buf, registry: dict) -> None:
-    """Runs in forked child process. Reads unified mailbox layout."""
+    """Runs in forked child process. Reads unified mailbox layout.
+
+    On success writes ``error=0`` and an empty message. On failure writes
+    ``error=1`` and ``f"sub_worker: <ExcType>: <msg>"`` into the mailbox
+    error-message region; the parent's ``WorkerThread::dispatch_process``
+    rethrows it as ``std::runtime_error``.
+    """
     while True:
         state = struct.unpack_from("i", buf, _OFF_STATE)[0]
         if state == _TASK_READY:
             cid = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
             fn = registry.get(int(cid))
-            error = 0
+            code = 0
+            msg = ""
             if fn is None:
-                error = 1
+                code = 1
+                msg = f"sub_worker: callable id {int(cid)} not registered"
             else:
                 try:
                     args = _read_args_from_mailbox(buf)
                     fn(args)
-                except Exception:  # noqa: BLE001
-                    error = 2
-            struct.pack_into("i", buf, _OFF_ERROR, error)
+                except Exception as e:  # noqa: BLE001
+                    code = 1
+                    msg = _format_exc("sub_worker", e)
+            _write_error(buf, code, msg)
             struct.pack_into("i", buf, _OFF_STATE, _TASK_DONE)
         elif state == _SHUTDOWN:
             break
@@ -183,9 +227,13 @@ def _chip_process_loop(
         cw = _ChipWorker()
         cw.init(host_lib_path, aicpu_path, aicore_path, sim_context_lib_path)
         cw.set_device(device_id)
-    except Exception:
+    except Exception as e:
         _tb.print_exc()
-        struct.pack_into("i", buf, _OFF_ERROR, 99)
+        # Write the message so any parent reader that *does* inspect this
+        # path sees the real cause. State handshake for this init-time
+        # failure is broken — see KNOWN_ISSUES.md — and that is not part
+        # of the L4 scope.
+        _write_error(buf, 1, _format_exc(f"chip_process dev={device_id} init", e))
         return
 
     mailbox_addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
@@ -201,16 +249,19 @@ def _chip_process_loop(
             aicpu_tn = struct.unpack_from("i", buf, _OFF_AICPU_THREAD_NUM)[0]
             profiling = struct.unpack_from("i", buf, _OFF_ENABLE_PROFILING)[0]
 
-            error = 0
+            code = 0
+            msg = ""
             try:
                 cw.run_from_blob(callable_ptr, args_ptr, block_dim, aicpu_tn, bool(profiling))
-            except Exception:  # noqa: BLE001
-                error = 1
-            struct.pack_into("i", buf, _OFF_ERROR, error)
+            except Exception as e:  # noqa: BLE001
+                code = 1
+                msg = _format_exc(f"chip_process dev={device_id}", e)
+            _write_error(buf, code, msg)
             struct.pack_into("i", buf, _OFF_STATE, _TASK_DONE)
         elif state == _CONTROL_REQUEST:
             sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
-            error = 0
+            code = 0
+            msg = ""
             try:
                 if sub_cmd == _CTRL_MALLOC:
                     size = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
@@ -229,9 +280,10 @@ def _chip_process_loop(
                     src = struct.unpack_from("Q", buf, _CTRL_OFF_ARG1)[0]
                     n = struct.unpack_from("Q", buf, _CTRL_OFF_ARG2)[0]
                     cw.copy_from(dst, src, n)
-            except Exception:  # noqa: BLE001
-                error = 1
-            struct.pack_into("i", buf, _OFF_ERROR, error)
+            except Exception as e:  # noqa: BLE001
+                code = 1
+                msg = _format_exc(f"chip_process dev={device_id} ctrl={int(sub_cmd)}", e)
+            _write_error(buf, code, msg)
             struct.pack_into("i", buf, _OFF_STATE, _CONTROL_DONE)
         elif state == _SHUTDOWN:
             cw.finalize()
@@ -265,17 +317,20 @@ def _child_worker_loop(
         if state == _TASK_READY:
             cid = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
             orch_fn = registry.get(int(cid))
-            error = 0
+            code = 0
+            msg = ""
             if orch_fn is None:
-                error = 1
+                code = 1
+                msg = f"child_worker: callable id {int(cid)} not registered"
             else:
                 try:
                     args = _read_args_from_mailbox(buf)
                     cfg = _read_config_from_mailbox(buf)
                     inner_worker.run(orch_fn, args, cfg)
-                except Exception:  # noqa: BLE001
-                    error = 2
-            struct.pack_into("i", buf, _OFF_ERROR, error)
+                except Exception as e:  # noqa: BLE001
+                    code = 1
+                    msg = _format_exc(f"child_worker level={inner_worker.level}", e)
+            _write_error(buf, code, msg)
             struct.pack_into("i", buf, _OFF_STATE, _TASK_DONE)
         elif state == _SHUTDOWN:
             inner_worker.close()
@@ -529,6 +584,7 @@ class Worker:
         shm = self._chip_shms[worker_id]
         buf = shm.buf
         assert buf is not None
+        _write_error(buf, 0, "")
         struct.pack_into("Q", buf, _OFF_CALLABLE, sub_cmd)
         struct.pack_into("Q", buf, _CTRL_OFF_ARG0, arg0)
         struct.pack_into("Q", buf, _CTRL_OFF_ARG1, arg1)
@@ -538,7 +594,9 @@ class Worker:
             pass
         error = struct.unpack_from("i", buf, _OFF_ERROR)[0]
         if error != 0:
-            raise RuntimeError(f"chip control command {sub_cmd} failed on worker {worker_id}")
+            err_msg = _read_error_msg(buf)
+            struct.pack_into("i", buf, _OFF_STATE, _IDLE)
+            raise RuntimeError(f"chip control command {sub_cmd} failed on worker {worker_id}: {err_msg}")
         result = struct.unpack_from("Q", buf, _CTRL_OFF_RESULT)[0]
         struct.pack_into("i", buf, _OFF_STATE, _IDLE)
         return result
@@ -595,12 +653,22 @@ class Worker:
             self._start_hierarchical()
             assert self._orch is not None
             assert self._worker is not None
+            # Drop any error stashed by a previous run() so this call starts
+            # clean. drain() rethrows on the way out; every successful run()
+            # leaves the error slot empty, but an unrelated caller may have
+            # poked it.
+            self._orch._clear_error()
             self._orch._scope_begin()
             try:
                 callable(self._orch, args, cfg)
             finally:
                 # Always release scope refs and drain so ring slots aren't
-                # stranded when the orch fn raises mid-DAG.
+                # stranded when the orch fn raises mid-DAG. drain() also
+                # rethrows the first dispatch failure for this run — that
+                # is how child-task exceptions surface to the caller of
+                # Worker.run(). scope_end deliberately does NOT throw: if
+                # it did, released refs would be incomplete and drain
+                # would hang on in-flight tasks.
                 self._orch._scope_end()
                 self._orch._drain()
 

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -168,6 +168,15 @@ SubmitResult Orchestrator::submit_impl(
 ) {
     if (args_list.empty()) throw std::invalid_argument("Orchestrator: args_list must not be empty");
 
+    // Fail-fast: if a previously-dispatched task has already failed, abort
+    // this submit before any bookkeeping so the orch fn unwinds promptly
+    // and no further work is queued. Tasks already in flight run to
+    // completion; drain() picks up any remaining bookkeeping and rethrows
+    // at the finally: _drain() site in Worker.run.
+    if (manager_ && manager_->has_error()) {
+        std::rethrow_exception(manager_->take_error());
+    }
+
     // Track this submission for drain() before any allocations so the count
     // is incremented exactly once per submitted DAG node, regardless of the
     // group_size N.
@@ -447,4 +456,15 @@ void Orchestrator::drain() {
     // next_task_id_). Drop all per-slot state so the next Worker.run()
     // starts from task_id = 0 with no accumulated memory.
     allocator_->reset_to_empty();
+
+    // Rethrow the first dispatch failure seen during this run. Deferred to
+    // after allocator reset so the next Worker.run() can proceed cleanly
+    // once clear_error() is called.
+    if (manager_ && manager_->has_error()) {
+        std::rethrow_exception(manager_->take_error());
+    }
+}
+
+void Orchestrator::clear_error() {
+    if (manager_) manager_->clear_error();
 }

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -130,7 +130,14 @@ public:
 
     // Block until every submitted task has reached CONSUMED. Invoked by
     // Worker::run after scope_end; not part of the user-facing orch-fn API.
+    // Rethrows the first exception reported by any WorkerThread during
+    // dispatch (fail-fast): the wait itself is unaffected — every in-flight
+    // task is allowed to finish so ring slots aren't leaked.
     void drain();
+
+    // Clear any stored dispatch error so the next Worker::run() starts
+    // from a clean slate. Called by Worker::run before scope_begin.
+    void clear_error();
 
     // Called by Scheduler (via Worker) when a task becomes CONSUMED:
     // erases TensorMap entries, releases the allocator slot (and implicitly

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -13,9 +13,24 @@
 
 #include <cstring>
 #include <stdexcept>
+#include <string>
 
 #include "../worker/chip_worker.h"
 #include "ring.h"
+
+namespace {
+
+// Read the child-written error message from the mailbox, guaranteeing
+// NUL-termination even if the child wrote exactly MAILBOX_ERROR_MSG_SIZE
+// bytes without a terminator.
+std::string read_error_msg(const char *mbox) {
+    char buf[MAILBOX_ERROR_MSG_SIZE + 1] = {};
+    std::memcpy(buf, mbox + MAILBOX_OFF_ERROR_MSG, MAILBOX_ERROR_MSG_SIZE);
+    buf[MAILBOX_ERROR_MSG_SIZE] = '\0';
+    return std::string(buf);
+}
+
+}  // namespace
 
 // =============================================================================
 // WorkerThread — mailbox helpers (PROCESS mode)
@@ -53,11 +68,13 @@ void WorkerThread::write_mailbox_state(MailboxState s) {
 // =============================================================================
 
 void WorkerThread::start(
-    Mode mode, IWorker *worker, Ring *ring, const std::function<void(TaskSlot)> &on_complete, void *mailbox
+    Mode mode, IWorker *worker, Ring *ring, WorkerManager *manager, const std::function<void(TaskSlot)> &on_complete,
+    void *mailbox
 ) {
     mode_ = mode;
     worker_ = worker;
     ring_ = ring;
+    manager_ = manager;
     on_complete_ = on_complete;
     mailbox_ = mailbox;
     shutdown_ = false;
@@ -106,10 +123,22 @@ void WorkerThread::loop() {
 
         TaskSlotState &s = *ring_->slot_state(d.task_slot);
 
-        if (mode_ == Mode::THREAD) {
-            dispatch_thread(s, d.group_index);
-        } else {
-            dispatch_process(s, d.group_index);
+        // Dispatch may throw from THREAD mode (worker_->run raised) or
+        // PROCESS mode (dispatch_process saw non-zero ERROR from the
+        // child). An uncaught exception escaping loop() would terminate
+        // the std::thread via std::terminate — instead, capture it and
+        // let the orch thread observe it at the next submit_*/drain.
+        // on_complete_ still fires so the scheduler releases consumers
+        // and active_tasks_ eventually reaches zero; otherwise drain()
+        // would hang.
+        try {
+            if (mode_ == Mode::THREAD) {
+                dispatch_thread(s, d.group_index);
+            } else {
+                dispatch_process(s, d.group_index);
+            }
+        } catch (...) {
+            if (manager_) manager_->report_error(std::current_exception());
         }
 
         idle_.store(true, std::memory_order_release);
@@ -126,6 +155,12 @@ void WorkerThread::dispatch_thread(TaskSlotState &s, int32_t group_index) {
 void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
     uint64_t callable = (s.worker_type == WorkerType::SUB) ? static_cast<uint64_t>(s.callable_id) : s.callable;
     TaskArgsView view = s.args_view(group_index);
+
+    // Clear the child-writable error fields so stale bytes from a prior
+    // dispatch cannot masquerade as a fresh failure.
+    int32_t zero_err = 0;
+    std::memcpy(mbox() + MAILBOX_OFF_ERROR, &zero_err, sizeof(int32_t));
+    std::memset(mbox() + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
 
     // Write callable.
     std::memcpy(mbox() + MAILBOX_OFF_CALLABLE, &callable, sizeof(uint64_t));
@@ -170,6 +205,20 @@ void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
         std::this_thread::sleep_for(std::chrono::microseconds(50));
     }
 
+    // Inspect the child's error report before releasing the mailbox back
+    // to IDLE. Non-zero error_code means the child-side Python loop
+    // caught an exception and filled OFF_ERROR_MSG with
+    // `f"{type(e).__name__}: {e}"` (truncated to MAILBOX_ERROR_MSG_SIZE).
+    int32_t error_code = 0;
+    std::memcpy(&error_code, mbox() + MAILBOX_OFF_ERROR, sizeof(int32_t));
+    if (error_code != 0) {
+        std::string msg = read_error_msg(mbox());
+        write_mailbox_state(MailboxState::IDLE);
+        throw std::runtime_error(
+            "WorkerThread::dispatch_process: child failed (code=" + std::to_string(error_code) + "): " + msg
+        );
+    }
+
     write_mailbox_state(MailboxState::IDLE);
 }
 
@@ -197,12 +246,31 @@ void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete) {
                             std::vector<std::unique_ptr<WorkerThread>> &threads) {
         for (const WorkerEntry &e : entries) {
             auto wt = std::make_unique<WorkerThread>();
-            wt->start(e.mode, e.worker, ring, on_complete, e.mailbox);
+            wt->start(e.mode, e.worker, ring, this, on_complete, e.mailbox);
             threads.push_back(std::move(wt));
         }
     };
     make_threads(next_level_entries_, next_level_threads_);
     make_threads(sub_entries_, sub_threads_);
+}
+
+void WorkerManager::report_error(std::exception_ptr e) {
+    if (!e) return;
+    std::lock_guard<std::mutex> lk(err_mu_);
+    if (first_error_) return;  // first-error-wins
+    first_error_ = std::move(e);
+    has_error_.store(true, std::memory_order_release);
+}
+
+std::exception_ptr WorkerManager::take_error() {
+    std::lock_guard<std::mutex> lk(err_mu_);
+    return first_error_;
+}
+
+void WorkerManager::clear_error() {
+    std::lock_guard<std::mutex> lk(err_mu_);
+    first_error_ = nullptr;
+    has_error_.store(false, std::memory_order_release);
 }
 
 void WorkerManager::stop() {
@@ -287,12 +355,19 @@ uint64_t WorkerThread::control_malloc(size_t size) {
         if (!cw) throw std::runtime_error("control_malloc: worker is not a ChipWorker");
         return cw->malloc(size);
     }
+    int32_t zero_err = 0;
+    std::memcpy(mbox() + MAILBOX_OFF_ERROR, &zero_err, sizeof(int32_t));
+    std::memset(mbox() + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
     write_control_args(mbox(), CTRL_MALLOC, static_cast<uint64_t>(size));
     write_mailbox_state(MailboxState::CONTROL_REQUEST);
     while (read_mailbox_state() != MailboxState::CONTROL_DONE) {}
     int32_t err;
     std::memcpy(&err, mbox() + MAILBOX_OFF_ERROR, sizeof(int32_t));
-    if (err != 0) throw std::runtime_error("control_malloc failed on child");
+    if (err != 0) {
+        std::string msg = read_error_msg(mbox());
+        write_mailbox_state(MailboxState::IDLE);
+        throw std::runtime_error("control_malloc failed on child: " + msg);
+    }
     uint64_t result = read_control_result(mbox());
     write_mailbox_state(MailboxState::IDLE);
     return result;

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -37,6 +37,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <cstring>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -47,6 +48,7 @@
 #include "types.h"
 
 class Ring;  // forward decl — owns the slot state pool
+class WorkerManager;
 
 // =============================================================================
 // Unified mailbox layout (PROCESS mode)
@@ -68,6 +70,12 @@ enum class MailboxState : int32_t {
 
 static constexpr size_t MAILBOX_SIZE = 4096;
 
+// Error message region lives at the mailbox tail so OFF_ARGS and all earlier
+// offsets stay byte-compatible with the pre-L4 layout. 256 B of headroom is
+// enough for `<ExceptionType>: <short message>` produced by the child-side
+// Python loops; anything longer is truncated + NUL-terminated.
+static constexpr size_t MAILBOX_ERROR_MSG_SIZE = 256;
+
 static constexpr ptrdiff_t MAILBOX_OFF_STATE = 0;
 static constexpr ptrdiff_t MAILBOX_OFF_ERROR = 4;
 static constexpr ptrdiff_t MAILBOX_OFF_CALLABLE = 8;  // also: control sub-command (uint64)
@@ -76,7 +84,10 @@ static constexpr ptrdiff_t MAILBOX_OFF_AICPU_THREAD_NUM = 20;
 static constexpr ptrdiff_t MAILBOX_OFF_ENABLE_PROFILING = 24;
 static constexpr ptrdiff_t MAILBOX_OFF_ENABLE_DUMP_TENSOR = 28;
 static constexpr ptrdiff_t MAILBOX_OFF_ARGS = 64;
-static constexpr size_t MAILBOX_ARGS_CAPACITY = MAILBOX_SIZE - static_cast<size_t>(MAILBOX_OFF_ARGS);
+static constexpr ptrdiff_t MAILBOX_OFF_ERROR_MSG =
+    static_cast<ptrdiff_t>(MAILBOX_SIZE) - static_cast<ptrdiff_t>(MAILBOX_ERROR_MSG_SIZE);
+static constexpr size_t MAILBOX_ARGS_CAPACITY =
+    MAILBOX_SIZE - static_cast<size_t>(MAILBOX_OFF_ARGS) - MAILBOX_ERROR_MSG_SIZE;
 
 // Control sub-commands (written at MAILBOX_OFF_CALLABLE when state == CONTROL_*)
 static constexpr uint64_t CTRL_MALLOC = 0;
@@ -133,9 +144,11 @@ public:
     // the thread reads callable/args/config from
     // `ring->slot_state(task_slot)` on each dispatch.
     // on_complete(slot) is called (in the WorkerThread) after each run().
+    // `manager` is a borrowed pointer used to report dispatch failures
+    // (exception_ptr routed out of the worker thread to the orch thread).
     void start(
-        Mode mode, IWorker *worker, Ring *ring, const std::function<void(TaskSlot)> &on_complete,
-        void *mailbox = nullptr
+        Mode mode, IWorker *worker, Ring *ring, WorkerManager *manager,
+        const std::function<void(TaskSlot)> &on_complete, void *mailbox = nullptr
     );
 
     // Enqueue a dispatch for the worker. Non-blocking.
@@ -164,6 +177,7 @@ private:
     Mode mode_{Mode::THREAD};
     IWorker *worker_{nullptr};
     Ring *ring_{nullptr};
+    WorkerManager *manager_{nullptr};
     void *mailbox_{nullptr};
     std::function<void(TaskSlot)> on_complete_;
 
@@ -217,6 +231,14 @@ public:
     // Write SHUTDOWN to every PROCESS-mode mailbox.
     void shutdown_children();
 
+    // Error propagation: first dispatch failure from any WorkerThread wins.
+    // The orch thread inspects via `has_error()` / `take_error()` and
+    // clears between Worker.run() invocations via `clear_error()`.
+    void report_error(std::exception_ptr e);
+    bool has_error() const { return has_error_.load(std::memory_order_acquire); }
+    std::exception_ptr take_error();
+    void clear_error();
+
 private:
     struct WorkerEntry {
         IWorker *worker;  // nullptr for PROCESS mode
@@ -229,4 +251,11 @@ private:
 
     std::vector<std::unique_ptr<WorkerThread>> next_level_threads_;
     std::vector<std::unique_ptr<WorkerThread>> sub_threads_;
+
+    // First-error-wins exception slot. Written under err_mu_ by
+    // WorkerThread::loop() catch handlers; read by the orch thread at
+    // submit_*/drain boundaries.
+    std::atomic<bool> has_error_{false};
+    mutable std::mutex err_mu_;
+    std::exception_ptr first_error_;
 };

--- a/tests/ut/py/test_worker/test_error_propagation.py
+++ b/tests/ut/py/test_worker/test_error_propagation.py
@@ -1,0 +1,234 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Unit tests for L4 error propagation from child workers up to Worker.run().
+
+Covers the three failure paths that the mailbox OFF_ERROR / OFF_ERROR_MSG
+channel has to carry:
+
+1. SubWorker callable raises   →  Worker.run(orch) re-raises with original
+                                  Python exception type + message in the text.
+2. Scope mid-failure           →  Nth submit sees has_error, next Worker.run
+                                  is not wedged (error state cleared).
+3. L4 → L3 → SubWorker chain   →  Exception raised in bottom sub surfaces at
+                                  L4 Worker.run() with an identifiable chain
+                                  (sub_worker / child_worker prefixes).
+
+All cases run on sub-workers only — no NPU required.
+"""
+
+import struct
+import time
+from multiprocessing.shared_memory import SharedMemory
+
+import pytest
+from simpler.task_interface import ChipCallConfig, TaskArgs
+from simpler.worker import Worker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_shared_counter():
+    shm = SharedMemory(create=True, size=4)
+    buf = shm.buf
+    assert buf is not None
+    struct.pack_into("i", buf, 0, 0)
+    return shm, buf
+
+
+def _read_counter(buf) -> int:
+    return struct.unpack_from("i", buf, 0)[0]
+
+
+def _increment_counter(buf) -> None:
+    v = struct.unpack_from("i", buf, 0)[0]
+    struct.pack_into("i", buf, 0, v + 1)
+
+
+class SentinelError(ValueError):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# 1. SubWorker callable raises — original type+message preserved
+# ---------------------------------------------------------------------------
+
+
+class TestSubWorkerException:
+    def test_sub_callable_raises_surfaces_at_run(self):
+        def boom(args):
+            raise SentinelError("boom-from-sub")
+
+        hw = Worker(level=3, num_sub_workers=1)
+        cid = hw.register(boom)
+        hw.init()
+        try:
+
+            def orch(o, args, cfg):
+                o.submit_sub(cid)
+
+            with pytest.raises(RuntimeError) as info:
+                hw.run(orch)
+
+            text = str(info.value)
+            assert "sub_worker" in text
+            assert "SentinelError" in text
+            assert "boom-from-sub" in text
+        finally:
+            hw.close()
+
+    def test_sub_callable_missing_id_surfaces(self):
+        hw = Worker(level=3, num_sub_workers=1)
+        hw.init()
+        try:
+
+            def orch(o, args, cfg):
+                o.submit_sub(42)
+
+            with pytest.raises(RuntimeError) as info:
+                hw.run(orch)
+            assert "not registered" in str(info.value)
+        finally:
+            hw.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Scope mid-failure — drain rethrows once, next run clean
+# ---------------------------------------------------------------------------
+
+
+class TestScopeMidFailure:
+    def test_failure_does_not_wedge_worker(self):
+        """After a run() fails, the next run() using a clean orch succeeds.
+
+        Register two callables — one that always raises, one that increments
+        a shared counter. Fire the failing one first (should raise) then the
+        succeeding one (should run to completion). Proves ``_clear_error`` at
+        the top of ``Worker.run`` resets the error slot so the next run is
+        not permanently poisoned.
+
+        Two callables rather than a shared-state toggle: the sub-worker is
+        a forked child that inherits closure state copy-on-write; updates
+        the parent makes to a Python dict are invisible on the child side.
+        """
+        counter_shm, counter_buf = _make_shared_counter()
+
+        try:
+
+            def boom(args):
+                raise SentinelError("first run failure")
+
+            hw = Worker(level=3, num_sub_workers=1)
+            fail_cid = hw.register(boom)
+            ok_cid = hw.register(lambda args: _increment_counter(counter_buf))
+            hw.init()
+            try:
+
+                def failing_orch(o, args, cfg):
+                    o.submit_sub(fail_cid)
+
+                def ok_orch(o, args, cfg):
+                    o.submit_sub(ok_cid)
+
+                with pytest.raises(RuntimeError):
+                    hw.run(failing_orch)
+
+                hw.run(ok_orch)
+                assert _read_counter(counter_buf) == 1
+
+                hw.run(ok_orch)
+                assert _read_counter(counter_buf) == 2
+            finally:
+                hw.close()
+        finally:
+            counter_shm.close()
+            counter_shm.unlink()
+
+    def test_subsequent_submit_raises_after_failure(self):
+        """A second submit_sub after a failed first one must not swallow the error.
+
+        With one sub worker we submit two tasks sequentially in the orch fn;
+        the first one fails, so the second submit sees has_error and re-raises
+        immediately (fail-fast). The exception reaching Worker.run is the
+        original child failure — not some generic "orchestrator poisoned"
+        wrapper.
+        """
+
+        def boom(args):
+            raise SentinelError("fail-fast")
+
+        hw = Worker(level=3, num_sub_workers=1)
+        cid = hw.register(boom)
+        hw.init()
+        try:
+
+            def orch(o, args, cfg):
+                o.submit_sub(cid)
+                # Give the child enough wall-clock time to run and fail
+                # before issuing the second submit, so the fail-fast check
+                # in submit_impl has something to trip on.
+                time.sleep(1.0)
+                o.submit_sub(cid)
+
+            with pytest.raises(RuntimeError) as info:
+                hw.run(orch)
+            assert "SentinelError" in str(info.value)
+            assert "fail-fast" in str(info.value)
+        finally:
+            hw.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. L4 → L3 → SubWorker chain — identifiable propagation
+# ---------------------------------------------------------------------------
+
+
+class TestL4ChainedFailure:
+    def test_bottom_sub_failure_surfaces_at_l4(self):
+        """A SentinelError in the innermost sub callable must reach the L4
+        caller's run() with enough context to identify both layers.
+
+        The error first bubbles from the SubWorker through the parent's
+        dispatch_process as `std::runtime_error("sub_worker: ... SentinelError: ...")`.
+        Inside the L3 orch fn this reaches _drain which rethrows. The L3
+        child process catches that in _child_worker_loop and rewrites it
+        as `child_worker level=3: RuntimeError: <original>`. The L4 parent's
+        dispatch_process rethrows again. The final string visible at the L4
+        caller contains both prefixes.
+        """
+
+        def boom_sub(args):
+            raise SentinelError("l3-sub-boom")
+
+        l3 = Worker(level=3, num_sub_workers=1)
+        l3_sub_cid = l3.register(boom_sub)
+
+        def l3_orch(orch, args, config):
+            orch.submit_sub(l3_sub_cid)
+
+        w4 = Worker(level=4, num_sub_workers=0)
+        l3_cid = w4.register(l3_orch)
+        w4.add_worker(l3)
+        w4.init()
+        try:
+
+            def l4_orch(orch, args, config):
+                orch.submit_next_level(l3_cid, TaskArgs(), ChipCallConfig())
+
+            with pytest.raises(RuntimeError) as info:
+                w4.run(l4_orch)
+            text = str(info.value)
+            # Two layers of prefix should both be visible in the message chain.
+            assert "child_worker" in text
+            assert "sub_worker" in text
+            assert "SentinelError" in text
+            assert "l3-sub-boom" in text
+        finally:
+            w4.close()


### PR DESCRIPTION
## Summary

Surfaces Python exceptions from forked SubWorker / ChipWorker / L4-inner-Worker
loops up to the caller of `Worker.run()`. Before this change, a child-side
exception was written to `OFF_ERROR` in the mailbox but never read by
`WorkerThread::dispatch_process` — the parent wrote `IDLE` on `TASK_DONE`
regardless and the caller saw silent success with garbage output. The
`CONTROL` path read `OFF_ERROR` but threw a message with no cause.

- Add `MAILBOX_OFF_ERROR_MSG` (256 B at the mailbox tail; no existing
  offset shifts) and expose it via nanobind so Python cannot drift.
- `dispatch_process` reads error + msg after `TASK_DONE` and throws
  `std::runtime_error` with the child-written message.
- `WorkerThread::loop()` wraps `dispatch_*` in try/catch so an uncaught
  exception cannot terminate the `std::thread`; failures route to
  `WorkerManager` (first-error-wins `std::exception_ptr`).
- `Orchestrator::submit_impl` and `drain()` check `WorkerManager::has_error()`
  and rethrow — submit is fail-fast, drain waits for in-flight tasks to
  finish before rethrowing so ring slots don't leak.
- `scope_end` deliberately does NOT throw (would strand scope refs and
  hang drain); the throw point is `submit_*` or `drain`.
- Python loops collapse error codes to `code=1` + message; `Worker.run`
  clears the error slot before `_scope_begin` so a prior failed run
  doesn't poison the next one.

## Design decisions (4)

1. **Error carrier**: int32 code + 256-byte NUL-terminated message at
   the mailbox tail. Existing offsets unchanged.
2. **Code semantics**: collapse `1` (registry miss) / `2` (callable
   raised) to `code=1` + msg. Subclassing exceptions deferred.
3. **Scope mid-failure**: fail-fast at `submit_*`, drain rethrow on
   exit. `scope_end` never throws. In-flight tasks complete naturally.
4. **Multi-child**: no active signal to peers. Fail-fast prevents new
   submits; in-flight peers finish their current task; `close()` writes
   SHUTDOWN as usual.

See the commit message for the full rationale.

## Test plan

- [x] `tests/ut/py/test_worker/test_error_propagation.py` (new, 5 cases)
- [x] `tests/ut/py/test_worker` entire suite (42 passed, 1 HCCL skip)
- [x] `tests/ut/cpp` entire suite via ctest (all 8 passed)
- [ ] Hardware CI (no local hardware; relying on CI)