### PR TITLE
Refactor: move torch helpers to simpler_setup.torch_interop

### DIFF
--- a/examples/workers/l3/multi_chip_dispatch/main.py
+++ b/examples/workers/l3/multi_chip_dispatch/main.py
@@ -42,12 +42,12 @@ from simpler.task_interface import (
     CoreCallable,
     TaskArgs,
     TensorArgType,
-    make_tensor_arg,
 )
 from simpler.worker import Worker
 
 from simpler_setup.kernel_compiler import KernelCompiler
 from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup.torch_interop import make_tensor_arg
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,11 @@ version = "0.1.0"
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
-test = ["pytest>=6.0", "pytest-xdist>=3.0"]
+# ``torch>=2.3`` is required by ``simpler_setup.torch_interop`` (uses
+# ``torch.uint16`` / ``torch.uint32``, added in PyTorch 2.3). CI installs
+# torch via a custom index URL and does not rely on this pin; it is here
+# so ``pip install -e '.[test]'`` resolves a usable version for local devs.
+test = ["pytest>=6.0", "pytest-xdist>=3.0", "torch>=2.3"]
 
 [tool.ruff]
 line-length = 120

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -10,10 +10,13 @@
 """Public Python API for task_interface nanobind bindings.
 
 Re-exports the canonical C++ types (DataType, ContinuousTensor, ChipStorageTaskArgs,
-TaskArgs, TensorArgType) and adds torch-aware convenience helpers.
+TaskArgs, TensorArgType) plus ``scalar_to_uint64``. Torch-aware helpers
+(``make_tensor_arg``, ``torch_dtype_to_datatype``) live in
+``simpler_setup.torch_interop`` — this module has no torch dependency.
 
 Usage:
-    from task_interface import DataType, ContinuousTensor, ChipStorageTaskArgs, make_tensor_arg
+    from simpler.task_interface import DataType, ContinuousTensor, ChipStorageTaskArgs
+    from simpler_setup.torch_interop import make_tensor_arg
 """
 
 import ctypes
@@ -65,8 +68,6 @@ __all__ = [
     "ChipCallConfig",
     "ChipWorker",
     "arg_direction_name",
-    "torch_dtype_to_datatype",
-    "make_tensor_arg",
     "scalar_to_uint64",
     # Distributed runtime
     "WorkerType",
@@ -88,56 +89,6 @@ __all__ = [
     "ChipBootstrapConfig",
     "ChipBootstrapResult",
 ]
-
-
-# Lazy-loaded torch dtype → DataType map (avoids importing torch at module load)
-_TORCH_DTYPE_MAP = None
-
-
-def _ensure_torch_map():
-    global _TORCH_DTYPE_MAP
-    if _TORCH_DTYPE_MAP is not None:
-        return
-    import torch  # pyright: ignore[reportMissingImports]
-
-    _TORCH_DTYPE_MAP = {
-        torch.float32: DataType.FLOAT32,
-        torch.float16: DataType.FLOAT16,
-        torch.int32: DataType.INT32,
-        torch.int16: DataType.INT16,
-        torch.int8: DataType.INT8,
-        torch.uint8: DataType.UINT8,
-        torch.bfloat16: DataType.BFLOAT16,
-        torch.int64: DataType.INT64,
-    }
-    # torch.uint16/uint32/uint64 were added in PyTorch 2.3; guard for older versions.
-    if hasattr(torch, "uint16"):
-        _TORCH_DTYPE_MAP[torch.uint16] = DataType.UINT16
-    if hasattr(torch, "uint32"):
-        _TORCH_DTYPE_MAP[torch.uint32] = DataType.UINT32
-
-
-def torch_dtype_to_datatype(dt) -> DataType:
-    """Convert a ``torch.dtype`` to a ``DataType`` enum value.
-
-    Raises ``KeyError`` for unsupported dtypes.
-    """
-    _ensure_torch_map()
-    return _TORCH_DTYPE_MAP[dt]  # pyright: ignore[reportOptionalSubscript]
-
-
-def make_tensor_arg(tensor) -> ContinuousTensor:
-    """Create a ``ContinuousTensor`` from a torch.Tensor.
-
-    The tensor must be CPU-contiguous. Its ``data_ptr()``, shape, and dtype
-    are read and stored in the returned ``ContinuousTensor``.
-    """
-    _ensure_torch_map()
-    dt = _TORCH_DTYPE_MAP.get(tensor.dtype)  # pyright: ignore[reportOptionalMemberAccess]
-    if dt is None:
-        raise ValueError(f"Unsupported tensor dtype for ContinuousTensor: {tensor.dtype}")
-    shapes = tuple(int(s) for s in tensor.shape)
-    return ContinuousTensor.make(tensor.data_ptr(), shapes, dt)
 
 
 def scalar_to_uint64(value) -> int:

--- a/simpler_setup/__init__.py
+++ b/simpler_setup/__init__.py
@@ -14,6 +14,7 @@ from .platform_info import parse_platform
 from .pto_isa import ensure_pto_isa_root
 from .runtime_builder import RuntimeBuilder
 from .scene_test import CallableNamespace, Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from .torch_interop import make_tensor_arg, torch_dtype_to_datatype
 
 __all__ = [
     "CallableNamespace",
@@ -25,6 +26,8 @@ __all__ = [
     "TaskArgsBuilder",
     "ensure_pto_isa_root",
     "extract_text_section",
+    "make_tensor_arg",
     "parse_platform",
     "scene_test",
+    "torch_dtype_to_datatype",
 ]

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -212,9 +212,10 @@ def _build_chip_task_args(test_args: TaskArgsBuilder, orch_signature: list):
     from simpler.task_interface import (  # noqa: PLC0415
         ArgDirection,
         ChipStorageTaskArgs,
-        make_tensor_arg,
         scalar_to_uint64,
     )
+
+    from simpler_setup.torch_interop import make_tensor_arg  # noqa: PLC0415
 
     chip_args = ChipStorageTaskArgs()
     output_names: list[str] = []
@@ -254,9 +255,10 @@ def _build_l3_task_args(test_args: TaskArgsBuilder, orch_signature: list):
         ArgDirection,
         TaskArgs,
         TensorArgType,
-        make_tensor_arg,
         scalar_to_uint64,
     )
+
+    from simpler_setup.torch_interop import make_tensor_arg  # noqa: PLC0415
 
     _DIR_TO_TAG = {
         ArgDirection.IN: TensorArgType.INPUT,

--- a/simpler_setup/torch_interop.py
+++ b/simpler_setup/torch_interop.py
@@ -1,0 +1,84 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: PLW0603, PLC0415
+"""Torch integration helpers.
+
+Canonical home for torch-aware helpers that convert ``torch.Tensor`` and
+``torch.dtype`` values into the runtime's ``ContinuousTensor`` / ``DataType``
+types. These helpers live in ``simpler_setup`` (not ``simpler``) so that the
+stable ``simpler`` runtime API can remain torch-free; torch integration is a
+setup-time/test-framework concern.
+
+Callers:
+    from simpler_setup.torch_interop import make_tensor_arg, torch_dtype_to_datatype
+
+torch is imported lazily inside ``_ensure_torch_map`` so that importing this
+module does not force torch onto users who only touch ``simpler_setup`` for
+other reasons (e.g. ``RuntimeBuilder``). ``simpler.task_interface`` is also
+imported lazily because ``simpler_setup/__init__.py`` is executed during
+``pip install`` (via ``build_runtimes.py``), before the ``_task_interface``
+nanobind extension is built.
+
+Requires torch >= 2.3 (for ``torch.uint16`` / ``torch.uint32``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from simpler.task_interface import ContinuousTensor, DataType
+
+_TORCH_DTYPE_MAP = None
+
+
+def _ensure_torch_map():
+    global _TORCH_DTYPE_MAP
+    if _TORCH_DTYPE_MAP is not None:
+        return
+    import torch  # pyright: ignore[reportMissingImports]
+    from simpler.task_interface import DataType
+
+    _TORCH_DTYPE_MAP = {
+        torch.float32: DataType.FLOAT32,
+        torch.float16: DataType.FLOAT16,
+        torch.int32: DataType.INT32,
+        torch.int16: DataType.INT16,
+        torch.int8: DataType.INT8,
+        torch.uint8: DataType.UINT8,
+        torch.bfloat16: DataType.BFLOAT16,
+        torch.int64: DataType.INT64,
+        torch.uint16: DataType.UINT16,
+        torch.uint32: DataType.UINT32,
+    }
+
+
+def torch_dtype_to_datatype(dt) -> DataType:
+    """Convert a ``torch.dtype`` to a ``DataType`` enum value.
+
+    Raises ``KeyError`` for unsupported dtypes.
+    """
+    _ensure_torch_map()
+    return _TORCH_DTYPE_MAP[dt]  # pyright: ignore[reportOptionalSubscript]
+
+
+def make_tensor_arg(tensor) -> ContinuousTensor:
+    """Create a ``ContinuousTensor`` from a torch.Tensor.
+
+    The tensor must be CPU-contiguous. Its ``data_ptr()``, shape, and dtype
+    are read and stored in the returned ``ContinuousTensor``.
+    """
+    from simpler.task_interface import ContinuousTensor
+
+    _ensure_torch_map()
+    dt = _TORCH_DTYPE_MAP.get(tensor.dtype)  # pyright: ignore[reportOptionalMemberAccess]
+    if dt is None:
+        raise ValueError(f"Unsupported tensor dtype for ContinuousTensor: {tensor.dtype}")
+    shapes = tuple(int(s) for s in tensor.shape)
+    return ContinuousTensor.make(tensor.data_ptr(), shapes, dt)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_child_memory.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_child_memory.py
@@ -20,9 +20,9 @@ tensors and does not record them in tensor_pairs.
 
 import torch
 from simpler.task_interface import ArgDirection as D
-from simpler.task_interface import ContinuousTensor, DataType, TaskArgs, TensorArgType, make_tensor_arg
+from simpler.task_interface import ContinuousTensor, DataType, TaskArgs, TensorArgType
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, make_tensor_arg, scene_test
 
 KERNELS_BASE = "../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py
@@ -16,9 +16,9 @@ SubWorker reads result produced by ChipWorker.
 
 import torch
 from simpler.task_interface import ArgDirection as D
-from simpler.task_interface import TaskArgs, TensorArgType, make_tensor_arg
+from simpler.task_interface import TaskArgs, TensorArgType
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, make_tensor_arg, scene_test
 from simpler_setup.scene_test import _build_l3_task_args
 
 KERNELS_BASE = "../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py
@@ -17,9 +17,9 @@ group completion aggregation, downstream dependency waits for group.
 
 import torch
 from simpler.task_interface import ArgDirection as D
-from simpler.task_interface import TaskArgs, TensorArgType, make_tensor_arg
+from simpler.task_interface import TaskArgs, TensorArgType
 
-from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, make_tensor_arg, scene_test
 
 KERNELS_BASE = "../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
 

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -104,29 +104,40 @@ class TestGetDtypeName:
 
 
 # ============================================================================
-# task_interface.py wrapper (torch integration)
+# torch_interop (canonical torch-aware helpers) + scalar_to_uint64
 # ============================================================================
 
 
-class TestTaskInterfaceWrapper:
+class TestTorchInterop:
     def test_torch_dtype_to_datatype(self):
         import torch  # pyright: ignore[reportMissingImports]
-        from simpler.task_interface import torch_dtype_to_datatype
+
+        from simpler_setup.torch_interop import torch_dtype_to_datatype
 
         assert torch_dtype_to_datatype(torch.float32) == DataType.FLOAT32
         assert torch_dtype_to_datatype(torch.int8) == DataType.INT8
         assert torch_dtype_to_datatype(torch.bfloat16) == DataType.BFLOAT16
 
+    def test_torch_dtype_uint32(self):
+        import torch  # pyright: ignore[reportMissingImports]
+
+        from simpler_setup.torch_interop import torch_dtype_to_datatype
+
+        assert torch_dtype_to_datatype(torch.uint16) == DataType.UINT16
+        assert torch_dtype_to_datatype(torch.uint32) == DataType.UINT32
+
     def test_torch_dtype_unsupported(self):
         import torch  # pyright: ignore[reportMissingImports]
-        from simpler.task_interface import torch_dtype_to_datatype
+
+        from simpler_setup.torch_interop import torch_dtype_to_datatype
 
         with pytest.raises(KeyError):
             torch_dtype_to_datatype(torch.complex64)
 
     def test_make_tensor_arg(self):
         import torch  # pyright: ignore[reportMissingImports]
-        from simpler.task_interface import make_tensor_arg
+
+        from simpler_setup.torch_interop import make_tensor_arg
 
         t = torch.zeros(4, 8, dtype=torch.float32)
         arg = make_tensor_arg(t)
@@ -136,6 +147,8 @@ class TestTaskInterfaceWrapper:
         assert arg.dtype == DataType.FLOAT32
         assert arg.nbytes() == 4 * 8 * 4
 
+
+class TestScalarToUint64:
     def test_scalar_to_uint64_int(self):
         from simpler.task_interface import scalar_to_uint64
 


### PR DESCRIPTION
## Summary

Resolves #617 in a single pass. Move the torch-aware helpers out of `simpler.task_interface` into a new `simpler_setup/torch_interop.py` so the stable `simpler` runtime API stays torch-free both in practice and in spirit. `simpler_setup` already hosts torch-using modules (goldens, scene_test), so this consolidates torch integration in one package.

- New: `simpler_setup/torch_interop.py` — canonical home for `_TORCH_DTYPE_MAP`, `_ensure_torch_map`, `torch_dtype_to_datatype`, `make_tensor_arg`. The `hasattr(torch, "uint16/uint32")` guard introduced in #615 is dropped: this module is only imported by callers who already opted into torch, and torch >= 2.3 (which added those dtypes) is now the supported minimum for that opt-in path.
- `simpler_setup/__init__.py` — re-exports `make_tensor_arg` and `torch_dtype_to_datatype` so callers can use `from simpler_setup import make_tensor_arg`.
- `simpler.task_interface` — old definitions removed outright (no deprecation shim). All in-repo callers are migrated in the same commit, so a shim would protect no external consumer we haven't already covered; an honest `ImportError` beats a silent forward.
- Migrated in-repo callers: `simpler_setup/scene_test.py`, `examples/workers/l3/multi_chip_dispatch/main.py`, and the three `tests/st/a2a3/.../test_l3_*.py` scene tests.
- Unit tests reorganized into `TestTorchInterop` (new import). Added a `uint16`/`uint32` torch-dtype case now that the guard is gone.
- `pyproject.toml` — added `torch>=2.3` to `[project.optional-dependencies].test`. Declarative: CI continues installing torch via its custom index URL; this lets `pip install -e '.[test]'` resolve a usable version for local devs. Not added to `project.dependencies` because torch is not a `simpler` runtime dependency.

## Deviation from the two-phase plan in #617

The issue proposed Phase 1 (ship deprecation shims) → Phase 2 (remove shims one release later). An earlier revision of this PR implemented that literal plan. Deciding to collapse into one phase because:

- The refactor affects only in-repo callers (scene_test, 3 scene tests, 1 example). All are migrated atomically in the same commit.
- The `simpler` package is not released independently on PyPI; consumers build from source at pinned commits.
- An `ImportError` at the old path surfaces the move immediately; a `DeprecationWarning` that everyone filters out would just delay the fix.

If any external consumer does turn up and needs the old import, a follow-up commit restoring a shim is cheap.

## Testing

- [x] 93 non-torch unit tests pass locally (`pytest tests/ut/py/test_task_interface.py`, excluding `TestTorchInterop` which fails environmentally in the macOS / Python 3.14 venv due to no torch wheel — same failures exist on `main`).
- [x] `from simpler.task_interface import make_tensor_arg` now raises `ImportError` (verified).
- [x] `from simpler_setup.torch_interop import make_tensor_arg` and `from simpler_setup import make_tensor_arg` both work.
- [x] All pre-commit hooks pass locally (ruff, ruff-format, pyright).
- [ ] CI simulation tests (torch available on CI runners).
- [ ] CI scene tests cover the migrated `test_l3_*.py` imports.

Closes #617.