### PR TITLE
Add: UINT16 and UINT32 to DataType enum

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -56,7 +56,9 @@ NB_MODULE(_task_interface, m) {
         .value("UINT8", DataType::UINT8)
         .value("BFLOAT16", DataType::BFLOAT16)
         .value("INT64", DataType::INT64)
-        .value("UINT64", DataType::UINT64);
+        .value("UINT64", DataType::UINT64)
+        .value("UINT16", DataType::UINT16)
+        .value("UINT32", DataType::UINT32);
 
     // --- Free functions ---
     m.def(

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -110,6 +110,11 @@ def _ensure_torch_map():
         torch.bfloat16: DataType.BFLOAT16,
         torch.int64: DataType.INT64,
     }
+    # torch.uint16/uint32/uint64 were added in PyTorch 2.3; guard for older versions.
+    if hasattr(torch, "uint16"):
+        _TORCH_DTYPE_MAP[torch.uint16] = DataType.UINT16
+    if hasattr(torch, "uint32"):
+        _TORCH_DTYPE_MAP[torch.uint32] = DataType.UINT32
 
 
 def torch_dtype_to_datatype(dt) -> DataType:

--- a/src/common/task_interface/data_type.h
+++ b/src/common/task_interface/data_type.h
@@ -41,6 +41,8 @@ enum class DataType : uint8_t {
     BFLOAT16,  // 2 bytes
     INT64,     // 8 bytes
     UINT64,    // 8 bytes
+    UINT16,    // 2 bytes
+    UINT32,    // 4 bytes
     DATA_TYPE_NUM,
 };
 
@@ -64,6 +66,8 @@ inline uint64_t get_element_size(DataType dtype) {
         2,  // DataType::BFLOAT16
         8,  // DataType::INT64
         8,  // DataType::UINT64
+        2,  // DataType::UINT16
+        4,  // DataType::UINT32
     };
     return data_type_size[static_cast<int>(dtype)];
 }
@@ -94,6 +98,10 @@ inline const char *get_dtype_name(DataType dtype) {
         return "INT64";
     case DataType::UINT64:
         return "UINT64";
+    case DataType::UINT16:
+        return "UINT16";
+    case DataType::UINT32:
+        return "UINT32";
     default:
         return "UNKNOWN";
     }

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -44,6 +44,8 @@ class TestDataType:
         assert DataType.BFLOAT16 is not None
         assert DataType.INT64 is not None
         assert DataType.UINT64 is not None
+        assert DataType.UINT16 is not None
+        assert DataType.UINT32 is not None
 
     def test_enum_int_values(self):
         assert DataType.FLOAT32.value == 0
@@ -55,6 +57,8 @@ class TestDataType:
         assert DataType.BFLOAT16.value == 6
         assert DataType.INT64.value == 7
         assert DataType.UINT64.value == 8
+        assert DataType.UINT16.value == 9
+        assert DataType.UINT32.value == 10
 
 
 class TestGetElementSize:
@@ -70,6 +74,8 @@ class TestGetElementSize:
             (DataType.BFLOAT16, 2),
             (DataType.INT64, 8),
             (DataType.UINT64, 8),
+            (DataType.UINT16, 2),
+            (DataType.UINT32, 4),
         ],
     )
     def test_element_sizes(self, dtype, expected):
@@ -89,6 +95,8 @@ class TestGetDtypeName:
             (DataType.BFLOAT16, "BFLOAT16"),
             (DataType.INT64, "INT64"),
             (DataType.UINT64, "UINT64"),
+            (DataType.UINT16, "UINT16"),
+            (DataType.UINT32, "UINT32"),
         ],
     )
     def test_dtype_names(self, dtype, expected):


### PR DESCRIPTION
## Summary

- Append `UINT16` (2 bytes) and `UINT32` (4 bytes) to the `DataType` enum, `get_element_size` array, and `get_dtype_name` switch. Appended at the end (ordinals 9 and 10) to preserve existing enum values and on-wire ABI.
- Register both values in the nanobind `DataType` enum.
- Map `torch.uint16` / `torch.uint32` in `_TORCH_DTYPE_MAP`, guarded with `hasattr` for PyTorch <2.3 where these dtypes do not exist.
- Extend unit tests for enum values, element sizes, and dtype names.

## Motivation

The enum previously had `INT8/16/32/64` but only `UINT8` and `UINT64` — a gap at `UINT16` and `UINT32`. Adding both together keeps the unsigned/signed shapes symmetric, and the change is mechanically identical for both sizes. This unblocks tensors and examples that want to carry `uint32` (offsets, indices, packed quantization metadata) and `uint16`.

Out of scope — deferred to separate issues, since each carries semantic decisions beyond a plain integer-widening:

- `BOOL` (storage width choice)
- FP8 variants (`E4M3` / `E5M2`, sim compute path like #460)
- `INT4` / `UINT4` (sub-byte sizing API)

## Testing

- [x] 24 `DataType`-related Python unit tests pass (`pytest tests/ut/py/test_task_interface.py::TestDataType ::TestGetElementSize ::TestGetDtypeName`)
- [x] Spot check via nanobind binding — `DataType.UINT32.value == 10`, `get_element_size(DataType.UINT32) == 4`, `get_dtype_name(DataType.UINT32) == "UINT32"`
- [x] All pre-commit hooks pass locally (clang-format, clang-tidy, cpplint, ruff, pyright)
- [ ] CI simulation tests
- [ ] CI hardware tests