### PR TITLE
Support: add discipline and doc-consistency rules

### DIFF
--- a/.claude/rules/discipline.md
+++ b/.claude/rules/discipline.md
@@ -1,0 +1,40 @@
+# Working Discipline
+
+Repo-agnostic behavioral guidelines that complement the built-in simplicity
+and surgical-edit rules already in the system prompt. These target gaps the
+system prompt does not cover.
+
+## 1. State assumptions on ambiguous requests
+
+If a task has multiple reasonable interpretations, name them and pick one
+explicitly, or ask. Do not silently choose one and implement it — when the
+silent choice turns out wrong, the rework costs more than the clarification
+would have.
+
+- "Add validation" → ask which inputs and what failure mode (raise? return
+  an error? log?) before writing any code.
+- "Refactor X" → ask what the success condition is (same tests pass?
+  benchmark unchanged? API preserved?).
+- "Make it faster" → ask what "fast enough" means and how to measure.
+
+## 2. Match local style when editing
+
+Follow the conventions of the file you are touching, even if you would write
+it differently elsewhere. Do not reformat, rename, or refactor adjacent code
+that is not part of the request.
+
+- If surrounding code uses snake_case and yours uses camelCase, match the
+  file.
+- If unrelated dead code is next to your edit, mention it — do not delete
+  it as a drive-by.
+- Every changed line should trace directly back to the user's request.
+
+## 3. Bug fixes start with a failing repro
+
+For any defect that can be reproduced in code, write a test that fails
+against the current behavior first, confirm it fails, then make it pass.
+This guarantees the fix actually addresses the reported bug and leaves a
+regression barrier behind.
+
+Exceptions: infrastructure/build breakage where a test is impractical, or
+one-character typo fixes where the diff itself is the verification.

--- a/.claude/rules/doc-consistency.md
+++ b/.claude/rules/doc-consistency.md
@@ -1,0 +1,91 @@
+# Doc and Comment Consistency
+
+Keep code, comments, and docs in sync on every change. The most expensive
+kind of documentation is the kind that silently lies — a comment or a doc
+paragraph that was true once but now disagrees with the code will mislead
+future readers for years.
+
+This rule is a *consistency* obligation, not a *volume* obligation. It does
+not override the system-prompt defaults ("default to writing no comments",
+"do not create new documentation files unless explicitly requested"). It
+sharpens them: when you *do* modify something that is documented, update
+the documentation in the same change.
+
+## 1. Audit references before and after the change
+
+Before finishing any non-trivial code edit, grep the repo for references to
+the identifiers, flags, file paths, and behaviors you modified. Anything
+stale that results from your edit is part of your edit:
+
+```bash
+# Symbol rename, removal, or signature change
+rg '\bold_name\b' docs/ .claude/rules/ src/ python/ examples/ tests/
+
+# Flag / CLI option added, renamed, or removed
+rg -- '--old-flag' docs/ .github/workflows/ .claude/skills/ README.md
+```
+
+Each match is either already correct, or a doc/comment you must update in
+the same commit. Never leave rename-churn for "someone else."
+
+## 2. Prefer updating over creating
+
+- If a relevant doc already exists (e.g. `docs/testing.md`, `docs/ci.md`,
+  a `README.md`), extend it rather than writing a new file.
+- If code you changed is referenced only by a comment that is now wrong,
+  fix the comment — do not write a new doc.
+- Only create a new doc file when the user asks for one, or when the
+  change is genuinely unclassifiable under any existing doc.
+
+## 3. Delete docs and comments when their referent is gone
+
+If you remove a function, flag, config knob, or workflow step, remove the
+doc section and comments that described it. A "deprecated — see …" line is
+only appropriate when external callers still rely on the old name; inside
+this repo, remove the stale text outright.
+
+## 4. Update the *same* commit, not a follow-up
+
+The doc/comment fix lands in the commit that changes the code. Splitting
+them invites the doc update to get dropped on review, rebase, or context
+switch. If the doc change is large enough to warrant its own commit, it is
+large enough to flag to the user before shipping either half.
+
+## 5. Comments describe *why*, docs describe *contracts*
+
+- **Comments**: non-obvious invariants, workarounds, hidden constraints.
+  Not file-level summaries, not WHAT-it-does narration (see the
+  codestyle rule and the system prompt default).
+- **Docs**: public contracts, pipeline shapes, decision tables, command
+  recipes, architectural invariants. Anything a new contributor would
+  need to operate the repo without reading every file.
+
+A rule of thumb: if your change breaks nothing but a reader's mental model
+of the system, the fix is in docs. If your change breaks a specific
+subtle behavior that future edits could regress, the fix is in a code
+comment on the load-bearing line.
+
+## 6. Keep docs maintainable — length and structure
+
+Line length is already enforced by `markdownlint-cli2` (MD013, 80 cols) via
+pre-commit. The rules below are the file-level counterparts that tooling
+cannot enforce for you.
+
+- **Soft size target.** Past roughly **300 lines** or **5 H2 sections**,
+  the reader has to scroll to orient. Treat that as a trigger to split or
+  restructure, not as a hard cap — a 400-line reference table is fine;
+  a 400-line prose page is not.
+- **Landing doc plus focused subdocs beats a mega-doc.** When a topic
+  grows past the soft target, create focused children (`docs/topic.md`
+  → `docs/topic/<subtopic>.md`) and leave a short landing page that
+  links to them. One page per reader intent (tutorial / how-to /
+  reference / explanation) is the cleanest split.
+- **Restructure in the commit that triggers the overflow.** If your edit
+  pushes a file past the soft target, reorganize in the same commit —
+  do not leave "TODO: split this" for the next contributor. If the split
+  is too large to bundle, flag it to the user before shipping the code
+  change.
+- **A doc edit is also a structural review.** Every time you touch a
+  doc, ask whether any section now belongs under a different heading,
+  or whether two sections have merged into one topic. Move or merge
+  sections in the same diff; do not accumulate structural debt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ clang-format -i <file>
 
 ## Important Rules
 
-1. **Consult `.claude/rules/` for coding conventions** (architecture, codestyle, terminology) — these are always-loaded guidelines. **Consult `.claude/skills/` for task-specific workflows** (e.g., `git-commit/` when committing, `testing/` when running tests)
+1. **Consult `.claude/rules/` for coding conventions** (architecture, codestyle, terminology, [discipline](.claude/rules/discipline.md), [doc-consistency](.claude/rules/doc-consistency.md)) — these are always-loaded guidelines. **Consult `.claude/skills/` for task-specific workflows** (e.g., `git-commit/` when committing, `testing/` when running tests)
 2. **Do not modify directories outside your assigned area** unless the user explicitly requests it
 3. Create new subdirectories under your assigned directory as needed
 4. When in doubt, ask the user before making changes to other areas


### PR DESCRIPTION
## Summary

Two always-loaded behavioral rules under `.claude/rules/`, linked from `CLAUDE.md` alongside the existing architecture/codestyle/terminology pointers.

- **`.claude/rules/discipline.md`** — three gaps the built-in Claude Code system prompt does not cover:
  1. **State assumptions on ambiguous requests.** Name alternatives and pick one explicitly (or ask) — do not silently choose.
  2. **Match local style when editing.** Follow the conventions of the file you are touching; do not reformat / rename / refactor adjacent code unrelated to the request.
  3. **Bug fixes start with a failing repro.** For any reproducible defect, write the failing test first, confirm it fails, then make it pass.

  Points derived from Andrej Karpathy's [`CLAUDE.md` observations](https://github.com/forrestchang/andrej-karpathy-skills) with the items already covered by the system prompt ("no speculative features", "no abstractions for single-use", "no error handling for impossible scenarios") intentionally omitted to avoid duplication.

- **`.claude/rules/doc-consistency.md`** — six points on keeping comments, docs, and code in sync and maintainable:
  1. **Audit references before/after.** Grep for identifiers, flags, file paths, and behaviors you modified; stale references are part of your edit.
  2. **Prefer updating existing docs over creating new ones.** Reconciles with the system-prompt default "never create new documentation files unless asked".
  3. **Delete docs when their referent is gone** — no "deprecated" tombstones inside the repo.
  4. **Doc/comment fix lands in the same commit as the code change** — do not split and invite drop-on-rebase.
  5. **Comments describe *why*, docs describe *contracts*** — clarifies the boundary so they do not grow into each other.
  6. **Keep docs maintainable — length and structure.** Line length is already enforced by `markdownlint-cli2` (MD013, 80 cols) via pre-commit; the file-level counterparts tooling cannot enforce are captured here: a soft ~300 line / ~5 H2 trigger for restructuring, a preference for landing doc + focused subdocs over mega-docs, and a norm to reorganize in the commit that triggers overflow instead of leaving structural debt.

- **`CLAUDE.md`** — one line extended to link the two new rules from the "consult `.claude/rules/`" pointer.

## Testing

- [ ] Docs-only change — no code tests applicable.
- [ ] Rule files load alongside the existing four in future sessions (verified by CLAUDE.md link).