### PR TITLE
Add: pipe_sync helper and migrate all kernels

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -33,6 +33,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -105,11 +107,7 @@ static __aicore__ void gemm_tile_impl(__gm__ float *input_a, __gm__ float *input
 
     TSTORE(dstGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
-
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -31,6 +31,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -65,11 +67,7 @@ static __aicore__ void tile_add_impl(__gm__ float *c_ptr, __gm__ float *p_ptr) {
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(outGlobal, outTile);
-    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -25,6 +25,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -93,8 +95,7 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __g
 
     TSTORE(oiGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -25,6 +25,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -94,8 +96,7 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm
 
     TSTORE(sijGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -27,6 +27,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -229,8 +231,7 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -32,6 +32,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -128,8 +130,7 @@ static __aicore__ void softmax_prepare_impl(
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
     TSTORE(lijGlobal, sumTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_add.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/aiv/kernel_add.cpp
@@ -26,6 +26,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -84,6 +86,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp
@@ -26,6 +26,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -84,6 +86,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -28,6 +28,8 @@
 // NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -83,6 +85,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_mul.cpp
@@ -26,6 +26,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -84,6 +86,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -25,6 +25,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -93,8 +95,7 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __g
 
     TSTORE(oiGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -25,6 +25,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -94,8 +96,7 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm
 
     TSTORE(sijGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -27,6 +27,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -221,8 +223,7 @@ static __aicore__ void online_update_impl(
         }
     }
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -32,6 +32,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -121,8 +123,7 @@ static __aicore__ void softmax_prepare_impl(
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
     TSTORE(lijGlobal, sumTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/examples/workers/l2/vector_add/kernels/aiv/vector_add_kernel.cpp
+++ b/examples/workers/l2/vector_add/kernels/aiv/vector_add_kernel.cpp
@@ -26,6 +26,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -84,6 +86,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/examples/workers/l3/multi_chip_dispatch/kernels/aiv/vector_add_kernel.cpp
+++ b/examples/workers/l3/multi_chip_dispatch/kernels/aiv/vector_add_kernel.cpp
@@ -18,6 +18,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -64,6 +66,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/simpler_setup/incore/pipe_sync.h
+++ b/simpler_setup/incore/pipe_sync.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file pipe_sync.h
+ * @brief Kernel-exit pipe drain for AIC/AIV kernels.
+ *
+ * Call pipe_sync() once after the final TSTORE in a kernel impl. It drains the
+ * core's output pipe (FIX for AIC, MTE3 for AIV) onto the scalar pipe so the
+ * GM write fully completes before kernel exit. Without this drain, the next
+ * dispatched kernel can read stale GM and produce silent numerical errors.
+ *
+ * Usage prerequisite: this header does NOT pull in <pto/pto-inst.hpp>; it
+ * leaves PTO-ISA includes to the caller. The caller must already have done
+ *   #include <pto/pto-inst.hpp>
+ *   using namespace pto;
+ * before including pipe_sync.h, so that set_flag, wait_flag, PIPE_*, and
+ * EVENT_ID7 are visible at the point where pipe_sync() is parsed.
+ *
+ * Core-type selection uses the kernel toolchain's predefined macros:
+ *   __DAV_VEC__  → AIV build (TSTORE through MTE3)
+ *   __DAV_CUBE__ → AIC build (TSTORE through FIX)
+ * On hardware these are auto-defined by ccec from --cce-aicore-arch; in sim
+ * they are passed explicitly by Gxx15Toolchain (see simpler_setup/toolchain.py).
+ */
+
+#pragma once
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static __aicore__ inline void pipe_sync() {
+#if defined(__DAV_VEC__)
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+#elif defined(__DAV_CUBE__)
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+#else
+#error "pipe_sync.h requires __DAV_VEC__ or __DAV_CUBE__ to be defined"
+#endif
+}

--- a/simpler_setup/kernel_compiler.py
+++ b/simpler_setup/kernel_compiler.py
@@ -12,6 +12,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 from typing import Optional, Union
 
 from simpler import env_manager
@@ -119,6 +120,19 @@ class KernelCompiler:
         runtime_common_dir = str(self.project_root / "src" / arch / "runtime" / runtime_name / "common")
         common_dir = str(self.project_root / "src" / "common" / "task_interface")
         return [runtime_dir, runtime_common_dir, common_dir] + self.get_platform_include_dirs()
+
+    def get_incore_include_dirs(self) -> list[str]:
+        """
+        Include directories always on the incore (AICore/AIVector) kernel path.
+
+        These hold convenience headers used by user kernels (tests, examples)
+        — e.g. the pipe_sync helper at simpler_setup/incore/pipe_sync.h. They
+        are not framework code and are colocated with the build tooling that
+        exposes them. Both compile_incore and _compile_incore_sim prepend
+        these regardless of what extra_include_dirs the caller passes, so
+        kernels can include them without the call site knowing the dependency.
+        """
+        return [str(Path(__file__).resolve().parent / "incore")]
 
     def _get_orchestration_config(self, runtime_name: str) -> tuple[list[str], list[str]]:
         """
@@ -322,6 +336,9 @@ class KernelCompiler:
         cmd = [self.ccec.cxx_path] + self.ccec.get_compile_flags(core_type=core_type)
         cmd.extend([f"-I{pto_include}", f"-I{pto_pto_include}"])
 
+        for inc_dir in self.get_incore_include_dirs():
+            cmd.append(f"-I{os.path.abspath(inc_dir)}")
+
         if extra_include_dirs:
             for inc_dir in extra_include_dirs:
                 cmd.append(f"-I{os.path.abspath(inc_dir)}")
@@ -511,6 +528,9 @@ class KernelCompiler:
             pto_include = os.path.join(pto_isa_root, "include")
             pto_pto_include = os.path.join(pto_isa_root, "include", "pto")
             cmd.extend([f"-I{pto_include}", f"-I{pto_pto_include}"])
+
+        for inc_dir in self.get_incore_include_dirs():
+            cmd.append(f"-I{os.path.abspath(inc_dir)}")
 
         # Add extra include directories if provided
         if extra_include_dirs:

--- a/tests/st/a2a3/aicpu_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -29,6 +29,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -108,8 +110,7 @@ gemm_tile_impl(__gm__ Tensor *input_a_tensor, __gm__ Tensor *input_b_tensor, __g
 
     TSTORE(dstGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/aicpu_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -27,6 +27,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -69,6 +71,5 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(outGlobal, outTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -25,6 +25,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -93,8 +95,7 @@ static __aicore__ void pv_matmul_impl(__gm__ Tensor *pij, __gm__ Tensor *vj, __g
 
     TSTORE(oiGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -25,6 +25,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -94,8 +96,7 @@ static __aicore__ void qk_matmul_impl(__gm__ Tensor *qi, __gm__ Tensor *kj, __gm
 
     TSTORE(sijGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -27,6 +27,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -229,8 +231,7 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -32,6 +32,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -128,8 +130,7 @@ static __aicore__ void softmax_prepare_impl(
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
     TSTORE(lijGlobal, sumTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -36,6 +36,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -126,8 +128,7 @@ static __aicore__ void pv_matmul_n_impl(
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     TSTORE(oiGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -33,6 +33,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -101,8 +103,7 @@ static __aicore__ void qk_matmul_n_impl(
             pipe_barrier(PIPE_ALL);
         }
     }
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -27,6 +27,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -229,8 +231,7 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -37,6 +37,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -229,8 +231,7 @@ static __aicore__ void softmax_prepare_n_impl(
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(lijGlobalDN, sumDN);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_add.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_add.cpp
@@ -21,6 +21,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -67,6 +69,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -21,6 +21,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -68,6 +70,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
@@ -21,6 +21,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -67,6 +69,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
+++ b/tests/st/a2a3/host_build_graph/bgemm/kernels/aic/kernel_gemm_tile.cpp
@@ -22,6 +22,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -98,6 +100,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     TSTORE(dstGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/host_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
+++ b/tests/st/a2a3/host_build_graph/bgemm/kernels/aiv/kernel_tile_add.cpp
@@ -21,6 +21,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -61,6 +63,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(outGlobal, outTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/host_build_graph/dump_tensor/kernels/aiv/kernel_add.cpp
+++ b/tests/st/a2a3/host_build_graph/dump_tensor/kernels/aiv/kernel_add.cpp
@@ -14,6 +14,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -57,6 +59,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/host_build_graph/dump_tensor/kernels/aiv/kernel_add_scalar_inplace.cpp
+++ b/tests/st/a2a3/host_build_graph/dump_tensor/kernels/aiv/kernel_add_scalar_inplace.cpp
@@ -14,6 +14,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -57,6 +59,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(inoutGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/host_build_graph/matmul/kernels/aic/kernel_matmul.cpp
+++ b/tests/st/a2a3/host_build_graph/matmul/kernels/aic/kernel_matmul.cpp
@@ -23,6 +23,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -114,6 +116,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // TSTORE: Store result to GM
     TSTORE(dstGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/host_build_graph/matmul/kernels/aiv/kernel_add_exp.cpp
+++ b/tests/st/a2a3/host_build_graph/matmul/kernels/aiv/kernel_add_exp.cpp
@@ -22,6 +22,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -82,6 +84,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/host_build_graph/matmul/kernels/aiv/kernel_log_sqrt.cpp
+++ b/tests/st/a2a3/host_build_graph/matmul/kernels/aiv/kernel_log_sqrt.cpp
@@ -22,6 +22,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -76,6 +78,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -23,6 +23,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -89,8 +91,7 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t *pij_raw, __gm__ uint8_t *v
 
     TSTORE(oiGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -23,6 +23,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -90,8 +92,7 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t *qi_raw, __gm__ uint8_t *kj
 
     TSTORE(sijGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -25,6 +25,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -223,8 +225,7 @@ static __aicore__ void online_update_impl(
         }
     }
 
-    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -30,6 +30,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -112,8 +114,7 @@ static __aicore__ void softmax_prepare_impl(
     TSTORE(lijGlobal, sumTile);
     TSTORE(pijGlobal, pijBf16Tile);
 
-    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add.cpp
+++ b/tests/st/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add.cpp
@@ -24,6 +24,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -80,6 +82,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
+++ b/tests/st/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_add_scalar.cpp
@@ -24,6 +24,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -84,6 +86,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
+++ b/tests/st/a2a3/host_build_graph/vector_example/kernels/aiv/kernel_mul.cpp
@@ -24,6 +24,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -80,6 +82,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aic/kernel_matmul.cpp
@@ -29,6 +29,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -106,8 +108,7 @@ static __aicore__ void matmul_impl(__gm__ float *input_a, __gm__ float *input_b,
 
     TSTORE(dstGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/aiv/kernel_add.cpp
@@ -27,6 +27,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -66,8 +68,7 @@ static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -28,6 +28,8 @@
 // NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -103,8 +105,7 @@ static __aicore__ void pv_matmul_batch_impl(
         }
     }
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -28,6 +28,8 @@
 // NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -105,8 +107,7 @@ static __aicore__ void qk_matmul_batch_impl(
         }
     }
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -31,6 +31,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -188,8 +190,7 @@ static __aicore__ void online_update_batch_impl(
         }
     }
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -32,6 +32,8 @@
 // NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -160,8 +162,7 @@ static __aicore__ void softmax_prepare_batch_impl(
         }
     }
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
@@ -29,6 +29,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -106,8 +108,7 @@ static __aicore__ void matmul_impl(__gm__ float *input_a, __gm__ float *input_b,
 
     TSTORE(dstGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
@@ -30,6 +30,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -69,8 +71,7 @@ static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
@@ -29,6 +29,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -63,8 +65,7 @@ static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
@@ -31,6 +31,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -70,8 +72,7 @@ static __aicore__ void mul_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
@@ -29,6 +29,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -63,8 +65,7 @@ static __aicore__ void mul_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
-    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -42,6 +42,8 @@
 // NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -140,8 +142,7 @@ static __aicore__ void pv_matmul_n_impl(
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     TSTORE(oiGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -37,6 +37,8 @@
 // NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -128,8 +130,7 @@ static __aicore__ void qk_matmul_n_impl(
             pipe_barrier(PIPE_ALL);
         }
     }
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -27,6 +27,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -230,8 +232,7 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -37,6 +37,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -259,8 +261,7 @@ static __aicore__ void softmax_prepare_n_impl(
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(lijGlobalDN, sumDN);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_pv_matmul.cpp
@@ -40,6 +40,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -147,8 +149,7 @@ static __aicore__ void pv_matmul_n_impl(
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     TSTORE(oiGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_qk_matmul.cpp
@@ -34,6 +34,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -111,8 +113,7 @@ static __aicore__ void qk_matmul_n_impl(
             pipe_barrier(PIPE_ALL);
         }
     }
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aiv/aiv_online_update.cpp
@@ -28,6 +28,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -236,8 +238,7 @@ static __aicore__ void online_update_impl(
             TSTORE(oiGlobal, oiTile);
         }
     }
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aiv/aiv_softmax_prepare.cpp
@@ -38,6 +38,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -247,8 +249,7 @@ static __aicore__ void softmax_prepare_n_impl(
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(lijGlobalDN, sumDN);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/host_build_graph/dump_tensor/kernels/aiv/kernel_add.cpp
+++ b/tests/st/a5/host_build_graph/dump_tensor/kernels/aiv/kernel_add.cpp
@@ -14,6 +14,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -57,6 +59,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a5/host_build_graph/dump_tensor/kernels/aiv/kernel_add_scalar_inplace.cpp
+++ b/tests/st/a5/host_build_graph/dump_tensor/kernels/aiv/kernel_add_scalar_inplace.cpp
@@ -14,6 +14,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -57,6 +59,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(inoutGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -23,6 +23,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -89,8 +91,7 @@ static __aicore__ void pv_matmul_impl(__gm__ uint8_t *pij_raw, __gm__ uint8_t *v
 
     TSTORE(oiGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -23,6 +23,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -90,8 +92,7 @@ static __aicore__ void qk_matmul_impl(__gm__ uint8_t *qi_raw, __gm__ uint8_t *kj
 
     TSTORE(sijGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -25,6 +25,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -214,8 +216,7 @@ static __aicore__ void online_update_impl(
         }
     }
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -30,6 +30,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -111,8 +113,7 @@ static __aicore__ void softmax_prepare_impl(
     TSTORE(lijGlobal, sumTile);
     TSTORE(pijGlobal, pijBf16Tile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/aic/kernel_matmul.cpp
@@ -30,6 +30,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -107,8 +109,7 @@ static __aicore__ void matmul_impl(__gm__ float *input_a, __gm__ float *input_b,
 
     TSTORE(dstGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add.cpp
@@ -31,6 +31,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -71,8 +73,7 @@ static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_add_standalone.cpp
@@ -30,6 +30,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -65,8 +67,7 @@ static __aicore__ void add_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul.cpp
@@ -32,6 +32,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -72,8 +74,7 @@ static __aicore__ void mul_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/aiv/kernel_mul_standalone.cpp
@@ -30,6 +30,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -65,8 +67,7 @@ static __aicore__ void mul_impl(__gm__ float *src0, __gm__ float *src1, __gm__ f
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(dstGlobal, dstTile);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -41,6 +41,8 @@
 // NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -139,8 +141,7 @@ static __aicore__ void pv_matmul_n_impl(
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     TSTORE(oiGlobal, cTile);
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -35,6 +35,8 @@
 // NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -104,8 +106,7 @@ static __aicore__ void qk_matmul_n_impl(
         }
     }
 
-    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -27,6 +27,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -221,8 +223,7 @@ static __aicore__ void online_update_impl(
         }
     }
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_softmax_prepare.cpp
@@ -37,6 +37,8 @@
 
 using namespace pto;
 
+#include "pipe_sync.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -222,8 +224,7 @@ static __aicore__ void softmax_prepare_n_impl(
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     TSTORE(lijGlobalDN, sumDN);
 
-    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
-    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    pipe_sync();
 }
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {

--- a/tools/verify_packaging.sh
+++ b/tools/verify_packaging.sh
@@ -45,6 +45,7 @@ smoke() {
     local mode="$1"
     echo "::group::[${mode}] import surface"
     python -c "
+import os
 import simpler, simpler_setup
 from simpler.worker import Worker
 from simpler.task_interface import ChipWorker
@@ -58,6 +59,14 @@ from simpler_setup.scene_test import SceneTestCase, scene_test
 from simpler_setup.goldens.paged_attention import generate_inputs, compute_golden
 print('simpler:', simpler.__file__)
 print('simpler_setup:', simpler_setup.__file__)
+# Verify shipped kernel-side helpers are reachable on the incore include path.
+# A wheel that misses these data files would fall through to a cryptic kernel
+# compilation error; this catches it at smoke time.
+inc_dirs = KernelCompiler('a2a3sim').get_incore_include_dirs()
+for d in inc_dirs:
+    h = os.path.join(d, 'pipe_sync.h')
+    assert os.path.isfile(h), 'incore helper not shipped: ' + h
+print('incore helpers OK:', inc_dirs)
 "
     echo "::endgroup::"
     echo "::group::[${mode}] standalone test_*.py --help"


### PR DESCRIPTION
## Summary

Introduces \`src/common/incore/pipe_sync.h\` — an inline helper \`pipe_sync()\`
that drains the core's output pipe (FIX for AIC, MTE3 for AIV) onto
\`PIPE_S\` so the GM write completes before kernel exit. Selection between
AIC and AIV is preprocess-time via \`__DAV_VEC__\` / \`__DAV_CUBE__\`, which
the kernel toolchain already defines (ccec auto-defines from
\`--cce-aicore-arch\`; \`Gxx15Toolchain\` passes \`-D__DAV_VEC__\` /
\`-D__DAV_CUBE__\` explicitly for sim).

The helper is plumbed onto the kernel include path via a new
\`KernelCompiler.get_incore_include_dirs()\` that both \`compile_incore\`
(ccec) and \`_compile_incore_sim\` (g++-15) prepend onto every kernel
build's \`-I\` list.

Then **every AIC/AIV kernel in the repo with a TSTORE-based exit drain**
is migrated to call \`pipe_sync()\` instead of writing the drain pair by
hand. Coverage:

- paged_attention: 4 \`host_build_graph\` (the ones #620 fixed) + 36 across
  \`examples/\`, \`aicpu_build_graph/\`, \`tensormap_and_ringbuffer/\`
  (unroll, unroll_4dims, batch), and a5 variants
- mixed_example (a2a3 + a5), alternating_matmul_add, dump_tensor (a2a3 +
  a5), vector_example (3 dirs), matmul, bgemm (host + aicpu),
  benchmark_bgemm, scalar_data_test, vector_add, multi_chip_dispatch

77 kernel files in total now call \`pipe_sync()\`. The 7 a2a3
\`mixed_example\` / \`alternating_matmul_add\` kernels previously drained
through \`→ PIPE_MTE2\` (loop-iter ordering) instead of \`→ PIPE_S\`;
switching them to \`pipe_sync()\` aligns them with the rest of the repo
and adds the explicit kernel-exit drain they did not have.

## Header design notes

- Does **not** include \`<pto/pto-inst.hpp>\` — that header is owned by
  upstream PTO-ISA. Callers already include it for \`TSTORE\` /
  \`set_flag\` / etc. The contract is: include \`pipe_sync.h\` after
  \`using namespace pto;\` so unqualified \`set_flag\` / \`PIPE_*\` /
  \`EVENT_ID7\` in the helper body resolve. Documented in the header.
- No namespace wrap. Matches the existing precedent in
  \`src/{arch}/runtime/tensormap_and_ringbuffer/common/intrinsic.h\`,
  which also declares its kernel-side helpers at file scope.
- \`#error\` fallback if neither \`__DAV_VEC__\` nor \`__DAV_CUBE__\` is
  defined.

## Files

- \`src/common/incore/pipe_sync.h\` — new helper (51 lines)
- \`simpler_setup/kernel_compiler.py\` — new \`get_incore_include_dirs()\`,
  hooked into both compile_incore paths
- 77 kernel \`.cpp\` files — drop raw drain, call \`pipe_sync()\`

## Testing

- [ ] Hardware re-run on a2a3 + a5 to confirm all 77 migrated kernels
      still drain correctly through the helper (sim does not reproduce
      the inter-kernel race the helper exists to fix)
- [x] Pre-commit hooks (clang-format, clang-tidy, cpplint, check-headers,
      pyright, ruff) all pass locally