### PR TITLE
Fix: release SceneTestCase ChipCallable cache at session end

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -667,6 +667,24 @@ def pytest_runtestloop(session):
     return _dispatch_test_phases(session)
 
 
+def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
+    """Drop session-lifetime nanobind references before interpreter shutdown.
+
+    ``simpler_setup.scene_test._compile_cache`` accumulates one
+    ``ChipCallable`` per ``SceneTestCase`` compiled during the run. At
+    interpreter exit the order in which Python clears module globals
+    versus the nanobind module destructor is undefined, which on macOS
+    surfaces as ``nanobind: leaked N instances of type
+    _task_interface.ChipCallable`` on stderr. Clearing the cache here
+    (session scope ends after every fixture teardown, including the L2
+    worker pool) lets those instances die while nanobind is still
+    available.
+    """
+    from simpler_setup.scene_test import clear_compile_cache  # noqa: PLC0415
+
+    clear_compile_cache()
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -22,6 +22,7 @@ A scene test class declares three things:
 
 from __future__ import annotations
 
+import gc
 import inspect
 import logging
 import os
@@ -36,6 +37,21 @@ from .pto_isa import ensure_pto_isa_root
 logger = logging.getLogger(__name__)
 
 _compile_cache: dict[tuple[str, str, str], object] = {}
+
+
+def clear_compile_cache() -> None:
+    """Drop every cached ``ChipCallable`` and force a GC pass.
+
+    The cache keeps nanobind-owned ``ChipCallable`` instances alive for the
+    whole pytest session. Module-level dicts are cleared by Python in an
+    order that can outlive the nanobind module destructor, which then
+    prints ``leaked N instances of type _task_interface.ChipCallable`` to
+    stderr at interpreter shutdown. Call this from ``pytest_sessionfinish``
+    (and other session-end paths) so the instances die while the nanobind
+    module is still wired up.
+    """
+    _compile_cache.clear()
+    gc.collect()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/py/test_scene_test_cache.py
+++ b/tests/ut/py/test_scene_test_cache.py
@@ -1,0 +1,69 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: PLC0415
+"""Regression: SceneTestCase compile cache must release its ChipCallables.
+
+The session-lifetime ``_compile_cache`` in ``simpler_setup.scene_test`` used
+to hold every compiled ``ChipCallable`` until Python interpreter shutdown.
+At shutdown the nanobind module destructor can run before module globals
+are cleared, which surfaces as ``nanobind: leaked N instances of type
+_task_interface.ChipCallable`` on stderr. ``clear_compile_cache`` (invoked
+from ``pytest_sessionfinish``) drops the cache and forces GC so those
+instances die while the extension is still live.
+"""
+
+from __future__ import annotations
+
+import gc
+
+from _task_interface import ArgDirection, ChipCallable  # pyright: ignore[reportMissingImports]
+
+# ``simpler_setup/__init__.py`` re-exports the ``scene_test`` *decorator*,
+# which shadows the submodule attribute when accessed via ``simpler_setup``.
+# Importing the names directly from the submodule avoids that ambiguity.
+from simpler_setup.scene_test import _compile_cache, clear_compile_cache
+
+
+def _build_chip_callable(tag: str) -> ChipCallable:
+    return ChipCallable.build(
+        signature=[ArgDirection.IN],
+        func_name=tag,
+        binary=b"\x00" * 16,
+        children=[],
+    )
+
+
+def test_clear_compile_cache_drops_cached_chip_callables():
+    """clear_compile_cache empties the dict so nanobind instances can die."""
+    _compile_cache.clear()
+    for i in range(3):
+        _compile_cache[("t", "plat", f"rt{i}")] = _build_chip_callable(f"n{i}")
+    assert len(_compile_cache) == 3
+
+    clear_compile_cache()
+
+    assert _compile_cache == {}
+
+
+def test_clear_compile_cache_releases_chip_callable_refs():
+    """After clear, the cache must no longer appear in a ChipCallable's referrers.
+
+    Guards against future refactors that cache ChipCallables anywhere else
+    (class attribute, session-scoped fixture that survives sessionfinish,
+    etc.): if a new holder is introduced, this test fails at the second
+    ``get_referrers`` assertion.
+    """
+    _compile_cache.clear()
+    cc = _build_chip_callable("refcount_probe")
+    _compile_cache[("t", "plat", "rt")] = cc
+    assert _compile_cache in gc.get_referrers(cc)
+
+    clear_compile_cache()
+
+    assert _compile_cache not in gc.get_referrers(cc)


### PR DESCRIPTION
## Summary

- ``simpler_setup.scene_test._compile_cache`` held one nanobind-owned ``ChipCallable`` per compiled ``SceneTestCase`` for the whole pytest session. At interpreter exit the order in which Python clears module globals vs. the nanobind module destructor is undefined, which on macOS surfaces as ``nanobind: leaked N instances of type _task_interface.ChipCallable`` on stderr — most visibly in the ``st-sim-a2a3 (macos-latest, 3.10)`` job.
- Add ``clear_compile_cache()`` in ``simpler_setup/scene_test.py`` and invoke it from a new ``pytest_sessionfinish`` hook in ``conftest.py``, after every session-scoped fixture (including ``_l2_worker_pool``) has torn down — so the cached instances die while the nanobind module is still wired up.
- Add a UT (``tests/ut/py/test_scene_test_cache.py``) asserting the cache empties and the cache dict is no longer a referrer of a cached ``ChipCallable``. Guards against future refactors that reintroduce a module- or class-level ``ChipCallable`` holder.

## Testing

- [x] `tests/ut/py/test_scene_test_cache.py` — 2/2 pass
- [x] `tests/ut/py/test_task_interface.py` — 97/97 pass
- [ ] CI `st-sim-a2a3 (macos-latest, 3.10)` must no longer print ``nanobind: leaked ... ChipCallable`` lines

## Notes

Other nanobind registry warnings (``leaked types``, ``leaked functions``) are not addressed here — those trigger during incomplete interpreter teardown and are documented as expected at <https://nanobind.readthedocs.io/en/latest/refleaks.html>.