### PR TITLE
Add: examples/workers/ — raw Worker API demos (L2 + L3)

### DIFF
--- a/examples/workers/README.md
+++ b/examples/workers/README.md
@@ -1,0 +1,80 @@
+# Worker API Examples
+
+This directory demonstrates how to drive PTO runtime **directly through the
+`Worker` class**, without going through the `@scene_test` framework.
+
+If you want to **write and test kernels** with golden comparison, automatic
+case parametrization, and pytest integration, use `@scene_test` instead — see
+the examples under `examples/a2a3/` and `examples/a5/`.
+
+If you want to **understand exactly what the framework does for you** — how a
+`ChipCallable` is built from source `.cpp` files, how `TaskArgs` map to device
+memory, how `Worker(level=N)` composes chips and sub-workers into a DAG — the
+examples here show the full lifecycle step by step.
+
+## Audience
+
+These examples are written for users who are seeing the `Worker` API for the
+first time. Every non-obvious line has a comment explaining **why**, and each
+example's README walks through the code block by block.
+
+If you already know `@scene_test` and just want a quick syntactic map to the
+raw API, skim [`l2/hello_worker/main.py`](l2/hello_worker/main.py) first — it
+is the smallest possible correct program.
+
+## Layout
+
+```text
+workers/
+  l2/                       # Single-chip examples (one NPU device)
+    hello_worker/           # Worker(level=2).init().close(), no kernels
+    vector_add/             # One AIV kernel, TaskArgs, golden check
+  l3/                       # Multi-chip examples (host-level DAG)
+    multi_chip_dispatch/    # Worker(level=3) + orchestration + SubWorker
+```
+
+Why no `tensormap_and_ringbuffer/` layer? Because every example here hard-codes
+`runtime="tensormap_and_ringbuffer"` in its `Worker(...)` call — that is the
+default user-facing runtime. Other runtimes (`host_build_graph`,
+`aicpu_build_graph`) are covered by scene tests under `tests/st/`, not here.
+
+## Prerequisites
+
+Examples assume you have built and installed the package in a venv:
+
+```bash
+python3 -m venv --system-site-packages .venv
+source .venv/bin/activate
+pip install --no-build-isolation .
+```
+
+`pip install .` pre-builds runtime binaries into `build/lib/`, which every
+example loads on `Worker.init()`. See
+[`docs/developer-guide.md`](../../docs/developer-guide.md) for the full build
+pipeline.
+
+## Running
+
+Each example has a `main.py` with uniform CLI:
+
+```bash
+python examples/workers/l2/hello_worker/main.py -p a2a3sim -d 0
+python examples/workers/l2/vector_add/main.py -p a2a3sim -d 0
+python examples/workers/l3/multi_chip_dispatch/main.py -p a2a3sim -d 0-1
+```
+
+Flags:
+
+- `-p / --platform`: `a2a3sim` (simulator, no NPU needed), `a2a3` (real
+  hardware), `a5sim`, `a5`. Matches the `--platform` flag on scene tests.
+- `-d / --device`: device id for L2, or device range for L3 (e.g. `0-1`).
+
+Simulator (`a2a3sim`) works on any Linux host with gcc; hardware platforms
+require an Ascend NPU box with `ASCEND_HOME_PATH` set.
+
+## Related documentation
+
+- [`docs/hierarchical_level_runtime.md`](../../docs/hierarchical_level_runtime.md) — the L0–L6 level model
+- [`docs/chip-level-arch.md`](../../docs/chip-level-arch.md) — what L2 sees
+- [`docs/task-flow.md`](../../docs/task-flow.md) — end-to-end data flow
+- [`python/simpler/worker.py`](../../python/simpler/worker.py) — Worker source (all comments are useful)

--- a/examples/workers/l2/README.md
+++ b/examples/workers/l2/README.md
@@ -1,0 +1,69 @@
+# L2 — Single-chip examples
+
+**L2 = CHIP**: one NPU device, managed by one on-device AICPU scheduler plus
+AICore/AIVector workers. This is the smallest self-contained unit of the
+runtime; everything larger (L3 multi-chip DAG, L4 multi-host) is built on top
+of L2 primitives.
+
+For the full hierarchy model see
+[`docs/hierarchical_level_runtime.md`](../../../docs/hierarchical_level_runtime.md).
+
+## Minimum Worker lifecycle
+
+Every L2 program looks like this:
+
+```python
+from simpler.worker import Worker
+
+worker = Worker(
+    level=2,
+    platform="a2a3sim",                    # or a2a3 / a5sim / a5
+    runtime="tensormap_and_ringbuffer",    # default user-facing runtime
+    device_id=0,
+)
+worker.init()             # load host.so + aicpu.so + aicore.o, set device
+try:
+    # ... allocate device buffers, build ChipCallable, run ...
+    worker.run(chip_callable, task_args, chip_call_config)
+finally:
+    worker.close()        # release ACL resources and device
+```
+
+The `try/finally` is important — if anything between `init()` and `close()`
+raises, you still want the device released. The
+[L2 conftest leak issue](https://github.com/hw-native-sys/simpler/issues/604)
+is a reminder that a stale `ChipWorker` on a self-hosted runner can poison
+the next job.
+
+## What each example demonstrates
+
+| Directory | New concept | Runnable on |
+| --------- | ----------- | ----------- |
+| [`hello_worker/`](hello_worker/) | `Worker.init()` / `close()` contract, venv + build prereqs. No kernels. | `a2a3sim`, `a5sim` |
+| [`vector_add/`](vector_add/) | Compile one AIV kernel → `ChipCallable`. Build `TaskArgs` with host→device buffer copy, run, copy back, compare against numpy. | `a2a3sim`, `a2a3` |
+
+Both examples use the same `main.py` shape:
+
+```python
+def main() -> int:
+    args = parse_args()
+    worker = build_worker(args)
+    worker.init()
+    try:
+        do_the_work(worker, args)
+    finally:
+        worker.close()
+    return 0
+```
+
+## When to reach for scene_test instead
+
+If your answer to *any* of these is "yes", `@scene_test` is the right tool:
+
+- I want my example to run in CI as part of `pytest examples tests/st ...`
+- I want automatic golden comparison across multiple parametrized cases
+- I need the kernel compiled once and cached across cases
+- I want `--rounds N` for benchmarking
+
+`Worker` API examples here are for learning the plumbing — not for shipping
+tests.

--- a/examples/workers/l2/hello_worker/README.md
+++ b/examples/workers/l2/hello_worker/README.md
@@ -1,0 +1,41 @@
+# `hello_worker/` — minimal L2 Worker lifecycle
+
+The smallest correct program using the `Worker` API. No kernels, no data —
+just prove that your venv, runtime binaries, and device/ACL setup all work.
+
+## What it does
+
+1. Parses `-p <platform> -d <device>`.
+2. Constructs `Worker(level=2, platform=..., runtime="tensormap_and_ringbuffer", device_id=...)`.
+3. Calls `init()` — this is where runtime binaries are resolved and the device is opened.
+4. `malloc(4096)` + `free(ptr)` as a sanity round-trip through the mailbox.
+5. `close()` in a `finally` block.
+
+## Why each line matters
+
+| Step | Line (`main.py`) | Why |
+| ---- | ---------------- | --- |
+| Construction | `Worker(level=2, platform=..., runtime=..., device_id=...)` | Stashes config; no ACL / binary loading yet. Cheap. |
+| `init()` | `worker.init()` | Loads `host_runtime.so` + `aicpu.so` + `aicore.o` from `build/lib/<platform>/tensormap_and_ringbuffer/`, calls `aclrtSetDevice`. First place errors show up (wrong platform, missing binaries, device busy). |
+| `malloc/free` | smoke test | Exercises the host↔device control path. If this works, a real kernel run will at least reach the dispatcher. |
+| `close()` in `finally` | lifecycle end | Releases ACL + device. If you skip this, a self-hosted runner keeps the device locked and the next job hangs. |
+
+## Run
+
+```bash
+python examples/workers/l2/hello_worker/main.py -p a2a3sim -d 0
+```
+
+Expected output (on `a2a3sim`):
+
+```text
+[hello_worker] init on a2a3sim device=0 ...
+[hello_worker] malloc/free round-trip OK (ptr=0x...)
+[hello_worker] close OK — lifecycle complete.
+```
+
+## Next step
+
+Once this runs end to end, move to [`../vector_add/`](../vector_add/) — same
+lifecycle, plus a real kernel compiled into a `ChipCallable` and a numpy
+golden check.

--- a/examples/workers/l2/hello_worker/main.py
+++ b/examples/workers/l2/hello_worker/main.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L2 Worker lifecycle demo — no kernels, no data, just init + close.
+
+This is the smallest correct program that drives the Worker API. It proves:
+
+  1. Your venv can import ``simpler.Worker`` (i.e. the nanobind extension is built).
+  2. Pre-built runtime binaries exist under ``build/lib/<platform>/tensormap_and_ringbuffer/``
+     so that ``RuntimeBuilder`` can find them on ``Worker.init()``.
+  3. ``set_device()`` + ACL init on the chosen platform works end-to-end.
+
+If this example runs cleanly, moving on to ``vector_add/`` (which adds a real
+kernel, TaskArgs, and a golden check) is safe.
+
+Run:
+    python examples/workers/l2/hello_worker/main.py -p a2a3sim -d 0
+"""
+
+import argparse
+import sys
+
+from simpler.worker import Worker
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse the uniform CLI used by every example under ``examples/workers/``."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "-p",
+        "--platform",
+        required=True,
+        choices=["a2a3sim", "a2a3", "a5sim", "a5"],
+        help="Target platform. 'sim' variants run on the CPU simulator and need no NPU.",
+    )
+    parser.add_argument(
+        "-d",
+        "--device",
+        type=int,
+        default=0,
+        help="Device id to bind this L2 worker to. Sim platforms accept any integer.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    # Worker(level=2, ...) wraps a single C++ ChipWorker. Construction does NOT
+    # load any binaries or touch the device — it just stashes config. The heavy
+    # work happens in init().
+    worker = Worker(
+        level=2,
+        platform=args.platform,
+        runtime="tensormap_and_ringbuffer",
+        device_id=args.device,
+    )
+
+    # init() resolves ``build/lib/<platform>/tensormap_and_ringbuffer/*`` via
+    # RuntimeBuilder, dlopens host_runtime.so, loads aicpu.so + aicore.o, and
+    # calls aclrtSetDevice(device_id). If any of those fails this raises.
+    print(f"[hello_worker] init on {args.platform} device={args.device} ...")
+    worker.init()
+
+    try:
+        # Nothing useful to do here — this example only proves the lifecycle.
+        # A real L2 program would now malloc device buffers, build a
+        # ChipCallable from compiled kernels, and call worker.run(...).
+        #
+        # We at least exercise the memory-control path: one malloc/free round
+        # trip confirms the host<->device mailbox works.
+        ptr = worker.malloc(4096)
+        assert ptr != 0, "malloc returned NULL — device memory is exhausted or not mapped"
+        worker.free(ptr)
+        print(f"[hello_worker] malloc/free round-trip OK (ptr=0x{ptr:x})")
+    finally:
+        # close() releases the ACL device, unloads the runtime libraries, and
+        # frees all per-worker C++ state. ALWAYS call it in a finally — a
+        # leaked ChipWorker on a self-hosted runner poisons the next CI job
+        # (see https://github.com/hw-native-sys/simpler/issues/604).
+        worker.close()
+        print("[hello_worker] close OK — lifecycle complete.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/workers/l2/vector_add/README.md
+++ b/examples/workers/l2/vector_add/README.md
@@ -1,0 +1,150 @@
+# `vector_add/` — one AIV kernel, end-to-end
+
+Adds two 128×128 float32 tensors on the NPU and verifies the result against a
+numpy reference. This is the smallest example that exercises the **full**
+L2 Worker API: kernel compilation, `ChipCallable` assembly, device memory
+management, `TaskArgs` construction, synchronous `run()`, and result readback.
+
+If the equivalent `@scene_test` version feels magical, this is what the magic
+unpacks into.
+
+## Layout
+
+```text
+vector_add/
+  main.py
+  kernels/
+    aiv/
+      vector_add_kernel.cpp         # element-wise add kernel (reused verbatim
+                                    #   from a2a3/../vector_example/kernels)
+    orchestration/
+      vector_add_orch.cpp           # simplified orchestration: single submit
+  README.md
+```
+
+The kernel source is a verbatim copy of
+`examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp`.
+The orchestration is intentionally simpler than the `vector_example` one — it
+calls `pto2_rt_submit_aiv_task` exactly once and has no nested scopes.
+
+## The six steps in `main.py`
+
+Open `main.py` and follow along.
+
+### 1. Compile kernel sources → binary bytes
+
+```python
+kc = KernelCompiler(platform=args.platform)
+kernel_bytes = kc.compile_incore(
+    source_path=".../vector_add_kernel.cpp",
+    core_type="aiv",
+    pto_isa_root=ensure_pto_isa_root(),
+    extra_include_dirs=kc.get_orchestration_include_dirs(runtime),
+)
+orch_bytes = kc.compile_orchestration(runtime, ".../vector_add_orch.cpp")
+```
+
+`compile_incore` picks the right toolchain for your platform (ccec on real
+hardware, g++-15 on sim) and returns the `.o` / `.so` bytes. `pto_isa_root`
+is the sibling header repo, auto-cloned on first call.
+
+### 2. Wrap kernel bytes → `CoreCallable`
+
+```python
+core_callable = CoreCallable.build(
+    signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+    binary=kernel_bytes,
+)
+```
+
+The `signature` matches the kernel's I/O: two inputs, one output.
+
+### 3. Wrap orchestration + children → `ChipCallable`
+
+```python
+chip_callable = ChipCallable.build(
+    signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+    func_name="vector_add_orchestration",
+    binary=orch_bytes,
+    children=[(0, core_callable)],   # func_id=0 → our one kernel
+)
+```
+
+`func_name` must match the `__attribute__((visibility("default")))` symbol in
+the orchestration `.cpp`. The `children` list maps `func_id` integers used in
+`pto2_rt_submit_aiv_task(func_id, ...)` to the corresponding `CoreCallable`.
+In our orch `func_id=0` is the only value, so one child.
+
+### 4. Allocate device memory, push inputs
+
+```python
+dev_a   = worker.malloc(NBYTES)
+dev_b   = worker.malloc(NBYTES)
+dev_out = worker.malloc(NBYTES)
+worker.copy_to(dev_a, host_a.ctypes.data, NBYTES)
+worker.copy_to(dev_b, host_b.ctypes.data, NBYTES)
+```
+
+`malloc` returns a device pointer (uint64). `copy_to(dst_dev, src_host, n)`
+does host→device DMA.
+
+### 5. Build `ChipStorageTaskArgs`, run
+
+```python
+args = ChipStorageTaskArgs()
+args.add_tensor(ContinuousTensor.make(dev_a,   shape, DataType.FLOAT32))
+args.add_tensor(ContinuousTensor.make(dev_b,   shape, DataType.FLOAT32))
+args.add_tensor(ContinuousTensor.make(dev_out, shape, DataType.FLOAT32))
+
+worker.run(chip_callable, args, ChipCallConfig())
+```
+
+The tensor order must match `signature` order on the `ChipCallable`. `run()`
+blocks until the kernel completes.
+
+### 6. Pull result back, verify, free
+
+```python
+worker.copy_from(host_out.ctypes.data, dev_out, NBYTES)
+worker.free(dev_a); worker.free(dev_b); worker.free(dev_out)
+np.testing.assert_allclose(host_out, expected, rtol=1e-5, atol=1e-5)
+```
+
+## Run
+
+```bash
+python examples/workers/l2/vector_add/main.py -p a2a3sim -d 0
+```
+
+Expected output (sim):
+
+```text
+[vector_add] compiling kernels for a2a3sim...
+[vector_add] compiled. binary_size=... bytes
+[vector_add] init worker (device=0)...
+[vector_add] running on device...
+[vector_add] max |host_out - expected| = ...e-07
+[vector_add] golden check PASSED ✅
+```
+
+First run will be slower because `ensure_pto_isa_root()` clones the PTO-ISA
+header repo into `build/pto-isa/` (~few seconds on a fast connection).
+
+## Why `@scene_test` still wins for real tests
+
+The plumbing in `main.py` is ~100 lines. `@scene_test` does all of this for
+you, plus:
+
+- Session-level compile cache (kernel not recompiled per case)
+- Parametrized `CASES` and auto-golden comparison
+- Parallel device dispatch via pytest-xdist
+- Integration with `--enable-profiling`, `--rounds`, `--dump-tensor`
+
+Use the raw API when you're **learning** or **embedding** the runtime in a
+larger Python program; use `@scene_test` for shippable test code.
+
+## Next step
+
+- Try `-p a2a3` if you have hardware access
+- Move on to [`../../l3/multi_chip_dispatch/`](../../l3/multi_chip_dispatch/)
+  to see how the same primitives compose into a multi-chip DAG

--- a/examples/workers/l2/vector_add/kernels/aiv/vector_add_kernel.cpp
+++ b/examples/workers/l2/vector_add/kernels/aiv/vector_add_kernel.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Element-wise Tensor Addition Kernel
+ *
+ * Implements: out[i] = src0[i] + src1[i]
+ *
+ * This kernel performs element-wise addition of two tensors. It's compiled
+ * separately as a standalone kernel and linked with the dispatcher using
+ * function pointers, demonstrating the separation pattern used in production
+ * systems where kernel binaries are loaded dynamically.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+/**
+ * Element-wise addition kernel implementation
+ *
+ * Unified signature: all arguments passed via int64_t array
+ * @param args  Argument array:
+ *              args[0] = src0 pointer (first input tensor)
+ *              args[1] = src1 pointer (second input tensor)
+ *              args[2] = out pointer (output tensor)
+ *              args[3] = size (number of elements)
+ */
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    // Unpack arguments (Tensor* pointers from runtime)
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    // Configuration: float, 128, 128, 128, 128
+    constexpr int kTRows_ = 128;
+    constexpr int kTCols_ = 128;
+    constexpr int vRows = 128;
+    constexpr int vCols = 128;
+
+    using DynShapeDim5 = Shape<1, 1, 1, vRows, vCols>;
+    using DynStridDim5 = Stride<1, 1, 1, kTCols_, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
+
+    TileData src0Tile(vRows, vCols);
+    TileData src1Tile(vRows, vCols);
+    TileData dstTile(vRows, vCols);
+    TASSIGN(src0Tile, 0x0);
+    TASSIGN(src1Tile, 0x10000);
+    TASSIGN(dstTile, 0x20000);
+
+    GlobalData src0Global(src0);
+    GlobalData src1Global(src1);
+    GlobalData dstGlobal(out);
+
+    TLOAD(src0Tile, src0Global);
+    TLOAD(src1Tile, src1Global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(dstTile, src0Tile, src1Tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+}

--- a/examples/workers/l2/vector_add/kernels/orchestration/vector_add_orch.cpp
+++ b/examples/workers/l2/vector_add/kernels/orchestration/vector_add_orch.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Simplest possible orchestration for the Worker API demo.
+ *
+ *   out = a + b
+ *
+ * Exactly one AIV task, no intermediate scopes. For a multi-kernel example
+ * with nested scopes see examples/a2a3/tensormap_and_ringbuffer/vector_example.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+vector_add_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 3,  // a, b, out
+    };
+}
+
+__attribute__((visibility("default"))) void vector_add_orchestration(const ChipStorageTaskArgs &orch_args) {
+    Tensor a = from_tensor_arg(orch_args.tensor(0));
+    Tensor b = from_tensor_arg(orch_args.tensor(1));
+    Tensor out = from_tensor_arg(orch_args.tensor(2));
+
+    Arg params;
+    params.add_input(a);
+    params.add_input(b);
+    params.add_output(out);
+    pto2_rt_submit_aiv_task(0, params);  // func_id=0 -> vector_add_kernel
+}
+
+}  // extern "C"

--- a/examples/workers/l2/vector_add/main.py
+++ b/examples/workers/l2/vector_add/main.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L2 Worker API demo — compile one AIV kernel, run it, verify against numpy.
+
+Pipeline (what the @scene_test framework normally does for you):
+
+    .cpp sources ──[KernelCompiler]──► binaries
+           │                              │
+           ▼                              ▼
+    CoreCallable.build(kernel bytes)   ChipCallable.build(orch bytes + children)
+                                          │
+    host arrays ──[worker.malloc + copy_to]──►  device buffers
+                                          │
+                                          ▼
+                              worker.run(chip_callable, task_args, cfg)
+                                          │
+    device result ──[worker.copy_from]──► host array ──[numpy compare]
+
+The code below walks through each stage explicitly so you can see what the
+``@scene_test`` decorator hides.
+
+Run:
+    python examples/workers/l2/vector_add/main.py -p a2a3sim -d 0
+"""
+
+import argparse
+import os
+import sys
+
+import numpy as np
+from simpler.task_interface import (
+    ArgDirection,
+    ChipCallable,
+    ChipCallConfig,
+    ChipStorageTaskArgs,
+    ContinuousTensor,
+    CoreCallable,
+    DataType,
+)
+from simpler.worker import Worker
+
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Matches the tile geometry hard-coded in vector_add_kernel.cpp (128x128 float32).
+# The kernel assumes tensors are exactly this shape; no boundary handling.
+N_ROWS = 128
+N_COLS = 128
+N_ELEMS = N_ROWS * N_COLS
+NBYTES = N_ELEMS * np.dtype(np.float32).itemsize
+
+
+def parse_args() -> argparse.Namespace:
+    """Same CLI shape as every example under ``examples/workers/``."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-p", "--platform", required=True, choices=["a2a3sim", "a2a3", "a5sim", "a5"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    return parser.parse_args()
+
+
+def build_chip_callable(platform: str) -> ChipCallable:
+    """Compile orchestration + kernel sources, wrap into a ChipCallable.
+
+    This is a thin wrapper around ``KernelCompiler`` that reads the CALLABLE
+    structure you'd see in a ``@scene_test`` class and returns the opaque
+    handle Worker.run(...) expects. In production code this lives inside
+    ``simpler_setup/scene_test.py`` (see ``_compile_chip_callable_from_spec``);
+    we inline a minimal version here so the flow is visible.
+    """
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+
+    # 1. Compile the AIV kernel source to a .o. ``pto_isa_root`` is the
+    # sibling header repo; ``ensure_pto_isa_root()`` clones it on first run
+    # (see docs/getting-started.md). Uses HTTPS clone by default; set
+    # PTO_ISA_ROOT to skip the clone and point at an existing checkout.
+    pto_isa_root = ensure_pto_isa_root(clone_protocol="https")
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+    kernel_bytes = kc.compile_incore(
+        source_path=os.path.join(HERE, "kernels/aiv/vector_add_kernel.cpp"),
+        core_type="aiv",
+        pto_isa_root=pto_isa_root,
+        extra_include_dirs=include_dirs,
+    )
+
+    # On real hardware (not sim) the .o needs its .text section extracted
+    # before being wrapped into a CoreCallable. Skip this on sim builds.
+    if not platform.endswith("sim"):
+        from simpler_setup.elf_parser import extract_text_section  # noqa: PLC0415
+
+        kernel_bytes = extract_text_section(kernel_bytes)
+
+    # 2. Compile the orchestration source to a .so (host-loadable).
+    orch_bytes = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/vector_add_orch.cpp"),
+    )
+
+    # 3. Wrap the kernel bytes as a CoreCallable with its tensor-arg signature
+    # (a, b are inputs; out is output). ``func_id=0`` matches the first
+    # (and only) ``pto2_rt_submit_aiv_task(0, ...)`` in vector_add_orch.cpp.
+    core_callable = CoreCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+        binary=kernel_bytes,
+    )
+
+    # 4. Wrap everything into a ChipCallable. The orchestration function name
+    # must match the ``__attribute__((visibility("default")))`` symbol in
+    # vector_add_orch.cpp.
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+        func_name="vector_add_orchestration",
+        binary=orch_bytes,
+        children=[(0, core_callable)],
+    )
+
+
+def run(worker: Worker, chip_callable: ChipCallable) -> None:
+    """Allocate device memory, copy inputs, execute, copy outputs back, verify."""
+    # --- 1. Prepare host arrays ---
+    rng = np.random.default_rng(seed=42)
+    host_a = rng.standard_normal((N_ROWS, N_COLS), dtype=np.float32)
+    host_b = rng.standard_normal((N_ROWS, N_COLS), dtype=np.float32)
+    expected = host_a + host_b
+    host_out = np.zeros((N_ROWS, N_COLS), dtype=np.float32)
+
+    # --- 2. Allocate device buffers + H2D copy ---
+    # malloc returns a uint64 device pointer. copy_to takes (dst_dev, src_host, nbytes).
+    dev_a = worker.malloc(NBYTES)
+    dev_b = worker.malloc(NBYTES)
+    dev_out = worker.malloc(NBYTES)
+    worker.copy_to(dev_a, host_a.ctypes.data, NBYTES)
+    worker.copy_to(dev_b, host_b.ctypes.data, NBYTES)
+
+    # --- 3. Build TaskArgs describing the tensors visible to the orchestration ---
+    # Each tensor is a ContinuousTensor(data_ptr, shape, dtype). Order must
+    # match the ``signature`` list in the ChipCallable (IN, IN, OUT).
+    args = ChipStorageTaskArgs()
+    args.add_tensor(ContinuousTensor.make(dev_a, (N_ROWS, N_COLS), DataType.FLOAT32))
+    args.add_tensor(ContinuousTensor.make(dev_b, (N_ROWS, N_COLS), DataType.FLOAT32))
+    args.add_tensor(ContinuousTensor.make(dev_out, (N_ROWS, N_COLS), DataType.FLOAT32))
+
+    # --- 4. Run. ChipCallConfig() defaults are fine for this kernel. ---
+    config = ChipCallConfig()
+    print("[vector_add] running on device...")
+    worker.run(chip_callable, args, config)
+
+    # --- 5. D2H copy back + verify ---
+    worker.copy_from(host_out.ctypes.data, dev_out, NBYTES)
+
+    # --- 6. Free device buffers. Order doesn't matter, but leaking is bad. ---
+    worker.free(dev_a)
+    worker.free(dev_b)
+    worker.free(dev_out)
+
+    max_diff = float(np.max(np.abs(host_out - expected)))
+    print(f"[vector_add] max |host_out - expected| = {max_diff:.3e}")
+    np.testing.assert_allclose(host_out, expected, rtol=1e-5, atol=1e-5)
+    print("[vector_add] golden check PASSED ✅")
+
+
+def main() -> int:
+    args = parse_args()
+    worker = Worker(
+        level=2,
+        platform=args.platform,
+        runtime="tensormap_and_ringbuffer",
+        device_id=args.device,
+    )
+
+    print(f"[vector_add] compiling kernels for {args.platform}...")
+    chip_callable = build_chip_callable(args.platform)
+    print(f"[vector_add] compiled. binary_size={chip_callable.binary_size} bytes")
+
+    print(f"[vector_add] init worker (device={args.device})...")
+    worker.init()
+    try:
+        run(worker, chip_callable)
+    finally:
+        worker.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/workers/l3/README.md
+++ b/examples/workers/l3/README.md
@@ -1,0 +1,72 @@
+# L3 — Host-level multi-chip examples
+
+**L3 = HOST**: one host machine that drives multiple L2 chips plus M
+SubWorkers (plain Python callables), coordinated by an Orchestrator running in
+the host process. This is where you first see the *DAG* model — you submit a
+task per chip, each task carries a dependency graph via `orchestrator` APIs,
+and the runtime schedules them onto available devices.
+
+See [`docs/hierarchical_level_runtime.md`](../../../docs/hierarchical_level_runtime.md)
+for the full L0–L6 diagram and [`docs/task-flow.md`](../../../docs/task-flow.md)
+for data-flow end to end.
+
+## Minimum Worker lifecycle
+
+L3 adds two steps before `init()`:
+
+```python
+from simpler.worker import Worker
+
+worker = Worker(
+    level=3,
+    platform="a2a3sim",
+    runtime="tensormap_and_ringbuffer",
+    device_ids=[0, 1],        # two chips
+    num_sub_workers=1,        # one Python post-processing callable
+)
+
+# 1. Register sub-worker callables BEFORE init (level >= 3 only).
+#    Returns an integer id you pass to orchestrator.submit_sub(...) later.
+postprocess_id = worker.register(
+    lambda args: print("post-process received", args)
+)
+
+worker.init()                 # forks chip child processes + sub children,
+                              # then starts the C++ scheduler
+
+def my_orch(orch, args, cfg):
+    # orch is the Orchestrator. Submit one task per chip + any sub work.
+    # orch.submit_next_level(...) schedules a ChipCallable onto a free chip.
+    # orch.submit_sub(cid, sub_args) schedules a Python callable.
+    ...
+
+try:
+    worker.run(my_orch, my_args, my_config)
+finally:
+    worker.close()            # shuts down child processes and releases shm
+```
+
+Two things to know before reading the example:
+
+1. **`register()` and `add_worker()` MUST run before `init()`**. The Python
+   callables get captured via copy-on-write when `init()` forks child
+   processes, so anything registered after the fork is invisible to the
+   children.
+2. **The orchestration function is a *plain Python function*, not a C++
+   kernel.** It runs in the host process and calls `orch.submit_*(...)` to
+   hand work to chip children. The children get the submitted `ChipCallable`
+   through shared-memory mailboxes.
+
+## What each example demonstrates
+
+| Directory | New concept |
+| --------- | ----------- |
+| [`multi_chip_dispatch/`](multi_chip_dispatch/) | Two chips + one SubWorker. An orchestration fn dispatches a `ChipCallable` to each chip, then submits a Python callable to collect/verify results. |
+
+## Prerequisites
+
+Same as L2 (see [`../l2/README.md`](../l2/README.md)): venv + `pip install .`.
+
+Additionally, L3 runs real child processes via `fork()`. On macOS you *can*
+run the L3 sim path, but fork + Python state can surface issues that don't
+appear on Linux. When in doubt, run L3 examples on a Linux host.

--- a/examples/workers/l3/multi_chip_dispatch/README.md
+++ b/examples/workers/l3/multi_chip_dispatch/README.md
@@ -1,0 +1,175 @@
+# `multi_chip_dispatch/` — two chips, one orchestration, one SubWorker
+
+Dispatches the same `vector_add` `ChipCallable` to two chips (each with its own
+input tensors), then fires a Python `SubWorker` callable that depends on both
+chip outputs. The smallest correct L3 program.
+
+## What's new vs. L2 `vector_add`
+
+| Concept | Where it shows up in `main.py` |
+| ------- | ------------------------------ |
+| Shared-memory tensors | `torch.randn(...).share_memory_()` — chip children see the same storage |
+| `TensorArgType` tags | `INPUT` / `OUTPUT_EXISTING` drive DAG dependency tracking |
+| Python SubWorker | `worker.register(fn)` **before** `init()` |
+| `Worker(level=3)` config | `device_ids=[0, 1]`, `num_sub_workers=1` |
+| Orchestration | `orch.submit_next_level(...)` per chip + `orch.submit_sub(cid, args)` |
+
+## Layout
+
+```text
+multi_chip_dispatch/
+  main.py
+  kernels/
+    aiv/vector_add_kernel.cpp       # same kernel as l2/vector_add (copy)
+    orchestration/vector_add_orch.cpp  # same orch as l2/vector_add (copy)
+  README.md
+```
+
+Both kernel files are verbatim copies from `../../l2/vector_add/kernels/` —
+kept in this directory so each example is independently readable. If you've
+read through the L2 example the kernel / orchestration sources are already
+familiar.
+
+## The DAG
+
+```text
+                         ┌────────────────────┐
+                         │  vector_add on     │
+                         │  chip 0            │ ──┐
+                         │  (a0, b0) → out0   │   │
+                         └────────────────────┘   │
+                                                  ▼
+                                         ┌───────────────┐
+                                         │  SubWorker    │
+                                         │  (Python fn)  │
+                                         └───────────────┘
+                                                  ▲
+                         ┌────────────────────┐   │
+                         │  vector_add on     │   │
+                         │  chip 1            │ ──┘
+                         │  (a1, b1) → out1   │
+                         └────────────────────┘
+```
+
+Three nodes, two edges. The sub waits until **both** chip tasks finish because
+its `TaskArgs` includes both `host_out[0]` and `host_out[1]` tagged `INPUT`.
+The scheduler infers this from the tags; you never list dependencies
+explicitly.
+
+## The lifecycle, step by step
+
+### 1. Pre-init — shared-memory tensors + callable registration
+
+```python
+host_a   = [torch.randn(...).share_memory_() for _ in device_ids]
+host_b   = [torch.randn(...).share_memory_() for _ in device_ids]
+host_out = [torch.zeros(...).share_memory_() for _ in device_ids]
+
+def subworker(sub_args): ...
+sub_cid = worker.register(subworker)   # BEFORE init() — see below
+```
+
+`share_memory_()` moves the tensor's storage to a `mmap` region. After
+`fork()`, the chip child process has that region mapped at the same virtual
+address, so when the kernel writes to `host_out[i]`, the parent's tensor sees
+it immediately. No explicit copy back.
+
+**`register()` MUST come before `init()`**. `init()` forks child processes;
+the registry is captured by copy-on-write. Anything registered after `init()`
+is invisible to the forked children.
+
+### 2. `init()` — fork + C++ scheduler
+
+Worker allocates `MAILBOX_SIZE` shared-memory mailboxes (one per chip, one per
+sub), forks child processes, and starts the C++ scheduler. After this call
+returns, 4 processes are alive: parent, sub, chip 0, chip 1.
+
+### 3. Orchestration function — submit nodes
+
+```python
+def orch_fn(orch, _args, cfg):
+    for i in range(len(device_ids)):
+        chip_args = TaskArgs()
+        chip_args.add_tensor(make_tensor_arg(host_a[i]),   TensorArgType.INPUT)
+        chip_args.add_tensor(make_tensor_arg(host_b[i]),   TensorArgType.INPUT)
+        chip_args.add_tensor(make_tensor_arg(host_out[i]), TensorArgType.OUTPUT_EXISTING)
+        orch.submit_next_level(chip_callable, chip_args, cfg, worker=i)
+
+    sub_args = TaskArgs()
+    for i in range(len(device_ids)):
+        sub_args.add_tensor(make_tensor_arg(host_out[i]), TensorArgType.INPUT)
+    orch.submit_sub(sub_cid, sub_args)
+```
+
+The orch function runs **in the parent process**. Each `orch.submit_*` adds a
+node to the DAG; the scheduler (running on C++ threads) actually picks up the
+nodes and dispatches them to the chip child processes. The orch function
+returns immediately after submitting all nodes — `Worker.run` will then drain
+the DAG before returning.
+
+### 4. `Worker.run(orch_fn, ...)` — blocks until DAG drains
+
+```python
+worker.run(orch_fn, args=None, config=ChipCallConfig())
+```
+
+After this returns, all tags on `host_out` are satisfied: chip tasks have
+written, sub task has run.
+
+### 5. Verify + close
+
+Because `host_out` is shared memory, reading it in the parent gives the chip
+output directly. No `copy_from` needed.
+
+```python
+for i in range(len(device_ids)):
+    assert torch.allclose(host_out[i], expected[i], rtol=1e-5, atol=1e-5)
+worker.close()
+```
+
+## Run
+
+```bash
+python examples/workers/l3/multi_chip_dispatch/main.py -p a2a3sim -d 0-1
+```
+
+Expected output (sim, macOS / Linux):
+
+```text
+[multi_chip_dispatch] devices=[0, 1]
+[multi_chip_dispatch] compiling kernels for a2a3sim...
+[multi_chip_dispatch] init worker...
+[multi_chip_dispatch] running DAG (2 chip tasks + 1 sub)...
+[chip_process pid=... dev=0] ready
+[chip_process pid=... dev=1] ready
+[multi_chip_dispatch] subworker fired (received 2 tensor refs) ✅
+[multi_chip_dispatch] chip 0: max |out - expected| = 0.000e+00
+[multi_chip_dispatch] chip 1: max |out - expected| = 0.000e+00
+[multi_chip_dispatch] all golden checks PASSED ✅
+```
+
+On real hardware (`-p a2a3 -d 0-1`) device memory is a separate address space
+from host memory, but the runtime handles DMA transparently based on the
+`TensorArgType` tags — the user-side code is identical to sim.
+
+## Common pitfalls
+
+- **Registering after `init()`** → sub task fires but hits `KeyError` for the
+  callable id. Always register first.
+- **Not using `share_memory_()`** → chip child sees zeros where it expects
+  inputs. `torch` tensors without `share_memory_()` live in each process's
+  private heap.
+- **Forgetting `OUTPUT_EXISTING` on writable tensors** → runtime treats them
+  as new allocations rather than writing into the provided buffer, and the
+  sub task reads from a different tensor than the one the host expects.
+- **Skipping `worker.close()`** → leaks chip child processes and shared
+  memory segments. See
+  [issue #604](https://github.com/hw-native-sys/simpler/issues/604) for the
+  kind of downstream CI breakage this causes.
+
+## Next step
+
+For multi-host (L4+) composition, where L3 workers themselves become children
+of a higher-level `Worker`, see the unit tests under
+`tests/ut/py/test_worker/test_l4_recursive.py` until a dedicated L4 example
+lands.

--- a/examples/workers/l3/multi_chip_dispatch/kernels/aiv/vector_add_kernel.cpp
+++ b/examples/workers/l3/multi_chip_dispatch/kernels/aiv/vector_add_kernel.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/* Same 128x128 float32 elementwise add kernel as vector_example/kernels/aiv/kernel_add.cpp.
+ * Duplicated here to keep this example self-contained (see ../../../README.md for rationale). */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *src1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ float *src0 = reinterpret_cast<__gm__ float *>(src0_tensor->buffer.addr) + src0_tensor->start_offset;
+    __gm__ float *src1 = reinterpret_cast<__gm__ float *>(src1_tensor->buffer.addr) + src1_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    constexpr int kTRows_ = 128;
+    constexpr int kTCols_ = 128;
+    constexpr int vRows = 128;
+    constexpr int vCols = 128;
+
+    using DynShapeDim5 = Shape<1, 1, 1, vRows, vCols>;
+    using DynStridDim5 = Stride<1, 1, 1, kTCols_, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
+
+    TileData src0Tile(vRows, vCols);
+    TileData src1Tile(vRows, vCols);
+    TileData dstTile(vRows, vCols);
+    TASSIGN(src0Tile, 0x0);
+    TASSIGN(src1Tile, 0x10000);
+    TASSIGN(dstTile, 0x20000);
+
+    GlobalData src0Global(src0);
+    GlobalData src1Global(src1);
+    GlobalData dstGlobal(out);
+
+    TLOAD(src0Tile, src0Global);
+    TLOAD(src1Tile, src1Global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(dstTile, src0Tile, src1Tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, dstTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+}

--- a/examples/workers/l3/multi_chip_dispatch/kernels/orchestration/vector_add_orch.cpp
+++ b/examples/workers/l3/multi_chip_dispatch/kernels/orchestration/vector_add_orch.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Simplest possible orchestration for the Worker API demo.
+ *
+ *   out = a + b
+ *
+ * Exactly one AIV task, no intermediate scopes. For a multi-kernel example
+ * with nested scopes see examples/a2a3/tensormap_and_ringbuffer/vector_example.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+vector_add_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 3,  // a, b, out
+    };
+}
+
+__attribute__((visibility("default"))) void vector_add_orchestration(const ChipStorageTaskArgs &orch_args) {
+    Tensor a = from_tensor_arg(orch_args.tensor(0));
+    Tensor b = from_tensor_arg(orch_args.tensor(1));
+    Tensor out = from_tensor_arg(orch_args.tensor(2));
+
+    Arg params;
+    params.add_input(a);
+    params.add_input(b);
+    params.add_output(out);
+    pto2_rt_submit_aiv_task(0, params);  // func_id=0 -> vector_add_kernel
+}
+
+}  // extern "C"

--- a/examples/workers/l3/multi_chip_dispatch/main.py
+++ b/examples/workers/l3/multi_chip_dispatch/main.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L3 Worker API demo — one orchestration, two chips, one SubWorker.
+
+Dispatches the same vector_add ChipCallable to two chips (each with its own
+input tensors), then runs a Python SubWorker that depends on the chip outputs.
+
+Primitives introduced over L2 (see ../../l2/vector_add/main.py for the L2 version):
+
+  * torch.share_memory_() tensors       — visible to forked chip children, IS the data plane
+  * TaskArgs + TensorArgType tags        — INPUT / OUTPUT_EXISTING drive DAG deps
+  * Worker.register(python_fn)           — register Python callable runnable as a sub task
+  * Worker(level=3, device_ids=[...], num_sub_workers=N) — multi-chip + sub fork-and-serve
+  * orch.submit_next_level(cb, args, cfg, worker=i)  — submit a chip task
+  * orch.submit_sub(cid, args)           — submit a Python sub task
+
+Run:
+    python examples/workers/l3/multi_chip_dispatch/main.py -p a2a3sim -d 0-1
+"""
+
+import argparse
+import os
+import sys
+
+# Workaround for the duplicate-libomp abort when homebrew numpy and pip torch
+# coexist in one macOS process. Harmless on Linux. Must be set before
+# ``import torch``. See docs/macos-libomp-collision.md.
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+import torch  # noqa: E402
+from simpler.task_interface import (
+    ArgDirection,
+    ChipCallable,
+    ChipCallConfig,
+    CoreCallable,
+    TaskArgs,
+    TensorArgType,
+    make_tensor_arg,
+)
+from simpler.worker import Worker
+
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+N_ROWS = 128
+N_COLS = 128
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-p", "--platform", required=True, choices=["a2a3sim", "a2a3", "a5sim", "a5"])
+    parser.add_argument("-d", "--device", default="0-1", help="Device range, e.g. '0-1' or '4-5'. Two chips required.")
+    return parser.parse_args()
+
+
+def parse_device_range(spec: str) -> list[int]:
+    if "-" in spec:
+        lo, hi = (int(x) for x in spec.split("-"))
+        ids = list(range(lo, hi + 1))
+    else:
+        ids = [int(spec)]
+    if len(ids) != 2:
+        raise ValueError(f"multi_chip_dispatch needs exactly 2 devices, got {ids}")
+    return ids
+
+
+def build_chip_callable(platform: str) -> ChipCallable:
+    """Same as L2 vector_add — see ../../l2/vector_add/main.py for the walk-through."""
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+    pto_isa_root = ensure_pto_isa_root(clone_protocol="https")
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+
+    kernel_bytes = kc.compile_incore(
+        source_path=os.path.join(HERE, "kernels/aiv/vector_add_kernel.cpp"),
+        core_type="aiv",
+        pto_isa_root=pto_isa_root,
+        extra_include_dirs=include_dirs,
+    )
+    if not platform.endswith("sim"):
+        from simpler_setup.elf_parser import extract_text_section  # noqa: PLC0415
+
+        kernel_bytes = extract_text_section(kernel_bytes)
+
+    orch_bytes = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/vector_add_orch.cpp"),
+    )
+    core_callable = CoreCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+        binary=kernel_bytes,
+    )
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+        func_name="vector_add_orchestration",
+        binary=orch_bytes,
+        children=[(0, core_callable)],
+    )
+
+
+def main() -> int:
+    cli = parse_args()
+    device_ids = parse_device_range(cli.device)
+    print(f"[multi_chip_dispatch] devices={device_ids}")
+
+    # --- 1. Allocate shared-memory tensors (visible to forked chip processes).
+    # ``share_memory_()`` moves the storage into an mmap region, so when the
+    # chip process writes to ``host_out[i]`` the parent's tensor sees the
+    # update immediately — no explicit copy_back needed.
+    torch.manual_seed(42)
+    host_a = [torch.randn(N_ROWS, N_COLS, dtype=torch.float32).share_memory_() for _ in device_ids]
+    host_b = [torch.randn(N_ROWS, N_COLS, dtype=torch.float32).share_memory_() for _ in device_ids]
+    host_out = [torch.zeros(N_ROWS, N_COLS, dtype=torch.float32).share_memory_() for _ in device_ids]
+    expected = [a + b for a, b in zip(host_a, host_b)]
+
+    # --- 2. Worker(level=3, ...) construction. No fork / no ACL yet.
+    worker = Worker(
+        level=3,
+        platform=cli.platform,
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=1,
+    )
+
+    # --- 3. Register the Python SubWorker callable BEFORE init().
+    # Note: init() forks chip children; the callable registry is captured by
+    # copy-on-write. Anything registered after init() is invisible to the
+    # forked children.
+    def subworker(sub_args: TaskArgs) -> None:
+        # sub_args carries the tensors we tagged INPUT on submit_sub below.
+        # In this demo we just print confirmation; a real app might write
+        # results to disk or trigger the next pipeline stage.
+        print(f"[multi_chip_dispatch] subworker fired (received {sub_args.tensor_count()} tensor refs) ✅")
+
+    sub_cid = worker.register(subworker)
+
+    # --- 4. Compile the ChipCallable once, reused on both chips.
+    print(f"[multi_chip_dispatch] compiling kernels for {cli.platform}...")
+    chip_callable = build_chip_callable(cli.platform)
+
+    # --- 5. init() forks chip + sub child processes, starts C++ scheduler.
+    print("[multi_chip_dispatch] init worker...")
+    worker.init()
+
+    try:
+        # --- 6. Define the orchestration function. It runs in the parent
+        # process once per worker.run() call. Each ``orch.submit_*`` adds a
+        # node to the DAG; the scheduler (running on C++ threads) actually
+        # dispatches the nodes to child processes.
+        def orch_fn(orch, _args, cfg):
+            # Submit one chip task per device. ``worker=i`` pins the task to
+            # the i-th ChipWorker. TensorArgType drives dependency tracking:
+            #   INPUT           = "must be ready before task starts"
+            #   OUTPUT_EXISTING = "task writes to this pre-allocated tensor"
+            for i in range(len(device_ids)):
+                chip_args = TaskArgs()
+                chip_args.add_tensor(make_tensor_arg(host_a[i]), TensorArgType.INPUT)
+                chip_args.add_tensor(make_tensor_arg(host_b[i]), TensorArgType.INPUT)
+                chip_args.add_tensor(make_tensor_arg(host_out[i]), TensorArgType.OUTPUT_EXISTING)
+                orch.submit_next_level(chip_callable, chip_args, cfg, worker=i)
+
+            # Sub task that depends on both chip outputs. Tagging the two
+            # host_out[i] tensors INPUT tells the scheduler to wait for
+            # both chip tasks to finish before running the sub.
+            sub_args = TaskArgs()
+            for i in range(len(device_ids)):
+                sub_args.add_tensor(make_tensor_arg(host_out[i]), TensorArgType.INPUT)
+            orch.submit_sub(sub_cid, sub_args)
+
+        # --- 7. Run the DAG. Worker.run() opens a scope, invokes orch_fn,
+        # drains the DAG to completion, then closes the scope.
+        print("[multi_chip_dispatch] running DAG (2 chip tasks + 1 sub)...")
+        worker.run(orch_fn, args=None, config=ChipCallConfig())
+
+        # --- 8. Verify outputs. ``host_out`` was written in-place by the
+        # chip processes via shared memory; no explicit copy needed.
+        for i in range(len(device_ids)):
+            max_diff = float(torch.max(torch.abs(host_out[i] - expected[i])))
+            print(f"[multi_chip_dispatch] chip {i}: max |out - expected| = {max_diff:.3e}")
+            assert torch.allclose(host_out[i], expected[i], rtol=1e-5, atol=1e-5), f"chip {i} result mismatch"
+
+        print("[multi_chip_dispatch] all golden checks PASSED ✅")
+    finally:
+        # close() shuts down sub + chip child processes, unlinks shared memory.
+        worker.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three self-contained examples that drive the runtime directly through the \`Worker\` class, without \`@scene_test\`. Fills the gap where every existing \`examples/\` entry goes through the test harness and there is no material showing the raw API call chain.

## Layout

\`\`\`text
examples/workers/
  README.md
  l2/
    README.md
    hello_worker/           # minimal Worker(level=2).init().close(), no kernel
      main.py  README.md
    vector_add/             # one AIV kernel, TaskArgs, golden check
      main.py  README.md
      kernels/{aiv,orchestration}/*.cpp
  l3/
    README.md
    multi_chip_dispatch/    # 2 chips + 1 SubWorker, submit_next_level + submit_sub
      main.py  README.md
      kernels/{aiv,orchestration}/*.cpp
\`\`\`

## Design choices

- **No \`tensormap_and_ringbuffer/\` directory layer.** Every example hard-codes \`runtime=\"tensormap_and_ringbuffer\"\` in its \`Worker(...)\` call — that's the default user-facing runtime. Other runtimes are covered under \`tests/st/\`, not here.
- **Self-contained per example.** The kernel + orchestration sources in \`vector_add\` and \`multi_chip_dispatch\` are verbatim copies from \`examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/\` (with the orchestration simplified to a single kernel submit). Readers shouldn't have to scroll up four directory levels to see what a file does.
- **Uniform CLI.** \`python main.py -p <platform> -d <device>\`, matching the flag shape of \`scene_test\`.
- **Entry-level audience.** Each \`main.py\` has block comments explaining *why* each step exists; each README walks through the code block by block.

## Testing

All three examples smoke-tested locally on \`a2a3sim\` with a macOS venv (\`python3 -m venv --system-site-packages\`, \`pip install --no-build-isolation .\`):

- \`hello_worker\` — lifecycle OK (\`init\` + \`malloc/free\` round-trip + \`close\`)
- \`vector_add\` — golden \`max_diff = 0.000e+00\`
- \`multi_chip_dispatch\` — golden \`max_diff = 0.000e+00\` on both chips, subworker fires after both finish

- [ ] CI: linters green (ruff auto-fixed import order on first commit attempt, re-staged)
- [ ] Follow-up: the existing \`examples/{a2a3,a5}/tensormap_and_ringbuffer/\` tree has a redundant \`tensormap_and_ringbuffer/\` layer that could be flattened too (runtime is already declared in \`@scene_test(runtime=...)\`). Out of scope here; separate PR.