### PR TITLE
Fix: align a5 paged_attention online_update dispatch with a2a3

### DIFF
--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -232,7 +232,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     int q_tile_size = static_cast<int>(args[9]);
     int head_dim = static_cast<int>(args[10]);
 
-    if (q_tile_size == 16 && head_dim <= 16) {
+    if (q_tile_size == 16 && head_dim == 16) {
         online_update_impl<16, 16>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);


### PR DESCRIPTION
## Summary

The \`online_update\` kernel_entry on a5 dispatched to the small
\`<16, 16>\` template when \`q_tile_size == 16 && head_dim <= 16\`, while
the a2a3 version uses \`head_dim == 16\`. Only \`head_dim\` values 16 and
128 are exercised in test cases, so in practice \`<=\` covered the same
single value as \`==\` — but if a future caller passed \`head_dim < 16\`,
a5 would silently route to a tile shape (N=16) that doesn't match the
real data layout, while a2a3 would fall through to the next branch.

Tighten the condition to \`== 16\` so the dispatch is unambiguous and the
two arches stay in sync.

## Files

- \`tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp\`
  — single-character condition fix

## Testing

- [ ] \`pytest tests/st/a5/host_build_graph/paged_attention --platform a5sim\`
      (functionally a no-op, but verifies the existing test cases still pass
      after tightening the condition)
- [x] Pre-commit hooks (clang-format, cpplint, check-headers) pass