### PR TITLE
Add: Worker-level chip bootstrap orchestration for distributed L3

### DIFF
--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -79,7 +79,7 @@ __all__ = [
     "MAILBOX_OFF_ERROR_MSG",
     "MAILBOX_ERROR_MSG_SIZE",
     "read_args_from_blob",
-    # Chip bootstrap (L5)
+    # Chip bootstrap
     "CHIP_BOOTSTRAP_MAILBOX_SIZE",
     "ChipBootstrapChannel",
     "ChipBootstrapMailboxState",
@@ -88,6 +88,8 @@ __all__ = [
     "HostBufferStaging",
     "ChipBootstrapConfig",
     "ChipBootstrapResult",
+    # Worker-level chip bootstrap orchestration
+    "ChipContext",
 ]
 
 
@@ -122,9 +124,9 @@ class ChipCommBootstrapConfig:
 
     A ``ChipBootstrapConfig`` with ``comm=None`` skips the communicator step
     entirely; in that mode ``cfg.buffers`` must be empty because
-    ``placement="window"`` is the only supported placement in L5 and the
-    window only exists once a communicator has been brought up.  Comm-less
-    configs are used by validation / error-path tests that need to trip
+    ``placement="window"`` is the only supported placement and the window
+    only exists once a communicator has been brought up.  Comm-less configs
+    are used by validation / error-path tests that need to trip
     ``bootstrap_context`` before it reaches any communicator call.
     """
 
@@ -144,8 +146,8 @@ class ChipBufferSpec:
 
     Buffers are placed sequentially inside the window in declaration order —
     ``ChipBootstrapResult.buffer_ptrs`` is 1:1 aligned with the ``buffers``
-    list so downstream code (L6's ``ChipContext``) can build a ``name → ptr``
-    dict by zipping the two.
+    list so downstream code (the Worker's ``ChipContext``) can build a
+    ``name → ptr`` dict by zipping the two.
     """
 
     name: str
@@ -203,6 +205,27 @@ class ChipBootstrapResult:
     local_window_base: int
     actual_window_size: int
     buffer_ptrs: list[int]
+
+
+@dataclass
+class ChipContext:
+    """Per-chip view of a successful bootstrap, exposed to L3+ orch functions.
+
+    Built by the parent `Worker` in `_start_hierarchical` from the
+    `ChipBootstrapConfig` it forwarded to the chip child and the
+    `ChipBootstrapResult` the child published via its `ChipBootstrapChannel`.
+    `buffer_ptrs` is the `name → device pointer` map obtained by zipping the
+    config's `ChipBufferSpec.name` with the result's `buffer_ptrs`, so orch
+    code can address a named window slice without tracking list indices.
+    """
+
+    device_id: int
+    rank: int
+    nranks: int
+    device_ctx: int
+    local_window_base: int
+    actual_window_size: int
+    buffer_ptrs: dict[str, int]
 
 
 class ChipWorker:
@@ -338,16 +361,17 @@ class ChipWorker:
         """One-shot per-chip bootstrap: set device, build communicator, slice window,
         stage inputs from host shared memory, and (optionally) publish the result.
 
-        Runs inside a forked chip child.  If ``channel`` is provided (the L6
-        integration path), the result is written as SUCCESS or — on any
-        exception — as ERROR (code=1, ``"<ExceptionType>: <message>"``) before
-        the exception is re-raised.  Standalone callers can pass
-        ``channel=None`` and consume the return value directly.
+        Runs inside a forked chip child.  If ``channel`` is provided (the
+        Worker-orchestrated integration path), the result is written as
+        SUCCESS or — on any exception — as ERROR (code=1,
+        ``"<ExceptionType>: <message>"``) before the exception is re-raised.
+        Standalone callers can pass ``channel=None`` and consume the return
+        value directly.
 
         The HCCL comm handle produced by ``comm_init`` is stashed on
         ``self._comm_handle`` so ``shutdown_bootstrap()`` can release it later;
         ``finalize()`` is intentionally *not* wired to this handle — teardown
-        ordering is the caller's (L6's) responsibility.
+        ordering is the caller's responsibility.
         """
         try:
             self.set_device(device_id)
@@ -422,9 +446,10 @@ class ChipWorker:
 
         Idempotent — safe to call multiple times, and safe to call if
         ``bootstrap_context`` was never invoked.  ``finalize()`` does *not*
-        chain into this method, so L6 must call ``shutdown_bootstrap()``
-        before ``finalize()`` (or after, if the comm handle was already
-        destroyed — the zero-handle guard makes a second call a no-op).
+        chain into this method, so callers (e.g. the Worker's chip child
+        loop) must call ``shutdown_bootstrap()`` before ``finalize()`` (or
+        after, if the comm handle was already destroyed — the zero-handle
+        guard makes a second call a no-op).
         """
         handle = getattr(self, "_comm_handle", 0)
         if handle != 0:

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -48,12 +48,18 @@ Usage::
 
 import ctypes
 import os
+import signal
 import struct
 import sys
+import time
+import traceback
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Callable, Optional
 
 from _task_interface import (  # pyright: ignore[reportMissingImports]
+    CHIP_BOOTSTRAP_MAILBOX_SIZE,
+    ChipBootstrapChannel,
+    ChipBootstrapMailboxState,
     _mailbox_load_i32,
     _mailbox_store_i32,
 )
@@ -63,7 +69,9 @@ from .task_interface import (
     MAILBOX_ERROR_MSG_SIZE,
     MAILBOX_OFF_ERROR_MSG,
     MAILBOX_SIZE,
+    ChipBootstrapConfig,
     ChipCallConfig,
+    ChipContext,
     ChipWorker,
     ContinuousTensor,
     DataType,
@@ -71,6 +79,12 @@ from .task_interface import (
     _ChipWorker,
     _Worker,
 )
+
+# Upper bound on how long the parent waits for every chip's bootstrap mailbox
+# to leave IDLE.  Well above a realistic HCCL init (seconds) but short enough
+# that a hung child fails the suite instead of the CI job timing out.
+_BOOTSTRAP_WAIT_TIMEOUT_S = 120.0
+_BOOTSTRAP_POLL_INTERVAL_S = 0.001
 
 # ---------------------------------------------------------------------------
 # Unified mailbox layout (must match worker_manager.h MAILBOX_OFF_*)
@@ -307,6 +321,115 @@ def _chip_process_loop(
             break
 
 
+def _chip_process_loop_with_bootstrap(
+    buf: memoryview,
+    host_lib_path: str,
+    device_id: int,
+    aicpu_path: str,
+    aicore_path: str,
+    sim_context_lib_path: str,
+    bootstrap_cfg: ChipBootstrapConfig,
+    bootstrap_mailbox_addr: int,
+    max_buffer_count: int,
+) -> None:
+    """Chip child variant that runs ``bootstrap_context`` before the main loop.
+
+    The child constructs its own ``ChipBootstrapChannel`` wrapping the
+    pre-fork shared-memory region, calls ``bootstrap_context`` (which
+    publishes SUCCESS/ERROR on the channel), and on success enters the same
+    task / control polling loop as ``_chip_process_loop``.  On any failure
+    before the main loop starts, the channel has already been written by the
+    callee and the function returns — the ``os._exit(0)`` in the fork
+    branch reaps the process without an extra non-zero exit code that would
+    confuse the parent's ``waitpid`` teardown.
+    """
+    channel = ChipBootstrapChannel(bootstrap_mailbox_addr, max_buffer_count)
+
+    cw = ChipWorker()
+    try:
+        cw.init(host_lib_path, aicpu_path, aicore_path, sim_context_lib_path)
+    except Exception as e:  # noqa: BLE001
+        traceback.print_exc()
+        channel.write_error(1, f"{type(e).__name__}: chip_worker.init: {e}")
+        return
+
+    try:
+        cw.bootstrap_context(device_id, bootstrap_cfg, channel=channel)
+    except Exception:  # noqa: BLE001
+        # bootstrap_context already wrote the error payload.  Release the
+        # comm handle (if any) best-effort and return; finalize() is safe to
+        # skip — the process is about to exit and the OS reclaims FDs.
+        traceback.print_exc()
+        try:
+            cw.shutdown_bootstrap()
+        except Exception:  # noqa: BLE001
+            pass
+        return
+
+    mailbox_addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
+    state_addr = mailbox_addr + _OFF_STATE
+    args_ptr = mailbox_addr + _OFF_ARGS
+    sys.stderr.write(f"[chip_process pid={os.getpid()} dev={device_id} bootstrap] ready\n")
+    sys.stderr.flush()
+
+    try:
+        while True:
+            state = _mailbox_load_i32(state_addr)
+            if state == _TASK_READY:
+                callable_ptr = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
+                block_dim = struct.unpack_from("i", buf, _OFF_BLOCK_DIM)[0]
+                aicpu_tn = struct.unpack_from("i", buf, _OFF_AICPU_THREAD_NUM)[0]
+                profiling = struct.unpack_from("i", buf, _OFF_ENABLE_PROFILING)[0]
+
+                code = 0
+                msg = ""
+                try:
+                    cw._impl.run_from_blob(callable_ptr, args_ptr, block_dim, aicpu_tn, bool(profiling))
+                except Exception as e:  # noqa: BLE001
+                    code = 1
+                    msg = _format_exc(f"chip_process dev={device_id}", e)
+                _write_error(buf, code, msg)
+                _mailbox_store_i32(state_addr, _TASK_DONE)
+            elif state == _CONTROL_REQUEST:
+                sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
+                code = 0
+                msg = ""
+                try:
+                    if sub_cmd == _CTRL_MALLOC:
+                        size = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
+                        ptr = cw._impl.malloc(size)
+                        struct.pack_into("Q", buf, _CTRL_OFF_RESULT, ptr)
+                    elif sub_cmd == _CTRL_FREE:
+                        ptr = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
+                        cw._impl.free(ptr)
+                    elif sub_cmd == _CTRL_COPY_TO:
+                        dst = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
+                        src = struct.unpack_from("Q", buf, _CTRL_OFF_ARG1)[0]
+                        n = struct.unpack_from("Q", buf, _CTRL_OFF_ARG2)[0]
+                        cw._impl.copy_to(dst, src, n)
+                    elif sub_cmd == _CTRL_COPY_FROM:
+                        dst = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
+                        src = struct.unpack_from("Q", buf, _CTRL_OFF_ARG1)[0]
+                        n = struct.unpack_from("Q", buf, _CTRL_OFF_ARG2)[0]
+                        cw._impl.copy_from(dst, src, n)
+                except Exception as e:  # noqa: BLE001
+                    code = 1
+                    msg = _format_exc(f"chip_process dev={device_id} ctrl={int(sub_cmd)}", e)
+                _write_error(buf, code, msg)
+                _mailbox_store_i32(state_addr, _CONTROL_DONE)
+            elif state == _SHUTDOWN:
+                break
+    finally:
+        # Teardown contract: release the comm handle before finalize so HCCL
+        # state is torn down in LIFO order; the channel shm the parent may
+        # still reference is not touched here — only the parent unlinks it
+        # once waitpid returns.
+        try:
+            cw.shutdown_bootstrap()
+        finally:
+            cw.finalize()
+
+
 def _read_config_from_mailbox(buf: memoryview) -> "ChipCallConfig":
     """Reconstruct a ChipCallConfig from the unified mailbox layout."""
     cfg = ChipCallConfig()
@@ -371,7 +494,12 @@ class Worker:
               add_worker() before init().
     """
 
-    def __init__(self, level: int, **config) -> None:
+    def __init__(
+        self,
+        level: int,
+        chip_bootstrap_configs: Optional[list[ChipBootstrapConfig]] = None,
+        **config,
+    ) -> None:
         self.level = level
         self._config = config
         self._callable_registry: dict[int, Callable] = {}
@@ -392,6 +520,23 @@ class Worker:
         self._next_level_workers: list[Worker] = []
         self._next_level_shms: list[SharedMemory] = []
         self._next_level_pids: list[int] = []
+
+        # Per-chip bootstrap: one `ChipBootstrapConfig` per device_id plus a
+        # matching shared-memory mailbox the child publishes its
+        # `ChipBootstrapResult` into.  The `ChipContext` list is populated by
+        # `_start_hierarchical` once every chip reports SUCCESS.
+        if chip_bootstrap_configs is not None:
+            if level < 3:
+                raise ValueError(f"chip_bootstrap_configs requires level >= 3 (got level={level})")
+            device_ids = config.get("device_ids", [])
+            if len(chip_bootstrap_configs) != len(device_ids):
+                raise ValueError(
+                    f"chip_bootstrap_configs length ({len(chip_bootstrap_configs)}) "
+                    f"must equal device_ids length ({len(device_ids)})"
+                )
+        self._chip_bootstrap_configs: Optional[list[ChipBootstrapConfig]] = chip_bootstrap_configs
+        self._bootstrap_shms: list[SharedMemory] = []
+        self._chip_contexts: list[ChipContext] = []
 
     # ------------------------------------------------------------------
     # Callable registration (before init)
@@ -434,6 +579,14 @@ class Worker:
             self._init_level2()
         elif self.level >= 3:
             self._init_hierarchical()
+            # When the caller passes chip_bootstrap_configs, bring up every
+            # chip child *during* init — the parent must be able to consume
+            # `worker.chip_contexts` before the first `run()`.  Any bootstrap
+            # failure is surfaced as a RuntimeError; the helper does its own
+            # best-effort teardown of partially-forked children and shms so
+            # the caller does not need to call close().
+            if self._chip_bootstrap_configs is not None:
+                self._start_hierarchical()
         else:
             raise ValueError(f"Worker: level {self.level} not supported")
 
@@ -500,6 +653,16 @@ class Worker:
             _mailbox_store_i32(_buffer_field_addr(shm.buf, _OFF_STATE), _IDLE)
             self._next_level_shms.append(shm)
 
+        # 3b. Allocate per-chip bootstrap mailboxes (one per device_id).  Must
+        # live in shared memory so the forked child's `ChipBootstrapChannel`
+        # and the parent's read-side view see the same region.  SharedMemory
+        # zero-fills on create, which is IDLE (=0) for ChipBootstrapMailboxState,
+        # so no explicit state reset is required.
+        if self._chip_bootstrap_configs is not None:
+            for _ in self._chip_bootstrap_configs:
+                shm = SharedMemory(create=True, size=CHIP_BOOTSTRAP_MAILBOX_SIZE)
+                self._bootstrap_shms.append(shm)
+
         # 4. Construct the _Worker *before* fork so the HeapRing mmap
         #    (taken in the C++ ctor) is inherited by every child process at
         #    the same virtual address. No C++ thread is spawned here; the
@@ -511,7 +674,7 @@ class Worker:
 
         self._hierarchical_started = False
 
-    def _start_hierarchical(self) -> None:
+    def _start_hierarchical(self) -> None:  # noqa: PLR0912 -- three parallel fork loops (sub/chip/next) + bootstrap wait + scheduler register/init; branches track the fork order documented in the body
         """Fork child processes and start C++ scheduler. Called on first run()."""
         if self._hierarchical_started:
             return
@@ -532,21 +695,44 @@ class Worker:
             else:
                 self._sub_pids.append(pid)
 
-        # Fork ChipWorker processes (L3 with device_ids)
+        # Fork ChipWorker processes (L3 with device_ids).  When
+        # chip_bootstrap_configs is provided the child runs a variant loop
+        # that publishes `bootstrap_context` on a dedicated mailbox *before*
+        # entering the normal task/control loop.
+        bootstrap_configs = self._chip_bootstrap_configs
+        use_bootstrap = bootstrap_configs is not None
         if device_ids:
             for idx, dev_id in enumerate(device_ids):
                 pid = os.fork()
                 if pid == 0:
                     buf = self._chip_shms[idx].buf
                     assert buf is not None
-                    _chip_process_loop(
-                        buf,
-                        self._l3_host_lib_path,
-                        dev_id,
-                        self._l3_aicpu_path,
-                        self._l3_aicore_path,
-                        self._l3_sim_ctx_path,
-                    )
+                    if bootstrap_configs is not None:
+                        bootstrap_cfg = bootstrap_configs[idx]
+                        max_buffer_count = len(bootstrap_cfg.buffers)
+                        bootstrap_buf = self._bootstrap_shms[idx].buf
+                        assert bootstrap_buf is not None
+                        bootstrap_addr = ctypes.addressof(ctypes.c_char.from_buffer(bootstrap_buf))
+                        _chip_process_loop_with_bootstrap(
+                            buf,
+                            self._l3_host_lib_path,
+                            dev_id,
+                            self._l3_aicpu_path,
+                            self._l3_aicore_path,
+                            self._l3_sim_ctx_path,
+                            bootstrap_cfg,
+                            bootstrap_addr,
+                            max_buffer_count,
+                        )
+                    else:
+                        _chip_process_loop(
+                            buf,
+                            self._l3_host_lib_path,
+                            dev_id,
+                            self._l3_aicpu_path,
+                            self._l3_aicore_path,
+                            self._l3_sim_ctx_path,
+                        )
                     os._exit(0)
                 else:
                     self._chip_pids.append(pid)
@@ -567,6 +753,19 @@ class Worker:
                 os._exit(0)
             else:
                 self._next_level_pids.append(pid)
+
+        # When chip_bootstrap_configs was provided, block here until every
+        # chip child publishes its result on its bootstrap mailbox.  We wait
+        # *before* registering the chip mailboxes with the scheduler so a
+        # failed bring-up never reaches `dw.init()`; the abort path below
+        # SIGKILLs every forked child and unlinks every shm so init() can
+        # raise cleanly without leaking state.
+        if use_bootstrap:
+            try:
+                self._wait_for_bootstrap()
+            except BaseException:
+                self._abort_hierarchical()
+                raise
 
         # _Worker was constructed in _init_hierarchical (pre-fork) so
         # children inherit the HeapRing MAP_SHARED mmap. Register PROCESS-mode
@@ -590,6 +789,135 @@ class Worker:
         dw.init()
 
         self._orch = Orchestrator(dw.get_orchestrator())
+
+    # ------------------------------------------------------------------
+    # Bootstrap plumbing
+    # ------------------------------------------------------------------
+
+    def _wait_for_bootstrap(self) -> None:
+        """Block until every chip child has left IDLE on its bootstrap mailbox.
+
+        Fails fast on the first ERROR — returning from this function only
+        when *all* chips reached SUCCESS.  Times out after
+        `_BOOTSTRAP_WAIT_TIMEOUT_S` to surface a hung child as a TimeoutError
+        rather than blocking the CI job.  On success, populates
+        `self._chip_contexts` with one `ChipContext` per chip.
+        """
+        assert self._chip_bootstrap_configs is not None
+        device_ids = self._config.get("device_ids", [])
+        assert len(self._bootstrap_shms) == len(device_ids) == len(self._chip_bootstrap_configs)
+
+        channels: list[ChipBootstrapChannel] = []
+        for shm, cfg in zip(self._bootstrap_shms, self._chip_bootstrap_configs):
+            addr = _mailbox_addr(shm)
+            channels.append(ChipBootstrapChannel(addr, max(len(cfg.buffers), 0)))
+
+        pending = set(range(len(channels)))
+        contexts: list[Optional[ChipContext]] = [None] * len(channels)
+        deadline = time.monotonic() + _BOOTSTRAP_WAIT_TIMEOUT_S
+
+        while pending:
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"bootstrap wait timed out after {_BOOTSTRAP_WAIT_TIMEOUT_S:.0f}s; "
+                    f"pending chip indices: {sorted(pending)}"
+                )
+            for idx in list(pending):
+                state = channels[idx].state
+                if state == ChipBootstrapMailboxState.IDLE:
+                    continue
+                if state == ChipBootstrapMailboxState.ERROR:
+                    raise RuntimeError(f"chip {idx} bootstrap failed: {channels[idx].error_message}")
+                # SUCCESS — assemble the ChipContext from the published fields.
+                cfg = self._chip_bootstrap_configs[idx]
+                comm = cfg.comm
+                rank = comm.rank if comm is not None else 0
+                nranks = comm.nranks if comm is not None else 1
+                ptrs = channels[idx].buffer_ptrs
+                # zip() silently truncates on mismatch, which would hide a
+                # child/parent buffer-count disagreement behind a short
+                # ChipContext — verify explicitly so the caller sees the real
+                # fault instead of a surprising missing key at orch time.
+                if len(ptrs) != len(cfg.buffers):
+                    raise RuntimeError(
+                        f"chip {idx} bootstrap success but buffer count mismatch: "
+                        f"expected {len(cfg.buffers)}, got {len(ptrs)}"
+                    )
+                buffer_ptrs = {spec.name: ptr for spec, ptr in zip(cfg.buffers, ptrs)}
+                contexts[idx] = ChipContext(
+                    device_id=device_ids[idx],
+                    rank=rank,
+                    nranks=nranks,
+                    device_ctx=channels[idx].device_ctx,
+                    local_window_base=channels[idx].local_window_base,
+                    actual_window_size=channels[idx].actual_window_size,
+                    buffer_ptrs=buffer_ptrs,
+                )
+                pending.discard(idx)
+            if pending:
+                time.sleep(_BOOTSTRAP_POLL_INTERVAL_S)
+
+        self._chip_contexts = [c for c in contexts if c is not None]
+
+    def _abort_hierarchical(self) -> None:
+        """Tear down all forked children + shms after a bootstrap failure.
+
+        Best-effort: SIGKILL every child we spawned, reap them, then close
+        and unlink every mailbox.  Called only from the init() failure path,
+        so `dw.init()` has not run and the C++ scheduler is not holding any
+        mailbox references.
+        """
+        pids = list(self._chip_pids) + list(self._sub_pids) + list(self._next_level_pids)
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            except OSError:
+                pass
+        for pid in pids:
+            try:
+                os.waitpid(pid, 0)
+            except ChildProcessError:
+                pass
+
+        for shm in self._sub_shms + self._chip_shms + self._next_level_shms + self._bootstrap_shms:
+            try:
+                shm.close()
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                shm.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception:  # noqa: BLE001
+                pass
+
+        # Release the pre-fork _Worker so a retry / close() won't double-free
+        # the HeapRing mmap the C++ ctor grabbed.
+        self._worker = None
+        self._orch = None
+
+        self._chip_pids.clear()
+        self._sub_pids.clear()
+        self._next_level_pids.clear()
+        self._sub_shms.clear()
+        self._chip_shms.clear()
+        self._next_level_shms.clear()
+        self._bootstrap_shms.clear()
+        self._chip_contexts.clear()
+
+    @property
+    def chip_contexts(self) -> list[ChipContext]:
+        """Per-chip bootstrap results, populated during `init()`.
+
+        Raises ``RuntimeError`` when accessed before `init()` so an orch
+        function that consumes this property in the wrong order fails
+        loudly rather than seeing a misleading empty list.
+        """
+        if not self._initialized:
+            raise RuntimeError("Worker.chip_contexts available only after init()")
+        return list(self._chip_contexts)
 
     # ------------------------------------------------------------------
     # memory management
@@ -706,7 +1034,7 @@ class Worker:
     # close
     # ------------------------------------------------------------------
 
-    def close(self) -> None:
+    def close(self) -> None:  # noqa: PLR0912 -- parallel teardown for _worker + sub/chip/next/bootstrap shms with ordering constraints documented inline
         if not self._initialized:
             return
 
@@ -754,6 +1082,21 @@ class Worker:
                 shm.close()
                 shm.unlink()
 
+            # Unlink the bootstrap mailboxes last — chip children touch their
+            # `ChipBootstrapChannel` from inside `shutdown_bootstrap()` +
+            # `finalize()`, which runs after they leave the main loop on
+            # SHUTDOWN.  Waiting until every chip pid has been reaped above
+            # guarantees no child is still reading from these shms.
+            for shm in self._bootstrap_shms:
+                try:
+                    shm.close()
+                except Exception:  # noqa: BLE001
+                    pass
+                try:
+                    shm.unlink()
+                except FileNotFoundError:
+                    pass
+
             self._sub_shms.clear()
             self._sub_pids.clear()
             self._chip_shms.clear()
@@ -761,6 +1104,8 @@ class Worker:
             self._next_level_shms.clear()
             self._next_level_pids.clear()
             self._next_level_workers.clear()
+            self._bootstrap_shms.clear()
+            self._chip_contexts.clear()
 
         self._initialized = False
 

--- a/tests/ut/py/test_worker/test_worker_distributed_hw.py
+++ b/tests/ut/py/test_worker/test_worker_distributed_hw.py
@@ -1,0 +1,94 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: PLC0415
+"""Hardware smoke test for `Worker(chip_bootstrap_configs=...)` on 2 Ascend devices.
+
+End-to-end equivalent of ``test_bootstrap_context_hw.py`` but driven through
+the top-level ``Worker`` class so the bootstrap happens inside forked chip
+children and the parent observes it via ``worker.chip_contexts``.
+
+Deliberately no ``comm_barrier`` — that path still trips HCCL 507018 on
+some CANN builds (tracked separately).  The non-barrier invariants are
+enough to prove each chip's communicator is up and both ranks carved a
+GVA-visible window.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.mark.requires_hardware
+@pytest.mark.platforms(["a2a3"])
+@pytest.mark.device_count(2)
+def test_worker_chip_bootstrap(st_device_ids):
+    from simpler.task_interface import ChipBootstrapConfig, ChipBufferSpec, ChipCommBootstrapConfig
+    from simpler.worker import Worker
+
+    assert len(st_device_ids) >= 2, "device_count(2) fixture must yield >= 2 ids"
+    device_ids = [int(st_device_ids[0]), int(st_device_ids[1])]
+    nranks = len(device_ids)
+    rootinfo_path = f"/tmp/pto_worker_l6_hw_rootinfo_{os.getpid()}.bin"
+    window_size = 4096
+    buffer_nbytes = 64
+
+    cfgs = [
+        ChipBootstrapConfig(
+            comm=ChipCommBootstrapConfig(
+                rank=rank,
+                nranks=nranks,
+                rootinfo_path=rootinfo_path,
+                window_size=window_size,
+            ),
+            buffers=[
+                ChipBufferSpec(
+                    name="x",
+                    dtype="float32",
+                    count=buffer_nbytes // 4,
+                    placement="window",
+                    nbytes=buffer_nbytes,
+                )
+            ],
+        )
+        for rank in range(nranks)
+    ]
+
+    worker = Worker(
+        level=3,
+        platform="a2a3",
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=0,
+        chip_bootstrap_configs=cfgs,
+    )
+    try:
+        worker.init()
+
+        ctxs = worker.chip_contexts
+        assert len(ctxs) == nranks
+        for rank, ctx in enumerate(ctxs):
+            assert ctx.device_id == device_ids[rank]
+            assert ctx.rank == rank
+            assert ctx.nranks == nranks
+            assert ctx.device_ctx != 0, f"rank {rank}: device_ctx is 0 (HCCL alloc failed)"
+            assert ctx.local_window_base != 0, f"rank {rank}: local_window_base is 0"
+            assert ctx.actual_window_size >= window_size, (
+                f"rank {rank}: actual_window_size={ctx.actual_window_size} < requested {window_size}"
+            )
+            # The single buffer spec carves offset 0, matching the
+            # ChipContext.buffer_ptrs → local_window_base invariant.
+            assert ctx.buffer_ptrs == {"x": ctx.local_window_base}
+    finally:
+        worker.close()
+        try:
+            os.unlink(rootinfo_path)
+        except FileNotFoundError:
+            pass

--- a/tests/ut/py/test_worker/test_worker_distributed_sim.py
+++ b/tests/ut/py/test_worker/test_worker_distributed_sim.py
@@ -1,0 +1,244 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: PLC0415
+"""Simulation tests for Worker-level chip bootstrap orchestration.
+
+Covers the two externally-visible guarantees:
+
+  1. Happy path — `Worker(level=3, chip_bootstrap_configs=...)` populates
+     `worker.chip_contexts` with one per chip, and `close()` leaves no
+     residue behind in `/dev/shm`.
+  2. Error path — a bad `ChipBootstrapConfig` (placement="bogus") trips
+     ValueError inside `bootstrap_context`; the channel publishes ERROR,
+     the parent raises `RuntimeError`, and every forked child is reaped so
+     the test process has no dangling descendants.
+
+These tests drive the sim backend of `tensormap_and_ringbuffer`, so no
+Ascend NPU is required.  `/dev/shm` only exists on Linux; the sweep
+helpers short-circuit on other platforms.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_SHM_DIR = "/dev/shm"
+
+
+def _shm_supported() -> bool:
+    return os.path.isdir(_SHM_DIR)
+
+
+def _shm_snapshot() -> set[str]:
+    """Return the set of ``SharedMemory``-created segment names in /dev/shm.
+
+    Only tracks names with the ``psm_`` prefix (Python's `SharedMemory`
+    default) so unrelated segments — most importantly the sim HCCL backend
+    uses ``simpler_`` and may legitimately outlive a SIGKILLed rank — do
+    not pollute the leak assertion.  Returns an empty set when /dev/shm
+    is absent (non-Linux).
+    """
+    if not _shm_supported():
+        return set()
+    try:
+        return {name for name in os.listdir(_SHM_DIR) if name.startswith("psm_")}
+    except OSError:
+        return set()
+
+
+def _sim_binaries():
+    """Resolve pre-built a2a3sim runtime binaries, or skip if unavailable."""
+    from simpler_setup.runtime_builder import RuntimeBuilder
+
+    build = bool(os.environ.get("PTO_UT_BUILD"))
+    try:
+        bins = RuntimeBuilder(platform="a2a3sim").get_binaries("tensormap_and_ringbuffer", build=build)
+    except FileNotFoundError as e:
+        pytest.skip(f"a2a3sim runtime binaries unavailable: {e}")
+    return bins
+
+
+def _make_configs(nranks: int, rootinfo_path: str, window_size: int = 4096):
+    """Build a `[ChipBootstrapConfig] * nranks` with a single named buffer.
+
+    The buffer carves the window at offset 0, so we get a deterministic
+    `buffer_ptrs["x"] == local_window_base` invariant to assert on.
+    """
+    from simpler.task_interface import ChipBootstrapConfig, ChipBufferSpec, ChipCommBootstrapConfig
+
+    return [
+        ChipBootstrapConfig(
+            comm=ChipCommBootstrapConfig(
+                rank=rank,
+                nranks=nranks,
+                rootinfo_path=rootinfo_path,
+                window_size=window_size,
+            ),
+            buffers=[
+                ChipBufferSpec(
+                    name="x",
+                    dtype="float32",
+                    count=16,
+                    placement="window",
+                    nbytes=64,
+                ),
+            ],
+        )
+        for rank in range(nranks)
+    ]
+
+
+class TestWorkerBootstrapHappyPath:
+    def test_init_populates_chip_contexts(self):
+        from simpler.worker import Worker
+
+        _sim_binaries()  # skip early if runtime binaries are missing
+        rootinfo_path = f"/tmp/pto_worker_l6_sim_{os.getpid()}_happy.bin"
+        nranks = 2
+
+        before = _shm_snapshot()
+
+        cfgs = _make_configs(nranks, rootinfo_path)
+        worker = Worker(
+            level=3,
+            platform="a2a3sim",
+            runtime="tensormap_and_ringbuffer",
+            device_ids=list(range(nranks)),
+            num_sub_workers=0,
+            chip_bootstrap_configs=cfgs,
+        )
+        try:
+            worker.init()
+
+            ctxs = worker.chip_contexts
+            assert len(ctxs) == nranks, f"expected {nranks} ChipContext, got {len(ctxs)}"
+            for rank, ctx in enumerate(ctxs):
+                assert ctx.device_id == rank
+                assert ctx.rank == rank
+                assert ctx.nranks == nranks
+                assert ctx.actual_window_size >= 4096
+                assert ctx.local_window_base != 0
+                # buffer_ptrs is a name → device-ptr dict, and the single
+                # "x" buffer lives at window base (offset 0).
+                assert set(ctx.buffer_ptrs.keys()) == {"x"}
+                assert ctx.buffer_ptrs["x"] == ctx.local_window_base
+        finally:
+            worker.close()
+            try:
+                os.unlink(rootinfo_path)
+            except FileNotFoundError:
+                pass
+
+        after = _shm_snapshot()
+        if _shm_supported():
+            leaked = after - before
+            assert not leaked, f"/dev/shm segments leaked after close(): {sorted(leaked)}"
+
+    def test_chip_contexts_before_init_raises(self):
+        """Accessing `chip_contexts` before `init()` must fail loudly."""
+        from simpler.worker import Worker
+
+        worker = Worker(
+            level=3,
+            platform="a2a3sim",
+            runtime="tensormap_and_ringbuffer",
+            device_ids=[0, 1],
+            num_sub_workers=0,
+            chip_bootstrap_configs=_make_configs(2, "/tmp/pto_unused.bin"),
+        )
+        with pytest.raises(RuntimeError, match="after init"):
+            _ = worker.chip_contexts
+
+
+class TestWorkerBootstrapErrorPath:
+    def test_invalid_placement_fails_init_and_cleans_up(self):
+        """A ValueError inside bootstrap_context → parent RuntimeError → clean teardown."""
+        from simpler.task_interface import ChipBootstrapConfig, ChipBufferSpec, ChipCommBootstrapConfig
+        from simpler.worker import Worker
+
+        _sim_binaries()  # skip if runtime binaries are missing
+
+        rootinfo_path = f"/tmp/pto_worker_l6_sim_{os.getpid()}_err.bin"
+        nranks = 2
+
+        # Rank 0 carries a bogus placement, which trips the `placement != 'window'`
+        # guard inside `bootstrap_context` *before* any communicator work —
+        # no peer rank is required to observe the failure.  Rank 1 uses a
+        # valid config; it will either observe ERROR on rank 0 via the
+        # shared sim segment or be reaped by the abort path before it
+        # completes bootstrap.
+        bad = ChipBootstrapConfig(
+            comm=ChipCommBootstrapConfig(rank=0, nranks=nranks, rootinfo_path=rootinfo_path, window_size=4096),
+            buffers=[
+                ChipBufferSpec(name="x", dtype="float32", count=1, placement="bogus", nbytes=4),
+            ],
+        )
+        good = ChipBootstrapConfig(
+            comm=ChipCommBootstrapConfig(rank=1, nranks=nranks, rootinfo_path=rootinfo_path, window_size=4096),
+            buffers=[
+                ChipBufferSpec(name="x", dtype="float32", count=1, placement="window", nbytes=4),
+            ],
+        )
+
+        before = _shm_snapshot()
+
+        worker = Worker(
+            level=3,
+            platform="a2a3sim",
+            runtime="tensormap_and_ringbuffer",
+            device_ids=[0, 1],
+            num_sub_workers=0,
+            chip_bootstrap_configs=[bad, good],
+        )
+        with pytest.raises(RuntimeError, match="chip 0 bootstrap failed"):
+            worker.init()
+
+        # init() abort path must return the Worker to an uninitialised state.
+        assert worker._initialized is False
+        # close() on a failed init() is a no-op guard but must not raise.
+        worker.close()
+
+        try:
+            os.unlink(rootinfo_path)
+        except FileNotFoundError:
+            pass
+
+        after = _shm_snapshot()
+        if _shm_supported():
+            leaked = after - before
+            assert not leaked, f"/dev/shm segments leaked after init() failure: {sorted(leaked)}"
+
+
+class TestWorkerBootstrapValidation:
+    def test_level_below_3_rejected(self):
+        from simpler.worker import Worker
+
+        with pytest.raises(ValueError, match="level >= 3"):
+            Worker(
+                level=2,
+                platform="a2a3sim",
+                runtime="tensormap_and_ringbuffer",
+                device_id=0,
+                chip_bootstrap_configs=_make_configs(1, "/tmp/pto_unused.bin"),
+            )
+
+    def test_length_mismatch_rejected(self):
+        from simpler.worker import Worker
+
+        with pytest.raises(ValueError, match="must equal device_ids length"):
+            Worker(
+                level=3,
+                platform="a2a3sim",
+                runtime="tensormap_and_ringbuffer",
+                device_ids=[0, 1],
+                num_sub_workers=0,
+                chip_bootstrap_configs=_make_configs(1, "/tmp/pto_unused.bin"),
+            )


### PR DESCRIPTION
## Summary

Wires `ChipWorker.bootstrap_context` into the `Worker` factory so an L3 `Worker(level>=3, chip_bootstrap_configs=[...])` brings up every chip child's communicator during `init()` and surfaces a `ChipContext` list to orch code before the first `run()`.

> Note on terminology: the `L3` in the title refers to **runtime hierarchy Level 3** (chip-level `Worker`) — see `docs/hierarchical_level_runtime.md`. Earlier split commits (`#608`, `#610`) used `(L2)`/`(L5)` tags as split-step labels, which collides with the Level-0..Level-6 hierarchy; this PR drops those labels from new and touched code.

- **`ChipContext` dataclass** in `task_interface` — `device_id / rank / nranks / device_ctx / local_window_base / actual_window_size / buffer_ptrs: dict[str, int]`. The per-buffer dict is built by zipping `cfg.buffers` with the result's `buffer_ptrs`, so orch code addresses a named window slice without tracking list indices. A length check before the zip raises `RuntimeError` on a parent/child buffer-count mismatch instead of silently truncating.
- **Parent**: per-chip `ChipBootstrapChannel` mailbox (4096 B shared-memory, zero-filled so state starts IDLE) allocated pre-fork. Parent polls each channel with `time.sleep(0.001)` + 120 s soft timeout; on the first `ERROR` raises `RuntimeError(f"chip {idx} bootstrap failed: {channel.error_message}")` and best-effort SIGKILLs every forked child + unlinks every shm so `init()` raises cleanly without leaking state. `chip_contexts` is a property that raises before `init()`.
- **Child**: new `_chip_process_loop_with_bootstrap` runs `bootstrap_context` first (channel publishes `SUCCESS`/`ERROR`), then enters the same task/control poll loop as `_chip_process_loop`. `try/finally` runs `shutdown_bootstrap` then `finalize` on `SHUTDOWN`. Bootstrap failure returns via `os._exit(0)` so the parent's `waitpid` isn't confused by a non-zero exit code layered on top of the channel's error.
- **Teardown ordering**: `_worker.close()` → `SHUTDOWN` → `waitpid` → unlink sub/chip/next-level mailboxes → **bootstrap mailboxes unlinked last**, because chip children touch their `ChipBootstrapChannel` inside `shutdown_bootstrap()` + `finalize()`.
- The original `_chip_process_loop` and `_Worker` scheduler wiring are untouched; the bootstrap path is gated on a non-None `chip_bootstrap_configs` argument and runs eagerly at `init()` time instead of the usual lazy `_start_hierarchical()` on first `run()`.

Does not extend to level-4+ recursive `Worker` children — the `_next_level_workers` fork path is unchanged; adding distributed bring-up for nested Workers is a follow-up.

## Testing

- [x] `tests/ut/py/test_worker/test_worker_distributed_sim.py` — happy path + error path (bogus placement triggers `RuntimeError`) + `chip_contexts`-before-init guard + `__init__` validation (level<3 reject, length-mismatch reject).
- [x] `tests/ut/py/test_worker/test_worker_distributed_hw.py` — 2-card hardware smoke, drives `Worker(level=3, chip_bootstrap_configs=[...])` end-to-end, asserts each rank's `device_ctx != 0`, `local_window_base != 0`, `actual_window_size >= requested`, and `buffer_ptrs == {"x": local_window_base}`. No `comm_barrier` — HCCL 507018 stays off the critical path. Lives under `tests/ut` so the `ut-a2a3` job picks it up without xdist's per-worker device-slicing (which would break a 2-device request under `tests/st`).
- [x] `pytest tests/ut/py/test_worker` with `chip_bootstrap_configs=None` paths — 59 green, no regression.

Ref: #571 (split), builds on #608, #610.