### PR TITLE
CI: schedule ut-a5 hardware UT via task-submit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,8 @@ jobs:
           set +e
           source ${ASCEND_HOME_PATH}/bin/setenv.bash
           set -e
-          python -m pytest tests -m requires_hardware --platform a5 -v
+          DEVICE_LIST=$(python -c "s,e='${DEVICE_RANGE}'.split('-'); print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python -m pytest tests -m requires_hardware --platform a5 --device ${DEVICE_RANGE} -v"
 
       - name: Build and run C++ hardware unit tests (a5)
         run: |
@@ -425,7 +426,15 @@ jobs:
           set -e
           cmake -B tests/ut/cpp/build -S tests/ut/cpp -DSIMPLER_ENABLE_HARDWARE_TESTS=ON
           cmake --build tests/ut/cpp/build
-          ctest --test-dir tests/ut/cpp/build -L "^requires_hardware(_a5)?$" --output-on-failure
+          python3 -c "
+          import json, os
+          s, e = os.environ['DEVICE_RANGE'].split('-')
+          npus = [{'id': str(i), 'slots': 1} for i in range(int(s), int(e)+1)]
+          json.dump({'version': {'major': 1, 'minor': 0}, 'local': [{'npus': npus}]},
+                    open('tests/ut/cpp/build/resources.json', 'w'))
+          "
+          DEVICE_LIST=$(python -c "s,e='${DEVICE_RANGE}'.split('-'); print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a5)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure"
 
   st-onboard-a5:
     needs: detect-changes


### PR DESCRIPTION
## Summary

Mirror `st-onboard-a5`'s device-scheduling pattern so `ut-a5` also acquires its NPUs through `task-submit` instead of assuming the self-hosted runner owns the chips outright.

- **Python hardware UT step**: compute `DEVICE_LIST` from `DEVICE_RANGE` and run pytest under `task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "..."`. Also pass `--device ${DEVICE_RANGE}` to pytest itself, for parity with `ut-a2a3`.
- **C++ hardware UT step**: after `cmake --build` (no chip needed), emit `tests/ut/cpp/build/resources.json` describing the allocated NPUs (same snippet as `ut-a2a3`), then run `ctest` under `task-submit`, passing `--resource-spec-file` and `-j$(nproc)` so tests distribute across the scheduled chips.

Build/cmake stays outside `task-submit` — only test execution holds a chip lease.

## Testing

- [ ] `ut-a5` job runs cleanly on the a5 self-hosted runner with scheduler allocation visible in the `task-submit` log
- [ ] `st-onboard-a5` still passes (unchanged)