### PR TITLE
CI: add venv isolation to a5 hardware CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,14 +406,15 @@ jobs:
 
       - name: Set up environment
         run: |
-          set +e
-          source ${ASCEND_HOME_PATH}/bin/setenv.bash
-          set -e
+          python3 -m venv --system-site-packages .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
           pip install '.[test]'
 
       - name: Run Python hardware unit tests (a5)
         run: |
           set +e
+          source .venv/bin/activate
           source ${ASCEND_HOME_PATH}/bin/setenv.bash
           set -e
           DEVICE_LIST=$(python -c "s,e='${DEVICE_RANGE}'.split('-'); print(','.join(str(i) for i in range(int(s),int(e)+1)))")
@@ -422,6 +423,7 @@ jobs:
       - name: Build and run C++ hardware unit tests (a5)
         run: |
           set +e
+          source .venv/bin/activate
           source ${ASCEND_HOME_PATH}/bin/setenv.bash
           set -e
           cmake -B tests/ut/cpp/build -S tests/ut/cpp -DSIMPLER_ENABLE_HARDWARE_TESTS=ON
@@ -448,15 +450,15 @@ jobs:
 
       - name: Set up environment
         run: |
-          set +e
-          source ${ASCEND_HOME_PATH}/bin/setenv.bash
-          set -e
+          python3 -m venv --system-site-packages .venv
+          source .venv/bin/activate
           pip install --upgrade pip
           pip install '.[test]'
 
       - name: Run pytest scene tests (a5)
         run: |
           set +e
+          source .venv/bin/activate
           source ${ASCEND_HOME_PATH}/bin/setenv.bash
           set -e
           DEVICE_LIST=$(python -c "s,e='${DEVICE_RANGE}'.split('-'); print(','.join(str(i) for i in range(int(s),int(e)+1)))")


### PR DESCRIPTION
- Create project-local .venv with --system-site-packages in setup step
- Activate venv before pytest and cmake test steps
- Pass venv activation into task-submit command for scene tests
- Aligns a5 jobs with existing a2a3 venv pattern