### PR TITLE
Fix: skip local ready buffer on PENDING dispatch to reduce same-thread re-claim

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -1125,7 +1125,7 @@ struct AicpuExecutor {
     }
 
     int pop_ready_tasks_batch(
-        PTO2ResourceShape shape, int32_t thread_idx, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out,
+        PTO2ResourceShape shape, int32_t thread_idx, PTO2LocalReadyBuffer *local_buf, PTO2TaskSlotState **out,
         int max_count
     ) {
 #if PTO2_SCHED_PROFILING
@@ -1354,9 +1354,11 @@ struct AicpuExecutor {
     // Dispatch tasks of a given shape during the specified phase (IDLE or PENDING).
     // IDLE: dispatches to idle cores, supports sync_start/drain, multi-block do-while.
     // PENDING: dispatches to pending slots of running cores, skips sync_start tasks.
+    // local_buf: pass nullptr for PENDING phase so tasks just released into the local buffer
+    //   are not immediately re-claimed by the same thread's pending slots.
     void dispatch_shape(
         Runtime *runtime, int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase,
-        PTO2LocalReadyBuffer &local_buf, CoreTracker &tracker, bool &entered_drain, bool &made_progress,
+        PTO2LocalReadyBuffer *local_buf, CoreTracker &tracker, bool &entered_drain, bool &made_progress,
         bool &try_pushed
     ) {
 #if PTO2_SCHED_PROFILING
@@ -2098,16 +2100,20 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         // === Two-phase dispatch: idle then pending ===
         for (int32_t si = 0; si < PTO2_NUM_RESOURCE_SHAPES && !entered_drain; si++) {
             PTO2ResourceShape shape = dispatch_order[si];
-#if PTO2_DISABLE_DUAL_ISSUE
-            for (auto phase : {CoreTracker::DispatchPhase::IDLE}) {
-#else
-            for (auto phase : {CoreTracker::DispatchPhase::IDLE, CoreTracker::DispatchPhase::PENDING}) {
+            auto &local_buf = local_bufs[static_cast<int32_t>(shape)];
+            // IDLE phase: pull from local buffer first, then global queue.
+            dispatch_shape(
+                runtime, thread_idx, shape, CoreTracker::DispatchPhase::IDLE, &local_buf, tracker, entered_drain,
+                made_progress, try_pushed
+            );
+#if !PTO2_DISABLE_DUAL_ISSUE
+            // PENDING phase: pass nullptr so tasks just released into the local buffer
+            //   are not immediately re-claimed by the same thread's pending slots.
+            dispatch_shape(
+                runtime, thread_idx, shape, CoreTracker::DispatchPhase::PENDING, nullptr, tracker, entered_drain,
+                made_progress, try_pushed
+            );
 #endif
-                dispatch_shape(
-                    runtime, thread_idx, shape, phase, local_bufs[static_cast<int32_t>(shape)], tracker, entered_drain,
-                    made_progress, try_pushed
-                );
-            }
         }
 
         // requeue in global ready queue

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_scheduler.h
@@ -806,11 +806,13 @@ struct PTO2SchedulerState {
 #endif
 
     int get_ready_tasks_batch(
-        PTO2ResourceShape shape, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out, int max_count
+        PTO2ResourceShape shape, PTO2LocalReadyBuffer *local_buf, PTO2TaskSlotState **out, int max_count
     ) {
         int count = 0;
-        while (count < max_count && local_buf.count > 0) {
-            out[count++] = local_buf.slot_states[--local_buf.count];
+        if (local_buf) {
+            while (count < max_count && local_buf->count > 0) {
+                out[count++] = local_buf->slot_states[--local_buf->count];
+            }
         }
         int remaining = max_count - count;
         if (remaining > 0) {
@@ -821,13 +823,15 @@ struct PTO2SchedulerState {
 
 #if PTO2_SCHED_PROFILING
     int get_ready_tasks_batch(
-        PTO2ResourceShape shape, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out, int max_count,
+        PTO2ResourceShape shape, PTO2LocalReadyBuffer *local_buf, PTO2TaskSlotState **out, int max_count,
         uint64_t &atomic_count, uint64_t &wait_cycle, uint64_t &local_dispatch_count
     ) {
         int count = 0;
-        while (count < max_count && local_buf.count > 0) {
-            local_dispatch_count++;
-            out[count++] = local_buf.slot_states[--local_buf.count];
+        if (local_buf) {
+            while (count < max_count && local_buf->count > 0) {
+                local_dispatch_count++;
+                out[count++] = local_buf->slot_states[--local_buf->count];
+            }
         }
         int remaining = max_count - count;
         if (remaining > 0) {


### PR DESCRIPTION
## Summary

- Add `skip_local` parameter to `PTO2SchedulerState::get_ready_tasks_batch()` and `AicpuExecutor::pop_ready_tasks_batch()`
- When a thread dispatches PENDING tasks (`is_pending == true`), it now passes `skip_local=true` to avoid immediately re-consuming tasks it just released into the local ready buffer
- This gives newly-released downstream tasks a window to be flushed to the global queue and picked up by other threads, preventing greedy same-thread re-claim

## Testing

- [x] All `tensormap_and_ringbuffer` L3 hardware tests passed (test_l3_child_memory, test_l3_group, test_l3_dependency)
- [x] Pre-commit hooks passed (check-headers, clang-format, clang-tidy, cpplint)