### PR TITLE
Refactor: remove dead pto2_dep_pool_get from PTO2DepListPool

### DIFF
--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_ring_buffer.h
@@ -597,14 +597,6 @@ struct PTO2DepListPool {
         return new_entry;
     }
 
-    /**
-     * Get entry by offset
-     */
-    PTO2DepListEntry *pto2_dep_pool_get(int32_t offset) {
-        if (offset <= 0) return NULL;
-        return &base[offset];
-    }
-
     int32_t used() const { return top - tail; }
 
     int32_t available() const { return capacity - used(); }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -656,14 +656,6 @@ struct PTO2DepListPool {
         return new_entry;
     }
 
-    /**
-     * Get entry by offset
-     */
-    PTO2DepListEntry *pto2_dep_pool_get(int32_t offset) {
-        if (offset <= 0) return NULL;
-        return &base[offset];
-    }
-
     int32_t used() const { return top - tail; }
 
     int32_t available() const { return capacity - used(); }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -656,14 +656,6 @@ struct PTO2DepListPool {
         return new_entry;
     }
 
-    /**
-     * Get entry by offset
-     */
-    PTO2DepListEntry *pto2_dep_pool_get(int32_t offset) {
-        if (offset <= 0) return NULL;
-        return &base[offset];
-    }
-
     int32_t used() const { return top - tail; }
 
     int32_t available() const { return capacity - used(); }


### PR DESCRIPTION
## Summary
- Remove unused `pto2_dep_pool_get` method from `PTO2DepListPool` struct
- The offset-based accessor has zero callers across the entire codebase — pool access now uses pointer-based `alloc()`/`prepend()` exclusively
- Removed from all 3 copies: `a2a3/aicpu_build_graph`, `a2a3/tensormap_and_ringbuffer`, `a5/tensormap_and_ringbuffer`

## Testing
- [x] Grep confirms zero remaining references to `pto2_dep_pool_get`
- [ ] Simulation tests pass
- [ ] Hardware tests pass (if applicable)