### PR TITLE
Fix: drain output pipe at paged_attention kernel exit

### DIFF
--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -88,6 +88,9 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t *pij_raw, __gm__ uint8_t *v
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(oiGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -89,6 +89,9 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t *qi_raw, __gm__ uint8_t *kj
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
     TSTORE(sijGlobal, cTile);
+
+    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -222,6 +222,9 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
+
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -111,6 +111,9 @@ static __aicore__ void softmax_prepare_impl(
     TSTORE(mijGlobal, maxTile);
     TSTORE(lijGlobal, sumTile);
     TSTORE(pijGlobal, pijBf16Tile);
+
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID7);
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {


### PR DESCRIPTION
## Summary

The four `host_build_graph/paged_attention` kernels (`aic_qk_matmul`,
`aic_pv_matmul`, `aiv_softmax_prepare`, `aiv_online_update`) ended with
a final `TSTORE` and no trailing pipe-drain sync. On hardware MTE3/FIX
could still be in flight when the kernel signaled completion to AICPU,
letting the next dispatched kernel read stale GM and producing ~1.0
errors on intermediate blocks of `online_update` (observed as a flake).

The fix adds `set/wait_flag(PIPE_FIX|PIPE_MTE3, PIPE_MTE2, EVENT_ID7)`
after the final `TSTORE` on every exit path, matching the convention
already used by `mixed_example` and `alternating_matmul_add` kernels.

## Files changed

- `tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp`
- `tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp`
- `tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp`
- `tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp`

`aiv_online_update.cpp` has four exit paths (combinations of `is_first`
and `is_last`); the drain is placed after the outer `if/else` so it
covers all of them with a single sync.

## Testing

- [ ] Hardware run of `tests/st/a2a3/host_build_graph/paged_attention` to
      confirm the flake is gone (sim does not reproduce the race)
- [x] `pre-commit` hooks (clang-format, cpplint, check-headers) pass

## Notes

A repo-wide scan turned up no other kernels with a missing tail drain.
Seven `mixed_example`/`alternating_matmul_add` kernels use the same
`producer→PIPE_MTE2` drain idiom and were left unchanged on purpose.

Fix #588 