### PR TITLE
Support: add a2a3 PMU profiling path

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -118,6 +118,16 @@ def pytest_addoption(parser):
         "--enable-profiling", action="store_true", default=False, help="Enable profiling (first round only)"
     )
     parser.addoption("--dump-tensor", action="store_true", default=False, help="Dump per-task tensor I/O at runtime")
+    parser.addoption(
+        "--enable-pmu",
+        nargs="?",
+        const=2,
+        default=0,
+        type=int,
+        metavar="EVENT_TYPE",
+        help="Enable PMU collection. Bare flag = PIPE_UTILIZATION(2). "
+        "Pass event type to override (e.g. --enable-pmu 4)",
+    )
     parser.addoption("--build", action="store_true", default=False, help="Compile runtime from source")
     parser.addoption(
         "--pto-isa-commit",

--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -118,7 +118,7 @@ size_t size = get_runtime_size();
 run_runtime(ctx, runtime, callable, args, block_dim,
             aicpu_thread_num, device_id,
             aicpu_binary, aicpu_size, aicore_binary, aicore_size,
-            enable_profiling);
+            enable_profiling, enable_dump_tensor, enable_pmu);
 finalize_device(ctx);
 destroy_device_context(ctx);
 ```
@@ -135,6 +135,7 @@ worker.set_device(device_id)
 config = ChipCallConfig()
 config.block_dim = 24
 config.aicpu_thread_num = 3
+config.enable_pmu = 0
 worker.run(callable, args, config)
 worker.finalize()
 ```

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -29,7 +29,7 @@ Every task flowing through any level carries exactly three pieces of data:
 | ------ | ---- | ---------- |
 | `Callable` | `uint64_t` (opaque) | What the target worker should execute — interpretation depends on the receiving `IWorker` subclass |
 | `TaskArgs` | user builder class | Tensors + scalars + per-tensor tags (IN/OUT/INOUT/etc.) |
-| `CallConfig` | small POD | Execution knobs (block_dim, aicpu_thread_num, enable_profiling, …) |
+| `CallConfig` | small POD | Execution knobs (block_dim, aicpu_thread_num, profiling/dump/PMU flags, …) |
 
 Everything else in the engine is either plumbing (slots, ring, tensormap,
 scheduler) or per-kernel state (stored in `Callable`).
@@ -186,7 +186,9 @@ struct CallConfig {
     int32_t block_dim = 1;
     int32_t aicpu_thread_num = 3;
     bool    enable_profiling = false;
-    // future fields here — same POD used at all levels
+    bool    enable_dump_tensor = false;
+    int32_t enable_pmu = 0;
+    // future fields here - same POD used at all levels
 };
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -78,6 +78,7 @@ Scene tests support advanced CLI options for benchmarking, profiling, and runtim
 pytest --platform a2a3sim                                        # default: 1 round + golden
 pytest --platform a2a3 --rounds 100 --skip-golden                # benchmark mode
 pytest --platform a2a3 --enable-profiling                        # profiling (first round)
+pytest --platform a2a3 --enable-pmu                              # PMU CSV (LuoPan)
 pytest --platform a2a3sim --build                                # compile runtime from source
 pytest --platform a2a3sim --log-level debug                        # verbose C++ logging
 ```
@@ -89,6 +90,7 @@ python test_xxx.py -p a2a3sim                                    # default: 1 ro
 python test_xxx.py -p a2a3 -d 0 --rounds 100 --skip-golden       # benchmark mode
 python test_xxx.py -p a2a3 --enable-profiling                    # profiling (first round)
 python test_xxx.py -p a2a3 --dump-tensor                         # dump per-task tensor I/O
+python test_xxx.py -p a2a3 --enable-pmu 4                        # PMU CSV (MEMORY)
 python test_xxx.py -p a2a3sim --build                            # compile runtime from source
 python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ logging
 ```
@@ -107,6 +109,7 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 | `--skip-golden` | | false | Skip golden comparison (for benchmarking) |
 | `--enable-profiling` | | false | Enable profiling on first round only. Works under parallelism — each subprocess writes to its own `outputs/perf_*/` subdir, flattened back to `outputs/` on completion. |
 | `--dump-tensor` | | false | Dump per-task tensor I/O during runtime execution |
+| `--enable-pmu [EVENT_TYPE]` | | `0` | Enable a2a3 PMU CSV collection. Bare flag selects `PIPE_UTILIZATION` (`2`); pass an event type such as `4` for `MEMORY`. |
 | `--build` | | false | Compile runtime from source (not pre-built) |
 | `--exitfirst` | `-x` | false | Stop on first failing test (fail-fast, primarily for CI) |
 | `--log-level LEVEL` | | (none) | Set `PTO_LOG_LEVEL` env var (`error`/`warn`/`info`/`debug`) |
@@ -130,7 +133,7 @@ Worked examples:
 | `--rounds` | both | **(none)** | pytest-xdist already uses `-n` for worker count. Standalone originally had `-n` for `--rounds`, creating a letter-level collision whenever a user switched between pytest (`-n 8` = 8 workers) and standalone (`-n 8` = 8 rounds). Removed in [#574](https://github.com/hw-native-sys/simpler/pull/574); do not reintroduce. |
 | `--max-parallel` | both | **(none)** | `-j` would be the natural make-style short, but pytest reserves all lowercase single letters (`parser.addoption` rejects lowercase shorts). Standalone mirrors this to keep both CLIs identical — no short in either, always spell out `--max-parallel`. |
 | `--runtime` / `--level` | both | **(none)** | Internal child-mode markers; users rarely type them. No short keeps them distinctive. |
-| `--build`, `--skip-golden`, `--enable-profiling`, `--dump-tensor`, `--manual`, `--case`, `--log-level` | both | **(none)** | Low-frequency; long form reads better in scripts and docs. Not worth reserving letters. |
+| `--build`, `--skip-golden`, `--enable-profiling`, `--dump-tensor`, `--enable-pmu`, `--manual`, `--case`, `--log-level` | both | **(none)** | Low-frequency; long form reads better in scripts and docs. Not worth reserving letters. |
 
 Practical guidance when adding a new CLI option:
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -558,11 +558,13 @@ NB_MODULE(_task_interface, m) {
         .def_rw("aicpu_thread_num", &ChipCallConfig::aicpu_thread_num)
         .def_rw("enable_profiling", &ChipCallConfig::enable_profiling)
         .def_rw("enable_dump_tensor", &ChipCallConfig::enable_dump_tensor)
+        .def_rw("enable_pmu", &ChipCallConfig::enable_pmu)
         .def("__repr__", [](const ChipCallConfig &self) -> std::string {
             std::ostringstream os;
             os << "ChipCallConfig(block_dim=" << self.block_dim << ", aicpu_thread_num=" << self.aicpu_thread_num
                << ", enable_profiling=" << (self.enable_profiling ? "True" : "False")
-               << ", enable_dump_tensor=" << (self.enable_dump_tensor ? "True" : "False") << ")";
+               << ", enable_dump_tensor=" << (self.enable_dump_tensor ? "True" : "False")
+               << ", enable_pmu=" << self.enable_pmu << ")";
             return os.str();
         });
 
@@ -587,29 +589,34 @@ NB_MODULE(_task_interface, m) {
         .def(
             "run_raw",
             [](ChipWorker &self, uint64_t callable, uint64_t args, int block_dim, int aicpu_thread_num,
-               bool enable_profiling) {
+               bool enable_profiling, bool enable_dump_tensor, int enable_pmu) {
                 ChipCallConfig config;
                 config.block_dim = block_dim;
                 config.aicpu_thread_num = aicpu_thread_num;
                 config.enable_profiling = enable_profiling;
+                config.enable_dump_tensor = enable_dump_tensor;
+                config.enable_pmu = enable_pmu;
                 self.run(reinterpret_cast<const void *>(callable), reinterpret_cast<const void *>(args), config);
             },
             nb::arg("callable"), nb::arg("args"), nb::arg("block_dim") = 1, nb::arg("aicpu_thread_num") = 3,
-            nb::arg("enable_profiling") = false, "Run with a raw ChipStorageTaskArgs POD pointer."
+            nb::arg("enable_profiling") = false, nb::arg("enable_dump_tensor") = false, nb::arg("enable_pmu") = 0,
+            "Run with raw pointer arguments (used from forked chip process)."
         )
         .def(
             "run_from_blob",
             [](ChipWorker &self, uint64_t callable, uint64_t blob_ptr, int block_dim, int aicpu_thread_num,
-               bool enable_profiling) {
+               bool enable_profiling, bool enable_dump_tensor, int enable_pmu) {
                 ChipCallConfig config;
                 config.block_dim = block_dim;
                 config.aicpu_thread_num = aicpu_thread_num;
                 config.enable_profiling = enable_profiling;
+                config.enable_dump_tensor = enable_dump_tensor;
+                config.enable_pmu = enable_pmu;
                 TaskArgsView view = read_blob(reinterpret_cast<const uint8_t *>(blob_ptr));
                 self.run(callable, view, config);
             },
             nb::arg("callable"), nb::arg("blob_ptr"), nb::arg("block_dim") = 1, nb::arg("aicpu_thread_num") = 3,
-            nb::arg("enable_profiling") = false,
+            nb::arg("enable_profiling") = false, nb::arg("enable_dump_tensor") = false, nb::arg("enable_pmu") = 0,
             "Decode a length-prefixed TaskArgs blob ([T][S][tensors][scalars]) at "
             "blob_ptr and dispatch to the runtime. Used from forked chip processes "
             "reading the WorkerThread mailbox."

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -87,6 +87,7 @@ _OFF_BLOCK_DIM = 16
 _OFF_AICPU_THREAD_NUM = 20
 _OFF_ENABLE_PROFILING = 24
 _OFF_ENABLE_DUMP_TENSOR = 28
+_OFF_ENABLE_PMU = 32
 _OFF_ARGS = 64
 # MAILBOX_OFF_ERROR_MSG / MAILBOX_ERROR_MSG_SIZE come from the C++
 # nanobind module so the two sides cannot drift.
@@ -265,11 +266,21 @@ def _chip_process_loop(
             block_dim = struct.unpack_from("i", buf, _OFF_BLOCK_DIM)[0]
             aicpu_tn = struct.unpack_from("i", buf, _OFF_AICPU_THREAD_NUM)[0]
             profiling = struct.unpack_from("i", buf, _OFF_ENABLE_PROFILING)[0]
+            dump_tensor = struct.unpack_from("i", buf, _OFF_ENABLE_DUMP_TENSOR)[0]
+            enable_pmu = struct.unpack_from("i", buf, _OFF_ENABLE_PMU)[0]
 
             code = 0
             msg = ""
             try:
-                cw.run_from_blob(callable_ptr, args_ptr, block_dim, aicpu_tn, bool(profiling))
+                cw.run_from_blob(
+                    callable_ptr,
+                    args_ptr,
+                    block_dim,
+                    aicpu_tn,
+                    bool(profiling),
+                    bool(dump_tensor),
+                    enable_pmu,
+                )
             except Exception as e:  # noqa: BLE001
                 code = 1
                 msg = _format_exc(f"chip_process dev={device_id}", e)
@@ -314,6 +325,7 @@ def _read_config_from_mailbox(buf: memoryview) -> "ChipCallConfig":
     cfg.aicpu_thread_num = struct.unpack_from("i", buf, _OFF_AICPU_THREAD_NUM)[0]
     cfg.enable_profiling = bool(struct.unpack_from("i", buf, _OFF_ENABLE_PROFILING)[0])
     cfg.enable_dump_tensor = bool(struct.unpack_from("i", buf, _OFF_ENABLE_DUMP_TENSOR)[0])
+    cfg.enable_pmu = struct.unpack_from("i", buf, _OFF_ENABLE_PMU)[0]
     return cfg
 
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -640,6 +640,7 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
     skip_golden,
     enable_profiling,
     enable_dump_tensor,
+    enable_pmu,
 ):
     """Execute a pre-filtered list of cases for one class (layers 5-6).
 
@@ -662,6 +663,7 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
                 skip_golden=skip_golden,
                 enable_profiling=enable_profiling,
                 enable_dump_tensor=enable_dump_tensor,
+                enable_pmu=enable_pmu,
             )
         finally:
             if enable_profiling:
@@ -838,7 +840,7 @@ class SceneTestCase:
             return self._compile_l3_callables(platform)
         raise ValueError(f"Unsupported level: {self._st_level}")
 
-    def _build_config(self, config_dict, enable_profiling=False, enable_dump_tensor=False):
+    def _build_config(self, config_dict, enable_profiling=False, enable_dump_tensor=False, enable_pmu=0):
         from simpler.task_interface import ChipCallConfig  # noqa: PLC0415
 
         config = ChipCallConfig()
@@ -846,6 +848,7 @@ class SceneTestCase:
         config.aicpu_thread_num = config_dict.get("aicpu_thread_num", 3)
         config.enable_profiling = enable_profiling
         config.enable_dump_tensor = enable_dump_tensor
+        config.enable_pmu = enable_pmu  # 0=disabled, >0=enabled with event type
         return config
 
     def _resolve_env(self):
@@ -875,6 +878,7 @@ class SceneTestCase:
         skip_golden=False,
         enable_profiling=False,
         enable_dump_tensor=False,
+        enable_pmu=0,
     ):
         if self._st_level == 2:
             self._run_and_validate_l2(
@@ -885,6 +889,7 @@ class SceneTestCase:
                 skip_golden=skip_golden,
                 enable_profiling=enable_profiling,
                 enable_dump_tensor=enable_dump_tensor,
+                enable_pmu=enable_pmu,
             )
         elif self._st_level == 3:
             self._run_and_validate_l3(
@@ -896,10 +901,19 @@ class SceneTestCase:
                 skip_golden=skip_golden,
                 enable_profiling=enable_profiling,
                 enable_dump_tensor=enable_dump_tensor,
+                enable_pmu=enable_pmu,
             )
 
     def _run_and_validate_l2(
-        self, worker, callable_obj, case, rounds=1, skip_golden=False, enable_profiling=False, enable_dump_tensor=False
+        self,
+        worker,
+        callable_obj,
+        case,
+        rounds=1,
+        skip_golden=False,
+        enable_profiling=False,
+        enable_dump_tensor=False,
+        enable_pmu=0,
     ):
         params = case.get("params", {})
         config_dict = case.get("config", {})
@@ -931,6 +945,7 @@ class SceneTestCase:
                 config_dict,
                 enable_profiling=(enable_profiling and round_idx == 0),
                 enable_dump_tensor=enable_dump_tensor,
+                enable_pmu=enable_pmu,
             )
 
             with _temporary_env(self._resolve_env()):
@@ -949,6 +964,7 @@ class SceneTestCase:
         skip_golden=False,
         enable_profiling=False,
         enable_dump_tensor=False,
+        enable_pmu=0,
     ):
         # Defensive belt-and-braces: the pytest dispatcher and run_module both
         # block --enable-profiling for L3 at the CLI boundary. Catch any code
@@ -997,6 +1013,7 @@ class SceneTestCase:
                 config_dict,
                 enable_profiling=(enable_profiling and round_idx == 0),
                 enable_dump_tensor=enable_dump_tensor,
+                enable_pmu=enable_pmu,
             )
 
             # Orch fn signature: (orch, args, cfg) — inner fn forwards to
@@ -1023,9 +1040,17 @@ class SceneTestCase:
         skip_golden = request.config.getoption("--skip-golden", default=False)
         enable_profiling = request.config.getoption("--enable-profiling", default=False)
         enable_dump_tensor = request.config.getoption("--dump-tensor", default=False)
-        if rounds > 1 and enable_profiling:
-            logger.warning("Profiling disabled: --rounds > 1")
-            enable_profiling = False
+        enable_pmu = request.config.getoption("--enable-pmu", default=0)
+        if rounds > 1:
+            if enable_profiling:
+                logger.warning("Profiling disabled: --rounds > 1")
+                enable_profiling = False
+            if enable_dump_tensor:
+                logger.warning("Dump tensor disabled: --rounds > 1")
+                enable_dump_tensor = False
+            if enable_pmu:
+                logger.warning("PMU disabled: --rounds > 1")
+                enable_pmu = 0
 
         cls_name = type(self).__name__
         callable_obj = self.build_callable(st_platform)
@@ -1070,6 +1095,7 @@ class SceneTestCase:
             skip_golden=skip_golden,
             enable_profiling=enable_profiling,
             enable_dump_tensor=enable_dump_tensor,
+            enable_pmu=enable_pmu,
         )
 
     # ------------------------------------------------------------------
@@ -1113,6 +1139,16 @@ class SceneTestCase:
         parser.add_argument("--skip-golden", action="store_true", help="Skip golden comparison (benchmark mode)")
         parser.add_argument("--enable-profiling", action="store_true", help="Enable profiling (first round only)")
         parser.add_argument("--dump-tensor", action="store_true", help="Dump per-task tensor I/O at runtime")
+        parser.add_argument(
+            "--enable-pmu",
+            nargs="?",
+            const=2,
+            default=0,
+            type=int,
+            metavar="EVENT_TYPE",
+            help="Enable PMU collection. Bare flag = PIPE_UTILIZATION(2). "
+            "Pass event type to override (e.g. --enable-pmu 4)",
+        )
         parser.add_argument("--build", action="store_true", help="Compile runtime from source")
         parser.add_argument(
             "--runtime",
@@ -1302,6 +1338,7 @@ class SceneTestCase:
                                 skip_golden=args.skip_golden,
                                 enable_profiling=args.enable_profiling,
                                 enable_dump_tensor=args.dump_tensor,
+                                enable_pmu=args.enable_pmu,
                             )
                             print("PASSED")
                         except Exception as e:  # noqa: BLE001

--- a/src/a2a3/docs/pmu-profiling.md
+++ b/src/a2a3/docs/pmu-profiling.md
@@ -1,0 +1,186 @@
+# PMU Profiling (a2a3)
+
+This document describes how to use a2a3 PMU profiling, what output it
+produces, and the current usage limitations.
+
+## Overview
+
+PMU profiling collects per-task AICore hardware counter data and exports a
+LuoPan-compatible CSV file on the host side.
+
+Use `a2a3` hardware runs for meaningful PMU data. The simulation path can
+exercise the PMU export flow, but does not provide real hardware counters.
+
+## Design
+
+### Design Goals
+
+The PMU path is designed around four goals:
+
+- attribute counters to individual runtime tasks instead of only whole-run
+  aggregates
+- keep the hot execution path lightweight so profiling does not heavily disturb
+  scheduling and kernel execution
+- separate counter collection from host-side export so PMU handling does not
+  block device progress
+- produce a stable CSV output that can be consumed directly by LuoPan
+
+### Layered Responsibilities
+
+The design splits PMU work across host, AICPU, and AICore:
+
+- **Host** owns user entry, event-type selection, PMU session setup, and final
+  CSV export
+- **AICPU** owns PMU control and task-level sampling, because it already
+  observes task dispatch/completion boundaries
+- **AICore** only defines the counting window around the kernel body, without
+  taking on export or formatting work
+
+This split keeps each side focused on the part it can identify most naturally:
+host is good at orchestration and file export, AICPU is good at associating
+counter snapshots with runtime tasks, and AICore is best used only to bracket
+actual execution.
+
+### Data Flow
+
+At a high level, one PMU run follows this flow:
+
+1. The user enables PMU and selects an event type.
+2. The host prepares a PMU session for the run.
+3. AICPU programs the selected PMU event group before task execution starts.
+4. AICore opens the PMU counting window only around each kernel execution.
+5. When a task completes, AICPU reads the counters and associates them with
+   that task.
+6. The host asynchronously drains the collected records and writes the final
+   CSV.
+
+The key idea is that PMU data is sampled at task completion time, not as a
+post-run aggregate. That makes the output suitable for per-task analysis in
+LuoPan.
+
+### Why This Architecture
+
+This architecture is chosen for a few practical reasons:
+
+- PMU counters are per-core resources, so task attribution has to happen at the
+  point where task boundaries are visible
+- AICPU already tracks when a task is dispatched and when it finishes, so it is
+  the natural place to bind PMU snapshots to task metadata
+- AICore should stay minimal in the PMU path; otherwise profiling overhead would
+  distort the execution being measured
+- host-side asynchronous export avoids turning profiling into a synchronous
+  device-to-host bottleneck
+
+In short, the design tries to maximize per-task observability while minimizing
+intrusion into the normal runtime path.
+
+## Usage
+
+### SceneTest CLI
+
+Enable PMU with the default event group:
+
+```bash
+python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-pmu
+```
+
+or with pytest:
+
+```bash
+pytest tests/st/<case> --platform a2a3 -d 0 --enable-pmu
+```
+
+The bare flag is equivalent to:
+
+```bash
+--enable-pmu 2
+```
+
+which selects `PIPE_UTILIZATION`.
+
+Pass an explicit event type to collect a different counter group:
+
+```bash
+python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-pmu 4
+```
+
+`--rounds > 1` disables PMU collection in the test harness.
+
+### Event Types
+
+| Value | Event Type | Example Counters |
+| ----- | ---------- | ---------------- |
+| `1` | `ARITHMETIC_UTILIZATION` | cube/vector execution counters |
+| `2` | `PIPE_UTILIZATION` | vector, cube, scalar, MTE busy cycles |
+| `4` | `MEMORY` | UB/L1/L2/main memory requests |
+| `5` | `MEMORY_L0` | L0A/L0B/L0C requests |
+| `6` | `RESOURCE_CONFLICT` | bank and vector resource stalls |
+| `7` | `MEMORY_UB` | UB and memory bandwidth counters |
+| `8` | `L2_CACHE` | L2 cache hit/miss allocation counters |
+
+Invalid nonzero values fall back to `PIPE_UTILIZATION`.
+
+The `SIMPLER_PMU_EVENT_TYPE` environment variable can override the CLI event
+type:
+
+```bash
+SIMPLER_PMU_EVENT_TYPE=4 \
+python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-pmu
+```
+
+## Output
+
+The PMU artifact is a CSV file under `outputs/`:
+
+```text
+outputs/pmu_<YYYYMMDD>_<HHMMSS>_<mmm>.csv
+```
+
+This CSV is the file to load into LuoPan.
+
+Common columns:
+
+| Column | Meaning |
+| ------ | ------- |
+| `thread_id` | AICPU scheduler thread id |
+| `core_id` | Logical AICore id in the runtime. |
+| `task_id` | Runtime task id, printed as hex |
+| `func_id` | Kernel function id. |
+| `core_type` | `0` = AIC, `1` = AIV. |
+| `pmu_total_cycles` | 64-bit PMU total cycle counter snapshot. |
+| event-specific counters | Counter columns selected by the event type. |
+| `event_type` | Numeric event type used for the run. |
+
+For the default `PIPE_UTILIZATION` event type (`2`), the counter columns are:
+
+```text
+vec_busy_cycles,cube_busy_cycles,scalar_busy_cycles,mte1_busy_cycles,
+mte2_busy_cycles,mte3_busy_cycles,icache_miss,icache_req
+```
+
+## Limitations
+
+Current PMU collection assumes each logical AICore has at most one in-flight
+task. The runtime's default dual-issue dispatch can preload a pending task while
+another task is still running on the same core. In that mode the per-core PMU
+registers can be polluted by overlapping task windows, so per-task PMU rows are
+not reliable.
+
+For PMU runs, rebuild the runtime with:
+
+```text
+PTO2_DISABLE_DUAL_ISSUE=1
+```
+
+Current limitations:
+
+- `--enable-pmu` enables collection but does not rebuild the runtime with
+  dual-issue disabled.
+- `PTO2_DISABLE_DUAL_ISSUE` is compile-time state in the runtime headers.
+- The limitation applies to runtimes that define and use this macro
+  (`host_build_graph` and `tensormap_and_ringbuffer`).
+- `a2a3sim` can validate the PMU export path, but the counter values are not
+  suitable for performance analysis.
+
+Keep PMU comparisons consistent by using the same dual-issue setting across all
+runs being compared.

--- a/src/a2a3/docs/runtimes.md
+++ b/src/a2a3/docs/runtimes.md
@@ -54,6 +54,7 @@ See [tensormap_and_ringbuffer/docs/](../runtime/tensormap_and_ringbuffer/docs/):
 - [SUBMIT_BY_CLUSTER.md](../runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md) — Cluster submission design
 - [profiling_levels.md](../runtime/tensormap_and_ringbuffer/docs/profiling_levels.md) — Profiling levels
 - [device_log_profiling.md](../runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md) — Device log profiling guide
+- [pmu-profiling.md](pmu-profiling.md) — a2a3 PMU design and LuoPan CSV usage
 
 ## Shared Components
 

--- a/src/a2a3/platform/include/aicore/pmu_collector_aicore.h
+++ b/src/a2a3/platform/include/aicore/pmu_collector_aicore.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * @file pmu_collector_aicore.h
+ * @brief AICore-side PMU counter gate (per-task enable/disable).
+ *
+ * Purpose:
+ *   AICPU programs the PMU event selectors and enables the PMU framework once
+ *   at init (pmu_aicpu_start). During the task loop, AICore toggles the CTRL
+ *   SPR bit0 around each kernel execution so the PMU counters only accumulate
+ *   during actual kernel work, excluding dispatch / idle polling overhead.
+ *
+ * Usage (from aicore_executor.cpp main loop):
+ *     if (pmu_enabled) pmu_aicore_begin();
+ *     execute_task(...);
+ *     if (pmu_enabled) pmu_aicore_end();
+ */
+
+#ifndef PLATFORM_AICORE_PMU_COLLECTOR_AICORE_H_
+#define PLATFORM_AICORE_PMU_COLLECTOR_AICORE_H_
+
+#include "aicore/aicore.h"
+#include "common/platform_config.h"
+
+// PMU enable bit in the AICore CTRL SPR (bit0 = GLB_PMU_EN).
+constexpr uint64_t PMU_AICORE_CTRL_ENABLE_BIT = 0x1ULL;
+
+/**
+ * Begin PMU counting window: set CTRL bit0 so hardware counters start accruing.
+ */
+__aicore__ __attribute__((always_inline)) static inline void pmu_aicore_begin() {
+    write_reg(RegId::CTRL, read_reg(RegId::CTRL) | PMU_AICORE_CTRL_ENABLE_BIT);
+}
+
+/**
+ * End PMU counting window: clear CTRL bit0 so counters freeze until next begin.
+ */
+__aicore__ __attribute__((always_inline)) static inline void pmu_aicore_end() {
+    write_reg(RegId::CTRL, read_reg(RegId::CTRL) & ~PMU_AICORE_CTRL_ENABLE_BIT);
+}
+
+#endif  // PLATFORM_AICORE_PMU_COLLECTOR_AICORE_H_

--- a/src/a2a3/platform/include/aicpu/platform_regs.h
+++ b/src/a2a3/platform/include/aicpu/platform_regs.h
@@ -50,6 +50,22 @@ void set_platform_regs(uint64_t regs);
  */
 uint64_t get_platform_regs();
 
+/**
+ * Set the per-core PMU MMIO register base address array.
+ * On hardware this is distinct from set_platform_regs (different HAL addr_type).
+ * On sim this stays 0 (PMU has no hardware model).
+ *
+ * @param pmu_regs  Pointer (as uint64_t) to per-core PMU register base address array, 0 if PMU unsupported
+ */
+void set_platform_pmu_reg_addrs(uint64_t pmu_regs);
+
+/**
+ * Get the per-core PMU MMIO register base address array.
+ *
+ * @return Pointer (as uint64_t) to per-core PMU register base address array, 0 if unset
+ */
+uint64_t get_platform_pmu_reg_addrs();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/a2a3/platform/include/aicpu/pmu_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/pmu_collector_aicpu.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file pmu_collector_aicpu.h
+ * @brief AICPU-side AICore PMU counter collection interface
+ *
+ * Lifecycle (called from aicpu_executor.cpp):
+ *   pmu_aicpu_init()            — resolve per-core PMU MMIO bases from the
+ *                                 caller-supplied physical_core_id array,
+ *                                 program events, start counters, and pop
+ *                                 initial PmuBuffers from free_queues
+ *   [task loop]
+ *     pmu_aicpu_record_task()   — read counters, write one PmuRecord; switch buffer when full
+ *   pmu_aicpu_flush_buffers()   — per-thread: flush each of this thread's non-empty
+ *                                 PmuBuffers to the ready_queue (mirrors perf_aicpu_flush_buffers)
+ *   pmu_aicpu_finalize()        — per-thread: restore CTRL registers on shutdown
+ */
+
+#ifndef PLATFORM_AICPU_PMU_COLLECTOR_AICPU_H_
+#define PLATFORM_AICPU_PMU_COLLECTOR_AICPU_H_
+
+#include <cstdint>
+
+#include "common/core_type.h"
+#include "common/pmu_profiling.h"
+
+extern "C" void set_platform_pmu_base(uint64_t pmu_data_base);
+extern "C" uint64_t get_platform_pmu_base();
+extern "C" void set_enable_pmu(bool enable);
+extern "C" bool get_enable_pmu();
+
+/**
+ * Initialize PMU for all cores.
+ *
+ * For each logical core i in [0, num_cores):
+ *   - Resolve the PMU MMIO base from physical_core_ids[i] via the platform's
+ *     PMU reg-addr table, cache it in the collector's file-local state.
+ *   - Program event selectors and start CTRL_0.
+ *   - Pop an initial PmuBuffer from the per-core free_queue.
+ *
+ * On sim (or when a core has no PMU reg addr), the core is skipped for CTRL
+ * programming and subsequent pmu_aicpu_record_task() calls for that core
+ * become no-ops.
+ *
+ * Must be called after host has initialized PMU shared memory (pmu_data_base
+ * set) and after every active core has reported its physical_core_id via
+ * handshake (i.e. after handshake_all_cores returns).
+ *
+ * @param physical_core_ids  Array of hardware physical core ids, indexed by
+ *                           logical core_id. Caller owns the memory; this
+ *                           function does not retain the pointer.
+ * @param num_cores          Number of active cores (logical core_id range is [0, num_cores))
+ */
+void pmu_aicpu_init(const uint32_t *physical_core_ids, int num_cores);
+
+/**
+ * Read PMU counters for one completed task and append a PmuRecord to the
+ * per-core buffer. Switches to a fresh buffer (via the SPSC free_queue /
+ * ready_queue protocol) when the current buffer is full.
+ * No-op if PMU is not enabled or the core has no PMU address bound.
+ *
+ * @param core_id    Logical core index
+ * @param thread_idx AICPU thread index (used to select the per-thread ready_queue)
+ * @param task_id    task_id.raw from the completed task slot
+ * @param func_id    kernel_id from the completed task slot
+ * @param core_type  AIC or AIV
+ */
+void pmu_aicpu_record_task(int core_id, int thread_idx, uint64_t task_id, uint32_t func_id, CoreType core_type);
+
+/**
+ * Per-thread PMU buffer flush. Mirrors perf_aicpu_flush_buffers().
+ *
+ * For each core in cur_thread_cores, enqueue its non-empty PmuBuffer into the
+ * thread's ready_queue so the host collector can pick it up.
+ *
+ * @param thread_idx        AICPU thread index (selects ready_queue)
+ * @param cur_thread_cores  Array of logical core ids owned by this thread
+ * @param core_num          Entries in cur_thread_cores
+ */
+void pmu_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int core_num);
+
+/**
+ * Per-thread PMU finalize: restore CTRL registers for this thread's cores.
+ * Called after pmu_aicpu_flush_buffers() during shutdown.
+ *
+ * @param cur_thread_cores  Array of logical core ids owned by this thread
+ * @param core_num          Entries in cur_thread_cores
+ */
+void pmu_aicpu_finalize(const int *cur_thread_cores, int core_num);
+
+#endif  // PLATFORM_AICPU_PMU_COLLECTOR_AICPU_H_

--- a/src/a2a3/platform/include/common/kernel_args.h
+++ b/src/a2a3/platform/include/common/kernel_args.h
@@ -61,6 +61,8 @@ extern "C" {
  *   handshake buffers)
  * - dump_data_base: Written by host, read by AICPU platform layer; zero when
  *   tensor dump is unused
+ * - pmu_data_base: Written by host platform, read by AICPU platform layer;
+ *   zero when PMU is unused
  *
  * Field Access Patterns:
  *       - AICPU: receives KernelArgs* via DynTileFwkBackendKernelServer
@@ -73,6 +75,8 @@ struct KernelArgs {
     uint64_t regs{0};                                       // Per-core register base address array (platform-specific)
     uint64_t ffts_base_addr{0};                             // FFTS base address for AICore
     uint64_t dump_data_base{0};  // Dump shared memory base address; use explicit flags to detect enablement
+    uint64_t pmu_data_base{0};   // PMU shared memory base address; use explicit flags to detect enablement
+    uint64_t pmu_reg_addrs{0};   // Per-core PMU MMIO register base address array (onboard only; 0 on sim)
 };
 
 #ifdef __cplusplus

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -145,6 +145,7 @@ inline double cycles_to_us(uint64_t cycles) {
 // Profiling-related runtime flags shared through AICPU-AICore handshake.
 #define PROFILING_FLAG_NONE 0u
 #define PROFILING_FLAG_DUMP_TENSOR (1u << 0)
+#define PROFILING_FLAG_PMU (1u << 1)
 #define GET_PROFILING_FLAG(flags, bit) ((((uint32_t)(flags)) & ((uint32_t)(bit))) != 0u)
 #define SET_PROFILING_FLAG(flags, bit) ((flags) |= (uint32_t)(bit))
 #define CLEAR_PROFILING_FLAG(flags, bit) ((flags) &= ~((uint32_t)(bit)))
@@ -196,6 +197,36 @@ constexpr int PLATFORM_DUMP_READYQUEUE_SIZE = PLATFORM_MAX_AICPU_THREADS * PLATF
 constexpr int PLATFORM_DUMP_TIMEOUT_SECONDS = 30;
 
 // =============================================================================
+// PMU Profiling Configuration
+// =============================================================================
+
+/**
+ * Number of PmuRecord entries per PmuBuffer.
+ */
+constexpr int PLATFORM_PMU_RECORDS_PER_BUFFER = 512;
+
+/**
+ * SPSC free_queue slot count for PMU buffers.
+ */
+constexpr int PLATFORM_PMU_SLOT_COUNT = 4;
+
+/**
+ * Pre-allocated PmuBuffer count per AICore.
+ */
+constexpr int PLATFORM_PMU_BUFFERS_PER_CORE = 4;
+
+/**
+ * Ready queue capacity for PMU data collection.
+ * Indexed by AICPU thread; each entry names the core and buffer pointer.
+ */
+constexpr int PLATFORM_PMU_READYQUEUE_SIZE = PLATFORM_MAX_CORES * PLATFORM_PMU_BUFFERS_PER_CORE;
+
+/**
+ * Idle timeout duration for PMU collection (seconds)
+ */
+constexpr int PLATFORM_PMU_TIMEOUT_SECONDS = 30;
+
+// =============================================================================
 // Register Communication Configuration
 // =============================================================================
 
@@ -203,6 +234,7 @@ constexpr int PLATFORM_DUMP_TIMEOUT_SECONDS = 30;
 constexpr uint32_t REG_SPR_DATA_MAIN_BASE_OFFSET = 0xA0;  // Task dispatch (AICPU→AICore)
 constexpr uint32_t REG_SPR_COND_OFFSET = 0x4C8;           // Status (AICore→AICPU): 0=IDLE, 1=BUSY
 constexpr uint32_t REG_SPR_FAST_PATH_ENABLE_OFFSET = 0x18;
+constexpr uint32_t REG_SPR_CTRL_OFFSET = 0x0;  // AICore internal CTRL SPR (bit0 = PMU enable)
 
 // Fast path control values
 constexpr uint32_t REG_SPR_FAST_PATH_OPEN = 0xE;
@@ -214,14 +246,92 @@ constexpr uint32_t AICORE_EXIT_SIGNAL = 0x7FFFFFF0;
 // Physical core ID mask for get_coreid()
 constexpr uint32_t AICORE_COREID_MASK = 0x0FFF;
 
+// PMU MMIO register offsets (DAV_2201 / a2a3). Accessed by AICPU through
+// the per-core register block. AICore does not touch these — it only toggles
+// its internal CTRL SPR (REG_SPR_CTRL_OFFSET) for per-task counter gating.
+constexpr uint32_t REG_MMIO_PMU_CTRL_0_OFFSET = 0x200;      // PMU framework enable (GLB_PMU_EN | USER | SAMPLE)
+constexpr uint32_t REG_MMIO_PMU_CNT0_OFFSET = 0x210;        // Event counter 0
+constexpr uint32_t REG_MMIO_PMU_CNT1_OFFSET = 0x218;        // Event counter 1
+constexpr uint32_t REG_MMIO_PMU_CNT2_OFFSET = 0x220;        // Event counter 2
+constexpr uint32_t REG_MMIO_PMU_CNT3_OFFSET = 0x228;        // Event counter 3
+constexpr uint32_t REG_MMIO_PMU_CNT4_OFFSET = 0x230;        // Event counter 4
+constexpr uint32_t REG_MMIO_PMU_CNT5_OFFSET = 0x238;        // Event counter 5
+constexpr uint32_t REG_MMIO_PMU_CNT6_OFFSET = 0x240;        // Event counter 6
+constexpr uint32_t REG_MMIO_PMU_CNT7_OFFSET = 0x248;        // Event counter 7
+constexpr uint32_t REG_MMIO_PMU_CNT_TOTAL0_OFFSET = 0x250;  // Total cycle counter, low 32 bits
+constexpr uint32_t REG_MMIO_PMU_CNT_TOTAL1_OFFSET = 0x254;  // Total cycle counter, high 32 bits
+constexpr uint32_t REG_MMIO_PMU_START_CYC0_OFFSET = 0x2A0;  // Counting-range start cycle, low 32 bits
+constexpr uint32_t REG_MMIO_PMU_START_CYC1_OFFSET = 0x2A4;  // Counting-range start cycle, high 32 bits
+constexpr uint32_t REG_MMIO_PMU_STOP_CYC0_OFFSET = 0x2A8;   // Counting-range stop cycle, low 32 bits
+constexpr uint32_t REG_MMIO_PMU_STOP_CYC1_OFFSET = 0x2AC;   // Counting-range stop cycle, high 32 bits
+constexpr uint32_t REG_MMIO_PMU_CNT0_IDX_OFFSET = 0x1280;   // Event selector for CNT0
+constexpr uint32_t REG_MMIO_PMU_CNT1_IDX_OFFSET = 0x1284;   // Event selector for CNT1
+constexpr uint32_t REG_MMIO_PMU_CNT2_IDX_OFFSET = 0x1288;   // Event selector for CNT2
+constexpr uint32_t REG_MMIO_PMU_CNT3_IDX_OFFSET = 0x128C;   // Event selector for CNT3
+constexpr uint32_t REG_MMIO_PMU_CNT4_IDX_OFFSET = 0x1290;   // Event selector for CNT4
+constexpr uint32_t REG_MMIO_PMU_CNT5_IDX_OFFSET = 0x1294;   // Event selector for CNT5
+constexpr uint32_t REG_MMIO_PMU_CNT6_IDX_OFFSET = 0x1298;   // Event selector for CNT6
+constexpr uint32_t REG_MMIO_PMU_CNT7_IDX_OFFSET = 0x129C;   // Event selector for CNT7
+
+// PMU_CTRL_0 enable value: GLB_PMU_EN | (USER_PMU_MODE_EN << 1) | (SAMPLE_PMU_MODE_EN << 2)
+constexpr uint32_t REG_MMIO_PMU_CTRL_0_ENABLE_VAL = 0x7;
+
 /**
- * Register identifier for unified read_reg/write_reg interface
+ * Register identifier for unified read_reg/write_reg interface.
+ *
+ * The PMU counter slots (PMU_CNT0..PMU_CNT7) and event selector slots
+ * (PMU_CNT0_IDX..PMU_CNT7_IDX) are assigned contiguous values so that
+ * reg_index(base, i) can index into them as arrays. Keep these runs
+ * contiguous — static_asserts below enforce this.
  */
 enum class RegId : uint8_t {
     DATA_MAIN_BASE = 0,    // Task dispatch (AICPU→AICore)
     COND = 1,              // Status (AICore→AICPU)
     FAST_PATH_ENABLE = 2,  // Fast path control
+    CTRL = 3,              // AICore internal CTRL SPR (PMU enable, etc.) — AICore-only
+
+    // PMU framework (AICPU-only; AICore does not access these)
+    PMU_CTRL_0 = 4,
+
+    // PMU counters (8 contiguous slots)
+    PMU_CNT0 = 5,
+    PMU_CNT1 = 6,
+    PMU_CNT2 = 7,
+    PMU_CNT3 = 8,
+    PMU_CNT4 = 9,
+    PMU_CNT5 = 10,
+    PMU_CNT6 = 11,
+    PMU_CNT7 = 12,
+
+    // PMU total cycle counter (64-bit split across two 32-bit regs)
+    PMU_CNT_TOTAL0 = 13,
+    PMU_CNT_TOTAL1 = 14,
+
+    // PMU counting-range start/stop cycle bounds
+    PMU_START_CYC0 = 15,
+    PMU_START_CYC1 = 16,
+    PMU_STOP_CYC0 = 17,
+    PMU_STOP_CYC1 = 18,
+
+    // PMU event selectors (8 contiguous slots, parallel to PMU_CNT0..CNT7)
+    PMU_CNT0_IDX = 19,
+    PMU_CNT1_IDX = 20,
+    PMU_CNT2_IDX = 21,
+    PMU_CNT3_IDX = 22,
+    PMU_CNT4_IDX = 23,
+    PMU_CNT5_IDX = 24,
+    PMU_CNT6_IDX = 25,
+    PMU_CNT7_IDX = 26,
 };
+
+static_assert(
+    static_cast<int>(RegId::PMU_CNT7) - static_cast<int>(RegId::PMU_CNT0) == 7,
+    "PMU_CNT0..PMU_CNT7 must be contiguous for reg_index()"
+);
+static_assert(
+    static_cast<int>(RegId::PMU_CNT7_IDX) - static_cast<int>(RegId::PMU_CNT0_IDX) == 7,
+    "PMU_CNT0_IDX..PMU_CNT7_IDX must be contiguous for reg_index()"
+);
 
 /**
  * Map RegId to hardware register offset
@@ -234,12 +344,71 @@ constexpr uint32_t reg_offset(RegId reg) {
         return REG_SPR_COND_OFFSET;
     case RegId::FAST_PATH_ENABLE:
         return REG_SPR_FAST_PATH_ENABLE_OFFSET;
+    case RegId::CTRL:
+        return REG_SPR_CTRL_OFFSET;
+    case RegId::PMU_CTRL_0:
+        return REG_MMIO_PMU_CTRL_0_OFFSET;
+    case RegId::PMU_CNT0:
+        return REG_MMIO_PMU_CNT0_OFFSET;
+    case RegId::PMU_CNT1:
+        return REG_MMIO_PMU_CNT1_OFFSET;
+    case RegId::PMU_CNT2:
+        return REG_MMIO_PMU_CNT2_OFFSET;
+    case RegId::PMU_CNT3:
+        return REG_MMIO_PMU_CNT3_OFFSET;
+    case RegId::PMU_CNT4:
+        return REG_MMIO_PMU_CNT4_OFFSET;
+    case RegId::PMU_CNT5:
+        return REG_MMIO_PMU_CNT5_OFFSET;
+    case RegId::PMU_CNT6:
+        return REG_MMIO_PMU_CNT6_OFFSET;
+    case RegId::PMU_CNT7:
+        return REG_MMIO_PMU_CNT7_OFFSET;
+    case RegId::PMU_CNT_TOTAL0:
+        return REG_MMIO_PMU_CNT_TOTAL0_OFFSET;
+    case RegId::PMU_CNT_TOTAL1:
+        return REG_MMIO_PMU_CNT_TOTAL1_OFFSET;
+    case RegId::PMU_START_CYC0:
+        return REG_MMIO_PMU_START_CYC0_OFFSET;
+    case RegId::PMU_START_CYC1:
+        return REG_MMIO_PMU_START_CYC1_OFFSET;
+    case RegId::PMU_STOP_CYC0:
+        return REG_MMIO_PMU_STOP_CYC0_OFFSET;
+    case RegId::PMU_STOP_CYC1:
+        return REG_MMIO_PMU_STOP_CYC1_OFFSET;
+    case RegId::PMU_CNT0_IDX:
+        return REG_MMIO_PMU_CNT0_IDX_OFFSET;
+    case RegId::PMU_CNT1_IDX:
+        return REG_MMIO_PMU_CNT1_IDX_OFFSET;
+    case RegId::PMU_CNT2_IDX:
+        return REG_MMIO_PMU_CNT2_IDX_OFFSET;
+    case RegId::PMU_CNT3_IDX:
+        return REG_MMIO_PMU_CNT3_IDX_OFFSET;
+    case RegId::PMU_CNT4_IDX:
+        return REG_MMIO_PMU_CNT4_IDX_OFFSET;
+    case RegId::PMU_CNT5_IDX:
+        return REG_MMIO_PMU_CNT5_IDX_OFFSET;
+    case RegId::PMU_CNT6_IDX:
+        return REG_MMIO_PMU_CNT6_IDX_OFFSET;
+    case RegId::PMU_CNT7_IDX:
+        return REG_MMIO_PMU_CNT7_IDX_OFFSET;
     }
     return 0;  // unreachable: all RegId cases handled above
 }
 
-// Size of simulated register block per core (covers largest offset + 4 bytes)
-constexpr uint32_t SIM_REG_BLOCK_SIZE = 0x500;
+/**
+ * Index into a contiguous RegId run (e.g. reg_index(PMU_CNT0, 3) == PMU_CNT3).
+ * Caller is responsible for keeping `i` within the run's length.
+ */
+constexpr RegId reg_index(RegId base, int i) { return static_cast<RegId>(static_cast<uint8_t>(base) + i); }
+
+// Size of simulated register block per core (covers largest offset + 4 bytes).
+// Bumped from 0x500 to 0x1400 to include DAV_2201 PMU registers:
+//   - CTRL_0 at 0x200, CNT/CNT_TOTAL at 0x210-0x254
+//   - START/STOP_CYC at 0x2A0-0x2AC
+//   - CNT_IDX at 0x1280-0x129C (highest offset + 4 = 0x12A0)
+// 0x1400 rounds up to a 64-byte boundary with headroom.
+constexpr uint32_t SIM_REG_BLOCK_SIZE = 0x1400;
 
 // =============================================================================
 // Hardware Configuration Constants

--- a/src/a2a3/platform/include/common/pmu_profiling.h
+++ b/src/a2a3/platform/include/common/pmu_profiling.h
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file pmu_profiling.h
+ * @brief DAV_2201 (a2a3) AICore Performance Monitoring Unit configuration
+ *
+ * PMU event ID tables (values from pypto's `pmu_common.cpp`, CANN Open
+ * Software License 2.0). Register offsets live in platform_config.h and are
+ * accessed via RegId / reg_index().
+ *
+ * Streaming buffer design (mirrors perf_profiling.h):
+ *   PmuFreeQueue    — SPSC queue: Host pushes free PmuBuffers, AICPU pops them.
+ *   PmuBufferState  — Per-core state: current active buffer pointer + free_queue.
+ *   PmuDataHeader   — Fixed shared-memory header: per-thread ready queues.
+ *   PmuBuffer       — Fixed-capacity record buffer (PLATFORM_PMU_RECORDS_PER_BUFFER).
+ */
+
+#ifndef SRC_A2A3_PLATFORM_INCLUDE_COMMON_PMU_PROFILING_H_
+#define SRC_A2A3_PLATFORM_INCLUDE_COMMON_PMU_PROFILING_H_
+
+#include <cstdint>
+#include <cstddef>
+
+#include "common/platform_config.h"
+
+// DAV_2201 hardware counter count.
+constexpr int PMU_COUNTER_COUNT_A2A3 = 8;
+
+/**
+ * PMU event type selector. Values match pypto's `PROF_PMU_EVENT_TYPE`.
+ * Simpler exposes this through the SIMPLER_PMU_EVENT_TYPE environment variable.
+ */
+enum class PmuEventType : uint32_t {
+    ARITHMETIC_UTILIZATION = 1,
+    PIPE_UTILIZATION = 2,  // default
+    MEMORY = 4,
+    MEMORY_L0 = 5,
+    RESOURCE_CONFLICT = 6,
+    MEMORY_UB = 7,
+    L2_CACHE = 8,
+};
+
+constexpr uint32_t PMU_EVENT_TYPE_DEFAULT = static_cast<uint32_t>(PmuEventType::PIPE_UTILIZATION);
+
+/**
+ * Event ID table for a single event type.
+ * `event_ids[i]` programs PMU_CNTi_IDX; `counters[i]` in the PerfRecord is the
+ * value of PMU_CNTi after the task completes.
+ * `counter_names[i]` is the human-readable CSV column name for counter i.
+ * Empty string ("") marks an unused slot.
+ *
+ * Names match pypto's `tilefwk_pmu_to_csv.py` so CSVs are comparable across projects.
+ */
+struct PmuEventConfig {
+    uint32_t event_ids[PMU_COUNTER_COUNT_A2A3];
+    const char *counter_names[PMU_COUNTER_COUNT_A2A3];
+};
+
+// DAV_2201 event tables (values from pypto pmu_common.cpp SetPmuEventTypeDAV2201).
+// Counter names follow pypto's tilefwk_pmu_to_csv.py tables for cross-project consistency.
+constexpr PmuEventConfig PMU_EVENTS_A2A3_ARITHMETIC = {
+    {0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x0},
+    {"cube_fp16_exec", "cube_int8_exec", "vec_fp32_exec", "vec_fp16_128lane_exec", "vec_fp16_64lane_exec",
+     "vec_int32_exec", "vec_misc_exec", ""},
+};
+constexpr PmuEventConfig PMU_EVENTS_A2A3_PIPE_UTIL = {
+    {0x08, 0x0a, 0x09, 0x0b, 0x0c, 0x0d, 0x55, 0x54},
+    {"vec_busy_cycles", "cube_busy_cycles", "scalar_busy_cycles", "mte1_busy_cycles", "mte2_busy_cycles",
+     "mte3_busy_cycles", "icache_miss", "icache_req"},
+};
+constexpr PmuEventConfig PMU_EVENTS_A2A3_MEMORY = {
+    {0x15, 0x16, 0x31, 0x32, 0x0f, 0x10, 0x12, 0x13},
+    {"ub_read_req", "ub_write_req", "l1_read_req", "l1_write_req", "l2_read_req", "l2_write_req", "main_read_req",
+     "main_write_req"},
+};
+constexpr PmuEventConfig PMU_EVENTS_A2A3_MEMORY_L0 = {
+    {0x1b, 0x1c, 0x21, 0x22, 0x27, 0x28, 0x0, 0x0},
+    {"l0a_read_req", "l0a_write_req", "l0b_read_req", "l0b_write_req", "l0c_read_req", "l0c_write_req", "", ""},
+};
+constexpr PmuEventConfig PMU_EVENTS_A2A3_RESOURCE_CONFLICT = {
+    {0x64, 0x65, 0x66, 0x0, 0x0, 0x0, 0x0, 0x0},
+    {"bankgroup_stall_cycles", "bank_stall_cycles", "vec_resc_conflict_cycles", "", "", "", "", ""},
+};
+constexpr PmuEventConfig PMU_EVENTS_A2A3_MEMORY_UB = {
+    {0x3d, 0x10, 0x13, 0x3e, 0x43, 0x44, 0x37, 0x38},
+    {"ub_read_bw_mte", "l2_write_bw", "main_mem_write_bw", "ub_write_bw_mte", "ub_read_bw_vector", "ub_write_bw_vector",
+     "ub_read_bw_scalar", "ub_write_bw_scalar"},
+};
+constexpr PmuEventConfig PMU_EVENTS_A2A3_L2_CACHE = {
+    {0x500, 0x502, 0x504, 0x506, 0x508, 0x50a, 0x0, 0x0},
+    {"write_cache_hit", "write_cache_miss_allocate", "r0_read_cache_hit", "r0_read_cache_miss_allocate",
+     "r1_read_cache_hit", "r1_read_cache_miss_allocate", "", ""},
+};
+
+/**
+ * Resolve an event type to the DAV_2201 event table. Returns nullptr for
+ * unknown values (caller falls back to PIPE_UTILIZATION).
+ */
+inline const PmuEventConfig *pmu_resolve_event_config_a2a3(uint32_t event_type) {
+    switch (static_cast<PmuEventType>(event_type)) {
+    case PmuEventType::ARITHMETIC_UTILIZATION:
+        return &PMU_EVENTS_A2A3_ARITHMETIC;
+    case PmuEventType::PIPE_UTILIZATION:
+        return &PMU_EVENTS_A2A3_PIPE_UTIL;
+    case PmuEventType::MEMORY:
+        return &PMU_EVENTS_A2A3_MEMORY;
+    case PmuEventType::MEMORY_L0:
+        return &PMU_EVENTS_A2A3_MEMORY_L0;
+    case PmuEventType::RESOURCE_CONFLICT:
+        return &PMU_EVENTS_A2A3_RESOURCE_CONFLICT;
+    case PmuEventType::MEMORY_UB:
+        return &PMU_EVENTS_A2A3_MEMORY_UB;
+    case PmuEventType::L2_CACHE:
+        return &PMU_EVENTS_A2A3_L2_CACHE;
+    }
+    return nullptr;
+}
+
+// =============================================================================
+// PMU Record
+// =============================================================================
+
+#include "common/core_type.h"
+
+/**
+ * Per-task PMU snapshot written by AICPU after each AICore task FIN.
+ */
+struct PmuRecord {
+    uint64_t task_id;                               // Same encoding as PerfRecord.task_id
+    uint32_t func_id;                               // Kernel function identifier
+    CoreType core_type;                             // AIC or AIV
+    uint64_t pmu_total_cycles;                      // PMU_CNT_TOTAL (64-bit combined)
+    uint32_t pmu_counters[PMU_COUNTER_COUNT_A2A3];  // PMU_CNT0..CNT7
+} __attribute__((aligned(64)));
+
+// =============================================================================
+// PMU Streaming Buffer Structures (mirrors perf_profiling.h)
+// =============================================================================
+
+/**
+ * Fixed-capacity PMU record buffer.
+ * Allocated by Host, pushed into per-core free_queue.
+ */
+struct PmuBuffer {
+    PmuRecord records[PLATFORM_PMU_RECORDS_PER_BUFFER];
+    volatile uint32_t count;
+} __attribute__((aligned(64)));
+
+/**
+ * SPSC lock-free queue for free PmuBuffer management.
+ *
+ * Producer: Host (PmuMemoryManager thread) pushes recycled/new buffers.
+ * Consumer: Device (AICPU thread) pops buffers when switching.
+ *
+ * Memory ordering:
+ *   Device pop:  rmb() → read tail → read buffer_ptrs[head % COUNT] → rmb() → write head → wmb()
+ *   Host push:   write buffer_ptrs[tail % COUNT] → wmb() → write tail → wmb()
+ */
+struct PmuFreeQueue {
+    volatile uint64_t buffer_ptrs[PLATFORM_PMU_SLOT_COUNT];  // 4 * 8 = 32 bytes
+    volatile uint32_t head;                                  // Consumer read position (Device increments)
+    volatile uint32_t tail;                                  // Producer write position (Host increments)
+    uint32_t pad[22];                                        // Pad 40 + 88 -> 128 bytes
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(PmuFreeQueue) == 128, "PmuFreeQueue must be 128 bytes");
+
+/**
+ * Per-core PMU buffer state.
+ *
+ * Writers:
+ *   free_queue.tail:        Host writes (pushes new/recycled buffers)
+ *   free_queue.head:        Device writes (pops buffers)
+ *   current_buf_ptr:        Device writes (after pop), Host reads (for collect/drain)
+ *   current_buf_seq:        Device writes (monotonic counter)
+ *   dropped_record_count:   Device writes (tasks whose PmuRecord was never handed
+ *                           to the host, e.g. free_queue empty, ready_queue full,
+ *                           no active buffer)
+ *   total_record_count:     Device writes — monotonic count of every task the
+ *                           AICPU attempted to record (success + dropped)
+ *
+ * Host reads dropped / total at finalize time to cross-check:
+ *   collected_on_host + sum(dropped) == sum(total)
+ */
+struct PmuBufferState {
+    PmuFreeQueue free_queue;                 // SPSC queue of free PmuBuffer addresses
+    volatile uint64_t current_buf_ptr;       // Current active PmuBuffer (0 = none)
+    volatile uint32_t current_buf_seq;       // Sequence number for ordering
+    volatile uint32_t dropped_record_count;  // Tasks whose record was dropped on device
+    volatile uint32_t total_record_count;    // Total tasks the AICPU attempted to record
+    uint32_t pad[11];                        // Pad to 192 bytes
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(PmuBufferState) == 192, "PmuBufferState must be 192 bytes");
+
+/**
+ * Ready queue entry.
+ * When a PmuBuffer is full, AICPU adds this entry to the thread's ready queue.
+ */
+struct PmuReadyQueueEntry {
+    uint32_t core_index;  // Core index (0 ~ num_cores-1)
+    uint32_t pad0;
+    uint64_t buffer_ptr;  // Device pointer to the full PmuBuffer
+    uint32_t buffer_seq;  // Sequence number for ordering
+    uint32_t pad1;
+} __attribute__((aligned(32)));
+
+static_assert(sizeof(PmuReadyQueueEntry) == 32, "PmuReadyQueueEntry must be 32 bytes");
+
+/**
+ * PMU data fixed header, located at the start of PMU shared memory.
+ *
+ * Per-thread ready queues (one per AICPU scheduling thread):
+ *   Producer: AICPU thread (adds full PmuBuffers)
+ *   Consumer: Host PmuMemoryManager thread
+ */
+struct PmuDataHeader {
+    PmuReadyQueueEntry queues[PLATFORM_MAX_AICPU_THREADS][PLATFORM_PMU_READYQUEUE_SIZE];
+    volatile uint32_t queue_heads[PLATFORM_MAX_AICPU_THREADS];  // Host reads (consumer)
+    volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // AICPU writes (producer)
+    uint32_t num_cores;
+    uint32_t event_type;  // PmuEventType value, written by host at init
+    uint32_t pad[2];
+} __attribute__((aligned(64)));
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+inline size_t calc_pmu_data_size(int num_cores) {
+    return sizeof(PmuDataHeader) + static_cast<size_t>(num_cores) * sizeof(PmuBufferState);
+}
+
+inline PmuDataHeader *get_pmu_header(void *base_ptr) { return reinterpret_cast<PmuDataHeader *>(base_ptr); }
+
+inline PmuBufferState *get_pmu_buffer_state(void *base_ptr, int core_id) {
+    return reinterpret_cast<PmuBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(PmuDataHeader)) + core_id;
+}
+
+#endif  // SRC_A2A3_PLATFORM_INCLUDE_COMMON_PMU_PROFILING_H_

--- a/src/a2a3/platform/include/host/host_regs.h
+++ b/src/a2a3/platform/include/host/host_regs.h
@@ -12,8 +12,8 @@
  * @file host_regs.h
  * @brief AICore register address retrieval via CANN HAL APIs
  *
- * Provides register base addresses for AICPU to perform MMIO-based
- * task dispatch to AICore cores.
+ * Provides register base addresses for AICPU/AICore to perform MMIO access
+ * (task dispatch via CTRL, counter reads via PMU).
  */
 
 #ifndef PLATFORM_HOST_HOST_REGS_H_
@@ -32,16 +32,38 @@ class MemoryAllocator;
 constexpr uint8_t PLATFORM_AICORE_MAP_BUFF_LEN = 2;
 
 /**
- * Initialize AICore register addresses for runtime
+ * Which MMIO register page to query from the HAL.
  *
- * Retrieves register addresses from HAL, allocates device memory,
- * copies addresses to device, and stores the device pointer in runtime.
+ * Each kind maps to a distinct HAL ADDR_MAP_TYPE constant; all other logic
+ * (per-core stride, AIC/AIV layout, device copy) is identical.
+ */
+enum class AicoreRegKind {
+    Ctrl,  // Task dispatch MMIO (DATA_MAIN_BASE / COND / CTRL SPR frame)
+    Pmu,   // PMU counter MMIO (per-core CNT/CTRL/IDX pages)
+};
+
+/**
+ * Initialize per-core AICore register addresses for runtime.
  *
- * @param runtime_regs_ptr Pointer to the regs field (e.g., KernelArgs.regs)
- * @param device_id Device ID
- * @param allocator Memory allocator for device memory
+ * Retrieves addresses from the HAL for the requested register kind, allocates
+ * device memory, copies the address array to device, and stores the device
+ * pointer via *runtime_regs_ptr.
+ *
+ * Failure returns a negative code; no placeholder addresses are generated.
+ * Callers must treat a failed return as fatal for that register kind (e.g. a
+ * failed Ctrl query means runtime cannot dispatch; a failed Pmu query means
+ * PMU must be disabled).
+ *
+ * @param runtime_regs_ptr  Pointer to the KernelArgs slot (e.g. &args.regs or
+ *                          &args.pmu_reg_addrs) that will receive the device
+ *                          pointer to the address array.
+ * @param device_id         Device ID
+ * @param allocator         Memory allocator for device memory
+ * @param kind              Which register page to query (Ctrl or Pmu)
  * @return 0 on success, negative on failure
  */
-int init_aicore_register_addresses(uint64_t *runtime_regs_ptr, uint64_t device_id, MemoryAllocator &allocator);
+int init_aicore_register_addresses(
+    uint64_t *runtime_regs_ptr, uint64_t device_id, MemoryAllocator &allocator, AicoreRegKind kind
+);
 
 #endif  // PLATFORM_HOST_HOST_REGS_H_

--- a/src/a2a3/platform/include/host/pmu_collector.h
+++ b/src/a2a3/platform/include/host/pmu_collector.h
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file pmu_collector.h
+ * @brief Host-side PMU buffer allocation, streaming collection, and CSV export.
+ *
+ * Lifecycle:
+ *   init()                    — Allocate PmuDataHeader + PmuBufferState shared memory,
+ *                               pre-allocate PmuBuffers and push into free_queues.
+ *   start_collector()         — Launch background thread that polls ready_queues,
+ *                               recycles buffers, and appends records to CSV.
+ *   [device execution]
+ *   signal_execution_complete() — Notify collector that device is done.
+ *   stop_collector()          — Join collector thread.
+ *   drain_remaining_buffers() — Scan any buffers still held by AICPU after execution.
+ *   finalize()                — Free all device memory and unregister shared memory.
+ *
+ * Memory model:
+ *   PmuDataHeader + PmuBufferState[] is allocated as a single shared-memory region
+ *   visible to both host and device (via halHostRegister on hardware, plain malloc
+ *   on simulation).  Individual PmuBuffers are also allocated in shared memory and
+ *   recycled via the SPSC free_queue on each core.
+ */
+
+#ifndef SRC_A2A3_PLATFORM_INCLUDE_HOST_PMU_COLLECTOR_H_
+#define SRC_A2A3_PLATFORM_INCLUDE_HOST_PMU_COLLECTOR_H_
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <sys/stat.h>
+#include <unordered_set>
+#include <vector>
+
+#include "common/pmu_profiling.h"
+#include "common/unified_log.h"
+
+// ---------------------------------------------------------------------------
+// Memory operation callbacks (injected by DeviceRunner)
+// ---------------------------------------------------------------------------
+
+/**
+ * Allocate device memory. Returns nullptr on failure.
+ */
+using PmuAllocCallback = void *(*)(size_t size, void *user_data);
+
+/**
+ * Register device memory for host-visible access.
+ * On hardware: wraps halHostRegister. On sim: nullptr (dev == host).
+ */
+using PmuRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void *user_data, void **host_ptr);
+
+/**
+ * Unregister previously registered host-visible device memory.
+ * On hardware: wraps halHostUnregister. On sim: nullptr.
+ */
+using PmuUnregisterCallback = int (*)(void *dev_ptr, int device_id, void *user_data);
+
+/**
+ * Free device memory.
+ */
+using PmuFreeCallback = int (*)(void *dev_ptr, void *user_data);
+
+// ---------------------------------------------------------------------------
+// PmuCollectorHost
+// ---------------------------------------------------------------------------
+
+class PmuCollectorHost {
+public:
+    PmuCollectorHost() = default;
+    ~PmuCollectorHost();
+
+    PmuCollectorHost(const PmuCollectorHost &) = delete;
+    PmuCollectorHost &operator=(const PmuCollectorHost &) = delete;
+
+    /**
+     * Allocate PMU shared memory and pre-populate free_queues.
+     *
+     * @param num_cores               Number of AICore instances in use
+     * @param num_threads             Number of AICPU scheduling threads
+     * @param kernel_args_pmu_data_base  Out: device address of PmuDataHeader
+     * @param csv_path                Output CSV file path
+     * @param event_type              PmuEventType value (written to CSV rows)
+     * @param alloc_cb / register_cb / free_cb  Memory operation callbacks
+     * @param user_data               Opaque pointer forwarded to callbacks
+     * @param device_id               Device ID (for halHostRegister)
+     * @return 0 on success, non-zero on failure
+     */
+    int init(
+        int num_cores, int num_threads, uint64_t *kernel_args_pmu_data_base, const std::string &csv_path,
+        uint32_t event_type, PmuAllocCallback alloc_cb, PmuRegisterCallback register_cb, PmuFreeCallback free_cb,
+        void *user_data, int device_id
+    );
+
+    /**
+     * Main body of the collector thread.
+     * Polls all per-thread ready_queues, appends records to CSV, recycles buffers.
+     * Called from a dedicated thread in DeviceRunner (same pattern as dump_collector_).
+     */
+    void poll_and_collect();
+
+    /**
+     * Signal that device execution has finished.
+     * The collector thread will drain remaining entries then exit.
+     */
+    void signal_execution_complete();
+
+    /**
+     * After stop_collector(), scan PmuBufferState.current_buf_ptr for any
+     * remaining non-empty buffers that AICPU flushed but the collector thread
+     * may not have consumed yet.
+     */
+    void drain_remaining_buffers();
+
+    /**
+     * Free all device/shared memory and unregister mapped regions.
+     */
+    void finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback free_cb, void *user_data);
+
+    bool is_initialized() const { return initialized_; }
+
+private:
+    bool initialized_ = false;
+    int num_cores_ = 0;
+    int num_threads_ = 0;
+    int device_id_ = -1;
+    uint32_t event_type_ = 0;
+
+    // Shared memory region (PmuDataHeader + PmuBufferState[])
+    void *shm_dev_ = nullptr;
+    void *shm_host_ = nullptr;  // Host-mapped pointer (sim: == shm_dev_)
+    bool shm_registered_ = false;
+    size_t shm_size_ = 0;
+
+    // Pre-allocated PmuBuffers (shared memory, one pool per core × BUFFERS_PER_CORE)
+    struct BufEntry {
+        void *dev_ptr = nullptr;
+        void *host_ptr = nullptr;
+        bool registered = false;
+    };
+    std::vector<BufEntry> buf_pool_;
+
+    PmuAllocCallback alloc_cb_ = nullptr;
+    PmuFreeCallback free_cb_ = nullptr;
+    void *user_data_ = nullptr;
+
+    // CSV output. File is opened lazily on the first record write so that a
+    // hung device run that produces no records does not leave a header-only
+    // CSV on disk. See write_buffer_to_csv().
+    std::string csv_path_;
+    std::string csv_header_;  // Pre-built header line (written on first open)
+    std::ofstream csv_file_;
+    std::mutex csv_mutex_;
+
+    std::atomic<bool> execution_complete_{false};
+
+    // Running total of records written to CSV (across all buffers and drain).
+    // Used at finalize to verify collected + device-side dropped == device-side total.
+    uint64_t total_collected_ = 0;
+
+    // Internal helpers
+    PmuDataHeader *pmu_header() const { return get_pmu_header(shm_host_); }
+    PmuBufferState *pmu_state(int core_id) const { return get_pmu_buffer_state(shm_host_, core_id); }
+
+    void write_buffer_to_csv(int core_id, int thread_idx, const void *buf_host_ptr);
+    void push_to_free_queue(int core_id, uint64_t buf_dev_addr);
+
+    // Open the CSV file and write the header on first record. Must be called
+    // with csv_mutex_ held. No-op if already open.
+    void ensure_csv_open_unlocked();
+
+    // Buffers already drained (to avoid double-processing)
+    std::unordered_set<uint64_t> drained_bufs_;
+};
+
+// ---------------------------------------------------------------------------
+// Utility: resolve PMU event type (env-var override)
+// ---------------------------------------------------------------------------
+
+inline uint32_t resolve_pmu_event_type(int requested_event_type) {
+    uint32_t resolved = PMU_EVENT_TYPE_DEFAULT;
+    if (requested_event_type > 0 &&
+        pmu_resolve_event_config_a2a3(static_cast<uint32_t>(requested_event_type)) != nullptr) {
+        resolved = static_cast<uint32_t>(requested_event_type);
+    } else if (requested_event_type != 0) {
+        // 0 means PMU disabled (enable_pmu == 0), not an invalid type — only warn for nonzero
+        LOG_WARN(
+            "Invalid PMU event type %u, using default (PIPE_UTILIZATION=%u)", requested_event_type,
+            PMU_EVENT_TYPE_DEFAULT
+        );
+    }
+    const char *pmu_env = std::getenv("SIMPLER_PMU_EVENT_TYPE");
+    if (pmu_env == nullptr) {
+        return resolved;
+    }
+    int val = std::atoi(pmu_env);
+    if (val > 0 && pmu_resolve_event_config_a2a3(static_cast<uint32_t>(val)) != nullptr) {
+        resolved = static_cast<uint32_t>(val);
+        LOG_INFO("PMU event type set to %u from SIMPLER_PMU_EVENT_TYPE", resolved);
+        return resolved;
+    }
+    LOG_WARN("Invalid SIMPLER_PMU_EVENT_TYPE=%s, using default (PIPE_UTILIZATION=%u)", pmu_env, PMU_EVENT_TYPE_DEFAULT);
+    return resolved;
+}
+
+/**
+ * Generate a timestamped CSV output path under outputs/.
+ */
+inline std::string make_pmu_csv_path() {
+    if (mkdir("outputs", 0755) != 0 && errno != EEXIST) {
+        LOG_WARN("Failed to create outputs directory for PMU CSV: errno=%d", errno);
+    }
+    char csv_name[128];
+    auto now = std::chrono::system_clock::now();
+    std::time_t t_now = std::chrono::system_clock::to_time_t(now);
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count() % 1000;
+    std::tm *tm_info = std::localtime(&t_now);
+    if (tm_info != nullptr) {
+        char base[96];
+        std::strftime(base, sizeof(base), "pmu_%Y%m%d_%H%M%S", tm_info);
+        std::snprintf(csv_name, sizeof(csv_name), "%s_%03ld.csv", base, static_cast<long>(ms));
+    } else {
+        std::snprintf(csv_name, sizeof(csv_name), "pmu_output.csv");
+    }
+    return std::string("outputs/") + csv_name;
+}
+
+#endif  // SRC_A2A3_PLATFORM_INCLUDE_HOST_PMU_COLLECTOR_H_

--- a/src/a2a3/platform/onboard/aicore/inner_kernel.h
+++ b/src/a2a3/platform/onboard/aicore/inner_kernel.h
@@ -57,8 +57,34 @@ __aicore__ inline uint64_t read_reg(RegId reg) {
         __asm__ volatile("MOV %0, DATA_MAIN_BASE\n" : "=l"(val));
         return static_cast<uint64_t>(val);
     }
+    case RegId::CTRL:
+        return static_cast<uint64_t>(get_ctrl());
     case RegId::COND:
     case RegId::FAST_PATH_ENABLE:
+    // PMU MMIO registers are AICPU-only; AICore has no read path for them.
+    case RegId::PMU_CTRL_0:
+    case RegId::PMU_CNT0:
+    case RegId::PMU_CNT1:
+    case RegId::PMU_CNT2:
+    case RegId::PMU_CNT3:
+    case RegId::PMU_CNT4:
+    case RegId::PMU_CNT5:
+    case RegId::PMU_CNT6:
+    case RegId::PMU_CNT7:
+    case RegId::PMU_CNT_TOTAL0:
+    case RegId::PMU_CNT_TOTAL1:
+    case RegId::PMU_START_CYC0:
+    case RegId::PMU_START_CYC1:
+    case RegId::PMU_STOP_CYC0:
+    case RegId::PMU_STOP_CYC1:
+    case RegId::PMU_CNT0_IDX:
+    case RegId::PMU_CNT1_IDX:
+    case RegId::PMU_CNT2_IDX:
+    case RegId::PMU_CNT3_IDX:
+    case RegId::PMU_CNT4_IDX:
+    case RegId::PMU_CNT5_IDX:
+    case RegId::PMU_CNT6_IDX:
+    case RegId::PMU_CNT7_IDX:
         return 0;
     }
 }
@@ -74,8 +100,35 @@ __aicore__ inline void write_reg(RegId reg, uint64_t value) {
     case RegId::COND:
         set_cond(static_cast<uint32_t>(value));
         break;
+    case RegId::CTRL:
+        set_ctrl(value);
+        break;
     case RegId::DATA_MAIN_BASE:
     case RegId::FAST_PATH_ENABLE:
+    // PMU MMIO registers are AICPU-only; AICore has no write path for them.
+    case RegId::PMU_CTRL_0:
+    case RegId::PMU_CNT0:
+    case RegId::PMU_CNT1:
+    case RegId::PMU_CNT2:
+    case RegId::PMU_CNT3:
+    case RegId::PMU_CNT4:
+    case RegId::PMU_CNT5:
+    case RegId::PMU_CNT6:
+    case RegId::PMU_CNT7:
+    case RegId::PMU_CNT_TOTAL0:
+    case RegId::PMU_CNT_TOTAL1:
+    case RegId::PMU_START_CYC0:
+    case RegId::PMU_START_CYC1:
+    case RegId::PMU_STOP_CYC0:
+    case RegId::PMU_STOP_CYC1:
+    case RegId::PMU_CNT0_IDX:
+    case RegId::PMU_CNT1_IDX:
+    case RegId::PMU_CNT2_IDX:
+    case RegId::PMU_CNT3_IDX:
+    case RegId::PMU_CNT4_IDX:
+    case RegId::PMU_CNT5_IDX:
+    case RegId::PMU_CNT6_IDX:
+    case RegId::PMU_CNT7_IDX:
         break;
     }
 }

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -14,6 +14,7 @@
 #include "common/kernel_args.h"
 #include "common/platform_config.h"
 #include "aicpu/device_log.h"
+#include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "aicpu/platform_aicpu_affinity.h"
 #include "aicpu/tensor_dump_aicpu.h"
@@ -85,6 +86,9 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_platform_regs(k_args->regs);
     set_platform_dump_base(k_args->dump_data_base);
     set_enable_dump_tensor(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
+    set_platform_pmu_base(k_args->pmu_data_base);
+    set_platform_pmu_reg_addrs(k_args->pmu_reg_addrs);
+    set_enable_pmu(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_PMU));
 
     // Affinity gate: drop excess threads before entering runtime
     if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -40,6 +40,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/performance_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/tensor_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/comm_hccl.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/pmu_collector.cpp"
 )
 if(DEFINED CUSTOM_SOURCE_DIRS)
     foreach(SRC_DIR ${CUSTOM_SOURCE_DIRS})

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -434,8 +434,10 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
 
 int DeviceRunner::run(
     Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor, int enable_pmu
 ) {
+    bool pmu_enabled = enable_pmu > 0;
+    uint32_t pmu_event_type = resolve_pmu_event_type(enable_pmu);
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -494,10 +496,25 @@ int DeviceRunner::run(
     runtime.sche_cpu_num = launch_aicpu_num;
 
     // Get AICore register addresses for register-based task dispatch
-    rc = init_aicore_register_addresses(&kernel_args_.args.regs, static_cast<uint64_t>(device_id), mem_alloc_);
+    rc = init_aicore_register_addresses(
+        &kernel_args_.args.regs, static_cast<uint64_t>(device_id), mem_alloc_, AicoreRegKind::Ctrl
+    );
     if (rc != 0) {
-        LOG_ERROR("init_aicore_register_addresses failed: %d", rc);
+        LOG_ERROR("init_aicore_register_addresses(Ctrl) failed: %d", rc);
         return rc;
+    }
+
+    // Get AICore PMU register addresses (distinct MMIO page from AIC_CTRL).
+    // Failure is non-fatal: PMU will be disabled if this query fails.
+    if (pmu_enabled) {
+        int pmu_rc = init_aicore_register_addresses(
+            &kernel_args_.args.pmu_reg_addrs, static_cast<uint64_t>(device_id), mem_alloc_, AicoreRegKind::Pmu
+        );
+        if (pmu_rc != 0) {
+            LOG_ERROR("init_aicore_register_addresses(Pmu) failed: %d, disabling PMU", pmu_rc);
+            kernel_args_.args.pmu_reg_addrs = 0;
+            pmu_enabled = false;
+        }
     }
 
     // Calculate number of AIC cores (1/3 of total)
@@ -505,6 +522,9 @@ int DeviceRunner::run(
     uint32_t enable_profiling_flag = PROFILING_FLAG_NONE;
     if (enable_dump_tensor) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
+    }
+    if (pmu_enabled) {
+        SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
     }
 
     for (int i = 0; i < num_aicore; i++) {
@@ -541,6 +561,13 @@ int DeviceRunner::run(
         }
     });
 
+    auto pmu_regs_cleanup = RAIIScopeGuard([this]() {
+        if (kernel_args_.args.pmu_reg_addrs != 0) {
+            mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.pmu_reg_addrs));
+            kernel_args_.args.pmu_reg_addrs = 0;
+        }
+    });
+
     auto runtime_args_cleanup = RAIIScopeGuard([this]() {
         kernel_args_.finalize_device_kernel_args();
         kernel_args_.finalize_runtime_args();
@@ -567,6 +594,15 @@ int DeviceRunner::run(
             return rc;
         }
         dump_collector_.start_memory_manager();
+    }
+
+    if (pmu_enabled) {
+        rc = init_pmu_buffers(num_aicore, launch_aicpu_num, make_pmu_csv_path(), pmu_event_type, device_id);
+        if (rc != 0) {
+            LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
+            kernel_args_.args.pmu_data_base = 0;
+            pmu_enabled = false;
+        }
     }
 
     auto perf_cleanup = RAIIScopeGuard([this]() {
@@ -624,7 +660,6 @@ int DeviceRunner::run(
     }
 
     {
-        // Poll and collect performance data in a separate collector thread
         std::thread collector_thread;
         if (runtime.enable_profiling) {
             collector_thread = create_thread([this, &runtime]() {
@@ -632,7 +667,7 @@ int DeviceRunner::run(
             });
         }
         auto thread_guard = RAIIScopeGuard([&]() {
-            if (runtime.enable_profiling && collector_thread.joinable()) {
+            if (collector_thread.joinable()) {
                 collector_thread.join();
             }
         });
@@ -642,20 +677,39 @@ int DeviceRunner::run(
             }
         });
 
+        std::thread dump_collector_thread;
         if (enable_dump_tensor) {
-            // Poll and collect dump data in a separate collector thread
-            std::thread dump_collector_thread([this]() {
+            dump_collector_thread = std::thread([this]() {
                 dump_collector_.poll_and_collect();
             });
-            auto dump_thread_guard = RAIIScopeGuard([&]() {
-                if (dump_collector_thread.joinable()) {
-                    dump_collector_thread.join();
-                }
-            });
-            auto dump_signal_guard = RAIIScopeGuard([this]() {
+        }
+        auto dump_thread_guard = RAIIScopeGuard([&]() {
+            if (dump_collector_thread.joinable()) {
+                dump_collector_thread.join();
+            }
+        });
+        auto dump_signal_guard = RAIIScopeGuard([this, enable_dump_tensor]() {
+            if (enable_dump_tensor) {
                 dump_collector_.signal_execution_complete();
+            }
+        });
+
+        std::thread pmu_collector_thread;
+        if (pmu_enabled) {
+            pmu_collector_thread = std::thread([this]() {
+                pmu_collector_.poll_and_collect();
             });
         }
+        auto pmu_thread_guard = RAIIScopeGuard([&]() {
+            if (pmu_collector_thread.joinable()) {
+                pmu_collector_thread.join();
+            }
+        });
+        auto pmu_signal_guard = RAIIScopeGuard([this, pmu_enabled]() {
+            if (pmu_enabled) {
+                pmu_collector_.signal_execution_complete();
+            }
+        });
 
         std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
         // Synchronize streams
@@ -687,6 +741,10 @@ int DeviceRunner::run(
         dump_collector_.drain_remaining_buffers();
         dump_collector_.scan_remaining_dump_buffers();
         dump_collector_.export_dump_files();
+    }
+
+    if (pmu_enabled && pmu_collector_.is_initialized()) {
+        pmu_collector_.drain_remaining_buffers();
     }
 
     // Print handshake results (reads from device memory, must be before free)
@@ -779,6 +837,24 @@ int DeviceRunner::finalize() {
         };
 
         dump_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+    }
+
+    if (pmu_collector_.is_initialized()) {
+        auto unregister_cb = [](void *dev_ptr, int device_id, void *user_data) -> int {
+            (void)user_data;
+            HalHostUnregisterFn fn = get_halHostUnregister();
+            if (fn != nullptr) {
+                return fn(dev_ptr, device_id);
+            }
+            return 0;
+        };
+
+        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+            auto *allocator = static_cast<MemoryAllocator *>(user_data);
+            return allocator->free(dev_ptr);
+        };
+
+        pmu_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
     }
 
     // Free all remaining allocations (including handshake buffer and binGmAddr)
@@ -1025,4 +1101,38 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
 
     kernel_args_.args.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_shm_device_ptr());
     return 0;
+}
+
+int DeviceRunner::init_pmu_buffers(
+    int num_cores, int num_threads, const std::string &csv_path, uint32_t event_type, int device_id
+) {
+    auto alloc_cb = [](size_t size, void *user_data) -> void * {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
+        return allocator->alloc(size);
+    };
+
+    auto register_cb = [](void *dev_ptr, size_t size, int device_id, void *user_data, void **host_ptr) -> int {
+        (void)user_data;
+        if (load_hal_if_needed() != 0) {
+            LOG_ERROR("Failed to load ascend_hal for PMU: %s", dlerror());
+            return -1;
+        }
+        HalHostRegisterFn fn = get_halHostRegister();
+        if (fn == nullptr) {
+            LOG_ERROR("halHostRegister symbol not found: %s", dlerror());
+            return -1;
+        }
+        return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
+    };
+
+    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
+        return allocator->free(dev_ptr);
+    };
+
+    int rc = pmu_collector_.init(
+        num_cores, num_threads, &kernel_args_.args.pmu_data_base, csv_path, event_type, alloc_cb, register_cb, free_cb,
+        &mem_alloc_, device_id
+    );
+    return rc;
 }

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -44,6 +44,7 @@
 #include "host/memory_allocator.h"
 #include "host/performance_collector.h"
 #include "host/tensor_dump_collector.h"
+#include "host/pmu_collector.h"
 #include "runtime.h"
 
 /**
@@ -252,7 +253,8 @@ public:
      */
     int
     run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false);
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false,
+        int enable_pmu = 0);
 
     /**
      * Print handshake results from device
@@ -451,6 +453,8 @@ private:
 
     // Tensor dump (independent shared memory + memory manager)
     TensorDumpCollector dump_collector_;
+    // PMU collector (independent of profiling pipeline)
+    PmuCollectorHost pmu_collector_;
 
     /**
      * Ensure device is initialized (lazy initialization)
@@ -510,6 +514,23 @@ private:
      * @return 0 on success, error code on failure
      */
     int init_tensor_dump(Runtime &runtime, int num_aicore, int device_id);
+
+    /**
+     * Initialize PMU streaming shared memory.
+     *
+     * Allocates PmuDataHeader + PmuBufferState array + pre-allocated PmuBuffers,
+     * registers them via halHostRegister, and stores the header address in
+     * kernel_args.pmu_data_base.
+     *
+     * @param num_cores  Number of AICore instances
+     * @param num_threads Number of AICPU scheduling threads
+     * @param csv_path   Output CSV file path
+     * @param event_type PMU event type (written to CSV rows)
+     * @param device_id  Device ID for host registration
+     * @return 0 on success, error code on failure
+     */
+    int
+    init_pmu_buffers(int num_cores, int num_threads, const std::string &csv_path, uint32_t event_type, int device_id);
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a2a3/platform/onboard/host/host_regs.cpp
+++ b/src/a2a3/platform/onboard/host/host_regs.cpp
@@ -22,6 +22,26 @@
 #include <dlfcn.h>
 #include <iostream>
 
+static int kind_to_addr_type(AicoreRegKind kind) {
+    switch (kind) {
+    case AicoreRegKind::Ctrl:
+        return ADDR_MAP_TYPE_REG_AIC_CTRL;
+    case AicoreRegKind::Pmu:
+        return ADDR_MAP_TYPE_REG_AIC_PMU_CTRL;
+    }
+    return ADDR_MAP_TYPE_REG_AIC_CTRL;
+}
+
+static const char *kind_to_name(AicoreRegKind kind) {
+    switch (kind) {
+    case AicoreRegKind::Ctrl:
+        return "AIC_CTRL";
+    case AicoreRegKind::Pmu:
+        return "AIC_PMU_CTRL";
+    }
+    return "UNKNOWN";
+}
+
 /**
  * Query valid AICore cores via HAL API
  */
@@ -52,7 +72,7 @@ static bool get_pg_mask(uint64_t &valid, int64_t device_id) {
 }
 
 /**
- * Retrieve AICore register base addresses via HAL API
+ * Retrieve AICore register base addresses via HAL API for one addr_type.
  */
 static int
 get_aicore_reg_info(std::vector<int64_t> &aic, std::vector<int64_t> &aiv, const int &addr_type, int64_t device_id) {
@@ -113,68 +133,71 @@ get_aicore_reg_info(std::vector<int64_t> &aic, std::vector<int64_t> &aiv, const 
     return 0;
 }
 
-static void get_aicore_regs(std::vector<int64_t> &regs, uint64_t device_id) {
-    std::vector<int64_t> aiv;
+/**
+ * Get one flat AIC-then-AIV address array for the requested register kind.
+ * Returns a negative code on HAL failure; does NOT generate placeholder
+ * addresses (callers must treat failure as fatal for that kind).
+ */
+static int get_aicore_regs(std::vector<int64_t> &regs, uint64_t device_id, AicoreRegKind kind) {
     std::vector<int64_t> aic;
+    std::vector<int64_t> aiv;
 
-    int rt = get_aicore_reg_info(aic, aiv, ADDR_MAP_TYPE_REG_AIC_CTRL, device_id);
-
-    if (rt != 0) {
-        LOG_ERROR("get_aicore_reg_info failed, using placeholder addresses");
-        // Fallback: generate placeholder addresses
-        for (uint32_t i = 0; i < DAV_2201::PLATFORM_MAX_PHYSICAL_CORES; i++) {
-            aic.push_back(0xDEADBEEF00000000ULL + (i * 0x800000));  // 8M stride
-            aiv.push_back(0xDEADBEEF00000000ULL + (i * 0x800000) + 0x100000);
-            aiv.push_back(0xDEADBEEF00000000ULL + (i * 0x800000) + 0x200000);
-        }
+    int rc = get_aicore_reg_info(aic, aiv, kind_to_addr_type(kind), device_id);
+    if (rc != 0) {
+        LOG_ERROR("get_aicore_regs(%s): halMemCtl failed: %d", kind_to_name(kind), rc);
+        return rc;
     }
 
     // AIC cores first, then AIV cores
     regs.insert(regs.end(), aic.begin(), aic.end());
     regs.insert(regs.end(), aiv.begin(), aiv.end());
 
-    LOG_INFO("get_aicore_regs: Retrieved %zu AIC and %zu AIV register addresses", aic.size(), aiv.size());
+    LOG_INFO(
+        "get_aicore_regs(%s): Retrieved %zu AIC and %zu AIV register addresses", kind_to_name(kind), aic.size(),
+        aiv.size()
+    );
+    return 0;
 }
 
-int init_aicore_register_addresses(uint64_t *runtime_regs_ptr, uint64_t device_id, MemoryAllocator &allocator) {
+int init_aicore_register_addresses(
+    uint64_t *runtime_regs_ptr, uint64_t device_id, MemoryAllocator &allocator, AicoreRegKind kind
+) {
     if (runtime_regs_ptr == nullptr) {
-        LOG_ERROR("init_aicore_register_addresses: Invalid parameters");
+        LOG_ERROR("init_aicore_register_addresses(%s): Invalid parameters", kind_to_name(kind));
         return -1;
     }
 
-    LOG_INFO("Retrieving and allocating AICore register addresses...");
+    LOG_INFO("Retrieving and allocating AICore %s register addresses...", kind_to_name(kind));
 
-    // Step 1: Get register addresses from HAL
     std::vector<int64_t> host_regs;
-    get_aicore_regs(host_regs, device_id);
-
+    int rc = get_aicore_regs(host_regs, device_id, kind);
+    if (rc != 0) {
+        return rc;
+    }
     if (host_regs.empty()) {
-        LOG_ERROR("Failed to get AICore register addresses");
+        LOG_ERROR("init_aicore_register_addresses(%s): Empty address array", kind_to_name(kind));
         return -1;
     }
 
-    // Step 2: Allocate device memory for register address array
     size_t regs_size = host_regs.size() * sizeof(int64_t);
     void *reg_ptr = allocator.alloc(regs_size);
     if (reg_ptr == nullptr) {
-        LOG_ERROR("Failed to allocate device memory for register addresses");
+        LOG_ERROR("Failed to allocate device memory for %s register addresses", kind_to_name(kind));
         return -1;
     }
 
-    // Step 3: Copy register addresses to device memory
     int ret = rtMemcpy(reg_ptr, regs_size, host_regs.data(), regs_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (ret != 0) {
-        LOG_ERROR("Failed to copy register addresses to device (rc=%d)", ret);
+        LOG_ERROR("Failed to copy %s register addresses to device (rc=%d)", kind_to_name(kind), ret);
         allocator.free(reg_ptr);
         return -1;
     }
 
-    // Step 4: Store device pointer in output regs field
     *runtime_regs_ptr = reinterpret_cast<uint64_t>(reg_ptr);
 
     LOG_INFO(
-        "Successfully initialized register addresses: %zu addresses at device 0x%llx", host_regs.size(),
-        *runtime_regs_ptr
+        "Successfully initialized %s register addresses: %zu addresses at device 0x%llx", kind_to_name(kind),
+        host_regs.size(), *runtime_regs_ptr
     );
 
     return 0;

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -189,7 +189,7 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
 int run_runtime(
     DeviceContextHandle ctx, RuntimeHandle runtime, const void *callable, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_profiling, int enable_dump_tensor
+    size_t aicore_size, int enable_profiling, int enable_dump_tensor, int enable_pmu
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
     if (aicpu_binary == NULL || aicpu_size == 0 || aicore_binary == NULL || aicore_size == 0) return -1;
@@ -235,7 +235,9 @@ int run_runtime(
 
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
-        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0);
+        rc = runner->run(
+            *r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0, enable_pmu
+        );
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -44,6 +44,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/unified_log_host.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/performance_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/tensor_dump_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../aicpu/platform_aicpu_affinity.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform_comm/comm_sim.cpp"
 )

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -27,7 +27,6 @@
 #include "device_runner.h"
 
 #include <stdlib.h>
-#include <sys/stat.h>
 
 #include <atomic>
 #include <cstdio>
@@ -47,6 +46,8 @@ typedef void (*aicore_execute_func_t)(
 typedef void (*set_platform_regs_func_t)(uint64_t regs);
 typedef void (*set_platform_dump_base_func_t)(uint64_t dump_data_base);
 typedef void (*set_enable_dump_tensor_func_t)(bool enable);
+typedef void (*set_platform_pmu_base_func_t)(uint64_t pmu_data_base);
+typedef void (*set_enable_pmu_func_t)(bool enable);
 
 namespace {
 
@@ -160,6 +161,26 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
+        set_platform_pmu_base_func_ =
+            reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_pmu_base"));
+        if (set_platform_pmu_base_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_platform_pmu_base: %s", dlerror());
+            return -1;
+        }
+
+        set_platform_pmu_reg_addrs_func_ =
+            reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_pmu_reg_addrs"));
+        if (set_platform_pmu_reg_addrs_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_platform_pmu_reg_addrs: %s", dlerror());
+            return -1;
+        }
+
+        set_enable_pmu_func_ = reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_enable_pmu"));
+        if (set_enable_pmu_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_enable_pmu: %s", dlerror());
+            return -1;
+        }
+
         LOG_INFO("DeviceRunner(sim): Loaded aicpu_execute from %s", aicpu_so_path_.c_str());
     }
 
@@ -224,8 +245,10 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
 
 int DeviceRunner::run(
     Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor, int enable_pmu
 ) {
+    bool pmu_enabled = enable_pmu > 0;
+    uint32_t pmu_event_type = resolve_pmu_event_type(enable_pmu);
     clear_cpu_sim_shared_storage();
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
@@ -290,6 +313,9 @@ int DeviceRunner::run(
     if (enable_dump_tensor) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     }
+    if (pmu_enabled) {
+        SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
+    }
 
     for (int i = 0; i < num_aicore; i++) {
         runtime.workers[i].aicpu_ready = 0;
@@ -341,6 +367,15 @@ int DeviceRunner::run(
         dump_collector_.start_memory_manager();
     }
 
+    if (pmu_enabled) {
+        rc = init_pmu_buffers(num_aicore, launch_aicpu_num, make_pmu_csv_path(), pmu_event_type, device_id);
+        if (rc != 0) {
+            LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
+            kernel_args_.pmu_data_base = 0;
+            pmu_enabled = false;
+        }
+    }
+
     auto perf_cleanup = RAIIScopeGuard([this]() {
         bool was_initialized = perf_collector_.is_initialized();
         if (was_initialized) {
@@ -383,15 +418,20 @@ int DeviceRunner::run(
     LOG_INFO("Allocated simulated registers: %d cores x 0x%x bytes", num_aicore, SIM_REG_BLOCK_SIZE);
 
     // Check if executors are loaded
-    if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr) {
+    if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
+        set_platform_dump_base_func_ == nullptr || set_enable_dump_tensor_func_ == nullptr ||
+        set_platform_pmu_base_func_ == nullptr || set_platform_pmu_reg_addrs_func_ == nullptr ||
+        set_enable_pmu_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }
 
-    // Set platform regs in the AICPU .so before launching threads
     set_platform_regs_func_(kernel_args_.regs);
     set_platform_dump_base_func_(kernel_args_.dump_data_base);
     set_enable_dump_tensor_func_(enable_dump_tensor);
+    set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
+    set_platform_pmu_reg_addrs_func_(kernel_args_.pmu_reg_addrs);  // 0 on sim (no PMU hardware)
+    set_enable_pmu_func_(pmu_enabled);
 
     // Launch AICPU threads (over-launch for affinity gate)
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
@@ -431,53 +471,49 @@ int DeviceRunner::run(
         });
     }
 
+    std::thread dump_collector_thread;
     if (enable_dump_tensor) {
-        // Poll and collect dump data in a separate collector thread
-        std::thread dump_collector_thread([this]() {
+        dump_collector_thread = std::thread([this]() {
             dump_collector_.poll_and_collect();
         });
+    }
 
-        // Wait for all threads to complete
-        LOG_INFO("Waiting for threads to complete");
-        for (auto &t : aicpu_threads) {
-            t.join();
-        }
-        for (auto &t : aicore_threads) {
-            t.join();
-        }
+    std::thread pmu_collector_thread;
+    if (pmu_enabled) {
+        pmu_collector_thread = std::thread([this]() {
+            pmu_collector_.poll_and_collect();
+        });
+    }
 
-        // Signal collector that device execution is complete
-        if (runtime.enable_profiling) {
-            perf_collector_.signal_execution_complete();
-        }
+    // Wait for all AICPU and AICore threads to complete
+    LOG_INFO("Waiting for threads to complete");
+    for (auto &t : aicpu_threads) {
+        t.join();
+    }
+    for (auto &t : aicore_threads) {
+        t.join();
+    }
+
+    // Signal all collectors that device execution is complete
+    if (runtime.enable_profiling) {
+        perf_collector_.signal_execution_complete();
+    }
+    if (enable_dump_tensor) {
         dump_collector_.signal_execution_complete();
+    }
+    if (pmu_enabled) {
+        pmu_collector_.signal_execution_complete();
+    }
 
-        // Wait for collector thread if it was launched
-        if (runtime.enable_profiling && collector_thread.joinable()) {
-            collector_thread.join();
-        }
-        if (dump_collector_thread.joinable()) {
-            dump_collector_thread.join();
-        }
-    } else {
-        // Wait for all threads to complete
-        LOG_INFO("Waiting for threads to complete");
-        for (auto &t : aicpu_threads) {
-            t.join();
-        }
-        for (auto &t : aicore_threads) {
-            t.join();
-        }
-
-        // Signal collector that device execution is complete
-        if (runtime.enable_profiling) {
-            perf_collector_.signal_execution_complete();
-        }
-
-        // Wait for collector thread if it was launched
-        if (runtime.enable_profiling && collector_thread.joinable()) {
-            collector_thread.join();
-        }
+    // Wait for all collector threads
+    if (collector_thread.joinable()) {
+        collector_thread.join();
+    }
+    if (dump_collector_thread.joinable()) {
+        dump_collector_thread.join();
+    }
+    if (pmu_collector_thread.joinable()) {
+        pmu_collector_thread.join();
     }
 
     LOG_INFO("All threads completed");
@@ -502,6 +538,10 @@ int DeviceRunner::run(
         dump_collector_.drain_remaining_buffers();
         dump_collector_.scan_remaining_dump_buffers();
         dump_collector_.export_dump_files();
+    }
+
+    if (pmu_enabled && pmu_collector_.is_initialized()) {
+        pmu_collector_.drain_remaining_buffers();
     }
 
     // Print handshake results at end of run
@@ -538,6 +578,9 @@ void DeviceRunner::unload_executor_binaries() {
         set_platform_regs_func_ = nullptr;
         set_platform_dump_base_func_ = nullptr;
         set_enable_dump_tensor_func_ = nullptr;
+        set_platform_pmu_base_func_ = nullptr;
+        set_platform_pmu_reg_addrs_func_ = nullptr;
+        set_enable_pmu_func_ = nullptr;
     }
     if (!aicpu_so_path_.empty()) {
         std::remove(aicpu_so_path_.c_str());
@@ -579,6 +622,16 @@ int DeviceRunner::finalize() {
         };
 
         dump_collector_.finalize(nullptr, free_cb, nullptr);
+    }
+
+    if (pmu_collector_.is_initialized()) {
+        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+            (void)user_data;
+            free(dev_ptr);
+            return 0;
+        };
+
+        pmu_collector_.finalize(nullptr, free_cb, nullptr);
     }
 
     // Kernel binaries should have been removed by validate_runtime_impl()
@@ -759,4 +812,24 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
 
     kernel_args_.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_shm_device_ptr());
     return 0;
+}
+
+int DeviceRunner::init_pmu_buffers(
+    int num_cores, int num_threads, const std::string &csv_path, uint32_t event_type, int /*device_id*/
+) {
+    auto alloc_cb = [](size_t size, void * /*user_data*/) -> void * {
+        return malloc(size);
+    };
+
+    auto free_cb = [](void *dev_ptr, void * /*user_data*/) -> int {
+        free(dev_ptr);
+        return 0;
+    };
+
+    // Simulation: no halHostRegister needed (dev == host)
+    int rc = pmu_collector_.init(
+        num_cores, num_threads, &kernel_args_.pmu_data_base, csv_path, event_type, alloc_cb, nullptr, free_cb, nullptr,
+        -1
+    );
+    return rc;
 }

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -51,6 +51,7 @@
 #include "host/memory_allocator.h"
 #include "host/performance_collector.h"
 #include "host/tensor_dump_collector.h"
+#include "host/pmu_collector.h"
 #include "runtime.h"
 
 /**
@@ -143,7 +144,8 @@ public:
      */
     int
     run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false);
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false,
+        int enable_pmu = 0);
 
     /**
      * Print handshake results
@@ -236,6 +238,9 @@ private:
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_platform_dump_base_func_)(uint64_t){nullptr};
     void (*set_enable_dump_tensor_func_)(bool){nullptr};
+    void (*set_platform_pmu_base_func_)(uint64_t){nullptr};
+    void (*set_platform_pmu_reg_addrs_func_)(uint64_t){nullptr};
+    void (*set_enable_pmu_func_)(bool){nullptr};
     std::string aicpu_so_path_;
     std::string aicore_so_path_;
 
@@ -244,6 +249,8 @@ private:
 
     // Tensor dump (independent shared memory + memory manager)
     TensorDumpCollector dump_collector_;
+    // PMU collector (independent of profiling pipeline)
+    PmuCollectorHost pmu_collector_;
 
     // Private helper methods
     int ensure_device_initialized(
@@ -267,6 +274,9 @@ private:
     int init_performance_profiling(Runtime &runtime, int num_aicore, int device_id);
 
     int init_tensor_dump(Runtime &runtime, int num_aicore, int device_id);
+
+    int
+    init_pmu_buffers(int num_cores, int num_threads, const std::string &csv_path, uint32_t event_type, int device_id);
 };
 
 #endif  // SRC_A2A3_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -158,7 +158,7 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
 int run_runtime(
     DeviceContextHandle ctx, RuntimeHandle runtime, const void *callable, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_profiling, int enable_dump_tensor
+    size_t aicore_size, int enable_profiling, int enable_dump_tensor, int enable_pmu
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
 
@@ -201,7 +201,9 @@ int run_runtime(
         if (aicore_binary != NULL && aicore_size > 0) {
             aicore_vec.assign(aicore_binary, aicore_binary + aicore_size);
         }
-        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0);
+        rc = runner->run(
+            *r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0, enable_pmu
+        );
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a2a3/platform/src/aicpu/platform_regs.cpp
+++ b/src/a2a3/platform/src/aicpu/platform_regs.cpp
@@ -31,10 +31,15 @@
 #include "common/platform_config.h"
 
 static uint64_t g_platform_regs = 0;
+static uint64_t g_platform_pmu_reg_addrs = 0;
 
 void set_platform_regs(uint64_t regs) { g_platform_regs = regs; }
 
 uint64_t get_platform_regs() { return g_platform_regs; }
+
+void set_platform_pmu_reg_addrs(uint64_t pmu_regs) { g_platform_pmu_reg_addrs = pmu_regs; }
+
+uint64_t get_platform_pmu_reg_addrs() { return g_platform_pmu_reg_addrs; }
 
 uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
     volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(reg_base_addr + reg_offset(reg));

--- a/src/a2a3/platform/src/aicpu/pmu_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/pmu_collector_aicpu.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file pmu_collector_aicpu.cpp
+ * @brief AICPU-side AICore PMU counter collection implementation
+ *
+ * Uses read_reg/write_reg from platform_regs for MMIO register access,
+ * consistent with the rest of the platform layer.
+ *
+ * Buffer switching mirrors performance_collector_aicpu.cpp:
+ *   - SPSC free_queue: Host pushes free PmuBuffers, AICPU pops when switching.
+ *   - Per-thread ready_queue: AICPU enqueues full buffers for host collection.
+ *   - On free_queue empty or ready_queue full: overwrite current buffer (data lost,
+ *     same policy as perf profiling — avoids blocking the AICPU dispatch loop).
+ */
+
+#include "aicpu/pmu_collector_aicpu.h"
+
+#include <cstring>
+
+#include "aicpu/platform_regs.h"
+#include "common/memory_barrier.h"
+#include "common/platform_config.h"
+#include "common/unified_log.h"
+
+static uint64_t g_platform_pmu_base = 0;
+static bool g_enable_pmu = false;
+
+// Saved CTRL register state per core, indexed by logical core_id.
+// Populated by pmu_aicpu_init(), consumed by pmu_aicpu_finalize().
+static uint32_t g_pmu_saved_ctrl0[PLATFORM_MAX_CORES];
+
+// Per-core cached PmuBufferState pointer and current buffer pointer.
+static PmuBufferState *s_pmu_buffer_states[PLATFORM_MAX_CORES];
+static PmuDataHeader *s_pmu_header = nullptr;
+
+// Per-core resolved PMU MMIO base address, keyed by logical core_id.
+// Populated by pmu_aicpu_init(); 0 means "no PMU for this core" (sim).
+static uint64_t s_pmu_reg_addrs[PLATFORM_MAX_CORES] = {0};
+
+extern "C" void set_platform_pmu_base(uint64_t pmu_data_base) { g_platform_pmu_base = pmu_data_base; }
+
+extern "C" uint64_t get_platform_pmu_base() { return g_platform_pmu_base; }
+
+extern "C" void set_enable_pmu(bool enable) { g_enable_pmu = enable; }
+
+extern "C" bool get_enable_pmu() { return g_enable_pmu; }
+
+// ---------------------------------------------------------------------------
+// Low-level MMIO helpers (internal use only)
+// ---------------------------------------------------------------------------
+
+static void pmu_program_events(uint64_t reg_base, const PmuEventConfig &events) {
+    for (int i = 0; i < PMU_COUNTER_COUNT_A2A3; i++) {
+        write_reg(reg_base, reg_index(RegId::PMU_CNT0_IDX, i), events.event_ids[i]);
+    }
+}
+
+static uint32_t pmu_start(uint64_t reg_base) {
+    // Clear counters by reading them once
+    for (int i = 0; i < PMU_COUNTER_COUNT_A2A3; i++) {
+        (void)read_reg(reg_base, reg_index(RegId::PMU_CNT0, i));
+    }
+    (void)read_reg(reg_base, RegId::PMU_CNT_TOTAL0);
+    (void)read_reg(reg_base, RegId::PMU_CNT_TOTAL1);
+
+    // Set full cycle counting range: start at 0, stop at 0xFFFFFFFF
+    write_reg(reg_base, RegId::PMU_START_CYC0, 0x0);
+    write_reg(reg_base, RegId::PMU_START_CYC1, 0x0);
+    write_reg(reg_base, RegId::PMU_STOP_CYC0, 0xFFFFFFFF);
+    write_reg(reg_base, RegId::PMU_STOP_CYC1, 0xFFFFFFFF);
+
+    // Save and set CTRL_0
+    uint32_t saved_ctrl0 = static_cast<uint32_t>(read_reg(reg_base, RegId::PMU_CTRL_0));
+    write_reg(reg_base, RegId::PMU_CTRL_0, REG_MMIO_PMU_CTRL_0_ENABLE_VAL);
+    return saved_ctrl0;
+}
+
+static void pmu_stop(uint64_t reg_base, uint32_t saved_ctrl0) { write_reg(reg_base, RegId::PMU_CTRL_0, saved_ctrl0); }
+
+static void pmu_read_counters(uint64_t reg_base, PmuRecord *out) {
+    for (int i = 0; i < PMU_COUNTER_COUNT_A2A3; i++) {
+        out->pmu_counters[i] = static_cast<uint32_t>(read_reg(reg_base, reg_index(RegId::PMU_CNT0, i)));
+    }
+    uint64_t lo = read_reg(reg_base, RegId::PMU_CNT_TOTAL0);
+    uint64_t hi = read_reg(reg_base, RegId::PMU_CNT_TOTAL1);
+    out->pmu_total_cycles = lo | (hi << 32);
+}
+
+// ---------------------------------------------------------------------------
+// Internal: enqueue full buffer to per-thread ready_queue
+// ---------------------------------------------------------------------------
+
+static int enqueue_pmu_ready_buffer(int thread_idx, uint32_t core_index, uint64_t buffer_ptr, uint32_t buffer_seq) {
+    uint32_t capacity = PLATFORM_PMU_READYQUEUE_SIZE;
+    uint32_t current_tail = s_pmu_header->queue_tails[thread_idx];
+    uint32_t current_head = s_pmu_header->queue_heads[thread_idx];
+
+    uint32_t next_tail = (current_tail + 1) % capacity;
+    if (next_tail == current_head) {
+        return -1;  // Queue full
+    }
+
+    s_pmu_header->queues[thread_idx][current_tail].core_index = core_index;
+    s_pmu_header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
+    s_pmu_header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
+    s_pmu_header->queue_tails[thread_idx] = next_tail;
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: switch the current buffer for one core
+// ---------------------------------------------------------------------------
+
+static void pmu_switch_buffer(int core_id, int thread_idx) {
+    PmuBufferState *state = s_pmu_buffer_states[core_id];
+    if (state == nullptr) {
+        return;
+    }
+
+    PmuBuffer *full_buf = reinterpret_cast<PmuBuffer *>(state->current_buf_ptr);
+    if (full_buf == nullptr) {
+        return;
+    }
+
+    // Check free_queue before committing the full buffer
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head == tail) {
+        // No replacement buffer available — overwrite current buffer to keep AICPU alive
+        LOG_WARN("Thread %d: Core %d no free PMU buffer, overwriting current buffer (data lost)", thread_idx, core_id);
+        state->dropped_record_count += full_buf->count;
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Enqueue full buffer to ready_queue
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_pmu_ready_buffer(thread_idx, static_cast<uint32_t>(core_id), state->current_buf_ptr, seq);
+    if (rc != 0) {
+        LOG_ERROR(
+            "Thread %d: Core %d failed to enqueue PMU buffer (ready_queue full), data lost!", thread_idx, core_id
+        );
+        state->dropped_record_count += full_buf->count;
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Pop next buffer from free_queue
+    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PMU_SLOT_COUNT];
+    rmb();
+    state->free_queue.head = head + 1;
+    state->current_buf_ptr = new_buf_ptr;
+    state->current_buf_seq = seq + 1;
+    wmb();
+
+    PmuBuffer *new_buf = reinterpret_cast<PmuBuffer *>(new_buf_ptr);
+    new_buf->count = 0;
+
+    LOG_INFO("Thread %d: Core %d switched to new PMU buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
+}
+
+// ---------------------------------------------------------------------------
+// High-level interface
+// ---------------------------------------------------------------------------
+
+void pmu_aicpu_init(const uint32_t *physical_core_ids, int num_cores) {
+    void *pmu_base = reinterpret_cast<void *>(get_platform_pmu_base());
+    if (pmu_base == nullptr) {
+        LOG_ERROR("pmu_aicpu_init: pmu_data_base is NULL");
+        return;
+    }
+
+    s_pmu_header = get_pmu_header(pmu_base);
+
+    // Read event_type from SHM header (written by host at init)
+    uint32_t pmu_event_type = s_pmu_header->event_type;
+
+    // Resolve per-core PMU MMIO base from physical_core_ids. 0 means "no PMU
+    // for this core" (sim or misconfigured) — subsequent record/stop become no-ops.
+    uint64_t *pmu_regs_array = reinterpret_cast<uint64_t *>(get_platform_pmu_reg_addrs());
+    for (int i = 0; i < num_cores; i++) {
+        if (i >= PLATFORM_MAX_CORES) {
+            LOG_ERROR("pmu_aicpu_init: num_cores %d exceeds PLATFORM_MAX_CORES %d", num_cores, PLATFORM_MAX_CORES);
+            break;
+        }
+        s_pmu_reg_addrs[i] = pmu_regs_array ? pmu_regs_array[physical_core_ids[i]] : 0;
+    }
+
+    // Program event selectors and start PMU counters on all cores
+    const PmuEventConfig *evt = pmu_resolve_event_config_a2a3(pmu_event_type);
+    if (evt == nullptr) {
+        evt = &PMU_EVENTS_A2A3_PIPE_UTIL;
+    }
+    for (int i = 0; i < num_cores; i++) {
+        uint64_t reg_addr = s_pmu_reg_addrs[i];
+        if (reg_addr == 0) {
+            LOG_WARN("pmu_aicpu_init: core %d has no PMU reg_addr, skipping (sim or misconfigured)", i);
+            continue;
+        }
+        pmu_program_events(reg_addr, *evt);
+        g_pmu_saved_ctrl0[i] = pmu_start(reg_addr);
+    }
+
+    // Pop initial PmuBuffer from each core's free_queue
+    for (int i = 0; i < num_cores; i++) {
+        PmuBufferState *state = get_pmu_buffer_state(pmu_base, i);
+        s_pmu_buffer_states[i] = state;
+
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PMU_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+
+            PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(buf_ptr);
+            buf->count = 0;
+
+            LOG_DEBUG("Core %d: popped initial PMU buffer (addr=0x%lx)", i, buf_ptr);
+        } else {
+            LOG_ERROR("Core %d: PMU free_queue is empty during init!", i);
+            state->current_buf_ptr = 0;
+        }
+    }
+
+    wmb();
+    LOG_INFO("PMU initialized: %d cores, event_type=%u", num_cores, pmu_event_type);
+}
+
+void pmu_aicpu_record_task(int core_id, int thread_idx, uint64_t task_id, uint32_t func_id, CoreType core_type) {
+    if (s_pmu_header == nullptr || core_id < 0 || core_id >= PLATFORM_MAX_CORES) {
+        return;
+    }
+    uint64_t reg_addr = s_pmu_reg_addrs[core_id];
+    if (reg_addr == 0) {
+        return;
+    }
+
+    PmuBufferState *state = s_pmu_buffer_states[core_id];
+    if (state == nullptr) {
+        return;
+    }
+
+    // Account the task *before* any drop path so total reflects every task the
+    // AICPU tried to record. total == collected + dropped invariant on host.
+    state->total_record_count += 1;
+
+    rmb();
+    uint64_t cur_ptr = state->current_buf_ptr;
+    if (cur_ptr == 0) {
+        state->dropped_record_count += 1;
+        wmb();
+        return;
+    }
+    PmuBuffer *pmu_buf = reinterpret_cast<PmuBuffer *>(cur_ptr);
+
+    // Switch buffer if full
+    if (pmu_buf->count >= static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
+        pmu_switch_buffer(core_id, thread_idx);
+        rmb();
+        cur_ptr = state->current_buf_ptr;
+        if (cur_ptr == 0) {
+            state->dropped_record_count += 1;
+            wmb();
+            return;
+        }
+        pmu_buf = reinterpret_cast<PmuBuffer *>(cur_ptr);
+    }
+
+    uint32_t idx = pmu_buf->count;
+    PmuRecord *rec = &pmu_buf->records[idx];
+    rec->task_id = task_id;
+    rec->func_id = func_id;
+    rec->core_type = core_type;
+    pmu_read_counters(reg_addr, rec);
+    pmu_buf->count = idx + 1;
+    wmb();
+}
+
+void pmu_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int core_num) {
+    if (s_pmu_header == nullptr) {
+        LOG_ERROR("pmu_aicpu_flush_buffers: PMU not initialized (s_pmu_header=NULL), thread %d", thread_idx);
+        return;
+    }
+
+    for (int i = 0; i < core_num; i++) {
+        int core_id = cur_thread_cores[i];
+        if (core_id < 0 || core_id >= PLATFORM_MAX_CORES) {
+            LOG_ERROR(
+                "pmu_aicpu_flush_buffers: thread %d got invalid core_id %d (max %d)", thread_idx, core_id,
+                PLATFORM_MAX_CORES
+            );
+            continue;
+        }
+
+        PmuBufferState *state = s_pmu_buffer_states[core_id];
+        if (state == nullptr) {
+            LOG_WARN(
+                "pmu_aicpu_flush_buffers: thread %d core %d has no PmuBufferState (skipped during init?)", thread_idx,
+                core_id
+            );
+            continue;
+        }
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) {
+            // No active buffer — either never allocated or already flushed. Not an error.
+            continue;
+        }
+
+        PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(buf_ptr);
+        if (buf->count == 0) {
+            // Active buffer but empty — nothing to flush.
+            continue;
+        }
+
+        uint32_t seq = state->current_buf_seq;
+        int rc = enqueue_pmu_ready_buffer(thread_idx, static_cast<uint32_t>(core_id), buf_ptr, seq);
+        if (rc == 0) {
+            LOG_INFO("Thread %d: Core %d flushed PMU buffer with %u records", thread_idx, core_id, buf->count);
+            state->current_buf_ptr = 0;
+            wmb();
+        } else {
+            LOG_ERROR(
+                "Thread %d: Core %d failed to flush PMU buffer (ready_queue full), data lost!", thread_idx, core_id
+            );
+            state->dropped_record_count += buf->count;
+            buf->count = 0;
+            wmb();
+        }
+    }
+}
+
+void pmu_aicpu_finalize(const int *cur_thread_cores, int core_num) {
+    if (s_pmu_header == nullptr) {
+        return;
+    }
+    for (int i = 0; i < core_num; i++) {
+        int core_id = cur_thread_cores[i];
+        if (core_id < 0 || core_id >= PLATFORM_MAX_CORES) {
+            LOG_ERROR("pmu_aicpu_finalize: invalid core_id %d (max %d)", core_id, PLATFORM_MAX_CORES);
+            continue;
+        }
+        uint64_t reg_addr = s_pmu_reg_addrs[core_id];
+        if (reg_addr != 0) {
+            pmu_stop(reg_addr, g_pmu_saved_ctrl0[core_id]);
+        }
+    }
+}

--- a/src/a2a3/platform/src/host/pmu_collector.cpp
+++ b/src/a2a3/platform/src/host/pmu_collector.cpp
@@ -1,0 +1,464 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/pmu_collector.h"
+
+#include <cassert>
+#include <chrono>
+#include <cstring>
+#include <iomanip>
+#include <ios>
+#include <thread>
+
+#include "common/unified_log.h"
+
+// ---------------------------------------------------------------------------
+// Destructor
+// ---------------------------------------------------------------------------
+
+PmuCollectorHost::~PmuCollectorHost() = default;
+
+// ---------------------------------------------------------------------------
+// init
+// ---------------------------------------------------------------------------
+
+int PmuCollectorHost::init(
+    int num_cores, int num_threads, uint64_t *kernel_args_pmu_data_base, const std::string &csv_path,
+    uint32_t event_type, PmuAllocCallback alloc_cb, PmuRegisterCallback register_cb, PmuFreeCallback free_cb,
+    void *user_data, int device_id
+) {
+    if (num_cores <= 0 || num_threads <= 0 || kernel_args_pmu_data_base == nullptr || alloc_cb == nullptr ||
+        free_cb == nullptr) {
+        LOG_ERROR("PmuCollectorHost::init: invalid arguments");
+        return -1;
+    }
+
+    num_cores_ = num_cores;
+    num_threads_ = num_threads;
+    device_id_ = device_id;
+    event_type_ = event_type;
+    alloc_cb_ = alloc_cb;
+    free_cb_ = free_cb;
+    user_data_ = user_data;
+    csv_path_ = csv_path;
+
+    // Reset per-run accumulators. The collector instance is reused across
+    // tests within the same process; without this, a small test running
+    // after a large one inherits the previous run's collected/drained state
+    // and the cross-check at drain time spuriously reports a mismatch.
+    total_collected_ = 0;
+    drained_bufs_.clear();
+    execution_complete_.store(false, std::memory_order_release);
+    if (csv_file_.is_open()) {
+        csv_file_.close();
+    }
+
+    // ---- Allocate shared header + buffer-state region ----
+    shm_size_ = calc_pmu_data_size(num_cores);
+    shm_dev_ = alloc_cb(shm_size_, user_data);
+    if (shm_dev_ == nullptr) {
+        LOG_ERROR("PmuCollectorHost: failed to allocate PMU shared memory (%zu bytes)", shm_size_);
+        return -1;
+    }
+
+    // Register for host-visible access (hardware only)
+    if (register_cb != nullptr) {
+        int rc = register_cb(shm_dev_, shm_size_, device_id, user_data, &shm_host_);
+        if (rc != 0) {
+            LOG_ERROR("PmuCollectorHost: halHostRegister for PMU SHM failed: %d", rc);
+            free_cb(shm_dev_, user_data);
+            shm_dev_ = nullptr;
+            return rc;
+        }
+        shm_registered_ = true;
+    } else {
+        // Simulation: dev == host
+        shm_host_ = shm_dev_;
+    }
+    // Zero-init via host-mapped pointer (shm_dev_ is device memory on hardware)
+    std::memset(shm_host_, 0, shm_size_);
+
+    // Write event_type into header so AICPU can read it from SHM
+    get_pmu_header(shm_host_)->event_type = event_type;
+
+    // Publish device address to KernelArgs
+    *kernel_args_pmu_data_base = reinterpret_cast<uint64_t>(shm_dev_);
+
+    // ---- Allocate per-core PmuBuffers and populate free_queues ----
+    const size_t buf_size = sizeof(PmuBuffer);
+    int total_bufs = num_cores * PLATFORM_PMU_BUFFERS_PER_CORE;
+    buf_pool_.resize(total_bufs);
+
+    for (int c = 0; c < num_cores; c++) {
+        PmuBufferState *state = pmu_state(c);
+
+        for (int b = 0; b < PLATFORM_PMU_BUFFERS_PER_CORE; b++) {
+            int idx = c * PLATFORM_PMU_BUFFERS_PER_CORE + b;
+            void *dev_ptr = alloc_cb(buf_size, user_data);
+            if (dev_ptr == nullptr) {
+                LOG_ERROR("PmuCollectorHost: failed to allocate PmuBuffer c=%d b=%d", c, b);
+                return -1;
+            }
+
+            void *host_ptr = dev_ptr;
+            bool registered = false;
+            if (register_cb != nullptr) {
+                int rc = register_cb(dev_ptr, buf_size, device_id, user_data, &host_ptr);
+                if (rc != 0) {
+                    LOG_ERROR("PmuCollectorHost: halHostRegister for PmuBuffer c=%d b=%d failed: %d", c, b, rc);
+                    free_cb(dev_ptr, user_data);
+                    return rc;
+                }
+                registered = true;
+            }
+            // Zero-init via host-mapped pointer (on hardware dev_ptr is not host-accessible)
+            std::memset(host_ptr, 0, buf_size);
+
+            buf_pool_[idx] = {dev_ptr, host_ptr, registered};
+
+            // Push into free_queue (host is producer, device is consumer)
+            uint32_t tail = state->free_queue.tail;
+            assert(tail - state->free_queue.head < PLATFORM_PMU_SLOT_COUNT && "free_queue overflow on init");
+            state->free_queue.buffer_ptrs[tail % PLATFORM_PMU_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
+            // wmb between writing buffer_ptrs and advancing tail
+            __sync_synchronize();
+            state->free_queue.tail = tail + 1;
+            __sync_synchronize();
+        }
+    }
+
+    // ---- Build CSV header string (file is opened lazily on first record) ----
+    // Deferring the open avoids leaving a header-only CSV on disk when the
+    // device hangs before producing any PMU records.
+    {
+        std::string header = "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
+        const PmuEventConfig *evt = pmu_resolve_event_config_a2a3(event_type);
+        if (evt == nullptr) {
+            evt = &PMU_EVENTS_A2A3_PIPE_UTIL;
+        }
+        // Emit only counters with a non-empty name (= valid counters for this event).
+        // Trailing slots in the event table are padded with empty names and skipped.
+        for (int i = 0; i < PMU_COUNTER_COUNT_A2A3; i++) {
+            const char *name = evt->counter_names[i];
+            if (name == nullptr || name[0] == '\0') {
+                continue;
+            }
+            header += ',';
+            header += name;
+        }
+        header += ",event_type\n";
+        csv_header_ = std::move(header);
+    }
+
+    initialized_ = true;
+    LOG_INFO(
+        "PMU collector initialized: %d cores, %d threads, SHM=0x%lx, CSV=%s (opened on first record)", num_cores,
+        num_threads, static_cast<unsigned long>(*kernel_args_pmu_data_base), csv_path_.c_str()
+    );
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Collector lifecycle
+// ---------------------------------------------------------------------------
+
+void PmuCollectorHost::signal_execution_complete() { execution_complete_.store(true, std::memory_order_release); }
+
+// ---------------------------------------------------------------------------
+// write_buffer_to_csv: append all records in one PmuBuffer to the CSV
+// ---------------------------------------------------------------------------
+
+void PmuCollectorHost::ensure_csv_open_unlocked() {
+    if (csv_file_.is_open()) {
+        return;
+    }
+    csv_file_.open(csv_path_, std::ios::out | std::ios::trunc);
+    if (!csv_file_.is_open()) {
+        LOG_ERROR("PmuCollectorHost: failed to open CSV file: %s", csv_path_.c_str());
+        return;
+    }
+    csv_file_ << csv_header_;
+}
+
+void PmuCollectorHost::write_buffer_to_csv(int core_id, int thread_idx, const void *buf_host_ptr) {
+    const PmuBuffer *buf = reinterpret_cast<const PmuBuffer *>(buf_host_ptr);
+    uint32_t n = buf->count;
+    if (n > static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
+        n = static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER);
+    }
+    if (n == 0) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(csv_mutex_);
+    ensure_csv_open_unlocked();
+    if (!csv_file_.is_open()) {
+        return;
+    }
+    total_collected_ += n;
+    const PmuEventConfig *evt = pmu_resolve_event_config_a2a3(event_type_);
+    if (evt == nullptr) {
+        evt = &PMU_EVENTS_A2A3_PIPE_UTIL;
+    }
+    for (uint32_t i = 0; i < n; i++) {
+        const PmuRecord &r = buf->records[i];
+        csv_file_ << thread_idx << ',' << core_id << ',';
+        // task_id is printed as hex so the PTO2 (ring_id<<32)|local_id encoding is
+        // readable at a glance.
+        csv_file_ << "0x" << std::hex << std::setw(16) << std::setfill('0') << r.task_id << std::dec
+                  << std::setfill(' ');
+        csv_file_ << ',' << r.func_id << ',' << static_cast<int>(r.core_type) << ',' << r.pmu_total_cycles;
+        // Only emit columns for counters with a non-empty name, matching the header.
+        for (int k = 0; k < PMU_COUNTER_COUNT_A2A3; k++) {
+            const char *name = evt->counter_names[k];
+            if (name == nullptr || name[0] == '\0') {
+                continue;
+            }
+            csv_file_ << ',' << r.pmu_counters[k];
+        }
+        csv_file_ << ',' << event_type_ << '\n';
+    }
+    csv_file_.flush();
+}
+
+// ---------------------------------------------------------------------------
+// push_to_free_queue: recycle a buffer back to a core's free_queue
+// ---------------------------------------------------------------------------
+
+void PmuCollectorHost::push_to_free_queue(int core_id, uint64_t buf_dev_addr) {
+    PmuBufferState *state = pmu_state(core_id);
+
+    // Find host pointer so we can zero the count
+    for (auto &entry : buf_pool_) {
+        if (reinterpret_cast<uint64_t>(entry.dev_ptr) == buf_dev_addr) {
+            PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(entry.host_ptr);
+            buf->count = 0;
+            break;
+        }
+    }
+
+    uint32_t tail = state->free_queue.tail;
+    state->free_queue.buffer_ptrs[tail % PLATFORM_PMU_SLOT_COUNT] = buf_dev_addr;
+    __sync_synchronize();
+    state->free_queue.tail = tail + 1;
+    __sync_synchronize();
+}
+
+// ---------------------------------------------------------------------------
+// poll_and_collect: collector thread body
+// ---------------------------------------------------------------------------
+
+void PmuCollectorHost::poll_and_collect() {
+    if (shm_host_ == nullptr) {
+        return;
+    }
+
+    PmuDataHeader *hdr = pmu_header();
+    constexpr int kIdleTimeoutMs = PLATFORM_PMU_TIMEOUT_SECONDS * 1000;
+    constexpr int kPollIntervalUs = 100;
+    int idle_ms = 0;
+
+    while (true) {
+        bool found_any = false;
+
+        for (int t = 0; t < num_threads_; t++) {
+            __sync_synchronize();
+            uint32_t head = hdr->queue_heads[t];
+            uint32_t tail = hdr->queue_tails[t];
+
+            while (head != tail) {
+                const PmuReadyQueueEntry &entry = hdr->queues[t][head % PLATFORM_PMU_READYQUEUE_SIZE];
+
+                uint32_t core_id = entry.core_index;
+                uint64_t buf_dev = entry.buffer_ptr;
+
+                // Resolve host pointer
+                void *buf_host = nullptr;
+                for (auto &e : buf_pool_) {
+                    if (reinterpret_cast<uint64_t>(e.dev_ptr) == buf_dev) {
+                        buf_host = e.host_ptr;
+                        break;
+                    }
+                }
+
+                if (buf_host != nullptr) {
+                    drained_bufs_.insert(buf_dev);
+                    write_buffer_to_csv(static_cast<int>(core_id), t, buf_host);
+                    push_to_free_queue(static_cast<int>(core_id), buf_dev);
+                } else {
+                    LOG_WARN("PMU collector: unknown buffer 0x%lx from core %u", buf_dev, core_id);
+                }
+
+                head = (head + 1) % PLATFORM_PMU_READYQUEUE_SIZE;
+                hdr->queue_heads[t] = head;
+                found_any = true;
+            }
+        }
+
+        if (!found_any) {
+            if (execution_complete_.load(std::memory_order_acquire)) {
+                // Done — exit after one final drain pass
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::microseconds(kPollIntervalUs));
+            idle_ms += kPollIntervalUs / 1000;
+            if (idle_ms >= kIdleTimeoutMs) {
+                LOG_WARN("PMU collector: idle timeout (%d ms), stopping", kIdleTimeoutMs);
+                break;
+            }
+        } else {
+            idle_ms = 0;
+        }
+    }
+
+    LOG_INFO("PMU collector thread exiting");
+}
+
+// ---------------------------------------------------------------------------
+// drain_remaining_buffers: after collector thread exits, pick up leftovers
+// ---------------------------------------------------------------------------
+
+void PmuCollectorHost::drain_remaining_buffers() {
+    if (shm_host_ == nullptr) {
+        return;
+    }
+
+    // Drain any ready_queue entries the collector thread may have missed
+    PmuDataHeader *hdr = pmu_header();
+    for (int t = 0; t < num_threads_; t++) {
+        __sync_synchronize();
+        uint32_t head = hdr->queue_heads[t];
+        uint32_t tail = hdr->queue_tails[t];
+
+        while (head != tail) {
+            const PmuReadyQueueEntry &entry = hdr->queues[t][head % PLATFORM_PMU_READYQUEUE_SIZE];
+            uint32_t core_id = entry.core_index;
+            uint64_t buf_dev = entry.buffer_ptr;
+
+            if (drained_bufs_.find(buf_dev) == drained_bufs_.end()) {
+                for (auto &e : buf_pool_) {
+                    if (reinterpret_cast<uint64_t>(e.dev_ptr) == buf_dev) {
+                        write_buffer_to_csv(static_cast<int>(core_id), t, e.host_ptr);
+                        drained_bufs_.insert(buf_dev);
+                        break;
+                    }
+                }
+            }
+
+            head = (head + 1) % PLATFORM_PMU_READYQUEUE_SIZE;
+            hdr->queue_heads[t] = head;
+        }
+    }
+
+    // Also check current_buf_ptr for each core (AICPU may have flushed but
+    // not enqueued if the ready_queue was observed full during flush)
+    for (int c = 0; c < num_cores_; c++) {
+        PmuBufferState *state = pmu_state(c);
+        __sync_synchronize();
+        uint64_t buf_dev = state->current_buf_ptr;
+        if (buf_dev == 0 || drained_bufs_.count(buf_dev) > 0) {
+            continue;
+        }
+        for (auto &e : buf_pool_) {
+            if (reinterpret_cast<uint64_t>(e.dev_ptr) == buf_dev) {
+                const PmuBuffer *buf = reinterpret_cast<const PmuBuffer *>(e.host_ptr);
+                if (buf->count > 0) {
+                    // current_buf_ptr was written by AICPU flush; we don't know
+                    // which thread owned it, so emit -1 for thread_id.
+                    write_buffer_to_csv(c, -1, e.host_ptr);
+                    drained_bufs_.insert(buf_dev);
+                }
+                break;
+            }
+        }
+    }
+
+    if (csv_file_.is_open()) {
+        csv_file_.flush();
+    }
+
+    // Cross-check device-side totals against what we wrote to CSV.
+    // Invariant: sum(total_record_count) == collected + sum(dropped_record_count).
+    uint64_t total_device = 0;
+    uint64_t dropped_device = 0;
+    for (int c = 0; c < num_cores_; c++) {
+        PmuBufferState *state = pmu_state(c);
+        __sync_synchronize();
+        total_device += state->total_record_count;
+        dropped_device += state->dropped_record_count;
+    }
+
+    if (dropped_device > 0) {
+        LOG_WARN(
+            "PMU collector: %lu records dropped on device side (free_queue empty or ready_queue full). "
+            "Increase PLATFORM_PMU_BUFFERS_PER_CORE / PLATFORM_PMU_READYQUEUE_SIZE if this is frequent.",
+            static_cast<unsigned long>(dropped_device)
+        );
+    }
+    if (total_collected_ + dropped_device != total_device) {
+        LOG_WARN(
+            "PMU collector: record count mismatch (collected=%lu + dropped=%lu != device_total=%lu)",
+            static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
+            static_cast<unsigned long>(total_device)
+        );
+    } else {
+        LOG_INFO(
+            "PMU collector: record counts match (collected=%lu, dropped=%lu, device_total=%lu)",
+            static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
+            static_cast<unsigned long>(total_device)
+        );
+    }
+
+    LOG_INFO("PMU collector: drain_remaining_buffers complete");
+}
+
+// ---------------------------------------------------------------------------
+// finalize
+// ---------------------------------------------------------------------------
+
+void PmuCollectorHost::finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback free_cb, void *user_data) {
+    if (!initialized_) {
+        return;
+    }
+
+    if (csv_file_.is_open()) {
+        csv_file_.close();
+    }
+
+    // Free individual PmuBuffers
+    for (auto &entry : buf_pool_) {
+        if (entry.dev_ptr == nullptr) {
+            continue;
+        }
+        if (entry.registered && unregister_cb != nullptr) {
+            unregister_cb(entry.dev_ptr, device_id_, user_data);
+        }
+        if (free_cb != nullptr) {
+            free_cb(entry.dev_ptr, user_data);
+        }
+    }
+    buf_pool_.clear();
+
+    // Free shared header region
+    if (shm_dev_ != nullptr) {
+        if (shm_registered_ && unregister_cb != nullptr) {
+            unregister_cb(shm_dev_, device_id_, user_data);
+        }
+        if (free_cb != nullptr) {
+            free_cb(shm_dev_, user_data);
+        }
+        shm_dev_ = nullptr;
+        shm_host_ = nullptr;
+    }
+
+    initialized_ = false;
+    LOG_INFO("PMU collector finalized");
+}

--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -11,6 +11,7 @@
 
 #include "aicore/aicore.h"
 #include "aicore/performance_collector_aicore.h"
+#include "aicore/pmu_collector_aicore.h"
 #include "common/perf_profiling.h"
 #include "common/platform_config.h"  // Register-based communication
 #include "pto2_dispatch_payload.h"
@@ -87,6 +88,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     bool profiling_enabled = runtime->enable_profiling;
     bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
+    bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
 
     // Phase 4: Main execution loop - poll register for tasks until exit signal
     // Register encoding: AICPU_IDLE_TASK_ID=idle, task_id=task, AICORE_EXIT_SIGNAL=exit
@@ -118,8 +120,16 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             // Performance profiling: record start time
             uint64_t start_time = get_sys_cnt_aicore();
 
+            if (pmu_enabled) {
+                pmu_aicore_begin();
+            }
+
             // Execute the task
             execute_task(payload);
+
+            if (pmu_enabled) {
+                pmu_aicore_end();
+            }
 
             if (dump_tensor_enabled) {
                 pipe_barrier(PIPE_ALL);

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -36,6 +36,7 @@
 
 // Performance profiling headers
 #include "aicpu/performance_collector_aicpu.h"
+#include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
 #include "common/memory_barrier.h"
 #include "common/perf_profiling.h"
@@ -189,6 +190,13 @@ struct AicpuExecutor {
     CoreInfo aiv_cores_[MAX_CORES_PER_THREAD];
     int32_t aic_count_{0};
     int32_t aiv_count_{0};
+
+#if PTO2_PROFILING
+    // Logical core_id -> hardware physical core id, collected during handshake.
+    // Handed to pmu_aicpu_init() so the platform can resolve per-core PMU MMIO
+    // bases.
+    uint32_t physical_core_ids_[RUNTIME_MAX_WORKER];
+#endif
 
     // Fast lookup: core_id -> reg_addr (for register-based dispatch)
     uint64_t core_id_to_reg_addr_[MAX_CORES_PER_THREAD];
@@ -397,6 +405,15 @@ struct AicpuExecutor {
 #if PTO2_SCHED_PROFILING
                     sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
 #endif
+                }
+#endif
+
+#if PTO2_PROFILING
+                if (get_enable_pmu()) {
+                    pmu_aicpu_record_task(
+                        core_id, thread_idx, slot_state.task->task_id.raw,
+                        slot_state.task->kernel_id[static_cast<int32_t>(subslot)], hank[core_id].core_type
+                    );
                 }
 #endif
 
@@ -650,6 +667,9 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime *runtime) {
         }
 
         core_id_to_reg_addr_[i] = reg_addr;
+#if PTO2_PROFILING
+        physical_core_ids_[i] = physical_core_id;
+#endif
     }
 
     if (handshake_failed) {
@@ -947,6 +967,14 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 #if PTO2_PROFILING
         if (get_enable_dump_tensor()) {
             dump_tensor_init(orch_to_sched_ ? thread_num_ : sched_thread_num_);
+        }
+#endif
+
+#if PTO2_PROFILING
+        // Initialize PMU: program events, start counters, and pop initial buffers
+        if (get_enable_pmu()) {
+            pmu_aicpu_init(physical_core_ids_, cores_total_num_);
+            DEV_INFO("PMU profiling started on %d cores", cores_total_num_);
         }
 #endif
 
@@ -1649,6 +1677,9 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         perf_aicpu_flush_buffers(runtime, thread_idx, core_assignments_[thread_idx], core_num);
         perf_aicpu_flush_phase_buffers(thread_idx);
     }
+    if (get_enable_pmu()) {
+        pmu_aicpu_flush_buffers(thread_idx, core_assignments_[thread_idx], core_num);
+    }
 #endif
 #if PTO2_PROFILING
     if (get_enable_dump_tensor()) {
@@ -2035,6 +2066,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         }
 #endif
         if (shutdown_count > 0) {
+#if PTO2_PROFILING
+            // Restore PMU CTRL registers for this thread's cores before AICore shutdown
+            if (get_enable_pmu()) {
+                pmu_aicpu_finalize(shutdown_cores, shutdown_count);
+            }
+#endif
             auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
             if (rc != 0) {
                 return rc;

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -11,6 +11,7 @@
 
 #include "aicore/aicore.h"
 #include "aicore/performance_collector_aicore.h"
+#include "aicore/pmu_collector_aicore.h"
 #include "common/perf_profiling.h"
 #include "common/platform_config.h"  // Platform configuration (C/C++ compatible)
 #include "runtime.h"
@@ -54,6 +55,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     bool profiling_enabled = runtime->enable_profiling;
     bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
+    bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
 
     volatile uint32_t task_id = AICPU_IDLE_TASK_ID;
     volatile uint32_t last_task_id = AICPU_IDLE_TASK_ID;
@@ -78,7 +80,15 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             __gm__ Task *task_ptr = &(runtime->tasks[actual_task_id]);
             uint64_t start_time = get_sys_cnt_aicore();
 
+            if (pmu_enabled) {
+                pmu_aicore_begin();
+            }
+
             execute_task(task_ptr);
+
+            if (pmu_enabled) {
+                pmu_aicore_end();
+            }
 
             if (dump_tensor_enabled) {
                 pipe_barrier(PIPE_ALL);

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -18,6 +18,7 @@
 #include "aicpu/device_time.h"
 #include "aicpu/performance_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
+#include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
 #include "callable.h"
 #include "common/memory_barrier.h"
@@ -59,6 +60,12 @@ struct AicpuExecutor {
     CoreInfo aiv_cores_[MAX_CORES_PER_THREAD];
     int aic_count_{0};
     int aiv_count_{0};
+
+#if PTO2_PROFILING
+    // Logical core_id -> hardware physical core id, collected during handshake.
+    // Handed to pmu_aicpu_init() so the platform can resolve per-core PMU MMIO bases.
+    uint32_t physical_core_ids_[RUNTIME_MAX_WORKER];
+#endif
 
     // Fast lookup: core_id -> reg_addr
     uint64_t core_id_to_reg_addr_[MAX_CORES_PER_THREAD];
@@ -337,6 +344,10 @@ int AicpuExecutor::init(Runtime *runtime) {
     if (get_enable_dump_tensor()) {
         dump_tensor_init(thread_num_);
     }
+    if (get_enable_pmu()) {
+        pmu_aicpu_init(physical_core_ids_, cores_total_num_);
+        LOG_INFO("PMU profiling started on %d cores", cores_total_num_);
+    }
 #endif
 
     init_done_.store(true, std::memory_order_release);
@@ -439,6 +450,10 @@ int AicpuExecutor::handshake_all_cores(Runtime *runtime) {
         }
 
         core_id_to_reg_addr_[i] = reg_addr;
+
+#if PTO2_PROFILING
+        physical_core_ids_[i] = physical_core_id;
+#endif
 
         LOG_INFO(
             "  Core %d: type=%s, physical_id=%u, reg_addr=0x%lx", i, core_type_to_string(type), physical_core_id,
@@ -772,6 +787,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                         cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                     );
 
+#if PTO2_PROFILING
+                    if (get_enable_pmu()) {
+                        pmu_aicpu_record_task(
+                            core_id, thread_idx, static_cast<uint64_t>(prev_running_id), prev_running_task->func_id,
+                            h->core_type
+                        );
+                    }
+#endif
+
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
@@ -780,6 +804,14 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
                     cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                 );
+
+#if PTO2_PROFILING
+                if (get_enable_pmu()) {
+                    pmu_aicpu_record_task(
+                        core_id, thread_idx, static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type
+                    );
+                }
+#endif
 
                 made_progress = true;
 
@@ -835,6 +867,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                         prev_running_task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
                         cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                     );
+
+#if PTO2_PROFILING
+                    if (get_enable_pmu()) {
+                        pmu_aicpu_record_task(
+                            core_id, thread_idx, static_cast<uint64_t>(prev_running_id), prev_running_task->func_id,
+                            h->core_type
+                        );
+                    }
+#endif
 
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
@@ -894,6 +935,14 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                 );
 
+#if PTO2_PROFILING
+                if (get_enable_pmu()) {
+                    pmu_aicpu_record_task(
+                        core_id, thread_idx, static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type
+                    );
+                }
+#endif
+
                 made_progress = true;
 
                 // Update timestamp if didn't dispatch (try_dispatch_task updates it if dispatched)
@@ -903,7 +952,13 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
             }
 
             // Case 4: Dispatch new task if pending slot is available
+            // With PTO2_DISABLE_DUAL_ISSUE=1, additionally require the running
+            // slot to be empty so each core has at most one outstanding task.
+#if PTO2_DISABLE_DUAL_ISSUE
+            if (pending_task_ids_[core_id] == AICPU_TASK_INVALID && running_task_ids_[core_id] == AICPU_TASK_INVALID) {
+#else
             if (pending_task_ids_[core_id] == AICPU_TASK_INVALID) {
+#endif
                 if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
                     if (try_dispatch_task(
                             core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,
@@ -1051,20 +1106,30 @@ int AicpuExecutor::run(Runtime *runtime) {
     int completed = resolve_and_dispatch(*runtime, thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
     LOG_INFO("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
 
-    int rc = shutdown_aicore(runtime, thread_idx, cur_thread_cores);
-    if (rc != 0) {
-        return rc;
-    }
-
     // Flush performance buffers for cores managed by this thread
     if (runtime->enable_profiling) {
         perf_aicpu_flush_buffers(runtime, thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
     }
 #if PTO2_PROFILING
+    if (get_enable_pmu()) {
+        pmu_aicpu_flush_buffers(thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
+    }
     if (get_enable_dump_tensor()) {
         dump_tensor_flush(thread_idx);
     }
 #endif
+
+#if PTO2_PROFILING
+    // Restore PMU CTRL registers for this thread's cores before AICore shutdown
+    if (get_enable_pmu()) {
+        pmu_aicpu_finalize(cur_thread_cores, thread_cores_num_[thread_idx]);
+    }
+#endif
+
+    int rc = shutdown_aicore(runtime, thread_idx, cur_thread_cores);
+    if (rc != 0) {
+        return rc;
+    }
 
     LOG_INFO("Thread %d: Completed", thread_idx);
 

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_PTO_RUNTIME2_TYPES_H_
+#define SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_PTO_RUNTIME2_TYPES_H_
+
+// =============================================================================
+// Profiling Configuration
+// =============================================================================
+
+#ifndef PTO2_PROFILING
+#define PTO2_PROFILING 1
+#endif
+
+// Disable dual-issue (pipelined) AICPU->AICore dispatch. When 1, the
+// scheduler only dispatches to a core when both the running and pending
+// slots are empty, so each core has at most one outstanding task at any
+// time. Orthogonal to PTO2_PROFILING / PMU: PMU users must set this
+// explicitly, since overlapping in-flight tasks pollute PMU registers.
+#ifndef PTO2_DISABLE_DUAL_ISSUE
+#define PTO2_DISABLE_DUAL_ISSUE 0
+#endif
+
+#endif  // SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_PTO_RUNTIME2_TYPES_H_

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -39,6 +39,7 @@
 #include "common/core_type.h"
 #include "common/perf_profiling.h"
 #include "common/platform_config.h"
+#include "pto_runtime2_types.h"
 #include "tensor_info.h"
 
 // Logging macros using unified logging interface

--- a/src/a2a3/runtime/host_build_graph/runtime/tensor_info.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/tensor_info.h
@@ -18,14 +18,6 @@
 #include "data_type.h"
 #include "tensor_arg.h"
 
-// =============================================================================
-// Profiling Configuration
-// =============================================================================
-
-#ifndef PTO2_PROFILING
-#define PTO2_PROFILING 1
-#endif
-
 struct TensorInfo {
     DataType dtype;
     uint8_t ndims;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -11,6 +11,7 @@
 
 #include "aicore/aicore.h"
 #include "aicore/performance_collector_aicore.h"
+#include "aicore/pmu_collector_aicore.h"
 #include "common/perf_profiling.h"
 #include "common/platform_config.h"  // Register-based communication
 #include "pto2_dispatch_payload.h"
@@ -90,6 +91,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     bool profiling_enabled = runtime->enable_profiling;
     bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
+    bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
 
     // Phase 4: Main execution loop - poll register for tasks until exit signal
     // Register encoding: AICPU_IDLE_TASK_ID=idle, task_id=task, AICORE_EXIT_SIGNAL=exit
@@ -124,8 +126,17 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             // Performance profiling: record start time
             uint64_t start_time = get_sys_cnt_aicore();
 
+            // PMU: start counting window around kernel execution
+            if (pmu_enabled) {
+                pmu_aicore_begin();
+            }
+
             // Execute the task
             execute_task(exec_payload);
+
+            if (pmu_enabled) {
+                pmu_aicore_end();
+            }
 
             if (dump_tensor_enabled) {
                 pipe_barrier(PIPE_ALL);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -36,6 +36,7 @@
 
 // Performance profiling headers
 #include "aicpu/performance_collector_aicpu.h"
+#include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
 #include "common/memory_barrier.h"
 #include "common/perf_profiling.h"
@@ -391,6 +392,14 @@ struct AicpuExecutor {
     int32_t aiv_worker_ids_[MAX_CORES_PER_THREAD];
     int32_t aic_count_{0};
     int32_t aiv_count_{0};
+
+#if PTO2_PROFILING
+    // Logical core_id -> hardware physical core id, collected during handshake.
+    // Handed to pmu_aicpu_init() so the platform can resolve per-core PMU MMIO
+    // bases. Separate storage is required because CoreExecState's 64-byte
+    // cache-line budget has no room for physical_core_id when PTO2_PROFILING=1.
+    uint32_t physical_core_ids_[RUNTIME_MAX_WORKER];
+#endif
 
     // Platform register base address array (set via get_platform_regs())
     uint64_t regs_{0};
@@ -953,6 +962,15 @@ struct AicpuExecutor {
 #if PTO2_SCHED_PROFILING
             perf.sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
 #endif
+        }
+#endif
+
+#if PTO2_PROFILING
+        if (get_enable_pmu()) {
+            pmu_aicpu_record_task(
+                core_id, thread_idx, slot_state.task->task_id.raw,
+                slot_state.task->kernel_id[static_cast<int32_t>(subslot)], hank[core_id].core_type
+            );
         }
 #endif
     }
@@ -1603,6 +1621,12 @@ int32_t AicpuExecutor::handshake_all_cores(Runtime *runtime) {
         CoreType type = hank->core_type;
 
         core_exec_states_[i].reg_addr = reg_addr;
+
+#if PTO2_PROFILING
+        // Record physical_core_id for PMU init later (CoreExecState has no room
+        // for this field under PTO2_PROFILING).
+        physical_core_ids_[i] = physical_core_id;
+#endif
 #if !PTO2_PROFILING
         core_exec_states_[i].worker_id = i;
         core_exec_states_[i].physical_core_id = physical_core_id;
@@ -1932,6 +1956,14 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         }
 #endif
 
+#if PTO2_PROFILING
+        // Initialize PMU: program events, start counters, and pop initial buffers
+        if (get_enable_pmu()) {
+            pmu_aicpu_init(physical_core_ids_, cores_total_num_);
+            DEV_INFO("PMU profiling started on %d cores", cores_total_num_);
+        }
+#endif
+
         DEV_INFO("Thread %d: one-time init done", thread_idx);
         pto2_init_complete_.store(true, std::memory_order_release);
     } else {
@@ -2069,7 +2101,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         // === Two-phase dispatch: idle then pending ===
         for (int32_t si = 0; si < PTO2_NUM_RESOURCE_SHAPES && !entered_drain; si++) {
             PTO2ResourceShape shape = dispatch_order[si];
+#if PTO2_DISABLE_DUAL_ISSUE
+            for (auto phase : {CoreTracker::DispatchPhase::IDLE}) {
+#else
             for (auto phase : {CoreTracker::DispatchPhase::IDLE, CoreTracker::DispatchPhase::PENDING}) {
+#endif
                 dispatch_shape(
                     runtime, thread_idx, shape, phase, local_bufs[static_cast<int32_t>(shape)], tracker, entered_drain,
                     made_progress, try_pushed
@@ -2175,8 +2211,11 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         perf_aicpu_flush_buffers(runtime, thread_idx, core_assignments_[thread_idx], core_num);
         perf_aicpu_flush_phase_buffers(thread_idx);
     }
-#endif
-#if PTO2_PROFILING
+
+    if (get_enable_pmu()) {
+        pmu_aicpu_flush_buffers(thread_idx, core_assignments_[thread_idx], core_num);
+    }
+
     if (get_enable_dump_tensor()) {
         dump_tensor_flush(thread_idx);
     }
@@ -2632,6 +2671,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         const int32_t *shutdown_cores = core_assignments_[thread_idx];
         int32_t shutdown_count = core_count_per_thread_[thread_idx];
         if (shutdown_count > 0) {
+#if PTO2_PROFILING
+            // Restore PMU CTRL registers for this thread's cores before AICore shutdown
+            if (get_enable_pmu()) {
+                pmu_aicpu_finalize(shutdown_cores, shutdown_count);
+            }
+#endif
             auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
             if (rc != 0) {
                 return rc;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -57,6 +57,15 @@
 #define PTO2_TENSORMAP_PROFILING 0
 #endif
 
+// Disable dual-issue (pipelined) AICPU->AICore dispatch. When 1, the
+// scheduler only loads the running slot and never pre-loads the pending
+// slot, so each core has at most one outstanding task at any time.
+// Orthogonal to PTO2_PROFILING / PMU: PMU users must set this explicitly,
+// since overlapping in-flight tasks pollute PMU registers.
+#ifndef PTO2_DISABLE_DUAL_ISSUE
+#define PTO2_DISABLE_DUAL_ISSUE 0
+#endif
+
 #if PTO2_ORCH_PROFILING && !PTO2_PROFILING
 #error "PTO2_ORCH_PROFILING requires PTO2_PROFILING=1"
 #endif

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -156,7 +156,7 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
 int run_runtime(
     DeviceContextHandle ctx, RuntimeHandle runtime, const void *callable, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_profiling, int enable_dump_tensor
+    size_t aicore_size, int enable_profiling, int enable_dump_tensor, int enable_pmu
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
     if (aicpu_binary == NULL || aicpu_size == 0 || aicore_binary == NULL || aicore_size == 0) return -1;

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -158,7 +158,7 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
 int run_runtime(
     DeviceContextHandle ctx, RuntimeHandle runtime, const void *callable, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_profiling, int enable_dump_tensor
+    size_t aicore_size, int enable_profiling, int enable_dump_tensor, int enable_pmu
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
 

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -170,10 +170,12 @@ void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
     int32_t aicpu_tn = s.config.aicpu_thread_num;
     int32_t profiling = s.config.enable_profiling ? 1 : 0;
     int32_t dump_tensor = s.config.enable_dump_tensor ? 1 : 0;
+    int32_t enable_pmu = s.config.enable_pmu;
     std::memcpy(mbox() + MAILBOX_OFF_BLOCK_DIM, &block_dim, sizeof(int32_t));
     std::memcpy(mbox() + MAILBOX_OFF_AICPU_THREAD_NUM, &aicpu_tn, sizeof(int32_t));
     std::memcpy(mbox() + MAILBOX_OFF_ENABLE_PROFILING, &profiling, sizeof(int32_t));
     std::memcpy(mbox() + MAILBOX_OFF_ENABLE_DUMP_TENSOR, &dump_tensor, sizeof(int32_t));
+    std::memcpy(mbox() + MAILBOX_OFF_ENABLE_PMU, &enable_pmu, sizeof(int32_t));
 
     // Write length-prefixed TaskArgs blob: [T][S][tensors][scalars].
     size_t blob_bytes = TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(view.tensor_count) * sizeof(ContinuousTensor) +

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -83,6 +83,7 @@ static constexpr ptrdiff_t MAILBOX_OFF_BLOCK_DIM = 16;
 static constexpr ptrdiff_t MAILBOX_OFF_AICPU_THREAD_NUM = 20;
 static constexpr ptrdiff_t MAILBOX_OFF_ENABLE_PROFILING = 24;
 static constexpr ptrdiff_t MAILBOX_OFF_ENABLE_DUMP_TENSOR = 28;
+static constexpr ptrdiff_t MAILBOX_OFF_ENABLE_PMU = 32;
 static constexpr ptrdiff_t MAILBOX_OFF_ARGS = 64;
 static constexpr ptrdiff_t MAILBOX_OFF_ERROR_MSG =
     static_cast<ptrdiff_t>(MAILBOX_SIZE) - static_cast<ptrdiff_t>(MAILBOX_ERROR_MSG_SIZE);

--- a/src/common/task_interface/chip_call_config.h
+++ b/src/common/task_interface/chip_call_config.h
@@ -11,7 +11,7 @@
 
 /**
  * ChipCallConfig — per-NEXT_LEVEL-task config (block_dim, aicpu_thread_num,
- * enable_profiling). Lives here (rather than chip_worker.h) so distributed
+ * enable_profiling, enable_dump_tensor, enable_pmu). Lives here (rather than chip_worker.h) so distributed
  * task slot state can store it directly without pulling in the full
  * ChipWorker header (which depends on types.h).
  */
@@ -23,4 +23,5 @@ struct ChipCallConfig {
     int aicpu_thread_num = 3;
     bool enable_profiling = false;
     bool enable_dump_tensor = false;
+    int enable_pmu = 0;  // 0 = disabled; >0 = enabled, value selects event type
 };

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -245,7 +245,7 @@ void ChipWorker::run(const void *callable, const void *args, const ChipCallConfi
     int rc = run_runtime_fn_(
         device_ctx_, rt, callable, args, config.block_dim, config.aicpu_thread_num, device_id_, aicpu_binary_.data(),
         aicpu_binary_.size(), aicore_binary_.data(), aicore_binary_.size(), config.enable_profiling ? 1 : 0,
-        config.enable_dump_tensor ? 1 : 0
+        config.enable_dump_tensor ? 1 : 0, config.enable_pmu
     );
     if (rc != 0) {
         throw std::runtime_error("run_runtime failed with code " + std::to_string(rc));

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -99,7 +99,7 @@ private:
     using GetRuntimeSizeFn = size_t (*)();
     using RunRuntimeFn = int (*)(
         void *, void *, const void *, const void *, int, int, int, const uint8_t *, size_t, const uint8_t *, size_t,
-        int, int
+        int, int, int
     );
     using FinalizeDeviceFn = int (*)(void *);
     using EnsureAclReadyFn = int (*)(void *, int);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -88,12 +88,13 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
  * @param aicore_size       Size of AICore binary
  * @param enable_profiling  1 to enable profiling, 0 to disable
  * @param enable_dump_tensor 1 to enable tensor dump, 0 to disable
+ * @param enable_pmu        0 = PMU disabled; >0 = enabled, value selects event type
  * @return 0 on success, negative on error
  */
 int run_runtime(
     DeviceContextHandle ctx, RuntimeHandle runtime, const void *callable, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_profiling, int enable_dump_tensor
+    size_t aicore_size, int enable_profiling, int enable_dump_tensor, int enable_pmu
 );
 
 /**


### PR DESCRIPTION
- Thread enable_pmu through SceneTest, Python bindings, worker mailbox, and runtime C API
- Add a2a3 host/AICPU/AICore PMU collection flow for onboard and sim builds, exporting LuoPan-compatible CSV files under outputs/
- Extend runtime and platform definitions for PMU registers, kernel args, event selection, and per-task counter sampling
- Add an a2a3 PMU guide covering design, usage, output, and the PTO2_DISABLE_DUAL_ISSUE limitation