### PR TITLE
CI: hoist pto-isa pin to env var and bump to 478daadb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PTO_ISA_COMMIT: 478daadb
+
 jobs:
   # ---------- Pre-commit hooks (format, lint, clang-tidy) ----------
   pre-commit:
@@ -206,7 +209,7 @@ jobs:
           if [ $rc -eq 124 ]; then
             echo "pytest timed out; retrying with pinned PTO-ISA commit"
             pytest examples tests/st --platform a2a3sim --device 0-15 -v \
-              --pto-session-timeout 600 --pto-isa-commit d96c8784 --clone-protocol https
+              --pto-session-timeout 600 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https
             rc=$?
           fi
           exit $rc
@@ -264,7 +267,7 @@ jobs:
           if [ $rc -eq 124 ]; then
             echo "pytest timed out; retrying with pinned PTO-ISA commit"
             pytest examples tests/st --platform a5sim --device 0-15 -v \
-              --pto-session-timeout 600 --pto-isa-commit 3cf259e8 --clone-protocol https
+              --pto-session-timeout 600 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https
             rc=$?
           fi
           exit $rc
@@ -342,7 +345,7 @@ jobs:
           if [ $rc -eq 124 ]; then
             echo "pytest timed out; retrying with pinned PTO-ISA commit"
             python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v \
-              --pto-session-timeout 600 --pto-isa-commit d96c8784 --clone-protocol https
+              --pto-session-timeout 600 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https
             rc=$?
           fi
           exit $rc
@@ -449,4 +452,4 @@ jobs:
           set -e
           DEVICE_LIST=$(python -c "s,e='${DEVICE_RANGE}'.split('-'); print(','.join(str(i) for i in range(int(s),int(e)+1)))")
           PYTEST="python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v --clone-protocol https"
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "set +e; $PYTEST --pto-session-timeout 1200; rc=\$?; if [ \$rc -eq 124 ]; then echo 'pytest timed out; retrying with pinned PTO-ISA commit'; $PYTEST --pto-session-timeout 1200 --pto-isa-commit d96c8784 --clone-protocol https; rc=\$?; fi; exit \$rc"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "set +e; $PYTEST --pto-session-timeout 1200; rc=\$?; if [ \$rc -eq 124 ]; then echo 'pytest timed out; retrying with pinned PTO-ISA commit'; $PYTEST --pto-session-timeout 1200 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https; rc=\$?; fi; exit \$rc"


### PR DESCRIPTION
## Summary

- Define `PTO_ISA_COMMIT` once at the workflow level in `.github/workflows/ci.yml` and replace the four inline call sites (a2a3sim retry, a5sim retry, a2a3 hardware retry, a5 hardware retry) with `${{ env.PTO_ISA_COMMIT }}` — future bumps touch one line.
- Bump the pin to `478daadb`, the latest `pto-isa` `main` after [PR #92](https://github.com/PTO-ISA/pto-isa/pull/92) (`refactor(backend): Replace runtime subblock detection with constexpr tile-type dispatch`) and [PR #93](https://github.com/PTO-ISA/pto-isa/pull/93) (`fix: Skip inactive Vec lanes in TPush/TPop/TFree for TILE_NO_SPLIT mode`).
- Previously the a2a3 paths pinned `d96c8784` (PR #61, 2026-04-09) and the a5 path pinned `3cf259e8` (PR #87, 2026-04-17).

## Testing

- [ ] CI pipeline runs cleanly on this PR (pin is only exercised on the timeout-retry path, so a green run without retry is the expected default).